### PR TITLE
docs(mintlify): document postgres gm_embed (#737)

### DIFF
--- a/docs-site/extensions/sql.mdx
+++ b/docs-site/extensions/sql.mdx
@@ -93,6 +93,7 @@ Registered UDFs:
 | `goldenmatch_connected_components(...)` | Group a candidate-pair graph into entities. |
 | `goldenmatch_pair_dedup(...)` | Keep the best score per canonical pair. |
 | `goldenmatch_embed_local(text, model_path)` | Embed text with a local in-house model. |
+| `gm_embed(text)` (PostgreSQL) | Embed text with the in-house model, dir from `GOLDENEMBED_MODEL_DIR`. |
 
 ## Graph and embedding kernels
 
@@ -155,6 +156,13 @@ SELECT goldenmatch.goldenmatch_embed_local('John Smith', '/path/to/model');  -- 
 ```
 
 </CodeGroup>
+
+On PostgreSQL, `gm_embed(text)` is a one-argument convenience that reads the model directory from the `GOLDENEMBED_MODEL_DIR` environment variable instead of taking it per call, and returns `real[]` (float4) to match the DataFusion `goldenmatch_embed` UDF. The model loads once per backend process and is cached. A `NULL` input embeds the empty string rather than returning `NULL`.
+
+```sql PostgreSQL
+-- Set GOLDENEMBED_MODEL_DIR in the server environment first.
+SELECT goldenmatch.gm_embed('John Smith');  -- real[]
+```
 
 <Note>
   The DuckDB embedding UDF needs the optional embed runtime: `pip install goldenmatch-duckdb[embed]`.

--- a/docs-site/goldenmatch/installation.mdx
+++ b/docs-site/goldenmatch/installation.mdx
@@ -66,15 +66,15 @@ Pre-built packages for the SQL extension (separate from the Python package):
 
 ```bash
 # Debian/Ubuntu
-sudo dpkg -i goldenmatch-pg-0.1.0-pg16-amd64.deb
+sudo dpkg -i goldenmatch-pg-0.7.0-pg16-amd64.deb
 sudo systemctl restart postgresql
 
 # RHEL/Fedora
-sudo rpm -i goldenmatch-pg-0.1.0-pg16.x86_64.rpm
+sudo rpm -i goldenmatch-pg-0.7.0-pg16.x86_64.rpm
 sudo systemctl restart postgresql
 ```
 
-Download `.deb` and `.rpm` from the [goldenmatch-extensions releases](https://github.com/benseverndev-oss/goldenmatch-extensions/releases) page.
+Download `.deb` and `.rpm` from the [goldenmatch releases](https://github.com/benseverndev-oss/goldenmatch/releases) page (look for the `goldenmatch-pg-v*` tags).
 
 ## DuckDB UDFs
 


### PR DESCRIPTION
Follows the v1.27.0 / goldenmatch-pg 0.7.0 release. Updates the Mintlify docs for the new user-facing SQL surface.

## Changes
- **`extensions/sql.mdx`**: adds `gm_embed(text)` to the PostgreSQL function table and the Local embedding section -- one-arg convenience over the in-house embedder, dir from `GOLDENEMBED_MODEL_DIR`, `real[]`/float4 output for DataFusion `goldenmatch_embed` parity, cached per backend, `NULL -> ""`.
- **`goldenmatch/installation.mdx`**: bumps the `.deb`/`.rpm` example from the stale `0.1.0` to `0.7.0`, and repoints the download link from `goldenmatch-extensions` to the monorepo releases (where `goldenmatch-pg-v*` artifacts now live).

## Validation
`mint validate` and `mint broken-links` both pass.

Note: #739 (distributed pipeline config) and #721 (probabilistic identifier admission) are internal auto-config/pipeline behaviors the docs site doesn't expose as a contract, so no doc change was warranted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)