### PR TITLE
docs: record Fellegi-Sunter Splink parity (context network + mintlify + vendor comparison)

### DIFF
--- a/context-network/architecture/fellegi-sunter-splink-parity.md
+++ b/context-network/architecture/fellegi-sunter-splink-parity.md
@@ -1,0 +1,72 @@
+# Fellegi-Sunter (probabilistic) matching — Splink parity
+
+The `type: probabilistic` matchkey went from an accuracy-competitive *scorer*
+to a full probabilistic-linkage *engine* on par with Splink: model lifecycle,
+supervised training, FS-native explainability, calibration, and scale-out — and
+then a perf pass that the scale-out exposed. The entity-resolution sibling of
+the suite's Arrow-native / engine-maturity arc.
+
+**Status:** SHIPPED (2026-06-08). Roadmap delivered across PRs #800 (Phases
+0–4 + 3c bench harness), #802 (bench ground-truth fix), #803 (EM sampling perf).
+**Decision:** [../decisions/0008-fellegi-sunter-splink-parity.md](../decisions/0008-fellegi-sunter-splink-parity.md).
+**Code-level notes:** `packages/python/goldenmatch/CLAUDE.md` (Fellegi-Sunter
+section), `docs/scale-envelope.md` (FS-at-scale), `docs-site/goldenmatch/scoring.mdx`.
+
+## The audit that framed it
+A 2026-06-07 audit reproduced DBLP-ACM **P=0.978 / R=0.958 / F1=0.968** and
+found the algorithm faithful to Splink (u from random pairs, m from EM, blocking
+fields excluded) — but the surrounding *engine* was missing: FS ran single-node
+sequential only (every scale backend declined it), retrained EM every run, had
+no supervised-from-labels path, no FS-native explainability, and an admittedly
+non-probability default score. The work closed those, in dependency order.
+
+## What shipped (the parity surface)
+- **Phase 0 — hygiene.** Match-weight monotonicity guard (PAV isotonic, default
+  *warn* — `enforce` measured to trade F1, so opt-in); fixed the mis-tuned
+  posterior cut (0.50 → 0.99) and stale calibration comments.
+- **Phase 1a — model lifecycle.** `EMResult` JSON save/load + `validate_for` +
+  `MatchkeyConfig.model_path` + `load_or_train_em` (train-once → reuse;
+  byte-identical pairs on reload).
+- **Phase 1b — supervised m.** `estimate_m_from_labels` (Splink's
+  `estimate_m_from_label_column`) + label adapters from the review-queue /
+  memory corrections store.
+- **Phase 2 — explainability.** Match-weight waterfall (`explain_pair_fs` /
+  `FSWaterfall`), surfaced in `goldenmatch explain --pair` + the lineage
+  sidecar; `EngineResult.em_results` exposed.
+- **Phase 3a — scale-out (numpy).** Probabilistic matchkeys ride the shared
+  `score_buckets` orchestration (which carries the Ray / DataFusion wiring) —
+  clusters identical to polars-direct.
+- **Phase 3b — native FS kernel (opt-in).** `score_block_pairs_fs` in
+  `goldenmatch-native`; default OFF (`GOLDENMATCH_FS_NATIVE=1`) because FS's
+  discrete levels amplify rapidfuzz float diffs at exact thresholds.
+- **Phase 4 — accuracy analysis from labels.** `threshold_sweep` /
+  `recommend_threshold` / `fs_model_report` /
+  `probability_two_random_records_match`; `goldenmatch evaluate
+  --threshold-sweep`.
+- **Phase 3c — distributed validation.** `bench-fs-distributed.yml`
+  (`workflow_dispatch`) — the at-scale gate, run on demand.
+
+## The perf pass the scale gate exposed
+The 6M bench (269 s native) was **train_em-bound, not scoring-bound** — the
+native kernel had already cut `bucket_score` to ~14 s. `_sample_blocked_pairs`
+enumerated **every** within-block pair across **every** block (`O(Σ size_i²)`,
+~140M tuples) before sampling 10K; fixed to a block-stratified early-exit (#803).
+A second, separate fix corrected the *bench's* ground truth from a star
+(`base→dup`) to the entity *clique* (#802) — FS was always right; the GT was
+incomplete.
+
+## Measured (6M rows, `backend=bucket`, 16c/64GB)
+| FS path | Wall | Peak RSS | `bucket_score` | F1 |
+|---|---|---|---|---|
+| numpy (default) | 288.5 s | 11.3 GB | 136.6 s | 1.000 |
+| native (`FS_NATIVE=1`) | 162.6 s | 11.3 GB | 12.7 s (~10.8×) | 1.000 |
+
+The EM fix shaved ~100 s off both paths and halved peak RSS; native is ~10.8×
+on the scoring step (tiny-block regime). Original pre-fix figures (269 s / 0.825)
+were the un-bounded EM + the star-GT bench bug.
+
+## Where Splink still leads
+Distributed Fellegi-Sunter at 1B+ rows on Spark, and the mature interactive
+m/u + comparison-viewer charting UI. GoldenMatch's FS scale-out is measured
+single-node at 6M and inherits the bucket → Ray path; the charting is
+data-export (`fs_model_report`, the waterfall) rather than a hosted dashboard.

--- a/context-network/decisions/0008-fellegi-sunter-splink-parity.md
+++ b/context-network/decisions/0008-fellegi-sunter-splink-parity.md
@@ -1,0 +1,40 @@
+# 0008 — Fellegi-Sunter: close the Splink engine gap, measure the scale-out, keep defaults reproducible
+
+**Status:** accepted (2026-06-08, Ben) • **Shipped:** PRs #800 / #802 / #803 • **Architecture:** [../architecture/fellegi-sunter-splink-parity.md](../architecture/fellegi-sunter-splink-parity.md)
+
+## Context
+The audit found GoldenMatch's Fellegi-Sunter matchkey accuracy-competitive with
+Splink (DBLP-ACM 0.968) but missing the *engine* around it: single-node only,
+retrains EM every run, no supervised-from-labels path, no FS-native
+explainability, score that isn't a probability. "Is it on par with Splink?" was
+the framing — and the honest answer was "the algorithm yes, the engine no."
+
+## Decision
+1. **Close the gap in dependency order, not all at once.** Lifecycle
+   (persistence + supervised m) → explainability (waterfall) → scale-out
+   (bucket, then native kernel) → calibration/accuracy-analysis. Each phase its
+   own PR with a measured gate.
+2. **Reuse the substrate, don't rebuild it.** FS scale-out rides the existing
+   `score_buckets` orchestration (which already carries the Ray/DataFusion
+   wiring) — the only greenfield low-level piece is one native kernel function.
+   The "scale-out is easy because the substrate exists" bet held.
+3. **Defaults stay reproducible; new power is opt-in.** Posterior calibration,
+   the native FS kernel (discrete-level float-boundary risk), and monotonicity
+   *enforce* are all opt-in; the default path is byte-stable. Don't relocate the
+   operating point or trade reproducibility for a benchmark number.
+4. **Measure the scale gate on a real runner, don't assert it from code.** The
+   distributed-FS claim is a `workflow_dispatch` bench, run on demand — and
+   running it is what surfaced the real bottleneck.
+
+## Consequence
+- FS feature parity with Splink is closed (lifecycle, supervised m,
+  explainability, calibration, accuracy analysis, scale-out); Splink retains the
+  distributed-1B+ and interactive-charting edge.
+- The scale gate paid for itself: it exposed that EM (`_sample_blocked_pairs`,
+  `O(Σ size_i²)`), not scoring, dominated the 6M wall. Fixing it cut native 6M
+  from 269 s → 162.6 s and halved peak RSS. Lesson reaffirmed: **measure the
+  whole pipeline at scale before claiming a stage is the bottleneck** — the
+  native kernel had already won scoring; the time was elsewhere.
+- A benchmark's *ground truth* is part of the measurement: the 6M F1 read 0.825
+  only because the bench scored against a star GT instead of the entity clique.
+  The matcher was right; the harness wasn't.

--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -13,7 +13,8 @@ links rather than reading everything.
 - [architecture/sql-native-extensions.md](architecture/sql-native-extensions.md) — graph + embedding UDFs on DuckDB/Postgres/DataFusion, native-direct (shared `graph-core` + `goldenembed-rs`); SHIPPED (#509).
 - [architecture/goldenflow-native-kernel.md](architecture/goldenflow-native-kernel.md) — GoldenFlow date/phone vectorized fast paths + the optional `goldenflow-native` phone kernel (NANP-only gated); SHIPPED (2026-06-07).
 - [architecture/goldencheck-native-kernel.md](architecture/goldencheck-native-kernel.md) — GoldenCheck's Arrow-native runtime (`goldencheck-native`) + deep-profiling expansion (Benford / composite-key / FD / fuzzy / approx-FD kernels, `--deep`, `refs`, freshness) + the `cell_quality` / `functional_dependencies` bridge APIs; SHIPPED (#793, 2026-06-07).
-- [architecture/goldencheck-goldenmatch-integration.md](architecture/goldencheck-goldenmatch-integration.md) — data quality feeds entity resolution: four fail-open, default-OFF doors (survivorship, blocking, FD negative-evidence, quality-gated review); #794/#795 shipped, #797/#798 open.
+- [architecture/goldencheck-goldenmatch-integration.md](architecture/goldencheck-goldenmatch-integration.md) — data quality feeds entity resolution: four fail-open, default-OFF doors (survivorship, blocking, FD negative-evidence, quality-gated review); #794/#795/#798 shipped, #797 open.
+- [architecture/fellegi-sunter-splink-parity.md](architecture/fellegi-sunter-splink-parity.md) — the `type: probabilistic` matchkey from scorer to Splink-class engine: model lifecycle, supervised m, match-weight waterfall, calibration, accuracy analysis, bucket/native scale-out + the EM-sampling perf fix it exposed; SHIPPED (#800/#802/#803, 2026-06-08).
 
 ## Decisions (records with no other home)
 - [decisions/0001-gate-reframe-engine-portability.md](decisions/0001-gate-reframe-engine-portability.md) — retire one-box RSS as the gate; engine portability is the destination.
@@ -23,6 +24,7 @@ links rather than reading everything.
 - [decisions/0005-sql-native-direct-udfs.md](decisions/0005-sql-native-direct-udfs.md) — SQL graph + embed UDFs go native-direct (drop the CPython bridge); shared `graph-core`, accept-both ids, embed wheel, 3 surfaces.
 - [decisions/0006-goldenflow-native-nanp-gating.md](decisions/0006-goldenflow-native-nanp-gating.md) — GoldenFlow: vectorize in Polars first; gate the native phone kernel to NANP-only (parity-safe by construction).
 - [decisions/0007-goldencheck-goldenmatch-integration.md](decisions/0007-goldencheck-goldenmatch-integration.md) — GoldenCheck→GoldenMatch: fail-open quality bridges, additive, default-OFF + benchmark-gated; hold the DQ↔ER boundary.
+- [decisions/0008-fellegi-sunter-splink-parity.md](decisions/0008-fellegi-sunter-splink-parity.md) — Fellegi-Sunter: close the Splink engine gap in dependency order, reuse the scale substrate, keep defaults reproducible (new power opt-in), measure the scale gate on a real runner.
 
 ## Processes (how work is done here)
 - [processes/development-workflow.md](processes/development-workflow.md) — spec → plan → execute → review → CI → merge, plus the hard environment constraints.

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,37 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-08 — Fellegi-Sunter → Splink parity (+ EM perf, scale-out, vendor reposition)
+- New architecture node + decision:
+  [../architecture/fellegi-sunter-splink-parity.md](../architecture/fellegi-sunter-splink-parity.md),
+  [../decisions/0008-fellegi-sunter-splink-parity.md](../decisions/0008-fellegi-sunter-splink-parity.md).
+- **The `type: probabilistic` (Fellegi-Sunter) matchkey went from accuracy-competitive
+  scorer to a Splink-class probabilistic-linkage engine** (PR #800, Phases 0–4 +
+  the 3c bench): model lifecycle (`save_json`/`load_json` + `model_path`),
+  supervised m from labels (`estimate_m_from_labels` + review/memory adapters),
+  match-weight waterfall (`explain_pair_fs`, surfaced in `explain`/lineage),
+  posterior calibration, label-driven threshold/accuracy analysis (`evaluate
+  --threshold-sweep`), and scale-out on the shared `score_buckets` path (Phase 3a)
+  + an opt-in native Rust kernel (Phase 3b, `GOLDENMATCH_FS_NATIVE=1`). The
+  scale-out bet held: only one greenfield kernel function; everything else reused
+  the existing bucket/Ray/DataFusion substrate.
+- **The scale gate exposed the real bottleneck.** The 6M FS bench was
+  `train_em`-bound, not scoring-bound (the native kernel had already cut
+  `bucket_score` to ~14 s). `_sample_blocked_pairs` enumerated every within-block
+  pair (`O(Σ size_i²)`, ~140M tuples) before sampling 10K; fixed to a
+  block-stratified early-exit (PR #803, 13.7× `train_em`, ~100 s off the 6M wall,
+  peak RSS halved). A separate fix corrected the *bench's* ground truth from a
+  star to the entity clique (PR #802) — F1 was 0.825 only because the harness was
+  scoring true matches as false; corrected to 1.000.
+- **Measured 6M / `bucket` / 16c-64GB:** numpy 288.5 s / native 162.6 s (was 269 s),
+  11.3 GB peak RSS, F1 1.000. Recorded in `docs/scale-envelope.md`.
+- Docs-site: `goldenmatch/scoring.mdx` FS section rewritten (parity surface +
+  scale + corrected DBLP-ACM 0.968, dropping the stale 57.6%-recall artifact);
+  `reference/vendor-comparison.mdx` Splink row repositioned (FS feature parity
+  closed; Splink retains distributed-1B+ and interactive-charting edge).
+- Also corrects the goldencheck-integration node: #798 (quality-gated review)
+  shipped.
+
 ## 2026-06-07 — GoldenCheck Arrow-native expansion + GoldenCheck→GoldenMatch integration
 - Two new architecture nodes + one decision:
   [../architecture/goldencheck-native-kernel.md](../architecture/goldencheck-native-kernel.md),

--- a/docs-site/goldenmatch/scoring.mdx
+++ b/docs-site/goldenmatch/scoring.mdx
@@ -112,7 +112,21 @@ Key details:
 - u-probabilities estimated from random pairs and fixed during EM (Splink approach)
 - Blocking fields must be excluded from training (always agree within blocks)
 - Comparison vectors apply field transforms before scoring
-- Achieves 98.8% precision, 57.6% recall on DBLP-ACM
+- **Achieves P=0.978 / R=0.958 / F1=0.968 on DBLP-ACM** (full-block vectorized scoring). The old "98.8% / 57.6%" figure was a benchmark artifact — a per-block size cap, not the scorer.
+
+### Splink-parity surface
+
+The Fellegi-Sunter matchkey is a full probabilistic-linkage engine, not just a scorer:
+
+- **Model lifecycle (train-once, reuse).** `EMResult.save_json` / `load_json` + `MatchkeyConfig.model_path` (or `dedupe_df(fs_model_path=...)`) train EM once and reuse the model — no retraining per run.
+- **Supervised m from labels.** `estimate_m_from_labels(df, mk, labels)` (Splink's `estimate_m_from_label_column`) estimates m directly from known matches; adapters pull labels straight from the review-queue / memory corrections store.
+- **Match-weight waterfall.** `explain_pair_fs` decomposes a pair into per-comparison `log2(m/u)` bits + prior + posterior, surfaced in `goldenmatch explain --pair` and the lineage sidecar.
+- **Calibration.** `GOLDENMATCH_FS_CALIBRATED=posterior` turns the score into a true match probability `1/(1+2^-(log2(λ/(1-λ)) + ΣW))`; `linear` (default) is monotonic in the summed weight.
+- **Accuracy analysis from labels.** `goldenmatch evaluate --threshold-sweep` emits the precision/recall/F1 operating-point curve, a recommended cut, `probability_two_random_records_match`, and the per-comparison m/u match-weight report.
+
+### Scale-out
+
+Probabilistic matchkeys ride the **`bucket`** backend's hash-bucketed parallel scorer (the same path that carries the Ray / DataFusion distribution wiring), so they scale single-node the same way weighted matchkeys do. Measured **6M-row dedupe on a 16c/64GB node: 162.6 s (native) / 288.5 s (numpy), 11.3 GB peak RSS, F1 1.000** on synthetic data with entity-clique ground truth. An opt-in Rust kernel (`GOLDENMATCH_FS_NATIVE=1`) is ~10.8× on the scoring step for tiny-block workloads. See [scale envelope](/concepts/scale-envelope).
 
 ## LLM scoring
 

--- a/docs-site/reference/vendor-comparison.mdx
+++ b/docs-site/reference/vendor-comparison.mdx
@@ -28,7 +28,7 @@ This page summarizes the entity-resolution landscape as recorded in the reposito
 
 | Engine | License | Where it beats GoldenMatch | Where GoldenMatch beats it |
 |--------|---------|----------------------------|----------------------------|
-| Splink (UK MoJ) | MIT | Throughput (1B+ rows); PII F1 on Febrl (0.998). | Non-PII accuracy (DBLP-ACM 0.964 vs 0.728); zero-config; polyglot; AI-native; PPRL. |
+| Splink (UK MoJ) | MIT | Distributed Fellegi-Sunter at 1B+ rows (Spark); PII F1 on Febrl (0.998); mature interactive m/u + comparison-viewer charts. | Non-PII accuracy (DBLP-ACM 0.964 vs 0.728); zero-config; polyglot; AI-native; PPRL. **FS feature parity closed:** GoldenMatch's `type: probabilistic` matchkey now has EM-trained m/u, supervised m from labels, model persistence, match-weight waterfall, posterior calibration, and label-driven threshold analysis — plus FS scale-out on the bucket/Ray path (measured 6M dedupe in 162.6 s / 11.3 GB single-node). |
 | dedupe.io | BSD | Cleanest active-learning UX in OSS. | Accuracy without labels; throughput at scale; polyglot; AI-native; PPRL. |
 | RecordLinkage Toolkit | BSD | DBLP-ACM F1 0.923 (narrowly). | Throughput, scale, PPRL, AI-native, zero-config, polyglot. |
 | Zingg | AGPL + commercial | Native Spark scale. | MIT license; polyglot; AI-native; zero-config; PPRL. |


### PR DESCRIPTION
Documents the Fellegi-Sunter → Splink-parity arc across the three surfaces.

**Context network**
- New architecture node `fellegi-sunter-splink-parity.md` (scorer → engine: lifecycle, supervised m, waterfall, calibration, accuracy analysis, bucket/native scale-out + the EM-sampling perf fix it exposed) and decision `0008` (close the gap in dependency order, reuse the scale substrate, keep defaults reproducible, measure the scale gate on a real runner).
- Linked from the discovery hub; logged in `meta/updates.md`. Also marks #798 (quality-gated review) shipped.

**Mintlify (`docs-site/`)**
- `goldenmatch/scoring.mdx`: FS section rewritten with the parity surface (model lifecycle, supervised m, match-weight waterfall, calibration, threshold/accuracy analysis) + scale-out numbers; **corrected DBLP-ACM to P=0.978/R=0.958/F1=0.968**, dropping the stale "98.8% / 57.6% recall" artifact.
- `reference/vendor-comparison.mdx`: Splink row repositioned — FS feature parity is closed (EM-trained m/u, supervised m, persistence, waterfall, posterior calibration, label-driven threshold analysis, bucket/Ray scale-out; 6M in 162.6s/11.3GB); Splink retains the distributed-1B+ and interactive-charting edge.

Doc-only change (context-network + docs-site). Mintlify validation runs in CI.

https://claude.ai/code/session_01DKPX87ExnkFXGrocGTjExp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKPX87ExnkFXGrocGTjExp)_