### PR TITLE
Wave 3.1: surface explain / lineage / anomalies as CLI commands

### DIFF
--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -57,7 +57,8 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 - `pipeline.py` refactored: `_run_dedupe_pipeline()` and `_run_match_pipeline()` extracted as shared internal functions, called by both file-based and DataFrame-based entry points
 - `goldenmatch/core/` — pipeline modules (no Textual dependency)
 - `goldenmatch/tui/` — Textual TUI + MatchEngine (engine.py has no Textual dependency)
-- `goldenmatch/cli/` — Typer CLI commands (23 commands, including `unmerge`, `evaluate`, `incremental`, `pprl`, `label`, `compare-clusters`, `sensitivity`)
+- `goldenmatch/cli/` — Typer CLI commands (including `unmerge`, `evaluate`, `incremental`, `pprl`, `label`, `compare-clusters`, `sensitivity`, `review`)
+- **Wave 3.1 (2026-06-05) surfaced 3 library features as CLI front doors** (each ran via the pipeline before, but had no standalone command): `goldenmatch explain` (NL pair/cluster explanation via `core/explain.py`; `--pair a,b` or `--cluster id`), `goldenmatch lineage` (per-pair audit trail via `core/lineage.py`; was MCP-tool-only), `goldenmatch anomalies` (standalone `core/anomaly.py` detection; was `dedupe --anomalies` only). `explain`/`lineage` run the pipeline through `tui/engine.py::MatchEngine` (clean `EngineResult.scored_pairs`/`.clusters` + `engine.data`) — NOT `run_dedupe`, whose result dict does NOT reliably carry `_df`/`scored_pairs` (label.py reconstructs the df when `_df` is None). Reuse MatchEngine for any new command that needs scored pairs + the row-id'd frame.
 - `goldenmatch/db/` — Postgres integration (connector, sync, reconcile, clusters, ANN index)
 - `goldenmatch/api/` — REST API server (`goldenmatch serve`)
 - `goldenmatch/mcp/` — MCP server for Claude Desktop (`goldenmatch mcp-serve`)

--- a/packages/python/goldenmatch/goldenmatch/cli/anomalies.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/anomalies.py
@@ -1,0 +1,77 @@
+"""CLI anomalies command -- standalone suspicious-record detection.
+
+Surfaces ``core.anomaly.detect_anomalies`` directly. Previously this was only
+reachable as the ``dedupe --anomalies`` flag; here it runs on its own without
+a dedupe pipeline.
+"""
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+def anomalies_cmd(
+    files: list[str] = typer.Argument(..., help="Input files (path or path:source_name)"),
+    sensitivity: str = typer.Option("medium", "--sensitivity", "-s", help="low, medium, or high"),
+    output: str = typer.Option(None, "--output", "-o", help="Write anomalies to a CSV instead of printing"),
+    limit: int = typer.Option(50, "--limit", "-n", help="Max rows to print"),
+) -> None:
+    """Detect suspicious/fake records (test emails, repeated digits, bad ZIPs, ...)."""
+    import polars as pl
+
+    from goldenmatch.cli.dedupe import _parse_file_source
+    from goldenmatch.core.anomaly import detect_anomalies
+    from goldenmatch.core.ingest import load_file
+
+    if sensitivity not in ("low", "medium", "high"):
+        console.print("[red]Error:[/red] --sensitivity must be low, medium, or high.")
+        raise typer.Exit(code=2)
+
+    frames = []
+    for raw in files:
+        path, source = _parse_file_source(raw)
+        lf = load_file(path).with_columns(pl.lit(source).alias("__source__"))
+        frames.append(lf.collect())
+    df = pl.concat(frames, how="diagonal").with_row_index("__row_id__").with_columns(
+        pl.col("__row_id__").cast(pl.Int64)
+    )
+
+    anomalies = detect_anomalies(df, sensitivity=sensitivity)
+
+    if not anomalies:
+        console.print(f"[#2ecc71]No anomalies found[/] at sensitivity '{sensitivity}'.")
+        return
+
+    if output:
+        pl.DataFrame(anomalies).write_csv(output)
+        console.print(f"[#2ecc71]Wrote {len(anomalies)} anomalies[/] to {output}")
+        return
+
+    table = Table(
+        title=f"{len(anomalies)} anomalies (sensitivity: {sensitivity})",
+        border_style="#d4a017",
+        header_style="bold #d4a017",
+    )
+    table.add_column("Row")
+    table.add_column("Column")
+    table.add_column("Type")
+    table.add_column("Value")
+    table.add_column("Severity")
+    table.add_column("Reason")
+    sev_color = {"high": "red", "medium": "yellow", "low": "#8892a0"}
+    for a in anomalies[:limit]:
+        sev = str(a.get("severity", ""))
+        table.add_row(
+            str(a.get("row_id", "")),
+            str(a.get("column", "")),
+            str(a.get("type", "")),
+            str(a.get("value", ""))[:40],
+            f"[{sev_color.get(sev, 'white')}]{sev}[/]",
+            str(a.get("reason", ""))[:60],
+        )
+    console.print(table)
+    if len(anomalies) > limit:
+        console.print(f"[dim]... {len(anomalies) - limit} more. Use --output to dump all.[/dim]")

