### PR TITLE
feat(bench): auto-pull benchmark datasets in run_benchmarks.py

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -79,7 +79,11 @@ jobs:
 
       - name: Install
         if: steps.prereqs.outputs.configured == 'true'
-        run: uv sync --all-packages
+        run: |
+          uv sync --all-packages
+          # recordlinkage powers Febrl3; dqbench ships the DQbench tier datasets.
+          # Both are bench-only, kept out of the package deps.
+          uv pip install recordlinkage dqbench || true
 
       # Native kernels ship gated OFF by default; build them so a `native=true`
       # dispatch measures DQbench on the native path (the parity + composite
@@ -102,11 +106,15 @@ jobs:
           # Memory disabled so cross-run state doesn't leak between scheduled runs.
           GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
           GOLDENMATCH_NATIVE: ${{ env.NATIVE }}
+          # DBLP-ACM auto-pulls from Leipzig; override with a mirror if it 404s.
+          # NCVR's 4.3 GB source isn't mirrored — point at a hosted 10k sample.
+          GOLDENMATCH_DBLP_ACM_URL: ${{ vars.DBLP_ACM_URL }}
+          GOLDENMATCH_NCVR_SAMPLE_URL: ${{ vars.NCVR_SAMPLE_URL }}
         run: |
           set -euo pipefail
-          # The runner script (committed in this PR — see scripts/run_benchmarks.py)
-          # measures each requested dataset and writes a JSON artifact + a
-          # markdown summary to $GITHUB_STEP_SUMMARY.
+          # The runner auto-pulls missing file-backed datasets (--download is the
+          # default), then measures each + writes a JSON artifact + a markdown
+          # summary to $GITHUB_STEP_SUMMARY.
           uv run python scripts/run_benchmarks.py \
             --datasets "$DATASETS" \
             --output benchmark_results.json \

--- a/docs/ci-lanes.md
+++ b/docs/ci-lanes.md
@@ -80,7 +80,13 @@ The lane's `case` block already checks `OPENAI_API_KEY`. Setting the secret in t
 - `tests/benchmarks/datasets/NCVR/` (488MB voter zip; sample at `ncvoter_sample_10k.txt`)
 - Febrl3 ships with `recordlinkage` PyPI package
 
-To enable: cache the datasets in CI runner storage, or download them in the lane's setup step from a controlled mirror. Out of scope for v1; this lane stays not-configured until the dataset hosting story lands. The synthetic-fixture smoke (`synthetic_benchmarks` job in `ci.yml`) covers regressions against committed synthetic fixtures on every PR.
+To enable: set repo var `RUN_BENCHMARKS=true`. `scripts/run_benchmarks.py` now **auto-pulls** missing file-backed datasets (`--download`, default on):
+- **DBLP-ACM** downloads from Leipzig automatically (override with repo var `DBLP_ACM_URL` → `GOLDENMATCH_DBLP_ACM_URL` if Leipzig 404s; the Magellan mirror carries identical CSVs). Verified end-to-end: fresh pull → F1 0.9641.
+- **Febrl3** is self-contained via `recordlinkage` (installed in the lane).
+- **NCVR**'s source is a 4.3 GB NC SBE extract we do NOT mirror — host the small derived `ncvoter_sample_10k.txt` on a controlled mirror (e.g. a release asset) and set repo var `NCVR_SAMPLE_URL` → `GOLDENMATCH_NCVR_SAMPLE_URL`. Without it, the NCVR lane skips.
+- **DQbench** datasets ship with the `dqbench` PyPI package (installed in the lane).
+
+The synthetic-fixture smoke (`synthetic_benchmarks` job in `ci.yml`) covers regressions against committed synthetic fixtures on every PR.
 
 ## Real-benchmark workflow (`benchmarks.yml`)
 

--- a/docs/reproducing-benchmarks.md
+++ b/docs/reproducing-benchmarks.md
@@ -242,17 +242,24 @@ Febrl3 and NCVR have working GT helpers under `dqbench_adapters/`.
 
 What still requires external work (not bugs, just dataset realities):
 
+0. **Auto-pull (default).** `scripts/run_benchmarks.py --download` (on by
+   default) fetches missing file-backed datasets before measuring: DBLP-ACM from
+   Leipzig (override via `GOLDENMATCH_DBLP_ACM_URL`), and the NCVR 10k sample from
+   `GOLDENMATCH_NCVR_SAMPLE_URL` when set. Febrl3 (`recordlinkage`) and DQbench
+   (`dqbench`) are self-contained. `--no-download` uses only local files.
+   Verified end-to-end: a fresh DBLP-ACM pull reproduces F1 0.9641.
 1. **NCVR dataset is not redistributable from this repo.** It is the
    first 10K rows of `ncvoter_Statewide.zip` from the NC State Board
