### PR TITLE
feat: unsupervised recall certificate (estimate + audit-calibrated safe bound; CLI/MCP/REST)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/api/server.py
+++ b/packages/python/goldenmatch/goldenmatch/api/server.py
@@ -16,6 +16,7 @@ Endpoints:
     POST /reviews/decide      Approve or reject a pair (steward action)
     POST /shatter             Break a cluster into singletons
     POST /unmerge             Pull a record out of its cluster
+    POST /certify-recall      Estimate match recall without ground truth
 """
 
 from __future__ import annotations
@@ -379,6 +380,25 @@ class MatchServer:
             return {"available": False, "source": None}
         return self._last_telemetry
 
+    def certify_recall(self) -> dict:
+        """Unsupervised recall estimate (no ground truth) over the loaded data,
+        via capture-recapture across the config's matchkeys/passes. Point
+        estimate; a safe lower bound needs a labelled audit (CLI --audit-out)."""
+        from goldenmatch.core.recall_certificate import certify_recall_df
+
+        df = getattr(self.engine, "data", None)
+        if df is None:
+            return {"error": "no data loaded"}
+        est = certify_recall_df(df, self.config)
+        return {
+            "estimated_recall": est.recall,
+            "n_systems": est.n_systems,
+            "found_pairs": est.found_pairs,
+            "system_overlap": round(est.mean_overlap, 3),
+            "estimable": est.estimable,
+            "note": est.note,
+        }
+
 
 # Global server instance
 _server_instance: MatchServer | None = None
@@ -539,6 +559,9 @@ class APIHandler(BaseHTTPRequestHandler):
                 threshold = float(data.get("threshold", 0.0))
                 result = _server_instance.unmerge_record_op(record_id, threshold)
                 self._json_response(result, 404 if "error" in result else 200)
+        elif path == "/certify-recall":
+            result = _server_instance.certify_recall()
+            self._json_response(result, 400 if "error" in result else 200)
         else:
             self._json_response({"error": "Not found"}, 404)
 

--- a/packages/python/goldenmatch/goldenmatch/cli/evaluate.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/evaluate.py
@@ -18,7 +18,7 @@ err_console = Console(stderr=True)
 def evaluate_cmd(
     files: list[str] = typer.Argument(..., help="Input files (path or path:source_name)"),
     config: Path = typer.Option(..., "--config", "-c", help="Config YAML path"),
-    ground_truth: Path = typer.Option(..., "--ground-truth", "--gt", help="Ground truth CSV path"),
+    ground_truth: Path | None = typer.Option(None, "--ground-truth", "--gt", help="Ground truth CSV path (required unless --certify)"),
     col_a: str = typer.Option("id_a", "--col-a", help="Ground truth column A"),
     col_b: str = typer.Option("id_b", "--col-b", help="Ground truth column B"),
     threshold: float | None = typer.Option(None, "--threshold", "-t", help="Override match threshold"),
@@ -27,6 +27,10 @@ def evaluate_cmd(
     min_precision: float | None = typer.Option(None, "--min-precision", help="Minimum precision (exit code 1 if below)"),
     min_recall: float | None = typer.Option(None, "--min-recall", help="Minimum recall (exit code 1 if below)"),
     threshold_sweep_flag: bool = typer.Option(False, "--threshold-sweep", help="Sweep the link threshold over scored pairs: P/R/F1 table + recommended cut (+ Fellegi-Sunter m/u model report when a probabilistic matchkey ran)."),
+    certify: bool = typer.Option(False, "--certify", help="Estimate recall WITHOUT ground truth (unsupervised, via capture-recapture over the config's matchkeys/passes; needs >=3)."),
+    audit_out: Path | None = typer.Option(None, "--audit-out", help="With --certify: emit a stratified audit sample CSV to label for a SAFE recall lower bound."),
+    audit_in: Path | None = typer.Option(None, "--audit-in", help="With --certify: read a labelled audit sample and print the audit-calibrated SAFE lower bound."),
+    audit_n: int = typer.Option(50, "--audit-n", help="Audit samples per stratum (default 50)."),
 ) -> None:
     """Evaluate matching quality against ground truth pairs.
 