--- a/packages/python/goldenmatch/goldenmatch/cli/explain.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/explain.py
@@ -1,0 +1,86 @@
+"""CLI explain command -- natural-language explanation of a pair or cluster.
+
+Surfaces ``core.explain.explain_pair_nl`` / ``explain_cluster_nl`` (zero LLM
+cost, template-based) which previously had no CLI front door.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+console = Console()
+
+
+def explain_cmd(
+    files: list[str] = typer.Argument(..., help="Input files (path or path:source_name)"),
+    config: Path = typer.Option(..., "--config", "-c", help="Config YAML path"),
+    pair: str = typer.Option(None, "--pair", help="Explain a pair: 'id_a,id_b'"),
+    cluster: int = typer.Option(None, "--cluster", help="Explain a cluster by id"),
+) -> None:
+    """Explain why a pair matched, or summarize a cluster, in plain language.
+
+    Provide exactly one of --pair or --cluster.
+    """
+    from goldenmatch.cli.dedupe import _parse_file_source
+    from goldenmatch.config.loader import load_config
+    from goldenmatch.core.explain import explain_cluster_nl
+    from goldenmatch.core.lineage import build_lineage
+    from goldenmatch.tui.engine import MatchEngine
+
+    if (pair is None) == (cluster is None):
+        console.print("[red]Error:[/red] provide exactly one of --pair or --cluster.")
+        raise typer.Exit(code=2)
+
+    cfg = load_config(str(config))
+    paths = [_parse_file_source(f)[0] for f in files]
+
+    console.print("[bold]Running pipeline...[/bold]")
+    engine = MatchEngine(paths)
+    result = engine.run_full(cfg)
+    df = engine.data
+    clusters = result.clusters
+    scored_pairs = result.scored_pairs
+
+    if pair is not None:
+        try:
+            id_a, id_b = (int(x) for x in pair.split(","))
+        except ValueError:
+            console.print("[red]Error:[/red] --pair must be 'id_a,id_b' (two integers).")
+            raise typer.Exit(code=2) from None
+        lineage = build_lineage(
+            scored_pairs, df, cfg.get_matchkeys(), clusters, natural_language=True
+        )
+        want = {(min(id_a, id_b), max(id_a, id_b))}
+        match = next(
+            (
+                r for r in lineage
+                if (min(r["row_id_a"], r["row_id_b"]), max(r["row_id_a"], r["row_id_b"])) in want
+            ),
+            None,
+        )
+        if match is None:
+            console.print(
+                f"[yellow]No scored pair ({id_a}, {id_b}).[/yellow] "
+                "[dim]The pair may have scored below threshold or not been blocked together.[/dim]"
+            )
+            raise typer.Exit(code=1)
+        console.print(Panel(
+            match.get("explanation") or "(no explanation available)",
+            title=f"Pair ({id_a}, {id_b}) · score {match.get('score', 0.0):.3f}",
+            border_style="#d4a017",
+        ))
+        return
+
+    cinfo = clusters.get(cluster)
+    if cinfo is None:
+        console.print(f"[yellow]No cluster {cluster}.[/yellow]")
+        raise typer.Exit(code=1)
+    summary = explain_cluster_nl(cinfo, df, cfg.get_matchkeys())
+    console.print(Panel(
+        summary,
+        title=f"Cluster {cluster} · {cinfo.get('size', '?')} records",
+        border_style="#d4a017",
+    ))

--- a/packages/python/goldenmatch/goldenmatch/cli/lineage.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/lineage.py
@@ -1,0 +1,60 @@
+"""CLI lineage command -- build + persist match lineage for a run.
+
+Surfaces ``core.lineage.build_lineage`` / ``save_lineage`` (the per-pair audit
+trail) which previously had no CLI front door (only the MCP ``lineage`` tool).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+
+def lineage_cmd(
+    files: list[str] = typer.Argument(..., help="Input files (path or path:source_name)"),
+    config: Path = typer.Option(..., "--config", "-c", help="Config YAML path"),
+    output_dir: str = typer.Option(None, "--output-dir", "-o", help="Write lineage.json here (default: print a summary)"),
+    run_name: str = typer.Option("lineage", "--run-name", help="Run name for the lineage file"),
+    max_pairs: int = typer.Option(10000, "--max-pairs", help="Cap on lineage records (0 = no cap)"),
+    natural_language: bool = typer.Option(False, "--nl", help="Include natural-language explanations"),
+) -> None:
+    """Build the per-pair match lineage for a dedupe run and save or summarize it."""
+    from goldenmatch.cli.dedupe import _parse_file_source
+    from goldenmatch.config.loader import load_config
+    from goldenmatch.core.lineage import build_lineage, save_lineage
+    from goldenmatch.tui.engine import MatchEngine
+
+    cfg = load_config(str(config))
+    paths = [_parse_file_source(f)[0] for f in files]
+
+    console.print("[bold]Running pipeline to build lineage...[/bold]")
+    engine = MatchEngine(paths)
+    result = engine.run_full(cfg)
+    if not result.scored_pairs:
+        console.print("[yellow]No scored pairs to build lineage from.[/yellow]")
+        raise typer.Exit(code=1)
+
+    lineage = build_lineage(
+        result.scored_pairs,
+        engine.data,
+        cfg.get_matchkeys(),
+        result.clusters,
+        max_pairs=max_pairs,
+        natural_language=natural_language,
+    )
+
+    if output_dir:
+        path = save_lineage(lineage, output_dir, run_name=run_name)
+        console.print(f"[#2ecc71]Wrote {len(lineage)} lineage records[/] to {path}")
+        return
+
+    console.print(f"[#2ecc71]Built {len(lineage)} lineage records.[/]")
+    console.print("[dim]Pass --output-dir to persist them, or --nl for explanations.[/dim]")
+    for rec in lineage[:3]:
+        a, b = rec.get("row_id_a"), rec.get("row_id_b")
+        score = rec.get("score", 0.0)
+        why = rec.get("explanation") or ""
+        console.print(f"  ({a}, {b}) score={score:.3f} {why}")

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -12,14 +12,17 @@ from rich.table import Table
 
 from goldenmatch import __version__
 from goldenmatch.cli.agent_serve import agent_serve_cmd
