### PR TITLE
feat(goldenanalysis-js): Phase 3b — TypeScript cross-run (ReportHistory, regressions, narrative, CLI)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-goldenanalysis-phase3b-ts-cross-run.md
+++ b/docs/superpowers/plans/2026-06-08-goldenanalysis-phase3b-ts-cross-run.md
@@ -1,0 +1,62 @@
+# GoldenAnalysis Phase 3b — TypeScript Cross-Run Plan
+
+> Use superpowers:executing-plans (inline; TS is safe to build/test locally). TDD-shaped.
+
+**Goal:** Port the cross-run layer to TypeScript — regression decision logic + narrative (edge-safe, `src/core`) and a JSONL-backed `ReportHistory` (`src/node`), plus the `trend`/`regressions` CLI. Behavioral parity with Python 2b (same flags on the same report sequence).
+
+**Architecture:** The pure decision logic + report-level `detectRegressions`/`buildTrend` + models live in `src/core` (edge-safe). The `ReportHistory` that persists to a JSONL file lives in `src/node` (uses `node:fs`). **JSONL only** — Node 20 has no stable built-in SQLite (`node:sqlite` is experimental in 22+); the SQLite backend is a documented follow-up (Python's default IS jsonl, so the surface parity holds). The cross-run models (`RegressionPolicy`/`Regression`/`TrendSeries`/`Baseline`) are camelCase TS-idiomatic — they are NOT wire types (the wire type is `AnalysisReport`, already snake_case).
+
+**Spec/Reference:** Python Phase 2b — `packages/python/goldenanalysis/goldenanalysis/{_regressions.py,history.py,narrative.py}` + the spec's `ReportHistory`/`Baseline`/`RegressionPolicy` blocks.
+
+**Builds on:** Phase 3a (merged) — the `AnalysisReport`/`Metric` types, `analyze`, `render.toMarkdown`.
+
+---
+
+## Conventions
+- From `packages/typescript/goldenanalysis/`. `npx vitest run`, `npx tsc --noEmit`, `npx tsup`.
+- Branch `feat/goldenanalysis-ts-cross-run`, off `main` (has 3a). Commit per task.
+
+## Tasks
+
+### 3b.0 — cross-run models + pure regression logic (`src/core/regressions.ts`)
+- [ ] Test (`tests/unit/regressions.test.ts`): `baselineValue([0.97,0.96,0.98,0.97,0.97,0.96,0.97], "rolling_median", 7)===0.97`; `previous`===last; `isRegression("higher_better", 0.97, 0.89, 2)===true` and `===false` at gate 10; direction-aware (lower_better flags on rise; neutral either way); rolling_median ignores one noisy night.
+- [ ] Impl: `type Baseline = "previous"|"rolling_median"|"last_known_good"|string`. `interface RegressionPolicy { defaultPct: number; perMetric: Record<string, number> }` + a `thresholdFor(policy, key)` helper. `interface Regression { metric; baseline; current; deltaPct; flagged; direction }`. `interface TrendSeries { metricKey; dataset; points: [string, number][] }`. `baselineValue`, `deltaPct`, `isRegression(direction, base, cur, pct)`.
+- [ ] Commit `feat(goldenanalysis-js): cross-run models + regression decision logic`
+
+### 3b.1 — report-level cross-run functions (`src/core/history.ts`)
+- [ ] Test (`tests/unit/history.test.ts`): over a hand-built `AnalysisReport[]` (7 healthy + 1 regressed, Maya scenario), `detectRegressions(reports, { baseline: "rolling_median", policy: { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } } })` flags `match.recall_safe_bound` (a 10% gate misses it) + `cluster.singleton_ratio`; `buildTrend(reports, "cluster.singleton_ratio", "customers")` returns ordered points; `baseline:"previous"` over a post-step pair flags nothing.
+- [ ] Impl: edge-safe. `numericValue(report, key)`; `buildTrend(reports, key, dataset, lastN=30)`; `detectRegressions(reports, opts)` — LATEST report is current, prior is history; per numeric metric compute baseline over the prior series + flag via policy/direction; return flagged. (Filtering by dataset happens in the node ReportHistory.)
+- [ ] Commit `feat(goldenanalysis-js): report-level detectRegressions + buildTrend (edge-safe)`
+
+### 3b.2 — narrative (`src/core/narrative.ts`)
+- [ ] Test (`tests/unit/narrative.test.ts`): `buildNarrative(report, regressions)` names the worst flagged regression (largest |deltaPct|) + co-movers + top `findings_by_class`; no-regression path is a neutral summary.
+- [ ] Impl: deterministic template (mirror Python). ASCII-clean.
+- [ ] Commit `feat(goldenanalysis-js): narrative generation`
+
+### 3b.3 — markdown regression callout (`src/core/render.ts`)
+- [ ] Test (extend `tests/unit/analyze.test.ts` or new): `toMarkdown(report, regressions)` adds a `> WARNING: N regression(s) flagged.` callout + a `Δ vs baseline` column; without regressions, **byte-identical** to 3a output (existing tests stay green).
+- [ ] Impl: add optional `regressions` param to `toMarkdown` (default undefined → current behavior). Use `.trimEnd()` (no `\s+$` — ReDoS, see 3a #813).
+- [ ] Commit `feat(goldenanalysis-js): markdown regression callout + delta column`
+
+### 3b.4 — `ReportHistory` (JSONL, `src/node/history.ts` + `src/node/index.ts`)
+- [ ] Test (`tests/node/history.test.ts`): with a tmp `.jsonl` path — `append` then `reports(dataset)` in order; idempotent upsert per `(analysisName, dataset, runId)`; `trend(...)`; `detectRegressions(...)` flags the scenario; a fresh handle on the same file sees persisted reports (durability).
+- [ ] Impl: `ReportHistory` class (constructor `{ path }`), `node:fs` append-only jsonl (one record/line `{analysisName, dataset, runId, schemaVersion, recordedAt, report}`), read = parse all lines, last-wins per key; `reports`/`trend`/`detectRegressions` delegate to `src/core/history`. Export from `src/node/index.ts`.
+- [ ] Commit `feat(goldenanalysis-js): ReportHistory (jsonl, node) + node entry`
+
+### 3b.5 — wire `./node` export + CLI trend/regressions
+- [ ] `package.json`: add `"./node"` export (mirror goldenpipe). `tsup.config.ts`: add `"node/index": "src/node/index.ts"`.
+- [ ] `src/cli.ts`: add `trend` + `regressions` commands (open `ReportHistory({ path: --history })`; `--metric`/`--dataset`/`--last`; `--baseline`/`--policy` (JSON or `key=pct`)/`--fail-on-regression`). Test (extend `tests/unit/cli.test.ts` or `tests/node/`): seed a tmp jsonl, assert `trend`/`regressions` output.
+- [ ] Commit `feat(goldenanalysis-js): trend/regressions CLI + ./node export`
+
+### 3b.6 — docs + verify + push
+- [ ] README: a "Cross-run" section (ReportHistory, detectRegressions, CLI). CHANGELOG-equivalent note if present.
+- [ ] Verify: `npx vitest run` green; `npx tsc --noEmit` clean; `npx tsup` build clean. `pnpm-lock.yaml` unchanged (no new deps).
+- [ ] Push `feat/goldenanalysis-ts-cross-run` (auth dance); PR vs main.
+
+## Acceptance
+- [ ] Edge-safe core (regression logic + narrative + render free of `node:`); `ReportHistory` (jsonl) in node; **no new deps**.
+- [ ] `detectRegressions` matches the Python 2b scenario (per-metric 2% gate catches a recall drop a 10% gate misses; direction-aware; previous-over-post-step flags nothing); `trend` ordered; narrative + markdown callout work; no-regression markdown byte-identical to 3a.
+- [ ] CLI `trend`/`regressions` real; tsc + tsup + vitest green.
+
+### Deferred
+SQLite backend (node lacks stable built-in sqlite). TS suite analyzers (3c). npm publish workflow.

--- a/packages/typescript/goldenanalysis/README.md
+++ b/packages/typescript/goldenanalysis/README.md
@@ -3,9 +3,9 @@
 Read-only cross-cutting analysis, metrics, and reporting for the Golden Suite — the
 TypeScript port of the Python [`goldenanalysis`](../../python/goldenanalysis) package.
 
-> **Phase 3a** ships the generic **frame path** with cross-surface parity. Suite
-> analyzers and the cross-run layer (`ReportHistory` / regressions) land in later
-> phases.
+> **Phase 3a** ships the generic **frame path** with cross-surface parity; **Phase
+> 3b** adds the **cross-run layer** (`ReportHistory`, regression detection, narrative,
+> `trend`/`regressions` CLI). Suite analyzers land in a later phase.
 
 ## Quickstart
 
@@ -29,6 +29,48 @@ CLI:
 goldenanalysis-js report customers.json --format markdown   # or a .csv
 goldenanalysis-js report customers.csv --analyzers frame.summary
 ```
+
+## Cross-run (trend + regressions)
+
+`ReportHistory` is an append-only **JSONL** log of `AnalysisReport`s, keyed by
+`(analysisName, dataset, runId)` (last-wins). It powers trend series and
+direction-aware regression detection across runs. The pure decision logic
+(`detectRegressions` / `buildTrend` / `buildNarrative` + the models) is edge-safe in
+`goldenanalysis/core`; the file-backed store needs `node:fs` and lives in
+`goldenanalysis/node`.
+
+```ts
+import { ReportHistory } from "goldenanalysis/node";
+
+const hist = new ReportHistory({ path: ".golden/analysis.jsonl" });
+hist.append(report); // after each run
+
+// A per-metric 2% gate on recall catches a drop a global 10% gate would miss.
+const flagged = hist.detectRegressions("customers", {
+  baseline: "rolling_median", // or "previous" / "last_known_good" / a pinned runId
+  policy: { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } },
+});
+const series = hist.trend("cluster.singleton_ratio", "customers", { lastN: 30 });
+```
+
+Regression flags are **direction-aware**: a `higher_better` metric flags only on a
+drop, `lower_better` only on a rise, `neutral` either way. `rolling_median` is immune
+to one noisy night where `previous` would alternately flag and un-flag.
+
+CLI:
+
+```bash
+# trend of one metric across the run history
+goldenanalysis-js trend cluster.singleton_ratio --history .golden/analysis.jsonl --dataset customers
+
+# detect regressions in the latest run vs history (exit 1 on any flag, for CI gating)
+goldenanalysis-js regressions --history .golden/analysis.jsonl --dataset customers \
+  --policy "match.recall_safe_bound=2,*=10" --fail-on-regression
+```
+
+> **JSONL only.** Node 20 has no stable built-in SQLite (`node:sqlite` is experimental
+> in 22+); the Python sibling's optional SQLite backend is a documented follow-up.
+> Python's *default* backend is also JSONL, so the surface parity holds.
 
 ## Cross-surface parity
 

--- a/packages/typescript/goldenanalysis/package.json
+++ b/packages/typescript/goldenanalysis/package.json
@@ -36,6 +36,11 @@
       "types": "./dist/core/index.d.ts",
       "import": "./dist/core/index.js",
       "require": "./dist/core/index.cjs"
+    },
+    "./node": {
+      "types": "./dist/node/index.d.ts",
+      "import": "./dist/node/index.js",
+      "require": "./dist/node/index.cjs"
     }
   },
   "bin": {

--- a/packages/typescript/goldenanalysis/src/cli.ts
+++ b/packages/typescript/goldenanalysis/src/cli.ts
@@ -4,8 +4,11 @@
 import { readFileSync } from "node:fs";
 import { Command } from "commander";
 import { analyze } from "./core/analyze.js";
+import { buildNarrative } from "./core/narrative.js";
+import type { RegressionPolicy } from "./core/regressions.js";
 import { toJson, toMarkdown } from "./core/render.js";
 import type { FrameRows } from "./core/types.js";
+import { ReportHistory } from "./node/history.js";
 
 /** Minimal CSV -> rows (empty cell => null; numeric strings => number). */
 function parseCsv(text: string): FrameRows {
@@ -51,6 +54,83 @@ export function renderReportFromFile(path: string, options: ReportOptions = {}):
   return (options.format ?? "markdown") === "json" ? toJson(report) : toMarkdown(report);
 }
 
+/** Parse `--policy` as JSON (`{defaultPct,perMetric}`) or `key=pct,...` (`*=pct`
+ * sets the global default). Returns undefined for an empty/absent spec. */
+export function parsePolicy(raw?: string): RegressionPolicy | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{")) {
+    const obj = JSON.parse(trimmed) as Partial<RegressionPolicy>;
+    return { defaultPct: obj.defaultPct ?? 10, perMetric: obj.perMetric ?? {} };
+  }
+  const perMetric: Record<string, number> = {};
+  let defaultPct = 10;
+  for (const pair of trimmed.split(",")) {
+    const eq = pair.indexOf("=");
+    if (eq < 0) continue;
+    const key = pair.slice(0, eq).trim();
+    const pct = Number(pair.slice(eq + 1).trim());
+    if (Number.isNaN(pct)) continue;
+    if (key === "*") defaultPct = pct;
+    else if (key.length > 0) perMetric[key] = pct;
+  }
+  return { defaultPct, perMetric };
+}
+
+export interface TrendCliOptions {
+  readonly history: string;
+  readonly dataset?: string;
+  readonly last?: number;
+  readonly analysis?: string;
+}
+
+/** Render a metric's run-history trend (the testable core of `trend`). */
+export function runTrend(metricKey: string, options: TrendCliOptions): string {
+  const hist = new ReportHistory({ path: options.history });
+  const series = hist.trend(metricKey, options.dataset ?? "frame", {
+    lastN: options.last ?? 30,
+    analysisName: options.analysis ?? "default",
+  });
+  const lines = [`# Trend — ${series.metricKey} (${series.dataset})`];
+  for (const [runId, value] of series.points) lines.push(`${runId}\t${value}`);
+  if (series.points.length === 0) lines.push("(no data)");
+  return lines.join("\n") + "\n";
+}
+
+export interface RegressionsCliOptions {
+  readonly history: string;
+  readonly dataset?: string;
+  readonly baseline?: string;
+  readonly window?: number;
+  readonly policy?: string;
+  readonly analysis?: string;
+}
+
+export interface RegressionsCliResult {
+  readonly text: string;
+  readonly flaggedCount: number;
+}
+
+/** Detect regressions in the latest run vs history and render the markdown report
+ * (callout + Δ column + narrative). The testable core of `regressions`. */
+export function runRegressions(options: RegressionsCliOptions): RegressionsCliResult {
+  const hist = new ReportHistory({ path: options.history });
+  const dataset = options.dataset ?? "frame";
+  const analysisName = options.analysis ?? "default";
+  const policy = parsePolicy(options.policy);
+  const flagged = hist.detectRegressions(dataset, {
+    baseline: options.baseline ?? "rolling_median",
+    window: options.window ?? 7,
+    analysisName,
+    ...(policy ? { policy } : {}), // omit (don't pass undefined) under exactOptionalPropertyTypes
+  });
+  const reports = hist.reports(dataset, { analysisName });
+  const latest = reports[reports.length - 1];
+  if (latest === undefined) return { text: "No reports in history.\n", flaggedCount: 0 };
+  const withNarrative = { ...latest, narrative: buildNarrative(latest, flagged) };
+  return { text: toMarkdown(withNarrative, flagged), flaggedCount: flagged.length };
+}
+
 export function buildProgram(): Command {
   const program = new Command();
   program.name("goldenanalysis-js").description("Measure and report across the Golden Suite.");
@@ -61,6 +141,30 @@ export function buildProgram(): Command {
     .option("--analyzers <list>", "comma-separated analyzer names, or 'all'", "all")
     .action((input: string, opts: { format?: "markdown" | "json"; analyzers?: string }) => {
       process.stdout.write(renderReportFromFile(input, opts) + "\n");
+    });
+  program
+    .command("trend")
+    .argument("<metric>", "metric key, e.g. cluster.singleton_ratio")
+    .requiredOption("--history <path>", "path to the analysis.jsonl history")
+    .option("--dataset <name>", "dataset name", "frame")
+    .option("--last <n>", "trailing points to show", (v) => Number(v))
+    .option("--analysis <name>", "analysis name", "default")
+    .action((metric: string, opts: TrendCliOptions) => {
+      process.stdout.write(runTrend(metric, opts));
+    });
+  program
+    .command("regressions")
+    .requiredOption("--history <path>", "path to the analysis.jsonl history")
+    .option("--dataset <name>", "dataset name", "frame")
+    .option("--baseline <strategy>", "previous | rolling_median | last_known_good | <run_id>", "rolling_median")
+    .option("--window <n>", "rolling-median window", (v) => Number(v))
+    .option("--policy <spec>", "JSON {defaultPct,perMetric} or key=pct,*=pct")
+    .option("--analysis <name>", "analysis name", "default")
+    .option("--fail-on-regression", "exit 1 when any regression is flagged", false)
+    .action((opts: RegressionsCliOptions & { failOnRegression?: boolean }) => {
+      const result = runRegressions(opts);
+      process.stdout.write(result.text);
+      if (opts.failOnRegression && result.flaggedCount > 0) process.exitCode = 1;
     });
   return program;
 }

--- a/packages/typescript/goldenanalysis/src/core/history.ts
+++ b/packages/typescript/goldenanalysis/src/core/history.ts
@@ -1,0 +1,76 @@
+/**
+ * Report-level cross-run functions (edge-safe; operate on an in-memory
+ * `AnalysisReport[]`). The node-only `ReportHistory` (jsonl) wraps storage around
+ * these. Parity with the Python `history.py` trend/detect_regressions logic.
+ */
+
+import { baselineValue, defaultPolicy, deltaPct, isRegression, policyThreshold } from "./regressions.js";
+import type { Baseline, Regression, RegressionPolicy, TrendSeries } from "./regressions.js";
+import type { AnalysisReport } from "./types.js";
+
+function numericValue(report: AnalysisReport, key: string): number | null {
+  for (const m of report.metrics) {
+    if (m.key === key) return typeof m.value === "number" ? m.value : null;
+  }
+  return null;
+}
+
+/** A metric's value across the reports (oldest -> newest), last `lastN`. */
+export function buildTrend(
+  reports: readonly AnalysisReport[],
+  metricKey: string,
+  dataset: string,
+  lastN = 30,
+): TrendSeries {
+  const points: Array<readonly [string, number]> = [];
+  for (const report of reports) {
+    const value = numericValue(report, metricKey);
+    if (value !== null) points.push([report.run_id, value] as const);
+  }
+  return { metricKey, dataset, points: points.slice(-lastN) };
+}
+
+export interface DetectOptions {
+  readonly baseline?: Baseline;
+  readonly window?: number;
+  readonly policy?: RegressionPolicy;
+}
+
+/**
+ * Flag metric movements in the LATEST report vs the prior history. Compares each
+ * numeric metric in the most-recent report against a baseline from the earlier
+ * reports under the chosen strategy + per-metric policy. Returns only the flagged.
+ */
+export function detectRegressions(reports: readonly AnalysisReport[], options: DetectOptions = {}): Regression[] {
+  if (reports.length < 2) return [];
+  const baseline: Baseline = options.baseline ?? "rolling_median";
+  const window = options.window ?? 7;
+  const policy = options.policy ?? defaultPolicy();
+
+  const current = reports[reports.length - 1]!;
+  const prior = reports.slice(0, -1);
+  const out: Regression[] = [];
+  for (const metric of current.metrics) {
+    if (typeof metric.value !== "number") continue;
+    const series: number[] = [];
+    for (const rep of prior) {
+      const v = numericValue(rep, metric.key);
+      if (v !== null) series.push(v);
+    }
+    const base = baselineValue(series, baseline, window);
+    if (base === null) continue;
+    const threshold = policyThreshold(policy, metric.key);
+    const flagged = isRegression(metric.direction, base, metric.value, threshold);
+    if (flagged) {
+      out.push({
+        metric: metric.key,
+        baseline: base,
+        current: metric.value,
+        deltaPct: deltaPct(base, metric.value),
+        flagged: true,
+        direction: metric.direction,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/typescript/goldenanalysis/src/core/index.ts
+++ b/packages/typescript/goldenanalysis/src/core/index.ts
@@ -7,6 +7,19 @@ export { availableAnalyzers, loadAnalyzer, frameCompatibleAnalyzers } from "./re
 export { FrameSummaryAnalyzer } from "./analyzers/frameSummary.js";
 export * as aggregate from "./aggregate.js";
 export { SCHEMA_VERSION } from "./types.js";
+
+// Cross-run (edge-safe): regression decision logic, report-level queries, narrative.
+export {
+  baselineValue,
+  defaultPolicy,
+  deltaPct,
+  isRegression,
+  policyThreshold,
+} from "./regressions.js";
+export type { Baseline, Regression, RegressionPolicy, TrendSeries } from "./regressions.js";
+export { buildTrend, detectRegressions } from "./history.js";
+export type { DetectOptions } from "./history.js";
+export { buildNarrative } from "./narrative.js";
 export type {
   Analyzer,
   AnalyzerInfo,

--- a/packages/typescript/goldenanalysis/src/core/narrative.ts
+++ b/packages/typescript/goldenanalysis/src/core/narrative.ts
@@ -1,0 +1,70 @@
+/**
+ * Narrative generation — one-paragraph NL summary from the flagged regressions +
+ * the largest co-moving metrics. Deterministic, ASCII-clean. Parity with the Python
+ * `narrative.py`.
+ */
+
+import type { Regression } from "./regressions.js";
+import type { AnalysisReport } from "./types.js";
+
+function pretty(key: string): string {
+  const last = key.split(".").pop() ?? key;
+  return last.replace(/_/g, " ");
+}
+
+function capitalize(text: string): string {
+  return text.length === 0 ? text : text[0]!.toUpperCase() + text.slice(1);
+}
+
+function num(value: number): string {
+  return String(value);
+}
+
+function topFindingClass(report: AnalysisReport): readonly [string, number] | null {
+  for (const table of report.tables) {
+    if (table.name === "findings_by_class" && table.rows.length > 0) {
+      let best: readonly unknown[] = table.rows[0]!;
+      for (const row of table.rows) {
+        const c = typeof row[1] === "number" ? row[1] : 0;
+        const b = typeof best[1] === "number" ? best[1] : 0;
+        if (c > b) best = row;
+      }
+      return [String(best[0]), Number(best[1])] as const;
+    }
+  }
+  return null;
+}
+
+export function buildNarrative(report: AnalysisReport, regressions: readonly Regression[] = []): string {
+  const flagged = regressions.filter((r) => r.flagged);
+
+  if (flagged.length === 0) {
+    const notable = report.metrics
+      .filter((m) => typeof m.value === "number")
+      .slice()
+      .sort((a, b) => Math.abs(Number(b.value)) - Math.abs(Number(a.value)))
+      .slice(0, 3);
+    if (notable.length === 0) return "No metrics to summarize.";
+    const bits = notable.map((m) => `${pretty(m.key)} = ${m.value}`).join(", ");
+    return `No regressions flagged. Notable metrics: ${bits}.`;
+  }
+
+  let worst = flagged[0]!;
+  for (const r of flagged) {
+    if (Math.abs(r.deltaPct) > Math.abs(worst.deltaPct)) worst = r;
+  }
+  const dir = worst.deltaPct < 0 ? "fell" : "rose";
+  const lead = `${capitalize(pretty(worst.metric))} ${dir} to ${num(worst.current)} (baseline ${num(worst.baseline)}; ${worst.deltaPct >= 0 ? "+" : ""}${worst.deltaPct.toFixed(1)}%).`;
+
+  const parts = [lead];
+  const comovers = flagged.filter((r) => r.metric !== worst.metric);
+  if (comovers.length > 0) {
+    const moves = comovers
+      .map((r) => `${pretty(r.metric)} ${num(r.baseline)} -> ${num(r.current)} (${r.deltaPct >= 0 ? "+" : ""}${r.deltaPct.toFixed(1)}%)`)
+      .join("; ");
+    parts.push(`Co-moving signals: ${moves}.`);
+  }
+  const fc = topFindingClass(report);
+  if (fc !== null) parts.push(`Most common quality finding: ${fc[0]} (${fc[1]}).`);
+  return parts.join(" ");
+}

--- a/packages/typescript/goldenanalysis/src/core/regressions.ts
+++ b/packages/typescript/goldenanalysis/src/core/regressions.ts
@@ -1,0 +1,75 @@
+/**
+ * Cross-run regression decision logic + models (edge-safe; no node: imports).
+ *
+ * Parity with the Python reference
+ * `packages/python/goldenanalysis/goldenanalysis/_regressions.py`. The two decisions
+ * the spec's worked scenario forced: the baseline is a *strategy* (not just
+ * "previous"), and thresholds are *per-metric* and respect each `Metric.direction`.
+ *
+ * These models are camelCase (TS-idiomatic) — they are NOT cross-language wire types
+ * (the wire type is `AnalysisReport`, kept snake_case in `types.ts`).
+ */
+
+import type { Direction } from "./types.js";
+
+/** "previous" / "rolling_median" / "last_known_good", or a pinned run_id. */
+export type Baseline = "previous" | "rolling_median" | "last_known_good" | string;
+
+/** Per-metric regression thresholds (percent); falls back to `defaultPct`. */
+export interface RegressionPolicy {
+  readonly defaultPct: number;
+  readonly perMetric: Record<string, number>;
+}
+
+export function policyThreshold(policy: RegressionPolicy, key: string): number {
+  return policy.perMetric[key] ?? policy.defaultPct;
+}
+
+export function defaultPolicy(): RegressionPolicy {
+  return { defaultPct: 10, perMetric: {} };
+}
+
+export interface Regression {
+  readonly metric: string;
+  readonly baseline: number;
+  readonly current: number;
+  readonly deltaPct: number;
+  readonly flagged: boolean;
+  readonly direction: Direction;
+}
+
+export interface TrendSeries {
+  readonly metricKey: string;
+  readonly dataset: string;
+  readonly points: ReadonlyArray<readonly [string, number]>; // (runId, value), oldest -> newest
+}
+
+function median(values: readonly number[]): number {
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+/**
+ * The baseline value to compare the current value against. `rolling_median` (median
+ * of the last `window`) is immune to one noisy night; `previous` / `last_known_good`
+ * (v1 alias) return the most recent historical value. Empty history => null.
+ */
+export function baselineValue(history: readonly number[], strategy: Baseline, window = 7): number | null {
+  if (history.length === 0) return null;
+  if (strategy === "rolling_median") return median(history.slice(-window));
+  return history[history.length - 1]!;
+}
+
+export function deltaPct(baseline: number, current: number): number {
+  if (baseline === 0) return 0;
+  return ((current - baseline) / baseline) * 100;
+}
+
+/** Direction-aware flag: higher_better flags on a drop; lower_better on a rise; neutral either way. */
+export function isRegression(direction: Direction, baseline: number, current: number, thresholdPct: number): boolean {
+  const d = deltaPct(baseline, current);
+  if (direction === "higher_better") return d <= -thresholdPct;
+  if (direction === "lower_better") return d >= thresholdPct;
+  return Math.abs(d) >= thresholdPct;
+}

--- a/packages/typescript/goldenanalysis/src/core/render.ts
+++ b/packages/typescript/goldenanalysis/src/core/render.ts
@@ -1,5 +1,6 @@
 /** Report exporters — JSON + Markdown (mirrors the Python output shape). */
 
+import type { Regression } from "./regressions.js";
 import type { AnalysisReport, Metric } from "./types.js";
 
 export function toJson(report: AnalysisReport, indent = 2): string {
@@ -16,17 +17,50 @@ function fmtValue(value: number | string, unit?: string | null): string {
   return unit ? `${text} ${unit}` : text;
 }
 
-export function toMarkdown(report: AnalysisReport): string {
+/** Python `:+.1f` — always-signed, one decimal (`+2.0%` / `-8.2%`). */
+function fmtDelta(pct: number): string {
+  return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+}
+
+/**
+ * Markdown report. With `regressions` (Phase 2b/3b) a flagged-regression callout and
+ * a `Δ vs baseline` column are added; with the default empty list the output is
+ * byte-identical to the Phase 3a form (existing parity tests stay green).
+ */
+export function toMarkdown(report: AnalysisReport, regressions: readonly Regression[] = []): string {
   const dataset = report.source["dataset"] ?? "frame";
   const lines: string[] = [`# Analysis — ${dataset} (run ${report.run_id})`, ""];
+
+  const byMetric = new Map<string, Regression>();
+  for (const r of regressions) byMetric.set(r.metric, r);
+  const flagged = regressions.filter((r) => r.flagged);
+  if (flagged.length > 0) {
+    const lead = flagged
+      .map((r) => `${r.metric} ${r.baseline} -> ${r.current} (${fmtDelta(r.deltaPct)})`)
+      .join("; ");
+    lines.push(`> WARNING: ${flagged.length} regression(s) flagged. ${lead}`, "");
+  }
 
   if (report.narrative) {
     lines.push(report.narrative, "");
   }
 
-  lines.push("| Metric | Value |", "|---|---|");
-  for (const m of report.metrics as readonly Metric[]) {
-    lines.push(`| ${m.key} | ${fmtValue(m.value, m.unit)} |`);
+  if (byMetric.size > 0) {
+    lines.push("| Metric | Value | Δ vs baseline |", "|---|---|---|");
+    for (const m of report.metrics as readonly Metric[]) {
+      const reg = byMetric.get(m.key);
+      let delta = "";
+      if (reg !== undefined) {
+        const mark = reg.flagged ? "🔴 " : "";
+        delta = `${mark}${fmtDelta(reg.deltaPct)}`;
+      }
+      lines.push(`| ${m.key} | ${fmtValue(m.value, m.unit)} | ${delta} |`);
+    }
+  } else {
+    lines.push("| Metric | Value |", "|---|---|");
+    for (const m of report.metrics as readonly Metric[]) {
+      lines.push(`| ${m.key} | ${fmtValue(m.value, m.unit)} |`);
+    }
   }
   lines.push("");
 

--- a/packages/typescript/goldenanalysis/src/node/history.ts
+++ b/packages/typescript/goldenanalysis/src/node/history.ts
@@ -1,0 +1,109 @@
+/**
+ * `ReportHistory` — append-only JSONL store of `AnalysisReport`s for cross-run trend
+ * + regression detection (Node-only; uses `node:fs`). The pure decision logic lives
+ * in `src/core` (`buildTrend` / `detectRegressions`); this wraps storage + dataset
+ * filtering around it. Keyed by `(analysisName, dataset, runId)`, last-wins on read.
+ *
+ * JSONL only — Node 20 has no stable built-in SQLite (`node:sqlite` is experimental
+ * in 22+). The SQLite backend the Python sibling offers is a documented follow-up;
+ * Python's DEFAULT backend is also jsonl, so the surface parity holds. Parity with
+ * `packages/python/goldenanalysis/goldenanalysis/history.py`.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { buildTrend, detectRegressions } from "../core/history.js";
+import type { DetectOptions } from "../core/history.js";
+import type { Regression, TrendSeries } from "../core/regressions.js";
+import type { AnalysisReport } from "../core/types.js";
+
+export const SCHEMA_VERSION = 1;
+
+/** One JSONL line: the wire `AnalysisReport` plus the storage envelope (camelCase —
+ * envelope metadata is internal, unlike the snake_case `report` wire payload). */
+interface HistoryRecord {
+  readonly analysisName: string;
+  readonly dataset: string;
+  readonly runId: string;
+  readonly schemaVersion: number;
+  readonly recordedAt: string;
+  readonly report: AnalysisReport;
+}
+
+export interface ReportHistoryOptions {
+  readonly path?: string;
+}
+
+export interface QueryOptions {
+  readonly analysisName?: string;
+}
+
+export class ReportHistory {
+  private readonly path: string;
+
+  constructor(options: ReportHistoryOptions = {}) {
+    this.path = options.path ?? ".golden/analysis.jsonl";
+    const dir = dirname(this.path);
+    if (dir.length > 0 && !existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+
+  /** Record a report. Re-appending the same `(analysisName, dataset, runId)` replaces
+   * the prior one on read (idempotent upsert). */
+  append(report: AnalysisReport, analysisName = "default"): void {
+    const dataset = report.source["dataset"] ?? "frame";
+    const record: HistoryRecord = {
+      analysisName,
+      dataset,
+      runId: report.run_id,
+      schemaVersion: report.schema_version,
+      recordedAt: new Date().toISOString(),
+      report,
+    };
+    appendFileSync(this.path, JSON.stringify(record) + "\n", "utf-8");
+  }
+
+  private allRecords(): HistoryRecord[] {
+    if (!existsSync(this.path)) return [];
+    const out: HistoryRecord[] = [];
+    for (const line of readFileSync(this.path, "utf-8").split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      out.push(JSON.parse(trimmed) as HistoryRecord);
+    }
+    return out;
+  }
+
+  private static key(rec: HistoryRecord): string {
+    return JSON.stringify([rec.analysisName, rec.dataset, rec.runId]);
+  }
+
+  /** Reports for `(analysisName, dataset)` in insertion order, last-wins per runId. */
+  reports(dataset: string, options: QueryOptions = {}): AnalysisReport[] {
+    const analysisName = options.analysisName ?? "default";
+    const order = new Map<string, number>();
+    const latest = new Map<string, HistoryRecord>();
+    this.allRecords().forEach((rec, i) => {
+      const key = ReportHistory.key(rec);
+      if (!order.has(key)) order.set(key, i);
+      latest.set(key, rec);
+    });
+    const picked: Array<readonly [number, HistoryRecord]> = [];
+    for (const [key, rec] of latest) {
+      if (rec.analysisName === analysisName && rec.dataset === dataset) {
+        picked.push([order.get(key)!, rec] as const);
+      }
+    }
+    picked.sort((a, b) => a[0] - b[0]);
+    return picked.map(([, rec]) => rec.report);
+  }
+
+  /** A metric's value across the run history (oldest -> newest). */
+  trend(metricKey: string, dataset: string, options: QueryOptions & { lastN?: number } = {}): TrendSeries {
+    return buildTrend(this.reports(dataset, options), metricKey, dataset, options.lastN ?? 30);
+  }
+
+  /** Flag metric movements in the LATEST report vs the prior history. */
+  detectRegressions(dataset: string, options: DetectOptions & QueryOptions = {}): Regression[] {
+    return detectRegressions(this.reports(dataset, options), options);
+  }
+}

--- a/packages/typescript/goldenanalysis/src/node/index.ts
+++ b/packages/typescript/goldenanalysis/src/node/index.ts
@@ -1,0 +1,27 @@
+/**
+ * GoldenAnalysis node entry — persistence that needs `node:fs` (`ReportHistory`).
+ *
+ * The pure cross-run logic (`buildTrend` / `detectRegressions` / `buildNarrative` and
+ * the regression models) is edge-safe and lives in `src/core`; it is re-exported here
+ * for convenience so a Node consumer has one import.
+ *
+ *   import { ReportHistory } from "goldenanalysis/node";
+ *   const hist = new ReportHistory({ path: ".golden/analysis.jsonl" });
+ *   hist.append(report);
+ *   const flagged = hist.detectRegressions("customers");
+ */
+
+export { ReportHistory, SCHEMA_VERSION } from "./history.js";
+export type { QueryOptions, ReportHistoryOptions } from "./history.js";
+
+export { buildTrend, detectRegressions } from "../core/history.js";
+export type { DetectOptions } from "../core/history.js";
+export { buildNarrative } from "../core/narrative.js";
+export {
+  baselineValue,
+  defaultPolicy,
+  deltaPct,
+  isRegression,
+  policyThreshold,
+} from "../core/regressions.js";
+export type { Baseline, Regression, RegressionPolicy, TrendSeries } from "../core/regressions.js";

--- a/packages/typescript/goldenanalysis/tests/fixtures/reports.ts
+++ b/packages/typescript/goldenanalysis/tests/fixtures/reports.ts
@@ -1,0 +1,56 @@
+// Hand-built `AnalysisReport` fixtures for the cross-run tests. Mirrors the Python
+// `_night` / `_report` helpers (packages/python/goldenanalysis/tests/) so the TS
+// cross-run layer is exercised on the same "Maya scenario": 7 healthy nights then a
+// regressed 8th where a per-metric 2% gate on recall catches a drop a 10% gate misses.
+
+import type { AnalysisReport, AnalysisTable, Direction, Metric } from "../../src/core/types.js";
+
+export function metric(
+  key: string,
+  value: number | string,
+  direction: Direction,
+  unit: string | null = "ratio",
+): Metric {
+  return { key, value, unit, direction };
+}
+
+export function report(
+  runId: string,
+  metrics: readonly Metric[],
+  options: { dataset?: string; tables?: readonly AnalysisTable[]; narrative?: string | null } = {},
+): AnalysisReport {
+  return {
+    schema_version: 1,
+    run_id: runId,
+    generated_at: "2026-06-08T00:00:00+00:00",
+    source: { dataset: options.dataset ?? "customers" },
+    metrics,
+    tables: options.tables ?? [],
+    narrative: options.narrative ?? null,
+    analyzers_run: [],
+  };
+}
+
+/** One night of the worked scenario: recall (higher_better), singleton (neutral),
+ * findings (lower_better), plus a `findings_by_class` table. */
+export function night(runId: string, recall: number, singleton: number, findings: number): AnalysisReport {
+  return report(
+    runId,
+    [
+      metric("match.recall_safe_bound", recall, "higher_better"),
+      metric("cluster.singleton_ratio", singleton, "neutral"),
+      metric("quality.findings_total", findings, "lower_better", "findings"),
+    ],
+    {
+      tables: [{ name: "findings_by_class", columns: ["class", "count"], rows: [["email_blanked", 1188]] }],
+    },
+  );
+}
+
+/** 7 healthy nights then a regressed 8th. */
+export function scenarioReports(): AnalysisReport[] {
+  const reps: AnalysisReport[] = [];
+  for (let i = 0; i < 7; i++) reps.push(night(`r${i}`, 0.97, 0.58, 410));
+  reps.push(night("r7", 0.89, 0.71, 1205));
+  return reps;
+}

--- a/packages/typescript/goldenanalysis/tests/node/cli-cross-run.test.ts
+++ b/packages/typescript/goldenanalysis/tests/node/cli-cross-run.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parsePolicy, runRegressions, runTrend } from "../../src/cli.js";
+import { ReportHistory } from "../../src/node/history.js";
+import { scenarioReports } from "../fixtures/reports.js";
+
+let dir: string;
+let historyPath: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ga-cli-"));
+  historyPath = join(dir, "analysis.jsonl");
+  const hist = new ReportHistory({ path: historyPath });
+  for (const rep of scenarioReports()) hist.append(rep);
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("parsePolicy", () => {
+  it("parses JSON form", () => {
+    expect(parsePolicy('{"defaultPct":5,"perMetric":{"a":2}}')).toEqual({ defaultPct: 5, perMetric: { a: 2 } });
+  });
+  it("parses key=pct form with a *=pct default", () => {
+    expect(parsePolicy("match.recall_safe_bound=2,*=15")).toEqual({
+      defaultPct: 15,
+      perMetric: { "match.recall_safe_bound": 2 },
+    });
+  });
+  it("returns undefined for an empty spec", () => {
+    expect(parsePolicy(undefined)).toBeUndefined();
+    expect(parsePolicy("")).toBeUndefined();
+  });
+});
+
+describe("runTrend", () => {
+  it("prints an ordered series for the metric", () => {
+    const out = runTrend("cluster.singleton_ratio", { history: historyPath, dataset: "customers", last: 14 });
+    expect(out).toContain("# Trend — cluster.singleton_ratio (customers)");
+    expect(out).toContain("r7\t0.71");
+    expect(out.trim().split("\n").length).toBe(9); // header + 8 points
+  });
+
+  it("reports no data for an unknown metric", () => {
+    const out = runTrend("does.not.exist", { history: historyPath, dataset: "customers" });
+    expect(out).toContain("(no data)");
+  });
+});
+
+describe("runRegressions", () => {
+  it("flags the scenario and renders a callout + delta column + narrative", () => {
+    const result = runRegressions({
+      history: historyPath,
+      dataset: "customers",
+      baseline: "rolling_median",
+      policy: "match.recall_safe_bound=2,*=10",
+    });
+    expect(result.flaggedCount).toBeGreaterThanOrEqual(2);
+    expect(result.text).toContain("> WARNING:");
+    expect(result.text).toContain("Δ vs baseline");
+    expect(result.text).toContain("🔴");
+    expect(result.text).toContain("email_blanked"); // narrative names the top finding class
+  });
+
+  it("handles an empty history gracefully", () => {
+    const result = runRegressions({ history: join(dir, "empty.jsonl"), dataset: "customers" });
+    expect(result.flaggedCount).toBe(0);
+    expect(result.text).toContain("No reports in history.");
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/node/history.test.ts
+++ b/packages/typescript/goldenanalysis/tests/node/history.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ReportHistory } from "../../src/node/history.js";
+import { metric, night, report, scenarioReports } from "../fixtures/reports.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ga-hist-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function seed(hist: ReportHistory): void {
+  for (const rep of scenarioReports()) hist.append(rep);
+}
+
+describe("ReportHistory (jsonl)", () => {
+  it("appends and reads back in insertion order", () => {
+    const hist = new ReportHistory({ path: join(dir, "a.jsonl") });
+    hist.append(report("r0", [metric("m", 1, "neutral")]));
+    hist.append(report("r1", [metric("m", 2, "neutral")]));
+    expect(hist.reports("customers").map((r) => r.run_id)).toEqual(["r0", "r1"]);
+  });
+
+  it("upserts idempotently per (analysisName, dataset, runId)", () => {
+    const hist = new ReportHistory({ path: join(dir, "a.jsonl") });
+    hist.append(report("r0", [metric("m", 1, "neutral")]));
+    hist.append(report("r0", [metric("m", 9, "neutral")])); // same key replaces
+    const reps = hist.reports("customers");
+    expect(reps.length).toBe(1);
+    expect(reps[0]!.metrics[0]!.value).toBe(9);
+  });
+
+  it("separates by analysis name", () => {
+    const hist = new ReportHistory({ path: join(dir, "a.jsonl") });
+    hist.append(report("r0", [metric("m", 1, "neutral")]), "nightly");
+    hist.append(report("r0", [metric("m", 2, "neutral")]), "adhoc");
+    expect(hist.reports("customers", { analysisName: "nightly" }).length).toBe(1);
+    expect(hist.reports("customers", { analysisName: "adhoc" })[0]!.metrics[0]!.value).toBe(2);
+  });
+
+  it("builds an ordered trend trimmed to lastN", () => {
+    const hist = new ReportHistory({ path: join(dir, "a.jsonl") });
+    seed(hist);
+    const series = hist.trend("cluster.singleton_ratio", "customers", { lastN: 14 });
+    expect(series.points.length).toBe(8);
+    expect(series.points[series.points.length - 1]).toEqual(["r7", 0.71]);
+  });
+
+  it("flags the worked scenario (2% recall gate catches what a 10% gate misses)", () => {
+    const hist = new ReportHistory({ path: join(dir, "a.jsonl") });
+    seed(hist);
+    const flagged = hist.detectRegressions("customers", {
+      baseline: "rolling_median",
+      policy: { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } },
+    });
+    const keys = new Set(flagged.map((r) => r.metric));
+    expect(keys.has("match.recall_safe_bound")).toBe(true);
+    expect(keys.has("cluster.singleton_ratio")).toBe(true);
+  });
+
+  it("previous baseline over a post-step pair flags nothing", () => {
+    const hist = new ReportHistory({ path: join(dir, "a.jsonl") });
+    hist.append(report("a", [metric("match.recall_safe_bound", 0.89, "higher_better")]));
+    hist.append(report("b", [metric("match.recall_safe_bound", 0.89, "higher_better")]));
+    const flagged = hist.detectRegressions("customers", {
+      baseline: "previous",
+      policy: { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } },
+    });
+    expect(flagged).toEqual([]);
+  });
+
+  it("persists durably — a fresh handle on the same file sees the reports", () => {
+    const path = join(dir, "a.jsonl");
+    const writer = new ReportHistory({ path });
+    seed(writer);
+    const reader = new ReportHistory({ path });
+    expect(reader.reports("customers").length).toBe(8);
+    expect(reader.reports("customers").map((r) => r.run_id)).toContain("r7");
+  });
+
+  it("returns an empty list for an unseen file", () => {
+    const hist = new ReportHistory({ path: join(dir, "missing.jsonl") });
+    expect(hist.reports("customers")).toEqual([]);
+    expect(hist.detectRegressions("customers")).toEqual([]);
+  });
+
+  it("creates parent directories as needed", () => {
+    const hist = new ReportHistory({ path: join(dir, "nested", "deep", "a.jsonl") });
+    hist.append(night("r0", 0.9, 0.5, 1));
+    expect(hist.reports("customers").length).toBe(1);
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/unit/history.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/history.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildTrend, detectRegressions } from "../../src/core/history.js";
+import { night, scenarioReports } from "../fixtures/reports.js";
+
+describe("buildTrend (edge-safe)", () => {
+  it("collects a metric oldest -> newest and trims to lastN", () => {
+    const series = buildTrend(scenarioReports(), "cluster.singleton_ratio", "customers", 14);
+    expect(series.metricKey).toBe("cluster.singleton_ratio");
+    expect(series.dataset).toBe("customers");
+    expect(series.points.length).toBe(8);
+    expect(series.points[series.points.length - 1]).toEqual(["r7", 0.71]);
+  });
+
+  it("skips reports missing the metric / non-numeric values", () => {
+    const series = buildTrend(scenarioReports(), "does.not.exist", "customers");
+    expect(series.points).toEqual([]);
+  });
+});
+
+describe("detectRegressions (edge-safe)", () => {
+  it("the 2% recall gate catches a drop the 10% gate misses; neutral + lower_better also flag", () => {
+    const policy = { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } };
+    const flagged = detectRegressions(scenarioReports(), { baseline: "rolling_median", policy });
+    const keys = new Set(flagged.map((r) => r.metric));
+    expect(keys.has("match.recall_safe_bound")).toBe(true);
+    expect(keys.has("cluster.singleton_ratio")).toBe(true);
+    expect(keys.has("quality.findings_total")).toBe(true);
+
+    // a global 10% gate does NOT flag recall (-8.2%)
+    const global = detectRegressions(scenarioReports(), { policy: { defaultPct: 10, perMetric: {} } });
+    expect(global.some((r) => r.metric === "match.recall_safe_bound")).toBe(false);
+  });
+
+  it("previous baseline over a post-step pair flags nothing", () => {
+    const reps = [night("a", 0.89, 0.71, 1205), night("b", 0.89, 0.71, 1205)];
+    const policy = { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } };
+    expect(detectRegressions(reps, { baseline: "previous", policy })).toEqual([]);
+  });
+
+  it("needs at least two reports", () => {
+    expect(detectRegressions([night("a", 0.9, 0.5, 1)], {})).toEqual([]);
+    expect(detectRegressions([], {})).toEqual([]);
+  });
+
+  it("reports carry direction + delta for the flagged metric", () => {
+    const policy = { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } };
+    const flagged = detectRegressions(scenarioReports(), { baseline: "rolling_median", policy });
+    const recall = flagged.find((r) => r.metric === "match.recall_safe_bound");
+    expect(recall?.direction).toBe("higher_better");
+    expect(recall?.baseline).toBe(0.97);
+    expect(recall?.current).toBe(0.89);
+    expect(recall?.deltaPct).toBeCloseTo(-8.247, 2);
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/unit/narrative.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/narrative.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildNarrative } from "../../src/core/narrative.js";
+import type { Regression } from "../../src/core/regressions.js";
+import { metric, report } from "../fixtures/reports.js";
+
+function scenarioReport() {
+  return report(
+    "r7",
+    [
+      metric("match.recall_safe_bound", 0.89, "higher_better"),
+      metric("cluster.singleton_ratio", 0.71, "neutral"),
+      metric("quality.findings_total", 1205, "lower_better", "findings"),
+    ],
+    {
+      tables: [
+        {
+          name: "findings_by_class",
+          columns: ["class", "count"],
+          rows: [
+            ["email_blanked", 1188],
+            ["phone_unparseable", 12],
+          ],
+        },
+      ],
+    },
+  );
+}
+
+describe("buildNarrative", () => {
+  it("leads with the largest-magnitude regression and lists co-movers + top finding", () => {
+    const regs: Regression[] = [
+      { metric: "match.recall_safe_bound", baseline: 0.97, current: 0.89, deltaPct: -8.2, flagged: true, direction: "higher_better" },
+      { metric: "cluster.singleton_ratio", baseline: 0.58, current: 0.71, deltaPct: 22.4, flagged: true, direction: "neutral" },
+    ];
+    const text = buildNarrative(scenarioReport(), regs).toLowerCase();
+    // largest |delta| is singleton (+22.4%) -> it leads; recall is a co-mover
+    expect(text).toContain("singleton");
+    expect(text).toContain("0.71");
+    expect(text).toContain("recall safe bound");
+    expect(text).toContain("0.89");
+    expect(text).toContain("email_blanked");
+  });
+
+  it("no-regression path is a neutral metric summary", () => {
+    const text = buildNarrative(scenarioReport(), []);
+    expect(text).toContain("No regressions flagged");
+  });
+
+  it("handles a report with no numeric metrics", () => {
+    const text = buildNarrative(report("r0", [metric("note", "n/a", "neutral", null)]), []);
+    expect(text).toBe("No metrics to summarize.");
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/unit/regressions.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/regressions.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  baselineValue,
+  defaultPolicy,
+  deltaPct,
+  isRegression,
+  policyThreshold,
+} from "../../src/core/regressions.js";
+
+const HEALTHY = [0.97, 0.96, 0.98, 0.97, 0.97, 0.96, 0.97];
+
+describe("baseline strategies", () => {
+  it("rolling_median is the median of the window; previous is the last value", () => {
+    expect(baselineValue(HEALTHY, "rolling_median", 7)).toBe(0.97);
+    expect(baselineValue(HEALTHY, "previous")).toBe(0.97);
+  });
+
+  it("empty history has no baseline", () => {
+    expect(baselineValue([], "rolling_median")).toBeNull();
+  });
+
+  it("rolling_median ignores one noisy night where previous would not", () => {
+    const noisy = [0.97, 0.97, 0.97, 0.5, 0.97, 0.97, 0.97];
+    expect(baselineValue(noisy, "rolling_median", 7)).toBe(0.97); // median unmoved
+    expect(baselineValue(noisy, "previous")).toBe(0.97);
+  });
+});
+
+describe("isRegression", () => {
+  it("recall flags under a per-metric 2% gate that a global 10% gate misses", () => {
+    const policy = { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } };
+    // higher_better: 0.97 -> 0.89 is -8.2%
+    expect(isRegression("higher_better", 0.97, 0.89, policyThreshold(policy, "match.recall_safe_bound"))).toBe(true);
+    expect(isRegression("higher_better", 0.97, 0.89, policyThreshold(policy, "anything_else"))).toBe(false);
+  });
+
+  it("is direction-aware", () => {
+    expect(isRegression("higher_better", 0.5, 0.9, 5)).toBe(false); // a rise is fine
+    expect(isRegression("lower_better", 100, 130, 10)).toBe(true); // only flags on a rise
+    expect(isRegression("lower_better", 100, 70, 10)).toBe(false);
+    expect(isRegression("neutral", 0.58, 0.71, 10)).toBe(true); // +22.4%
+    expect(isRegression("neutral", 0.71, 0.58, 10)).toBe(true);
+  });
+
+  it("ignores noise wobble under the gate", () => {
+    expect(isRegression("neutral", 1.0, 1.03, 10)).toBe(false); // +3% < 10%
+  });
+});
+
+describe("helpers", () => {
+  it("deltaPct guards a zero baseline", () => {
+    expect(deltaPct(0, 5)).toBe(0);
+    expect(deltaPct(100, 130)).toBeCloseTo(30, 9);
+  });
+
+  it("defaultPolicy is a 10% global gate with no per-metric overrides", () => {
+    expect(defaultPolicy()).toEqual({ defaultPct: 10, perMetric: {} });
+  });
+
+  it("policyThreshold falls back to defaultPct", () => {
+    const policy = { defaultPct: 10, perMetric: { a: 2 } };
+    expect(policyThreshold(policy, "a")).toBe(2);
+    expect(policyThreshold(policy, "b")).toBe(10);
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/unit/render.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/render.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { analyze } from "../../src/core/analyze.js";
+import type { Regression } from "../../src/core/regressions.js";
+import { toMarkdown } from "../../src/core/render.js";
+import { buildCustomersSmall } from "../fixtures/customersSmall.js";
+import { night } from "../fixtures/reports.js";
+
+describe("toMarkdown regression callout", () => {
+  it("is byte-identical to the 2-column form when no regressions are passed", () => {
+    const report = analyze(buildCustomersSmall(), ["frame.summary"], { dataset: "customers" });
+    expect(toMarkdown(report, [])).toBe(toMarkdown(report));
+    const md = toMarkdown(report);
+    expect(md).toContain("| Metric | Value |");
+    expect(md).not.toContain("Δ vs baseline");
+    expect(md).not.toContain("WARNING");
+  });
+
+  it("adds a callout + Δ column when regressions are flagged", () => {
+    const report = night("r7", 0.89, 0.71, 1205);
+    const regs: Regression[] = [
+      { metric: "match.recall_safe_bound", baseline: 0.97, current: 0.89, deltaPct: -8.2, flagged: true, direction: "higher_better" },
+    ];
+    const md = toMarkdown(report, regs);
+    expect(md).toContain("> WARNING: 1 regression(s) flagged.");
+    expect(md).toContain("match.recall_safe_bound 0.97 -> 0.89 (-8.2%)");
+    expect(md).toContain("| Metric | Value | Δ vs baseline |");
+    expect(md).toContain("🔴 -8.2%");
+    // a metric not in the regression set gets a blank delta cell
+    expect(md).toContain("| cluster.singleton_ratio | 0.71 ratio |  |");
+  });
+
+  it("renders the Δ column without a callout for a considered-but-not-flagged metric", () => {
+    const report = night("r7", 0.96, 0.58, 410);
+    const regs: Regression[] = [
+      { metric: "match.recall_safe_bound", baseline: 0.97, current: 0.96, deltaPct: -1.0, flagged: false, direction: "higher_better" },
+    ];
+    const md = toMarkdown(report, regs);
+    expect(md).not.toContain("WARNING");
+    expect(md).toContain("| Metric | Value | Δ vs baseline |");
+    expect(md).toContain("| match.recall_safe_bound | 0.96 ratio | -1.0% |");
+  });
+});

--- a/packages/typescript/goldenanalysis/tsup.config.ts
+++ b/packages/typescript/goldenanalysis/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     "core/index": "src/core/index.ts",
+    "node/index": "src/node/index.ts",
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],


### PR DESCRIPTION
Ports the GoldenAnalysis **cross-run layer** to TypeScript (parity with Python Phase 2b). Builds on Phase 3a (#813, merged): the `AnalysisReport`/`Metric` wire types, `analyze`, `toMarkdown`.

## What's here
- **Edge-safe core** (`src/core`, no `node:` imports):
  - `regressions.ts` — baseline strategy (`rolling_median` / `previous` / `last_known_good` / pinned runId), per-metric **direction-aware** thresholds (`higher_better` flags on a drop, `lower_better` on a rise, `neutral` either way), `RegressionPolicy`/`Regression`/`TrendSeries` models (camelCase — these are NOT wire types).
  - `history.ts` — report-level `detectRegressions` (latest vs prior history) + `buildTrend`.
  - `narrative.ts` — deterministic one-paragraph summary (worst regression + co-movers + top finding class).
  - `render.ts` — `toMarkdown(report, regressions?)` adds a `> WARNING:` callout + `Δ vs baseline` column; **byte-identical to 3a when no regressions** (existing parity tests stay green).
- **Node store** (`src/node`, uses `node:fs`): `ReportHistory` — append-only **JSONL** keyed by `(analysisName, dataset, runId)`, last-wins; `trend`/`detectRegressions` delegate to the core. New `goldenanalysis/node` export + tsup entry.
- **CLI**: `goldenanalysis-js trend <metric>` and `regressions` (`--baseline`/`--policy`/`--window`/`--fail-on-regression` for CI gating; `--policy` accepts JSON or `key=pct,*=pct`).

## Design notes
- **JSONL only.** Node 20 has no stable built-in SQLite (`node:sqlite` is experimental in 22+). Python's *default* backend is also JSONL, so the surface parity holds; the optional SQLite backend is a documented follow-up.
- Cross-run models are camelCase (TS-idiomatic); only the `AnalysisReport` wire payload stays snake_case.

## Test plan
- `npx vitest run` — 57 passed (29 new: regression logic, report-level detect/trend, narrative, render callout, node `ReportHistory` durability/upsert, CLI `trend`/`regressions`/`parsePolicy`).
- The Python "Maya scenario" is reproduced in TS: a per-metric **2% gate on `match.recall_safe_bound` catches a −8.2% drop a global 10% gate misses**; `previous` over a post-step pair flags nothing.
- `npx tsc --noEmit` clean; `npx tsup` builds all 4 entries (incl. `dist/node/*`); built CLI smoke-tested end-to-end (callout + narrative + `🔴` Δ column; `--fail-on-regression` exits 1).
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)