### PR TITLE
test(autoconfig): prove the Phase-1 routing win + benchmark tier A/B tooling

### DIFF
--- a/context-network/planning/autoconfig-search-strategy.md
+++ b/context-network/planning/autoconfig-search-strategy.md
@@ -47,6 +47,25 @@ The load-bearing spine:
   own (today the exemption is the bugfix; the higher tiers reserve the seam).
 - **Phase 4** the labeling objective (LLM-judge on borderline pairs).
 
+## Verifying it works (the Phase-1 win is real, not just safe)
+A default-tier benchmark only proves *non-regression* (Febrl3 F1 0.9665 on 1.28.0,
+identical across tiers — correct, since the cheap config is already optimal there).
+The *value* of `thinking`/`einstein` only shows on data where `normal` mis-routes.
+That case is now pinned:
+- **`scripts/bench_planning_effort.py`** — A/B on a skewed fixture (40k rows, 12k
+  dominant block). `normal` extrapolates ~3.5M pairs → routes `bucket` (in-memory,
+  would choke); `thinking` measures the true ~72M → routes `chunked` (RAM-safe).
+  A 20x under-count that flips the backend.
+- **`tests/test_planning_effort_routing.py`** — locks the flip in as a regression
+  (`plan_selected_simple` → `plan_selected_chunked` once measured).
+- **`scripts/run_benchmarks.py --planning-effort {fast,normal,thinking,einstein}`**
+  — A/B the tiers on the canonical sets (records `planning_effort` + `backend`).
+
+Still open (the Phase-2/4 upside): an *F1* win from broader search / labeling is
+unmeasured — backends are output-equivalent on one box, so the Phase-1 win is
+correct routing / scale-safety, not accuracy. An accuracy A/B needs the Phase-2
+search + a labeled hard set.
+
 ## Future direction (out of scope)
 **GoldenAnalyze** — extract auto-config into a standalone package that produces a
 reusable, drop-in `GoldenMatchConfig` from a team's data. The 1.28.0 work keeps