+from goldenmatch.cli.anomalies import anomalies_cmd
 from goldenmatch.cli.autoconfig import autoconfig_cmd
 from goldenmatch.cli.compare import compare_clusters_cmd
 from goldenmatch.cli.dedupe import dedupe_cmd
 from goldenmatch.cli.demo import demo_cmd
 from goldenmatch.cli.evaluate import evaluate_cmd
+from goldenmatch.cli.explain import explain_cmd
 from goldenmatch.cli.identity import identity_app
 from goldenmatch.cli.incremental import incremental_cmd
 from goldenmatch.cli.label import label_cmd
+from goldenmatch.cli.lineage import lineage_cmd
 from goldenmatch.cli.match import match_cmd
 from goldenmatch.cli.mcp_serve import mcp_serve_cmd
 from goldenmatch.cli.memory import memory_app
@@ -116,6 +119,9 @@ app.add_typer(memory_app, name="memory")
 app.add_typer(identity_app, name="identity")
 app.command("label", help="Build ground truth by labeling record pairs interactively.")(label_cmd)
 app.command("review", help="Review borderline pairs interactively; decisions feed Learning Memory.")(review_cmd)
+app.command("explain", help="Explain why a pair matched or summarize a cluster (plain language).")(explain_cmd)
+app.command("lineage", help="Build + persist the per-pair match lineage for a run.")(lineage_cmd)
+app.command("anomalies", help="Detect suspicious/fake records (standalone).")(anomalies_cmd)
 app.command("agent-serve", help="Start the A2A agent server for AI-to-AI discovery.")(agent_serve_cmd)
 app.command("incremental", help="Match new records against an existing base dataset.")(incremental_cmd)
 app.command("compare-clusters", help="Compare two ER clustering outcomes (CCMS).")(compare_clusters_cmd)

