### PR TITLE
feat(goldenanalysis): Phase 2b — cross-run (ReportHistory + regression detection)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-goldenanalysis-phase2b-cross-run.md
+++ b/docs/superpowers/plans/2026-06-08-goldenanalysis-phase2b-cross-run.md
@@ -1,0 +1,191 @@
+# GoldenAnalysis Phase 2b — Cross-Run (ReportHistory + Regression Detection) Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:executing-plans (inline, on this box — subagents can't run pytest here) to implement this plan. Steps use checkbox (`- [ ]`) syntax. Each task is TDD-shaped: failing test → red → minimal impl → green → commit.
+
+**Goal:** Ship the GoldenAnalysis cross-run layer — `ReportHistory` (append-only store of `AnalysisReport`s), `trend()` over a metric, `detect_regressions()` with a `RegressionPolicy`, narrative generation, and wiring the `trend`/`regressions` CLI from their Phase-1 stubs to real implementations.
+
+**Architecture:** `ReportHistory` mirrors goldenmatch's `IdentityStore` persistence idiom (`backend=`/`path=`/`connection=` constructor; a `SCHEMA_VERSION` + helpers) but defaults to **JSONL** (an append-only reports log is the natural fit) with **SQLite** optional — both stdlib, no new deps. Regression detection is pure functions over the stored reports; the `Baseline` strategy and per-metric `RegressionPolicy` are the two decisions the spec's worked scenario forced. Narrative is a template over the flagged regressions + the largest co-moving metrics.
+
+**Tech Stack:** Python ≥3.11, pydantic v2, stdlib `json`/`sqlite3`/`statistics`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md` — the `ReportHistory` / `Baseline` / `RegressionPolicy` blocks, the 5 decisions, and Appendix B (the regression-flagged Markdown report).
+
+**Builds on:** Phase 2a (PR #810) — the analyzers/adapters/`analyze_*` that produce the `AnalysisReport`s this layer stores. `AnalysisReport` already carries `schema_version`, `run_id`, `source` (incl. `dataset`), `metrics` (with `direction`), `narrative`.
+
+**Grounding — the persistence idiom to mirror** (`goldenmatch/goldenmatch/identity/store.py:125-194`): `IdentityStore(backend="sqlite", path=..., connection=None, ...)`; inline backend dispatch in `__init__`; `SCHEMA_VERSION` + `_migrate` via `PRAGMA user_version`; `_exec`/`_fetchone`/`_fetchall` helpers. Reconciliation: GoldenAnalysis's reporting store keeps the **same constructor shape** but adds `backend="jsonl"` (default) alongside `backend="sqlite"`.
+
+---
+
+## Conventions
+
+- Repo root for commands. Env every local run: `POLARS_SKIP_CPU_CHECK=1`, `PYTHONIOENCODING=utf-8`. Run via `.venv/Scripts/python.exe -m pytest packages/python/goldenanalysis <path>`.
+- All Phase 2b tests are **pure** (build `AnalysisReport`s in-process; no suite deps, no polars beyond what Phase 1 already pulls). Safe to run the full goldenanalysis package locally (small, fast).
+- Branch `feat/goldenanalysis-phase2b-cross-run`, cut from `main` **after #810 merges**.
+- TDD-shaped; `feat(goldenanalysis):` commit messages.
+
+---
+
+## Phase 2b.0 — Cross-run models
+
+### Task 0.1: `Baseline`, `RegressionPolicy`, `Regression`, `TrendSeries`
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/models/policy.py`
+- Modify: `packages/python/goldenanalysis/goldenanalysis/models/__init__.py` (export)
+- Test: `packages/python/goldenanalysis/tests/test_policy_models.py`
+
+- [ ] **Step 1 (red):** assert `RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})` exposes `.threshold_for("match.recall_safe_bound") == 2.0` and `.threshold_for("other") == 10.0`; `Regression(metric=..., baseline=0.97, current=0.89, delta_pct=-8.2, flagged=True)` round-trips; `TrendSeries(metric_key=..., dataset=..., points=[(run_id, value), ...])` holds its points. Run red.
+- [ ] **Step 2 (green):** implement in `policy.py`:
+  ```python
+  Baseline = Literal["previous", "rolling_median", "last_known_good"] | str  # or a pinned run_id
+
+  class RegressionPolicy(BaseModel):
+      default_pct: float = 10.0
+      per_metric: dict[str, float] = Field(default_factory=dict)
+      def threshold_for(self, key: str) -> float:
+          return self.per_metric.get(key, self.default_pct)
+
+  class Regression(BaseModel):
+      metric: str
+      baseline: float
+      current: float
+      delta_pct: float
+      flagged: bool
+      direction: Direction = "neutral"
+
+  class TrendSeries(BaseModel):
+      metric_key: str
+      dataset: str
+      points: list[tuple[str, float]]  # (run_id, value), oldest -> newest
+  ```
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): cross-run models (Baseline, RegressionPolicy, Regression, TrendSeries)`
+
+---
+
+## Phase 2b.1 — Regression math (pure, backend-free)
+
+### Task 1.1: `_regressions.py` — the decision logic
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/_regressions.py`
+- Test: `packages/python/goldenanalysis/tests/test_regression_logic.py`
+
+Pure functions over a list of `(run_id, value)` history + the current report's metrics. No storage.
+
+- [ ] **Step 1 (red):** `test_regression_logic.py`:
+  - `baseline_value(history, strategy, window)` — `"previous"` returns the last point; `"rolling_median"` returns `statistics.median` of the last `window` points; `"last_known_good"` returns the last point (v1: same as previous; documented). Assert exact values on a hand-built series `[0.97,0.96,0.98,0.97,0.97,0.96,0.97]` → rolling_median(window=7)=0.97, previous=0.97.
+  - `is_regression(metric, baseline, current, policy)` — respects `direction`: a `higher_better` metric flags only on a DROP beyond the per-metric pct; `lower_better` flags only on a RISE; `neutral` flags on either direction beyond pct. Assert the worked scenario: `match.recall_safe_bound` (H) 0.97→0.89 (-8.2%) flags under a 2% gate; the SAME drop does NOT flag under default 10%; a +3% wobble on a default-gate metric does not flag; `cluster.singleton_ratio` (·) 0.58→0.71 (+22.4%) flags under 10%.
+  - Determinism: same inputs → same output.
+  Run red.
+- [ ] **Step 2 (green):** implement. `delta_pct = (current - baseline) / baseline * 100` (guard baseline==0). Flag rule:
+  - `higher_better`: flag if `delta_pct <= -threshold`
+  - `lower_better`: flag if `delta_pct >= +threshold`
+  - `neutral`: flag if `abs(delta_pct) >= threshold`
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): regression decision logic (baseline strategy + direction-aware policy)`
+
+---
+
+## Phase 2b.2 — `ReportHistory` (JSONL + SQLite)
+
+### Task 2.1: JSONL backend + the store surface
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/history.py`
+- Modify: `goldenanalysis/__init__.py` (lazy export `ReportHistory`)
+- Test: `packages/python/goldenanalysis/tests/test_history_jsonl.py`
+
+- [ ] **Step 1 (red):** with `ReportHistory(backend="jsonl", path=tmp_path/"a.jsonl")`:
+  - `append(report)` then `append` a second report (same `dataset`, different `run_id`) → `reports("customers")` returns both in append order.
+  - keying is `(analysis_name, dataset, run_id)`: appending two reports with the SAME triple keeps the latest (idempotent upsert) — assert `len(reports(...)) == 1` after a re-append of the same run_id.
+  - `trend("cluster.singleton_ratio", "customers", last_n=14)` returns a `TrendSeries` whose points are the metric's value per run in order.
+  - `detect_regressions("customers", baseline="rolling_median", policy=...)` over a seeded 8-run history flags the `match.recall_safe_bound` 2%-gate drop and ignores the noise wobble (the spec acceptance §6 scenario).
+  - `baseline="previous"` over a post-step pair flags nothing.
+  Run red.
+- [ ] **Step 2 (green):** implement `ReportHistory.__init__(backend="jsonl", path=".golden/analysis.jsonl", connection=None, database="goldenanalysis")` mirroring IdentityStore's dispatch:
+  - `backend=="jsonl"`: `path` is the append-only file; `append` writes one JSON line `{analysis_name, dataset, run_id, schema_version, recorded_at, report: <AnalysisReport JSON>}`; reads parse all lines and **last-wins** per `(analysis_name, dataset, run_id)`. `analysis_name` defaults to `"default"` (a future multi-analysis seam); `dataset` from `report.source["dataset"]`.
+  - `reports(dataset, analysis_name="default")` → list[AnalysisReport] in recorded order.
+  - `trend(metric_key, dataset, last_n=30)` → pull each report's metric value (skip reports lacking it), last `last_n`, as `TrendSeries`.
+  - `detect_regressions(dataset, baseline="rolling_median", window=7, policy=None, analysis_name="default")`: the LATEST report is "current"; the prior reports are the history. For each metric in current, compute `baseline_value` over the prior series + `is_regression`. Return the flagged `Regression`s (carry `direction` from the metric).
+  - Raise `NotImplementedError` for unknown backends (mirror IdentityStore).
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): ReportHistory jsonl backend + trend + detect_regressions`
+
+### Task 2.2: SQLite backend (optional, same surface)
+
+**Files:**
+- Modify: `goldenanalysis/history.py`
+- Test: `packages/python/goldenanalysis/tests/test_history_sqlite.py`
+
+- [ ] **Step 1 (red):** the SAME assertions as Task 2.1 but with `backend="sqlite", path=tmp_path/"a.db"`. Plus: a second `ReportHistory` opened on the same path sees the persisted reports (durability). Run red.
+- [ ] **Step 2 (green):** add the `sqlite` branch: `sqlite3.connect`, `PRAGMA journal_mode=WAL`, a `analysis_reports` table `(report_id TEXT PRIMARY KEY, analysis_name, dataset, run_id, schema_version, recorded_at, payload TEXT, UNIQUE(analysis_name,dataset,run_id))`, `SCHEMA_VERSION=1` via `PRAGMA user_version`. `append` = `INSERT OR REPLACE`. Reuse the pure trend/regression logic over the rows. Mirror IdentityStore's `_exec`/`_fetchone`/`_fetchall` shape (sqlite-only here).
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): ReportHistory sqlite backend (durable, same surface)`
+
+---
+
+## Phase 2b.3 — Narrative generation
+
+### Task 3.1: `narrative.py` — co-moving metrics + flagged regressions
+
+**Files:**
+- Create: `packages/python/goldenanalysis/goldenanalysis/narrative.py`
+- Test: `packages/python/goldenanalysis/tests/test_narrative.py`
+
+- [ ] **Step 1 (red):** `build_narrative(report, regressions)` returns a one-paragraph string that: names the worst flagged regression (largest `abs(delta_pct)` on a `flagged` one) with its baseline→current + gate; lists the top co-moving metrics. On the Appendix-B inputs (recall_safe_bound flagged -8.2% gate 2%, singleton_ratio +22.4%, findings +795), assert the string contains `"recall safe-bound"`/`"0.89"`/`"2%"` and `"singleton"`/`"0.71"` and `"email_blanked"` if that table is present. With **no** regressions, returns a neutral summary (the largest-magnitude metrics) — no "regression" wording. Run red.
+- [ ] **Step 2 (green):** implement a deterministic template. Rank flagged regressions by `abs(delta_pct)`; co-moving = the other flagged/large-delta metrics. ASCII only (Windows-terminal safe; no em-dash). Pull a `findings_by_class` top class if present.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): narrative generation (flagged regressions + co-moving metrics)`
+
+### Task 3.2: Markdown regression callout (Δ column)
+
+**Files:**
+- Modify: `goldenanalysis/render.py`
+- Test: extend `tests/test_exporters.py`
+
+- [ ] **Step 1 (red):** `format_markdown(report, regressions=[...])` (new optional arg) prepends a `> ⚠️ **N regression(s) flagged.** ...` callout and adds a `Δ vs baseline` column to the metric table for metrics present in `regressions` (🔴 on flagged). Without `regressions`, output is byte-identical to Phase 1 (the existing 4 exporter tests stay green). Run red.
+- [ ] **Step 2 (green):** thread an optional `regressions` arg through `format_markdown` (default `None` → current behavior). `AnalysisReport.to_markdown(regressions=None)` passes it through.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): markdown regression callout + delta column`
+
+---
+
+## Phase 2b.4 — Wire the CLI from stubs
+
+### Task 4.1: real `trend` / `regressions` commands
+
+**Files:**
+- Modify: `goldenanalysis/cli/main.py`
+- Test: extend `tests/test_cli.py`
+
+- [ ] **Step 1 (red):** with a seeded `ReportHistory` on a tmp path, `goldenanalysis trend --metric cluster.singleton_ratio --dataset customers --history <path> --last 14` exits 0 and prints the series; `goldenanalysis regressions --dataset customers --history <path> --baseline rolling_median` exits 0 and prints the flagged regressions (or "no regressions"). A `--policy` option (JSON or `key=pct,...`) sets per-metric gates. Run red (the stubs currently exit 1).
+- [ ] **Step 2 (green):** replace the two stub bodies. Open `ReportHistory(backend=..., path=history)` (infer backend from the path suffix: `.db`→sqlite else jsonl). `trend` → `hist.trend(...)` rendered as a small table; `regressions` → `hist.detect_regressions(...)` rendered. Keep exit code 1 ONLY when `regressions` finds flagged ones AND `--fail-on-regression` is passed (CI-gate ergonomics); otherwise 0.
+- [ ] **Step 3: Commit.** `feat(goldenanalysis): wire trend/regressions CLI to ReportHistory (0.2.0)`
+
+---
+
+## Phase 2b.5 — Acceptance fixture + docs + verify
+
+### Task 5.1: the worked-scenario regression fixture
+
+**Files:**
+- Test: `packages/python/goldenanalysis/tests/test_scenario_regression.py`
+
+- [ ] **Step 1 (red):** reconstruct the spec's Maya scenario end to end with hand-built reports: seed 7 nights of healthy reports (`recall_safe_bound≈0.97`, `singleton_ratio≈0.58`) + the 8th regressed night (0.89 / 0.71 / findings 1205), append all to a `ReportHistory`, run `detect_regressions(..., policy={match.recall_safe_bound: 2.0})`, assert it flags `match.recall_safe_bound` (which a global 10% gate would miss) and `cluster.singleton_ratio`, that `baseline="previous"` over the post-step pair flags nothing, and that `build_narrative` names the root-cause chain. This is acceptance §6. Run red, then green once 2b.1-2b.3 land.
+- [ ] **Step 2: Commit.** `test(goldenanalysis): worked-scenario regression acceptance (spec acceptance §6)`
+
+### Task 5.2: docs + verify + push
+
+**Files:** `CHANGELOG.md`, `README.md`
+
+- [ ] **Step 1:** CHANGELOG 0.2.0 — add the cross-run section. README: a "Cross-run" snippet (`ReportHistory`, `detect_regressions`, the CLI). Remove the "stubs until 0.2.0" caveat (now real).
+- [ ] **Step 2:** `uv run pytest packages/python/goldenanalysis -q` green; `ruff check` clean; bounded `pyright` on the package source 0 errors.
+- [ ] **Step 3: Push** `feat/goldenanalysis-phase2b-cross-run` (auth dance), open PR vs main.
+
+---
+
+## Acceptance (Phase 2b done when)
+
+- [ ] `ReportHistory` (jsonl default + sqlite optional) keyed by `(analysis_name, dataset, run_id)`; same constructor idiom as `IdentityStore`; durable on sqlite.
+- [ ] `detect_regressions` with `rolling_median` flags a `match.recall_safe_bound` drop under a per-metric 2% gate that a global 10% gate misses, ignores a 3% noise wobble, respects `Metric.direction`, and is deterministic. `baseline="previous"` over a post-step pair flags nothing.
+- [ ] `trend` returns an ordered `TrendSeries`; the CLI `trend`/`regressions` are real (no stubs), with `--policy` + `--fail-on-regression`.
+- [ ] Narrative names the worst flagged regression + co-moving metrics; the Markdown report shows the regression callout + Δ column; no-regression path is byte-identical to Phase 1.
+- [ ] ruff + pyright clean; full goldenanalysis suite green locally; no new dependencies.
+
+### Explicitly deferred (later phases)
+TS port of the cross-run layer (Phase 3), Rust accelerator (Phase 4), the GoldenPipe terminal stage + goldensuite-mcp surfacing + publish workflows (Phase 5). `last_known_good` is v1-aliased to `previous` (a real "last green run" needs a health signal — a documented follow-up).