-   of Elections. Public data but bandwidth-heavy; we don't mirror it.
-   Drop the sample at
+   of Elections. Public data but bandwidth-heavy; we don't mirror the 4.3 GB
+   source. Host the small derived `ncvoter_sample_10k.txt` once (e.g. a release
+   asset) and set `GOLDENMATCH_NCVR_SAMPLE_URL` for auto-pull, or drop it at
    `packages/python/goldenmatch/tests/benchmarks/datasets/NCVR/ncvoter_sample_10k.txt`
    before running `--datasets ncvr`.
 2. **Leipzig DBLP-ACM mirror availability.** The canonical link at
    `dbs.uni-leipzig.de` has been intermittently 404-ing in 2026. If
-   the link is dead, the Magellan benchmark mirror at
-   `sites.google.com/site/anhaidgroup/projects/data` carries identical
-   CSVs.
+   the link is dead, set `GOLDENMATCH_DBLP_ACM_URL` to the Magellan benchmark
+   mirror at `sites.google.com/site/anhaidgroup/projects/data`, which carries
+   identical CSVs.
 3. **DQbench dataset bundling.** The `dqbench` PyPI package ships its
    own tier datasets. Pinning the `dqbench` version (currently any
    2024+ release) is enough; we don't re-publish the tiers.

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -24,16 +24,30 @@ from __future__ import annotations
 
 import argparse
 import functools
+import io
 import json
 import os
 import sys
 import time
+import urllib.error
+import urllib.request
+import zipfile
 from pathlib import Path
 from typing import Any
 
 # Planning-effort tier applied to every dedupe/match call (spec 2026-06-06).
 # Set from --planning-effort in main(); "normal" reproduces the prior numbers.
 _PLANNING_EFFORT = "normal"
+
+# Dataset sources for --download (auto-pull missing datasets). DBLP-ACM is small
+# + public (Leipzig); the Magellan mirror carries identical CSVs when Leipzig
+# 404s. NCVR's full source is a 4.3 GB NC SBE extract we do NOT mirror — the
+# runner pulls only the small derived 10k sample from a controlled mirror URL
+# (host it once on a release asset and point GOLDENMATCH_NCVR_SAMPLE_URL at it).
+_DBLP_ACM_URL = os.environ.get(
+    "GOLDENMATCH_DBLP_ACM_URL", "https://dbs.uni-leipzig.de/file/DBLP-ACM.zip"
+)
+_NCVR_SAMPLE_URL = os.environ.get("GOLDENMATCH_NCVR_SAMPLE_URL", "")
 
 # Make `dqbench_adapters.*` importable when this file is invoked as
 # `python scripts/run_benchmarks.py` from the repo root. The scripts/
@@ -47,6 +61,86 @@ if str(_SCRIPTS_DIR) not in sys.path:
 
 def _info(msg: str) -> None:
     print(f"[run_benchmarks] {msg}", flush=True)
+
+
+def _http_get(url: str, timeout: int = 180) -> bytes:
+    """GET with a few retries + exponential backoff. Raises on final failure."""
+    last: Exception | None = None
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 (trusted bench mirrors)
+                return resp.read()
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
+            last = exc
+            time.sleep(2 ** attempt)
+    raise RuntimeError(f"download failed after retries: {url} ({last})")
+
+
+def _fetch_dblp_acm(datasets_dir: Path) -> bool:
+    """Auto-pull the Leipzig DBLP-ACM CSVs (idempotent). Returns True if present."""
+    out = datasets_dir / "DBLP-ACM"
+    if (out / "DBLP2.csv").exists():
+        return True
+    out.mkdir(parents=True, exist_ok=True)
+    _info(f"  DBLP-ACM: downloading from {_DBLP_ACM_URL} ...")
+    try:
+        raw = _http_get(_DBLP_ACM_URL)
+        zipfile.ZipFile(io.BytesIO(raw)).extractall(out)
+    except zipfile.BadZipFile:
+        _info("  DBLP-ACM: response was not a zip (dead mirror returning HTML?); "
+              "set GOLDENMATCH_DBLP_ACM_URL to the Magellan mirror. Skipping.")
+        return False
+    except Exception as exc:  # noqa: BLE001 - download is best-effort
+        _info(f"  DBLP-ACM: download failed ({exc}); set GOLDENMATCH_DBLP_ACM_URL "
+              "to a mirror. Skipping.")
+        return False
+    # The zip may nest the CSVs under a folder; flatten so DBLP2.csv sits in out/.
+    if not (out / "DBLP2.csv").exists():
+        for p in out.rglob("DBLP2.csv"):
+            for f in p.parent.iterdir():
+                f.rename(out / f.name)
+            break
+    ok = (out / "DBLP2.csv").exists()
+    _info(f"  DBLP-ACM: {'ready' if ok else 'still missing after extract'}.")
+    return ok
+
+
+def _fetch_ncvr_sample(datasets_dir: Path) -> bool:
+    """Pull the small derived NCVR 10k sample from a controlled mirror URL.
+
+    The full NC SBE extract (4.3 GB) is intentionally NOT auto-pulled. Host the
+    `ncvoter_sample_10k.txt` once (e.g. a release asset) and set
+    GOLDENMATCH_NCVR_SAMPLE_URL.
+    """
+    dest = datasets_dir / "NCVR" / "ncvoter_sample_10k.txt"
+    if dest.exists():
+        return True
+    if not _NCVR_SAMPLE_URL:
+        _info("  NCVR: no local sample and GOLDENMATCH_NCVR_SAMPLE_URL unset — "
+              "skipping (the 4.3 GB NC SBE source isn't mirrored; host the 10k "
+              "sample on a release asset and set the URL).")
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _info(f"  NCVR: downloading 10k sample from {_NCVR_SAMPLE_URL} ...")
+    try:
+        dest.write_bytes(_http_get(_NCVR_SAMPLE_URL))
+    except Exception as exc:  # noqa: BLE001 - download is best-effort
+        _info(f"  NCVR: sample download failed ({exc}). Skipping.")
+        return False
+    return dest.exists()
+
+
+def _ensure_datasets(datasets_dir: Path, selected: set[str]) -> None:
+    """Auto-pull any selected file-backed datasets that aren't already present.
+
+    Febrl3 (recordlinkage) and dqbench (PyPI) are self-contained; only DBLP-ACM
+    and NCVR are file-backed. Best-effort: a failed/skip download just lets the
+    per-dataset runner emit its existing 'missing — skipping' notice.
+    """
+    if "dblp-acm" in selected:
+        _fetch_dblp_acm(datasets_dir)
+    if "ncvr" in selected:
+        _fetch_ncvr_sample(datasets_dir)
 
 
 def _measure_with_polars(
@@ -316,6 +410,10 @@ def main() -> int:
                         help="Auto-config planning-effort tier applied to every "
                              "dedupe/match call (default: normal = prior behavior). "
                              "Use to A/B the tiers head-to-head on a dataset.")
