### PR TITLE
Wave 2.2: wire the goldenpipe TUI from stub to real

### DIFF
--- a/packages/python/goldenpipe/CLAUDE.md
+++ b/packages/python/goldenpipe/CLAUDE.md
@@ -10,6 +10,7 @@ Sibling packages live in this monorepo at `packages/python/{goldencheck,goldenfl
 - `goldenpipe/pipeline.py` -- Pipeline class, run() function. ONLY file that imports from tools.
 - `goldenpipe/decisions.py` -- Adaptive logic (decide_flow, decide_match). NO tool imports. Testable independently.
 - `goldenpipe/cli/main.py` -- Typer CLI
+- `goldenpipe/tui/app.py` -- Textual TUI (`[tui]` extra). **Wave 2.2 (2026-06-05): wired from stub to real.** 4 tabs (Pipeline/Config/Results/Log) populate from a `PipeResult`: `r` runs `goldenpipe.run(source)` in a worker thread, then `_render_result` fills the Pipeline tab (stage status + per-stage timing), Config (realized stage chain), Results (artifacts browser via `_summarize`), and Log (reasoning + errors + total time). `goldenpipe interactive [SOURCE] [-c CONFIG]` now takes an optional data file (was no-arg). Test seam: call `_render_result(result)` directly with a real `PipeResult`; for the full path `app.action_run()` then `await app.workers.wait_for_complete()`.
 - Tools imported with try/except ImportError guards (HAS_CHECK, HAS_FLOW, HAS_MATCH)
 - Data flows as Polars DataFrames in memory between stages
 

--- a/packages/python/goldenpipe/goldenpipe/cli/main.py
+++ b/packages/python/goldenpipe/goldenpipe/cli/main.py
@@ -210,11 +210,14 @@ def agent_serve(
 
 
 @app.command()
-def interactive() -> None:
+def interactive(
+    source: str = typer.Argument(None, help="Optional data file to load (press 'r' to run)."),
+    config: str = typer.Option(None, "--config", "-c", help="Optional pipeline YAML config."),
+) -> None:
     """Launch the TUI."""
     try:
         from goldenpipe.tui.app import GoldenPipeApp
-        GoldenPipeApp().run()
+        GoldenPipeApp(source=source, config_path=config).run()
     except ImportError:
         console.print("[red]Textual not installed. Run: pip install goldenpipe[tui][/red]")
         raise typer.Exit(code=1)

--- a/packages/python/goldenpipe/goldenpipe/tui/app.py
+++ b/packages/python/goldenpipe/goldenpipe/tui/app.py
@@ -1,15 +1,48 @@
-"""GoldenPipe TUI -- 4-tab pipeline interface."""
+"""GoldenPipe TUI -- 4-tab pipeline interface (Pipeline / Config / Results / Log).
+
+Wired to the real pipeline: press ``r`` to run the loaded source through
+``goldenpipe.run`` and the tabs populate from the resulting ``PipeResult``
+(stage statuses + timing, the stage chain, artifacts, and the reasoning log).
+"""
 from __future__ import annotations
 
 try:
+    from textual import work
     from textual.app import App, ComposeResult
-    from textual.widgets import Footer, Header, Static, TabbedContent, TabPane
+    from textual.widgets import (
+        DataTable,
+        Footer,
+        Header,
+        Static,
+        TabbedContent,
+        TabPane,
+    )
     HAS_TEXTUAL = True
 except ImportError:
     HAS_TEXTUAL = False
 
 
 if HAS_TEXTUAL:
+    _STATUS_COLOR = {
+        "success": "#2ecc71",
+        "skipped": "#8892a0",
+        "failed": "red",
+        "partial": "#d4a017",
+    }
+
+    def _summarize(val) -> str:
+        """One-line summary of an artifact value for the Results table."""
+        try:
+            height = getattr(val, "height", None)
+            if height is not None:  # polars DataFrame
+                width = getattr(val, "width", "?")
+                return f"{height} rows x {width} cols"
+            if isinstance(val, (list, tuple, set, dict)):
+                return f"{len(val)} items"
+            return str(val)[:60]
+        except Exception:
+            return type(val).__name__
+
     class GoldenPipeApp(App):
         """GoldenPipe interactive TUI."""
 
@@ -17,24 +50,127 @@ if HAS_TEXTUAL:
 
         BINDINGS = [
             ("q", "quit", "Quit"),
+            ("r", "run", "Run"),
             ("1", "tab_pipeline", "Pipeline"),
             ("2", "tab_config", "Config"),
             ("3", "tab_results", "Results"),
             ("4", "tab_log", "Log"),
         ]
 
+        def __init__(self, source: str | None = None, config_path: str | None = None, **kwargs):
+            super().__init__(**kwargs)
+            self.source = source
+            self.config_path = config_path
+            self.result = None
+
         def compose(self) -> ComposeResult:
             yield Header()
             with TabbedContent():
                 with TabPane("Pipeline", id="tab-pipeline"):
-                    yield Static("Pipeline stages will appear here.\nPress 'r' to run.")
+                    yield Static("", id="pipeline-hint")
+                    yield DataTable(id="pipeline-table")
                 with TabPane("Config", id="tab-config"):
-                    yield Static("YAML config editor.\nLoad a config file to edit.")
+                    yield Static("", id="config-view")
                 with TabPane("Results", id="tab-results"):
-                    yield Static("Artifacts browser.\nRun a pipeline to see results.")
+                    yield DataTable(id="results-table")
                 with TabPane("Log", id="tab-log"):
-                    yield Static("Reasoning and timing log.\nRun a pipeline to see logs.")
+                    yield Static("", id="log-view")
             yield Footer()
+
+        def on_mount(self) -> None:
+            self.query_one("#pipeline-table", DataTable).add_columns(
+                "Stage", "Status", "Time (s)"
+            )
+            self.query_one("#results-table", DataTable).add_columns(
+                "Artifact", "Type", "Summary"
+            )
+            hint = self.query_one("#pipeline-hint", Static)
+            if self.source:
+                hint.update(
+                    f"Source: [bold]{self.source}[/]   ·   press [bold #d4a017]r[/] to run"
+                )
+                self.query_one("#config-view", Static).update(
+                    f"Source: [bold]{self.source}[/]\n"
+                    f"Config: [bold]{self.config_path or 'auto (check -> flow -> dedupe)'}[/]"
+                )
+            else:
+                hint.update(
+                    "[yellow]No source loaded.[/] "
+                    "Launch with a file: goldenpipe interactive data.csv"
+                )
+
+        # ── Run ───────────────────────────────────────────────────────
+
+        def action_run(self) -> None:
+            if not self.source:
+                self.notify("No source to run. Launch with a data file.", severity="warning")
+                return
+            self.notify("Running pipeline...", severity="information")
+            self._run_pipeline()
+
+        @work(thread=True)
+        def _run_pipeline(self) -> None:
+            try:
+                from goldenpipe._api import run as run_pipeline
+
+                result = run_pipeline(self.source, config=self.config_path)
+                self.call_from_thread(self._render_result, result)
+            except Exception as e:  # pragma: no cover - surfaced as a toast
+                self.call_from_thread(
+                    self.notify, f"Pipeline error: {e}", severity="error"
+                )
+
+        def _render_result(self, result) -> None:
+            """Populate all four tabs from a PipeResult."""
+            self.result = result
+
+            # Pipeline tab: stage statuses + per-stage timing.
+            ptable = self.query_one("#pipeline-table", DataTable)
+            ptable.clear()
+            for name, sr in result.stages.items():
+                status = sr.status.value
+                color = _STATUS_COLOR.get(status, "white")
+                t = result.timing.get(name, 0.0)
+                ptable.add_row(name, f"[{color}]{status}[/]", f"{t:.3f}")
+            for name in result.skipped:
+                if name not in result.stages:
+                    ptable.add_row(name, "[#8892a0]skipped[/]", "-")
+            self.query_one("#pipeline-hint", Static).update(
+                f"Source: [bold]{result.source}[/]   ·   "
+                f"rows: [bold #2ecc71]{result.input_rows:,}[/]   ·   "
+                f"status: [{_STATUS_COLOR.get(result.status.value, 'white')}]{result.status.value}[/]"
+            )
+
+            # Config tab: the realized stage chain.
+            chain = " -> ".join(result.stages.keys()) or "(none)"
+            self.query_one("#config-view", Static).update(
+                f"Source: [bold]{result.source}[/]\n"
+                f"Config: [bold]{self.config_path or 'auto'}[/]\n\n"
+                f"[bold #d4a017]Stage chain:[/] {chain}"
+            )
+
+            # Results tab: artifacts browser.
+            rtable = self.query_one("#results-table", DataTable)
+            rtable.clear()
+            for key, val in result.artifacts.items():
+                rtable.add_row(key, type(val).__name__, _summarize(val))
+
+            # Log tab: reasoning per stage + errors + total time.
+            lines = [f"[bold #d4a017]Total time:[/] {sum(result.timing.values()):.3f}s\n"]
+            if result.errors:
+                lines.append("[bold red]Errors:[/]")
+                lines.extend(f"  {e}" for e in result.errors)
+                lines.append("")
+            lines.append("[bold #d4a017]Reasoning:[/]")
+            if result.reasoning:
+                lines.extend(f"  [bold]{name}[/]: {why}" for name, why in result.reasoning.items())
+            else:
+                lines.append("  [dim](no reasoning recorded)[/]")
+            self.query_one("#log-view", Static).update("\n".join(lines))
+
+            self.notify("Pipeline complete.", severity="information")
+
+        # ── Tab navigation ────────────────────────────────────────────
 
         def action_tab_pipeline(self) -> None:
             self.query_one(TabbedContent).active = "tab-pipeline"

--- a/packages/python/goldenpipe/tests/test_tui.py
+++ b/packages/python/goldenpipe/tests/test_tui.py
@@ -31,3 +31,44 @@ class TestGoldenPipeApp:
             assert "Config" in tab_labels
             assert "Results" in tab_labels
             assert "Log" in tab_labels
+
+
+class TestGoldenPipeAppWiring:
+    """Wave 2.2: the four tabs are wired to a real PipeResult."""
+
+    async def test_no_source_run_warns_not_crashes(self):
+        app = GoldenPipeApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.action_run()  # no source -> notify only
+            await pilot.pause()
+            assert app.result is None
+
+    async def test_render_result_populates_tabs(self, sample_csv):
+        import goldenpipe
+        from textual.widgets import DataTable, Static
+
+        result = goldenpipe.run(str(sample_csv))
+        app = GoldenPipeApp(source=str(sample_csv))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app._render_result(result)
+            await pilot.pause()
+            # Pipeline tab has a row per stage.
+            ptable = app.query_one("#pipeline-table", DataTable)
+            assert ptable.row_count == len(result.stages)
+            # Config tab shows the stage chain.
+            assert "Stage chain" in app.query_one("#config-view", Static).render().plain
+            assert app.result is result
+
+    async def test_action_run_executes_pipeline(self, sample_csv):
+        from textual.widgets import DataTable
+
+        app = GoldenPipeApp(source=str(sample_csv))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.action_run()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert app.result is not None
+            assert app.query_one("#pipeline-table", DataTable).row_count >= 1


### PR DESCRIPTION
From the 2026-06-05 surface audit (Wave 2.2). The goldenpipe orchestrator TUI was a 4-tab skeleton of empty `Static` placeholders — the package that chains check→flow→match had the least-complete TUI despite having the most to show.

### What changed
`goldenpipe/tui/app.py` is now wired to the real pipeline:
- **`r`** runs `goldenpipe.run(source)` in a worker thread; `_render_result` populates all four tabs from the `PipeResult`:
  - **Pipeline** — per-stage status (color-coded success/skipped/failed) + per-stage timing.
  - **Config** — the realized stage chain.
  - **Results** — artifacts browser (DataFrames as `rows x cols`, collections as item counts).
  - **Log** — reasoning per stage + errors + total time.
- **`goldenpipe interactive [SOURCE] [-c CONFIG]`** now takes an optional data file (was no-arg); `GoldenPipeApp(source=..., config_path=...)`.

### Tests
`tests/test_tui.py` +3: no-source `action_run` warns (no crash), `_render_result` populates the tabs from a real `PipeResult`, and the full threaded path via `app.action_run()` + `await app.workers.wait_for_complete()`. TUI + CLI suites: **12 passed**. Ruff clean. Existing stub tests (`GoldenPipeApp()` no-arg) still pass.

Touches only the **goldenpipe** package — zero overlap with the open goldenmatch PRs. Merges to `main` on its own.

Remaining Wave 2: 2.3 (TS-TUI boost write-back + real export). Then Wave 4+ (TS parity).

Plan: `docs/superpowers/plans/2026-06-05-surface-gap-roadmap.md` (Wave 2.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)