### PR TITLE
feat(bench): DQbench ER hook-in (git) + synthetic NCVR fixture + memory guard

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -81,9 +81,11 @@ jobs:
         if: steps.prereqs.outputs.configured == 'true'
         run: |
           uv sync --all-packages
-          # recordlinkage powers Febrl3; dqbench ships the DQbench tier datasets.
-          # Both are bench-only, kept out of the package deps.
-          uv pip install recordlinkage dqbench || true
+          # recordlinkage powers Febrl3. DQbench is installed from the org repo,
+          # NOT PyPI: PyPI dqbench 1.0.0 is a stale slice with only the detection
+          # API (no EntityResolutionAdapter), so the ER lane needs the git version.
+          uv pip install recordlinkage || true
+          uv pip install "git+https://github.com/benseverndev-oss/dqbench" || true
 
       # Native kernels ship gated OFF by default; build them so a `native=true`
       # dispatch measures DQbench on the native path (the parity + composite

--- a/docs/ci-lanes.md
+++ b/docs/ci-lanes.md
@@ -83,8 +83,8 @@ The lane's `case` block already checks `OPENAI_API_KEY`. Setting the secret in t
 To enable: set repo var `RUN_BENCHMARKS=true`. `scripts/run_benchmarks.py` now **auto-pulls** missing file-backed datasets (`--download`, default on):
 - **DBLP-ACM** downloads from Leipzig automatically (override with repo var `DBLP_ACM_URL` → `GOLDENMATCH_DBLP_ACM_URL` if Leipzig 404s; the Magellan mirror carries identical CSVs). Verified end-to-end: fresh pull → F1 0.9641.
 - **Febrl3** is self-contained via `recordlinkage` (installed in the lane).
-- **NCVR**'s source is a 4.3 GB NC SBE extract we do NOT mirror — host the small derived `ncvoter_sample_10k.txt` on a controlled mirror (e.g. a release asset) and set repo var `NCVR_SAMPLE_URL` → `GOLDENMATCH_NCVR_SAMPLE_URL`. Without it, the NCVR lane skips.
-- **DQbench** datasets ship with the `dqbench` PyPI package (installed in the lane).
+- **NCVR**'s real source is a 4.3 GB NC SBE extract carrying real voter PII (names + home addresses), so it's gitignored and NOT mirrored. The lane now **falls back to a committed PII-free synthetic NCVR-shaped fixture** (`dqbench_adapters.ncvr.generate_synthetic_ncvr`) when the real sample is absent — results are labelled **`NCVR-synthetic`** (its own baseline, ~0.98, NOT the real-data 0.9719). To run the real-data number, host `ncvoter_sample_10k.txt` privately and set repo var `NCVR_SAMPLE_URL` → `GOLDENMATCH_NCVR_SAMPLE_URL`.
+- **DQbench** is installed from the **org repo** (`git+https://github.com/benseverndev-oss/dqbench`), NOT PyPI — PyPI `dqbench` 1.0.0 is a stale slice with only the detection API (no `EntityResolutionAdapter`), so the ER lane needs the git version. The ER composite responds to `--planning-effort` (`thinking` lifts it 51.56 → 57.11 by fixing budget-limited RED commits on T2).
 
 The synthetic-fixture smoke (`synthetic_benchmarks` job in `ci.yml`) covers regressions against committed synthetic fixtures on every PR.
 