@@ -36,12 +40,11 @@ def evaluate_cmd(
     Add --threshold-sweep for an operating-point curve over the scored pairs
     (which cut to use) plus, for Fellegi-Sunter matchkeys, the m/u match-weight
     model report.
+    With --certify, estimate recall WITHOUT ground truth (each matchkey/pass is
+    treated as a decorrelated system):
+    goldenmatch evaluate data.csv -c config.yaml --certify
     """
     from goldenmatch.core.pipeline import run_dedupe
-
-    if not ground_truth.exists():
-        err_console.print(f"[red]Ground truth file not found: {ground_truth}[/red]")
-        raise typer.Exit(1)
 
     cfg = load_config(str(config))
 
@@ -53,6 +56,15 @@ def evaluate_cmd(
 
     parsed = [_parse_file_source(f) for f in files]
     file_specs = _resolve_column_maps(parsed, cfg)
+
+    if certify or audit_in is not None:
+        _run_certify(file_specs, cfg, run_dedupe, output,
+                     audit_out=audit_out, audit_in=audit_in, audit_n=audit_n)
+        return
+
+    if ground_truth is None or not ground_truth.exists():
+        err_console.print("[red]Ground truth required (use --gt PATH) unless --certify is set.[/red]")
+        raise typer.Exit(1)
 
     gt_pairs = load_ground_truth_csv(str(ground_truth), col_a, col_b)
 
@@ -184,3 +196,204 @@ def _emit_threshold_sweep(scored_pairs, gt_pairs, em_results, cfg) -> dict:
     if fs_reports:
         payload["fs_model"] = fs_reports
     return payload
+def _build_systems(matchkeys) -> list[list]:
+    """K decorrelated systems from the config's matchkeys/passes; split a
+    multi-field matchkey into per-field systems when there are <3 matchkeys."""
+    systems: list[list] = [[mk] for mk in matchkeys]
+    if len(systems) < 3:
+        for mk in matchkeys:
+            flds = getattr(mk, "fields", None) or []
+            if len(flds) >= 3:
+                systems = [
+                    [mk.model_copy(update={"fields": [f], "name": f"{mk.name}__f{i}"})]
+                    for i, f in enumerate(flds)
+                ]
+                break
+    return systems
+
+
+def _system_pairsets(file_specs, cfg, systems, run_dedupe, relax: float = 1.0):
+    """Run each system; return its matched row-pair set. `relax` < 1 lowers each
+    matchkey threshold to surface sub-threshold candidates."""
+    from goldenmatch.core.recall_certificate import clusters_to_pairs
+    out = []
+    for sys_mks in systems:
+        if relax != 1.0:
+            sys_mks = [mk.model_copy(update={"threshold": (mk.threshold or 0.85) * relax})
+                       for mk in sys_mks]
+        sub_cfg = cfg.model_copy(update={"matchkeys": sys_mks})
+        res = run_dedupe(file_specs, sub_cfg)
+        out.append(clusters_to_pairs(res["clusters"]))
+    return out
+
+
+def _run_certify(file_specs, cfg, run_dedupe, output,
+                 audit_out=None, audit_in=None, audit_n: int = 50) -> None:
+    """Estimate recall WITHOUT ground truth (capture-recapture over decorrelated
+    systems). With --audit-out/--audit-in, additionally produce an audit-calibrated
+    SAFE lower bound from a small labelled sample of the sub-threshold stratum."""
+    from goldenmatch.core.recall_certificate import estimate_recall
+
+    if audit_in is not None:
+        _certify_ingest(audit_in)
+        return
+
+    matchkeys = cfg.get_matchkeys()
+    if not matchkeys:
+        err_console.print("[red]No matchkeys in config — cannot certify recall.[/red]")
+        raise typer.Exit(1)
+
+    systems = _build_systems(matchkeys)
+    console.print(
+        f"[bold]Estimating recall (unsupervised) from {len(systems)} decorrelated "
+        f"system(s)...[/bold]\n"
+    )
+    pairsets = _system_pairsets(file_specs, cfg, systems, run_dedupe)
+    est = estimate_recall(pairsets)
+
+    if audit_out is not None:
+        _emit_audit_sample(file_specs, cfg, run_dedupe, audit_out, audit_n)
+
+    table = Table(title="Recall Certificate (unsupervised)", show_header=True)
+    table.add_column("Metric", style="bold cyan")
+    table.add_column("Value", justify="right")
+    table.add_row("Systems (matchkeys)", str(est.n_systems))
+    table.add_row("Found pairs (union)", str(est.found_pairs))
+    table.add_row("System overlap", f"{est.mean_overlap:.2f}")
+    if est.recall is not None:
+        table.add_row("Estimated recall", f"{est.recall:.1%}")
+        table.add_row("Per-system capture p", f"{est.per_system_capture_prob:.2f}")
+    else:
+        table.add_row("Estimated recall", "n/a")
+    console.print(table)
+    console.print(f"\n[dim]{est.note}[/dim]")
+
+    if audit_out is not None:
+        console.print(
+            f"\n[bold]Audit sample written to {audit_out}[/bold] — label the "
+            f"`is_match` column (1/0), then run:\n  goldenmatch evaluate ... "
+            f"--certify --audit-in {audit_out}"
+        )
+
+    if output:
+        import json
+        output.write_text(json.dumps({
+            "estimated_recall": est.recall, "n_systems": est.n_systems,
+            "found_pairs": est.found_pairs, "mean_overlap": est.mean_overlap,
+            "per_system_capture_prob": est.per_system_capture_prob,
+            "capture_histogram": est.capture_histogram, "estimable": est.estimable,
+            "note": est.note,
+        }, indent=2))
+        console.print(f"\n[green]Results saved to {output}[/green]")
+
+
+def _row_count(file_specs) -> int:
+    import polars as pl
+    total = 0
+    for spec in file_specs:
+        path = spec[0]
+        try:
+            total += pl.scan_csv(path, encoding="utf8-lossy", ignore_errors=True
+                                 ).select(pl.len()).collect().item()
+        except Exception:
+            pass
+    return total
+
+
+def _emit_audit_sample(file_specs, cfg, run_dedupe, out_path, n) -> None:
+    """Emit a stratified audit sample for the steward to label. Stratum A = the
+    FULL-config matched pairs (the high-precision set being certified); B =
+    sub-threshold candidates (relaxed-threshold matches minus strict); C =
+    no-feature pairs (blocking-completeness check)."""
+    import csv
+    import json
+    import random
+
+    from goldenmatch.core.recall_certificate import clusters_to_pairs
+
+    rng = random.Random(0)
+    union = clusters_to_pairs(run_dedupe(file_specs, cfg)["clusters"])
+    relaxed_mks = [mk.model_copy(update={"threshold": (mk.threshold or 0.85) * 0.6})
+                   for mk in cfg.get_matchkeys()]
+    relaxed_cfg = cfg.model_copy(update={"matchkeys": relaxed_mks})
+    relaxed_union = clusters_to_pairs(run_dedupe(file_specs, relaxed_cfg)["clusters"])
+    sub = relaxed_union - union
+
+    n_rows = _row_count(file_specs)
+
+    def _sample(pool, k):
+        pool = list(pool)
+        rng.shuffle(pool)
+        return pool[:k]
+
+    rows = [("A", a, b) for (a, b) in _sample(union, n)]
+    rows += [("B", a, b) for (a, b) in _sample(sub, n)]
+    # stratum C: random row pairs that no system (even relaxed) proposed
+    seen = union | relaxed_union
+    c, tries = [], 0
+    while len(c) < n and tries < n * 100 and n_rows > 1:
+        i, j = rng.randrange(n_rows), rng.randrange(n_rows)
+        tries += 1
+        if i == j:
+            continue
+        pr = (i, j) if i < j else (j, i)
+        if pr in seen:
+            continue
+        c.append(pr)
+    rows += [("C", a, b) for (a, b) in c]
+
+    with open(out_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["stratum", "row_a", "row_b", "is_match"])
+        for stratum, a, b in rows:
+            w.writerow([stratum, a, b, ""])
+    meta = {"a_size": len(union), "b_size": len(sub)}
+    with open(str(out_path) + ".meta.json", "w") as f:
+        json.dump(meta, f)
+
+
+def _certify_ingest(in_path) -> None:
+    """Read a labelled audit sample + sizes meta, compute the safe lower bound."""
+    import csv
+    import json
+
+    from goldenmatch.core.recall_certificate import audit_calibrated_bound
+
+    meta_path = str(in_path) + ".meta.json"
+    try:
+        meta = json.load(open(meta_path))
+    except FileNotFoundError:
+        err_console.print(f"[red]Missing sizes file {meta_path} (emit with --audit-out first).[/red]")
+        raise typer.Exit(1)
+
+    tally = {"A": [0, 0], "B": [0, 0], "C": [0, 0]}  # [true, n]
+    with open(in_path, newline="") as f:
+        for row in csv.DictReader(f):
+            s = (row.get("stratum") or "").strip().upper()
+            lab = (row.get("is_match") or "").strip()
+            if s not in tally or lab == "":
+                continue
+            tally[s][1] += 1
+            if lab in ("1", "true", "yes", "y", "True"):
+                tally[s][0] += 1
+
+    cert = audit_calibrated_bound(
+        found_size=meta["a_size"], sub_size=meta["b_size"],
+        a_true=tally["A"][0], a_n=tally["A"][1],
+        b_true=tally["B"][0], b_n=tally["B"][1],
+        c_true=tally["C"][0], c_n=tally["C"][1] or None,
+    )
+    table = Table(title="Recall Certificate (audit-calibrated)", show_header=True)
+    table.add_column("Metric", style="bold cyan")
+    table.add_column("Value", justify="right")
+    table.add_row("Matched pairs |A|", str(cert.found_pairs))
+    table.add_row("Sub-threshold |B|", str(cert.candidate_pairs))
+    table.add_row("Audit labels used", str(cert.audit_labels))
+    if cert.recall is not None:
+        table.add_row("Estimated recall", f"{cert.recall:.1%}")
+        table.add_row("SAFE lower bound", f"{cert.recall_lower:.1%}")
+        table.add_row("Upper bound", f"{cert.recall_upper:.1%}")
+    if cert.blocking_complete is not None:
+        table.add_row("Blocking complete", "yes" if cert.blocking_complete else "NO (unsafe)")
+    console.print(table)
+    console.print(f"\n[dim]{cert.note}[/dim]")

--- a/packages/python/goldenmatch/goldenmatch/core/recall_certificate.py
+++ b/packages/python/goldenmatch/goldenmatch/core/recall_certificate.py
@@ -1,0 +1,226 @@
+"""Unsupervised recall estimation for a multi-matchkey run (no ground truth).
+
+In production you can estimate PRECISION cheaply (sample matches, check them) but
+RECALL is normally unknowable without labels -- you can't sample the true matches
+you didn't find. This estimates the recall of a multi-matchkey / multi-pass run
+WITHOUT ground truth, via capture-recapture (the dual-system math used for census
+undercount): each matchkey/pass is treated as a decorrelated "system"; the
+overlap structure of which systems matched each pair estimates how many true
+pairs every system missed -> the recall of the run's union.
+
+This is a POINT estimate. A trustworthy *lower bound* additionally needs a small
+labelled audit of the sub-threshold candidate stratum (see the recall-assurance
+research notes); it cannot be obtained from the capture data alone because the
+pairs no system ever proposes are fundamentally invisible.
+
+Method + assumptions (validated in scripts/research/, incl. on real GoldenMatch
+output -- RESULTS-phase0-goldenmatch.md):
+  * >= 3 decorrelated systems (multi_pass blocking and/or multiple matchkeys).
+  * FALSE POSITIVES are ~all singletons: a spurious match by one system is rarely
+    reproduced by an independent one, so the multi-capture cells f_k (k>=2) are
+    ~FP-free. We fit the true-pair capture model from those cells and IGNORE the
+    FP-contaminated singleton cell (naive Chao2 on the raw union is wrecked by FP
+    singletons; this fix is what makes it work at scale).
+  * Homogeneous capture probability across true pairs. Under the binomial capture
+    model, recall of the union = 1 - (1-p)^K, with p fit from the slope of
+    log f_k - log C(K,k) over k>=2. Heterogeneity makes the estimate mildly
+    optimistic (flagged via the overlap diagnostic).
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+Pair = tuple[int, int]
+
+
+@dataclass
+class RecallEstimate:
+    """Result of an unsupervised recall estimate. `recall` is None when the
+    capture structure can't support an estimate (see `note`)."""
+    recall: float | None
+    n_systems: int
+    found_pairs: int
+    per_system_capture_prob: float          # fitted p (per-system capture prob)
+    mean_overlap: float                     # decorrelation diagnostic in [0,1]
+    capture_histogram: dict[int, int] = field(default_factory=dict)
+    estimable: bool = False
+    note: str = ""
+
+
+def _fit_capture_prob(counts: dict[Pair, int], K: int) -> float | None:
+    """Fit p from the FP-free higher-order cells: regress log f_k - log C(K,k)
+    on k for k>=2; slope = logit(p). Returns None if <2 usable cells."""
+    ck = {k: 0 for k in range(1, K + 1)}
+    for v in counts.values():
+        if 1 <= v <= K:
+            ck[v] += 1
+    pts = [(k, ck[k]) for k in range(2, K + 1) if ck[k] > 0]
+    if len(pts) < 2:
+        return None
+    xs = [float(k) for k, _ in pts]
+    ys = [math.log(c) - math.log(math.comb(K, k)) for k, c in pts]
+    n = len(xs)
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    sxx = sum((x - mx) ** 2 for x in xs)
+    if sxx == 0:
+        return None
+    b = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / sxx
+    return 1.0 / (1.0 + math.exp(-b))
+
+
+def estimate_recall(pairsets: list[set[Pair]]) -> RecallEstimate:
+    """Estimate the recall of the UNION of `pairsets`, where each set is the
+    matches found by one decorrelated system (matchkey/pass). No labels needed.
+
+    Returns a `RecallEstimate`; `.recall is None` (with an explanatory `.note`)
+    when there are too few decorrelated systems or too few multi-captured pairs
+    to support an estimate.
+    """
+    K = len(pairsets)
+    union: set[Pair] = set().union(*pairsets) if pairsets else set()
+    counts: dict[Pair, int] = {}
+    for ps in pairsets:
+        for p in ps:
+            counts[p] = counts.get(p, 0) + 1
+    hist = {k: sum(1 for v in counts.values() if v == k) for k in range(1, K + 1)}
+
+    overlaps: list[float] = []
+    for a in range(K):
+        for b in range(a + 1, K):
+            A, B = pairsets[a], pairsets[b]
+            if A or B:
+                overlaps.append(len(A & B) / len(A | B))
+    mean_overlap = sum(overlaps) / len(overlaps) if overlaps else 0.0
+
+    if K < 3:
+        return RecallEstimate(
+            None, K, len(union), 0.0, mean_overlap, hist, False,
+            "need >=3 decorrelated systems (enable multi_pass blocking or use "
+            ">=3 matchkeys) to estimate recall",
+        )
+    p = _fit_capture_prob(counts, K)
+    if p is None or not (0.0 < p < 1.0):
+        return RecallEstimate(
+            None, K, len(union), p or 0.0, mean_overlap, hist, False,
+            "too few multi-captured pairs to estimate (systems too correlated, "
+            "or too few matches)",
+        )
+    recall = 1.0 - (1.0 - p) ** K
+    note = ("point estimate (no labels); a trustworthy lower bound needs a small "
+            "labelled audit")
+    if mean_overlap > 0.85:
+        note += "; WARNING: high system overlap -> systems correlated, estimate may be optimistic"
+    return RecallEstimate(recall, K, len(union), p, mean_overlap, hist, True, note)
+
+
+def wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion k/n."""
+    if n == 0:
+        return 0.0, 1.0
+    p = k / n
+    d = 1.0 + z * z / n
+    centre = (p + z * z / (2 * n)) / d
+    half = (z * ((p * (1 - p) / n + z * z / (4 * n * n)) ** 0.5)) / d
+    return max(0.0, centre - half), min(1.0, centre + half)
+
+
+@dataclass
+class RecallCertificate:
+    """Audit-calibrated recall certificate. `recall_lower` is a SAFE lower bound
+    (conditional on blocking completeness — that true matches share >=1 feature,
+    i.e. appear as a candidate in some system). A capture-data-only safe bound is
+    impossible (the invisible-to-every-system tail is unbounded); the audit
+    measures the miss mass directly instead."""
+    recall: float | None
+    recall_lower: float | None      # the safety bound
+    recall_upper: float | None
+    found_pairs: int                # |stratum A| (matched union)
+    candidate_pairs: int            # |stratum B| (sub-threshold candidates)
+    audit_labels: int
+    blocking_complete: bool | None  # stratum-C check (None = not run)
+    note: str = ""
+
+
+def audit_calibrated_bound(
+    found_size: int, sub_size: int,
+    a_true: int, a_n: int,          # audit of stratum A (matched): true count / sampled
+    b_true: int, b_n: int,          # audit of stratum B (sub-threshold): true / sampled
+    c_true: int | None = None, c_n: int | None = None,  # stratum C (no-feature) check
+) -> RecallCertificate:
+    """Compute a SAFE recall lower bound from stratified audit counts.
+
+    recall = found / (found + missed), where found = precision(A)*|A| and
+    missed = true_rate(B)*|B|. The safe bound under-counts found (Wilson-lower on
+    A) and over-counts missed (Wilson-upper on B). Stratum C (pairs sharing no
+    feature) is assumed non-matching under blocking completeness; if audited
+    (c_n given) and any are true, the assumption is flagged violated.
+    """
+    pA, pA_lo, pA_hi = (a_true / a_n if a_n else 0.0, *wilson_ci(a_true, a_n))
+    pB, pB_lo, pB_hi = (b_true / b_n if b_n else 0.0, *wilson_ci(b_true, b_n))
+
+    def _rec(found, missed):
+        return found / (found + missed) if (found + missed) > 0 else None
+
+    recall = _rec(pA * found_size, pB * sub_size)
+    recall_lo = _rec(pA_lo * found_size, pB_hi * sub_size)      # conservative
+    recall_hi = _rec(pA_hi * found_size, pB_lo * sub_size)      # optimistic
+    blocking_complete = None if c_n is None else (c_true == 0)
+    note = ("safe lower bound under blocking completeness; tightens with more "
+            "audit labels")
+    if blocking_complete is False:
+        note += "; WARNING: blocking-completeness check FAILED (true pairs share no feature) -> bound NOT safe"
+    return RecallCertificate(recall, recall_lo, recall_hi, found_size, sub_size,
+                             a_n + b_n + (c_n or 0), blocking_complete, note)
+
+
+def build_decorrelated_systems(matchkeys) -> list[list]:
+    """K decorrelated systems from a config's matchkeys/passes. If <3 matchkeys,
+    split a multi-field matchkey into per-field systems (each field a pass)."""
+    systems: list[list] = [[mk] for mk in matchkeys]
+    if len(systems) < 3:
+        for mk in matchkeys:
+            flds = getattr(mk, "fields", None) or []
+            if len(flds) >= 3:
+                systems = [
+                    [mk.model_copy(update={"fields": [f], "name": f"{mk.name}__f{i}"})]
+                    for i, f in enumerate(flds)
+                ]
+                break
+    return systems
+
+
+def certify_recall_df(df, config=None) -> RecallEstimate:
+    """Unsupervised recall estimate for a DataFrame (no ground truth). Runs each
+    matchkey/pass as a decorrelated system through the real pipeline and applies
+    the FP-aware capture-recapture estimator. Used by the CLI, MCP tool, and REST
+    endpoint. Lazy imports keep core import-light and avoid pipeline cycles."""
+    from goldenmatch._api import dedupe_df
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    if config is None:
+        config = auto_configure_df(df, confidence_required=False)
+    systems = build_decorrelated_systems(config.get_matchkeys())
+    pairsets: list[set[Pair]] = []
+    for sys_mks in systems:
+        sub = config.model_copy(update={"matchkeys": sys_mks})
+        res = dedupe_df(df, config=sub)
+        clusters = getattr(res, "clusters", None)
+        if clusters is None and isinstance(res, dict):
+            clusters = res.get("clusters")
+        pairsets.append(clusters_to_pairs(clusters or {}))
+    return estimate_recall(pairsets)
+
+
+def clusters_to_pairs(clusters) -> set[Pair]:
+    """Convert a dedupe `clusters` dict (cluster -> {'members': [row_id,...]}) to
+    the set of within-cluster (row_id, row_id) pairs."""
+    out: set[Pair] = set()
+    for cl in (clusters or {}).values():
+        members = cl.get("members", []) if isinstance(cl, dict) else getattr(cl, "members", [])
+        ms = sorted(int(m) for m in members)
+        for i in range(len(ms)):
+            for j in range(i + 1, len(ms)):
+                out.add((ms[i], ms[j]))
+    return out

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -361,6 +361,24 @@ AGENT_TOOLS = [
             "required": ["base_file", "new_records"],
         },
     ),
+    Tool(
+        name="certify_recall",
+        description=(
+            "Estimate match RECALL without ground truth (unsupervised). Treats "
+            "each auto-configured matchkey/pass as a decorrelated system and uses "
+            "capture-recapture over their overlaps to estimate how many true "
+            "matches were missed. Returns a point estimate (a safe lower bound "
+            "additionally needs a small labelled audit; see `goldenmatch evaluate "
+            "--certify --audit-out`). Needs >=3 decorrelated systems."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string", "description": "Dataset to dedupe + certify"},
+            },
+            "required": ["file_path"],
+        },
+    ),
 ]
 
 _AGENT_TOOL_NAMES = frozenset(t.name for t in AGENT_TOOLS)
@@ -784,5 +802,27 @@ def _dispatch(
             cfg,
             threshold=args.get("threshold"),
         )
+
+    if name == "certify_recall":
+        import polars as pl
+
+        from goldenmatch.core.recall_certificate import certify_recall_df
+
+        file_path = args["file_path"]
+        try:
+            df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
+        except FileNotFoundError:
+            return {"error": f"File not found: {file_path}"}
+        except Exception as exc:
+            return {"error": f"Could not read CSV '{file_path}': {exc}"}
+        est = certify_recall_df(df)
+        return {
+            "estimated_recall": est.recall,
+            "n_systems": est.n_systems,
+            "found_pairs": est.found_pairs,
+            "system_overlap": round(est.mean_overlap, 3),
+            "estimable": est.estimable,
+            "note": est.note,
+        }
 
     return {"error": f"Unknown agent tool: {name}"}

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1601,7 +1601,7 @@ async def run_server_http(
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenMatch",
-            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 54 MCP tools for matching, explaining, reviewing, evaluating, blocking analysis, lineage, data quality, transforms, identity graph, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
+            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 55 MCP tools for matching, explaining, reviewing, evaluating, blocking analysis, lineage, data quality, transforms, identity graph, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
             "homepage": "https://github.com/benseverndev-oss/goldenmatch",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -16,17 +16,17 @@ import pytest
 # ── Registration ──────────────────────────────────────────────────────────────
 
 
-def test_total_tool_count_is_54():
+def test_total_tool_count_is_55():
     from goldenmatch.mcp.agent_tools import AGENT_TOOLS
     from goldenmatch.mcp.identity_tools import IDENTITY_TOOLS
     from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
     from goldenmatch.mcp.server import _BASE_TOOLS, TOOLS
 
-    assert len(AGENT_TOOLS) == 16
+    assert len(AGENT_TOOLS) == 17   # +1 certify_recall
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 7
     assert len(_BASE_TOOLS) == 24
-    assert len(TOOLS) == 54
+    assert len(TOOLS) == 55
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/packages/python/goldenmatch/tests/test_recall_certificate.py
+++ b/packages/python/goldenmatch/tests/test_recall_certificate.py
@@ -1,0 +1,95 @@
+"""Unit tests for unsupervised recall estimation (core/recall_certificate.py)."""
+from __future__ import annotations
+
+from goldenmatch.core.recall_certificate import (
+    audit_calibrated_bound,
+    clusters_to_pairs,
+    estimate_recall,
+    wilson_ci,
+)
+
+
+def _build(K: int, spec: dict[int, int]) -> list[set]:
+    """Build K system pairsets with `spec[k]` pairs captured by exactly k systems.
+    (Which systems doesn't affect the recall fit, only the overlap diagnostic.)"""
+    sets: list[set] = [set() for _ in range(K)]
+    pid = 0
+    for k, n in spec.items():
+        for _ in range(n):
+            pair = (pid, pid + 1)
+            pid += 2
+            for s in range(k):
+                sets[s].add(pair)
+    return sets
+
+
+def test_needs_three_systems():
+    est = estimate_recall(_build(2, {1: 50, 2: 50}))
+    assert est.recall is None
+    assert not est.estimable
+    assert ">=3" in est.note
+
+
+def test_recovers_known_recall():
+    # capture counts ~ Binomial(K=4, p=0.6) * 1000 -> recall = 1-(1-0.6)^4 ~= 0.974
+    est = estimate_recall(_build(4, {1: 154, 2: 346, 3: 346, 4: 130}))
+    assert est.estimable
+    assert est.recall is not None
+    assert abs(est.recall - 0.974) < 0.05
+    assert 0.5 < est.per_system_capture_prob < 0.7
+
+
+def test_fp_robust_ignores_singleton_cell():
+    # The singleton cell is FP-contaminated; flooding it must not move the estimate
+    # (the estimator fits from k>=2 only).
+    base = estimate_recall(_build(4, {2: 346, 3: 346, 4: 130})).recall
+    flooded = estimate_recall(_build(4, {1: 20000, 2: 346, 3: 346, 4: 130})).recall
+    assert base is not None and flooded is not None
+    assert abs(base - flooded) < 0.03
+
+
+def test_too_few_multicaptured_not_estimable():
+    # all singletons -> no k>=2 cells -> cannot estimate
+    est = estimate_recall(_build(3, {1: 100}))
+    assert est.recall is None
+    assert not est.estimable
+
+
+def test_clusters_to_pairs():
+    clusters = {0: {"members": [3, 1, 2]}, 1: {"members": [5]}}
+    assert clusters_to_pairs(clusters) == {(1, 2), (1, 3), (2, 3)}
+
+
+def test_wilson_ci_brackets_proportion():
+    lo, hi = wilson_ci(45, 50)
+    assert lo < 0.9 < hi
+    assert 0.0 <= lo <= hi <= 1.0
+    assert wilson_ci(0, 0) == (0.0, 1.0)
+
+
+def test_audit_bound_is_safe_and_ordered():
+    # 1000 matched (all true, audited 50/50), 2000 sub-threshold candidates with
+    # ~10% true (audited 5/50). true found=1000, missed=200 -> true recall ~0.833.
+    cert = audit_calibrated_bound(
+        found_size=1000, sub_size=2000,
+        a_true=50, a_n=50,        # precision ~1.0
+        b_true=5, b_n=50,         # miss rate ~0.10
+        c_true=0, c_n=50,         # blocking-completeness check passes
+    )
+    assert cert.recall_lower <= cert.recall <= cert.recall_upper
+    assert cert.recall_lower <= 0.833 + 1e-9          # SAFE: bound at/below truth
+    assert abs(cert.recall - 0.833) < 0.05            # point estimate close
+    assert cert.blocking_complete is True
+
+
+def test_audit_bound_flags_blocking_violation():
+    cert = audit_calibrated_bound(1000, 2000, 50, 50, 5, 50, c_true=3, c_n=50)
+    assert cert.blocking_complete is False
+    assert "NOT safe" in cert.note
+
+
+def test_audit_bound_tightens_with_more_labels():
+    # same true rates, more labels in B -> tighter (higher) safe lower bound
+    loose = audit_calibrated_bound(1000, 2000, 50, 50, 5, 50).recall_lower
+    tight = audit_calibrated_bound(1000, 2000, 600, 600, 60, 600).recall_lower
+    assert tight > loose

--- a/packages/python/goldenmatch/tests/test_recall_surfaces.py
+++ b/packages/python/goldenmatch/tests/test_recall_surfaces.py
@@ -1,0 +1,78 @@
+"""MCP tool + REST endpoint surfaces for unsupervised recall estimation."""
+from __future__ import annotations
+
+import random
+
+import polars as pl
+import pytest
+
+
+def _dupe_df(n_entities: int = 40) -> pl.DataFrame:
+    rng = random.Random(7)
+    fn = ["jonathan", "margaret", "robert", "elizabeth", "william", "patricia",
+          "michael", "jennifer", "charles", "barbara"]
+    ln = ["anderson", "richardson", "williams", "thompson", "martinez", "clark"]
+    st = ["maple ave", "oak st", "cedar ln", "pine rd", "elm blvd", "main st"]
+    rows = []
+    rid = 0
+    for _ in range(n_entities):
+        g, s, a = rng.choice(fn), rng.choice(ln), rng.choice(st)
+        for _ in range(rng.randint(1, 3)):
+            gg = g if rng.random() < 0.5 else g[:-1]
+            rows.append({"id": rid, "given": gg, "surname": s, "street": a})
+            rid += 1
+    return pl.DataFrame(rows)
+
+
+def test_mcp_certify_recall_tool_present():
+    from goldenmatch.mcp.agent_tools import AGENT_TOOLS
+    names = {t.name for t in AGENT_TOOLS}
+    assert "certify_recall" in names
+
+
+def test_mcp_certify_recall_dispatch(tmp_path):
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    csv = tmp_path / "data.csv"
+    _dupe_df().write_csv(csv)
+    out = _dispatch("certify_recall", {"file_path": str(csv)}, object)
+    assert set(out) >= {"estimated_recall", "n_systems", "found_pairs",
+                        "system_overlap", "estimable", "note"}
+    assert out["n_systems"] >= 3
+    assert out["estimable"] is True
+    assert 0.0 <= out["estimated_recall"] <= 1.0
+
+
+def test_mcp_certify_recall_missing_file():
+    from goldenmatch.mcp.agent_tools import _dispatch
+    out = _dispatch("certify_recall", {"file_path": "/no/such/file.csv"}, object)
+    assert "error" in out
+
+
+def test_rest_certify_recall_method():
+    from goldenmatch.api.server import MatchServer
+
+    df = _dupe_df()
+    cfg = __import__("goldenmatch").auto_configure_df(df, confidence_required=False)
+    for mk in cfg.get_matchkeys():
+        if getattr(mk, "rerank", False):
+            mk.rerank = False
+
+    class _StubEngine:
+        def __init__(self, data):
+            self.data = data
+
+    out = MatchServer(_StubEngine(df), cfg).certify_recall()
+    assert out["estimable"] is True
+    assert out["n_systems"] >= 3
+    assert 0.0 <= out["estimated_recall"] <= 1.0
+
+
+def test_rest_certify_recall_no_data():
+    from goldenmatch.api.server import MatchServer
+
+    class _Empty:
+        data = None
+
+    out = MatchServer(_Empty(), None).certify_recall()
+    assert "error" in out


### PR DESCRIPTION
Clean, mergeable carve-out of the one validated, shippable capability from the research branch (PR #801). Branched fresh from `main`; 8 files, no `scripts/research/` or docs churn.

## What it does

Estimate ER **recall without ground truth**, plus an **audit-calibrated safe lower bound**. In production, precision is cheap to estimate (sample matches, check them) but recall is normally unknowable - you can't sample the true matches you didn't find. This fills that gap.

**Method.** Each matchkey/pass is treated as a decorrelated "system"; capture-recapture (the census-undercount dual-system math) over their overlaps estimates how many true pairs every system missed. The estimator is **FP-aware**: false positives are ~all singletons, so it fits the true-pair model from the FP-free higher-order capture cells and ignores the contaminated singleton cell (naive Chao2 on the raw union is wrecked by FP singletons). The safe lower bound is **audit-calibrated** - a small stratified labelled sample directly measures the miss mass, because a capture-data-only bound is impossible (the invisible-to-every-system tail is unbounded).

## Surfaces

- `core/recall_certificate.py` - pure estimator + safe bound + df orchestration (`estimate_recall`, `audit_calibrated_bound`, `wilson_ci`, `certify_recall_df`).
- **CLI** `goldenmatch evaluate --certify` (label-free point estimate); `--audit-out` / `--audit-in` (emit a stratified audit sample, label it, get the SAFE lower bound). `--gt` is now optional.
- **MCP tool** `certify_recall` and **REST** `POST /certify-recall` - same estimate over loaded data.

## Tests

- 14 new unit tests (`test_recall_certificate.py`, `test_recall_surfaces.py`) incl. the safety property (`recall_lower <= true`), FP-robustness (flooding the singleton cell doesn't move the estimate), and the MCP/REST surfaces.
- Tool count bumped 54 -> 55 (`test_total_tool_count`).
- Regression-checked: 133 tests pass across REST + MCP + cert + evaluate on the source branch; on this rebased branch the affected suites (incl. `main`'s `--threshold-sweep` evaluate tests, which merged cleanly alongside `--certify`) pass.

## Validation

On **real GoldenMatch pipeline output** (full Febrl3, N=5000): the FP-aware estimate tracks true recall within 0.002-0.012, including a genuine sub-1.0 case (true 0.928 -> estimate 0.941). The audit-calibrated bound is safe across configs where the naive bound was optimistic.

## Scope / deferred

- Point estimate is computed via per-matchkey runs today; single-run provenance (tagging the matchkey id into `EngineResult.scored_pairs`) is a perf optimization deferred behind a measured need.
- Auto-emitting the estimate inside the controller costs K extra runs, so it's left as an on-demand signal (CLI/MCP/REST), not on the default `auto_configure` path.

The exploratory research arc this came from (amortized Bayesian ER, topology/landscape - documented negative/partial results) stays on PR #801.

https://claude.ai/code/session_01F32CKbirGCqkGiTMU3KQv7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F32CKbirGCqkGiTMU3KQv7)_