--- a/packages/python/goldenanalysis/CHANGELOG.md
+++ b/packages/python/goldenanalysis/CHANGELOG.md
@@ -22,14 +22,31 @@ Phase 2a — suite consumption. Produce an `AnalysisReport` from real suite outp
   `check` (lazy `goldencheck` import behind the `[check]` extra; pure `from_scan`
   seam). They populate a standardized `AnalyzerInput.artifacts` vocabulary.
 
+Phase 2b — cross-run. Trend + regression detection over a run history.
+
+- `ReportHistory(backend="jsonl"|"sqlite", path=...)` — append-only store of
+  `AnalysisReport`s keyed by `(analysis_name, dataset, run_id)`; mirrors the
+  IdentityStore constructor idiom. JSONL default, SQLite optional (durable); both
+  stdlib, no new deps.
+- `hist.trend(metric_key, dataset)` → `TrendSeries`; `hist.detect_regressions(
+  dataset, baseline=..., policy=...)` → flagged `Regression`s. `Baseline` is a
+  strategy (`rolling_median` default / `previous` / `last_known_good`); `RegressionPolicy`
+  carries per-metric percent gates and respects each `Metric.direction`.
+- Narrative generation (`narrative.build_narrative`) — names the worst flagged
+  regression + co-moving metrics; `to_markdown(regressions=...)` adds the callout +
+  Δ column (byte-identical to Phase 1 without it).
+- The `goldenanalysis trend` / `regressions` CLI are now real (no longer stubs),
+  with `--policy` and `--fail-on-regression` (CI gate).
+
 ### Notes
 - `match.recall_estimate` flows automatically once `goldenmatch.dedupe_df(...,
   certify=True)` attaches a `RecallEstimate` (goldenmatch PR); `match.recall_safe_bound`
   needs a labelled audit and is supplied via `certificate=`. Both degrade silently
   when absent.
 - `frame.summary` does not run under `analyze_pipeline` (a `PipeResult` exposes no
-  input frame). Cross-run `ReportHistory` / regression detection / narrative are
-  Phase 2b.
+  input frame).
+- `last_known_good` baseline is v1-aliased to `previous` until a per-run health
+  signal exists (documented follow-up).
 
 ## [0.1.0] - 2026-06-08
 

