### PR TITLE
feat(goldenanalysis): Phase 2a — suite adapters + analyzers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,14 @@ jobs:
       # carries a loud no-importorskip guard that fails if this install is missing.
       - if: matrix.pkg == 'goldenmatch'
         run: uv pip install 'datafusion>=53,<54'
+      # GoldenAnalysis's suite adapters consume goldenmatch/goldencheck/goldenflow/
+      # goldenpipe outputs. uv sync --all-packages installs those workspace members,
+      # but install the [match,check,flow,pipe] extras explicitly so the real-producer
+      # integration tests (tests/integration/) actually RUN rather than self-skip via
+      # their importlib.find_spec markers — the same false-green guard as the
+      # goldenmatch datafusion lane above.
+      - if: matrix.pkg == 'goldenanalysis'
+        run: uv pip install -e 'packages/python/goldenanalysis[match,check,flow,pipe]'
       # Ruff config is driven by the root pyproject.toml [tool.ruff.lint] section
       # (F/I/B-narrowed/UP). Drop the --select override so pyproject's select+ignore wins.
       - run: uv run ruff check packages/python/${{ matrix.pkg }}

--- a/docs/superpowers/plans/2026-06-08-goldenanalysis-phase2a-suite-adapters.md
+++ b/docs/superpowers/plans/2026-06-08-goldenanalysis-phase2a-suite-adapters.md
@@ -1,0 +1,355 @@
+# GoldenAnalysis Phase 2a — Suite Adapters + Analyzers Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking. Each task is TDD-shaped: write the failing test, run it red, write the minimal implementation, run it green, commit.
+
+**Goal:** Ship the GoldenAnalysis suite-consumption layer — `match.rates`, `cluster.distribution`, `quality.rollup` analyzers + the `match`/`check`/`flow`/`pipe` artifact adapters + `analyze_match()` / `analyze_pipeline()` — so an `AnalysisReport` can be produced from real GoldenMatch / GoldenCheck / GoldenFlow / GoldenPipe outputs.
+
+**Architecture:** Analyzers are **pure functions over `AnalyzerInput.artifacts`** (a dict of typed producer outputs); adapters are the only code that touches a suite package, and they lazy-import it so the core install stays dependency-light. Analyzers degrade gracefully — they emit the metrics their available artifacts support and silently omit the rest. The cross-run layer (`ReportHistory`, regressions, narrative) is **Phase 2b, not here**.
+
+**Tech Stack:** Python ≥3.11, polars, pydantic v2; optional `goldenmatch` / `goldencheck` / `goldenflow` / `goldenpipe` (the `[match]`/`[check]`/`[flow]`/`[pipe]` extras).
+
+**Spec:** `docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md` (Appendix A = metric catalog; the worked scenario = the integration target).
+
+**Builds on:** Phase 1 (`goldenanalysis 0.1.0`, PR #808). This plan assumes the Phase 1 package exists: `models/`, `core/aggregate.py`, `analyzers/base.py` + `frame_summary.py`, `registry.py`, `adapters/frame.py`, `_api.analyze`, exporters, CLI.
+
+---
+
+## Grounding: the REAL producer APIs (verified 2026-06-08)
+
+These are the actual shapes the adapters consume. **Do not trust the spec's illustrative shapes over these.**
+
+**GoldenMatch** (`goldenmatch/_api.py:67-95`): `dedupe_df(df, config=None, ...) -> DedupeResult` with fields `golden`, `clusters: dict[int, dict]`, `dupes`, `unique`, `stats: dict`, `scored_pairs: list[tuple[int,int,float]]` (**retained by default**, `(min_id, max_id, score)`), `config`, `postflight_report`, `memory_stats`.
+- `stats` keys: `total_records`, `total_clusters`, `matched_records`, `match_rate`.
+- `clusters` per-entry: multi-member `{members: list[int], size: int, oversized: bool, pair_scores: dict, confidence: float, bottleneck_pair, cluster_quality: str}`; singleton `{members, size, oversized}`.
+- **Recall certificate is NOT on `DedupeResult`** and **NOT re-exported**. It lives in `goldenmatch/core/recall_certificate.py`: `RecallEstimate{recall, ...}` (unsupervised point estimate) and `RecallCertificate{recall, recall_lower (SAFE bound), recall_upper, ...}`. `match.rates` therefore treats the certificate as an **optional input** the adapter passes in (see Task 2).
+- `match_df(...) -> MatchResult{matched, unmatched, stats, ...}` — NO clusters/scored_pairs.
+
+**GoldenCheck** (`goldencheck/engine/scanner.py`): `scan_dataframe(df) -> (findings, profile)` — **true in-memory, no file path**. `Finding` (`goldencheck/models/finding.py:14-26`) `{severity: Severity(INFO=1/WARNING=2/ERROR=3), column, check: str, message, affected_rows, confidence, source, metadata}`. `profile.health_score(findings_by_column, errors, warnings) -> (grade: str, score: int 0-100)` is a **method on `DatasetProfile`** (no top-level `health_score`). Also `cell_quality(df) -> dict[(row,col), float]`, `functional_dependencies(df) -> list[FunctionalDependency]`.
+
+**GoldenFlow** (`goldenflow/engine/transformer.py:17-20`): `transform_df(df) -> TransformResult{df, manifest}`. `Manifest{source, records: list[TransformRecord], errors, created_at}`; `TransformRecord{column, transform, affected_rows, total_rows, ...}`. So `flow.rows_changed = sum(r.affected_rows for r in records)` (derived), `flow.rules_fired = len(records)`.
+
+**GoldenPipe** (`goldenpipe/models/context.py:52-90`): `PipeResult{status, source, input_rows, stages, artifacts: dict, skipped, errors, reasoning, timing}`. `artifacts` real keys: `findings` (list[dict]), `profile`, `manifest` (GoldenFlow Manifest), `clusters` (dict[int,dict]), `golden`/`unique`/`dupes`, `match_stats` (dict), `scored_pairs` (list[tuple]), `matchkey_used` (str), `identity_summary` (dict), `conflicts`. **No `recall_certificate` key** unless the prerequisite GoldenMatch PR (below) adds it.
+
+---
+
+## The `AnalyzerInput.artifacts` convention (the contract this plan establishes)
+
+Phase 1's `AnalyzerInput` already has `dataset: str`, `frame: Any`, `artifacts: dict[str, Any]`. This plan standardizes the artifact keys (mirroring `PipeResult.artifacts` so the `pipe` adapter is a near-passthrough):
+
+| key | value | produced by |
+|---|---|---|
+| `clusters` | `dict[int, dict]` | match, pipe |
+| `scored_pairs` | `list[tuple[int,int,float]]` | match, pipe |
+| `match_stats` | `dict` (total_records, match_rate, ...) | match, pipe |
+| `match_threshold` | `float \| None` (primary matchkey threshold from config) | match, pipe |
+| `recall_certificate` | `dict{estimate: float\|None, safe_bound: float\|None}` (normalized) | match (if supplied), pipe (if present) |
+| `findings` | `list[Finding \| dict]` | check, pipe |
+| `profile` | `DatasetProfile \| None` | check, pipe |
+| `manifest` | GoldenFlow `Manifest \| dict` | flow, pipe |
+
+Analyzers read these keys and **degrade**: emit the metrics the present keys support, omit the rest.
+
+---
+
+## Prerequisite (separate, named PR — NOT part of this plan's branch)
+
+**`feat(goldenmatch): surface unsupervised recall estimate on DedupeResult + pipe artifact`** — opt-in `certify: bool = False` on `dedupe_df` that, when set, computes `estimate_recall(build_decorrelated_systems(config.matchkeys))` after clustering and attaches `result.recall_certificate` (a `RecallEstimate`); the `goldenmatch.dedupe` pipe stage surfaces it as `artifacts["recall_certificate"]`. The **audit-calibrated safe bound stays evaluate-only** (it needs labels). This makes `match.recall_estimate` real end-to-end; `match.recall_safe_bound` remains an optional passed-in input. **This plan does not depend on that PR** — `match.rates` consumes the cert optionally and degrades — but the headline scenario only becomes real once it lands.
+
+---
+
+## Conventions
+
+- Commands run from the repo root. Env for every local run: `POLARS_SKIP_CPU_CHECK=1`, `PYTHONIOENCODING=utf-8`. Use `.venv/Scripts/python.exe -m pytest <path>` (Windows; `uv run pytest` misses workspace members per packages/python/CLAUDE.md).
+- **Local runs touch the pure tests only** (`test_match_rates.py`, `test_cluster_dist.py`, `test_quality_rollup.py`, `test_adapters_unit.py`, `test_analyze_suite.py`). The `@requires_extra` integration tests import `goldenmatch`/`goldencheck`/etc. and run **in CI only** (importing those locally risks the zombie-python box starvation documented in MEMORY). Do NOT run them locally.
+- TDD-shaped: failing test → red → minimal impl → green → commit. `feat(goldenanalysis):` / `test(goldenanalysis):` messages.
+- Branch: `feat/goldenanalysis-phase2a-suite-adapters`, cut from `main` AFTER #808 (Phase 1) merges. If #808 hasn't merged, stack on its branch and rebase post-merge (heed the squash-merge stacked-PR gotcha in CLAUDE.md).
+
+---
+
+## Phase 2a.0 — Artifact convention + shared report assembly
+
+### Task 0.1: Refactor `_api` to share report assembly
+
+**Files:**
+- Modify: `packages/python/goldenanalysis/goldenanalysis/_api.py`
+- Test: `packages/python/goldenanalysis/tests/test_assemble.py`
+
+Phase 1's `analyze()` inlines metric/table concatenation + run_id stamping. Extract it so `analyze_match`/`analyze_pipeline` reuse it.
+
+- [ ] **Step 1 (red):** `test_assemble.py` — import a new `_assemble_report(inp, analyzer_names, *, run_id=None, generated_at=None)` from `goldenanalysis._api`; feed an `AnalyzerInput(frame=pl.DataFrame({"a":[1]}), dataset="d")` and `["frame.summary"]`; assert it returns an `AnalysisReport` with `analyzers_run == ["frame.summary"]`, `source["dataset"]=="d"`, and a `frame.row_count` metric. Run red (ImportError).
+- [ ] **Step 2 (green):** Extract the body of `analyze()` (the loop that resolves analyzers, runs each over `inp`, concatenates `metrics`/`tables`, records unavailable, stamps `run_id`/`source`) into `_assemble_report(inp, analyzer_names, *, run_id=None, generated_at=None) -> AnalysisReport`. `source` = `{"dataset": inp.dataset, "producer": inp.artifacts.get("__producer__", "frame")}`; carry `source["unavailable"]` for requested-but-undiscoverable names. Re-implement `analyze(df, analyzers=None, ...)` to build the `frame` `AnalyzerInput` then call `_assemble_report`. **All 4 existing `test_analyze.py` tests must still pass unchanged.**
+- [ ] **Step 3 (green):** Run `test_assemble.py` + `test_analyze.py`. Expected: all pass.
+- [ ] **Step 4: Commit.** `refactor(goldenanalysis): extract _assemble_report for reuse across analyze entrypoints`
+
+---
+
+## Phase 2a.1 — `match.rates` analyzer (pure)
+
+### Task 1.1: `match.rates` over hand-built artifacts
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/analyzers/match_rates.py`
+- Test: `packages/python/goldenanalysis/tests/test_match_rates.py`
+
+Metrics (Appendix A): `match.pair_count` (pairs, ·), `match.match_rate` (ratio, ·), `match.threshold` (score, ·), `match.recall_estimate` (ratio, H), `match.recall_safe_bound` (ratio, H), `match.mean_pair_score` (score, ·); table `score_histogram`.
+
+- [ ] **Step 1 (red):** `test_match_rates.py`:
+  ```python
+  from goldenanalysis.analyzers.match_rates import MatchRatesAnalyzer
+  from goldenanalysis.models import AnalyzerInput
+
+  def _input(**artifacts):
+      return AnalyzerInput(dataset="customers", artifacts=artifacts)
+
+  def test_core_metrics():
+      inp = _input(
+          scored_pairs=[(0, 1, 0.9), (1, 2, 0.8), (3, 4, 0.95)],
+          match_stats={"total_records": 10, "match_rate": 0.3, "total_clusters": 2, "matched_records": 3},
+          match_threshold=0.82,
+      )
+      m = {x.key: x for x in MatchRatesAnalyzer().run(inp).metrics}
+      assert m["match.pair_count"].value == 3
+      assert m["match.match_rate"].value == 0.3
+      assert m["match.threshold"].value == 0.82
+      assert abs(m["match.mean_pair_score"].value - (0.9 + 0.8 + 0.95) / 3) < 1e-9
+      assert "match.recall_estimate" not in m   # no cert supplied -> omitted
+      assert "match.recall_safe_bound" not in m
+
+  def test_recall_from_certificate():
+      inp = _input(
+          scored_pairs=[(0, 1, 0.9)],
+          match_stats={"total_records": 4, "match_rate": 0.5},
+          recall_certificate={"estimate": 0.94, "safe_bound": 0.89},
+      )
+      m = {x.key: x for x in MatchRatesAnalyzer().run(inp).metrics}
+      assert m["match.recall_estimate"].value == 0.94
+      assert m["match.recall_estimate"].direction == "higher_better"
+      assert m["match.recall_safe_bound"].value == 0.89
+      assert m["match.recall_safe_bound"].direction == "higher_better"
+
+  def test_score_histogram_table():
+      inp = _input(scored_pairs=[(0,1,0.1),(2,3,0.9)], match_stats={"total_records": 4, "match_rate": 0.5})
+      tables = {t.name: t for t in MatchRatesAnalyzer().run(inp).tables}
+      assert "score_histogram" in tables
+
+  def test_empty_pairs_degrades():
+      inp = _input(scored_pairs=[], match_stats={"total_records": 5, "match_rate": 0.0})
+      m = {x.key: x for x in MatchRatesAnalyzer().run(inp).metrics}
+      assert m["match.pair_count"].value == 0
+      assert "match.mean_pair_score" not in m  # no pairs -> omit
+  ```
+  Run red.
+- [ ] **Step 2 (green):** implement. Read `cert = inp.artifacts.get("recall_certificate")`; normalize with a helper accepting a dict `{estimate, safe_bound}` OR a dataclass (`getattr(cert, "recall", None)` for estimate, `getattr(cert, "recall_lower", None)` for safe_bound). Emit `match.recall_estimate`/`match.recall_safe_bound` only when the respective value is not None. `match.threshold` only when `match_threshold` present. `match.mean_pair_score` only when pairs non-empty. `score_histogram` via `goldenanalysis.core.aggregate.histogram([s for *_, s in scored_pairs], bins=10)` → `AnalysisTable(name="score_histogram", columns=["bin_left","count"], rows=[[edge,c] for edge,c in hist])`. `info = AnalyzerInfo(name="match.rates", consumes=["scored_pairs","match_stats"], produces=[...])`.
+- [ ] **Step 3 (green):** run `test_match_rates.py`. Expected: pass.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): match.rates analyzer (pairs, match_rate, recall cert, score histogram)`
+
+---
+
+## Phase 2a.2 — `cluster.distribution` analyzer (pure)
+
+### Task 2.1: `cluster.distribution` over a hand-built cluster dict
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/analyzers/cluster_dist.py`
+- Test: `packages/python/goldenanalysis/tests/test_cluster_dist.py`
+
+Metrics: `cluster.count`, `cluster.record_count`, `cluster.singleton_ratio`, `cluster.size_p50`/`size_p95`/`size_max`, `cluster.reduction_ratio`; table `cluster_size_histogram` (buckets `1,2,3,"4+"`).
+
+- [ ] **Step 1 (red):** `test_cluster_dist.py` — build `clusters = {0:{"members":[0],"size":1}, 1:{"members":[1],"size":1}, 2:{"members":[2,3,4],"size":3}, 3:{"members":[5,6],"size":2}}` (4 clusters; sizes [1,1,3,2]; records=7). Assert: `cluster.count==4`, `cluster.record_count==7`, `cluster.singleton_ratio==0.5`, `cluster.size_max==3`, `cluster.reduction_ratio == 1 - 4/7`, and a `cluster_size_histogram` table with rows `[[1,2],[2,1],[3,1],["4+",0]]`. Run red.
+- [ ] **Step 2 (green):** implement reading `clusters = inp.artifacts["clusters"]`; `sizes = [c["size"] for c in clusters.values()]`; quantiles via `aggregate.quantile(sizes, 0.5/0.95)`; `record_count = sum(sizes)` (fall back to `match_stats["total_records"]` if clusters absent but stats present — but if `clusters` absent the analyzer emits nothing). `reduction_ratio = 1 - len(clusters)/record_count` (guard record_count==0). Histogram buckets: counts of size==1/2/3 and size>=4 → rows `[[1,n1],[2,n2],[3,n3],["4+",n4]]`. `info` consumes `["clusters"]`. Directions all neutral except none H/L (per Appendix A, all `·`).
+- [ ] **Step 3 (green):** run. Expected pass.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): cluster.distribution analyzer (sizes, singletons, reduction, histogram)`
+
+---
+
+## Phase 2a.3 — `quality.rollup` analyzer (pure, degrades per-producer)
+
+### Task 3.1: `quality.rollup` over findings + manifest
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/analyzers/quality_rollup.py`
+- Test: `packages/python/goldenanalysis/tests/test_quality_rollup.py`
+
+Metrics: `quality.findings_total` (findings, L), `quality.columns_with_findings` (columns, L), `quality.score` (ratio, H, only if a `profile` is present), `flow.rows_changed` (rows, ·), `flow.rules_fired` (count, ·); table `findings_by_class`.
+
+- [ ] **Step 1 (red):** `test_quality_rollup.py` uses **dicts** for findings (the `PipeResult.artifacts` shape) and a duck-typed manifest:
+  ```python
+  from types import SimpleNamespace
+  from goldenanalysis.analyzers.quality_rollup import QualityRollupAnalyzer
+  from goldenanalysis.models import AnalyzerInput
+
+  FINDINGS = [
+      {"severity": "WARNING", "column": "email", "check": "email_blanked"},
+      {"severity": "WARNING", "column": "email", "check": "email_blanked"},
+      {"severity": "ERROR", "column": "phone", "check": "phone_unparseable"},
+  ]
+  MANIFEST = SimpleNamespace(records=[
+      SimpleNamespace(column="email", transform="blank_malformed", affected_rows=1188, total_rows=4000),
+      SimpleNamespace(column="phone", transform="e164", affected_rows=12, total_rows=4000),
+  ])
+
+  def test_quality_and_flow_metrics():
+      inp = AnalyzerInput(dataset="customers", artifacts={"findings": FINDINGS, "manifest": MANIFEST})
+      r = QualityRollupAnalyzer().run(inp)
+      m = {x.key: x for x in r.metrics}
+      assert m["quality.findings_total"].value == 3
+      assert m["quality.columns_with_findings"].value == 2     # email, phone
+      assert m["flow.rows_changed"].value == 1200              # 1188 + 12
+      assert m["flow.rules_fired"].value == 2
+      assert "quality.score" not in m                          # no profile supplied
+      tbl = {t.name: t for t in r.tables}["findings_by_class"]
+      rows = {row[0]: row[1] for row in tbl.rows}
+      assert rows["email_blanked"] == 2 and rows["phone_unparseable"] == 1
+
+  def test_degrades_findings_only():
+      inp = AnalyzerInput(dataset="d", artifacts={"findings": FINDINGS})
+      m = {x.key: x for x in QualityRollupAnalyzer().run(inp).metrics}
+      assert "quality.findings_total" in m and "flow.rows_changed" not in m
+
+  def test_degrades_manifest_only():
+      inp = AnalyzerInput(dataset="d", artifacts={"manifest": MANIFEST})
+      m = {x.key: x for x in QualityRollupAnalyzer().run(inp).metrics}
+      assert "flow.rules_fired" in m and "quality.findings_total" not in m
+  ```
+  Run red.
+- [ ] **Step 2 (green):** implement with field accessors that handle dict OR object: `_get(f, "column")` = `f[k] if isinstance(f, dict) else getattr(f, k)`; severity normalized to upper-string. From findings: `findings_total=len`, `columns_with_findings=len({col})`, `findings_by_class` = Counter of `check`. `quality.score` only if `inp.artifacts.get("profile")` is not None: call `profile.health_score(findings_by_column=<{col:{"errors":e,"warnings":w}}>)[1] / 100.0` (build the per-column severity counts from findings). From manifest: `records = manifest.records if not dict else manifest["records"]`; `flow.rows_changed = sum(_get(r,"affected_rows"))`, `flow.rules_fired = len(records)`. Emit only the groups whose source artifact is present. `info` consumes `["findings","manifest"]`.
+- [ ] **Step 3 (green):** run. Expected pass.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): quality.rollup analyzer (findings + flow stats, per-producer degrade)`
+
+---
+
+## Phase 2a.4 — Adapters (lazy-import producers)
+
+### Task 4.1: `match` adapter (DedupeResult → AnalyzerInput) — duck-typed test
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/adapters/match.py`
+- Test: `packages/python/goldenanalysis/tests/test_adapters_unit.py`
+
+- [ ] **Step 1 (red):** in `test_adapters_unit.py`, feed `MatchArtifactAdapter().load(result, dataset="customers", certificate={"estimate":0.94,"safe_bound":0.89})` a `SimpleNamespace(clusters={0:{"members":[0],"size":1}}, scored_pairs=[(0,1,0.9)], stats={"total_records":2,"match_rate":0.5}, config=None)`. Assert the returned `AnalyzerInput.dataset=="customers"` and `.artifacts` has `clusters`, `scored_pairs`, `match_stats` (== result.stats), `recall_certificate=={"estimate":0.94,"safe_bound":0.89}`, and `__producer__=="goldenmatch"`. Run red.
+- [ ] **Step 2 (green):** implement `MatchArtifactAdapter.load(self, result, *, dataset=None, certificate=None) -> AnalyzerInput`. It reads `result.clusters/scored_pairs/stats` (duck-typed; no `goldenmatch` import). `match_threshold` extracted from `result.config` if it exposes matchkeys with a threshold (best-effort try/except → None). `recall_certificate`: if `certificate` arg given, normalize to `{estimate, safe_bound}` (accept dict or `RecallEstimate`/`RecallCertificate` via getattr `recall`/`recall_lower`); else if `getattr(result, "recall_certificate", None)` present (the prerequisite GoldenMatch PR), normalize that; else omit. `artifacts["__producer__"]="goldenmatch"`.
+- [ ] **Step 3 (green):** run. Expected pass.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): match adapter (DedupeResult -> artifacts, optional recall cert)`
+
+### Task 4.2: `flow` + `check` adapters
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/adapters/flow.py`
+- Create: `packages/python/goldenanalysis/goldenanalysis/adapters/check.py`
+- Test: extend `tests/test_adapters_unit.py`
+
+- [ ] **Step 1 (red):** `FlowArtifactAdapter().load(SimpleNamespace(df=<pl df>, manifest=<SimpleNamespace records=[...]>), dataset="d")` → `AnalyzerInput.artifacts["manifest"]` is the manifest, `frame` is the transformed df, `__producer__=="goldenflow"`. For check: `CheckArtifactAdapter().load(df)` requires the `goldencheck` import — test it raises a clear `ImportError`-derived message when goldencheck is absent (use `monkeypatch` to force the lazy import to fail) OR mark this assertion `@requires_extra`. Test the pure path: `CheckArtifactAdapter().from_scan(findings=[...], profile=None, dataset="d")` (a constructor that takes pre-computed scan output, no goldencheck needed) → artifacts has `findings`, `profile`, `__producer__=="goldencheck"`. Run red.
+- [ ] **Step 2 (green):** `FlowArtifactAdapter.load(result, *, dataset=None)` reads `result.df` + `result.manifest` (duck-typed). `CheckArtifactAdapter` has two entry points: `from_scan(findings, profile, *, dataset=None)` (pure, no import) and `load(df, *, dataset=None, **scan_kwargs)` which lazy-imports `goldencheck`, calls `goldencheck.scan_dataframe(df, **scan_kwargs)`, then delegates to `from_scan`. The lazy import raises `RuntimeError("goldenanalysis[check] requires goldencheck: pip install goldenanalysis[check]")` on ImportError.
+- [ ] **Step 3 (green):** run pure tests. Expected pass.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): flow + check adapters (lazy producer import, pure from_scan seam)`
+
+### Task 4.3: `pipe` adapter (PipeResult → AnalyzerInput)
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/adapters/pipe.py`
+- Test: extend `tests/test_adapters_unit.py`
+
+- [ ] **Step 1 (red):** `PipeArtifactAdapter().load(SimpleNamespace(artifacts={"clusters":{...},"scored_pairs":[...],"match_stats":{...},"findings":[...],"manifest":<ns>,"recall_certificate":<ns recall=0.94 recall_lower=0.89>}, source="customers.parquet", input_rows=4000))` → `AnalyzerInput.dataset=="customers"` (stem of source), `.artifacts` carries the same keys through, `recall_certificate` normalized to `{estimate:0.94, safe_bound:0.89}`, `__producer__=="goldenpipe"`. Run red.
+- [ ] **Step 2 (green):** implement. `dataset` = `Path(result.source).stem` (or "frame" for `<DataFrame>`). Copy `result.artifacts` into `artifacts` (shallow), normalize any `recall_certificate` to the `{estimate, safe_bound}` dict, set `__producer__="goldenpipe"`. No `goldenpipe` import needed (duck-typed).
+- [ ] **Step 3 (green):** run. Expected pass.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): pipe adapter (PipeResult.artifacts passthrough + cert normalize)`
+
+---
+
+## Phase 2a.5 — `analyze_match` / `analyze_pipeline` + registration
+
+### Task 5.1: entry points
+
+**Files:**
+- Modify: `packages/python/goldenanalysis/goldenanalysis/_api.py`
+- Modify: `packages/python/goldenanalysis/goldenanalysis/__init__.py` (lazy export)
+- Test: `packages/python/goldenanalysis/tests/test_analyze_suite.py`
+
+- [ ] **Step 1 (red):** `test_analyze_suite.py` builds a duck-typed dedupe result + calls `ga.analyze_match(result, dataset="customers")`; asserts `analyzers_run` contains `match.rates` and `cluster.distribution`, metrics include `match.pair_count` and `cluster.count`, `source["dataset"]=="customers"`. A second test builds a duck-typed pipe result (artifacts with findings+manifest+clusters) and calls `ga.analyze_pipeline(result)`; asserts `analyzers_run` is the subset whose artifacts are present (e.g. `quality.rollup`, `match.rates`, `cluster.distribution`) and NOT analyzers whose artifacts are absent. Run red.
+- [ ] **Step 2 (green):** `analyze_match(result, *, dataset=None, certificate=None, run_id=None)` = `MatchArtifactAdapter().load(...)` then `_assemble_report(inp, ["match.rates","cluster.distribution"])`. `analyze_pipeline(result, *, run_id=None)` = `PipeArtifactAdapter().load(result)` then select analyzers whose `info.consumes` is satisfied by present artifact keys (`_artifact_compatible(inp)` helper: an analyzer runs iff at least one of its `consumes` keys is in `inp.artifacts`), then `_assemble_report`. Lazy-export both from `__init__._LAZY`.
+
+  > **Known limitation (by design; full Appendix-B parity is a 2b concern):** `frame.summary` will NOT fire under `analyze_pipeline` because `PipeResult` does **not** expose the input DataFrame (confirmed: `PipeContext.df` is not on `PipeResult`; only `input_rows` is). So `analyze_pipeline`'s `analyzers_run` is the suite-analyzer subset, not including `frame.summary`. The Appendix-B example report (which lists `frame.summary` + a `frame.row_count`) is the **parity-fixture target deferred to Phase 2b alongside narrative** — if it's wanted, 2b can emit `frame.row_count` from `result.input_rows` without the frame. Do not expand 2a to chase it.
+- [ ] **Step 3 (green):** run. Expected pass.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): analyze_match + analyze_pipeline entrypoints`
+
+### Task 5.2: register the 3 analyzers
+
+**Files:**
+- Modify: `packages/python/goldenanalysis/pyproject.toml` (`[project.entry-points."goldenanalysis.analyzers"]`)
+- Modify: `packages/python/goldenanalysis/goldenanalysis/registry.py` (`_FALLBACK`)
+- Test: extend `tests/test_registry.py`
+
+- [ ] **Step 1 (red):** assert `available_analyzers()` ⊇ `{"frame.summary","match.rates","cluster.distribution","quality.rollup"}` and each `load_analyzer(name).info.name == name`. Run red.
+- [ ] **Step 2 (green):** add the 3 entry points + fallback map entries (`match.rates`→`analyzers.match_rates:MatchRatesAnalyzer`, etc.). Re-run `uv pip install -e packages/python/goldenanalysis` so the entry-points refresh.
+- [ ] **Step 3 (green):** run. Expected pass.
+- [ ] **Step 4: Commit.** `feat(goldenanalysis): register match.rates/cluster.distribution/quality.rollup`
+
+---
+
+## Phase 2a.6 — Integration tests (CI-only, require extras)
+
+### Task 6.1: real-producer end-to-end (marked, no local run)
+
+**Files:**
+- Create: `packages/python/goldenanalysis/tests/conftest.py` add `requires_extra` marker helper
+- Create: `packages/python/goldenanalysis/tests/integration/test_real_producers.py`
+
+- [ ] **Step 1:** add a `requires(pkg)` skip helper in `conftest.py`: `requires_goldenmatch = pytest.mark.skipif(importlib.util.find_spec("goldenmatch") is None, reason="needs goldenanalysis[match]")` etc.
+- [ ] **Step 2 (CI-green):** `test_real_producers.py`:
+  - `@requires_goldenmatch` build a tiny synthetic dedupe fixture (surnames spread across soundex codes per MEMORY `feedback_synthetic_surname_fixtures`), run `goldenmatch.dedupe_df`, `ga.analyze_match(result, dataset="t")`, assert `cluster.count >= 1` and `match.pair_count >= 0` and the report round-trips to markdown.
+  - `@requires_goldencheck @requires_goldenflow` run `scan_dataframe` + `transform_df` on a messy frame, hand-assemble a `quality.rollup` input via the adapters, assert `quality.findings_total >= 0` and `flow.rules_fired >= 0`.
+  - `@requires_goldenpipe` run `goldenpipe.run_df`/`run`, `ga.analyze_pipeline(result)`, assert ≥2 analyzers ran.
+  - Each integration test carries a loud comment: these prove the adapters against REAL shapes; a producer shape change breaks them here, not silently.
+- [ ] **Step 3: Commit.** `test(goldenanalysis): real-producer integration (CI-only, require extras)`
+
+> **Do NOT run these locally** (imports goldenmatch/polars → box risk). They run in the CI lane wired in Task 7.1.
+
+---
+
+## Phase 2a.7 — CI wiring + docs
+
+### Task 7.1: install extras in the goldenanalysis CI lane
+
+**Files:** `.github/workflows/ci.yml`
+
+- [ ] **Step 1:** In the `python` job, after `uv sync --all-packages`, add a goldenanalysis-only step mirroring the goldenmatch datafusion pattern:
+  ```yaml
+  - if: matrix.pkg == 'goldenanalysis'
+    run: uv pip install -e 'packages/python/goldenanalysis[match,check,flow,pipe]'
+  ```
+  so the `@requires_*` integration tests actually RUN (the sibling packages resolve via the workspace). Without this they silently skip — a false green (the goldenmatch CLAUDE.md importorskip lesson).
+- [ ] **Step 2:** Confirm the `python_goldenanalysis` path filter (added in Phase 1) still triggers the lane; no new filter entry needed (same package path). A change under `packages/python/goldenanalysis/**` already enters the matrix.
+- [ ] **Step 3: Commit.** `ci(goldenanalysis): install suite extras so adapter integration tests run`
+
+### Task 7.2: CHANGELOG + README
+
+**Files:** `packages/python/goldenanalysis/CHANGELOG.md`, `README.md`
+
+- [ ] **Step 1:** CHANGELOG `0.2.0` (unreleased) entry: suite adapters + 3 analyzers + analyze_match/analyze_pipeline. README: add a "Over a GoldenMatch result" + "Whole pipeline" snippet (mirror spec Public API). Note `recall_safe_bound` needs a labeled audit; `recall_estimate` needs the GoldenMatch `certify` prerequisite.
+- [ ] **Step 2: Commit.** `docs(goldenanalysis): document suite adapters + analyze_match/analyze_pipeline (0.2.0)`
+
+---
+
+## Phase 2a.8 — Verify + push
+
+### Task 8.1: full local verification (pure tests only)
+
+- [ ] **Step 1:** `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 .venv/Scripts/python.exe -m pytest packages/python/goldenanalysis -q --ignore=packages/python/goldenanalysis/tests/integration` → all pure tests green.
+- [ ] **Step 2:** `.venv/Scripts/python.exe -m ruff check packages/python/goldenanalysis` → clean.
+- [ ] **Step 3:** bounded pyright: `uv run --with pyright pyright packages/python/goldenanalysis/goldenanalysis` → 0 errors.
+- [ ] **Step 4:** Push (auth dance: `gh auth switch --user benzsevern`, push, switch back to `benzsevern-mjh`). Open PR vs main. CI runs the integration lane (extras installed) — confirm the `@requires_*` tests actually ran (grep the log for their node ids, not "skipped").
+
+---
+
+## Acceptance (Phase 2a done when)
+
+- [ ] `match.rates`, `cluster.distribution`, `quality.rollup` emit the exact Appendix-A metrics with correct `direction`; pure unit tests lock the values.
+- [ ] `match`/`check`/`flow`/`pipe` adapters map real producer outputs → the standardized `artifacts` keys; core install stays zero-suite-dep (adapters lazy-import; pure `from_scan`/duck-typed seams tested without the producers).
+- [ ] `analyze_match(result)` and `analyze_pipeline(result)` assemble reports; `analyze_pipeline` fans out only to analyzers whose artifacts are present.
+- [ ] `match.rates` emits `recall_estimate`/`recall_safe_bound` when a certificate is supplied and **degrades silently** when not.
+- [ ] The 3 analyzers are registered (entry-point + fallback); `available_analyzers()` lists all four.
+- [ ] CI installs `[match,check,flow,pipe]` and the integration tests RUN (not skip) — verified in the log.
+- [ ] ruff + pyright clean; pure suite green locally.
+
+### Explicitly deferred to Phase 2b (do NOT build here)
+`ReportHistory` (jsonl + sqlite), `trend`, `detect_regressions`, `RegressionPolicy`, `Baseline` strategies, **narrative generation**, wiring the `trend`/`regressions` CLI from stubs. The GoldenMatch `certify`-surfacing PR is a separate named producer PR.

--- a/packages/python/goldenanalysis/CHANGELOG.md
+++ b/packages/python/goldenanalysis/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to GoldenAnalysis are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.2.0] - unreleased
+
+Phase 2a — suite consumption. Produce an `AnalysisReport` from real suite outputs.
+
+### Added
+- `ga.analyze_match(result, *, certificate=None)` — analyze a GoldenMatch
+  `DedupeResult` (`match.rates` + `cluster.distribution`).
+- `ga.analyze_pipeline(result)` — analyze a GoldenPipe `PipeResult`, fanning out to
+  every analyzer whose consumed artifacts are present.
+- Analyzers: `match.rates` (pair count, match rate, threshold, recall estimate +
+  safe bound from a certificate, mean score, score histogram), `cluster.distribution`
+  (count, singleton ratio, size quantiles, reduction ratio, size histogram),
+  `quality.rollup` (findings totals + GoldenCheck score + GoldenFlow rows-changed /
+  rules-fired, degrading per-producer).
+- Adapters: `match` / `flow` / `pipe` (duck-typed, no eager suite imports) and
+  `check` (lazy `goldencheck` import behind the `[check]` extra; pure `from_scan`
+  seam). They populate a standardized `AnalyzerInput.artifacts` vocabulary.
+
+### Notes
+- `match.recall_estimate` flows automatically once `goldenmatch.dedupe_df(...,
+  certify=True)` attaches a `RecallEstimate` (goldenmatch PR); `match.recall_safe_bound`
+  needs a labelled audit and is supplied via `certificate=`. Both degrade silently
+  when absent.
+- `frame.summary` does not run under `analyze_pipeline` (a `PipeResult` exposes no
+  input frame). Cross-run `ReportHistory` / regression detection / narrative are
+  Phase 2b.
+
 ## [0.1.0] - 2026-06-08
 
 Phase 1 — Python core. The generic frame path, end to end.

--- a/packages/python/goldenanalysis/README.md
+++ b/packages/python/goldenanalysis/README.md
@@ -43,6 +43,24 @@ goldenanalysis report report.json --format markdown      # re-render a saved rep
 `trend` and `regressions` are visible in `--help` but are stubs until `0.2.0`
 (they need cross-run `ReportHistory`).
 
+## Over the suite (`0.2.0`)
+
+With the relevant extra installed (`pip install goldenanalysis[match,check,flow,pipe]`):
+
+```python
+# A GoldenMatch dedupe result -> match.rates + cluster.distribution
+report = ga.analyze_match(dedupe_result)
+
+# A whole-pipeline manifest -> every analyzer whose artifacts are present
+report = ga.analyze_pipeline(pipe_result)
+```
+
+`match.rates` emits `match.recall_estimate` when GoldenMatch ran
+`dedupe_df(..., certify=True)` (it attaches an unsupervised `RecallEstimate`), and
+`match.recall_safe_bound` when you pass an audit-calibrated certificate
+(`analyze_match(result, certificate=...)`) — the safe bound needs a labelled
+sample, so it can't be computed automatically. Both degrade silently when absent.
+
 ## GoldenCheck vs GoldenAnalysis
 
 They are easy to confuse and are deliberately distinct:

--- a/packages/python/goldenanalysis/goldenanalysis/__init__.py
+++ b/packages/python/goldenanalysis/goldenanalysis/__init__.py
@@ -19,15 +19,24 @@ from typing import TYPE_CHECKING, Any
 
 __version__ = "0.1.0"
 
-__all__ = ["analyze", "AnalysisReport", "Metric", "__version__"]
+__all__ = [
+    "analyze",
+    "analyze_match",
+    "analyze_pipeline",
+    "AnalysisReport",
+    "Metric",
+    "__version__",
+]
 
 if TYPE_CHECKING:
-    from goldenanalysis._api import analyze
+    from goldenanalysis._api import analyze, analyze_match, analyze_pipeline
     from goldenanalysis.models import AnalysisReport, Metric
 
 # Map exported name -> (submodule, attribute). Resolved on first access.
 _LAZY: dict[str, tuple[str, str]] = {
     "analyze": ("goldenanalysis._api", "analyze"),
+    "analyze_match": ("goldenanalysis._api", "analyze_match"),
+    "analyze_pipeline": ("goldenanalysis._api", "analyze_pipeline"),
     "AnalysisReport": ("goldenanalysis.models", "AnalysisReport"),
     "Metric": ("goldenanalysis.models", "Metric"),
 }

--- a/packages/python/goldenanalysis/goldenanalysis/_api.py
+++ b/packages/python/goldenanalysis/goldenanalysis/_api.py
@@ -1,27 +1,76 @@
-"""Top-level ``analyze()`` — resolve analyzers, run them over an artifact, assemble
-a single ``AnalysisReport``.
+"""Top-level analyze entrypoints — resolve analyzers, run them over an artifact,
+assemble a single ``AnalysisReport``.
 
-Phase 1 is the generic frame path only. Suite entry points (``analyze_match``,
-``analyze_pipeline``) and narrative generation land in Phase 2.
+- ``analyze(df, ...)`` — the generic frame path (Phase 1).
+- ``analyze_match(result, ...)`` / ``analyze_pipeline(result)`` — suite paths
+  (Phase 2a) over a GoldenMatch ``DedupeResult`` / GoldenPipe ``PipeResult``.
+
+Cross-run aggregation + narrative generation land in Phase 2b.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import UTC, datetime
+from typing import Any
 
 import polars as pl
 
 from goldenanalysis.adapters import FrameArtifactAdapter
-from goldenanalysis.models import AnalysisReport
+from goldenanalysis.models import AnalysisReport, AnalyzerInput
 from goldenanalysis.registry import available_analyzers, load_analyzer
+
+
+def _assemble_report(
+    inp: AnalyzerInput,
+    analyzer_names: Sequence[str],
+    *,
+    run_id: str | None = None,
+    generated_at: datetime | None = None,
+) -> AnalysisReport:
+    """Run ``analyzer_names`` over ``inp`` and assemble one ``AnalysisReport``.
+
+    Shared by every analyze entrypoint. Names that are requested but not
+    discoverable are recorded in ``source["unavailable"]`` rather than raising.
+    """
+    ds = inp.dataset
+    discoverable = set(available_analyzers())
+
+    ran: list[str] = []
+    unavailable: list[str] = []
+    metrics = []
+    tables = []
+    for name in analyzer_names:
+        if name not in discoverable:
+            unavailable.append(name)
+            continue
+        result = load_analyzer(name).run(inp)
+        metrics.extend(result.metrics)
+        tables.extend(result.tables)
+        ran.append(name)
+
+    gen = generated_at or datetime.now(UTC)
+    rid = run_id or f"{gen.isoformat()}#{ds}"
+    source = {"dataset": ds, "producer": inp.artifacts.get("__producer__", "frame")}
+    if unavailable:
+        source["unavailable"] = ",".join(unavailable)
+
+    return AnalysisReport(
+        run_id=rid,
+        generated_at=gen,
+        source=source,
+        metrics=metrics,
+        tables=tables,
+        narrative=None,
+        analyzers_run=ran,
+    )
 
 
 def _frame_compatible_analyzers() -> list[str]:
     """Discoverable analyzers that consume a generic ``frame`` and import cleanly.
 
-    Loading is guarded so analyzers needing optional suite deps (Phase 2+) are
-    simply skipped from the default set rather than breaking the generic path.
+    Loading is guarded so analyzers needing optional suite deps are simply skipped
+    from the default set rather than breaking the generic path.
     """
     out: list[str] = []
     for name in available_analyzers():
@@ -30,6 +79,21 @@ def _frame_compatible_analyzers() -> list[str]:
         except Exception:
             continue
         if "frame" in analyzer.info.consumes:
+            out.append(name)
+    return out
+
+
+def _artifact_compatible_analyzers(inp: AnalyzerInput) -> list[str]:
+    """Discoverable analyzers at least one of whose ``consumes`` keys is present
+    in ``inp.artifacts`` — the fan-out selector for ``analyze_pipeline``."""
+    present = set(inp.artifacts)
+    out: list[str] = []
+    for name in available_analyzers():
+        try:
+            analyzer = load_analyzer(name)
+        except Exception:
+            continue
+        if any(key in present for key in analyzer.info.consumes):
             out.append(name)
     return out
 
@@ -49,36 +113,42 @@ def analyze(
     than raising — the report says what it could and couldn't compute.
     """
     inp = FrameArtifactAdapter().load(df, dataset=dataset)
-    ds = inp.dataset
-
     requested = list(analyzers) if analyzers is not None else _frame_compatible_analyzers()
-    discoverable = set(available_analyzers())
+    return _assemble_report(inp, requested, run_id=run_id, generated_at=generated_at)
 
-    ran: list[str] = []
-    unavailable: list[str] = []
-    metrics = []
-    tables = []
-    for name in requested:
-        if name not in discoverable:
-            unavailable.append(name)
-            continue
-        result = load_analyzer(name).run(inp)
-        metrics.extend(result.metrics)
-        tables.extend(result.tables)
-        ran.append(name)
 
-    gen = generated_at or datetime.now(UTC)
-    rid = run_id or f"{gen.isoformat()}#{ds}"
-    source = {"dataset": ds, "producer": "frame"}
-    if unavailable:
-        source["unavailable"] = ",".join(unavailable)
+def analyze_match(
+    result: Any,
+    *,
+    dataset: str | None = None,
+    certificate: Any = None,
+    run_id: str | None = None,
+    generated_at: datetime | None = None,
+) -> AnalysisReport:
+    """Analyze a GoldenMatch ``DedupeResult``: ``match.rates`` + ``cluster.distribution``.
 
-    return AnalysisReport(
-        run_id=rid,
-        generated_at=gen,
-        source=source,
-        metrics=metrics,
-        tables=tables,
-        narrative=None,
-        analyzers_run=ran,
+    ``certificate`` (optional) is a recall certificate — a ``{estimate, safe_bound}``
+    dict or a ``RecallEstimate``/``RecallCertificate``. When absent, the recall
+    metrics are omitted (graceful degradation).
+    """
+    from goldenanalysis.adapters.match import MatchArtifactAdapter
+
+    inp = MatchArtifactAdapter().load(result, dataset=dataset, certificate=certificate)
+    return _assemble_report(
+        inp, ["match.rates", "cluster.distribution"], run_id=run_id, generated_at=generated_at
     )
+
+
+def analyze_pipeline(
+    result: Any,
+    *,
+    run_id: str | None = None,
+    generated_at: datetime | None = None,
+) -> AnalysisReport:
+    """Analyze a GoldenPipe ``PipeResult``, fanning out to every analyzer whose
+    consumed artifacts are present in ``result.artifacts``."""
+    from goldenanalysis.adapters.pipe import PipeArtifactAdapter
+
+    inp = PipeArtifactAdapter().load(result)
+    names = _artifact_compatible_analyzers(inp)
+    return _assemble_report(inp, names, run_id=run_id, generated_at=generated_at)

--- a/packages/python/goldenanalysis/goldenanalysis/adapters/check.py
+++ b/packages/python/goldenanalysis/goldenanalysis/adapters/check.py
@@ -1,0 +1,33 @@
+"""``check`` adapter — GoldenCheck scan output → ``AnalyzerInput.artifacts``.
+
+Two entry points:
+- ``from_scan(findings, profile, ...)`` — pure, no ``goldencheck`` import (the seam
+  the unit tests and the pipe adapter use).
+- ``load(df, ...)`` — lazy-imports ``goldencheck`` and runs ``scan_dataframe``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldenanalysis.models import AnalyzerInput
+
+
+class CheckArtifactAdapter:
+    """Normalizes GoldenCheck scan output into an ``AnalyzerInput``."""
+
+    def from_scan(self, findings: Any, profile: Any = None, *, dataset: str | None = None) -> AnalyzerInput:
+        return AnalyzerInput(
+            dataset=dataset or "check",
+            artifacts={"__producer__": "goldencheck", "findings": findings, "profile": profile},
+        )
+
+    def load(self, df: Any, *, dataset: str | None = None, **scan_kwargs: Any) -> AnalyzerInput:
+        try:
+            import goldencheck  # pyright: ignore[reportMissingImports]  # optional [check] extra
+        except ImportError as exc:  # pragma: no cover - exercised in CI with the extra
+            raise RuntimeError(
+                "goldenanalysis[check] requires goldencheck: pip install goldenanalysis[check]"
+            ) from exc
+        findings, profile = goldencheck.scan_dataframe(df, **scan_kwargs)
+        return self.from_scan(findings, profile, dataset=dataset)

--- a/packages/python/goldenanalysis/goldenanalysis/adapters/flow.py
+++ b/packages/python/goldenanalysis/goldenanalysis/adapters/flow.py
@@ -1,0 +1,25 @@
+"""``flow`` adapter — GoldenFlow ``TransformResult`` → ``AnalyzerInput.artifacts``.
+
+Duck-typed: reads ``.df`` and ``.manifest`` off the result; imports nothing from
+``goldenflow``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldenanalysis.models import AnalyzerInput
+
+
+class FlowArtifactAdapter:
+    """Normalizes a GoldenFlow ``TransformResult`` into an ``AnalyzerInput``."""
+
+    def load(self, result: Any, *, dataset: str | None = None) -> AnalyzerInput:
+        return AnalyzerInput(
+            dataset=dataset or "flow",
+            frame=getattr(result, "df", None),
+            artifacts={
+                "__producer__": "goldenflow",
+                "manifest": getattr(result, "manifest", None),
+            },
+        )

--- a/packages/python/goldenanalysis/goldenanalysis/adapters/match.py
+++ b/packages/python/goldenanalysis/goldenanalysis/adapters/match.py
@@ -1,0 +1,59 @@
+"""``match`` adapter — GoldenMatch ``DedupeResult`` → ``AnalyzerInput.artifacts``.
+
+Duck-typed: reads ``.clusters`` / ``.scored_pairs`` / ``.stats`` off the result,
+so it imports nothing from ``goldenmatch``. The recall certificate is optional —
+passed in by the caller, or read off ``result.recall_certificate`` when the
+producer attached one (``dedupe_df(..., certify=True)``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldenanalysis.models import AnalyzerInput
+
+
+def _normalize_cert(cert: Any) -> dict[str, Any] | None:
+    """Normalize a recall certificate to ``{estimate, safe_bound}`` (or None)."""
+    if cert is None:
+        return None
+    if isinstance(cert, dict):
+        return {
+            "estimate": cert.get("estimate", cert.get("recall")),
+            "safe_bound": cert.get("safe_bound", cert.get("recall_lower")),
+        }
+    return {
+        "estimate": getattr(cert, "recall", None),
+        "safe_bound": getattr(cert, "recall_lower", None),
+    }
+
+
+def _primary_threshold(config: Any) -> float | None:
+    """Best-effort: the first matchkey's threshold from the result's config."""
+    try:
+        matchkeys = config.get_matchkeys() if hasattr(config, "get_matchkeys") else getattr(config, "matchkeys", None)
+        for mk in matchkeys or []:
+            thr = getattr(mk, "threshold", None)
+            if thr is not None:
+                return float(thr)
+    except Exception:
+        return None
+    return None
+
+
+class MatchArtifactAdapter:
+    """Normalizes a GoldenMatch ``DedupeResult`` into an ``AnalyzerInput``."""
+
+    def load(self, result: Any, *, dataset: str | None = None, certificate: Any = None) -> AnalyzerInput:
+        cert = certificate if certificate is not None else getattr(result, "recall_certificate", None)
+        artifacts: dict[str, Any] = {
+            "__producer__": "goldenmatch",
+            "clusters": getattr(result, "clusters", {}) or {},
+            "scored_pairs": getattr(result, "scored_pairs", []) or [],
+            "match_stats": getattr(result, "stats", {}) or {},
+            "match_threshold": _primary_threshold(getattr(result, "config", None)),
+        }
+        normalized = _normalize_cert(cert)
+        if normalized is not None:
+            artifacts["recall_certificate"] = normalized
+        return AnalyzerInput(dataset=dataset or "match", artifacts=artifacts)

--- a/packages/python/goldenanalysis/goldenanalysis/adapters/pipe.py
+++ b/packages/python/goldenanalysis/goldenanalysis/adapters/pipe.py
@@ -1,0 +1,36 @@
+"""``pipe`` adapter — GoldenPipe ``PipeResult`` → ``AnalyzerInput.artifacts``.
+
+Near-passthrough: ``PipeResult.artifacts`` already carries the per-stage outputs
+(findings / manifest / clusters / scored_pairs / match_stats / recall_certificate
+/ ...) under the same keys the analyzers read. Duck-typed; no ``goldenpipe`` import.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from goldenanalysis.adapters.match import _normalize_cert
+from goldenanalysis.models import AnalyzerInput
+
+
+def _dataset_from_source(source: Any) -> str:
+    if not source or not isinstance(source, str) or source.startswith("<"):
+        return "frame"
+    return Path(source).stem or "frame"
+
+
+class PipeArtifactAdapter:
+    """Normalizes a GoldenPipe ``PipeResult`` into an ``AnalyzerInput``."""
+
+    def load(self, result: Any, *, dataset: str | None = None) -> AnalyzerInput:
+        artifacts: dict[str, Any] = dict(getattr(result, "artifacts", {}) or {})
+        artifacts["__producer__"] = "goldenpipe"
+        if "recall_certificate" in artifacts:
+            normalized = _normalize_cert(artifacts["recall_certificate"])
+            if normalized is None:
+                artifacts.pop("recall_certificate", None)
+            else:
+                artifacts["recall_certificate"] = normalized
+        ds = dataset or _dataset_from_source(getattr(result, "source", None))
+        return AnalyzerInput(dataset=ds, artifacts=artifacts)

--- a/packages/python/goldenanalysis/goldenanalysis/analyzers/cluster_dist.py
+++ b/packages/python/goldenanalysis/goldenanalysis/analyzers/cluster_dist.py
@@ -1,0 +1,77 @@
+"""``cluster.distribution`` — cluster-size shape from a GoldenMatch result.
+
+Reads ``clusters`` (and optionally ``match_stats`` for the record count) from
+``AnalyzerInput.artifacts``.
+"""
+
+from __future__ import annotations
+
+from goldenanalysis.core import aggregate as agg
+from goldenanalysis.models import (
+    AnalysisTable,
+    AnalyzerInfo,
+    AnalyzerInput,
+    AnalyzerResult,
+    Metric,
+)
+
+_PRODUCES = [
+    "cluster.count",
+    "cluster.record_count",
+    "cluster.singleton_ratio",
+    "cluster.size_p50",
+    "cluster.size_p95",
+    "cluster.size_max",
+    "cluster.reduction_ratio",
+]
+
+
+class ClusterDistributionAnalyzer:
+    """Cluster count, singleton ratio, size quantiles, reduction ratio, histogram."""
+
+    info = AnalyzerInfo(name="cluster.distribution", consumes=["clusters"], produces=_PRODUCES)
+
+    def run(self, inp: AnalyzerInput) -> AnalyzerResult:
+        clusters = inp.artifacts.get("clusters")
+        if not clusters:
+            return AnalyzerResult(metrics=[], tables=[])
+
+        sizes = [int(c.get("size", len(c.get("members", []))) if isinstance(c, dict) else c) for c in clusters.values()]
+        count = len(clusters)
+        # Prefer the engine's own record total; fall back to summed cluster sizes.
+        stats = inp.artifacts.get("match_stats", {}) or {}
+        record_count = int(stats.get("total_records", sum(sizes)))
+        singletons = sum(1 for s in sizes if s == 1)
+
+        metrics = [
+            Metric(key="cluster.count", value=count, unit="clusters", direction="neutral"),
+            Metric(key="cluster.record_count", value=record_count, unit="rows", direction="neutral"),
+            Metric(
+                key="cluster.singleton_ratio",
+                value=(singletons / count) if count else 0.0,
+                unit="ratio",
+                direction="neutral",
+            ),
+            Metric(key="cluster.size_p50", value=agg.quantile(sizes, 0.5), unit="rows", direction="neutral"),
+            Metric(key="cluster.size_p95", value=agg.quantile(sizes, 0.95), unit="rows", direction="neutral"),
+            Metric(key="cluster.size_max", value=max(sizes) if sizes else 0, unit="rows", direction="neutral"),
+            Metric(
+                key="cluster.reduction_ratio",
+                value=(1 - count / record_count) if record_count else 0.0,
+                unit="ratio",
+                direction="neutral",
+            ),
+        ]
+
+        # Discrete size histogram, buckets 1 / 2 / 3 / "4+".
+        n1 = sum(1 for s in sizes if s == 1)
+        n2 = sum(1 for s in sizes if s == 2)
+        n3 = sum(1 for s in sizes if s == 3)
+        n4 = sum(1 for s in sizes if s >= 4)
+        table = AnalysisTable(
+            name="cluster_size_histogram",
+            columns=["size", "count"],
+            rows=[[1, n1], [2, n2], [3, n3], ["4+", n4]],
+        )
+
+        return AnalyzerResult(metrics=metrics, tables=[table])

--- a/packages/python/goldenanalysis/goldenanalysis/analyzers/match_rates.py
+++ b/packages/python/goldenanalysis/goldenanalysis/analyzers/match_rates.py
@@ -1,0 +1,92 @@
+"""``match.rates`` — match metrics from a GoldenMatch result's artifacts.
+
+Reads ``scored_pairs`` / ``match_stats`` (+ optional ``recall_certificate`` and
+``match_threshold``) from ``AnalyzerInput.artifacts``. Degrades: emits the metrics
+its present artifacts support and omits the rest.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldenanalysis.core import aggregate as agg
+from goldenanalysis.models import (
+    AnalysisTable,
+    AnalyzerInfo,
+    AnalyzerInput,
+    AnalyzerResult,
+    Metric,
+)
+
+_PRODUCES = [
+    "match.pair_count",
+    "match.match_rate",
+    "match.threshold",
+    "match.recall_estimate",
+    "match.recall_safe_bound",
+    "match.mean_pair_score",
+]
+
+
+def _cert_values(cert: Any) -> tuple[float | None, float | None]:
+    """Normalize a certificate (dict or RecallEstimate/RecallCertificate) to
+    ``(estimate, safe_bound)``. Either may be None."""
+    if cert is None:
+        return None, None
+    if isinstance(cert, dict):
+        return cert.get("estimate", cert.get("recall")), cert.get("safe_bound", cert.get("recall_lower"))
+    # dataclass: RecallEstimate has .recall; RecallCertificate adds .recall_lower
+    return getattr(cert, "recall", None), getattr(cert, "recall_lower", None)
+
+
+class MatchRatesAnalyzer:
+    """Pair counts, match rate, recall (from a certificate), score distribution."""
+
+    info = AnalyzerInfo(name="match.rates", consumes=["scored_pairs", "match_stats"], produces=_PRODUCES)
+
+    def run(self, inp: AnalyzerInput) -> AnalyzerResult:
+        art = inp.artifacts
+        scored_pairs = art.get("scored_pairs", [])
+        stats = art.get("match_stats", {}) or {}
+
+        metrics: list[Metric] = [
+            Metric(key="match.pair_count", value=len(scored_pairs), unit="pairs", direction="neutral"),
+        ]
+        if "match_rate" in stats:
+            metrics.append(
+                Metric(key="match.match_rate", value=stats["match_rate"], unit="ratio", direction="neutral")
+            )
+        if art.get("match_threshold") is not None:
+            metrics.append(
+                Metric(key="match.threshold", value=art["match_threshold"], unit="score", direction="neutral")
+            )
+
+        estimate, safe_bound = _cert_values(art.get("recall_certificate"))
+        if estimate is not None:
+            metrics.append(
+                Metric(key="match.recall_estimate", value=estimate, unit="ratio", direction="higher_better")
+            )
+        if safe_bound is not None:
+            metrics.append(
+                Metric(
+                    key="match.recall_safe_bound", value=safe_bound, unit="ratio", direction="higher_better"
+                )
+            )
+
+        tables: list[AnalysisTable] = []
+        if scored_pairs:
+            scores = [float(s) for *_, s in scored_pairs]
+            mean_score = sum(scores) / len(scores)
+            metrics.append(
+                Metric(key="match.mean_pair_score", value=mean_score, unit="score", direction="neutral")
+            )
+            hist = agg.histogram(scores, bins=10)
+            tables.append(
+                AnalysisTable(
+                    name="score_histogram",
+                    columns=["bin_left", "count"],
+                    rows=[[edge, count] for edge, count in hist],
+                )
+            )
+
+        return AnalyzerResult(metrics=metrics, tables=tables)

--- a/packages/python/goldenanalysis/goldenanalysis/analyzers/quality_rollup.py
+++ b/packages/python/goldenanalysis/goldenanalysis/analyzers/quality_rollup.py
@@ -1,0 +1,130 @@
+"""``quality.rollup`` — a single "is the data healthy" view rolling up both
+GoldenCheck (scan findings + profile) and GoldenFlow (transform manifest).
+
+Reads ``findings`` / ``profile`` / ``manifest`` from ``AnalyzerInput.artifacts``,
+degrading per-producer: the ``quality.*`` keys need ``findings``; the ``flow.*``
+keys need ``manifest``; either can be absent.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from goldenanalysis.models import (
+    AnalysisTable,
+    AnalyzerInfo,
+    AnalyzerInput,
+    AnalyzerResult,
+    Metric,
+)
+
+_PRODUCES = [
+    "quality.findings_total",
+    "quality.columns_with_findings",
+    "quality.score",
+    "flow.rows_changed",
+    "flow.rules_fired",
+]
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from a dict or an object (Finding/TransformRecord either way)."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _severity_name(value: Any) -> str:
+    """Normalize a severity (enum / int / str) to an upper-case name."""
+    name = getattr(value, "name", None)
+    if name:
+        return str(name).upper()
+    if isinstance(value, int):
+        return {1: "INFO", 2: "WARNING", 3: "ERROR"}.get(value, str(value))
+    return str(value).upper()
+
+
+class QualityRollupAnalyzer:
+    """Findings totals + GoldenCheck score + GoldenFlow transform stats."""
+
+    info = AnalyzerInfo(name="quality.rollup", consumes=["findings", "manifest"], produces=_PRODUCES)
+
+    def run(self, inp: AnalyzerInput) -> AnalyzerResult:
+        art = inp.artifacts
+        metrics: list[Metric] = []
+        tables: list[AnalysisTable] = []
+
+        findings = art.get("findings")
+        if findings is not None:
+            by_class = Counter(str(_get(f, "check", "unknown")) for f in findings)
+            columns = {_get(f, "column") for f in findings}
+            metrics.append(
+                Metric(key="quality.findings_total", value=len(findings), unit="findings", direction="lower_better")
+            )
+            metrics.append(
+                Metric(
+                    key="quality.columns_with_findings",
+                    value=len({c for c in columns if c is not None}),
+                    unit="columns",
+                    direction="lower_better",
+                )
+            )
+            profile = art.get("profile")
+            if profile is not None:
+                score = _health_score(profile, findings)
+                if score is not None:
+                    metrics.append(
+                        Metric(key="quality.score", value=score, unit="ratio", direction="higher_better")
+                    )
+            tables.append(
+                AnalysisTable(
+                    name="findings_by_class",
+                    columns=["class", "count"],
+                    rows=[[cls, n] for cls, n in by_class.most_common()],
+                )
+            )
+
+        manifest = art.get("manifest")
+        if manifest is not None:
+            records = _get(manifest, "records", []) or []
+            metrics.append(
+                Metric(
+                    key="flow.rows_changed",
+                    value=sum(int(_get(r, "affected_rows", 0)) for r in records),
+                    unit="rows",
+                    direction="neutral",
+                )
+            )
+            metrics.append(
+                Metric(key="flow.rules_fired", value=len(records), unit="count", direction="neutral")
+            )
+
+        return AnalyzerResult(metrics=metrics, tables=tables)
+
+
+def _health_score(profile: Any, findings: Any) -> float | None:
+    """GoldenCheck ``DatasetProfile.health_score`` normalized to a 0-1 ratio.
+
+    Builds the per-column severity counts the method expects from the findings.
+    Returns None if the profile doesn't expose ``health_score``.
+    """
+    health = getattr(profile, "health_score", None)
+    if health is None:
+        return None
+    by_col: dict[str, dict[str, int]] = {}
+    for f in findings:
+        col = _get(f, "column")
+        if col is None:
+            continue
+        sev = _severity_name(_get(f, "severity"))
+        bucket = by_col.setdefault(col, {"errors": 0, "warnings": 0})
+        if sev == "ERROR":
+            bucket["errors"] += 1
+        elif sev == "WARNING":
+            bucket["warnings"] += 1
+    try:
+        _grade, score = health(findings_by_column=by_col)
+    except Exception:
+        return None
+    return score / 100.0

--- a/packages/python/goldenanalysis/goldenanalysis/registry.py
+++ b/packages/python/goldenanalysis/goldenanalysis/registry.py
@@ -18,6 +18,9 @@ _GROUP = "goldenanalysis.analyzers"
 # Fallback: name -> (module, class). Mirror pyproject's [project.entry-points].
 _FALLBACK: dict[str, tuple[str, str]] = {
     "frame.summary": ("goldenanalysis.analyzers.frame_summary", "FrameSummaryAnalyzer"),
+    "match.rates": ("goldenanalysis.analyzers.match_rates", "MatchRatesAnalyzer"),
+    "cluster.distribution": ("goldenanalysis.analyzers.cluster_dist", "ClusterDistributionAnalyzer"),
+    "quality.rollup": ("goldenanalysis.analyzers.quality_rollup", "QualityRollupAnalyzer"),
 }
 
 

--- a/packages/python/goldenanalysis/pyproject.toml
+++ b/packages/python/goldenanalysis/pyproject.toml
@@ -50,6 +50,9 @@ Author = "https://bensevern.dev"
 
 [project.entry-points."goldenanalysis.analyzers"]
 "frame.summary" = "goldenanalysis.analyzers.frame_summary:FrameSummaryAnalyzer"
+"match.rates" = "goldenanalysis.analyzers.match_rates:MatchRatesAnalyzer"
+"cluster.distribution" = "goldenanalysis.analyzers.cluster_dist:ClusterDistributionAnalyzer"
+"quality.rollup" = "goldenanalysis.analyzers.quality_rollup:QualityRollupAnalyzer"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/python/goldenanalysis/tests/integration/test_real_producers.py
+++ b/packages/python/goldenanalysis/tests/integration/test_real_producers.py
@@ -1,0 +1,131 @@
+"""Real-producer integration tests — these prove the adapters against the ACTUAL
+GoldenMatch / GoldenCheck / GoldenFlow / GoldenPipe output shapes.
+
+They run in CI where the [match,check,flow,pipe] extras are installed (see the
+goldenanalysis lane in .github/workflows/ci.yml) and SKIP on a bare local install.
+A producer-side shape change breaks them HERE rather than silently. Do NOT run
+these locally on the dev box (importing the suite packages risks the documented
+polars/torch hangs + zombie-process starvation).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import goldenanalysis as ga
+import polars as pl
+import pytest
+from goldenanalysis.adapters.check import CheckArtifactAdapter
+from goldenanalysis.adapters.flow import FlowArtifactAdapter
+
+
+def _requires(pkg: str) -> pytest.MarkDecorator:
+    return pytest.mark.skipif(
+        importlib.util.find_spec(pkg) is None, reason=f"needs goldenanalysis extra providing {pkg}"
+    )
+
+
+requires_goldenmatch = _requires("goldenmatch")
+requires_goldencheck = _requires("goldencheck")
+requires_goldenflow = _requires("goldenflow")
+requires_goldenpipe = _requires("goldenpipe")
+
+
+def _people_df() -> pl.DataFrame:
+    # Small dedupe fixture; surnames spread across distinct soundex codes so
+    # blocking makes several small blocks (no mega-block hang). 4 duplicate pairs.
+    return pl.DataFrame(
+        {
+            "first_name": [
+                "John", "Jon", "Mary", "Mari", "Robert", "Bob",
+                "Susan", "Sue", "Peter", "Linda", "Karl", "Omar",
+            ],
+            "last_name": [
+                "Smith", "Smith", "Jones", "Jones", "Brown", "Brown",
+                "Davis", "Davis", "Wilson", "Taylor", "Klein", "Hassan",
+            ],
+            "email": [
+                "j@x.com", "j@x.com", "m@x.com", "m@x.com", "r@x.com", "r@x.com",
+                "s@x.com", "s@x.com", "p@x.com", "l@x.com", "k@x.com", "o@x.com",
+            ],
+        }
+    )
+
+
+@requires_goldenmatch
+def test_analyze_match_over_real_dedupe_result() -> None:
+    import goldenmatch
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    config = GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["last_name"], transforms=["soundex"])],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="identity",
+                type="weighted",
+                threshold=0.7,
+                fields=[
+                    MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0),
+                    MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0),
+                    MatchkeyField(field="email", scorer="jaro_winkler", weight=0.8),
+                ],
+            )
+        ],
+    )
+    result = goldenmatch.dedupe_df(_people_df(), config=config)
+    report = ga.analyze_match(result, dataset="people")
+
+    keys = {m.key: m.value for m in report.metrics}
+    assert keys["cluster.count"] >= 1
+    assert keys["match.pair_count"] >= 0
+    assert set(report.analyzers_run) == {"match.rates", "cluster.distribution"}
+    # The report round-trips to markdown.
+    assert "cluster.count" in report.to_markdown()
+
+
+@requires_goldencheck
+@requires_goldenflow
+def test_quality_rollup_over_real_scan_and_transform() -> None:
+    import goldencheck
+    import goldenflow
+
+    messy = pl.DataFrame(
+        {
+            "name": ["  Alice ", "BOB", None, "carol", "Dave  "],
+            "email": ["a@x.com", "B@X.COM", "c@x.com", None, "d@x.com"],
+        }
+    )
+    findings, profile = goldencheck.scan_dataframe(messy)
+    transform = goldenflow.transform_df(messy)
+
+    check_inp = CheckArtifactAdapter().from_scan(findings, profile, dataset="messy")
+    flow_inp = FlowArtifactAdapter().load(transform, dataset="messy")
+    # Merge both producers' artifacts into one input for quality.rollup.
+    merged = check_inp.model_copy(update={"artifacts": {**check_inp.artifacts, **flow_inp.artifacts}})
+
+    from goldenanalysis.analyzers.quality_rollup import QualityRollupAnalyzer
+
+    metrics = {m.key for m in QualityRollupAnalyzer().run(merged).metrics}
+    assert "quality.findings_total" in metrics
+    assert "flow.rules_fired" in metrics
+
+
+@requires_goldenpipe
+def test_analyze_pipeline_over_real_pipe_result(tmp_path) -> None:
+    import goldenpipe
+
+    src = tmp_path / "people.csv"
+    _people_df().write_csv(src)
+    result = goldenpipe.run(str(src))
+    report = ga.analyze_pipeline(result)
+    # At least the producers whose artifacts are present should have run.
+    assert len(report.analyzers_run) >= 1

--- a/packages/python/goldenanalysis/tests/test_adapters_unit.py
+++ b/packages/python/goldenanalysis/tests/test_adapters_unit.py
@@ -1,0 +1,79 @@
+"""Suite adapters (pure — duck-typed producer stand-ins, no suite imports)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import polars as pl
+from goldenanalysis.adapters.check import CheckArtifactAdapter
+from goldenanalysis.adapters.flow import FlowArtifactAdapter
+from goldenanalysis.adapters.match import MatchArtifactAdapter
+from goldenanalysis.adapters.pipe import PipeArtifactAdapter
+
+
+def test_match_adapter() -> None:
+    result = SimpleNamespace(
+        clusters={0: {"members": [0], "size": 1}},
+        scored_pairs=[(0, 1, 0.9)],
+        stats={"total_records": 2, "match_rate": 0.5},
+        config=None,
+    )
+    inp = MatchArtifactAdapter().load(
+        result, dataset="customers", certificate={"estimate": 0.94, "safe_bound": 0.89}
+    )
+    assert inp.dataset == "customers"
+    assert inp.artifacts["__producer__"] == "goldenmatch"
+    assert inp.artifacts["clusters"] == result.clusters
+    assert inp.artifacts["scored_pairs"] == result.scored_pairs
+    assert inp.artifacts["match_stats"] == result.stats
+    assert inp.artifacts["recall_certificate"] == {"estimate": 0.94, "safe_bound": 0.89}
+
+
+def test_match_adapter_reads_result_certificate() -> None:
+    # Producer-attached RecallEstimate (dedupe_df certify=True) is normalized.
+    cert = SimpleNamespace(recall=0.94, recall_lower=None)
+    result = SimpleNamespace(clusters={}, scored_pairs=[], stats={}, config=None, recall_certificate=cert)
+    inp = MatchArtifactAdapter().load(result)
+    assert inp.artifacts["recall_certificate"] == {"estimate": 0.94, "safe_bound": None}
+
+
+def test_flow_adapter() -> None:
+    df = pl.DataFrame({"a": [1]})
+    manifest = SimpleNamespace(records=[])
+    inp = FlowArtifactAdapter().load(SimpleNamespace(df=df, manifest=manifest), dataset="d")
+    assert inp.artifacts["__producer__"] == "goldenflow"
+    assert inp.artifacts["manifest"] is manifest
+    assert inp.frame is df
+
+
+def test_check_adapter_from_scan_is_pure() -> None:
+    inp = CheckArtifactAdapter().from_scan(findings=[{"check": "x"}], profile=None, dataset="d")
+    assert inp.artifacts["__producer__"] == "goldencheck"
+    assert inp.artifacts["findings"] == [{"check": "x"}]
+    assert inp.artifacts["profile"] is None
+
+
+def test_pipe_adapter_passthrough_and_dataset() -> None:
+    cert = SimpleNamespace(recall=0.94, recall_lower=0.89)
+    result = SimpleNamespace(
+        artifacts={
+            "clusters": {0: {"members": [0], "size": 1}},
+            "scored_pairs": [(0, 1, 0.9)],
+            "match_stats": {"match_rate": 0.5},
+            "findings": [{"check": "x", "column": "a", "severity": "WARNING"}],
+            "manifest": SimpleNamespace(records=[]),
+            "recall_certificate": cert,
+        },
+        source="customers.parquet",
+        input_rows=4000,
+    )
+    inp = PipeArtifactAdapter().load(result)
+    assert inp.dataset == "customers"
+    assert inp.artifacts["__producer__"] == "goldenpipe"
+    assert inp.artifacts["clusters"] == result.artifacts["clusters"]
+    assert inp.artifacts["recall_certificate"] == {"estimate": 0.94, "safe_bound": 0.89}
+
+
+def test_pipe_adapter_dataframe_source() -> None:
+    inp = PipeArtifactAdapter().load(SimpleNamespace(artifacts={}, source="<DataFrame>"))
+    assert inp.dataset == "frame"

--- a/packages/python/goldenanalysis/tests/test_analyze.py
+++ b/packages/python/goldenanalysis/tests/test_analyze.py
@@ -32,6 +32,7 @@ def test_analyze_named_dataset_in_runid() -> None:
 
 def test_analyze_records_unavailable() -> None:
     df = pl.DataFrame({"a": [1]})
-    report = ga.analyze(df, analyzers=["frame.summary", "match.rates"])
+    # "does.not.exist" is not a registered analyzer -> recorded as unavailable.
+    report = ga.analyze(df, analyzers=["frame.summary", "does.not.exist"])
     assert report.analyzers_run == ["frame.summary"]
-    assert "match.rates" in report.source["unavailable"]
+    assert "does.not.exist" in report.source["unavailable"]

--- a/packages/python/goldenanalysis/tests/test_analyze_suite.py
+++ b/packages/python/goldenanalysis/tests/test_analyze_suite.py
@@ -1,0 +1,49 @@
+"""analyze_match / analyze_pipeline entrypoints (pure — duck-typed results)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import goldenanalysis as ga
+
+
+def test_analyze_match() -> None:
+    result = SimpleNamespace(
+        clusters={0: {"members": [0], "size": 1}, 1: {"members": [1, 2], "size": 2}},
+        scored_pairs=[(1, 2, 0.9)],
+        stats={"total_records": 3, "match_rate": 0.66},
+        config=None,
+    )
+    report = ga.analyze_match(result, dataset="customers")
+    assert set(report.analyzers_run) == {"match.rates", "cluster.distribution"}
+    keys = {m.key for m in report.metrics}
+    assert "match.pair_count" in keys and "cluster.count" in keys
+    assert report.source["dataset"] == "customers"
+    assert report.source["producer"] == "goldenmatch"
+
+
+def test_analyze_pipeline_fans_out_to_present_artifacts() -> None:
+    result = SimpleNamespace(
+        artifacts={
+            "findings": [{"check": "x", "column": "a", "severity": "WARNING"}],
+            "manifest": SimpleNamespace(records=[]),
+            "clusters": {0: {"members": [0], "size": 1}},
+            "scored_pairs": [],
+            "match_stats": {"match_rate": 0.5},
+        },
+        source="customers.parquet",
+    )
+    report = ga.analyze_pipeline(result)
+    ran = set(report.analyzers_run)
+    assert "quality.rollup" in ran
+    assert "cluster.distribution" in ran
+    assert "match.rates" in ran
+    # frame.summary needs a `frame` artifact, which PipeResult doesn't expose.
+    assert "frame.summary" not in ran
+
+
+def test_analyze_pipeline_omits_absent() -> None:
+    # Only a manifest present -> only quality.rollup runs.
+    result = SimpleNamespace(artifacts={"manifest": SimpleNamespace(records=[])}, source="d.csv")
+    report = ga.analyze_pipeline(result)
+    assert report.analyzers_run == ["quality.rollup"]

--- a/packages/python/goldenanalysis/tests/test_cluster_dist.py
+++ b/packages/python/goldenanalysis/tests/test_cluster_dist.py
@@ -1,0 +1,48 @@
+"""cluster.distribution analyzer (pure)."""
+
+from __future__ import annotations
+
+from goldenanalysis.analyzers.cluster_dist import ClusterDistributionAnalyzer
+from goldenanalysis.models import AnalyzerInput
+
+# 4 clusters, sizes [1, 1, 3, 2] -> 7 records.
+_CLUSTERS = {
+    0: {"members": [0], "size": 1},
+    1: {"members": [1], "size": 1},
+    2: {"members": [2, 3, 4], "size": 3},
+    3: {"members": [5, 6], "size": 2},
+}
+
+
+def _run(**artifacts):
+    inp = AnalyzerInput(dataset="customers", artifacts=artifacts)
+    return ClusterDistributionAnalyzer().run(inp)
+
+
+def test_core_metrics() -> None:
+    r = _run(clusters=_CLUSTERS)
+    m = {x.key: x for x in r.metrics}
+    assert m["cluster.count"].value == 4
+    assert m["cluster.record_count"].value == 7
+    assert m["cluster.singleton_ratio"].value == 0.5
+    assert m["cluster.size_max"].value == 3
+    assert abs(m["cluster.reduction_ratio"].value - (1 - 4 / 7)) < 1e-9
+
+
+def test_histogram_buckets() -> None:
+    r = _run(clusters=_CLUSTERS)
+    tbl = {t.name: t for t in r.tables}["cluster_size_histogram"]
+    assert tbl.rows == [[1, 2], [2, 1], [3, 1], ["4+", 0]]
+
+
+def test_record_count_prefers_stats() -> None:
+    # When match_stats carries total_records, use it (the engine's own total).
+    r = _run(clusters=_CLUSTERS, match_stats={"total_records": 20})
+    m = {x.key: x for x in r.metrics}
+    assert m["cluster.record_count"].value == 20
+    assert abs(m["cluster.reduction_ratio"].value - (1 - 4 / 20)) < 1e-9
+
+
+def test_no_clusters_emits_nothing() -> None:
+    r = _run(clusters={})
+    assert r.metrics == []

--- a/packages/python/goldenanalysis/tests/test_match_rates.py
+++ b/packages/python/goldenanalysis/tests/test_match_rates.py
@@ -1,0 +1,63 @@
+"""match.rates analyzer (pure — hand-built artifacts)."""
+
+from __future__ import annotations
+
+from goldenanalysis.analyzers.match_rates import MatchRatesAnalyzer
+from goldenanalysis.models import AnalyzerInput
+
+
+def _input(**artifacts) -> AnalyzerInput:
+    return AnalyzerInput(dataset="customers", artifacts=artifacts)
+
+
+def test_core_metrics() -> None:
+    inp = _input(
+        scored_pairs=[(0, 1, 0.9), (1, 2, 0.8), (3, 4, 0.95)],
+        match_stats={"total_records": 10, "match_rate": 0.3, "total_clusters": 2, "matched_records": 3},
+        match_threshold=0.82,
+    )
+    m = {x.key: x for x in MatchRatesAnalyzer().run(inp).metrics}
+    assert m["match.pair_count"].value == 3
+    assert m["match.match_rate"].value == 0.3
+    assert m["match.threshold"].value == 0.82
+    assert abs(m["match.mean_pair_score"].value - (0.9 + 0.8 + 0.95) / 3) < 1e-9
+    assert "match.recall_estimate" not in m  # no cert supplied -> omitted
+    assert "match.recall_safe_bound" not in m
+
+
+def test_recall_from_certificate() -> None:
+    inp = _input(
+        scored_pairs=[(0, 1, 0.9)],
+        match_stats={"total_records": 4, "match_rate": 0.5},
+        recall_certificate={"estimate": 0.94, "safe_bound": 0.89},
+    )
+    m = {x.key: x for x in MatchRatesAnalyzer().run(inp).metrics}
+    assert m["match.recall_estimate"].value == 0.94
+    assert m["match.recall_estimate"].direction == "higher_better"
+    assert m["match.recall_safe_bound"].value == 0.89
+    assert m["match.recall_safe_bound"].direction == "higher_better"
+
+
+def test_recall_estimate_only() -> None:
+    # A RecallEstimate (no safe bound) -> estimate emitted, safe_bound omitted.
+    inp = _input(
+        scored_pairs=[(0, 1, 0.9)],
+        match_stats={"match_rate": 0.5},
+        recall_certificate={"estimate": 0.94, "safe_bound": None},
+    )
+    m = {x.key: x for x in MatchRatesAnalyzer().run(inp).metrics}
+    assert m["match.recall_estimate"].value == 0.94
+    assert "match.recall_safe_bound" not in m
+
+
+def test_score_histogram_table() -> None:
+    inp = _input(scored_pairs=[(0, 1, 0.1), (2, 3, 0.9)], match_stats={"match_rate": 0.5})
+    tables = {t.name: t for t in MatchRatesAnalyzer().run(inp).tables}
+    assert "score_histogram" in tables
+
+
+def test_empty_pairs_degrades() -> None:
+    inp = _input(scored_pairs=[], match_stats={"total_records": 5, "match_rate": 0.0})
+    m = {x.key: x for x in MatchRatesAnalyzer().run(inp).metrics}
+    assert m["match.pair_count"].value == 0
+    assert "match.mean_pair_score" not in m

--- a/packages/python/goldenanalysis/tests/test_quality_rollup.py
+++ b/packages/python/goldenanalysis/tests/test_quality_rollup.py
@@ -1,0 +1,56 @@
+"""quality.rollup analyzer (pure — dict findings + duck-typed manifest)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from goldenanalysis.analyzers.quality_rollup import QualityRollupAnalyzer
+from goldenanalysis.models import AnalyzerInput
+
+FINDINGS = [
+    {"severity": "WARNING", "column": "email", "check": "email_blanked"},
+    {"severity": "WARNING", "column": "email", "check": "email_blanked"},
+    {"severity": "ERROR", "column": "phone", "check": "phone_unparseable"},
+]
+MANIFEST = SimpleNamespace(
+    records=[
+        SimpleNamespace(column="email", transform="blank_malformed", affected_rows=1188, total_rows=4000),
+        SimpleNamespace(column="phone", transform="e164", affected_rows=12, total_rows=4000),
+    ]
+)
+
+
+def _run(**artifacts):
+    return QualityRollupAnalyzer().run(AnalyzerInput(dataset="customers", artifacts=artifacts))
+
+
+def test_quality_and_flow_metrics() -> None:
+    r = _run(findings=FINDINGS, manifest=MANIFEST)
+    m = {x.key: x for x in r.metrics}
+    assert m["quality.findings_total"].value == 3
+    assert m["quality.findings_total"].direction == "lower_better"
+    assert m["quality.columns_with_findings"].value == 2
+    assert m["flow.rows_changed"].value == 1200
+    assert m["flow.rules_fired"].value == 2
+    assert "quality.score" not in m  # no profile supplied
+    tbl = {t.name: t for t in r.tables}["findings_by_class"]
+    rows = {row[0]: row[1] for row in tbl.rows}
+    assert rows["email_blanked"] == 2 and rows["phone_unparseable"] == 1
+
+
+def test_quality_score_from_profile() -> None:
+    profile = SimpleNamespace(health_score=lambda findings_by_column: ("B", 80))
+    r = _run(findings=FINDINGS, profile=profile)
+    m = {x.key: x for x in r.metrics}
+    assert m["quality.score"].value == 0.8
+    assert m["quality.score"].direction == "higher_better"
+
+
+def test_degrades_findings_only() -> None:
+    m = {x.key: x for x in _run(findings=FINDINGS).metrics}
+    assert "quality.findings_total" in m and "flow.rows_changed" not in m
+
+
+def test_degrades_manifest_only() -> None:
+    m = {x.key: x for x in _run(manifest=MANIFEST).metrics}
+    assert "flow.rules_fired" in m and "quality.findings_total" not in m

--- a/packages/python/goldenanalysis/tests/test_registry.py
+++ b/packages/python/goldenanalysis/tests/test_registry.py
@@ -15,6 +15,13 @@ def test_available_includes_frame_summary() -> None:
     assert "frame.summary" in available_analyzers()
 
 
+def test_all_phase2a_analyzers_registered() -> None:
+    expected = {"frame.summary", "match.rates", "cluster.distribution", "quality.rollup"}
+    assert expected.issubset(set(available_analyzers()))
+    for name in expected:
+        assert load_analyzer(name).info.name == name
+
+
 def test_unknown_analyzer_raises() -> None:
     import pytest
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ resolution-markers = [
 
 [manifest]
 members = [
+    "goldenanalysis",
     "goldencheck",
     "goldencheck-types",
     "goldenflow",
@@ -881,6 +882,71 @@ wheels = [
 ]
 
 [[package]]
+name = "goldenanalysis"
+version = "0.1.0"
+source = { editable = "packages/python/goldenanalysis" }
+dependencies = [
+    { name = "polars" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+api = [
+    { name = "fastapi" },
+    { name = "uvicorn" },
+]
+check = [
+    { name = "goldencheck" },
+]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+flow = [
+    { name = "goldenflow" },
+]
+match = [
+    { name = "goldenmatch" },
+]
+mcp = [
+    { name = "mcp" },
+]
+pipe = [
+    { name = "goldenpipe" },
+]
+suite = [
+    { name = "goldencheck" },
+    { name = "goldenflow" },
+    { name = "goldenmatch" },
+    { name = "goldenpipe" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.110" },
+    { name = "goldenanalysis", extras = ["match", "check", "flow", "pipe"], marker = "extra == 'suite'", editable = "packages/python/goldenanalysis" },
+    { name = "goldencheck", marker = "extra == 'check'", editable = "packages/python/goldencheck" },
+    { name = "goldenflow", marker = "extra == 'flow'", editable = "packages/python/goldenflow" },
+    { name = "goldenmatch", marker = "extra == 'match'", editable = "packages/python/goldenmatch" },
+    { name = "goldenpipe", marker = "extra == 'pipe'", editable = "packages/python/goldenpipe" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
+    { name = "polars", specifier = ">=1.0" },
+    { name = "pyarrow", specifier = ">=15" },
+    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "rich", specifier = ">=13.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+    { name = "typer", specifier = ">=0.12" },
+    { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.30" },
+]
+provides-extras = ["match", "check", "flow", "pipe", "suite", "mcp", "api", "dev"]
+
+[[package]]
 name = "goldencheck"
 version = "1.3.0"
 source = { editable = "packages/python/goldencheck" }
@@ -918,6 +984,10 @@ llm = [
 mcp = [
     { name = "mcp" },
 ]
+native = [
+    { name = "goldencheck-native" },
+    { name = "pyarrow" },
+]
 semantic = [
     { name = "sentence-transformers" },
 ]
@@ -927,12 +997,14 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'agent'", specifier = ">=3.14.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.30" },
     { name = "connectorx", marker = "extra == 'db'", specifier = ">=0.3" },
+    { name = "goldencheck-native", marker = "extra == 'native'", directory = "packages/rust/extensions/goldencheck-native" },
     { name = "goldencheck-types", editable = "packages/python/goldencheck-types" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "numpy", marker = "extra == 'baseline'", specifier = ">=1.26" },
     { name = "openai", marker = "extra == 'llm'", specifier = ">=1.30" },
     { name = "openpyxl", specifier = ">=3.1" },
     { name = "polars", specifier = ">=1.0" },
+    { name = "pyarrow", marker = "extra == 'native'", specifier = ">=14" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -944,7 +1016,12 @@ requires-dist = [
     { name = "textual", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
-provides-extras = ["dev", "llm", "db", "mcp", "agent", "baseline", "semantic"]
+provides-extras = ["dev", "llm", "db", "mcp", "agent", "baseline", "native", "semantic"]
+
+[[package]]
+name = "goldencheck-native"
+version = "0.1.0"
+source = { directory = "packages/rust/extensions/goldencheck-native" }
 
 [[package]]
 name = "goldencheck-types"
@@ -1024,6 +1101,10 @@ llm = [
 mcp = [
     { name = "mcp" },
 ]
+native = [
+    { name = "goldenflow-native" },
+    { name = "pyarrow" },
+]
 s3 = [
     { name = "boto3" },
 ]
@@ -1037,6 +1118,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.110" },
     { name = "goldencheck", marker = "extra == 'check'", editable = "packages/python/goldencheck" },
     { name = "goldenflow", extras = ["check", "excel", "db", "mcp", "agent", "s3", "gcs"], marker = "extra == 'all'", editable = "packages/python/goldenflow" },
+    { name = "goldenflow-native", marker = "extra == 'native'", directory = "packages/rust/extensions/native-flow" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.14" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
@@ -1044,6 +1126,7 @@ requires-dist = [
     { name = "openpyxl", marker = "extra == 'excel'", specifier = ">=3.1" },
     { name = "phonenumbers", specifier = ">=8.13" },
     { name = "polars", specifier = ">=1.0" },
+    { name = "pyarrow", marker = "extra == 'native'", specifier = ">=10" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -1058,11 +1141,22 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["dev", "check", "excel", "db", "mcp", "llm", "s3", "gcs", "agent", "all"]
+provides-extras = ["dev", "check", "excel", "db", "mcp", "llm", "s3", "gcs", "agent", "native", "all"]
+
+[[package]]
+name = "goldenflow-native"
+version = "0.1.1"
+source = { directory = "packages/rust/extensions/native-flow" }
+dependencies = [
+    { name = "pyarrow" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyarrow", specifier = ">=10" }]
 
 [[package]]
 name = "goldenmatch"
-version = "1.25.0"
+version = "1.28.1"
 source = { editable = "packages/python/goldenmatch" }
 dependencies = [
     { name = "diptest" },
@@ -1252,6 +1346,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1266,6 +1361,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27" },
+    { name = "hypothesis", specifier = ">=6.0" },
     { name = "pyright", specifier = ">=1.1.380" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
@@ -1277,7 +1373,7 @@ dev = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.3"
+version = "0.1.4"
 source = { directory = "packages/rust/extensions/native" }
 
 [[package]]


### PR DESCRIPTION
Implements **Phase 2a** of GoldenAnalysis (plan: `docs/superpowers/plans/2026-06-08-goldenanalysis-phase2a-suite-adapters.md`; design #807). Produces an `AnalysisReport` from real GoldenMatch / GoldenCheck / GoldenFlow / GoldenPipe outputs. Builds on Phase 1 (#808, merged).

## What ships
- **3 analyzers** (pure functions over `AnalyzerInput.artifacts` — zero suite imports):
  - `match.rates` — `pair_count` / `match_rate` / `threshold` / `recall_estimate` + `recall_safe_bound` (from an optional certificate) / `mean_pair_score` + `score_histogram`.
  - `cluster.distribution` — `count` / `record_count` / `singleton_ratio` / `size_p50`/`p95`/`max` / `reduction_ratio` + size histogram.
  - `quality.rollup` — GoldenCheck `findings_total`/`columns_with_findings`/`score` + GoldenFlow `rows_changed`/`rules_fired`, **degrading per-producer**.
- **4 adapters** mapping real producer outputs → a standardized `artifacts` vocabulary: `match`/`flow`/`pipe` (duck-typed, no eager suite imports) + `check` (lazy `goldencheck` behind the `[check]` extra; pure `from_scan` seam).
- **`analyze_match(result)`** (DedupeResult → match.rates + cluster.distribution) and **`analyze_pipeline(result)`** (PipeResult → fan-out to every analyzer whose artifacts are present). `_assemble_report` shared with `analyze`.

## Grounded in the REAL APIs (verified, not the spec's illustrations)
- `DedupeResult.scored_pairs` is retained by default → `match.rates` computes counts/score-histogram directly.
- The **recall certificate is NOT on `DedupeResult`/`PipeResult`** (CLI-only). So `match.rates` consumes it as an **optional** input and degrades. `recall_estimate` flows automatically once **#809** (`dedupe_df(..., certify=True)`) merges; `recall_safe_bound` needs a labelled audit and is supplied via `analyze_match(result, certificate=...)`.

## Verification
- [x] 63 pure unit tests (analyzers + adapters + entrypoints via hand-built artifacts / duck-typed stand-ins — zero suite deps); ruff clean; **pyright 0/0/0** on source.
- [ ] **Real-producer integration** (`tests/integration/`) runs in the goldenanalysis CI lane — the lane installs `[match,check,flow,pipe]` so the `@requires_*`-marked tests RUN (not skip): a producer shape change breaks them here, not silently.

## Notes / deferred
- `frame.summary` does **not** run under `analyze_pipeline` (a `PipeResult` exposes no input frame) — by design.
- **Phase 2b** (separate PR): `ReportHistory` (jsonl+sqlite) + `trend` + `detect_regressions` + `RegressionPolicy` + narrative + wiring the `trend`/`regressions` CLI from stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)