### PR TITLE
docs(goldenanalysis): design spec + Phase 1 plan for a cross-cutting analysis engine

### DIFF
--- a/docs/superpowers/plans/2026-06-08-goldenanalysis-phase1-python-core.md
+++ b/docs/superpowers/plans/2026-06-08-goldenanalysis-phase1-python-core.md
@@ -17,12 +17,12 @@
 ## Pre-flight requirements
 
 - `uv` installed; repo synced once (`uv sync` at repo root succeeds on `main`).
-- Working tree on the development branch `claude/goldencheck-rust-expansion-NmjWl`.
+- Working tree on a **fresh** development branch `feat/goldenanalysis-phase1-python-core`, cut from `main` (NOT the design branch, and NOT the merged `claude/goldencheck-rust-expansion-NmjWl` — that was #801).
 - `cargo`/`node` NOT required this phase.
 
 ## Conventions
 
-- All commands run from the **repo root** (`/home/user/goldenmatch`) unless stated. Note the CLAUDE.md gotcha: CI CWD = repo root, local CWD may = package dir. **Anchor every fixture path to `__file__`**, never a bare relative path.
+- All commands run from the **repo root** (the dir holding the top-level `pyproject.toml`; on the dev box this is `D:\show_case\goldenmatch`, on CI it's the checkout root) unless stated. Note the CLAUDE.md gotcha: CI CWD = repo root, local CWD may = package dir. **Anchor every fixture path to `__file__`**, never a bare relative path.
 - "Run red" = the new test fails for the expected reason (assertion/ImportError), not a collection error elsewhere.
 - "Run green" = `uv run pytest packages/python/goldenanalysis -x -q` passes.
 - Tests must be self-contained for `pytest -n auto` worker isolation: register analyzers/transforms **inside** the test that asserts on them; never rely on import-time global registration leaking across workers.
@@ -276,17 +276,24 @@ uv run goldenanalysis report packages/python/goldenanalysis/tests/fixtures/custo
 
 Expected: all tests pass, ruff clean, CLI prints a markdown report.
 
-- [ ] **Step 2:** Verify zero-dep claim — in a throwaway venv with ONLY `goldenanalysis` core installed (no goldenmatch/check/flow/pipe), `ga.analyze(df, ["frame.summary"])` works.
+- [ ] **Step 2:** Verify zero-dep claim — in a throwaway venv with ONLY `goldenanalysis` core installed (no goldenmatch/check/flow/pipe), `ga.analyze(df, ["frame.summary"])` works. (Windows venv scripts live under `Scripts\`, not `bin/`.)
 
 ```bash
+# POSIX
 python -m venv /tmp/ga-clean && /tmp/ga-clean/bin/pip install -q packages/python/goldenanalysis
 /tmp/ga-clean/bin/python -c "import polars as pl, goldenanalysis as ga; print(ga.analyze(pl.DataFrame({'a':[1,1,None]}), ['frame.summary']).metrics[0])"
+```
+
+```powershell
+# Windows (PowerShell)
+python -m venv $env:TEMP\ga-clean; & "$env:TEMP\ga-clean\Scripts\pip.exe" install -q packages/python/goldenanalysis
+& "$env:TEMP\ga-clean\Scripts\python.exe" -c "import polars as pl, goldenanalysis as ga; print(ga.analyze(pl.DataFrame({'a':[1,1,None]}), ['frame.summary']).metrics[0])"
 ```
 
 - [ ] **Step 3: Push** the branch (retry with backoff per repo git policy):
 
 ```bash
-for i in 1 2 3 4; do git push -u origin claude/goldencheck-rust-expansion-NmjWl && break || sleep $((2**i)); done
+for i in 1 2 3 4; do git push -u origin feat/goldenanalysis-phase1-python-core && break || sleep $((2**i)); done
 ```
 
 ---

--- a/docs/superpowers/plans/2026-06-08-goldenanalysis-phase1-python-core.md
+++ b/docs/superpowers/plans/2026-06-08-goldenanalysis-phase1-python-core.md
@@ -1,0 +1,312 @@
+# GoldenAnalysis Phase 1 — Python Core Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking. Each task is TDD-shaped: write the failing test, run it red, write the minimal implementation, run it green, commit.
+
+**Goal:** Ship `goldenanalysis 0.1.0` — the Python core of the cross-cutting analysis engine. The generic frame path (`ga.analyze(df, analyzers=["frame.summary"])`) works end to end with zero other suite packages installed, produces an `AnalysisReport` that round-trips JSON/Markdown/Parquet, and is reachable from a `goldenanalysis` CLI. The package is uv-workspace-registered and runs real pytest in the CI Python matrix.
+
+**Architecture:** Pure-Python/Polars throughout (no Rust this phase — the native loader is a stub that always falls back). One analyzer (`frame.summary`), one adapter (`frame`), the model layer, a registry keyed on the `goldenanalysis.analyzers` entry-point, report exporters, and a Typer CLI. Layout mirrors `packages/python/goldenpipe`.
+
+**Tech Stack:** Python ≥3.11, polars, pydantic v2, typer, rich, pyarrow (for Parquet), hatchling, uv workspace, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md` (Appendix A = metric catalog, Appendix B = the exact `frame.summary` report shape / parity fixture).
+
+**Scope boundary (do NOT build this phase):** suite adapters (`match`/`check`/`flow`/`pipe`), the other three analyzers, `ReportHistory`/regression/`RegressionPolicy`, TS port, Rust crates, MCP/API surfaces, GoldenPipe stage. Those are Phases 2–5.
+
+---
+
+## Pre-flight requirements
+
+- `uv` installed; repo synced once (`uv sync` at repo root succeeds on `main`).
+- Working tree on the development branch `claude/goldencheck-rust-expansion-NmjWl`.
+- `cargo`/`node` NOT required this phase.
+
+## Conventions
+
+- All commands run from the **repo root** (`/home/user/goldenmatch`) unless stated. Note the CLAUDE.md gotcha: CI CWD = repo root, local CWD may = package dir. **Anchor every fixture path to `__file__`**, never a bare relative path.
+- "Run red" = the new test fails for the expected reason (assertion/ImportError), not a collection error elsewhere.
+- "Run green" = `uv run pytest packages/python/goldenanalysis -x -q` passes.
+- Tests must be self-contained for `pytest -n auto` worker isolation: register analyzers/transforms **inside** the test that asserts on them; never rely on import-time global registration leaking across workers.
+- Commit at the end of every task with a `feat(goldenanalysis):` / `test(goldenanalysis):` message. Do not push until Task 1.11.
+
+---
+
+## Phase 1.0 — Skeleton & workspace wiring
+
+### Task 1.0.1: Create the package skeleton
+
+**Files:**
+- `packages/python/goldenanalysis/pyproject.toml`
+- `packages/python/goldenanalysis/goldenanalysis/__init__.py`
+- `packages/python/goldenanalysis/goldenanalysis/py.typed`
+- `packages/python/goldenanalysis/README.md` (stub; filled in Task 1.10)
+- `packages/python/goldenanalysis/LICENSE` (copy `packages/python/goldenpipe/LICENSE`)
+
+- [ ] **Step 1:** Author `pyproject.toml` from the goldenpipe template (hatchling backend). Core deps: `polars>=1.0`, `pydantic>=2.7`, `typer>=0.12`, `rich>=13.0`, `pyarrow>=15`. Optional extras exactly as the spec lists (`match`/`check`/`flow`/`pipe`/`suite`/`native`/`mcp`/`api`/`dev`). `version = "0.1.0"`. `[project.scripts] goldenanalysis = "goldenanalysis.cli.main:app"`. Add the `[project.entry-points."goldenanalysis.analyzers"]` table with the four keys (only `frame.summary` resolves this phase; the other three point at modules created in Phase 2 — **register only `frame.summary` now** to keep imports clean).
+- [ ] **Step 2:** `__init__.py` exports the public names that exist this phase: `analyze`, `AnalysisReport`, `Metric` (re-exported lazily; the rest land later). `py.typed` is empty.
+
+```bash
+mkdir -p packages/python/goldenanalysis/goldenanalysis
+cp packages/python/goldenpipe/LICENSE packages/python/goldenanalysis/LICENSE
+```
+
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): package skeleton (pyproject, init, license)`
+
+### Task 1.0.2: Register in the uv workspace and verify import
+
+**Files:** `/pyproject.toml` (root)
+
+- [ ] **Step 1:** Add to root `[tool.uv.sources]`: `goldenanalysis = { workspace = true }`. (The `[tool.uv.workspace] members = ["packages/python/*"]` glob already covers it — do not edit that line.) Per `packages/python/CLAUDE.md`, the workspace member is picked up by the glob; the `sources` entry is what lets siblings resolve it.
+- [ ] **Step 2:** Sync and confirm editable import.
+
+```bash
+uv sync
+uv run python -c "import goldenanalysis; print(goldenanalysis.__file__)"
+# If import fails: uv pip install -e packages/python/goldenanalysis
+```
+
+Expected: prints the path under `packages/python/goldenanalysis/`.
+
+- [ ] **Step 3: Commit.** `chore(goldenanalysis): register uv workspace source`
+
+### Task 1.0.3: Test harness collects
+
+**Files:**
+- `packages/python/goldenanalysis/tests/conftest.py`
+- `packages/python/goldenanalysis/tests/test_smoke.py`
+
+- [ ] **Step 1 (red):** `test_smoke.py` asserts `import goldenanalysis` and `goldenanalysis.__version__ == "0.1.0"`. Run red (no `__version__` yet).
+- [ ] **Step 2 (green):** add `__version__ = "0.1.0"` to `__init__.py`.
+
+```bash
+uv run pytest packages/python/goldenanalysis -q
+```
+
+- [ ] **Step 3: Commit.** `test(goldenanalysis): smoke test + version`
+
+---
+
+## Phase 1.1 — Model layer
+
+### Task 1.1.1: `Metric`, `AnalysisTable`, `AnalysisReport`, analyzer I/O
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/models/__init__.py`
+- `packages/python/goldenanalysis/goldenanalysis/models/report.py`
+- `packages/python/goldenanalysis/goldenanalysis/models/analyzer.py` (`AnalyzerInfo`, `AnalyzerInput`, `AnalyzerResult`)
+- `packages/python/goldenanalysis/tests/test_models.py`
+
+- [ ] **Step 1 (red):** `test_models.py` asserts: `Metric(key="frame.row_count", value=10, unit="rows")` defaults `direction="neutral"`; `AnalysisReport(run_id=..., generated_at=..., source={}, metrics=[], tables=[])` defaults `schema_version == 1` and `analyzers_run == []`; the report serializes via `.model_dump_json()` and re-parses equal. Run red (ImportError).
+- [ ] **Step 2 (green):** implement the pydantic models exactly per the spec's "Core domain types" block. `direction` is a `Literal["higher_better","lower_better","neutral"]`. `AnalyzerResult` carries `metrics: list[Metric]` + `tables: list[AnalysisTable]`. `AnalyzerInfo` carries `name`, `consumes: list[str]`, `produces: list[str]`.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): model layer (Metric, AnalysisReport, analyzer I/O)`
+
+---
+
+## Phase 1.2 — Pure-Python aggregation primitives
+
+### Task 1.2.1: `core/aggregate.py`
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/core/__init__.py`
+- `packages/python/goldenanalysis/goldenanalysis/core/aggregate.py`
+- `packages/python/goldenanalysis/tests/test_aggregate.py`
+
+Primitives needed by `frame.summary` (and the reference path for the future Rust kernel): `null_ratio_per_column(df) -> dict[str,float]`, `duplicate_row_ratio(df) -> float`, `histogram(values, bins) -> list[tuple]`, `quantile(values, q) -> float`.
+
+- [ ] **Step 1 (red):** `test_aggregate.py` asserts exact values on a tiny hand-built `pl.DataFrame` (e.g. 5 rows, one column 40% null → `null_ratio == 0.4`; two identical rows of five → `duplicate_row_ratio == 0.4`). Run red.
+- [ ] **Step 2 (green):** implement with polars expressions only. Determinism: stable bin edges, no float-key dict ordering reliance.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): pure-Python aggregation primitives`
+
+---
+
+## Phase 1.3 — Analyzer base + registry
+
+### Task 1.3.1: Protocol + entry-point discovery
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/analyzers/__init__.py`
+- `packages/python/goldenanalysis/goldenanalysis/analyzers/base.py`
+- `packages/python/goldenanalysis/goldenanalysis/registry.py`
+- `packages/python/goldenanalysis/tests/test_registry.py`
+
+- [ ] **Step 1 (red):** `test_registry.py` — `load_analyzer("frame.summary")` returns an object whose `.info.name == "frame.summary"`; `available_analyzers()` contains `"frame.summary"`. (frame_summary module lands in 1.4 — this test goes red now, green after 1.4. Mark it `xfail(reason="frame.summary lands in 1.4")` if you want a clean bar between tasks, then drop the xfail in 1.4.)
+- [ ] **Step 2 (green-ish):** implement `registry.py` reading `importlib.metadata.entry_points(group="goldenanalysis.analyzers")`, with a fallback hard-coded map for editable-install reliability (entry-points sometimes miss editable members — same friction noted in `packages/python/CLAUDE.md`). `Analyzer` Protocol in `base.py`: `info: AnalyzerInfo`, `run(self, inp: AnalyzerInput) -> AnalyzerResult`.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): analyzer protocol + entry-point registry`
+
+---
+
+## Phase 1.4 — `frame` adapter + `frame.summary` analyzer
+
+### Task 1.4.1: The `frame` adapter
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/adapters/__init__.py`
+- `packages/python/goldenanalysis/goldenanalysis/adapters/frame.py`
+- `packages/python/goldenanalysis/tests/test_adapter_frame.py`
+
+- [ ] **Step 1 (red):** asserts `FrameArtifactAdapter().load(df)` returns an `AnalyzerInput` whose payload exposes the frame and a `dataset` field (defaulting to `"frame"` when unnamed). Run red.
+- [ ] **Step 2 (green):** implement. The adapter is the zero-suite-dep path; it must import nothing from other suite packages.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): frame adapter (generic zero-dep path)`
+
+### Task 1.4.2: The `frame.summary` analyzer
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/analyzers/frame_summary.py`
+- `packages/python/goldenanalysis/tests/fixtures/__init__.py`
+- `packages/python/goldenanalysis/tests/fixtures/customers_small.parquet` (committed; ~20 rows, with nulls + duplicates so every metric is exercised)
+- `packages/python/goldenanalysis/tests/test_frame_summary.py`
+
+- [ ] **Step 1 (red):** load the fixture parquet (path anchored to `__file__`), run the analyzer, assert the **exact** five metric values + the `per_column` table from Appendix A: `frame.row_count`, `frame.column_count`, `frame.null_ratio_mean` (L), `frame.duplicate_row_ratio` (L), `frame.memory_bytes`. Assert `direction` is set correctly on each. Run red.
+- [ ] **Step 2 (green):** implement `FrameSummaryAnalyzer` delegating to `core/aggregate.py`. Generate the fixture with a small committed script or inline `pl.DataFrame(...).write_parquet(...)` (commit the `.parquet`, not the generator, but keep the generator in the test module as a `@pytest.fixture(scope="session")` guard that regenerates if missing — deterministic seed).
+- [ ] **Step 3:** drop the `xfail` from `test_registry.py` (now green).
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): frame.summary analyzer + fixture`
+
+---
+
+## Phase 1.5 — `analyze()` + report assembly
+
+### Task 1.5.1: Top-level `analyze()`
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/_api.py`
+- `packages/python/goldenanalysis/goldenanalysis/__init__.py` (wire export)
+- `packages/python/goldenanalysis/tests/test_analyze.py`
+
+- [ ] **Step 1 (red):** `ga.analyze(df, analyzers=["frame.summary"])` returns an `AnalysisReport` whose `analyzers_run == ["frame.summary"]`, `source["dataset"] == "frame"`, `schema_version == 1`, and metrics include `frame.row_count`. `ga.analyze(df)` (no analyzers arg) defaults to all *frame-compatible* analyzers (just `frame.summary` this phase). Run red.
+- [ ] **Step 2 (green):** `_api.analyze()` resolves analyzers via the registry, runs each over the `frame` adapter's `AnalyzerInput`, concatenates `metrics`/`tables`, stamps `run_id` (deterministic: caller-supplied or `f"{generated_at}#{dataset}"`), and records any requested-but-unavailable analyzers in `source["unavailable"]`. No narrative yet (narrative is Phase 2, tied to regressions) — leave `narrative=None`.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): analyze() entrypoint + report assembly`
+
+---
+
+## Phase 1.6 — Exporters
+
+### Task 1.6.1: `to_json` / `to_markdown` / `to_parquet`
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/models/report.py` (add methods)
+- `packages/python/goldenanalysis/goldenanalysis/render.py` (markdown templating)
+- `packages/python/goldenanalysis/tests/test_exporters.py`
+
+- [ ] **Step 1 (red):** round-trip — `AnalysisReport.from_json(report.to_json())` equals the original; `to_markdown()` output contains the metric table header and each metric key; `to_parquet(path)` then `pl.read_parquet(path)` yields a frame with one row per metric (`key,value,unit,direction` columns) + a sidecar for tables. Run red.
+- [ ] **Step 2 (green):** implement. `to_json(path=None)` returns str or writes; `to_markdown()` renders the metric table + (when present) embedded `AnalysisTable`s; `to_parquet()` writes the long-form metric frame, large tables as `<path>.<table>.parquet` sidecars. Markdown matches the Appendix B shape minus the regression column (regressions are Phase 2).
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): report exporters (json/markdown/parquet)`
+
+---
+
+## Phase 1.7 — CLI
+
+### Task 1.7.1: `goldenanalysis report`
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/cli/__init__.py`
+- `packages/python/goldenanalysis/goldenanalysis/cli/main.py`
+- `packages/python/goldenanalysis/tests/test_cli.py`
+
+- [ ] **Step 1 (red):** with `typer.testing.CliRunner`, invoke `report <fixture.parquet> --analyzers frame.summary --format markdown`; assert exit 0 and stdout contains `frame.row_count`. Also `--format json` emits valid JSON parseable into `AnalysisReport`. Run red.
+- [ ] **Step 2 (green):** Typer `app` with a `report` command (input path → load via polars if `.parquet`/`.csv`, else treat as a JSON report and re-render). `--analyzers` (comma-list, default all), `--format {markdown,json}` default markdown, `--out` optional. `trend`/`regressions` subcommands are **stubs** this phase that exit with a clear "available in 0.2.0 (ReportHistory)" message — keep the surface visible but honest.
+- [ ] **Step 3:** verify the console script resolves: `uv run goldenanalysis report packages/python/goldenanalysis/tests/fixtures/customers_small.parquet --analyzers frame.summary`.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): CLI (report; trend/regressions stubbed)`
+
+---
+
+## Phase 1.8 — Native loader stub (always falls back)
+
+### Task 1.8.1: `core/_native_loader.py`
+
+**Files:**
+- `packages/python/goldenanalysis/goldenanalysis/core/_native_loader.py`
+- `packages/python/goldenanalysis/tests/test_native_loader.py`
+
+- [ ] **Step 1 (red):** with the wheel absent, `native_module()` returns `None` and `GOLDENANALYSIS_NATIVE` unset → pure path; `GOLDENANALYSIS_NATIVE="1"` → raises `RuntimeError` (require-native parity lane contract); `_GATED_ON` is an empty set. Run red.
+- [ ] **Step 2 (green):** copy the structure of `packages/python/goldencheck/goldencheck/core/_native_loader.py`, env var `GOLDENANALYSIS_NATIVE` (`0`/`1`/`auto`), import order `goldenanalysis._native` → `goldenanalysis_native._native` → `None`, `_GATED_ON: set[str] = set()`. No call site uses it yet — it exists so Phase 4 has the gate ready and the contract is under test from day one.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): native loader gate stub (pure fallback)`
+
+---
+
+## Phase 1.9 — Parity fixture (the Appendix B report)
+
+### Task 1.9.1: Commit the canonical report fixture
+
+**Files:**
+- `packages/python/goldenanalysis/tests/fixtures/report_frame_summary.json`
+- `packages/python/goldenanalysis/tests/test_report_schema.py`
+
+- [ ] **Step 1 (red):** `test_report_schema.py` runs `analyze(fixture_df, ["frame.summary"])`, strips volatile fields (`generated_at`, `run_id` — reuse a `_strip_volatile` helper), and asserts byte-equality against `report_frame_summary.json`. This is the file the future TS port (Phase 3) will assert against too. Run red.
+- [ ] **Step 2 (green):** generate the fixture from the analyzer output once, hand-verify the values against Appendix A, commit it. Lock it: the test now guards every future change to `frame.summary` output.
+- [ ] **Step 3: Commit.** `test(goldenanalysis): canonical frame.summary report fixture (P/TS parity anchor)`
+
+---
+
+## Phase 1.10 — Docs & package metadata
+
+### Task 1.10.1: README, CHANGELOG, server.json, golden-suite.json
+
+**Files:**
+- `packages/python/goldenanalysis/README.md`
+- `packages/python/goldenanalysis/CHANGELOG.md`
+- `packages/python/goldenanalysis/server.json`
+- `packages/python/goldenanalysis/golden-suite.json`
+
+- [ ] **Step 1:** README with quickstart (`pip install goldenanalysis` → `ga.analyze(df)` + CLI), and a **"GoldenCheck vs GoldenAnalysis"** disambiguation section (read-only / consumes-other-stages / cross-run framing per the spec). Mermaid sideband diagram optional (single-line node labels per root CLAUDE.md).
+- [ ] **Step 2:** `CHANGELOG.md` with a `0.1.0` entry. `server.json` + `golden-suite.json` copied from goldenpipe and re-pointed (`io.github.benseverndev-oss/goldenanalysis`).
+- [ ] **Step 3: Commit.** `docs(goldenanalysis): README, CHANGELOG 0.1.0, server/golden-suite manifests`
+
+---
+
+## Phase 1.11 — CI wiring, full green, push
+
+### Task 1.11.1: Path-filter + matrix inclusion
+
+**Files:** `.github/workflows/ci.yml`
+
+- [ ] **Step 1:** In the `changes` job `filters:` block add `python_goldenanalysis: ['packages/python/goldenanalysis/**']`. Confirm the Python dynamic-matrix emit step (the `set_python` step, ~`ci.yml:155`) includes the new package name when its filter is true — follow exactly how `goldenpipe` is wired (grep `python_goldenpipe` and mirror every occurrence).
+- [ ] **Step 2:** Seed the package conservatively in the pytest matrix case statement: no `--ignore` entries needed (small green suite), `continue-on-error: true` like its siblings.
+- [ ] **Step 3:** Do NOT add `publish-goldenanalysis.yml` in this task — Python publish is its own follow-up once 0.1.0 is tagged (and per CLAUDE.md must derive version from the git tag). Note it in the PR description as the immediate next step.
+- [ ] **Step 4: Commit.** `ci(goldenanalysis): path filter + python matrix inclusion`
+
+### Task 1.11.2: Full local verification
+
+- [ ] **Step 1:** Clean run.
+
+```bash
+uv sync
+uv run pytest packages/python/goldenanalysis -q
+uv run ruff check packages/python/goldenanalysis
+uv run goldenanalysis report packages/python/goldenanalysis/tests/fixtures/customers_small.parquet --analyzers frame.summary
+```
+
+Expected: all tests pass, ruff clean, CLI prints a markdown report.
+
+- [ ] **Step 2:** Verify zero-dep claim — in a throwaway venv with ONLY `goldenanalysis` core installed (no goldenmatch/check/flow/pipe), `ga.analyze(df, ["frame.summary"])` works.
+
+```bash
+python -m venv /tmp/ga-clean && /tmp/ga-clean/bin/pip install -q packages/python/goldenanalysis
+/tmp/ga-clean/bin/python -c "import polars as pl, goldenanalysis as ga; print(ga.analyze(pl.DataFrame({'a':[1,1,None]}), ['frame.summary']).metrics[0])"
+```
+
+- [ ] **Step 3: Push** the branch (retry with backoff per repo git policy):
+
+```bash
+for i in 1 2 3 4; do git push -u origin claude/goldencheck-rust-expansion-NmjWl && break || sleep $((2**i)); done
+```
+
+---
+
+## Acceptance (Phase 1 done when)
+
+Mirrors spec acceptance §1–§4, §7–§9 scoped to the frame path:
+
+- [ ] `uv run pytest packages/python/goldenanalysis` green; package enters the CI Python matrix; doc-only changes to it skip code jobs.
+- [ ] `ga.analyze(df, analyzers=["frame.summary"])` works with no other suite package installed (verified in clean venv).
+- [ ] `frame.summary` emits the exact Appendix A metrics with correct `direction`; locked by the `report_frame_summary.json` fixture.
+- [ ] `AnalysisReport` round-trips JSON ↔ object ↔ Markdown ↔ Parquet; `schema_version == 1`.
+- [ ] Native loader contract under test (absent → fallback; `=1` → raises; `_GATED_ON` empty).
+- [ ] README has the GoldenCheck-vs-GoldenAnalysis disambiguation; `CHANGELOG.md` at `0.1.0`; `server.json` + `golden-suite.json` present.
+
+**Explicitly deferred to later phases (do not let them creep into the Phase 1 PR):** suite adapters & the other three analyzers (Phase 2), `ReportHistory`/regression/narrative (Phase 2), TS port (Phase 3), Rust `analysis-core`/`analysis-native` (Phase 4), GoldenPipe stage + goldensuite-mcp surfacing (Phase 5), the `publish-goldenanalysis*.yml` triplet (follow-up once 0.1.0 is tagged).
+
+## Risks specific to execution
+
+- **Editable-install entry-point flakiness** (CLAUDE.md): the registry's hard-coded fallback map (Task 1.3.1) is the mitigation; keep it in sync with the entry-points table.
+- **Fixture CWD** (CLAUDE.md): every fixture read anchored to `__file__`, or it passes locally and fails in CI.
+- **`pytest -n auto` isolation** (CLAUDE.md): no cross-test registration assumptions.
+- **Parquet dep weight:** pyarrow is already in the suite graph; if a fresh `goldenanalysis`-only install pulls an unexpectedly heavy tree, gate `to_parquet` behind a clear ImportError message rather than a hard core dep — but default is core, matching the spec.

--- a/docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md
+++ b/docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md
@@ -1,0 +1,331 @@
+# GoldenAnalysis — Cross-Cutting Analysis Engine (design)
+
+**Status:** Design proposed. No implementation yet — this doc is the first PR.
+**Owner:** GoldenAnalysis (new package).
+**Targets:** new `goldenanalysis` package on Python + TypeScript + Rust (`*-core` / `*-native` split). No version bumps to existing packages required; integration is additive and opt-in.
+**Date:** 2026-06-08
+
+---
+
+## Problem
+
+The suite has five product layers, each of which **emits structured run artifacts** but none of which **measures, aggregates, or reports across them**:
+
+- GoldenCheck emits a scan report (column stats, type inference, quality findings).
+- GoldenFlow emits transform stats (rows changed, rule hit-counts).
+- GoldenMatch emits scored pairs, clusters, a golden frame, and (v1.15+) an identity summary with conflict counts.
+- GoldenPipe emits a run manifest stitching the above into `PipeResult.artifacts`.
+- InferMap emits a mapping with per-field confidence.
+
+Today, answering questions *about* a run — "what was the match rate?", "how did cluster-size distribution shift vs last week?", "which blocking key carried the recall?", "did quality-finding counts regress after the GoldenFlow rule change?", "roll all five stage outputs into one report for the data steward" — means hand-writing a notebook against each package's bespoke output shape. There is no shared vocabulary for *metrics over artifacts*, no run-over-run aggregation, and no single report surface.
+
+GoldenCheck is sometimes mistaken for this layer, but it is **not**: GoldenCheck profiles a *single input dataset at ingest* and emits findings. It does not consume other stages' outputs, does not aggregate across runs, and is itself a *producer* of artifacts that GoldenAnalysis would consume. The gap is a **read-only, cross-cutting analysis/metrics/reporting engine** that sits *beside* the pipeline, consumes any stage's typed artifacts, and produces unified, comparable, exportable analysis.
+
+---
+
+## Goal
+
+A new package `goldenanalysis` that:
+
+1. **Ingests typed artifacts** from any suite package via a small set of adapters (GoldenCheck scan report, GoldenFlow transform stats, GoldenMatch cluster / scored-pair / identity summary, GoldenPipe manifest, InferMap mapping) — and from a raw Polars/Arrow frame for the generic case.
+2. **Runs composable analyzers** (a registry, mirroring GoldenPipe's stage entry-points) that each compute a typed `Metric` set + optional tables.
+3. **Aggregates across runs** — trend lines, drift, and regression detection over a history of `AnalysisReport`s keyed by `run_id`.
+4. **Emits one `AnalysisReport`** with a stable schema, exportable to JSON / Markdown / Parquet, plus a one-paragraph NL summary.
+5. Ships with **parity-by-construction across Python + TS** (byte-identical metric values on shared fixtures) and an **optional Rust accelerator** (`goldenanalysis[native]`) for the heavy aggregation primitives, gated exactly like `goldenmatch[native]` / `goldencheck[native]`.
+
+**Non-goal:** GoldenAnalysis does **not** transform data, mutate any store, or make pipeline decisions. It is read-only. It is *not* a GoldenPipe stage that gates the run (it may be invoked *after* a run as a reporting step, but its analyzers never write back into the dataset). It does not replace GoldenCheck's ingest-time profiling.
+
+---
+
+## Why a new package and not a GoldenCheck/GoldenPipe feature
+
+| Option | Why rejected |
+|---|---|
+| Fold into **GoldenCheck** | GoldenCheck is single-dataset ingest profiling and a *producer* of artifacts GoldenAnalysis consumes. Making it also consume GoldenMatch/identity outputs inverts its dependency direction (GoldenCheck would import goldenmatch) and muddies its "validation by discovery" promise. |
+| Fold into **GoldenPipe** | GoldenPipe orchestrates *forward* execution and is decision-bearing. Cross-run aggregation, drift, and reporting are read-only and run-history-shaped, not orchestration. GoldenPipe would *consume* GoldenAnalysis as an optional terminal reporting stage, not contain it. |
+| A `scripts/` notebook | No shared schema, no parity surface, no reuse across the five packages, no published artifact. The whole problem is the absence of a *vocabulary*. |
+
+A standalone layer keeps each existing package single-purpose, gives the metrics/report schema one home, and matches the suite's established "one product layer = one package, P+TS+Rust" shape.
+
+---
+
+## Design
+
+### Package identity
+
+- **Tagline:** "Measure and report across the Golden Suite."
+- **Pipeline position:** sideband / terminal. `… GoldenMatch.dedupe → GoldenMatch.identity_resolve → [GoldenAnalysis.report]`.
+- **Direction of dependency:** GoldenAnalysis depends (optionally) on the other packages' *types* only, never the reverse for core. It consumes their outputs; it is imported by nothing in their hot paths.
+
+### Core domain types (Python; TS mirrors field-for-field)
+
+```python
+# goldenanalysis/models/report.py
+class Metric(BaseModel):
+    key: str                 # dotted, stable: "match.pair_count", "cluster.size_p95"
+    value: float | int | str
+    unit: str | None = None  # "rows", "ratio", "ms", None
+    direction: Literal["higher_better", "lower_better", "neutral"] = "neutral"
+
+class AnalysisTable(BaseModel):
+    name: str                # "cluster_size_histogram"
+    columns: list[str]
+    rows: list[list[Any]]    # small, report-embeddable; large tables go to Parquet sidecar
+
+class AnalysisReport(BaseModel):
+    schema_version: int = 1
+    run_id: str
+    generated_at: datetime
+    source: dict[str, str]            # which artifacts fed this report
+    metrics: list[Metric]
+    tables: list[AnalysisTable]
+    narrative: str | None = None      # one-paragraph NL summary
+    analyzers_run: list[str]
+```
+
+`schema_version` is the cross-surface contract anchor (same discipline as the identity store's `schema_version`); bumping it requires a parity-test update on both Python and TS.
+
+### Artifact adapters
+
+One adapter per producer, each normalizing a package's native output into the inputs an analyzer expects. Adapters live behind optional extras so the core install stays dependency-light:
+
+```python
+# goldenanalysis/adapters/match.py
+class MatchArtifactAdapter:
+    """Normalizes goldenmatch DedupeResult / identity summary into AnalyzerInput."""
+    def load(self, result: "goldenmatch.DedupeResult") -> AnalyzerInput: ...
+
+# goldenanalysis/adapters/check.py    -> goldencheck ScanReport
+# goldenanalysis/adapters/flow.py     -> goldenflow transform stats
+# goldenanalysis/adapters/pipe.py     -> goldenpipe PipeResult.artifacts (multi-stage)
+# goldenanalysis/adapters/frame.py    -> raw polars.DataFrame (generic fallback)
+```
+
+The `frame` adapter is the always-available generic path (zero suite deps), so GoldenAnalysis is useful on any DataFrame even with no other package installed.
+
+### Analyzer registry (mirrors `goldenpipe.stages`)
+
+Analyzers are discovered via entry-points, so third parties and other suite packages can register their own without editing GoldenAnalysis:
+
+```toml
+# packages/python/goldenanalysis/pyproject.toml
+[project.entry-points."goldenanalysis.analyzers"]
+"match.rates"          = "goldenanalysis.analyzers.match_rates:MatchRatesAnalyzer"
+"cluster.distribution" = "goldenanalysis.analyzers.cluster_dist:ClusterDistributionAnalyzer"
+"quality.rollup"       = "goldenanalysis.analyzers.quality_rollup:QualityRollupAnalyzer"
+"frame.summary"        = "goldenanalysis.analyzers.frame_summary:FrameSummaryAnalyzer"
+```
+
+```python
+# goldenanalysis/analyzers/base.py
+class Analyzer(Protocol):
+    info: AnalyzerInfo                 # name, consumes=[...], produces metric keys
+    def run(self, inp: AnalyzerInput) -> AnalyzerResult: ...   # metrics + tables
+```
+
+Ship four analyzers in the first cut (see Phasing). The registry pattern is the extensibility story; the four shipped analyzers are the proof.
+
+### Cross-run aggregation
+
+```python
+# goldenanalysis/history.py
+class ReportHistory:
+    """Append-only store of AnalysisReports keyed by (analysis_name, run_id)."""
+    def append(self, report: AnalysisReport) -> None: ...
+    def trend(self, metric_key: str, last_n: int = 30) -> TrendSeries: ...
+    def detect_regressions(self, baseline: str = "previous",
+                           threshold_pct: float = 10.0) -> list[Regression]: ...
+```
+
+Backend mirrors the identity store's pluggability: default JSONL on disk, optional SQLite, same `backend=` / `path=` / `connection=` constructor shape as `IdentityStore` so the suite has *one* persistence idiom.
+
+### Public API
+
+```python
+import goldenanalysis as ga
+
+# Generic frame (no other package needed)
+report = ga.analyze(df, analyzers=["frame.summary"])
+
+# Over a GoldenMatch result
+report = ga.analyze_match(dedupe_result)        # runs match.* + cluster.*
+print(report.to_markdown())
+report.to_json("report.json"); report.to_parquet("report.parquet")
+
+# Whole pipeline manifest
+report = ga.analyze_pipeline(pipe_result)
+
+# Cross-run
+hist = ga.ReportHistory(backend="sqlite", path=".golden/analysis.db")
+hist.append(report)
+regressions = hist.detect_regressions(threshold_pct=10.0)
+```
+
+CLI (Typer, mirrors the other packages' `[project.scripts]` convention):
+
+```bash
+goldenanalysis report match_result.json --format markdown
+goldenanalysis report customers.parquet --analyzers frame.summary
+goldenanalysis trend --metric match.pair_count --history .golden/analysis.db --last 30
+goldenanalysis regressions --history .golden/analysis.db --threshold 10
+```
+
+---
+
+## The three surfaces
+
+### Python — `packages/python/goldenanalysis/`
+
+Layout mirrors goldenpipe/goldencheck:
+
+```
+goldenanalysis/
+  __init__.py            # analyze(), analyze_match(), analyze_pipeline(), ReportHistory
+  _api.py
+  py.typed
+  models/                # Metric, AnalysisTable, AnalysisReport, AnalyzerInput/Result
+  adapters/              # match, check, flow, pipe, infermap, frame
+  analyzers/             # base + the four shipped analyzers
+  core/
+    _native_loader.py    # GOLDENANALYSIS_NATIVE gate (copy of goldencheck's)
+    aggregate.py         # pure-Python/Polars reference primitives
+  history.py
+  cli/main.py            # [project.scripts] goldenanalysis = "goldenanalysis.cli.main:app"
+  mcp/                   # optional, [analysis] extra — analyze_artifact / get_trend tools
+tests/
+  conftest.py
+  fixtures/              # shared P/TS parity fixtures (committed JSON)
+  test_analyzers.py
+  test_native_parity.py  # native == pure-Python, gated like goldencheck
+  test_report_schema.py
+CHANGELOG.md  README.md  LICENSE  pyproject.toml  server.json  golden-suite.json
+```
+
+`pyproject.toml` follows the goldenpipe template (hatchling, Typer/rich/pydantic/polars core deps, optional extras for each adapter + `native`/`mcp`/`api`):
+
+```toml
+[project.optional-dependencies]
+match = ["goldenmatch>=1.15.0"]
+check = ["goldencheck>=1.2.0"]
+flow  = ["goldenflow>=1.1.5"]
+pipe  = ["goldenpipe>=1.2.0"]
+suite = ["goldenanalysis[match,check,flow,pipe]"]
+native = ["goldenanalysis-native"]   # optional Rust accelerator
+mcp   = ["mcp>=1.0"]
+api   = ["fastapi>=0.110", "uvicorn>=0.30"]
+dev   = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.6"]
+```
+
+Workspace registration (per `packages/python/CLAUDE.md`, BOTH must change):
+
+```toml
+# /pyproject.toml
+[tool.uv.workspace] members = ["packages/python/*"]   # already globs goldenanalysis
+[tool.uv.sources]
+goldenanalysis = { workspace = true }
+goldenanalysis-native = { path = "packages/rust/extensions/analysis-native" }
+```
+
+### TypeScript — `packages/typescript/goldenanalysis/`
+
+Mirrors goldenpipe TS: own `package.json` (not a pnpm-workspace member — Windows EISDIR), `src/{index.ts, cli.ts, core/, node/}`, `tests/{unit,parity,fixtures}`, tsup + vitest + tsconfig. camelCase fields per the TS CLAUDE.md, **except** the `AnalysisReport`/`Metric` wire types, which keep the Python snake_case keys (same exception as `goldencheck-types`) so reports cross the JSON wire between surfaces without remapping. Edge-safe (`import type`, `.js` suffixes).
+
+Parity is enforced by `tests/parity/` reading the same committed `fixtures/*.json` the Python `test_report_schema.py` reads, asserting identical metric values.
+
+### Rust — `*-core` / `*-native` split
+
+Two crates under `packages/rust/extensions/`, modeled exactly on the `goldencheck-core` (pyo3-free, standalone workspace, path dep) + `goldencheck-native` (abi3 maturin wheel) pair:
+
+```
+packages/rust/extensions/analysis-core/      # pyo3-free aggregation primitives
+  Cargo.toml   (standalone [workspace], no rust-toolchain.toml — inherits parent)
+  src/lib.rs   histogram, quantiles (P²/streaming), group-by rollup, reservoir summary
+packages/rust/extensions/analysis-native/    # abi3 ext-module wheel
+  Cargo.toml   pyproject.toml
+  python/goldenanalysis_native/__init__.py
+  src/lib.rs   PyO3 bindings delegating to analysis-core
+```
+
+The native kernel accelerates *only* the heavy aggregation primitives (large `tables` over big artifact frames). The pure-Python/Polars path in `core/aggregate.py` is the **byte-identical reference**; `analysis-core` mirrors it value-for-value. Loader gate `goldenanalysis/core/_native_loader.py` is a copy of goldencheck's, with `GOLDENANALYSIS_NATIVE` env (`0`/`1`/`auto`) and a `_GATED_ON` set that starts **empty** — a primitive only joins `_GATED_ON` after `test_native_parity.py` proves identical output. (Heed the `goldenmatch-native` lessons in root CLAUDE.md: bump `pyproject.toml` *and* `Cargo.toml` in lockstep on republish; confirm a new symbol is in the *published* wheel before assuming any env benefits; verify wall-clock moved, not just that the version shipped.)
+
+---
+
+## Integration with the suite (additive, opt-in)
+
+1. **GoldenPipe terminal stage (optional, separate follow-up PR).** Register `goldenanalysis.report` at `goldenpipe.stages`, adapter at `goldenpipe/adapters/analysis.py`, `consumes=["df","clusters","identity_summary"]`, `produces=["analysis_report"]`. It appends to `PipeResult.artifacts["analysis_report"]` and writes nothing back. This makes "one CLI runs Check → Flow → Match → Identity → **Analysis**" literally true. *Not in the first PR* — GoldenAnalysis must exist standalone first.
+2. **goldensuite-mcp** picks up GoldenAnalysis's MCP tools transitively once `goldenanalysis.mcp.server.TOOLS` exists (same aggregator pattern that already surfaces identity tools).
+3. **No changes to GoldenCheck/Flow/Match/InferMap.** Adapters read their *existing* public output types. If an adapter needs a field a producer doesn't expose, that's a separate, named PR against that producer — never a silent coupling.
+
+---
+
+## CI + publish wiring (the parts that bite if skipped)
+
+Per the post-2026-05-06 path-filter rules in root CLAUDE.md, adding a package means **adding a filter entry AND wiring the `if:` gate** in `.github/workflows/ci.yml`:
+
+- `changes` job: add `python_goldenanalysis: ['packages/python/goldenanalysis/**']`, `analysis_native: ['packages/rust/extensions/analysis-{core,native}/**']`; the Python dynamic matrix (`ci.yml:~155`) picks up the new package automatically once it has a `tests/` dir, but the **emit step** that builds the matrix array must include it.
+- TS lane already globs `packages/typescript/**`; the new package is covered.
+- Native parity lane: mirror the `goldencheck_native` job (build the abi3 wheel, run `test_native_parity.py` under `GOLDENANALYSIS_NATIVE=1`).
+- pytest `--ignore` list + coverage floors: seed conservatively, mirroring a young package; tighten later.
+
+Publish workflows — three new files mirroring the existing triplet naming (root-level only; pre-fold orphans under `packages/**/.github` are ignored):
+
+- `publish-goldenanalysis.yml` — `release: published` on `goldenanalysis-v*`, PyPI via `PYPI_TOKEN`.
+- `publish-goldenanalysis-js.yml` — npm on `goldenanalysis-js-v*`.
+- `publish-goldenanalysis-native.yml` — maturin wheels on `goldenanalysis-native-v*`, both macOS arches on `macos-14` (Intel runners queue forever — see CLAUDE.md).
+- `publish-mcp.yml` — add `goldenanalysis` to the `package` enum so its `server.json` syncs to the registry under `io.github.benseverndev-oss/goldenanalysis`.
+
+Derive publish version from the **git tag**, not PyPI (the duplicate-version race documented in CLAUDE.md / PR #167).
+
+---
+
+## Acceptance criteria for the feature this spec describes
+
+The implementation PR(s) that follow are accepted when:
+
+1. **Package builds + tests green on all three surfaces.** `uv run pytest packages/python/goldenanalysis`, `npm test` in the TS package, and `cargo test` in both Rust crates all pass; the package enters the CI Python matrix and the TS lane.
+2. **`ga.analyze(df, analyzers=["frame.summary"])` works with zero other suite packages installed** (generic frame path, core deps only).
+3. **Four analyzers shipped** — `frame.summary`, `match.rates`, `cluster.distribution`, `quality.rollup` — each with a fixture-backed test asserting exact metric values.
+4. **`AnalysisReport` round-trips** JSON ↔ object ↔ Markdown ↔ Parquet; `schema_version == 1`.
+5. **Cross-surface parity:** `tests/parity/` (TS) and `test_report_schema.py` (Python) read the same committed fixtures and assert identical metric values and report keys.
+6. **`ReportHistory` cross-run:** append two reports, `detect_regressions(threshold_pct=10)` flags a seeded 12% drop and ignores a seeded 3% drop; deterministic.
+7. **Native parity:** every primitive in `_GATED_ON` produces byte-identical output to the pure-Python reference under `GOLDENANALYSIS_NATIVE=1`; with the wheel absent, all paths fall back and tests still pass.
+8. **CI wired:** path-filter entry + matrix inclusion + native parity lane; doc-only changes to the package still skip code jobs.
+9. **Docs:** package README with quickstart, a "GoldenCheck vs GoldenAnalysis" disambiguation section, `CHANGELOG.md` at `0.1.0`, `server.json` + `golden-suite.json`.
+
+### Explicit non-goals (do not creep)
+
+- No GoldenPipe stage in the first PR (separate, named follow-up).
+- No web UI / workbench tab.
+- No new output from any *other* package (adapters read existing fields only; gaps become their own PRs).
+- No write-back of any kind — GoldenAnalysis is read-only by construction.
+- No dashboards/charts service; `to_markdown()`/`to_parquet()` is the v0.1 surface, charts are deferred.
+- No `_GATED_ON` entries shipped un-parity-tested.
+
+---
+
+## Phasing
+
+- **Phase 0 (this doc).** Spec committed. No code.
+- **Phase 1 — Python core.** Models, `frame` adapter, `frame.summary` analyzer, `AnalysisReport` + exporters, CLI, pure-Python aggregation. Workspace-registered, in CI matrix. Ship `goldenanalysis 0.1.0`.
+- **Phase 2 — suite adapters + analyzers.** `match`/`check`/`flow`/`pipe` adapters; `match.rates`, `cluster.distribution`, `quality.rollup`; `ReportHistory` + regression detection.
+- **Phase 3 — TS parity.** Mirror Phase 1–2 surface; parity fixtures + lane.
+- **Phase 4 — Rust accelerator.** `analysis-core` + `analysis-native`; loader gate; parity lane; first `_GATED_ON` primitive (likely the cluster-size histogram on large frames — verify the wall actually moves on a real shape before gating, per the perf-audit lesson).
+- **Phase 5 — GoldenPipe terminal stage + goldensuite-mcp surfacing.**
+
+Each phase is an independent, releasable PR; Phase 1 alone is a usable product.
+
+---
+
+## Risks / unknowns
+
+- **Overlap perception with GoldenCheck.** Mitigated by the read-only, consumes-other-stages, cross-run framing and a README disambiguation section. The dependency direction (GoldenAnalysis → others' types, never reverse) is the hard line that keeps them distinct.
+- **Adapter coupling to producer output shapes.** Producers evolve their result objects. Mitigation: adapters depend on the *typed* public result classes (versioned via the optional extras' `>=` pins), and a contract test per adapter asserts the fields it reads still exist. A producer-side field gap is a named PR, never a silent reach into internals.
+- **`scored_pairs` availability for `match.rates`.** Same coupling noted in the GoldenPipe identity spec: a `DedupeResult` may not retain `scored_pairs` by default. The adapter degrades gracefully — it computes what the available artifacts support and records *which* metrics it could not compute in `report.source`, rather than failing.
+- **Native parity drift / wheel skew.** The exact `goldenmatch-native` footguns (symbol-skew slow fallback, pyproject-vs-Cargo version drift, ship-vs-wall confusion) apply verbatim. Start `_GATED_ON` empty; add primitives one parity-proven, wall-verified step at a time.
+- **Parquet as a core dependency.** polars+pyarrow already in the suite's dependency graph, so `to_parquet` adds no new heavyweight dep; the generic frame path needs polars regardless.
+
+---
+
+## What this PR changes in the repo
+
+Only this spec doc. No package code, no workspace edits, no CI changes. The next PR is **Phase 1** (Python core, `goldenanalysis 0.1.0`) per the acceptance criteria above.

--- a/docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md
+++ b/docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md
@@ -125,16 +125,44 @@ class Analyzer(Protocol):
 
 Ship four analyzers in the first cut (see Phasing). The registry pattern is the extensibility story; the four shipped analyzers are the proof.
 
+Two analyzer requirements the worked scenario below forced:
+
+- **`match.rates` reads GoldenMatch's recall certificate as a first-class input** (decision 4). When the match artifact carries a certificate (`goldenmatch … --certify`, shipped on this branch), `match.rates` emits `match.recall_estimate` *and* `match.recall_safe_bound` as distinct metrics. The **safe bound** is the one you alert on; it ties GoldenAnalysis to real shipped behavior instead of inventing a recall number, and it works unsupervised (no ground-truth labels).
+- **The report assembler sees every analyzer's output, not just one** (decision 3). Narrative generation ranks *co-moving* metrics across analyzers — the scenario's root cause was only visible by crossing `quality.rollup` + `flow.rows_changed` against the flagged `cluster.singleton_ratio`. So analyzers compute in isolation, but `AnalysisReport` assembly + narrative templating operate over the full metric set.
+
 ### Cross-run aggregation
 
 ```python
 # goldenanalysis/history.py
+Baseline = Literal["previous", "rolling_median", "last_known_good"] | str  # or a pinned run_id
+
 class ReportHistory:
-    """Append-only store of AnalysisReports keyed by (analysis_name, run_id)."""
+    """Append-only store of AnalysisReports keyed by (analysis_name, dataset, run_id)."""
     def append(self, report: AnalysisReport) -> None: ...
-    def trend(self, metric_key: str, last_n: int = 30) -> TrendSeries: ...
-    def detect_regressions(self, baseline: str = "previous",
-                           threshold_pct: float = 10.0) -> list[Regression]: ...
+    def trend(self, metric_key: str, dataset: str, last_n: int = 30) -> TrendSeries: ...
+    def detect_regressions(
+        self,
+        dataset: str,
+        baseline: Baseline = "rolling_median",
+        window: int = 7,                       # for rolling_median
+        policy: "RegressionPolicy | None" = None,
+    ) -> list[Regression]: ...
+```
+
+Three design points the worked scenario below forced (decisions 1, 2, 5):
+
+- **Keyed by `(analysis_name, dataset, run_id)`**, not `(analysis_name, run_id)`. A stable `dataset` identity is mandatory — otherwise last night's `customers` run gets compared against an unrelated table. `dataset` is carried on `AnalysisReport.source["dataset"]`.
+- **Baseline is a strategy, not "previous".** A *step* change is only legible against a stable window; `rolling_median` (default, `window`=7) is immune to one noisy night, where `previous` would alternately flag and un-flag. `last_known_good` and a pinned `run_id` are the other modes.
+- **Thresholds are per-metric, respecting `direction`** — a single global `%` let a recall-bound drop slip while catching a louder-but-less-important metric. See `RegressionPolicy` below.
+
+```python
+# goldenanalysis/models/policy.py
+class RegressionPolicy(BaseModel):
+    """Per-metric regression thresholds. Falls back to `default_pct` for unlisted keys.
+    `direction` comes from the Metric itself, so a 'lower_better' metric only
+    flags on an INCREASE and vice-versa."""
+    default_pct: float = 10.0
+    per_metric: dict[str, float] = {}          # e.g. {"match.recall_safe_bound": 2.0}
 ```
 
 Backend mirrors the identity store's pluggability: default JSONL on disk, optional SQLite, same `backend=` / `path=` / `connection=` constructor shape as `IdentityStore` so the suite has *one* persistence idiom.
@@ -155,10 +183,11 @@ report.to_json("report.json"); report.to_parquet("report.parquet")
 # Whole pipeline manifest
 report = ga.analyze_pipeline(pipe_result)
 
-# Cross-run
+# Cross-run (dataset identity is mandatory for comparability)
 hist = ga.ReportHistory(backend="sqlite", path=".golden/analysis.db")
-hist.append(report)
-regressions = hist.detect_regressions(threshold_pct=10.0)
+hist.append(report)                                   # report.source["dataset"] == "customers"
+policy = ga.RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+regressions = hist.detect_regressions("customers", baseline="rolling_median", policy=policy)
 ```
 
 CLI (Typer, mirrors the other packages' `[project.scripts]` convention):
@@ -166,9 +195,83 @@ CLI (Typer, mirrors the other packages' `[project.scripts]` convention):
 ```bash
 goldenanalysis report match_result.json --format markdown
 goldenanalysis report customers.parquet --analyzers frame.summary
-goldenanalysis trend --metric match.pair_count --history .golden/analysis.db --last 30
-goldenanalysis regressions --history .golden/analysis.db --threshold 10
+goldenanalysis trend --metric cluster.singleton_ratio --dataset customers --history .golden/analysis.db --last 14
+goldenanalysis regressions --dataset customers --history .golden/analysis.db --baseline rolling_median
 ```
+
+---
+
+## Worked scenario: "Why did last night's dedupe get worse?"
+
+This end-to-end story drove the design decisions folded into the sections above. It is grounded in behavior already shipped on this branch — GoldenMatch's **unsupervised recall certificate** (estimate + SAFE lower bound) — so "recall" here is a real, label-free number, not a hypothetical.
+
+**Cast.** Maya, a data steward. A nightly Airflow DAG runs `GoldenCheck → GoldenFlow → GoldenMatch.dedupe → identity_resolve` over `customers.parquet` (~4M rows) via GoldenPipe. She has no ground-truth labels — this is production data — so "recall" means the recall certificate, not a measured number.
+
+**1. The run happens (no GoldenAnalysis involved yet).** The DAG produces a `PipeResult` whose `artifacts` dict already carries every stage's output: scan report, transform stats, scored pairs, clusters, identity summary, and — because GoldenMatch ran `--certify` — a recall certificate `{estimate: 0.94, safe_bound: 0.89}`.
+
+**2. Analyze the run → one report.**
+
+```python
+import goldenanalysis as ga
+report = ga.analyze_pipeline(pipe_result)        # fans out to every analyzer whose inputs are present
+hist = ga.ReportHistory(backend="sqlite", path="s3cache/analysis.db")
+hist.append(report)                              # report.source["dataset"] == "customers"
+```
+
+`analyze_pipeline` runs `frame.summary`, `match.rates`, `cluster.distribution`, and `quality.rollup` because all their inputs are in the manifest. The resulting `AnalysisReport` (abridged):
+
+| metric.key | value | unit | direction |
+|---|---|---|---|
+| `match.pair_count` | 612,300 | pairs | neutral |
+| `match.recall_estimate` | 0.94 | ratio | higher_better |
+| `match.recall_safe_bound` | **0.89** | ratio | higher_better |
+| `cluster.count` | 1,840,210 | clusters | neutral |
+| `cluster.size_p95` | 4 | rows | neutral |
+| `cluster.singleton_ratio` | **0.71** | ratio | neutral |
+| `quality.findings_total` | 1,205 | findings | lower_better |
+| `flow.rows_changed` | 3,910,442 | rows | neutral |
+
+**3. The regression check fires.**
+
+```python
+policy = ga.RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+regs = hist.detect_regressions("customers", baseline="rolling_median", policy=policy)
+```
+
+The 7-night rolling median had `recall_safe_bound ≈ 0.97` and `singleton_ratio ≈ 0.58`. Tonight: `0.89` and `0.71`.
+
+```
+Regression(metric="match.recall_safe_bound", baseline=0.97, current=0.89, delta_pct=-8.2, flagged=True)   # 2% gate
+Regression(metric="cluster.singleton_ratio", baseline=0.58, current=0.71, delta_pct=+22.4, flagged=True)  # 10% gate
+```
+
+With a **global** 10% gate the recall-bound drop (-8.2%) would have slipped through; the per-metric 2% gate on `match.recall_safe_bound` catches it — exactly why decision 2 exists. More records are also landing as singletons: GoldenMatch is splitting things it used to merge.
+
+**4. Drill: which run, which metric, when did it move.**
+
+```python
+hist.trend(metric_key="cluster.singleton_ratio", dataset="customers", last_n=14)
+```
+
+returns a `TrendSeries` — flat at ~0.58 for 13 nights, then a *step* to 0.71 on the most recent. A step, not a drift: something changed between two runs. (A `baseline="previous"` would have compared two post-step nights and seen nothing — decision 1.)
+
+**5. Root-cause: cross the report against the other analyzers.** `quality.rollup` in the *same* report shows `quality.findings_total` jumped 410 → 1,205, almost all one new class: `email_blanked`. And `flow.rows_changed` is up 40%. The story assembles: a GoldenFlow rule started blanking malformed emails, GoldenMatch lost its strongest blocking key on those rows, they fell out into singletons — dragging the recall safe-bound down too. `report.narrative` says exactly this in prose, because it is templated from the flagged regressions + the largest co-moving metrics across analyzers (decision 3).
+
+**6. What Maya actually reads.** She never touches Python. The DAG wrote `report.to_markdown()` to the run folder and surfaced `cluster.singleton_ratio` as an Airflow XCom her alert watched. Or by hand:
+
+```bash
+goldenanalysis report s3cache/run-2026-06-08.json --format markdown
+goldenanalysis regressions --dataset customers --history s3cache/analysis.db --baseline rolling_median
+goldenanalysis trend --metric cluster.singleton_ratio --dataset customers --history s3cache/analysis.db --last 14
+```
+
+### The five decisions this scenario settled
+
+1. **Baseline is a strategy** (`rolling_median` default, plus `previous` / `last_known_good` / pinned `run_id`). A step change is only legible against a stable window. → folded into `ReportHistory.detect_regressions`.
+2. **Per-metric thresholds, not one global %**, respecting each `Metric.direction`. Recall regressions warrant a tighter gate than noisier metrics. → `RegressionPolicy`.
+3. **Narrative ranks co-moving metrics across analyzers.** Root cause was only visible by crossing analyzers, so report assembly + narrative see the full metric set. → folded into the analyzer-registry section.
+4. **The recall certificate is a first-class input.** `match.rates` emits `recall_estimate` + `recall_safe_bound`; the safe bound is the alerting metric. Ties the package to shipped, unsupervised behavior. → folded into the analyzer-registry section.
+5. **`ReportHistory` is keyed by `(analysis_name, dataset, run_id)`** with a stable `dataset` identity carried on `AnalysisReport.source["dataset"]`. → folded into `ReportHistory` + the API/CLI.
 
 ---
 
@@ -183,7 +286,8 @@ goldenanalysis/
   __init__.py            # analyze(), analyze_match(), analyze_pipeline(), ReportHistory
   _api.py
   py.typed
-  models/                # Metric, AnalysisTable, AnalysisReport, AnalyzerInput/Result
+  models/                # Metric, AnalysisTable, AnalysisReport, AnalyzerInput/Result,
+                         #   RegressionPolicy, Regression, TrendSeries
   adapters/              # match, check, flow, pipe, infermap, frame
   analyzers/             # base + the four shipped analyzers
   core/
@@ -287,7 +391,7 @@ The implementation PR(s) that follow are accepted when:
 3. **Four analyzers shipped** — `frame.summary`, `match.rates`, `cluster.distribution`, `quality.rollup` — each with a fixture-backed test asserting exact metric values.
 4. **`AnalysisReport` round-trips** JSON ↔ object ↔ Markdown ↔ Parquet; `schema_version == 1`.
 5. **Cross-surface parity:** `tests/parity/` (TS) and `test_report_schema.py` (Python) read the same committed fixtures and assert identical metric values and report keys.
-6. **`ReportHistory` cross-run:** append two reports, `detect_regressions(threshold_pct=10)` flags a seeded 12% drop and ignores a seeded 3% drop; deterministic.
+6. **`ReportHistory` cross-run:** keyed by `(analysis_name, dataset, run_id)`. With a `rolling_median` baseline over a seeded window, `detect_regressions("customers", policy=...)` flags a `match.recall_safe_bound` drop under its per-metric 2% gate that a global 10% gate would miss, ignores a 3% noise wobble on a default-gate metric, respects `Metric.direction`, and is deterministic. `baseline="previous"` over a post-step pair flags nothing (proving the step-vs-window distinction).
 7. **Native parity:** every primitive in `_GATED_ON` produces byte-identical output to the pure-Python reference under `GOLDENANALYSIS_NATIVE=1`; with the wheel absent, all paths fall back and tests still pass.
 8. **CI wired:** path-filter entry + matrix inclusion + native parity lane; doc-only changes to the package still skip code jobs.
 9. **Docs:** package README with quickstart, a "GoldenCheck vs GoldenAnalysis" disambiguation section, `CHANGELOG.md` at `0.1.0`, `server.json` + `golden-suite.json`.

--- a/docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md
+++ b/docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md
@@ -123,7 +123,7 @@ class Analyzer(Protocol):
     def run(self, inp: AnalyzerInput) -> AnalyzerResult: ...   # metrics + tables
 ```
 
-Ship four analyzers in the first cut (see Phasing). The registry pattern is the extensibility story; the four shipped analyzers are the proof.
+Ship four analyzers in the first cut (see Phasing). The registry pattern is the extensibility story; the four shipped analyzers are the proof. Their exact metric keys, units, and directions are enumerated in **Appendix A — Metric catalog**; a fully filled-in report is in **Appendix B**.
 
 Two analyzer requirements the worked scenario below forced:
 
@@ -427,6 +427,132 @@ Each phase is an independent, releasable PR; Phase 1 alone is a usable product.
 - **`scored_pairs` availability for `match.rates`.** Same coupling noted in the GoldenPipe identity spec: a `DedupeResult` may not retain `scored_pairs` by default. The adapter degrades gracefully — it computes what the available artifacts support and records *which* metrics it could not compute in `report.source`, rather than failing.
 - **Native parity drift / wheel skew.** The exact `goldenmatch-native` footguns (symbol-skew slow fallback, pyproject-vs-Cargo version drift, ship-vs-wall confusion) apply verbatim. Start `_GATED_ON` empty; add primitives one parity-proven, wall-verified step at a time.
 - **Parquet as a core dependency.** polars+pyarrow already in the suite's dependency graph, so `to_parquet` adds no new heavyweight dep; the generic frame path needs polars regardless.
+
+---
+
+## Appendix A — Metric catalog (first cut)
+
+The exact metrics the four shipped analyzers emit. Keys are dotted and stable (the cross-run contract — renaming one breaks `ReportHistory` comparability, so a rename is a `schema_version` bump). `dir` is `Metric.direction`; `H`=higher_better, `L`=lower_better, `·`=neutral. Tables are emitted alongside metrics but are not individually thresholded.
+
+### `frame.summary` — generic frame, zero suite deps (always available)
+
+| key | unit | dir | notes |
+|---|---|---|---|
+| `frame.row_count` | rows | · | |
+| `frame.column_count` | columns | · | |
+| `frame.null_ratio_mean` | ratio | L | mean across columns |
+| `frame.duplicate_row_ratio` | ratio | L | exact-duplicate rows / rows |
+| `frame.memory_bytes` | bytes | · | estimated in-memory size |
+| *table* `per_column` | — | — | column, dtype, null_ratio, n_unique |
+
+### `match.rates` — from GoldenMatch result + recall certificate
+
+| key | unit | dir | notes |
+|---|---|---|---|
+| `match.pair_count` | pairs | · | scored pairs above threshold |
+| `match.match_rate` | ratio | · | matched records / input records |
+| `match.threshold` | score | · | decision threshold used |
+| `match.recall_estimate` | ratio | H | from the certificate (unsupervised) |
+| `match.recall_safe_bound` | ratio | H | **the alerting metric** (SAFE lower bound) |
+| `match.mean_pair_score` | score | · | central tendency of accepted pairs |
+| *table* `score_histogram` | — | — | binned pair-score distribution |
+
+Degrades gracefully (Risks §3): if `scored_pairs` or the certificate is absent, the unavailable keys are omitted and listed in `report.source["unavailable"]` rather than failing.
+
+### `cluster.distribution` — from GoldenMatch clusters
+
+| key | unit | dir | notes |
+|---|---|---|---|
+| `cluster.count` | clusters | · | |
+| `cluster.record_count` | rows | · | clustered input records |
+| `cluster.singleton_ratio` | ratio | · | size-1 clusters / clusters |
+| `cluster.size_p50` / `size_p95` / `size_max` | rows | · | size quantiles |
+| `cluster.reduction_ratio` | ratio | · | `1 − clusters / records` (dedup rate) |
+| *table* `cluster_size_histogram` | — | — | size bucket → count |
+
+### `quality.rollup` — from GoldenCheck scan + GoldenFlow stats
+
+Rolls up both quality producers (a single "is the data healthy" view), hence both `quality.*` and `flow.*` keys live here.
+
+| key | unit | dir | notes |
+|---|---|---|---|
+| `quality.findings_total` | findings | L | |
+| `quality.columns_with_findings` | columns | L | |
+| `quality.score` | ratio | H | overall GoldenCheck quality score, if emitted |
+| `flow.rows_changed` | rows | · | from GoldenFlow transform stats |
+| `flow.rules_fired` | count | · | |
+| *table* `findings_by_class` | — | — | finding class → count (e.g. `email_blanked → 1188`) |
+
+New analyzers extend this catalog by registering at the `goldenanalysis.analyzers` entry-point; they own their `<namespace>.*` key prefix.
+
+---
+
+## Appendix B — Example `AnalysisReport` (the scenario's run)
+
+The full report `ga.analyze_pipeline(pipe_result)` produces in the worked scenario, as persisted JSON (tables truncated for length):
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "2026-06-08T02:14:07Z#customers",
+  "generated_at": "2026-06-08T06:31:55Z",
+  "source": {
+    "dataset": "customers",
+    "producer": "goldenpipe",
+    "stages": "goldencheck.scan,goldenflow.transform,goldenmatch.dedupe,goldenmatch.identity_resolve",
+    "certificate": "present",
+    "unavailable": ""
+  },
+  "metrics": [
+    {"key": "frame.row_count", "value": 4012880, "unit": "rows", "direction": "neutral"},
+    {"key": "match.pair_count", "value": 612300, "unit": "pairs", "direction": "neutral"},
+    {"key": "match.match_rate", "value": 0.31, "unit": "ratio", "direction": "neutral"},
+    {"key": "match.threshold", "value": 0.82, "unit": "score", "direction": "neutral"},
+    {"key": "match.recall_estimate", "value": 0.94, "unit": "ratio", "direction": "higher_better"},
+    {"key": "match.recall_safe_bound", "value": 0.89, "unit": "ratio", "direction": "higher_better"},
+    {"key": "cluster.count", "value": 1840210, "unit": "clusters", "direction": "neutral"},
+    {"key": "cluster.singleton_ratio", "value": 0.71, "unit": "ratio", "direction": "neutral"},
+    {"key": "cluster.size_p95", "value": 4, "unit": "rows", "direction": "neutral"},
+    {"key": "cluster.reduction_ratio", "value": 0.54, "unit": "ratio", "direction": "neutral"},
+    {"key": "quality.findings_total", "value": 1205, "unit": "findings", "direction": "lower_better"},
+    {"key": "flow.rows_changed", "value": 3910442, "unit": "rows", "direction": "neutral"}
+  ],
+  "tables": [
+    {"name": "cluster_size_histogram", "columns": ["size", "count"],
+     "rows": [[1, 1306549], [2, 401203], [3, 88210], ["4+", 44248]]},
+    {"name": "findings_by_class", "columns": ["class", "count"],
+     "rows": [["email_blanked", 1188], ["phone_unparseable", 12], ["name_empty", 5]]}
+  ],
+  "narrative": "Recall safe-bound fell to 0.89 (rolling-median baseline 0.97; -8.2%, over the 2% gate for this metric). The co-moving signals are a singleton-ratio step from 0.58 to 0.71 and a quality regression of +795 findings, almost all 'email_blanked' (1188). Likely cause: a GoldenFlow rule began blanking malformed emails, removing a primary blocking key and splitting affected records into singletons.",
+  "analyzers_run": ["frame.summary", "match.rates", "cluster.distribution", "quality.rollup"]
+}
+```
+
+`report.to_markdown()` renders this for Maya as:
+
+```markdown
+# Analysis — customers (run 2026-06-08T02:14:07Z)
+
+> ⚠️ **1 regression flagged.** Recall safe-bound 0.97 → 0.89 (-8.2%, gate 2%).
+
+Recall safe-bound fell to 0.89 (rolling-median baseline 0.97; -8.2%, over the
+2% gate for this metric). The co-moving signals are a singleton-ratio step from
+0.58 to 0.71 and a quality regression of +795 findings, almost all
+'email_blanked' (1188). Likely cause: a GoldenFlow rule began blanking malformed
+emails, removing a primary blocking key and splitting affected records into singletons.
+
+| Metric | Value | Δ vs baseline |
+|---|---|---|
+| match.recall_safe_bound | 0.89 | 🔴 -8.2% |
+| cluster.singleton_ratio | 0.71 | 🔴 +22.4% |
+| quality.findings_total  | 1,205 | 🔴 +194% |
+| match.pair_count        | 612,300 | +1.1% |
+| cluster.reduction_ratio | 0.54 | -0.6% |
+
+**Findings by class:** email_blanked 1188 · phone_unparseable 12 · name_empty 5
+```
+
+The committed parity fixtures (acceptance §5) are exactly this report's JSON, so Python and TS must both produce it byte-for-byte from the same input artifacts.
 
 ---
 


### PR DESCRIPTION
## What this is

Design-only PR (no package code) introducing **GoldenAnalysis**, a proposed new suite layer: a **read-only, cross-cutting analysis / metrics / reporting engine** that consumes any stage's typed artifacts (GoldenCheck scan, GoldenFlow stats, GoldenMatch clusters / identity / recall certificate, GoldenPipe manifest, InferMap mapping) and emits a unified `AnalysisReport` plus cross-run trend / regression detection.

Two documents:

- `docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md` — the design: package identity and the GoldenCheck-vs-GoldenAnalysis dependency-direction line, three-surface scaffold (Python + TypeScript + Rust `*-core`/`*-native` split), analyzer entry-point registry, the five cross-run decisions, a worked end-to-end scenario, the metric catalog (Appendix A), and a fully filled-in example report (Appendix B).
- `docs/superpowers/plans/2026-06-08-goldenanalysis-phase1-python-core.md` — a TDD-shaped (failing test -> minimal impl -> commit) plan to ship `goldenanalysis 0.1.0`: the generic frame path end to end, workspace-registered and in the CI matrix.

## Why a separate PR

These commits were originally developed on the recall-certificate branch (now merged as #801) because that was the assigned working branch. They are unrelated to recall work, so they were split onto a fresh branch off `main` to keep scope clean.

## Scope

Docs only. No package code, no workspace edits, no CI changes. The design draws hard boundaries (read-only by construction; depends on other packages' types, never the reverse) and defers the GoldenPipe stage, TS port, and Rust accelerator to later phases. Phase 1 (Python core) is the proposed first implementation PR if the design is approved.

https://claude.ai/code/session_01F32CKbirGCqkGiTMU3KQv7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F32CKbirGCqkGiTMU3KQv7)_