### PR TITLE
chore(ci): job-level write permissions on badges + containers workflows

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -30,11 +30,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # pushes images to ghcr.io
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update-download-badges.yml
+++ b/.github/workflows/update-download-badges.yml
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/update-download-badges.yml"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: update-download-badges
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # pushes refreshed badge JSON to the `badges` branch
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 


### PR DESCRIPTION
Kills the last two top-level `write` grants in the repo's workflows -- the reason Scorecard **Token-Permissions** scores 0:

- `update-download-badges.yml`: top-level `contents: write` -> job-level (the badge-branch push)
- `publish-containers.yml`: top-level `packages: write` -> job-level (the ghcr.io push)

Same pattern as PR #760. Remaining job-level `contents: write` grants (release-upload workflows) are required and don't zero the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)