### PR TITLE
chore(release): sign goldenmatch-pg release artifacts

### DIFF
--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -24,13 +24,17 @@ on:
         default: ""
 
 permissions:
-  contents: write  # needed to upload release assets
+  contents: read
 
 jobs:
   build:
     # Only fire for goldenmatch-pg release tags.
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-pg-v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # upload release assets
+      id-token: write      # cosign keyless OIDC signing
+      attestations: write  # GitHub build-provenance attestation
     strategy:
       fail-fast: false
       matrix:
@@ -122,11 +126,41 @@ jobs:
           echo "ASSET=${ASSET}" >> "$GITHUB_ENV"
           ls -la "${ASSET}"
 
+      # --- Signing + provenance (Scorecard Signed-Releases) ---------------
+      # cosign keyless: OIDC identity = this workflow on this ref; verifiers
+      # run `cosign verify-blob --bundle <asset>.sigstore <asset>` with
+      # --certificate-identity-regexp pinned to this repo's workflow path.
+      - name: Install cosign
+        if: github.event_name == 'release'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Sign artifact (cosign keyless)
+        if: github.event_name == 'release'
+        working-directory: packages/rust/extensions/postgres
+        run: cosign sign-blob --yes --bundle "${ASSET}.sigstore" "${ASSET}"
+
+      - name: Attest build provenance
+        if: github.event_name == 'release'
+        id: attest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: packages/rust/extensions/postgres/${{ env.ASSET }}
+
+      - name: Stage provenance bundle as a release asset
+        if: github.event_name == 'release'
+        # The attestation lives in GitHub's attestation store; also attach it
+        # to the release so consumers (and Scorecard) see it next to the
+        # artifact.
+        run: cp "${{ steps.attest.outputs.bundle-path }}" "packages/rust/extensions/postgres/${ASSET}.intoto.jsonl"
+
       - name: Upload to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8  # v2
         with:
-          files: packages/rust/extensions/postgres/${{ env.ASSET }}
+          files: |
+            packages/rust/extensions/postgres/${{ env.ASSET }}
+            packages/rust/extensions/postgres/${{ env.ASSET }}.sigstore
+            packages/rust/extensions/postgres/${{ env.ASSET }}.intoto.jsonl
           tag_name: ${{ github.event.release.tag_name }}
 
       - name: Upload artifact (workflow_dispatch only)

--- a/.github/workflows/sign-release-assets.yml
+++ b/.github/workflows/sign-release-assets.yml
@@ -1,0 +1,59 @@
+name: sign-release-assets
+
+# Retro-signs the assets of an EXISTING GitHub release with cosign keyless
+# (sigstore bundle per asset, uploaded next to it). Used to backfill
+# signatures on releases published before publish-goldenmatch-pg.yml signed
+# at build time (Scorecard Signed-Releases).
+#
+# Deliberately signature-only: no build-provenance attestation here, because
+# provenance asserts "this artifact was built by this workflow" -- which is
+# false for a retro-signed artifact. Signing asserts only "the repo owner
+# vouches for this asset as published", which is true.
+#
+# Verify with:
+#   cosign verify-blob --bundle <asset>.sigstore <asset> \
+#     --certificate-identity-regexp 'github.com/benseverndev-oss/goldenmatch' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag whose assets to sign (e.g. goldenmatch-pg-v0.7.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # upload .sigstore bundles to the release
+      id-token: write  # cosign keyless OIDC
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Download, sign, and upload bundles
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir assets && cd assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY"
+          signed=0
+          for f in *; do
+            case "$f" in
+              *.sigstore|*.intoto.jsonl|*.sig|*.asc) echo "skip existing signature artifact: $f"; continue ;;
+            esac
+            cosign sign-blob --yes --bundle "${f}.sigstore" "$f"
+            signed=$((signed + 1))
+          done
+          if [ "$signed" -eq 0 ]; then
+            echo "::error::no signable assets found on release $TAG"
+            exit 1
+          fi
+          gh release upload "$TAG" ./*.sigstore --repo "$GITHUB_REPOSITORY" --clobber
+          echo "signed and uploaded $signed bundle(s) to $TAG"


### PR DESCRIPTION
Addresses the Scorecard **Signed-Releases** finding (goldenmatch-pg-v0.6.0 / v0.7.0 unsigned, no provenance).

**`publish-goldenmatch-pg.yml`** (future releases):
- cosign keyless-signs each tarball -> `<asset>.sigstore` bundle attached to the release
- `actions/attest-build-provenance` -> `<asset>.intoto.jsonl` attached (also lands in GitHub's attestation store)
- token permissions moved to job level (top-level `contents: read`) so this workflow doesn't trip TokenPermissions next

**`sign-release-assets.yml`** (new, `workflow_dispatch`): retro-signs assets of an existing release. Signature only -- deliberately NO retroactive provenance, since provenance would falsely claim the old artifacts were built by this workflow. After merge, dispatch it for `goldenmatch-pg-v0.6.0` and `goldenmatch-pg-v0.7.0`.

Verification command documented in the workflow header (`cosign verify-blob --bundle ...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)