--- a/packages/python/goldenmatch/tests/test_cli_wave3.py
+++ b/packages/python/goldenmatch/tests/test_cli_wave3.py
@@ -1,0 +1,105 @@
+"""Wave 3.1: library features surfaced as CLI commands.
+
+- anomalies: standalone suspicious-record detection (was dedupe --anomalies only)
+- lineage: per-pair audit trail (was MCP-tool-only)
+- explain: NL pair/cluster explanation (had no CLI front door)
+"""
+from __future__ import annotations
+
+from goldenmatch.cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+_EXACT_EMAIL_CFG = (
+    "matchkeys:\n"
+    "  - name: email_exact\n"
+    "    type: exact\n"
+    "    fields:\n"
+    "      - field: email\n"
+    "        transforms: [lowercase, strip]\n"
+)
+
+
+def _dataset(tmp_path):
+    csv = tmp_path / "data.csv"
+    csv.write_text(
+        "id,email,name\n"
+        "1,a@x.com,Alice\n"
+        "2,a@x.com,Alicia\n"
+        "3,bob@test.com,Bob\n"
+    )
+    return csv
+
+
+def _cfg(tmp_path):
+    cfg = tmp_path / "gm.yml"
+    cfg.write_text(_EXACT_EMAIL_CFG)
+    return cfg
+
+
+class TestAnomalies:
+    def test_help(self):
+        result = runner.invoke(app, ["anomalies", "--help"])
+        assert result.exit_code == 0
+
+    def test_detects_fake_email_and_writes_output(self, tmp_path):
+        csv = tmp_path / "data.csv"
+        csv.write_text("id,email\n1,real@company.com\n2,test@test.com\n")
+        out = tmp_path / "anom.csv"
+        result = runner.invoke(
+            app, ["anomalies", str(csv), "--sensitivity", "high", "-o", str(out)]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert out.exists()
+        import polars as pl
+
+        df = pl.read_csv(out)
+        assert df.height >= 1
+        assert "test@test.com" in set(df["value"].to_list())
+
+    def test_rejects_bad_sensitivity(self, tmp_path):
+        csv = _dataset(tmp_path)
+        result = runner.invoke(app, ["anomalies", str(csv), "--sensitivity", "bogus"])
+        assert result.exit_code == 2
+
+
+class TestLineage:
+    def test_help(self):
+        result = runner.invoke(app, ["lineage", "--help"])
+        assert result.exit_code == 0
+
+    def test_builds_and_writes_lineage(self, tmp_path):
+        csv = _dataset(tmp_path)
+        cfg = _cfg(tmp_path)
+        outdir = tmp_path / "out"
+        outdir.mkdir()
+        result = runner.invoke(
+            app, ["lineage", str(csv), "-c", str(cfg), "-o", str(outdir), "--nl"]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert list(outdir.glob("*lineage*.json"))
+
+
+class TestExplain:
+    def test_requires_exactly_one_target(self, tmp_path):
+        csv = _dataset(tmp_path)
+        cfg = _cfg(tmp_path)
+        # neither --pair nor --cluster
+        r1 = runner.invoke(app, ["explain", str(csv), "-c", str(cfg)])
+        assert r1.exit_code == 2
+        # both
+        r2 = runner.invoke(
+            app, ["explain", str(csv), "-c", str(cfg), "--pair", "0,1", "--cluster", "0"]
+        )
+        assert r2.exit_code == 2
+
+    def test_explain_pair(self, tmp_path):
+        csv = _dataset(tmp_path)
+        cfg = _cfg(tmp_path)
+        result = runner.invoke(
+            app, ["explain", str(csv), "-c", str(cfg), "--pair", "0,1"]
+        )
+        assert result.exit_code == 0, result.stdout
+        # rows 0 and 1 share an email -> a real explanation panel
+        assert "0" in result.stdout and "1" in result.stdout


### PR DESCRIPTION
From the 2026-06-05 surface audit (Wave 3). Three library capabilities had no standalone CLI front door — present in the API/MCP but not invokable from the command line.

| New command | Surfaces | Was |
|-------------|----------|-----|
| `goldenmatch explain` | `core/explain.py` NL pair/cluster explanation (`--pair a,b` or `--cluster id`), zero LLM cost | no CLI |
| `goldenmatch lineage` | `core/lineage.py` per-pair audit trail (`--output-dir` persists, `--nl` explanations) | MCP-tool-only |
| `goldenmatch anomalies` | `core/anomaly.py` standalone suspicious-record detection | `dedupe --anomalies` flag only |

### Implementation note
`explain`/`lineage` run the pipeline through `tui/engine.py::MatchEngine` (clean `EngineResult.scored_pairs`/`.clusters` + `engine.data`), **not** `run_dedupe` — whose result dict doesn't reliably carry `_df`/`scored_pairs` (label.py reconstructs the df when `_df` is None). Documented in CLAUDE.md so future commands reuse MatchEngine.

### Tests
`tests/test_cli_wave3.py` — 7 (anomalies fake-email detection + CSV output + bad-sensitivity guard; lineage build+persist; explain pair + the exactly-one-target guard). + dedupe/label CLI regression: **19 passed**. Ruff clean.

Independent — touches only `cli/` + a new test. Merges to `main` on its own.

Still open in Wave 3: 3.2 (schedule subcommands, port-default unification, `match` zero-config, `--backend` help), 3.3 (shatter/sensitivity over HTTP, GT upload). Wave 2 remnants (2.2 goldenpipe TUI, 2.3 TS boost/export, 2.4 in-TUI triage loop) also still open.

Plan: `docs/superpowers/plans/2026-06-05-surface-gap-roadmap.md` (Wave 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)