--- a/scripts/dqbench_adapters/ncvr.py
+++ b/scripts/dqbench_adapters/ncvr.py
@@ -19,9 +19,9 @@ ncvoter_sample_10k.txt` (gitignored).
 from __future__ import annotations
 
 import random
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 import polars as pl
 
@@ -85,6 +85,75 @@ def build_ncvr_df_and_gt(
     df = pl.read_csv(
         ncvr_path, separator="\t", encoding="utf8-lossy", ignore_errors=True,
     )
+    return _sample_and_corrupt(df, seed=seed, n_base_cap=n_base_cap)
+
+
+# --- Synthetic NCVR-shaped generator (PII-free, committable) ----------------
+# The real NCVR sample carries real voters' names + home addresses (PII), so it
+# stays gitignored. This generator emits the SAME schema + value shapes from
+# syllable wordlists — every person is fabricated, zero PII — so the NCVR lane
+# can run in CI from a fresh clone with no secrets. Its F1 is its OWN committed
+# baseline, NOT the real-data 0.9719.
+_SYL = [
+    "an", "ber", "cha", "dle", "el", "fer", "gan", "hol", "ix", "jon", "kel",
+    "lor", "mor", "nor", "ol", "per", "quin", "ros", "sten", "tan", "ven",
+    "wes", "yor", "zel", "bre", "cle", "dar", "fen", "gil", "han",
+]
+_STREETS = [
+    "Oak St", "Main St", "Elm Ave", "Pine Rd", "Maple Dr", "Cedar Ln",
+    "Birch Way", "Walnut St", "Ash Ct", "Holly Blvd", "Dogwood Dr", "Magnolia Ave",
+]
+_CITIES = [
+    "RALEIGH", "DURHAM", "CHARLOTTE", "GREENSBORO", "ASHEVILLE", "CARY",
+    "WILMINGTON", "CONCORD", "GASTONIA", "APEX", "HICKORY", "SALISBURY",
+]
+
+
+def _syl_name(rng: random.Random, n_syl: int = 2) -> str:
+    return "".join(rng.choice(_SYL) for _ in range(n_syl)).capitalize()
+
+
+def generate_synthetic_ncvr(n: int = 10_000, seed: int = 7) -> pl.DataFrame:
+    """A PII-free, NCVR-SHAPED synthetic voter table (deterministic, committable).
+
+    Same columns + value shapes as the real NC voter file (``_KEEP_COLS``), but
+    fabricated from syllable wordlists so there is no real PII. Names are drawn
+    from a large combinatorial space so coincidental collisions are rare (a
+    realistic ER shape, unlike a tiny name pool).
+    """
+    rng = random.Random(seed)
+    rows = []
+    for i in range(n):
+        rows.append({
+            "ncid": f"SY{i:08d}",
+            "first_name": _syl_name(rng, 2),
+            "last_name": _syl_name(rng, rng.choice([2, 2, 3])),
+            "middle_name": _syl_name(rng, 1) if rng.random() < 0.6 else "",
+            "res_street_address": f"{rng.randint(100, 9999)} {rng.choice(_STREETS)}",
+            "res_city_desc": rng.choice(_CITIES),
+            "state_cd": "NC",
+            "zip_code": f"2{rng.randint(7000, 8999)}",
+            "birth_year": str(rng.randint(1940, 2004)),
+            "gender_code": rng.choice(["M", "F"]),
+        })
+    return pl.DataFrame(rows)
+
+
+def build_ncvr_synthetic_df_and_gt(
+    n: int = 10_000, seed: int = 42, n_base_cap: int = 5000,
+) -> tuple[pl.DataFrame, set[tuple[str, str]]]:
+    """Synthetic NCVR-shaped (combined_df, gt) — same sample+corrupt pipeline as
+    the real file, but PII-free and committable. Use when the real sample is
+    absent. Label results 'NCVR-synthetic' so they're never confused with the
+    real-data number."""
+    df = generate_synthetic_ncvr(n=n, seed=seed)
+    return _sample_and_corrupt(df, seed=seed, n_base_cap=n_base_cap)
+
+
+def _sample_and_corrupt(
+    df: pl.DataFrame, seed: int, n_base_cap: int,
+) -> tuple[pl.DataFrame, set[tuple[str, str]]]:
+    """Shared base-sample + corruption-dup GT construction (real & synthetic)."""
     df = df.filter(
         (pl.col("last_name").str.len_chars() > 1)
         & (pl.col("first_name").str.len_chars() > 1)

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -294,14 +294,23 @@ def _measure_ncvr(datasets_dir: Path) -> dict[str, Any] | None:
     The 0.9719 F1 in the v1.8 CHANGELOG was measured against this
     construction; the 10K-row source file is gitignored.
     """
-    from dqbench_adapters.ncvr import build_ncvr_df_and_gt, evaluate_ncvr
+    from dqbench_adapters.ncvr import (
+        build_ncvr_df_and_gt,
+        build_ncvr_synthetic_df_and_gt,
+        evaluate_ncvr,
+    )
     from goldenmatch import dedupe_df
 
     ncvr_path = datasets_dir / "NCVR" / "ncvoter_sample_10k.txt"
     loaded = build_ncvr_df_and_gt(ncvr_path)
+    label = "NCVR"
     if loaded is None:
-        _info(f"  NCVR: sample missing at {ncvr_path} — skipping")
-        return None
+        # No real (PII-bearing, gitignored) sample -> fall back to the committed
+        # PII-free synthetic NCVR-shaped fixture so the lane runs anywhere. Its
+        # F1 is its OWN baseline, NOT the real-data 0.9719 -> label it distinctly.
+        _info(f"  NCVR: real sample absent at {ncvr_path} — using synthetic NCVR-shaped fixture.")
+        loaded = build_ncvr_synthetic_df_and_gt()
+        label = "NCVR-synthetic"
     df, gt_pairs = loaded
 
     _dedupe = functools.partial(dedupe_df, planning_effort=_PLANNING_EFFORT)
@@ -309,16 +318,17 @@ def _measure_ncvr(datasets_dir: Path) -> dict[str, Any] | None:
     res = evaluate_ncvr(df, gt_pairs, _dedupe)
     elapsed = time.time() - start
     _info(
-        f"  NCVR: f1={res.f1:.4f} precision={res.precision:.4f} "
-        f"recall={res.recall:.4f} elapsed={elapsed:.2f}s"
+        f"  {label}: f1={res.f1:.4f} precision={res.precision:.4f} "
+        f"recall={res.recall:.4f} elapsed={elapsed:.2f}s effort={_PLANNING_EFFORT}"
     )
     return {
-        "name": "NCVR", "f1": round(res.f1, 4),
+        "name": label, "f1": round(res.f1, 4),
         "precision": round(res.precision, 4), "recall": round(res.recall, 4),
         "tp": res.true_positives, "fp": res.false_positives,
         "fn": res.false_negatives,
         "elapsed_seconds": round(elapsed, 2),
         "health": "n/a", "stop_reason": "n/a",
+        "planning_effort": _PLANNING_EFFORT,
     }
 
 
@@ -339,6 +349,11 @@ def _run_dqbench(with_llm: bool = False) -> dict[str, Any] | None:
         return None
 
     env = os.environ.copy()
+    # The adapter calls dedupe_df, which reads GOLDENMATCH_PLANNING_EFFORT — so
+    # --planning-effort flows into the DQbench subprocess and the tiers can be
+    # A/B'd on the ER composite (thinking lifts T2 by fixing budget-limited RED
+    # commits: 51.56 -> 57.11 measured 2026-06-06).
+    env["GOLDENMATCH_PLANNING_EFFORT"] = _PLANNING_EFFORT
     if not with_llm:
         # Strip API keys so DQbench measures the no-LLM path
         for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
@@ -416,9 +431,14 @@ def main() -> int:
                              "Default on; --no-download to use only local files.")
     args = parser.parse_args()
 
+    # Benchmarks must NOT use the cross-run auto-config cache — a config learned
+    # on a prior run would leak across datasets and make numbers irreproducible.
+    # Force it off unless the caller has deliberately overridden it.
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+
     global _PLANNING_EFFORT
     _PLANNING_EFFORT = args.planning_effort
-    _info(f"planning_effort={_PLANNING_EFFORT}")
+    _info(f"planning_effort={_PLANNING_EFFORT} memory={os.environ.get('GOLDENMATCH_AUTOCONFIG_MEMORY')}")
 
     selected = {args.datasets} if args.datasets != "all" else {"dblp-acm", "febrl3", "ncvr", "dqbench"}
 


### PR DESCRIPTION
## Summary

Both deliverables you asked for, plus the answers to all 5 questions fell out of the work.

### Q5 — DQbench ER hook-in (the big one)
The PyPI `dqbench` 1.0.0 is a **stale slice** that ships only the detection API (`DQBenchAdapter.validate → findings`) — no `EntityResolutionAdapter` — which is why the committed ER adapter couldn't import and the composite came back `None`. The **org repo** (`benseverndev-oss/dqbench`, public/MIT) has the ER category, and the committed adapter already matches its `EntityResolutionAdapter.deduplicate()` contract. **Fix: install dqbench from git in `benchmarks.yml`.** The ER lane now runs end-to-end (composite **51.56** via the runner), and `--planning-effort` is propagated into the DQbench subprocess.

**🎯 Headline result — the first measured accuracy win from the tiers:**

| effort | ER composite | T2 F1 | T2 precision |
|---|---|---|---|
| normal | 51.56 | 60.9 | 44.5% |
| **thinking** | **57.11** | **74.7** | **61.2%** |
| einstein | 57.11 | 74.7 | 61.2% |

`thinking` lifts the composite **+5.55** by fixing **budget-limited RED commits** (`stop_reason=BUDGET_ITERATIONS`). The clean canonical sets (Febrl3/DBLP) showed *no* tier change because `normal` already finds their optimal config — the tiers pay off exactly where `normal` is budget-starved.

### Q1 — the 0.51 mystery, solved
It's **not** learned history (both occurrences were already `MEMORY=0`). It's the same **budget-limited RED commit** as DQbench's low tiers — deterministic given the iteration budget, fixed by more effort. This PR also makes `run_benchmarks.py` **force `GOLDENMATCH_AUTOCONFIG_MEMORY=0`** so the cross-run cache can never leak a config across datasets.

### Q3 — synthetic NCVR (PII-free, committable)
The real NCVR sample is real voter PII (names + home addresses), so it stays gitignored. Added a **deterministic, PII-free, NCVR-shaped generator** (`generate_synthetic_ncvr`) and a synthetic fallback in the NCVR lane — labelled **`NCVR-synthetic`** (F1 ~**0.9806**, its own baseline, *not* the real-data 0.9719). The lane now runs anywhere with no secrets and no PII. (On GitHub "secure storage": there isn't a clean native option for multi-MB PII in a public repo — Actions secrets are tiny strings, Release assets/LFS are public — so synthetic-committed + optional private `NCVR_SAMPLE_URL` for the real number is the right split.)

### Q2 — do the tiers change outcomes? **Yes, where it matters.**
No change on already-optimal clean sets (Febrl3 0.9665, DBLP 0.9641 flat across tiers); **+5.55 composite on DQbench ER** where normal is budget-starved.

### Q4 — regression from legacy? **No.**
`bucket` (current) == `polars-direct` (legacy) == **0.9641** on DBLP-ACM. DBLP 0.9641 + Febrl3 0.9665 both match/exceed documented.

## Verified locally
`NCVR-synthetic` F1 0.9806; DQbench composite 51.56 (normal) / 57.11 (thinking) via the runner; generator deterministic + PII-free; ruff + yaml clean.

https://claude.ai/code/session_01DKPX87ExnkFXGrocGTjExp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKPX87ExnkFXGrocGTjExp)_