### PR TITLE
test(goldenmatch): fix xdist flake in prepared-record-store pipeline test

### DIFF
--- a/packages/python/goldenmatch/tests/test_prepared_record_store_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_prepared_record_store_pipeline.py
@@ -16,6 +16,14 @@ def _force_polars_direct(monkeypatch):
     # path, which only runs under polars-direct. Native-by-default would route
     # to bucket and bypass the machinery under test.
     monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    # Every test in this file uses the SAME _df(); the process-global in-memory
+    # _PREP_CACHE is keyed by df content, so one test's dedupe_df leaves a cache
+    # entry that makes a sibling's "first call must prep" assertion flake under
+    # `pytest -n auto` (worker-order dependent). Reset it before each test so
+    # every test is self-contained (per CLAUDE.md xdist-isolation rule).
+    from goldenmatch.core import pipeline as _pipeline
+
+    _pipeline._prep_cache_clear()
 
 
 def _df() -> pl.DataFrame:


### PR DESCRIPTION
## Summary
Fixes the flaky `test_dedupe_df_with_prepared_store_skips_second_run_transform` that reddened **main** on the #808 push-to-main CI run (`assert 0 >= 1`, "first call must invoke run_transform at least once").

## Root cause (xdist worker-isolation)
Every test in `test_prepared_record_store_pipeline.py` dedupes the **same** `_df()`. The process-global in-memory `_PREP_CACHE` (`core/pipeline.py`) is keyed by df content, so `test_dedupe_df_with_prepared_store_writes_to_disk` leaves a cache entry. When `..._skips_second_run_transform` runs next in the same `pytest -n auto` worker, its "first" `dedupe_df` already hits the cache → `run_transform` is called **0** times → the assertion fails. Worker-order dependent, which is why it passed on the PR run (3972 passed) but failed on the push-to-main run.

This is **not** caused by any recent feature work — it's a pre-existing test-isolation bug in the goldenmatch suite (Phase 1 / the certify PR only touched goldenanalysis / `dedupe_df`'s opt-in flag respectively).

## Fix
Clear `_PREP_CACHE` before each test in the file via the existing `pipeline._prep_cache_clear()` helper (which was added "to isolate state" for exactly this) in the file's autouse fixture. Every test becomes self-contained, per the CLAUDE.md `pytest -n auto` worker-isolation rule. **No production change.**

## Test plan
- [x] `pytest tests/test_prepared_record_store_pipeline.py` green locally (4 passed).
- [ ] goldenmatch CI lane green (the xdist reproduction env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)