### PR TITLE
feat(security): safe_path validation for user-supplied file paths

### DIFF
--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -1101,6 +1101,22 @@ GoldenMatch includes a gold-themed interactive terminal UI:
 
 ![Golden Tab](docs/screenshots/tui-golden.svg)
 
+## Environment Variables
+
+Key environment variables for tuning and hardening GoldenMatch:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GOLDENMATCH_ALLOWED_ROOT` | *(unset)* | Opt-in path sandbox. When set, every user-supplied file path (MCP tools, ingest, rollback, lineage, domain registry) must resolve under this directory. Raises `PathOutsideAllowedRootError` on escape. Recommended for network-exposed deployments (e.g. the Railway MCP server sets it to the `/data` volume). |
+| `GOLDENMATCH_AUTOCONFIG_MEMORY` | `1` | Set to `0` to disable cross-run auto-config memory (`~/.goldenmatch/autoconfig_memory.db`). Useful in CI. |
+| `GOLDENMATCH_AUTOCONFIG_LLM` | `0` | Set to `1` to enable LLM policy fallback when heuristic auto-config rules are exhausted. Requires `OPENAI_API_KEY`. |
+| `GOLDENMATCH_NOISE_AWARE_SCORERS` | `1` | Set to `0` to disable noise-aware scorer upgrades (`token_sort` -> `jaro_winkler` on address/string columns). |
+| `GOLDENMATCH_ENABLE_DISTRIBUTED_RAY` | `0` | Set to `1` to let the v3 planner auto-pick Ray at 50M+ rows. |
+| `GOLDENMATCH_DISTRIBUTED_PIPELINE` | `0` | Set to `2` to activate the full Phase-5 distributed pipeline (no driver-side materialization). |
+| `GOLDENMATCH_BUCKET_DEBUG` | `0` | Set to `1` to print per-bucket prep/kernel/post-filter timing for `backend=bucket`. Zero production overhead. |
+| `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS` | `20000000` | Minimum candidate-pair count per call before the native kernel fans out to rayon threads. |
+| `POLARS_SKIP_CPU_CHECK` | `0` | Set to `1` on Windows to skip the polars CPU-check WMI query (avoids startup hang). |
+
 ## Settings Persistence
 
 GoldenMatch saves preferences across sessions:

--- a/packages/python/goldenmatch/goldenmatch/core/_paths.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_paths.py
@@ -5,6 +5,12 @@ product, so containment is OPT-IN. Setting GOLDENMATCH_ALLOWED_ROOT (or
 passing base_dir) jails all user-supplied paths under that root --
 deploy-time hardening for network-exposed surfaces (the Railway MCP
 server sets it to the /data volume).
+
+An empty string for base_dir or GOLDENMATCH_ALLOWED_ROOT is treated as
+unset, meaning containment checking is disabled. Symlink TOCTOU
+(resolve-then-open race) is an accepted non-goal: the threat model is
+attacker-supplied path STRINGS, not attacker control of the server's
+filesystem state.
 """
 
 from __future__ import annotations

--- a/packages/python/goldenmatch/goldenmatch/core/_paths.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_paths.py
@@ -1,0 +1,38 @@
+"""Path validation (CodeQL py/path-injection mitigation).
+
+GoldenMatch is local-first: reading the user's own files by path is the
+product, so containment is OPT-IN. Setting GOLDENMATCH_ALLOWED_ROOT (or
+passing base_dir) jails all user-supplied paths under that root --
+deploy-time hardening for network-exposed surfaces (the Railway MCP
+server sets it to the /data volume).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ENV_ROOT = "GOLDENMATCH_ALLOWED_ROOT"
+
+
+class PathOutsideAllowedRootError(ValueError):
+    """Raised when a user-supplied path escapes the configured root."""
+
+
+def safe_path(value: str | os.PathLike, *, base_dir: str | os.PathLike | None = None) -> Path:
+    """Normalize *value* and (when a root is configured) enforce containment.
+
+    Raises ValueError on NUL bytes, PathOutsideAllowedRootError on escape.
+    """
+    raw = os.fspath(value)
+    if "\x00" in raw:
+        raise ValueError("path contains NUL byte")
+    resolved = Path(raw).resolve()
+    root = base_dir if base_dir is not None else os.environ.get(_ENV_ROOT)
+    if root:
+        root_resolved = Path(root).resolve()
+        if not resolved.is_relative_to(root_resolved):
+            raise PathOutsideAllowedRootError(
+                f"path {str(resolved)!r} is outside allowed root {str(root_resolved)!r}"
+            )
+    return resolved

--- a/packages/python/goldenmatch/goldenmatch/core/_paths.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_paths.py
@@ -26,19 +26,23 @@ class PathOutsideAllowedRootError(ValueError):
 
 
 def safe_path(value: str | os.PathLike, *, base_dir: str | os.PathLike | None = None) -> Path:
-    """Normalize *value* and (when a root is configured) enforce containment.
+    """Normalize *value* and enforce containment within a configured root.
 
-    Raises ValueError on NUL bytes, PathOutsideAllowedRootError on escape.
+    Raises ValueError on NUL bytes, PathOutsideAllowedRootError on missing root
+    configuration or containment escape.
     """
     raw = os.fspath(value)
     if "\x00" in raw:
         raise ValueError("path contains NUL byte")
     resolved = Path(raw).resolve()
     root = base_dir if base_dir is not None else os.environ.get(_ENV_ROOT)
-    if root:
-        root_resolved = Path(root).resolve()
-        if not resolved.is_relative_to(root_resolved):
-            raise PathOutsideAllowedRootError(
-                f"path {str(resolved)!r} is outside allowed root {str(root_resolved)!r}"
-            )
+    if not root:
+        raise PathOutsideAllowedRootError(
+            f"allowed root is not configured; set {_ENV_ROOT} or pass base_dir"
+        )
+    root_resolved = Path(root).resolve()
+    if not resolved.is_relative_to(root_resolved):
+        raise PathOutsideAllowedRootError(
+            f"path {str(resolved)!r} is outside allowed root {str(root_resolved)!r}"
+        )
     return resolved

--- a/packages/python/goldenmatch/goldenmatch/core/_paths.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_paths.py
@@ -26,23 +26,19 @@ class PathOutsideAllowedRootError(ValueError):
 
 
 def safe_path(value: str | os.PathLike, *, base_dir: str | os.PathLike | None = None) -> Path:
-    """Normalize *value* and enforce containment within a configured root.
+    """Normalize *value* and (when a root is configured) enforce containment.
 
-    Raises ValueError on NUL bytes, PathOutsideAllowedRootError on missing root
-    configuration or containment escape.
+    Raises ValueError on NUL bytes, PathOutsideAllowedRootError on escape.
     """
     raw = os.fspath(value)
     if "\x00" in raw:
         raise ValueError("path contains NUL byte")
     resolved = Path(raw).resolve()
     root = base_dir if base_dir is not None else os.environ.get(_ENV_ROOT)
-    if not root:
-        raise PathOutsideAllowedRootError(
-            f"allowed root is not configured; set {_ENV_ROOT} or pass base_dir"
-        )
-    root_resolved = Path(root).resolve()
-    if not resolved.is_relative_to(root_resolved):
-        raise PathOutsideAllowedRootError(
-            f"path {str(resolved)!r} is outside allowed root {str(root_resolved)!r}"
-        )
+    if root:
+        root_resolved = Path(root).resolve()
+        if not resolved.is_relative_to(root_resolved):
+            raise PathOutsideAllowedRootError(
+                f"path {str(resolved)!r} is outside allowed root {str(root_resolved)!r}"
+            )
     return resolved

--- a/packages/python/goldenmatch/goldenmatch/core/domain_registry.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain_registry.py
@@ -35,6 +35,7 @@ from pathlib import Path
 import yaml
 
 from goldenmatch.core._logging import sanitize_for_log
+from goldenmatch.core._paths import safe_path
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +166,7 @@ def load_rulebook(path: str | Path) -> DomainRulebook:
 
 def save_rulebook(rulebook: DomainRulebook, path: str | Path) -> Path:
     """Save a domain rulebook to a YAML file."""
-    path = Path(path)
+    path = safe_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
     data = {

--- a/packages/python/goldenmatch/goldenmatch/core/ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/core/ingest.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import polars as pl
 
+from goldenmatch.core._paths import safe_path
+
 # Text-file extensions that should route through smart_load
 _TEXT_SUFFIXES = {".csv", ".txt", ".tsv", ".dat", ".tab", ".psv", ".log", ".asc"}
 
@@ -44,7 +46,7 @@ def load_file(
         FileNotFoundError: If the file does not exist.
         ValueError: If the file format is not supported.
     """
-    path = Path(path)
+    path = safe_path(path)
     if not path.exists():
         raise FileNotFoundError(f"File not found: {path}")
 

--- a/packages/python/goldenmatch/goldenmatch/core/lineage.py
+++ b/packages/python/goldenmatch/goldenmatch/core/lineage.py
@@ -18,6 +18,7 @@ import polars as pl
 
 from goldenmatch.config.schemas import MatchkeyConfig
 from goldenmatch.core._logging import sanitize_for_log
+from goldenmatch.core._paths import safe_path
 
 logger = logging.getLogger(__name__)
 
@@ -132,8 +133,9 @@ def save_lineage(
     Returns:
         Path to the saved lineage file.
     """
-    output_dir = Path(output_dir)
+    output_dir = safe_path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    run_name = Path(run_name).name  # strip any directory components
 
     path = output_dir / f"{run_name}_lineage.json"
     data = {

--- a/packages/python/goldenmatch/goldenmatch/core/rollback.py
+++ b/packages/python/goldenmatch/goldenmatch/core/rollback.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 
 from goldenmatch.core._logging import sanitize_for_log
+from goldenmatch.core._paths import PathOutsideAllowedRootError, safe_path
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ def rollback_run(
     Returns:
         Summary of what was rolled back.
     """
-    output_dir = Path(output_dir)
+    output_dir = safe_path(output_dir)
     log_path = output_dir / RUN_LOG_FILE
     runs = _load_run_log(log_path)
 
@@ -94,6 +95,12 @@ def rollback_run(
         p = Path(filepath)
         if not p.is_absolute():
             p = output_dir / p
+        try:
+            p = safe_path(p)
+        except PathOutsideAllowedRootError:
+            logger.warning("Skipping rollback of path outside allowed root: %s", sanitize_for_log(str(p)))
+            not_found.append(str(p))
+            continue
         if p.exists():
             p.unlink()
             deleted.append(str(p))

--- a/packages/python/goldenmatch/goldenmatch/core/rollback.py
+++ b/packages/python/goldenmatch/goldenmatch/core/rollback.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 
 from goldenmatch.core._logging import sanitize_for_log
-from goldenmatch.core._paths import PathOutsideAllowedRootError, safe_path
+from goldenmatch.core._paths import safe_path
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,9 @@ def rollback_run(
             p = output_dir / p
         try:
             p = safe_path(p)
-        except PathOutsideAllowedRootError:
+        except ValueError:
+            # Path is jailed (outside allowed root) or contains NUL — skip and
+            # report as not_found so callers see it in the summary.
             logger.warning("Skipping rollback of path outside allowed root: %s", sanitize_for_log(str(p)))
             not_found.append(str(p))
             continue

--- a/packages/python/goldenmatch/goldenmatch/core/smart_ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/core/smart_ingest.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import polars as pl
 
+from goldenmatch.core._paths import safe_path
+
 # ---------------------------------------------------------------------------
 # Encoding Detection
 # ---------------------------------------------------------------------------
@@ -516,7 +518,7 @@ def smart_load(
 
     Returns (dataframe, metadata_dict).
     """
-    path = Path(path)
+    path = safe_path(path)
     log: list[str] = []
 
     # 1. Encoding

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1203,6 +1203,14 @@ def _tool_profile_data() -> dict:
     return {"columns": cols, "total_records": _engine.row_count}
 
 
+def _safe_path_or_error(value: str) -> Path | dict:
+    """Validate *value* via safe_path; return the resolved Path or an error dict."""
+    try:
+        return safe_path(value)
+    except (ValueError, PathOutsideAllowedRootError) as exc:
+        return {"error": str(exc)}
+
+
 def _tool_export_results(output_path: str, fmt: str) -> dict:
     try:
         path = safe_path(output_path)
@@ -1429,7 +1437,10 @@ def _tool_evaluate(ground_truth_path: str, col_a: str = "id_a", col_b: str = "id
     from goldenmatch.core.evaluate import evaluate_clusters, load_ground_truth_csv
     if _result is None:
         return {"error": "No dataset loaded"}
-    gt = load_ground_truth_csv(ground_truth_path, col_a, col_b)
+    validated = _safe_path_or_error(ground_truth_path)
+    if isinstance(validated, dict):
+        return validated
+    gt = load_ground_truth_csv(str(validated), col_a, col_b)
     return evaluate_clusters(_result.clusters, gt).summary()
 
 
@@ -1453,16 +1464,28 @@ def _tool_analyze_blocking(
 
 def _tool_compare_clusters(clusters_a_path: str, clusters_b_path: str) -> dict:
     from goldenmatch.core.compare_clusters import compare_clusters
-    a = _load_clusters_json(clusters_a_path)
-    b = _load_clusters_json(clusters_b_path)
+    va = _safe_path_or_error(clusters_a_path)
+    if isinstance(va, dict):
+        return va
+    vb = _safe_path_or_error(clusters_b_path)
+    if isinstance(vb, dict):
+        return vb
+    a = _load_clusters_json(str(va))
+    b = _load_clusters_json(str(vb))
     return compare_clusters(a, b).summary()
 
 
 def _tool_schema_match(file_a: str, file_b: str, min_score: float = 0.5) -> dict:
     from goldenmatch.core.ingest import load_file
     from goldenmatch.core.schema_match import auto_map_columns
-    df_a = load_file(file_a).collect()
-    df_b = load_file(file_b).collect()
+    va = _safe_path_or_error(file_a)
+    if isinstance(va, dict):
+        return va
+    vb = _safe_path_or_error(file_b)
+    if isinstance(vb, dict):
+        return vb
+    df_a = load_file(str(va)).collect()
+    df_b = load_file(str(vb)).collect()
     return {"mappings": auto_map_columns(df_a, df_b, min_score=min_score)}
 
 
@@ -1472,6 +1495,11 @@ def _tool_lineage(
     from goldenmatch.core.lineage import build_lineage, save_lineage
     if _result is None or _engine is None or _config is None:
         return {"error": "No dataset loaded"}
+    if output_dir is not None:
+        vdir = _safe_path_or_error(output_dir)
+        if isinstance(vdir, dict):
+            return vdir
+        output_dir = str(vdir)
     lineage = build_lineage(
         _result.scored_pairs,
         _engine.data,
@@ -1488,12 +1516,18 @@ def _tool_lineage(
 
 def _tool_list_runs(output_dir: str = ".") -> dict:
     from goldenmatch.core.rollback import list_runs
-    return {"runs": list_runs(output_dir)}
+    vdir = _safe_path_or_error(output_dir)
+    if isinstance(vdir, dict):
+        return vdir
+    return {"runs": list_runs(str(vdir))}
 
 
 def _tool_rollback(run_id: str, output_dir: str = ".") -> dict:
     from goldenmatch.core.rollback import rollback_run
-    return rollback_run(run_id, output_dir)
+    vdir = _safe_path_or_error(output_dir)
+    if isinstance(vdir, dict):
+        return vdir
+    return rollback_run(run_id, str(vdir))
 
 
 async def run_server_http(

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -31,6 +31,7 @@ from mcp.types import (
     Tool,
 )
 
+from goldenmatch.core._paths import PathOutsideAllowedRootError, safe_path
 from goldenmatch.mcp.agent_tools import AGENT_TOOLS, handle_agent_tool
 from goldenmatch.mcp.identity_tools import (
     IDENTITY_TOOL_NAMES,
@@ -1203,8 +1204,10 @@ def _tool_profile_data() -> dict:
 
 
 def _tool_export_results(output_path: str, fmt: str) -> dict:
-
-    path = Path(output_path)
+    try:
+        path = safe_path(output_path)
+    except (ValueError, PathOutsideAllowedRootError) as exc:
+        return {"error": str(exc)}
     if fmt == "json":
         if _result.golden is not None:
             golden_dicts = _result.golden.to_dicts()
@@ -1349,14 +1352,15 @@ def _tool_pprl_auto_config(security_level: str = "high", use_llm: bool = False) 
 
 def _tool_pprl_link(args: dict) -> dict:
     """Run PPRL linkage between two files."""
-    from pathlib import Path
-
     import polars as pl
 
     from goldenmatch.pprl.protocol import PPRLConfig, run_pprl
 
-    file_a = Path(args["file_a"])
-    file_b = Path(args["file_b"])
+    try:
+        file_a = safe_path(args["file_a"])
+        file_b = safe_path(args["file_b"])
+    except (ValueError, PathOutsideAllowedRootError) as exc:
+        return {"error": str(exc)}
     if not file_a.exists():
         return {"error": f"File not found: {file_a}"}
     if not file_b.exists():

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1212,10 +1212,9 @@ def _safe_path_or_error(value: str) -> Path | dict:
 
 
 def _tool_export_results(output_path: str, fmt: str) -> dict:
-    try:
-        path = safe_path(output_path)
-    except (ValueError, PathOutsideAllowedRootError) as exc:
-        return {"error": str(exc)}
+    path = _safe_path_or_error(output_path)
+    if isinstance(path, dict):
+        return path
     if fmt == "json":
         if _result.golden is not None:
             golden_dicts = _result.golden.to_dicts()
@@ -1364,11 +1363,12 @@ def _tool_pprl_link(args: dict) -> dict:
 
     from goldenmatch.pprl.protocol import PPRLConfig, run_pprl
 
-    try:
-        file_a = safe_path(args["file_a"])
-        file_b = safe_path(args["file_b"])
-    except (ValueError, PathOutsideAllowedRootError) as exc:
-        return {"error": str(exc)}
+    file_a = _safe_path_or_error(args["file_a"])
+    if isinstance(file_a, dict):
+        return file_a
+    file_b = _safe_path_or_error(args["file_b"])
+    if isinstance(file_b, dict):
+        return file_b
     if not file_a.exists():
         return {"error": f"File not found: {file_a}"}
     if not file_b.exists():

--- a/packages/python/goldenmatch/tests/unit/test_safe_path.py
+++ b/packages/python/goldenmatch/tests/unit/test_safe_path.py
@@ -57,3 +57,16 @@ def test_mcp_export_respects_root(tmp_path, monkeypatch):
     from goldenmatch.mcp import server as mcp_server
     result = mcp_server._tool_export_results(str(tmp_path / "escape.json"), "json")
     assert "error" in result
+
+
+def test_mcp_compare_clusters_respects_root(tmp_path, monkeypatch):
+    root = tmp_path / "jail"
+    root.mkdir()
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(root))
+    from goldenmatch.mcp import server as mcp_server
+    # clusters_a_path escapes the jail — must get an error dict, not an open() call
+    result = mcp_server._tool_compare_clusters(
+        str(tmp_path / "escape_a.json"),
+        str(root / "b.json"),
+    )
+    assert "error" in result

--- a/packages/python/goldenmatch/tests/unit/test_safe_path.py
+++ b/packages/python/goldenmatch/tests/unit/test_safe_path.py
@@ -1,0 +1,59 @@
+"""Tests for goldenmatch.core._paths.safe_path."""
+
+
+import pytest
+from goldenmatch.core._paths import PathOutsideAllowedRootError, safe_path
+
+
+def test_plain_path_resolves(tmp_path):
+    f = tmp_path / "data.csv"
+    f.write_text("a,b\n1,2")
+    assert safe_path(str(f)) == f.resolve()
+
+
+def test_rejects_null_byte():
+    with pytest.raises(ValueError):
+        safe_path("data\x00.csv")
+
+
+def test_traversal_collapsed(tmp_path):
+    p = safe_path(str(tmp_path / "sub" / ".." / "data.csv"))
+    assert ".." not in p.parts
+
+
+def test_containment_blocks_escape(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "secret.txt"
+    with pytest.raises(PathOutsideAllowedRootError):
+        safe_path(str(outside), base_dir=root)
+
+
+def test_containment_allows_inside(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    inside = root / "ok.csv"
+    assert safe_path(str(inside), base_dir=root) == inside.resolve()
+
+
+def test_env_root(tmp_path, monkeypatch):
+    root = tmp_path / "jail"
+    root.mkdir()
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(root))
+    with pytest.raises(PathOutsideAllowedRootError):
+        safe_path(str(tmp_path / "outside.csv"))
+    assert safe_path(str(root / "in.csv")) == (root / "in.csv").resolve()
+
+
+def test_no_root_no_containment(tmp_path, monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_ALLOWED_ROOT", raising=False)
+    assert safe_path(str(tmp_path / "anything")) == (tmp_path / "anything").resolve()
+
+
+def test_mcp_export_respects_root(tmp_path, monkeypatch):
+    root = tmp_path / "jail"
+    root.mkdir()
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(root))
+    from goldenmatch.mcp import server as mcp_server
+    result = mcp_server._tool_export_results(str(tmp_path / "escape.json"), "json")
+    assert "error" in result


### PR DESCRIPTION
Hardens all 19 CodeQL `py/path-injection` alerts (377-395).

**New `goldenmatch/core/_paths.py`:** `safe_path()` — NUL-byte rejection, `resolve()` traversal collapse, opt-in containment root via `base_dir` or `GOLDENMATCH_ALLOWED_ROOT` env (unset = no containment; local-first default). `PathOutsideAllowedRootError(ValueError)` on escape. Symlink TOCTOU is a documented non-goal (threat model = attacker-supplied path strings, not server filesystem state).

**Applied at entry boundaries:**
- `load_file`, `smart_load`, `save_rulebook`: validate at entry
- `rollback_run`: validates `output_dir` + the final joined path before `unlink()` (the delete primitive; run-log JSON is attacker-influenceable). Escaping/NUL paths are skipped with a warning and reported in the summary.
- `save_lineage`: validates `output_dir`; `run_name` stripped to its basename
- `mcp/server.py`: 9 `_tool_*` handlers validate via a shared `_safe_path_or_error` helper returning `{"error": ...}` (export_results, pprl_link, evaluate, compare_clusters, schema_match, lineage, list_runs, rollback)

**Behavior note:** MCP tools that echoed a user-relative path now return the resolved absolute path (e.g. `exported`, `saved_to`) — deliberate.

**Deploy-time hardening:** the Railway MCP service should set `GOLDENMATCH_ALLOWED_ROOT=/data` (separate step, needs service-layout confirmation). Documented in README.

**Verified:** 9/9 new tests (incl. 2 jailed-MCP-boundary integration tests); existing tests for all touched modules green (92 passed); ruff clean; Windows semantics probed (case-insensitive is_relative_to, drive-relative, UNC).

Some alerts may need dismissal after merge if CodeQL's taint tracking doesn't recognize the conditional containment barrier — hardening is real either way.

Part 5/5 of the security-alerts remediation plan (docs/superpowers/plans/2026-06-05-security-alerts-remediation.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)