+    parser.add_argument("--download", action=argparse.BooleanOptionalAction, default=True,
+                        help="Auto-pull missing file-backed datasets (DBLP-ACM from "
+                             "Leipzig; NCVR 10k sample from GOLDENMATCH_NCVR_SAMPLE_URL). "
+                             "Default on; --no-download to use only local files.")
     args = parser.parse_args()
 
     global _PLANNING_EFFORT
@@ -323,6 +421,9 @@ def main() -> int:
     _info(f"planning_effort={_PLANNING_EFFORT}")
 
     selected = {args.datasets} if args.datasets != "all" else {"dblp-acm", "febrl3", "ncvr", "dqbench"}
+
+    if args.download:
+        _ensure_datasets(args.datasets_dir, selected)
     results: list[dict[str, Any] | None] = []
 
     if "dblp-acm" in selected:


### PR DESCRIPTION
## Why

You'd benchmarked with the DBLP-ACM/NCVR datasets before, but the CI lanes for them **never actually ran** — the datasets were always missing, and `docs/ci-lanes.md` explicitly deferred this *"until the dataset hosting story lands."* This wires that story: the runner now auto-pulls the missing datasets.

## What's here

**`scripts/run_benchmarks.py --download`** (default on) fetches missing file-backed datasets before measuring:
- **DBLP-ACM** — downloads + unzips from Leipzig automatically; idempotent, with retry/backoff. Override via `GOLDENMATCH_DBLP_ACM_URL` (the Magellan mirror carries identical CSVs when Leipzig 404s).
- **NCVR** — pulls the small derived `ncvoter_sample_10k.txt` from `GOLDENMATCH_NCVR_SAMPLE_URL`. The **4.3 GB NC SBE source is intentionally *not* auto-pulled** — host the 10k sample once (e.g. a release asset) and point the var at it.
- **Febrl3** (`recordlinkage`) + **DQbench** (`dqbench` PyPI) are self-contained.
- `--no-download` uses only local files; any download failure degrades to the existing per-dataset "missing — skipping" notice.

**`benchmarks.yml`** — installs `recordlinkage` + `dqbench`, and passes `DBLP_ACM_URL` / `NCVR_SAMPLE_URL` repo vars through to the runner.

**Docs** — `ci-lanes.md` + `reproducing-benchmarks.md` updated for auto-pull + the NCVR mirror requirement.

## Verified end-to-end (real numbers)

I ran the actual auto-pull here (network's available in this env). A **fresh DBLP-ACM download → F1 0.9641** (P 0.9691, R 0.9591) — **exactly the documented value**, identical across `normal`/`thinking`/`einstein`. That's a **second canonical non-regression confirmation** for 1.28.0 (Febrl3 was 0.9665).

> Heads-up worth recording: the very first download-and-run gave a bogus 0.51 — traced to **autoconfig-memory contamination** from earlier un-memory-disabled runs in the same session. With `GOLDENMATCH_AUTOCONFIG_MEMORY=0` (which the workflow already sets) it's a clean, reproducible 0.9641. No code change needed; just a reminder that the memory cache must be off for clean benchmark numbers.

## To light up the full set on CI
1. `RUN_BENCHMARKS=true` (already set).
2. Host `ncvoter_sample_10k.txt` somewhere and set repo var `NCVR_SAMPLE_URL` (DBLP-ACM + Febrl3 + DQbench need nothing further).

https://claude.ai/code/session_01DKPX87ExnkFXGrocGTjExp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKPX87ExnkFXGrocGTjExp)_