### PR TITLE
docs: context network + Mintlify updates for the security-hardening arc

### DIFF
--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -24,7 +24,8 @@ links rather than reading everything.
 
 ## Planning (where it's going)
 - [planning/roadmap.md](planning/roadmap.md) — the Arrow-native arc and what's next.
-- [planning/surface-hardening.md](planning/surface-hardening.md) — the 2026-06-05 four-surface audit arc: fail-closed HTTP auth, CLI/TUI fixes, Python→TS parity ports (+ the parity-fixture methodology), and the open PR queue.
+- [planning/surface-hardening.md](planning/surface-hardening.md) — the 2026-06-05 four-surface audit arc: fail-closed HTTP auth, CLI/TUI fixes, Python->TS parity ports (+ the parity-fixture methodology), and the open PR queue.
+- [planning/security-hardening.md](planning/security-hardening.md) — the 2026-06-05 security-hardening arc: 42-alert remediation (Dependabot + code scanning), Scorecard 6.1->7.3 (Token-Permissions/Signed-Releases/Fuzzing), the CodeQL Autofix incident, property-test bug ledger, and open actions.
 
 ## Meta (keeping the network alive)
 - [meta/updates.md](meta/updates.md) — chronological change log for the network.

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,18 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-05 — Security hardening arc (42 alerts cleared, Scorecard 6.1->7.3)
+- New workstream node: [../planning/security-hardening.md](../planning/security-hardening.md)
+  — Dependabot 7/7 (#761/#762), code-scanning 35/35 (log-injection #764,
+  path-injection #768, TokenPermissions #760/#772, dismissals), Scorecard
+  climbs (Token-Permissions->10, Signed-Releases->8, Fuzzing->10 via
+  #770/#778/#783), the CodeQL Autofix incident, the 4-bug property-test
+  ledger, and 3 open actions.
+- Promoted in [../planning/roadmap.md](../planning/roadmap.md) as an adjacent arc.
+- Docs-site updated in the same change: `GOLDENMATCH_ALLOWED_ROOT` in
+  configuration + MCP path-sandbox section; cosign release-verification
+  snippet in installation.
+
 ## 2026-06-05 — Surface hardening + parity arc (Waves 0-4)
 - New workstream node: [../planning/surface-hardening.md](../planning/surface-hardening.md)
   — the four-surface audit, the merged auth/bug/TUI waves (#766/#767/#769), the

--- a/context-network/planning/roadmap.md
+++ b/context-network/planning/roadmap.md
@@ -47,6 +47,16 @@ Spec: `docs/superpowers/specs/2026-06-03-sail-tier-design.md`. Staged, each a ga
 - **Fix the pre-existing empty/all-singleton `run_spine` SchemaError** (frames-out tail,
   null vs i64 join key) — flagged during Stage D, out of scope there.
 
+## Adjacent — security hardening arc (2026-06-05, COMPLETE)
+Cleared 42 open alerts (7 Dependabot + 35 code scanning) and lifted Scorecard
+6.1->7.3: Token-Permissions 0->10 (#760/#772), Signed-Releases 0->8 (#770;
+->10 on next pg release), Fuzzing 0->10 (#778/#783). New hardening helpers:
+`_logging.sanitize_for_log()` (9 sites), `_paths.safe_path()` (all entry
+boundaries + 9 MCP tool handlers; opt-in `GOLDENMATCH_ALLOWED_ROOT` sandbox).
+Property suites found 4 real bugs pre-merge. OPEN ACTIONS: Railway
+`GOLDENMATCH_ALLOWED_ROOT=/data`; issue #784 (dice/jaccard bloom); TS
+`stdNameProper` titlecase. See [security-hardening.md](security-hardening.md).
+
 ## Adjacent — surface hardening + parity arc (2026-06-05, Waves 0-4 executed)
 A risk-first sweep of the four user surfaces (CLI/TUI/web/API) from the same-day
 audit: fail-closed auth on all five HTTP servers, the confirmed CLI bugs, the three

--- a/context-network/planning/security-hardening.md
+++ b/context-network/planning/security-hardening.md
@@ -1,0 +1,108 @@
+# Security hardening arc — 2026-06-05
+
+A sweep of goldenmatch's Dependabot + code-scanning alert queue plus a
+targeted Scorecard climb. Working ledger:
+`docs/superpowers/plans/2026-06-05-security-alerts-remediation.md`
+(gitignored, local-only — the STATUS LEDGER section there is the fine-
+grained source of truth; this node carries the durable shape).
+
+## What the sweep covered
+
+- **42 open alerts** (7 Dependabot + 35 code scanning) as of 2026-06-05.
+- **Scorecard 6.1** across Token-Permissions (0), Signed-Releases (0),
+  and Fuzzing (0) checks.
+
+## Shipped (merged)
+
+- **#760 — TokenPermissions (2 of 3 fixed):** moved two top-level
+  `contents: write` and `packages: write` grants down to job level.
+- **#761 — Dependabot lockfile regen (infermap TS bench runner):**
+  vitest 1.6.1->4.1.8, vite/esbuild/postcss/fast-uri transitives; also
+  fixed a broken pre-fold `file:` dep path that had been silently stale.
+- **#762 — Dependabot pyo3 bridge pin:** `>=0.24.1,<0.25` per
+  GHSA-pph8-gcv7-4qj5.
+- **#764 — py/log-injection (9 sites):** new
+  `goldenmatch/core/_logging.py` `sanitize_for_log()` applied at the
+  9 call sites identified by CodeQL.
+- **#768 — py/path-injection (19 sites):** new
+  `goldenmatch/core/_paths.py` `safe_path()` — NUL rejection,
+  `resolve()`, opt-in containment via `GOLDENMATCH_ALLOWED_ROOT` env or
+  `base_dir` arg; applied at all entry boundaries including 9 MCP
+  `_tool_*` handlers via `_safe_path_or_error`; the rollback delete
+  loop validates the final joined path. Dismissed post-merge with
+  justification (CodeQL cannot credit a conditional barrier; local file
+  access is the product for a local-first tool; containment is deploy-
+  time policy via `GOLDENMATCH_ALLOWED_ROOT`).
+- **#770 — Signed-Releases (Scorecard 0->8):** `publish-goldenmatch-pg.yml`
+  now cosign-keyless-signs each tarball (`.sigstore` bundle) + attaches
+  GitHub build provenance (`.intoto.jsonl`) on release; new
+  `sign-release-assets.yml` retro-signed goldenmatch-pg v0.6.0/v0.7.0
+  (signature only; no retroactive provenance). Scores 10 automatically
+  on the next pg release.
+- **#772 — TokenPermissions last grant (Scorecard 0->10):**
+  `update-download-badges` `contents: write` and `publish-containers`
+  `packages: write` moved to job level; resolves the third dismissed
+  finding.
+- **#778 — Fuzzing (Python, Scorecard):** hypothesis property suite
+  (`tests/test_property_invariants.py`); also fixed hypothesis missing
+  from the root `[dependency-groups] dev` (property tests had been
+  silently skipping in CI).
+- **#783 — Fuzzing (TS, Scorecard 0->10):** fast-check property suite
+  (`packages/typescript/goldenmatch/tests/unit/property-invariants.test.ts`);
+  this is the surface Scorecard detects (it does not credit hypothesis).
+- **3 TokenPermissions dismissed:** `generate-bench-dataset.yml`
+  job-level `contents: write` is required for release uploads and has no
+  narrower scope; documented in the dismissal.
+- **4 PinnedDependencies dismissed:** Dockerfiles already
+  digest+version-pinned (#742); pip `--require-hashes` ruled
+  disproportionate for internal one-shot images.
+
+## The CodeQL Autofix incident
+
+A CodeQL "Potential fix..." commit landed on the #768 branch mid-session
+and rewrote `safe_path` to fail-closed, breaking every file-touching
+test. Reverted.
+
+**Lesson (durable):** never apply Autofix to the validation barrier
+itself. Check the remote branch log when CI errors do not match local
+code; a ghost commit is the likely culprit.
+
+## Property-test bug ledger
+
+Four real bugs found by the new suites before they merged:
+
+1. **Python dice/jaccard single-pair scorers crash on different-length
+   bloom hex** (numpy broadcast error). `strict-xfail` pinned; tracked
+   as issue #784.
+2. **The literal string `"null"` collapses auto-config** (goldencheck
+   sentinel drop -> `ConfigValidationError`). Tolerated; `@example`-
+   pinned in the hypothesis suite.
+3. **TS `jaro("","")` returns 1 vs Python 0.** Canary-pinned divergence
+   in the fast-check suite; no fix yet.
+4. **TS `stdNameProper` non-idempotent on 3-way-case unicode (U+1F80).**
+   `it.fails`-pinned; source fix pending (no issue yet).
+
+## OPEN ACTIONS
+
+1. **Railway `goldenmatch-mcp` service:** set
+   `GOLDENMATCH_ALLOWED_ROOT=/data` once the service's data layout is
+   confirmed (pairs with the `GOLDENMATCH_MCP_TOKEN` open action from
+   the surface-hardening node).
+2. **Issue #784** — fix dice/jaccard bloom scorer on different-length
+   inputs (numpy broadcast).
+3. **TS `stdNameProper` titlecase fix** — no issue filed yet.
+
+## Remaining Scorecard zeros and why they stay
+
+| Check | Score | Why it stays |
+|---|---|---|
+| Maintained | 0 | Repo-age gate; auto-heals mid-August 2026. |
+| CII-Best-Practices | 0 | Needs maintainer questionnaire (manual). |
+| Code-Review | 0 | Solo-maintainer; structural. |
+| Contributors | 0 | Solo-maintainer; structural. |
+| Branch-Protection | 4 | Requires second-person approvals to reach 8; structural. |
+| Pinned-Dependencies | 6 | pip hash-pinning ruled disproportionate for internal images. |
+| SAST | 9 | pip hash-pinning is the last gap; same ruling. |
+
+---
+**Classification:** planning/workstream • **Last updated:** 2026-06-05

--- a/docs-site/goldenmatch/configuration.mdx
+++ b/docs-site/goldenmatch/configuration.mdx
@@ -328,6 +328,44 @@ validation:
 Rule types: `regex`, `min_length`, `max_length`, `not_null`, `in_set`, `format`.
 Actions: `flag` (mark but keep), `null` (set to null), `quarantine` (remove from matching).
 
+## Environment variables
+
+Key environment variables that affect runtime behaviour:
+
+| Variable | Default | Description |
+|---|---|---|
+| `GOLDENMATCH_ALLOWED_ROOT` | unset | When set, every user-supplied file path (MCP tools, ingest, rollback, lineage, domain registry) must resolve under this root. Paths that escape it return an error instead of executing. Unset = no containment; local-first default. See [Path sandbox](#path-sandbox) below. |
+| `GOLDENMATCH_MCP_TOKEN` | unset | Bearer token for the MCP HTTP server. Required on non-loopback binds (fail-closed). |
+| `GOLDENMATCH_API_TOKEN` | unset | Bearer token for the REST API server. Required on non-loopback binds. |
+| `GOLDENMATCH_AGENT_TOKEN` | unset | Bearer token for the A2A agent server. Required on non-loopback binds. |
+| `GOLDENMATCH_ENABLE_DISTRIBUTED_RAY` | `0` | Enable the Ray distributed backend. |
+| `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS` | `20000000` | Candidate-pair threshold below which the native kernel scores in the calling thread (avoids rayon futex contention on small workloads). |
+| `GOLDENMATCH_BUCKET_DEBUG` | `0` | When `1`, prints per-bucket prep/kernel/post-filter timing for `backend=bucket`. |
+| `POLARS_SKIP_CPU_CHECK` | unset | Set to `1` to skip the Polars WMI CPU check on Windows (avoids startup hang). |
+
+### Path sandbox
+
+`GOLDENMATCH_ALLOWED_ROOT` activates an opt-in path containment layer
+for deployed or shared instances. When set, `safe_path()` resolves every
+incoming file argument with `Path.resolve()`, checks for NUL bytes, and
+then asserts the resolved path falls under the root. Paths that fail
+this check are rejected before any I/O occurs.
+
+```bash
+# Deployed MCP server on Railway: restrict to the /data volume
+export GOLDENMATCH_ALLOWED_ROOT=/data
+goldenmatch mcp-serve --transport http --port 8200
+```
+
+Unset (the default) means no containment check — any accessible path is
+valid. This is the correct default for a local-first desktop tool.
+
+<Info>
+The Railway `goldenmatch-mcp` service should set
+`GOLDENMATCH_ALLOWED_ROOT=/data` to scope the MCP tools to the mounted
+data volume. See [MCP Server](/goldenmatch/mcp#path-sandbox).
+</Info>
+
 ## Settings persistence
 
 - **Global**: `~/.goldenmatch/settings.yaml` — output mode, default model, API keys

--- a/docs-site/goldenmatch/installation.mdx
+++ b/docs-site/goldenmatch/installation.mdx
@@ -76,6 +76,31 @@ sudo systemctl restart postgresql
 
 Download `.deb` and `.rpm` from the [goldenmatch releases](https://github.com/benseverndev-oss/goldenmatch/releases) page (look for the `goldenmatch-pg-v*` tags).
 
+### Verifying release artifacts
+
+Releases since goldenmatch-pg v0.6.0 ship a `.sigstore` bundle alongside
+each tarball. Releases from v0.8.0 onward also ship an `.intoto.jsonl`
+build-provenance attestation.
+
+Verify a tarball with cosign (keyless, GitHub Actions OIDC):
+
+```bash
+cosign verify-blob \
+  --bundle goldenmatch_pg-0.7.0.tar.gz.sigstore \
+  goldenmatch_pg-0.7.0.tar.gz \
+  --certificate-identity-regexp 'github.com/benseverndev-oss/goldenmatch' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A successful run prints `Verified OK`. The `.sigstore` bundle contains the
+certificate, transparency-log entry, and signature in a single file -- no
+separate key management required.
+
+<Tip>
+Install cosign with `brew install cosign` (macOS) or
+`go install github.com/sigstore/cosign/v2/cmd/cosign@latest` (any platform).
+</Tip>
+
 ## DuckDB UDFs
 
 ```bash

--- a/docs-site/goldenmatch/installation.mdx
+++ b/docs-site/goldenmatch/installation.mdx
@@ -79,15 +79,15 @@ Download `.deb` and `.rpm` from the [goldenmatch releases](https://github.com/be
 ### Verifying release artifacts
 
 Releases since goldenmatch-pg v0.6.0 ship a `.sigstore` bundle alongside
-each tarball. Releases from v0.8.0 onward also ship an `.intoto.jsonl`
-build-provenance attestation.
+each tarball. Releases published after 2026-06-05 also ship an
+`.intoto.jsonl` build-provenance attestation next to each asset.
 
 Verify a tarball with cosign (keyless, GitHub Actions OIDC):
 
 ```bash
 cosign verify-blob \
-  --bundle goldenmatch_pg-0.7.0.tar.gz.sigstore \
-  goldenmatch_pg-0.7.0.tar.gz \
+  --bundle goldenmatch_pg-0.7.0-pg17-linux-x86_64.tar.gz.sigstore \
+  goldenmatch_pg-0.7.0-pg17-linux-x86_64.tar.gz \
   --certificate-identity-regexp 'github.com/benseverndev-oss/goldenmatch' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -69,6 +69,24 @@ Local development on loopback runs token-free:
 (Claude Desktop) is local-only and never requires a token.
 </Info>
 
+### Path sandbox
+
+For deployed or shared MCP servers, set `GOLDENMATCH_ALLOWED_ROOT` to
+restrict every user-supplied file path to a specific directory tree. Any
+path that resolves outside that root returns `{"error": "..."}` from the
+tool rather than raising an unhandled exception.
+
+```bash
+# Railway / Docker: scope MCP tools to the /data volume
+export GOLDENMATCH_ALLOWED_ROOT=/data
+goldenmatch mcp-serve --transport http --port 8200
+```
+
+Unset (the default) means no containment -- any path accessible to the
+server process is valid. This is the correct default for local stdio
+usage (Claude Desktop). See [Configuration](/goldenmatch/configuration#path-sandbox)
+for the full variable reference.
+
 Or add to your Claude Desktop configuration (`claude_desktop_config.json`):
 
 ```json


### PR DESCRIPTION
Companion to #785's surface-hardening docs pass -- same structure, for the security arc that ran in parallel today.

**Context network:** new `planning/security-hardening.md` node (42-alert remediation incl. dismissal rationale, Scorecard 6.1 -> 7.3, signed releases, the property-test 4-bug ledger, the CodeQL Autofix incident + lesson, open actions); indexed in `discovery.md`, promoted in `roadmap.md`, `updates.md` entry.

**Mintlify (merged work only):**
- `configuration.mdx`: `GOLDENMATCH_ALLOWED_ROOT` env var + Path sandbox section (opt-in containment; unset = local-first default)
- `mcp.mdx`: Path sandbox subsection next to the auth section (deployed servers should jail to the data volume; jailed paths return `{"error": ...}`)
- `installation.mdx`: Verifying release artifacts -- `cosign verify-blob` with real asset names; `.sigstore` since pg v0.6.0, `.intoto.jsonl` provenance on releases after 2026-06-05

🤖 Generated with [Claude Code](https://claude.com/claude-code)