--- a/packages/python/goldenmatch/tests/test_planning_effort_routing.py
+++ b/packages/python/goldenmatch/tests/test_planning_effort_routing.py
@@ -1,0 +1,80 @@
+"""Phase 1 routing regression: measuring (not extrapolating) flips the backend
+on skewed blocking. Spec 2026-06-06 §Phase 1.
+
+This is the durable proof that measure-don't-extrapolate changes the planner's
+*decision* — the thing that makes the higher tiers worth their cost. It tests at
+the planner-decision level (no full pipeline) so it's fast + deterministic.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import polars as pl
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_planner import apply_planner_rules
+from goldenmatch.core.autoconfig_planner_rules import DEFAULT_RULES, SIMPLE_PLAN_MAX_PAIRS
+from goldenmatch.core.blocker import measure_blocking_profile
+from goldenmatch.core.complexity_profile import ComplexityProfile
+from goldenmatch.core.runtime_profile import RuntimeProfile
+
+# 40k rows with a 12k dominant block -> ~72M true candidate pairs, while a
+# uniform 2k sample extrapolates to ~3.5M. The 50M threshold sits between them.
+_N_ROWS = 40_000
+_DOMINANT = 12_000
+_SAMPLE = 2_000
+
+
+def _skewed_df() -> pl.DataFrame:
+    tail = _N_ROWS - _DOMINANT
+    last = ["SMITH"] * _DOMINANT + [f"name{i % (tail // 6)}" for i in range(tail)]
+    return pl.DataFrame({"last": last, "email": [f"r{i}@x.com" for i in range(_N_ROWS)]})
+
+
+def _cfg() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="m", type="exact", fields=[MatchkeyField(field="email")])],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["last"])]),
+    )
+
+
+def _plan_rule(blocking_profile) -> str:
+    runtime = RuntimeProfile(available_ram_gb=64.0, cpu_count=8, disk_free_gb=500.0)
+    profile = dataclasses.replace(ComplexityProfile(), blocking=blocking_profile)
+    plan = apply_planner_rules(
+        profile=profile, runtime=runtime, n_rows_full=_N_ROWS,
+        rules=DEFAULT_RULES, context={"user_backend": None},
+    )
+    return plan.rule_name
+
+
+def test_skewed_pair_counts_straddle_the_threshold():
+    """The fixture must actually cross the 50M line: extrapolate < 50M <= measure."""
+    df = _skewed_df()
+    cfg = _cfg()
+    extrap = measure_blocking_profile(df.sample(_SAMPLE, seed=0), cfg).extrapolate_to(
+        n_rows_sample=_SAMPLE, n_rows_full=_N_ROWS
+    )
+    measured = measure_blocking_profile(df, cfg)
+    assert extrap.estimated_pair_count < SIMPLE_PLAN_MAX_PAIRS
+    assert measured.estimated_pair_count >= SIMPLE_PLAN_MAX_PAIRS
+    # The under-count is large (quadratic-in-block-size), not marginal.
+    assert measured.estimated_pair_count > 10 * extrap.estimated_pair_count
+
+
+def test_measurement_flips_the_backend_decision():
+    """normal (extrapolate) -> simple plan; thinking (measure) -> chunked plan."""
+    df = _skewed_df()
+    cfg = _cfg()
+    extrap = measure_blocking_profile(df.sample(_SAMPLE, seed=0), cfg).extrapolate_to(
+        n_rows_sample=_SAMPLE, n_rows_full=_N_ROWS
+    )
+    measured = measure_blocking_profile(df, cfg)
+
+    assert _plan_rule(extrap) == "plan_selected_simple"
+    assert _plan_rule(measured) == "plan_selected_chunked"

--- a/scripts/bench_planning_effort.py
+++ b/scripts/bench_planning_effort.py
@@ -1,0 +1,109 @@
+"""A/B demonstration: planning-effort `thinking` routes skewed data correctly.
+
+The win that the `thinking`/`einstein` tiers buy (spec 2026-06-06 §Phase 1):
+on skewed blocking, a uniform sample's pair count is a *quadratic* under-estimate
+of the real load, so the old linear extrapolation routes the run to an in-memory
+plan that the true workload would blow past. Measuring real blocking on the full
+frame sees the true load and routes to the RAM-safe out-of-core plan instead.
+
+This script makes that concrete: it builds a dataset with one dominant block,
+then shows the planner pick a DIFFERENT (heavier, safe) backend once it measures
+instead of extrapolates.
+
+    python scripts/bench_planning_effort.py            # defaults: 40k rows, 12k block
+    python scripts/bench_planning_effort.py --rows 60000 --dominant 16000
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+from pathlib import Path
+
+import polars as pl
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+def build_skewed(n_rows: int, dominant: int, seed: int = 0) -> pl.DataFrame:
+    """One dominant blocking-key value + a long tail of small ones."""
+    tail = n_rows - dominant
+    last = ["SMITH"] * dominant + [f"name{i % max(1, tail // 6)}" for i in range(tail)]
+    return pl.DataFrame({
+        "last": last,
+        "email": [f"r{i}@example.com" for i in range(n_rows)],
+    })
+
+
+def plan_backend(blocking_profile, n_rows: int):
+    """Run the real v3 planner over a profile carrying the given blocking signal."""
+    from goldenmatch.core.autoconfig_planner import apply_planner_rules
+    from goldenmatch.core.autoconfig_planner_rules import DEFAULT_RULES
+    from goldenmatch.core.complexity_profile import ComplexityProfile
+    from goldenmatch.core.runtime_profile import RuntimeProfile
+
+    # Fix the runtime so the demo is deterministic across boxes: a fat box with
+    # plenty of RAM (so the heavy rung is `chunked`, not the <16GB `duckdb`).
+    runtime = RuntimeProfile(available_ram_gb=64.0, cpu_count=8, disk_free_gb=500.0)
+    profile = dataclasses.replace(ComplexityProfile(), blocking=blocking_profile)
+    return apply_planner_rules(
+        profile=profile, runtime=runtime, n_rows_full=n_rows,
+        rules=DEFAULT_RULES, context={"user_backend": None},
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rows", type=int, default=40_000)
+    ap.add_argument("--dominant", type=int, default=12_000)
+    ap.add_argument("--sample", type=int, default=2_000, help="controller sample size (normal tier)")
+    args = ap.parse_args()
+
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    from goldenmatch.core.blocker import measure_blocking_profile
+
+    df = build_skewed(args.rows, args.dominant)
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="m", type="exact", fields=[MatchkeyField(field="email")])],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["last"])]),
+    )
+
+    # normal: linear extrapolation from a uniform sample (the prior default).
+    sample_prof = measure_blocking_profile(df.sample(args.sample, seed=0), cfg)
+    extrapolated = sample_prof.extrapolate_to(n_rows_sample=args.sample, n_rows_full=args.rows)
+    # thinking/einstein: measure real blocking on the full frame (Phase 1).
+    measured = measure_blocking_profile(df, cfg)
+
+    plan_normal = plan_backend(extrapolated, args.rows)
+    plan_thinking = plan_backend(measured, args.rows)
+
+    print("=" * 74)
+    print(f"Skewed dataset: {args.rows:,} rows, one dominant block of {args.dominant:,}")
+    print("=" * 74)
+    print(f"{'tier':10} {'pair-count basis':18} {'candidate pairs':>16}  {'backend':9} rule")
+    print(f"{'normal':10} {'extrapolate(2k)':18} {extrapolated.estimated_pair_count:>16,}  "
+          f"{plan_normal.backend:9} {plan_normal.rule_name}")
+    print(f"{'thinking':10} {'measure(full)':18} {measured.estimated_pair_count:>16,}  "
+          f"{plan_thinking.backend:9} {plan_thinking.rule_name}")
+    print("-" * 74)
+    ratio = measured.estimated_pair_count / max(1, extrapolated.estimated_pair_count)
+    flipped = plan_normal.rule_name != plan_thinking.rule_name
+    print(f"extrapolation under-counts the true load by {ratio:.1f}x")
+    if flipped:
+        print(f"ROUTING FLIP: normal -> '{plan_normal.backend}' (would choke on the real load); "
+              f"thinking -> '{plan_thinking.backend}' (RAM-safe out-of-core). The brain works.")
+    else:
+        print("No routing flip at this size — increase --dominant to cross the 50M-pair line.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -23,12 +23,17 @@ Environment:
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import os
 import sys
 import time
 from pathlib import Path
 from typing import Any
+
+# Planning-effort tier applied to every dedupe/match call (spec 2026-06-06).
+# Set from --planning-effort in main(); "normal" reproduces the prior numbers.
+_PLANNING_EFFORT = "normal"
 
 # Make `dqbench_adapters.*` importable when this file is invoked as
 # `python scripts/run_benchmarks.py` from the repo root. The scripts/
@@ -51,11 +56,10 @@ def _measure_with_polars(
     import polars as pl
     from goldenmatch import dedupe_df
 
-    start = time.time()
     df: pl.DataFrame = df_loader()
     gt_pairs: set[tuple[int, int]] = gt_pairs_loader(df)
     config_start = time.time()
-    result = dedupe_df(df)
+    result = dedupe_df(df, planning_effort=_PLANNING_EFFORT)
     elapsed = time.time() - config_start
 
     # Extract emitted pairs from clusters (canonical form: (min, max))
@@ -87,8 +91,15 @@ def _measure_with_polars(
         if hist is not None and getattr(hist, "stop_reason", None) is not None:
             stop_reason = hist.stop_reason.value
 
+    backend = "unknown"
+    plan = getattr(getattr(result, "postflight_report", None), "controller_history", None)
+    plan = getattr(plan, "execution_plan", None)
+    if plan is not None and getattr(plan, "backend", None):
+        backend = plan.backend
+
     _info(f"  {name}: f1={f1:.4f} precision={precision:.4f} recall={recall:.4f} "
-          f"elapsed={elapsed:.2f}s health={health} stop_reason={stop_reason}")
+          f"elapsed={elapsed:.2f}s health={health} stop_reason={stop_reason} "
+          f"effort={_PLANNING_EFFORT} backend={backend}")
 
     return {
         "name": name, "f1": round(f1, 4),
@@ -96,6 +107,7 @@ def _measure_with_polars(
         "tp": tp, "fp": fp, "fn": fn,
         "elapsed_seconds": round(elapsed, 2),
         "health": health, "stop_reason": stop_reason,
+        "planning_effort": _PLANNING_EFFORT, "backend": backend,
     }
 
 
@@ -110,17 +122,17 @@ def _measure_dblp_acm(
     emitted pairs back to source IDs the same way the package's own
     `tests/benchmarks/run_leipzig.py` harness does.
     """
-    from goldenmatch import match_df
-
     from dqbench_adapters.leipzig_eval import run_dblp_acm_zeroconfig
+    from goldenmatch import match_df
 
     dblp_path = datasets_dir / "DBLP-ACM" / "DBLP2.csv"
     if not dblp_path.exists():
         _info(f"  DBLP-ACM: dataset files missing at {datasets_dir} — skipping")
         return None
 
+    _match = functools.partial(match_df, planning_effort=_PLANNING_EFFORT)
     start = time.time()
-    res = run_dblp_acm_zeroconfig(datasets_dir, match_df)
+    res = run_dblp_acm_zeroconfig(datasets_dir, _match)
     elapsed = time.time() - start
     if res is None:
         _info(f"  DBLP-ACM: dataset files missing at {datasets_dir} — skipping")
@@ -149,12 +161,11 @@ def _measure_febrl3() -> dict[str, Any] | None:
     `.profile_tmp/baseline_febrl3_ncvr.py` did, so F1 matches the v1.8
     CHANGELOG value (0.9443).
     """
-    from goldenmatch import dedupe_df
-
     from dqbench_adapters.febrl3 import (
         evaluate_febrl3,
         load_febrl3_df_and_gt,
     )
+    from goldenmatch import dedupe_df
 
     loaded = load_febrl3_df_and_gt()
     if loaded is None:
@@ -162,8 +173,9 @@ def _measure_febrl3() -> dict[str, Any] | None:
         return None
     df, gt_pairs = loaded
 
+    _dedupe = functools.partial(dedupe_df, planning_effort=_PLANNING_EFFORT)
     start = time.time()
-    res = evaluate_febrl3(df, gt_pairs, dedupe_df)
+    res = evaluate_febrl3(df, gt_pairs, _dedupe)
     elapsed = time.time() - start
     _info(
         f"  Febrl3: f1={res.f1:.4f} precision={res.precision:.4f} "
@@ -188,9 +200,8 @@ def _measure_ncvr(datasets_dir: Path) -> dict[str, Any] | None:
     The 0.9719 F1 in the v1.8 CHANGELOG was measured against this
     construction; the 10K-row source file is gitignored.
     """
-    from goldenmatch import dedupe_df
-
     from dqbench_adapters.ncvr import build_ncvr_df_and_gt, evaluate_ncvr
+    from goldenmatch import dedupe_df
 
     ncvr_path = datasets_dir / "NCVR" / "ncvoter_sample_10k.txt"
     loaded = build_ncvr_df_and_gt(ncvr_path)
@@ -199,8 +210,9 @@ def _measure_ncvr(datasets_dir: Path) -> dict[str, Any] | None:
         return None
     df, gt_pairs = loaded
 
+    _dedupe = functools.partial(dedupe_df, planning_effort=_PLANNING_EFFORT)
     start = time.time()
-    res = evaluate_ncvr(df, gt_pairs, dedupe_df)
+    res = evaluate_ncvr(df, gt_pairs, _dedupe)
     elapsed = time.time() - start
     _info(
         f"  NCVR: f1={res.f1:.4f} precision={res.precision:.4f} "
@@ -299,7 +311,16 @@ def main() -> int:
     parser.add_argument("--datasets-dir", type=Path,
                         default=Path("packages/python/goldenmatch/tests/benchmarks/datasets"),
                         help="Directory containing benchmark datasets")
+    parser.add_argument("--planning-effort", default="normal",
+                        choices=["fast", "normal", "thinking", "einstein"],
+                        help="Auto-config planning-effort tier applied to every "
+                             "dedupe/match call (default: normal = prior behavior). "
+                             "Use to A/B the tiers head-to-head on a dataset.")
     args = parser.parse_args()
+
+    global _PLANNING_EFFORT
+    _PLANNING_EFFORT = args.planning_effort
+    _info(f"planning_effort={_PLANNING_EFFORT}")
 
     selected = {args.datasets} if args.datasets != "all" else {"dblp-acm", "febrl3", "ncvr", "dqbench"}
     results: list[dict[str, Any] | None] = []
@@ -320,6 +341,7 @@ def main() -> int:
             "results": results,
             "metadata": {
                 "with_llm": args.with_llm,
+                "planning_effort": _PLANNING_EFFORT,
                 "datasets_dir": str(args.datasets_dir),
                 "memory_disabled": os.environ.get("GOLDENMATCH_AUTOCONFIG_MEMORY") == "0",
             },


### PR DESCRIPTION
## Why

After 1.28.0 shipped the planning-effort tiers, the open question was: **how do we actually tell the new brain is working?** A default-tier benchmark only proves *non-regression* (Febrl3 F1 **0.9665** on 1.28.0, identical across all tiers — correct, since the cheap config is already optimal there). The *value* of `thinking`/`einstein` only shows on data where `normal` mis-routes. This PR pins that case down and gives us the A/B tooling.

## What's here

**1. The proof — `scripts/bench_planning_effort.py`**
An A/B on a skewed fixture (40k rows, one 12k dominant block):

```
tier       pair-count basis    candidate pairs  backend   rule
normal     extrapolate(2k)           3,525,680  bucket    plan_selected_simple
thinking   measure(full)            72,064,014  chunked   plan_selected_chunked
extrapolation under-counts the true load by 20.4x
ROUTING FLIP: normal -> 'bucket' (would choke on the real load);
              thinking -> 'chunked' (RAM-safe out-of-core). The brain works.
```

`normal`'s uniform-sample extrapolation under-counts the real candidate-pair load **quadratically** (3.5M vs the true 72M), so it routes to the in-memory `bucket` plan the workload would blow past. `thinking` measures real blocking on the full frame (Phase 1), sees the true 72M, and routes to the RAM-safe `chunked` plan. That's the win, made concrete.

**2. The regression — `tests/test_planning_effort_routing.py`**
Locks the flip in (`plan_selected_simple` → `plan_selected_chunked` once measured) at the planner-decision level — fast, deterministic, no full pipeline. 2 tests: the fixture straddles the 50M threshold, and measurement flips the rung.

**3. The A/B tooling — `--planning-effort` on `scripts/run_benchmarks.py`**
`{fast,normal,thinking,einstein}` threaded through every `dedupe_df`/`match_df` call, with `planning_effort` + chosen `backend` recorded in the results JSON — so the tiers can be benchmarked head-to-head on DBLP-ACM/Febrl3/NCVR/DQbench.

## Honest scope

On a single box the backends are **output-equivalent**, so the Phase-1 win here is **correct routing / scale-safety, not an F1 delta**. An *accuracy* win from broader search would come from the staged Phase-2 (successive-halving) + a labeled hard set — explicitly out of scope for this PR, noted in the context-network node.

## Tests
- New: 2 routing-regression tests (green); existing 18 planning-effort tests still green.
- `bench_planning_effort.py` and the `--planning-effort` flag verified locally; ruff clean.

https://claude.ai/code/session_01DKPX87ExnkFXGrocGTjExp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKPX87ExnkFXGrocGTjExp)_