### PR TITLE
feat(goldenmatch): opt-in certify on dedupe_df → unsupervised recall estimate

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -203,6 +203,15 @@ from goldenmatch.core.probabilistic import score_probabilistic, train_em
 
 # ── Profiling ────────────────────────────────────────────────────────────
 from goldenmatch.core.profiler import profile_dataframe
+
+# ── Recall certificate (unsupervised) ────────────────────────────────────
+from goldenmatch.core.recall_certificate import (
+    RecallCertificate,
+    RecallEstimate,
+    audit_calibrated_bound,
+    certify_recall_df,
+    estimate_recall,
+)
 from goldenmatch.core.review_queue import ReviewQueue, gate_pairs
 from goldenmatch.core.rollback import rollback_run
 
@@ -315,6 +324,8 @@ __all__ = [
     "match_one", "StreamProcessor", "run_stream",
     # Evaluation
     "evaluate_pairs", "evaluate_clusters", "load_ground_truth_csv", "EvalResult",
+    "RecallEstimate", "RecallCertificate", "estimate_recall", "certify_recall_df",
+    "audit_calibrated_bound",
     # Explain
     "explain_pair", "explain_pair_nl", "explain_cluster", "explain_cluster_nl",
     # Domain

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -31,6 +31,7 @@ from goldenmatch.core.autoconfig_verify import PostflightReport
 
 if TYPE_CHECKING:
     from goldenmatch.core.memory.corrections import CorrectionStats
+    from goldenmatch.core.recall_certificate import RecallEstimate
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,11 @@ class DedupeResult:
     # pipeline's direct field assignment pattern. Single source of truth would
     # require refactoring _attach_memory_to_postflight; tracked as follow-up.
     memory_stats: CorrectionStats | None = None
+    # Unsupervised recall estimate (capture-recapture over decorrelated
+    # matchkey/pass systems). Populated only when dedupe_df(..., certify=True);
+    # None otherwise. The audit-calibrated SAFE lower bound stays evaluate-only
+    # (it needs a labelled sample). See goldenmatch.core.recall_certificate.
+    recall_certificate: RecallEstimate | None = None
 
     def to_csv(self, path: str, which: str = "golden") -> Path:
         """Write results to CSV.
@@ -326,6 +332,7 @@ def dedupe_df(
     exclude_columns: list[str] | None = None,
     planning_effort: str | None = None,
     fs_model_path: str | None = None,
+    certify: bool = False,
 ) -> DedupeResult:
     """Deduplicate a Polars DataFrame directly (no file I/O).
 
@@ -346,6 +353,13 @@ def dedupe_df(
             probabilistic matchkey without its own ``model_path`` loads the
             model from here (skipping EM) if it exists, or trains and saves it
             there on first run (Splink-style train-once -> reuse).
+        certify: When True, also compute an unsupervised recall estimate
+            (capture-recapture over the config's decorrelated matchkey/pass
+            systems) and attach it to ``DedupeResult.recall_certificate``.
+            Off by default — it re-runs the pipeline once per system, so it
+            roughly K-times the cost. The audit-calibrated SAFE lower bound is
+            NOT computed here (it needs a labelled sample; use the ``evaluate``
+            CLI / ``audit_calibrated_bound`` for that).
 
     Returns:
         DedupeResult with golden records, clusters, dupes, unique, and stats.
@@ -483,6 +497,21 @@ def dedupe_df(
                 pf = PostflightReport()
             pf.autoconfig_exclusions = list(_exclusions)
 
+    # Unsupervised recall certificate (opt-in). Runs each decorrelated
+    # matchkey/pass system through the pipeline and applies the FP-aware
+    # capture-recapture estimator. Reuses the resolved `config` so it does
+    # NOT re-run auto-config; the per-system dedupe_df calls default
+    # certify=False, so there is no recursion. Fail-open: a certify failure
+    # never breaks the dedupe result it annotates.
+    _recall_cert = None
+    if certify:
+        from goldenmatch.core.recall_certificate import certify_recall_df
+
+        try:
+            _recall_cert = certify_recall_df(df, config=config)
+        except Exception:  # noqa: BLE001 - certify is additive; never break dedupe
+            logger.warning("recall certify failed; returning result without certificate", exc_info=True)
+
     return DedupeResult(
         golden=result.get("golden"),
         clusters=result.get("clusters", {}),
@@ -493,6 +522,7 @@ def dedupe_df(
         config=config,
         postflight_report=pf,
         memory_stats=_mem,
+        recall_certificate=_recall_cert,
     )
 
 

--- a/packages/python/goldenmatch/tests/test_dedupe_certify.py
+++ b/packages/python/goldenmatch/tests/test_dedupe_certify.py
@@ -1,0 +1,75 @@
+"""dedupe_df(..., certify=True) attaches an unsupervised RecallEstimate.
+
+The estimate runs each decorrelated matchkey/pass system through the pipeline and
+applies the FP-aware capture-recapture estimator (the same machinery the
+``evaluate --certify`` CLI uses). Off by default.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch import RecallEstimate, dedupe_df
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+
+
+def _config() -> GoldenMatchConfig:
+    # One 3-field weighted matchkey -> build_decorrelated_systems splits it into
+    # 3 per-field systems, which is the >=3 minimum estimate_recall needs.
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["last_name"], transforms=["soundex"])],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="identity",
+                type="weighted",
+                threshold=0.7,
+                fields=[
+                    MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0),
+                    MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0),
+                    MatchkeyField(field="email", scorer="jaro_winkler", weight=0.8),
+                ],
+            )
+        ],
+    )
+
+
+def _df() -> pl.DataFrame:
+    # 12 rows, 4 duplicate pairs; surnames spread across distinct soundex codes
+    # so soundex blocking makes several small blocks (no mega-block hang).
+    return pl.DataFrame(
+        {
+            "first_name": [
+                "John", "Jon", "Mary", "Mari", "Robert", "Bob",
+                "Susan", "Sue", "Peter", "Linda", "Karl", "Omar",
+            ],
+            "last_name": [
+                "Smith", "Smith", "Jones", "Jones", "Brown", "Brown",
+                "Davis", "Davis", "Wilson", "Taylor", "Klein", "Hassan",
+            ],
+            "email": [
+                "j@x.com", "j@x.com", "m@x.com", "m@x.com", "r@x.com", "r@x.com",
+                "s@x.com", "s@x.com", "p@x.com", "l@x.com", "k@x.com", "o@x.com",
+            ],
+        }
+    )
+
+
+def test_certify_attaches_recall_estimate() -> None:
+    res = dedupe_df(_df(), config=_config(), certify=True)
+    assert res.recall_certificate is not None
+    assert isinstance(res.recall_certificate, RecallEstimate)
+    # 3-field matchkey -> 3 decorrelated systems.
+    assert res.recall_certificate.n_systems == 3
+
+
+def test_no_certify_leaves_certificate_none() -> None:
+    res = dedupe_df(_df(), config=_config())
+    assert res.recall_certificate is None


### PR DESCRIPTION
## Summary
Adds an opt-in `certify` flag to `dedupe_df` that attaches an **unsupervised recall estimate** to the result, and re-exports the recall-certificate types from the top-level package.

This is a small **prerequisite** for GoldenAnalysis Phase 2a: it lets `match.rates` surface `recall_estimate` end-to-end from a real `DedupeResult` (today the certificate is reachable only via the `evaluate --certify` CLI path).

## What changed
- `DedupeResult.recall_certificate: RecallEstimate | None` (default `None`).
- `dedupe_df(df, ..., certify=False)`: when `True`, runs `certify_recall_df(df, config)` (each decorrelated matchkey/pass system through the pipeline + the FP-aware capture-recapture estimator) and attaches the `RecallEstimate`. Reuses the resolved `config` (no re-auto-config); per-system calls default `certify=False` (no recursion); **fail-open** (a certify failure logs + returns the result without a certificate, never breaks dedupe).
- Re-export `RecallEstimate` / `RecallCertificate` / `estimate_recall` / `certify_recall_df` / `audit_calibrated_bound` from `goldenmatch` (were `core`-only).

## Scope / honesty
- **Off by default** — `certify=True` re-runs the pipeline once per system (~K× cost), so it's opt-in exactly like the CLI `--certify`.
- The **audit-calibrated SAFE lower bound** is *not* computed here — it needs a labelled sample (`evaluate --certify --audit-*` / `audit_calibrated_bound`). Only the unsupervised point estimate auto-attaches.
- Byte-identical behavior when `certify=False` (the default) — purely additive.

## Test plan
- [ ] `tests/test_dedupe_certify.py`: `certify=True` attaches a `RecallEstimate` with `n_systems == 3` (one 3-field weighted matchkey → 3 decorrelated systems); `certify=False` leaves it `None`. (Validated by the goldenmatch CI lane — explicit config, no torch/embedding.)
- [x] ruff clean; py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)