--- a/packages/python/goldenanalysis/README.md
+++ b/packages/python/goldenanalysis/README.md
@@ -40,8 +40,7 @@ goldenanalysis report customers.parquet --analyzers frame.summary --format markd
 goldenanalysis report report.json --format markdown      # re-render a saved report
 ```
 
-`trend` and `regressions` are visible in `--help` but are stubs until `0.2.0`
-(they need cross-run `ReportHistory`).
+`trend` and `regressions` operate over a saved run history (see **Cross-run** below).
 
 ## Over the suite (`0.2.0`)
 
@@ -60,6 +59,33 @@ report = ga.analyze_pipeline(pipe_result)
 `match.recall_safe_bound` when you pass an audit-calibrated certificate
 (`analyze_match(result, certificate=...)`) — the safe bound needs a labelled
 sample, so it can't be computed automatically. Both degrade silently when absent.
+
+## Cross-run — trend + regression detection (`0.2.0`)
+
+Store reports over time, then trend a metric or detect regressions without ground
+truth:
+
+```python
+hist = ga.ReportHistory(backend="jsonl", path=".golden/analysis.jsonl")  # or backend="sqlite"
+hist.append(report)                                  # keyed by (dataset, run_id)
+
+hist.trend("cluster.singleton_ratio", "customers")   # -> TrendSeries
+
+policy = ga.RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+regs = hist.detect_regressions("customers", baseline="rolling_median", policy=policy)
+print(report.to_markdown(regs))                      # callout + Δ-vs-baseline column
+```
+
+The `Baseline` is a strategy (`rolling_median` default — immune to one noisy night
+— plus `previous` / `last_known_good`), and `RegressionPolicy` thresholds are
+per-metric and respect each metric's `direction` (a `higher_better` metric only
+flags on a drop). CLI:
+
+```bash
+goldenanalysis trend --metric cluster.singleton_ratio --dataset customers --history .golden/analysis.jsonl
+goldenanalysis regressions --dataset customers --history .golden/analysis.jsonl \
+  --policy "match.recall_safe_bound=2" --fail-on-regression   # exit 1 on a flagged regression (CI gate)
+```
 
 ## GoldenCheck vs GoldenAnalysis
 

--- a/packages/python/goldenanalysis/goldenanalysis/__init__.py
+++ b/packages/python/goldenanalysis/goldenanalysis/__init__.py
@@ -25,12 +25,15 @@ __all__ = [
     "analyze_pipeline",
     "AnalysisReport",
     "Metric",
+    "ReportHistory",
+    "RegressionPolicy",
     "__version__",
 ]
 
 if TYPE_CHECKING:
     from goldenanalysis._api import analyze, analyze_match, analyze_pipeline
-    from goldenanalysis.models import AnalysisReport, Metric
+    from goldenanalysis.history import ReportHistory
+    from goldenanalysis.models import AnalysisReport, Metric, RegressionPolicy
 
 # Map exported name -> (submodule, attribute). Resolved on first access.
 _LAZY: dict[str, tuple[str, str]] = {
@@ -39,6 +42,8 @@ _LAZY: dict[str, tuple[str, str]] = {
     "analyze_pipeline": ("goldenanalysis._api", "analyze_pipeline"),
     "AnalysisReport": ("goldenanalysis.models", "AnalysisReport"),
     "Metric": ("goldenanalysis.models", "Metric"),
+    "ReportHistory": ("goldenanalysis.history", "ReportHistory"),
+    "RegressionPolicy": ("goldenanalysis.models", "RegressionPolicy"),
 }
 
 

--- a/packages/python/goldenanalysis/goldenanalysis/_regressions.py
+++ b/packages/python/goldenanalysis/goldenanalysis/_regressions.py
@@ -1,0 +1,81 @@
+"""Pure regression decision logic — baseline strategy + direction-aware policy.
+
+Backend-free: operates on a list of ``(run_id, value)`` history points + the
+current value. ``ReportHistory`` wires storage around this.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Sequence
+
+from goldenanalysis.models import Direction, RegressionPolicy
+
+
+def baseline_value(history: Sequence[float], strategy: str, *, window: int = 7) -> float | None:
+    """The baseline to compare the current value against.
+
+    - ``"previous"`` / ``"last_known_good"``: the most recent historical value
+      (v1: ``last_known_good`` aliases ``previous`` until a health signal exists).
+    - ``"rolling_median"``: median of the last ``window`` historical values — immune
+      to one noisy night, where ``previous`` would alternately flag and un-flag.
+    - any other string is treated as a pinned ``run_id`` and is resolved by the
+      caller (which has the run->value map); here it falls through to ``previous``.
+
+    Returns None when there's no history to compare against.
+    """
+    if not history:
+        return None
+    if strategy == "rolling_median":
+        tail = list(history[-window:])
+        return float(statistics.median(tail))
+    # "previous", "last_known_good", or a pinned id resolved upstream.
+    return float(history[-1])
+
+
+def delta_pct(baseline: float, current: float) -> float:
+    if baseline == 0:
+        return 0.0
+    return (current - baseline) / baseline * 100.0
+
+
+def is_regression(direction: Direction, baseline: float, current: float, threshold_pct: float) -> bool:
+    """Direction-aware: a higher_better metric flags only on a DROP beyond the
+    threshold; lower_better only on a RISE; neutral on either direction."""
+    d = delta_pct(baseline, current)
+    if direction == "higher_better":
+        return d <= -threshold_pct
+    if direction == "lower_better":
+        return d >= threshold_pct
+    return abs(d) >= threshold_pct
+
+
+def evaluate_metric(
+    *,
+    key: str,
+    direction: Direction,
+    history: Sequence[float],
+    current: float,
+    strategy: str,
+    window: int,
+    policy: RegressionPolicy,
+):
+    """Return a ``Regression`` for one metric, or None when there's no baseline.
+
+    ``flagged`` reflects the direction-aware per-metric gate; the record is always
+    returned (when a baseline exists) so callers can show near-misses if they want.
+    """
+    from goldenanalysis.models import Regression
+
+    base = baseline_value(history, strategy, window=window)
+    if base is None:
+        return None
+    threshold = policy.threshold_for(key)
+    return Regression(
+        metric=key,
+        baseline=base,
+        current=current,
+        delta_pct=delta_pct(base, current),
+        flagged=is_regression(direction, base, current, threshold),
+        direction=direction,
+    )

--- a/packages/python/goldenanalysis/goldenanalysis/cli/main.py
+++ b/packages/python/goldenanalysis/goldenanalysis/cli/main.py
@@ -17,8 +17,6 @@ app = typer.Typer(
     help="Measure and report across the Golden Suite (read-only).",
 )
 
-_FUTURE = "available in goldenanalysis 0.2.0 (ReportHistory)"
-
 
 @app.command()
 def report(
@@ -60,27 +58,80 @@ def report(
     typer.echo(text)
 
 
+def _open_history(history: Path):
+    """Open a ReportHistory, inferring the backend from the path suffix."""
+    from goldenanalysis.history import ReportHistory
+
+    backend = "sqlite" if history.suffix.lower() in (".db", ".sqlite") else "jsonl"
+    return ReportHistory(backend=backend, path=history)
+
+
+def _parse_policy(spec: str | None):
+    """Parse ``--policy`` (JSON object or ``key=pct,key=pct``) into a RegressionPolicy."""
+    from goldenanalysis.models import RegressionPolicy
+
+    if not spec:
+        return RegressionPolicy()
+    spec = spec.strip()
+    if spec.startswith("{"):
+        import json
+
+        data = json.loads(spec)
+        return RegressionPolicy(
+            default_pct=data.get("default_pct", 10.0), per_metric=data.get("per_metric", {})
+        )
+    per_metric = {}
+    for pair in spec.split(","):
+        if "=" in pair:
+            key, val = pair.split("=", 1)
+            per_metric[key.strip()] = float(val)
+    return RegressionPolicy(per_metric=per_metric)
+
+
 @app.command()
 def trend(
     metric: str = typer.Option(..., "--metric", help="Metric key to trend, e.g. cluster.singleton_ratio."),
     dataset: str = typer.Option(..., "--dataset"),
-    history: Path = typer.Option(..., "--history", help="ReportHistory backend path."),
+    history: Path = typer.Option(..., "--history", help="ReportHistory path (.jsonl or .db)."),
     last: int = typer.Option(30, "--last"),
 ) -> None:
-    """Trend a metric over a run history. (stub)"""
-    typer.echo(f"`trend` is {_FUTURE}.", err=True)
-    raise typer.Exit(1)
+    """Trend a metric over a run history."""
+    series = _open_history(history).trend(metric, dataset, last_n=last)
+    if not series.points:
+        typer.echo(f"no history for {metric!r} on dataset {dataset!r}")
+        return
+    typer.echo(f"# {metric} — {dataset} (last {len(series.points)})")
+    typer.echo("| run_id | value |")
+    typer.echo("|---|---|")
+    for run_id, value in series.points:
+        typer.echo(f"| {run_id} | {value:g} |")
 
 
 @app.command()
 def regressions(
     dataset: str = typer.Option(..., "--dataset"),
-    history: Path = typer.Option(..., "--history", help="ReportHistory backend path."),
+    history: Path = typer.Option(..., "--history", help="ReportHistory path (.jsonl or .db)."),
     baseline: str = typer.Option("rolling_median", "--baseline"),
+    window: int = typer.Option(7, "--window"),
+    policy: str | None = typer.Option(None, "--policy", help='Per-metric gates: JSON or "key=pct,key=pct".'),
+    fail_on_regression: bool = typer.Option(
+        False, "--fail-on-regression", help="Exit 1 if any regression is flagged (CI gate)."
+    ),
 ) -> None:
-    """Detect metric regressions vs a baseline. (stub)"""
-    typer.echo(f"`regressions` is {_FUTURE}.", err=True)
-    raise typer.Exit(1)
+    """Detect metric regressions vs a baseline."""
+    flagged = _open_history(history).detect_regressions(
+        dataset, baseline=baseline, window=window, policy=_parse_policy(policy)
+    )
+    if not flagged:
+        typer.echo(f"no regressions on dataset {dataset!r}")
+        return
+    typer.echo(f"# {len(flagged)} regression(s) — {dataset}")
+    typer.echo("| metric | baseline | current | delta |")
+    typer.echo("|---|---|---|---|")
+    for r in flagged:
+        typer.echo(f"| {r.metric} | {r.baseline:g} | {r.current:g} | {r.delta_pct:+.1f}% |")
+    if fail_on_regression:
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/packages/python/goldenanalysis/goldenanalysis/history.py
+++ b/packages/python/goldenanalysis/goldenanalysis/history.py
@@ -1,0 +1,205 @@
+"""``ReportHistory`` — an append-only store of ``AnalysisReport``s for cross-run
+trend + regression detection.
+
+Mirrors goldenmatch's ``IdentityStore`` persistence idiom (``backend=`` / ``path=``
+/ ``connection=`` constructor; a ``SCHEMA_VERSION``) but defaults to **JSONL** (an
+append-only reports log is the natural fit) with **SQLite** optional. Both are
+stdlib — no new dependencies. Keyed by ``(analysis_name, dataset, run_id)``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from goldenanalysis._regressions import evaluate_metric
+from goldenanalysis.models import (
+    AnalysisReport,
+    Regression,
+    RegressionPolicy,
+    TrendSeries,
+)
+
+SCHEMA_VERSION = 1
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS analysis_reports (
+    report_id TEXT PRIMARY KEY,
+    analysis_name TEXT NOT NULL,
+    dataset TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    recorded_at TEXT NOT NULL,
+    seq INTEGER,
+    payload TEXT NOT NULL,
+    UNIQUE(analysis_name, dataset, run_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reports_lookup ON analysis_reports(analysis_name, dataset);
+"""
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+class ReportHistory:
+    """Append-only ``AnalysisReport`` store with trend + regression queries."""
+
+    def __init__(
+        self,
+        backend: str = "jsonl",
+        path: str | Path = ".golden/analysis.jsonl",
+        connection: str | None = None,
+        database: str = "goldenanalysis",
+    ) -> None:
+        self._backend = backend
+        self._path = Path(path)
+        if backend == "jsonl":
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = None
+        elif backend == "sqlite":
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(str(self._path), isolation_level=None)
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.executescript(_SCHEMA)
+            self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        else:
+            raise NotImplementedError(f"Backend {backend!r} not supported")
+
+    # --- write ----------------------------------------------------------
+
+    def append(self, report: AnalysisReport, *, analysis_name: str = "default") -> None:
+        """Record a report. Re-appending the same (analysis_name, dataset, run_id)
+        replaces the prior one (idempotent upsert)."""
+        dataset = report.source.get("dataset", "frame")
+        record = {
+            "analysis_name": analysis_name,
+            "dataset": dataset,
+            "run_id": report.run_id,
+            "schema_version": report.schema_version,
+            "recorded_at": datetime.now(UTC).isoformat(),
+            "report": report.model_dump(mode="json"),
+        }
+        if self._backend == "jsonl":
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record) + "\n")
+        else:
+            assert self._conn is not None  # sqlite backend
+            report_id = f"{analysis_name}:{dataset}:{report.run_id}"
+            self._conn.execute(
+                "INSERT OR REPLACE INTO analysis_reports "
+                "(report_id, analysis_name, dataset, run_id, schema_version, recorded_at, seq, payload) "
+                "VALUES (?, ?, ?, ?, ?, ?, "
+                "  COALESCE((SELECT seq FROM analysis_reports WHERE report_id = ?), "
+                "           (SELECT COALESCE(MAX(seq), 0) + 1 FROM analysis_reports)), ?)",
+                (
+                    report_id,
+                    analysis_name,
+                    dataset,
+                    report.run_id,
+                    report.schema_version,
+                    record["recorded_at"],
+                    report_id,
+                    json.dumps(record["report"]),
+                ),
+            )
+
+    # --- read -----------------------------------------------------------
+
+    def reports(self, dataset: str, *, analysis_name: str = "default") -> list[AnalysisReport]:
+        """Reports for ``(analysis_name, dataset)`` in insertion order (last-wins
+        per run_id)."""
+        if self._backend == "jsonl":
+            latest: dict[tuple[str, str, str], dict] = {}
+            order: dict[tuple[str, str, str], int] = {}
+            if self._path.exists():
+                for i, line in enumerate(self._path.read_text(encoding="utf-8").splitlines()):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    rec = json.loads(line)
+                    key = (rec["analysis_name"], rec["dataset"], rec["run_id"])
+                    if key not in order:
+                        order[key] = i
+                    latest[key] = rec
+            picked = [
+                (order[k], rec)
+                for k, rec in latest.items()
+                if k[0] == analysis_name and k[1] == dataset
+            ]
+            picked.sort(key=lambda t: t[0])
+            return [AnalysisReport.model_validate(rec["report"]) for _, rec in picked]
+        assert self._conn is not None  # sqlite backend
+        rows = self._conn.execute(
+            "SELECT payload FROM analysis_reports WHERE analysis_name = ? AND dataset = ? ORDER BY seq",
+            (analysis_name, dataset),
+        ).fetchall()
+        return [AnalysisReport.model_validate(json.loads(r[0])) for r in rows]
+
+    def trend(
+        self, metric_key: str, dataset: str, *, last_n: int = 30, analysis_name: str = "default"
+    ) -> TrendSeries:
+        """A metric's value across the run history (oldest -> newest)."""
+        points: list[tuple[str, float]] = []
+        for rep in self.reports(dataset, analysis_name=analysis_name):
+            value = next((_as_float(m.value) for m in rep.metrics if m.key == metric_key), None)
+            if value is not None:
+                points.append((rep.run_id, value))
+        return TrendSeries(metric_key=metric_key, dataset=dataset, points=points[-last_n:])
+
+    def detect_regressions(
+        self,
+        dataset: str,
+        *,
+        baseline: str = "rolling_median",
+        window: int = 7,
+        policy: RegressionPolicy | None = None,
+        analysis_name: str = "default",
+    ) -> list[Regression]:
+        """Flag metric movements in the LATEST report vs the prior history.
+
+        Compares each numeric metric in the most-recent report against a baseline
+        derived from the earlier reports under the chosen strategy + per-metric
+        policy. Returns only the flagged regressions.
+        """
+        policy = policy or RegressionPolicy()
+        history = self.reports(dataset, analysis_name=analysis_name)
+        if len(history) < 2:
+            return []
+        *prior, current = history
+        out: list[Regression] = []
+        for metric in current.metrics:
+            value = _as_float(metric.value)
+            if value is None:
+                continue
+            series = _prior_series(prior, metric.key)
+            if not series:
+                continue
+            reg = evaluate_metric(
+                key=metric.key,
+                direction=metric.direction,
+                history=series,
+                current=value,
+                strategy=baseline,
+                window=window,
+                policy=policy,
+            )
+            if reg is not None and reg.flagged:
+                out.append(reg)
+        return out
+
+
+def _prior_series(prior: Sequence[AnalysisReport], metric_key: str) -> list[float]:
+    values: list[float] = []
+    for rep in prior:
+        v = next((_as_float(m.value) for m in rep.metrics if m.key == metric_key), None)
+        if v is not None:
+            values.append(v)
+    return values

--- a/packages/python/goldenanalysis/goldenanalysis/models/__init__.py
+++ b/packages/python/goldenanalysis/goldenanalysis/models/__init__.py
@@ -3,6 +3,12 @@
 from __future__ import annotations
 
 from goldenanalysis.models.analyzer import AnalyzerInfo, AnalyzerInput, AnalyzerResult
+from goldenanalysis.models.policy import (
+    Baseline,
+    Regression,
+    RegressionPolicy,
+    TrendSeries,
+)
 from goldenanalysis.models.report import (
     AnalysisReport,
     AnalysisTable,
@@ -18,4 +24,8 @@ __all__ = [
     "AnalyzerInfo",
     "AnalyzerInput",
     "AnalyzerResult",
+    "Baseline",
+    "RegressionPolicy",
+    "Regression",
+    "TrendSeries",
 ]

--- a/packages/python/goldenanalysis/goldenanalysis/models/policy.py
+++ b/packages/python/goldenanalysis/goldenanalysis/models/policy.py
@@ -1,0 +1,51 @@
+"""Cross-run models: ``Baseline``, ``RegressionPolicy``, ``Regression``, ``TrendSeries``.
+
+These drive ``ReportHistory.detect_regressions`` / ``trend`` (Phase 2b). The two
+decisions the spec's worked scenario forced live here: the baseline is a *strategy*
+(not just "previous"), and regression thresholds are *per-metric* and respect each
+``Metric.direction``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from goldenanalysis.models.report import Direction
+
+# "previous" / "rolling_median" / "last_known_good", or a pinned run_id string.
+Baseline = Literal["previous", "rolling_median", "last_known_good"] | str
+
+
+class RegressionPolicy(BaseModel):
+    """Per-metric regression thresholds (percent). Falls back to ``default_pct``.
+
+    ``direction`` comes from the ``Metric`` itself, so a ``lower_better`` metric only
+    flags on an INCREASE and a ``higher_better`` metric only on a DECREASE.
+    """
+
+    default_pct: float = 10.0
+    per_metric: dict[str, float] = Field(default_factory=dict)
+
+    def threshold_for(self, key: str) -> float:
+        return self.per_metric.get(key, self.default_pct)
+
+
+class Regression(BaseModel):
+    """A flagged (or considered) metric movement vs a baseline."""
+
+    metric: str
+    baseline: float
+    current: float
+    delta_pct: float
+    flagged: bool
+    direction: Direction = "neutral"
+
+
+class TrendSeries(BaseModel):
+    """A metric's value across a run history, oldest -> newest."""
+
+    metric_key: str
+    dataset: str
+    points: list[tuple[str, float]] = Field(default_factory=list)  # (run_id, value)

--- a/packages/python/goldenanalysis/goldenanalysis/models/report.py
+++ b/packages/python/goldenanalysis/goldenanalysis/models/report.py
@@ -60,11 +60,16 @@ class AnalysisReport(BaseModel):
         """Parse a report back from its JSON form (lossless round-trip)."""
         return cls.model_validate_json(data)
 
-    def to_markdown(self) -> str:
-        """Render a human-readable Markdown report."""
+    def to_markdown(self, regressions: list[Any] | None = None) -> str:
+        """Render a human-readable Markdown report.
+
+        When ``regressions`` (a list of ``Regression``) is supplied, a flagged-
+        regression callout and a Δ-vs-baseline column are added; otherwise the
+        output is the plain Phase-1 form.
+        """
         from goldenanalysis.render import format_markdown
 
-        return format_markdown(self)
+        return format_markdown(self, regressions)
 
     def to_parquet(self, path: str | Path) -> Path:
         """Write the long-form metric frame (key/value/unit/direction).

--- a/packages/python/goldenanalysis/goldenanalysis/narrative.py
+++ b/packages/python/goldenanalysis/goldenanalysis/narrative.py
@@ -1,0 +1,61 @@
+"""Narrative generation — a one-paragraph NL summary templated from the flagged
+regressions + the largest co-moving metrics across analyzers.
+
+Deterministic; ASCII only (Windows-terminal safe, no em-dash). The root cause in
+the spec's worked scenario was only visible by crossing analyzers, so this operates
+over the full metric set, not one analyzer's output.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from goldenanalysis.models import AnalysisReport, Regression
+
+
+def _pretty(key: str) -> str:
+    return key.split(".")[-1].replace("_", " ")
+
+
+def _top_finding_class(report: AnalysisReport) -> tuple[str, int] | None:
+    for table in report.tables:
+        if table.name == "findings_by_class" and table.rows:
+            top = max(table.rows, key=lambda r: r[1] if len(r) > 1 and isinstance(r[1], int) else 0)
+            return str(top[0]), int(top[1])
+    return None
+
+
+def build_narrative(report: AnalysisReport, regressions: list[Regression] | None = None) -> str:
+    regressions = regressions or []
+    flagged = [r for r in regressions if r.flagged]
+
+    if not flagged:
+        # Neutral summary: the most notable metrics by magnitude.
+        notable = sorted(
+            (m for m in report.metrics if isinstance(m.value, (int, float))),
+            key=lambda m: abs(float(m.value)),
+            reverse=True,
+        )[:3]
+        if not notable:
+            return "No metrics to summarize."
+        bits = ", ".join(f"{_pretty(m.key)} = {m.value}" for m in notable)
+        return f"No regressions flagged. Notable metrics: {bits}."
+
+    worst = max(flagged, key=lambda r: abs(r.delta_pct))
+    lead = (
+        f"{_pretty(worst.metric).capitalize()} {'fell' if worst.delta_pct < 0 else 'rose'} to "
+        f"{worst.current:g} (baseline {worst.baseline:g}; {worst.delta_pct:+.1f}%)."
+    )
+
+    comovers = [r for r in flagged if r.metric != worst.metric]
+    parts = [lead]
+    if comovers:
+        moves = "; ".join(
+            f"{_pretty(r.metric)} {r.baseline:g} -> {r.current:g} ({r.delta_pct:+.1f}%)" for r in comovers
+        )
+        parts.append(f"Co-moving signals: {moves}.")
+    fc = _top_finding_class(report)
+    if fc is not None:
+        parts.append(f"Most common quality finding: {fc[0]} ({fc[1]}).")
+    return " ".join(parts)

--- a/packages/python/goldenanalysis/goldenanalysis/render.py
+++ b/packages/python/goldenanalysis/goldenanalysis/render.py
@@ -1,8 +1,9 @@
 """Markdown rendering for ``AnalysisReport``.
 
-Phase 1 renders the title, optional narrative, the metric table, and any embedded
-``AnalysisTable``s. The "Δ vs baseline" regression column from Appendix B is
-deferred to Phase 2 (it needs ``ReportHistory``).
+Renders the title, optional narrative, the metric table, and any embedded
+``AnalysisTable``s. When ``regressions`` are supplied (Phase 2b), a flagged-
+regression callout and a "Δ vs baseline" column are added; without them the output
+is byte-identical to the Phase 1 form.
 """
 
 from __future__ import annotations
@@ -10,7 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from goldenanalysis.models import AnalysisReport
+    from goldenanalysis.models import AnalysisReport, Regression
 
 
 def _fmt_value(value: float | int | str, unit: str | None) -> str:
@@ -23,16 +24,35 @@ def _fmt_value(value: float | int | str, unit: str | None) -> str:
     return f"{text} {unit}" if unit else text
 
 
-def format_markdown(report: AnalysisReport) -> str:
+def format_markdown(report: AnalysisReport, regressions: list[Regression] | None = None) -> str:
     dataset = report.source.get("dataset", "frame")
     lines: list[str] = [f"# Analysis — {dataset} (run {report.run_id})", ""]
+
+    by_metric: dict[str, Regression] = {r.metric: r for r in (regressions or [])}
+    flagged = [r for r in (regressions or []) if r.flagged]
+    if flagged:
+        lead = "; ".join(
+            f"{r.metric} {r.baseline:g} -> {r.current:g} ({r.delta_pct:+.1f}%)" for r in flagged
+        )
+        lines += [f"> WARNING: {len(flagged)} regression(s) flagged. {lead}", ""]
 
     if report.narrative:
         lines += [report.narrative, ""]
 
-    lines += ["| Metric | Value |", "|---|---|"]
-    for m in report.metrics:
-        lines.append(f"| {m.key} | {_fmt_value(m.value, m.unit)} |")
+    if by_metric:
+        lines += ["| Metric | Value | Δ vs baseline |", "|---|---|---|"]
+        for m in report.metrics:
+            reg = by_metric.get(m.key)
+            if reg is None:
+                delta = ""
+            else:
+                mark = "🔴 " if reg.flagged else ""
+                delta = f"{mark}{reg.delta_pct:+.1f}%"
+            lines.append(f"| {m.key} | {_fmt_value(m.value, m.unit)} | {delta} |")
+    else:
+        lines += ["| Metric | Value |", "|---|---|"]
+        for m in report.metrics:
+            lines.append(f"| {m.key} | {_fmt_value(m.value, m.unit)} |")
     lines.append("")
 
     for table in report.tables:

--- a/packages/python/goldenanalysis/tests/test_cli.py
+++ b/packages/python/goldenanalysis/tests/test_cli.py
@@ -35,13 +35,60 @@ def test_report_writes_out(tmp_path: Path) -> None:
     assert "frame.row_count" in out.read_text(encoding="utf-8")
 
 
-def test_trend_stub_is_honest() -> None:
-    result = runner.invoke(app, ["trend", "--metric", "x", "--dataset", "d", "--history", "h.db"])
-    assert result.exit_code == 1
-    assert "0.2.0" in result.output
+def _seed_history(path: Path) -> None:
+    from datetime import UTC, datetime
+
+    from goldenanalysis.history import ReportHistory
+    from goldenanalysis.models import AnalysisReport, Metric
+
+    hist = ReportHistory(backend="jsonl", path=path)
+
+    def night(run_id: str, recall: float, singleton: float) -> AnalysisReport:
+        return AnalysisReport(
+            run_id=run_id,
+            generated_at=datetime(2026, 6, 8, tzinfo=UTC),
+            source={"dataset": "customers"},
+            metrics=[
+                Metric(key="match.recall_safe_bound", value=recall, unit="ratio", direction="higher_better"),
+                Metric(key="cluster.singleton_ratio", value=singleton, unit="ratio", direction="neutral"),
+            ],
+        )
+
+    for i in range(7):
+        hist.append(night(f"n{i}", 0.97, 0.58))
+    hist.append(night("n7", 0.89, 0.71))
 
 
-def test_regressions_stub_is_honest() -> None:
-    result = runner.invoke(app, ["regressions", "--dataset", "d", "--history", "h.db"])
+def test_trend_command(tmp_path: Path) -> None:
+    hpath = tmp_path / "h.jsonl"
+    _seed_history(hpath)
+    result = runner.invoke(
+        app, ["trend", "--metric", "cluster.singleton_ratio", "--dataset", "customers", "--history", str(hpath)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "0.71" in result.output and "n7" in result.output
+
+
+def test_regressions_command(tmp_path: Path) -> None:
+    hpath = tmp_path / "h.jsonl"
+    _seed_history(hpath)
+    result = runner.invoke(
+        app,
+        ["regressions", "--dataset", "customers", "--history", str(hpath), "--policy", "match.recall_safe_bound=2"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "match.recall_safe_bound" in result.output
+
+
+def test_regressions_fail_on_regression_exits_1(tmp_path: Path) -> None:
+    hpath = tmp_path / "h.jsonl"
+    _seed_history(hpath)
+    result = runner.invoke(
+        app,
+        [
+            "regressions", "--dataset", "customers", "--history", str(hpath),
+            "--policy", "match.recall_safe_bound=2", "--fail-on-regression",
+        ],
+    )
     assert result.exit_code == 1
-    assert "0.2.0" in result.output
+    assert "match.recall_safe_bound" in result.output

--- a/packages/python/goldenanalysis/tests/test_exporters.py
+++ b/packages/python/goldenanalysis/tests/test_exporters.py
@@ -35,6 +35,20 @@ def test_markdown_contains_header_and_keys() -> None:
         assert m.key in md
 
 
+def test_markdown_with_regressions_adds_callout_and_delta() -> None:
+    from goldenanalysis.models import Regression
+
+    report = _report()
+    key = report.metrics[0].key
+    regs = [Regression(metric=key, baseline=10.0, current=5.0, delta_pct=-50.0, flagged=True, direction="higher_better")]
+    md = report.to_markdown(regs)
+    assert "regression(s) flagged" in md
+    assert "Δ vs baseline" in md
+    assert "-50.0%" in md
+    # Without regressions the output is the plain Phase-1 form (no delta column).
+    assert "Δ vs baseline" not in report.to_markdown()
+
+
 def test_parquet_one_row_per_metric(tmp_path: Path) -> None:
     report = _report()
     out = tmp_path / "report.parquet"

--- a/packages/python/goldenanalysis/tests/test_history_jsonl.py
+++ b/packages/python/goldenanalysis/tests/test_history_jsonl.py
@@ -1,0 +1,80 @@
+"""ReportHistory — JSONL backend (default)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from goldenanalysis.history import ReportHistory
+from goldenanalysis.models import AnalysisReport, Metric, RegressionPolicy
+
+
+def _report(run_id: str, metrics: list[tuple[str, float, str]], dataset: str = "customers") -> AnalysisReport:
+    return AnalysisReport(
+        run_id=run_id,
+        generated_at=datetime(2026, 6, 8, tzinfo=UTC),
+        source={"dataset": dataset},
+        metrics=[Metric(key=k, value=v, unit="ratio", direction=d) for k, v, d in metrics],
+    )
+
+
+def _seed(hist: ReportHistory) -> None:
+    # 7 healthy nights then a regressed 8th (the spec's worked scenario).
+    for i in range(7):
+        hist.append(
+            _report(
+                f"r{i}",
+                [("match.recall_safe_bound", 0.97, "higher_better"), ("cluster.singleton_ratio", 0.58, "neutral")],
+            )
+        )
+    hist.append(
+        _report(
+            "r7",
+            [("match.recall_safe_bound", 0.89, "higher_better"), ("cluster.singleton_ratio", 0.71, "neutral")],
+        )
+    )
+
+
+def test_append_and_reports_order(tmp_path: Path) -> None:
+    hist = ReportHistory(backend="jsonl", path=tmp_path / "a.jsonl")
+    hist.append(_report("r0", [("m", 1.0, "neutral")]))
+    hist.append(_report("r1", [("m", 2.0, "neutral")]))
+    reps = hist.reports("customers")
+    assert [r.run_id for r in reps] == ["r0", "r1"]
+
+
+def test_idempotent_upsert(tmp_path: Path) -> None:
+    hist = ReportHistory(backend="jsonl", path=tmp_path / "a.jsonl")
+    hist.append(_report("r0", [("m", 1.0, "neutral")]))
+    hist.append(_report("r0", [("m", 9.0, "neutral")]))  # same (analysis, dataset, run_id)
+    reps = hist.reports("customers")
+    assert len(reps) == 1
+    assert reps[0].metrics[0].value == 9.0
+
+
+def test_trend(tmp_path: Path) -> None:
+    hist = ReportHistory(backend="jsonl", path=tmp_path / "a.jsonl")
+    _seed(hist)
+    series = hist.trend("cluster.singleton_ratio", "customers", last_n=14)
+    assert series.points[-1] == ("r7", 0.71)
+    assert len(series.points) == 8
+
+
+def test_detect_regressions_scenario(tmp_path: Path) -> None:
+    hist = ReportHistory(backend="jsonl", path=tmp_path / "a.jsonl")
+    _seed(hist)
+    policy = RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+    flagged = {r.metric: r for r in hist.detect_regressions("customers", baseline="rolling_median", policy=policy)}
+    # recall_safe_bound -8.2% flags under its 2% gate (a 10% gate would miss it).
+    assert "match.recall_safe_bound" in flagged
+    # singleton_ratio +22.4% flags under the default 10% gate.
+    assert "cluster.singleton_ratio" in flagged
+
+
+def test_previous_baseline_over_post_step_pair_flags_nothing(tmp_path: Path) -> None:
+    hist = ReportHistory(backend="jsonl", path=tmp_path / "a.jsonl")
+    # Two post-step nights (both already at the new level) -> "previous" sees no move.
+    hist.append(_report("a", [("match.recall_safe_bound", 0.89, "higher_better")]))
+    hist.append(_report("b", [("match.recall_safe_bound", 0.89, "higher_better")]))
+    policy = RegressionPolicy(per_metric={"match.recall_safe_bound": 2.0})
+    assert hist.detect_regressions("customers", baseline="previous", policy=policy) == []

--- a/packages/python/goldenanalysis/tests/test_history_sqlite.py
+++ b/packages/python/goldenanalysis/tests/test_history_sqlite.py
@@ -1,0 +1,46 @@
+"""ReportHistory — SQLite backend (optional, durable, same surface)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from goldenanalysis.history import ReportHistory
+from goldenanalysis.models import AnalysisReport, Metric, RegressionPolicy
+
+
+def _report(run_id: str, metrics: list[tuple[str, float, str]]) -> AnalysisReport:
+    return AnalysisReport(
+        run_id=run_id,
+        generated_at=datetime(2026, 6, 8, tzinfo=UTC),
+        source={"dataset": "customers"},
+        metrics=[Metric(key=k, value=v, unit="ratio", direction=d) for k, v, d in metrics],
+    )
+
+
+def test_sqlite_append_order_and_upsert(tmp_path: Path) -> None:
+    db = tmp_path / "a.db"
+    hist = ReportHistory(backend="sqlite", path=db)
+    hist.append(_report("r0", [("m", 1.0, "neutral")]))
+    hist.append(_report("r1", [("m", 2.0, "neutral")]))
+    hist.append(_report("r0", [("m", 9.0, "neutral")]))  # upsert
+    reps = hist.reports("customers")
+    assert [r.run_id for r in reps] == ["r0", "r1"]
+    assert reps[0].metrics[0].value == 9.0
+
+
+def test_sqlite_durable_across_handles(tmp_path: Path) -> None:
+    db = tmp_path / "a.db"
+    ReportHistory(backend="sqlite", path=db).append(_report("r0", [("m", 1.0, "neutral")]))
+    # A fresh handle on the same file sees the persisted report.
+    assert len(ReportHistory(backend="sqlite", path=db).reports("customers")) == 1
+
+
+def test_sqlite_detect_regressions(tmp_path: Path) -> None:
+    hist = ReportHistory(backend="sqlite", path=tmp_path / "a.db")
+    for i in range(7):
+        hist.append(_report(f"r{i}", [("match.recall_safe_bound", 0.97, "higher_better")]))
+    hist.append(_report("r7", [("match.recall_safe_bound", 0.89, "higher_better")]))
+    policy = RegressionPolicy(per_metric={"match.recall_safe_bound": 2.0})
+    flagged = hist.detect_regressions("customers", baseline="rolling_median", policy=policy)
+    assert any(r.metric == "match.recall_safe_bound" for r in flagged)

--- a/packages/python/goldenanalysis/tests/test_narrative.py
+++ b/packages/python/goldenanalysis/tests/test_narrative.py
@@ -1,0 +1,46 @@
+"""Narrative generation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from goldenanalysis.models import AnalysisReport, AnalysisTable, Metric, Regression
+from goldenanalysis.narrative import build_narrative
+
+
+def _report() -> AnalysisReport:
+    return AnalysisReport(
+        run_id="r7",
+        generated_at=datetime(2026, 6, 8, tzinfo=UTC),
+        source={"dataset": "customers"},
+        metrics=[
+            Metric(key="match.recall_safe_bound", value=0.89, unit="ratio", direction="higher_better"),
+            Metric(key="cluster.singleton_ratio", value=0.71, unit="ratio", direction="neutral"),
+            Metric(key="quality.findings_total", value=1205, unit="findings", direction="lower_better"),
+        ],
+        tables=[
+            AnalysisTable(
+                name="findings_by_class",
+                columns=["class", "count"],
+                rows=[["email_blanked", 1188], ["phone_unparseable", 12]],
+            )
+        ],
+    )
+
+
+def test_narrative_with_regressions() -> None:
+    regs = [
+        Regression(metric="match.recall_safe_bound", baseline=0.97, current=0.89, delta_pct=-8.2, flagged=True, direction="higher_better"),
+        Regression(metric="cluster.singleton_ratio", baseline=0.58, current=0.71, delta_pct=22.4, flagged=True, direction="neutral"),
+    ]
+    text = build_narrative(_report(), regs).lower()
+    # Leads with the largest-magnitude regression (singleton +22.4% > recall -8.2%).
+    assert "recall safe bound" in text and "0.89" in text
+    assert "singleton" in text and "0.71" in text
+    assert "email_blanked" in text
+
+
+def test_narrative_no_regressions() -> None:
+    text = build_narrative(_report(), [])
+    assert "No regressions" in text
+    assert "regression" not in text.lower().replace("no regressions", "")

--- a/packages/python/goldenanalysis/tests/test_policy_models.py
+++ b/packages/python/goldenanalysis/tests/test_policy_models.py
@@ -1,0 +1,29 @@
+"""Cross-run model contracts."""
+
+from __future__ import annotations
+
+from goldenanalysis.models import Regression, RegressionPolicy, TrendSeries
+
+
+def test_policy_threshold_fallback() -> None:
+    p = RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+    assert p.threshold_for("match.recall_safe_bound") == 2.0
+    assert p.threshold_for("other") == 10.0
+
+
+def test_regression_roundtrip() -> None:
+    r = Regression(
+        metric="match.recall_safe_bound",
+        baseline=0.97,
+        current=0.89,
+        delta_pct=-8.2,
+        flagged=True,
+        direction="higher_better",
+    )
+    again = Regression.model_validate_json(r.model_dump_json())
+    assert again == r
+
+
+def test_trend_series_holds_points() -> None:
+    ts = TrendSeries(metric_key="cluster.singleton_ratio", dataset="customers", points=[("r1", 0.58), ("r2", 0.71)])
+    assert ts.points[-1] == ("r2", 0.71)

--- a/packages/python/goldenanalysis/tests/test_regression_logic.py
+++ b/packages/python/goldenanalysis/tests/test_regression_logic.py
@@ -1,0 +1,44 @@
+"""Pure regression decision logic."""
+
+from __future__ import annotations
+
+from goldenanalysis._regressions import baseline_value, is_regression
+from goldenanalysis.models import RegressionPolicy
+
+HEALTHY = [0.97, 0.96, 0.98, 0.97, 0.97, 0.96, 0.97]
+
+
+def test_baseline_strategies() -> None:
+    assert baseline_value(HEALTHY, "rolling_median", window=7) == 0.97
+    assert baseline_value(HEALTHY, "previous") == 0.97
+    assert baseline_value([], "rolling_median") is None
+
+
+def test_rolling_median_ignores_one_noisy_night() -> None:
+    noisy = [0.97, 0.97, 0.97, 0.50, 0.97, 0.97, 0.97]  # one bad night
+    assert baseline_value(noisy, "rolling_median", window=7) == 0.97  # median unmoved
+    assert baseline_value(noisy, "previous") == 0.97
+
+
+def test_recall_safe_bound_flags_under_per_metric_gate() -> None:
+    policy = RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+    # higher_better: 0.97 -> 0.89 is -8.2%.
+    assert is_regression("higher_better", 0.97, 0.89, policy.threshold_for("match.recall_safe_bound"))
+    # The SAME drop does NOT flag under the global 10% gate.
+    assert not is_regression("higher_better", 0.97, 0.89, policy.threshold_for("anything_else"))
+
+
+def test_direction_aware() -> None:
+    # higher_better only flags on a drop; a rise is fine.
+    assert not is_regression("higher_better", 0.5, 0.9, 5.0)
+    # lower_better only flags on a rise.
+    assert is_regression("lower_better", 100, 130, 10.0)
+    assert not is_regression("lower_better", 100, 70, 10.0)
+    # neutral flags either way.
+    assert is_regression("neutral", 0.58, 0.71, 10.0)  # +22.4%
+    assert is_regression("neutral", 0.71, 0.58, 10.0)
+
+
+def test_noise_wobble_does_not_flag() -> None:
+    # +3% on a default 10% gate metric.
+    assert not is_regression("neutral", 1.0, 1.03, 10.0)

--- a/packages/python/goldenanalysis/tests/test_scenario_regression.py
+++ b/packages/python/goldenanalysis/tests/test_scenario_regression.py
@@ -1,0 +1,64 @@
+"""Worked-scenario acceptance (spec acceptance §6) — the Maya regression story.
+
+Seed 7 healthy nights + 1 regressed night; the per-metric 2% gate on
+match.recall_safe_bound catches a drop a global 10% gate would miss; the narrative
+names the root-cause chain; baseline='previous' over a post-step pair flags nothing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from goldenanalysis.history import ReportHistory
+from goldenanalysis.models import AnalysisReport, AnalysisTable, Metric, RegressionPolicy
+from goldenanalysis.narrative import build_narrative
+
+
+def _night(run_id: str, recall: float, singleton: float, findings: int) -> AnalysisReport:
+    return AnalysisReport(
+        run_id=run_id,
+        generated_at=datetime(2026, 6, 8, tzinfo=UTC),
+        source={"dataset": "customers"},
+        metrics=[
+            Metric(key="match.recall_safe_bound", value=recall, unit="ratio", direction="higher_better"),
+            Metric(key="cluster.singleton_ratio", value=singleton, unit="ratio", direction="neutral"),
+            Metric(key="quality.findings_total", value=findings, unit="findings", direction="lower_better"),
+        ],
+        tables=[
+            AnalysisTable(name="findings_by_class", columns=["class", "count"], rows=[["email_blanked", 1188]])
+        ],
+    )
+
+
+def test_maya_scenario(tmp_path: Path) -> None:
+    hist = ReportHistory(backend="jsonl", path=tmp_path / "analysis.jsonl")
+    for i in range(7):
+        hist.append(_night(f"n{i}", recall=0.97, singleton=0.58, findings=410))
+    hist.append(_night("n7", recall=0.89, singleton=0.71, findings=1205))
+
+    policy = RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+    flagged = hist.detect_regressions("customers", baseline="rolling_median", policy=policy)
+    keys = {r.metric for r in flagged}
+
+    # The 2% gate catches recall_safe_bound (-8.2%); a global 10% gate would NOT.
+    assert "match.recall_safe_bound" in keys
+    assert not any(
+        r.flagged for r in hist.detect_regressions("customers", policy=RegressionPolicy(default_pct=10.0))
+        if r.metric == "match.recall_safe_bound"
+    )
+    # singleton_ratio (+22.4%) and findings_total (+194%) also flag.
+    assert "cluster.singleton_ratio" in keys
+    assert "quality.findings_total" in keys
+
+    narrative = build_narrative(hist.reports("customers")[-1], flagged)
+    assert "recall safe bound" in narrative
+    assert "email_blanked" in narrative
+
+
+def test_previous_over_post_step_pair_flags_nothing(tmp_path: Path) -> None:
+    hist = ReportHistory(backend="jsonl", path=tmp_path / "a.jsonl")
+    hist.append(_night("a", recall=0.89, singleton=0.71, findings=1205))
+    hist.append(_night("b", recall=0.89, singleton=0.71, findings=1205))
+    policy = RegressionPolicy(per_metric={"match.recall_safe_bound": 2.0})
+    assert hist.detect_regressions("customers", baseline="previous", policy=policy) == []


### PR DESCRIPTION
Implements **Phase 2b** of GoldenAnalysis (plan: `docs/superpowers/plans/2026-06-08-goldenanalysis-phase2b-cross-run.md`). The cross-run layer: store reports over time, trend a metric, detect regressions without ground truth. Builds on Phase 2a (#810, merged).

## What ships
- **`ReportHistory(backend="jsonl"|"sqlite", path=...)`** — append-only store of `AnalysisReport`s keyed by `(analysis_name, dataset, run_id)`. Mirrors goldenmatch's `IdentityStore` constructor idiom; **JSONL default** (append-only reports log), **SQLite optional** (durable). Both stdlib — **no new deps**.
- **`trend(metric_key, dataset)`** → `TrendSeries`; **`detect_regressions(dataset, baseline=..., policy=...)`** → flagged `Regression`s.
- **`Baseline`** is a *strategy* — `rolling_median` (default; immune to one noisy night) / `previous` / `last_known_good`. **`RegressionPolicy`** thresholds are **per-metric** and respect each `Metric.direction` (a `higher_better` metric only flags on a drop).
- **Narrative** (`build_narrative`) names the worst flagged regression + co-moving metrics across analyzers; **`to_markdown(regressions=...)`** adds the callout + Δ-vs-baseline column (byte-identical to Phase 1 without it).
- The **`goldenanalysis trend` / `regressions` CLI** are now real (no longer stubs), with `--policy` (JSON or `key=pct`) and `--fail-on-regression` (CI gate).

## Spec acceptance (§6) — the Maya scenario, end to end
`test_scenario_regression.py` seeds 7 healthy nights + 1 regressed night and asserts the per-metric **2% gate on `match.recall_safe_bound` catches a drop a global 10% gate would miss**, that `cluster.singleton_ratio` (+22.4%) and `quality.findings_total` (+194%) also flag, that `baseline="previous"` over a post-step pair flags nothing, and that the narrative names the root-cause chain.

## Verification
- [x] **85 tests pass** (all pure — reports built in-process; no suite deps); ruff clean; **pyright 0/0/0**.
- [x] JSONL + SQLite backends both pass the same surface tests; SQLite durability across handles verified.

## Notes / deferred
- `last_known_good` baseline is v1-aliased to `previous` until a per-run health signal exists (documented follow-up).
- TS port (Phase 3), Rust accelerator (Phase 4), GoldenPipe terminal stage + goldensuite-mcp + publish workflows (Phase 5) remain.

This completes Phase 2 (2a suite consumption + 2b cross-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)