### PR TITLE
feat(goldenanalysis-js): Phase 3c — TypeScript suite analyzers (match/cluster/quality + analyzeMatch/analyzePipeline)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-goldenanalysis-phase3c-ts-suite.md
+++ b/docs/superpowers/plans/2026-06-08-goldenanalysis-phase3c-ts-suite.md
@@ -1,0 +1,68 @@
+# GoldenAnalysis Phase 3c — TypeScript Suite Analyzers Plan
+
+> Use superpowers:executing-plans (inline; TS is safe to build/test locally). TDD-shaped.
+
+**Goal:** Port the suite analyzers + adapters + suite entry points to TypeScript — `match.rates`, `cluster.distribution`, `quality.rollup`, the match/flow/check/pipe artifact adapters, and `analyzeMatch`/`analyzePipeline`. Behavioral parity with Python Phase 2a on hand-built artifacts.
+
+**Architecture:** All edge-safe (`src/core`, no `node:` imports). Analyzers consume the SAME snake_case artifact keys the Python sibling reads (`scored_pairs`/`match_stats`/`clusters`/`findings`/`manifest`/`recall_certificate`/`__producer__`) so a serialized Python `PipeResult.artifacts` feeds the TS analyzers identically. Adapters are duck-typed functions (read properties off an `unknown` producer object — no goldenmatch/goldenflow/goldencheck/goldenpipe import). `analyze.ts` is refactored to share one `assembleReport` across the frame + suite entry points.
+
+**Spec/Reference:** Python Phase 2a — `packages/python/goldenanalysis/goldenanalysis/{analyzers/{match_rates,cluster_dist,quality_rollup}.py,adapters/{match,flow,check,pipe}.py,_api.py,registry.py}`.
+
+**Builds on:** Phase 3a/3b (merged) — `AnalysisReport`/`Metric` types, `analyze`, `aggregate` (has `histogram`/`quantile`), registry, render.
+
+---
+
+## Conventions
+- From `packages/typescript/goldenanalysis/`. `npx vitest run`, `npx tsc --noEmit`, `npx tsup`.
+- Branch `feat/goldenanalysis-ts-suite`, off `main` (has 3b). Commit per task.
+- Parity gotchas (caught from the Python source/tests):
+  - empty `clusters` `{}` is **truthy** in JS → guard with `Object.keys(clusters).length === 0`.
+  - `findings_by_class` rows follow `Counter.most_common()` (count desc, ties in first-appearance order).
+  - pipe dataset = `Path(source).stem`; `<DataFrame>` / non-string / empty → `"frame"`.
+  - `analyzePipeline` fan-out iterates **sorted** `availableAnalyzers()`; `analyzeMatch` uses the explicit ordered pair `["match.rates","cluster.distribution"]`.
+  - `cluster.record_count` uses `match_stats.total_records` only when present, else `sum(sizes)`.
+  - recall cert normalizes to `{estimate, safe_bound}` accepting `{recall, recall_lower}` too.
+
+## Tasks
+
+### 3c.0 — `match.rates` analyzer (`src/core/analyzers/matchRates.ts`)
+- [ ] Test (`tests/unit/matchRates.test.ts`): core metrics (`pair_count`/`match_rate`/`threshold`/`mean_pair_score`; recall omitted w/o cert); recall from `{estimate,safe_bound}` cert (both `higher_better`); estimate-only (safe_bound omitted); `score_histogram` table present; empty pairs degrades (no `mean_pair_score`). Mirror `test_match_rates.py`.
+- [ ] Impl: `MatchRatesAnalyzer implements Analyzer`, consumes `["scored_pairs","match_stats"]`. Score = last element of each pair. `histogram(scores, 10)`. `certValues(cert)` accepts `{estimate|recall, safe_bound|recall_lower}`.
+- [ ] Commit `feat(goldenanalysis-js): match.rates analyzer`
+
+### 3c.1 — `cluster.distribution` analyzer (`src/core/analyzers/clusterDist.ts`)
+- [ ] Test (`tests/unit/clusterDist.test.ts`): 4 clusters sizes [1,1,3,2] → count 4 / record_count 7 / singleton_ratio 0.5 / size_max 3 / reduction 1-4/7; histogram rows `[[1,2],[2,1],[3,1],["4+",0]]`; `total_records` in `match_stats` overrides record_count (→20); empty `clusters` `{}` emits nothing. Mirror `test_cluster_dist.py`.
+- [ ] Impl: consumes `["clusters"]`. **Guard `Object.keys(clusters).length===0` → empty result.** Size = `c.size ?? c.members.length` for object, else `Number(c)`. `quantile(sizes, .5/.95)`, `max(sizes)`, discrete 1/2/3/4+ histogram.
+- [ ] Commit `feat(goldenanalysis-js): cluster.distribution analyzer`
+
+### 3c.2 — `quality.rollup` analyzer (`src/core/analyzers/qualityRollup.ts`)
+- [ ] Test (`tests/unit/qualityRollup.test.ts`): findings+manifest → `findings_total` 3 (`lower_better`) / `columns_with_findings` 2 / `flow.rows_changed` 1200 / `flow.rules_fired` 2; `findings_by_class` {email_blanked:2, phone_unparseable:1}; `quality.score` from a stub `profile.healthScore` (→0.8, `higher_better`); degrades findings-only / manifest-only. Mirror `test_quality_rollup.py`.
+- [ ] Impl: consumes `["findings","manifest"]`. `get(obj,key)` reads dict/object. `findings_by_class` via most-common-stable sort. `healthScore`: if `profile.healthScore`/`health_score` is a function, call with the per-column `{errors,warnings}` map; interpret return `[grade,score]` or `score`; `/100`; guard in try/catch. `flow.*` from `manifest.records` (`affected_rows` sum + count).
+- [ ] Commit `feat(goldenanalysis-js): quality.rollup analyzer`
+
+### 3c.3 — suite adapters (`src/core/adapters/{match,flow,check,pipe}.ts` + `index.ts`)
+- [ ] Test (`tests/unit/adapters.test.ts`): `matchArtifacts(result, {certificate})` → `__producer__=goldenmatch`, clusters/scored_pairs/match_stats passthrough, cert normalized; reads `result.recallCertificate`/`recall_certificate` when no explicit cert (RecallEstimate `{recall, recall_lower:null}` → `{estimate, safe_bound:null}`); `flowArtifacts` → `goldenflow`, manifest passthrough, frame=df; `checkArtifacts(findings, profile)` pure → `goldencheck`; `pipeArtifacts` passthrough + dataset from `source` stem + cert normalize; `<DataFrame>` source → `frame`. Mirror `test_adapters_unit.py`.
+- [ ] Impl: duck-typed functions returning `AnalyzerInput`. `normalizeCert` shared (match + pipe). `datasetFromSource(stem)`. The goldencheck-`load(df)` variant (lazy import) is OUT of scope — TS has no goldencheck dep; only the pure `checkArtifacts` (fromScan) seam ships (documented).
+- [ ] Commit `feat(goldenanalysis-js): suite artifact adapters (match/flow/check/pipe)`
+
+### 3c.4 — suite entry points + registry (`src/core/analyze.ts`, `src/core/registry.ts`)
+- [ ] Test (`tests/unit/analyzeSuite.test.ts`): `analyzeMatch(result, {dataset})` → `analyzers_run` == {match.rates, cluster.distribution}, has `match.pair_count`+`cluster.count`, `source.producer=goldenmatch`; `analyzePipeline(result)` fans out to present-artifact analyzers (quality.rollup+cluster.distribution+match.rates, NOT frame.summary); manifest-only → `["quality.rollup"]`. Mirror `test_analyze_suite.py`.
+- [ ] Impl: extract `assembleReport(input, names, options)` (producer = `artifacts["__producer__"] ?? "frame"`); refactor `analyze()` to delegate (frame path byte-identical: empty artifacts → producer "frame"). Add `artifactCompatibleAnalyzers(input)` (sorted; any `consumes` key present in `artifacts`). `analyzeMatch`/`analyzePipeline`. Registry: add the 3 analyzers to `FACTORIES`.
+- [ ] Verify the 3a parity test still passes (`npx vitest run tests/parity`).
+- [ ] Commit `feat(goldenanalysis-js): analyzeMatch + analyzePipeline + register suite analyzers`
+
+### 3c.5 — exports + README
+- [ ] `src/core/index.ts`: export the 3 analyzers, the adapters (`matchArtifacts`/`flowArtifacts`/`checkArtifacts`/`pipeArtifacts`/`normalizeCert`), and `analyzeMatch`/`analyzePipeline`. (No new tsup entry — all under `core`.)
+- [ ] README: phase banner → 3c; a "Suite analyzers" section (match/cluster/quality + analyzeMatch/analyzePipeline + the snake_case artifact-key contract).
+- [ ] Commit `docs(goldenanalysis-js): README suite analyzers + exports`
+
+### 3c.6 — verify + push
+- [ ] `npx vitest run` green (incl. the 3a parity + all 3b cross-run tests); `npx tsc --noEmit` clean; `npx tsup` build clean. No new deps.
+- [ ] Push `feat/goldenanalysis-ts-suite` (auth dance); PR vs main; babysit (ci-required + CodeQL); merge.
+
+## Acceptance
+- [ ] `match.rates`/`cluster.distribution`/`quality.rollup` match the Python 2a unit scenarios; adapters duck-type the same shapes; `analyzeMatch`/`analyzePipeline` select + assemble identically (sorted fan-out; explicit match pair).
+- [ ] Frame path unchanged (3a parity byte-identical; producer reads `__producer__ ?? "frame"`). Edge-safe; no new deps. tsc + tsup + vitest green.
+
+### Deferred
+goldencheck-js `load(df)` adapter variant (needs a goldencheck-js dep). P4 Rust accelerator. P5 GoldenPipe stage + MCP + publish.

--- a/packages/typescript/goldenanalysis/README.md
+++ b/packages/typescript/goldenanalysis/README.md
@@ -5,7 +5,9 @@ TypeScript port of the Python [`goldenanalysis`](../../python/goldenanalysis) pa
 
 > **Phase 3a** ships the generic **frame path** with cross-surface parity; **Phase
 > 3b** adds the **cross-run layer** (`ReportHistory`, regression detection, narrative,
-> `trend`/`regressions` CLI). Suite analyzers land in a later phase.
+> `trend`/`regressions` CLI); **Phase 3c** adds the **suite analyzers**
+> (`match.rates` / `cluster.distribution` / `quality.rollup`) + the `analyzeMatch` /
+> `analyzePipeline` entry points.
 
 ## Quickstart
 
@@ -29,6 +31,43 @@ CLI:
 goldenanalysis-js report customers.json --format markdown   # or a .csv
 goldenanalysis-js report customers.csv --analyzers frame.summary
 ```
+
+## Suite analyzers
+
+Beyond the generic frame path, three analyzers read the artifacts other Golden Suite
+stages produce. They consume the **same snake_case artifact keys** the Python sibling
+reads (`scored_pairs` / `match_stats` / `clusters` / `findings` / `manifest` /
+`recall_certificate`), so a serialized Python `PipeResult.artifacts` feeds the TS
+analyzers identically.
+
+| Analyzer | Consumes | Emits |
+|---|---|---|
+| `match.rates` | `scored_pairs`, `match_stats` (+ `match_threshold`, `recall_certificate`) | `match.pair_count` / `match_rate` / `threshold` / `recall_estimate` / `recall_safe_bound` / `mean_pair_score` + a `score_histogram` |
+| `cluster.distribution` | `clusters` (+ `match_stats`) | `cluster.count` / `record_count` / `singleton_ratio` / `size_p50` / `size_p95` / `size_max` / `reduction_ratio` + a `cluster_size_histogram` |
+| `quality.rollup` | `findings`, `manifest` (+ `profile`) | `quality.findings_total` / `columns_with_findings` / `score` + `flow.rows_changed` / `rules_fired` + a `findings_by_class` |
+
+Two suite entry points assemble a report directly from a producer's result object
+(duck-typed — no goldenmatch/goldenpipe import):
+
+```ts
+import { analyzeMatch, analyzePipeline } from "goldenanalysis";
+
+// A GoldenMatch DedupeResult-like object -> match.rates + cluster.distribution.
+const report = analyzeMatch(dedupeResult, {
+  dataset: "customers",
+  certificate: { estimate: 0.94, safe_bound: 0.89 }, // optional recall cert
+});
+
+// A GoldenPipe PipeResult-like object -> fans out to every analyzer whose
+// consumed artifacts are present in result.artifacts (frame.summary is skipped —
+// a PipeResult exposes no `frame`).
+const pipeReport = analyzePipeline(pipeResult);
+```
+
+The match/flow/check/pipe **artifact adapters** (`matchArtifacts` / `flowArtifacts` /
+`checkArtifacts` / `pipeArtifacts`) are also exported for building an `AnalyzerInput`
+by hand. (The goldencheck `load(df)` adapter variant is deferred — TS has no
+goldencheck dependency yet.)
 
 ## Cross-run (trend + regressions)
 

--- a/packages/typescript/goldenanalysis/src/core/adapters/check.ts
+++ b/packages/typescript/goldenanalysis/src/core/adapters/check.ts
@@ -1,0 +1,22 @@
+/**
+ * `check` adapter — GoldenCheck scan output → `AnalyzerInput.artifacts`.
+ *
+ * Ships only the pure `checkArtifacts` (the Python `from_scan` seam) — no goldencheck
+ * import. The `load(df)` variant that lazy-imports goldencheck and runs
+ * `scan_dataframe` is deferred (TS has no goldencheck dep yet). Parity with the
+ * `from_scan` path of `adapters/check.py`.
+ */
+
+import type { AnalyzerInput } from "../types.js";
+
+/** Normalize already-computed scan output (findings + optional profile). */
+export function checkArtifacts(
+  findings: unknown,
+  profile: unknown = null,
+  options: { dataset?: string } = {},
+): AnalyzerInput {
+  return {
+    dataset: options.dataset ?? "check",
+    artifacts: { __producer__: "goldencheck", findings, profile },
+  };
+}

--- a/packages/typescript/goldenanalysis/src/core/adapters/flow.ts
+++ b/packages/typescript/goldenanalysis/src/core/adapters/flow.ts
@@ -1,0 +1,23 @@
+/**
+ * `flow` adapter — a GoldenFlow `TransformResult`-like object → `AnalyzerInput`.
+ *
+ * Duck-typed: reads `.df` and `.manifest`; imports nothing from goldenflow. Parity
+ * with `adapters/flow.py`.
+ */
+
+import type { AnalyzerInput, FrameRows } from "../types.js";
+
+function prop(obj: unknown, key: string): unknown {
+  return obj !== null && typeof obj === "object" ? (obj as Record<string, unknown>)[key] : undefined;
+}
+
+export function flowArtifacts(result: unknown, options: { dataset?: string } = {}): AnalyzerInput {
+  const artifacts: Record<string, unknown> = {
+    __producer__: "goldenflow",
+    manifest: prop(result, "manifest") ?? null,
+  };
+  const base = { dataset: options.dataset ?? "flow", artifacts };
+  const df = prop(result, "df");
+  // Build conditionally so we never set `frame: undefined` (exactOptionalPropertyTypes).
+  return df !== null && df !== undefined ? { ...base, frame: df as FrameRows } : base;
+}

--- a/packages/typescript/goldenanalysis/src/core/adapters/match.ts
+++ b/packages/typescript/goldenanalysis/src/core/adapters/match.ts
@@ -1,0 +1,68 @@
+/**
+ * `match` adapter — a GoldenMatch `DedupeResult`-like object → `AnalyzerInput`.
+ *
+ * Duck-typed: reads `.clusters` / `.scoredPairs|.scored_pairs` / `.stats` / `.config`
+ * off the result, so it imports nothing from goldenmatch. The recall certificate is
+ * optional — passed in by the caller, or read off the result when the producer
+ * attached one. Parity with `adapters/match.py`.
+ */
+
+import type { AnalyzerInput } from "../types.js";
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function prop(obj: unknown, key: string): unknown {
+  return obj !== null && typeof obj === "object" ? (obj as Record<string, unknown>)[key] : undefined;
+}
+
+/** Normalize a recall certificate to `{estimate, safe_bound}` (or null). */
+export function normalizeCert(cert: unknown): { estimate: number | null; safe_bound: number | null } | null {
+  if (cert === null || cert === undefined || typeof cert !== "object") return null;
+  const c = cert as Record<string, unknown>;
+  return {
+    estimate: asNumber(c["estimate"] ?? c["recall"]),
+    safe_bound: asNumber(c["safe_bound"] ?? c["recall_lower"]),
+  };
+}
+
+/** Best-effort: the first matchkey's threshold from the result's config. */
+function primaryThreshold(config: unknown): number | null {
+  try {
+    const getter = prop(config, "getMatchkeys") ?? prop(config, "get_matchkeys");
+    const matchkeys =
+      typeof getter === "function"
+        ? (getter as () => unknown[]).call(config)
+        : (prop(config, "matchkeys") as unknown[] | undefined);
+    for (const mk of matchkeys ?? []) {
+      const thr = prop(mk, "threshold");
+      if (thr !== null && thr !== undefined) return Number(thr);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export interface MatchAdapterOptions {
+  readonly dataset?: string;
+  readonly certificate?: unknown;
+}
+
+export function matchArtifacts(result: unknown, options: MatchAdapterOptions = {}): AnalyzerInput {
+  const cert =
+    options.certificate !== undefined && options.certificate !== null
+      ? options.certificate
+      : prop(result, "recallCertificate") ?? prop(result, "recall_certificate");
+  const artifacts: Record<string, unknown> = {
+    __producer__: "goldenmatch",
+    clusters: prop(result, "clusters") ?? {},
+    scored_pairs: prop(result, "scoredPairs") ?? prop(result, "scored_pairs") ?? [],
+    match_stats: prop(result, "stats") ?? {},
+    match_threshold: primaryThreshold(prop(result, "config")),
+  };
+  const normalized = normalizeCert(cert);
+  if (normalized !== null) artifacts["recall_certificate"] = normalized;
+  return { dataset: options.dataset ?? "match", artifacts };
+}

--- a/packages/typescript/goldenanalysis/src/core/adapters/pipe.ts
+++ b/packages/typescript/goldenanalysis/src/core/adapters/pipe.ts
@@ -1,0 +1,36 @@
+/**
+ * `pipe` adapter — a GoldenPipe `PipeResult`-like object → `AnalyzerInput`.
+ *
+ * Near-passthrough: `result.artifacts` already carries the per-stage outputs
+ * (findings / manifest / clusters / scored_pairs / match_stats / recall_certificate)
+ * under the same keys the analyzers read. Duck-typed; no goldenpipe import. Parity
+ * with `adapters/pipe.py`.
+ */
+
+import type { AnalyzerInput } from "../types.js";
+import { normalizeCert } from "./match.js";
+
+function prop(obj: unknown, key: string): unknown {
+  return obj !== null && typeof obj === "object" ? (obj as Record<string, unknown>)[key] : undefined;
+}
+
+/** `Path(source).stem`, or "frame" for empty / non-string / "<...>" sources. */
+function datasetFromSource(source: unknown): string {
+  if (typeof source !== "string" || source.length === 0 || source.startsWith("<")) return "frame";
+  const stem = source.replace(/^.*[\\/]/, "").replace(/\.[^.]+$/, "");
+  return stem.length > 0 ? stem : "frame";
+}
+
+export function pipeArtifacts(result: unknown, options: { dataset?: string } = {}): AnalyzerInput {
+  const src = prop(result, "artifacts");
+  const artifacts: Record<string, unknown> =
+    src !== null && typeof src === "object" ? { ...(src as Record<string, unknown>) } : {};
+  artifacts["__producer__"] = "goldenpipe";
+  if ("recall_certificate" in artifacts) {
+    const normalized = normalizeCert(artifacts["recall_certificate"]);
+    if (normalized === null) delete artifacts["recall_certificate"];
+    else artifacts["recall_certificate"] = normalized;
+  }
+  const dataset = options.dataset ?? datasetFromSource(prop(result, "source"));
+  return { dataset, artifacts };
+}

--- a/packages/typescript/goldenanalysis/src/core/analyze.ts
+++ b/packages/typescript/goldenanalysis/src/core/analyze.ts
@@ -1,13 +1,18 @@
-/** Top-level `analyze()` — run analyzers over frame rows, assemble an AnalysisReport. */
+/**
+ * Top-level analyze entry points — resolve analyzers, run them over an artifact,
+ * assemble one `AnalysisReport`.
+ *
+ * - `analyze(rows, ...)` — the generic frame path.
+ * - `analyzeMatch(result, ...)` / `analyzePipeline(result)` — suite paths over a
+ *   GoldenMatch `DedupeResult`-like / GoldenPipe `PipeResult`-like object.
+ *
+ * Parity with `packages/python/goldenanalysis/goldenanalysis/_api.py`.
+ */
 
+import { matchArtifacts } from "./adapters/match.js";
+import { pipeArtifacts } from "./adapters/pipe.js";
 import { availableAnalyzers, frameCompatibleAnalyzers, loadAnalyzer } from "./registry.js";
-import type {
-  AnalysisReport,
-  AnalysisTable,
-  AnalyzerInput,
-  FrameRows,
-  Metric,
-} from "./types.js";
+import type { AnalysisReport, AnalysisTable, AnalyzerInput, FrameRows, Metric } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 
 export interface AnalyzeOptions {
@@ -16,22 +21,29 @@ export interface AnalyzeOptions {
   readonly generatedAt?: string;
 }
 
-export function analyze(
-  rows: FrameRows,
-  analyzers?: readonly string[],
+export interface AnalyzeMatchOptions extends AnalyzeOptions {
+  readonly certificate?: unknown;
+}
+
+/**
+ * Run `names` over `input` and assemble one `AnalysisReport`. Shared by every entry
+ * point. Names requested but not discoverable are recorded in `source.unavailable`
+ * rather than raising — the report says what it could and couldn't compute. The
+ * producer is read off `artifacts.__producer__` (the frame path has none → "frame").
+ */
+function assembleReport(
+  input: AnalyzerInput,
+  names: readonly string[],
   options: AnalyzeOptions = {},
 ): AnalysisReport {
-  const dataset = options.dataset ?? "frame";
-  const input: AnalyzerInput = { dataset, frame: rows, artifacts: {} };
-
-  const requested = analyzers ?? frameCompatibleAnalyzers();
+  const dataset = input.dataset;
   const discoverable = new Set(availableAnalyzers());
 
   const ran: string[] = [];
   const unavailable: string[] = [];
   const metrics: Metric[] = [];
   const tables: AnalysisTable[] = [];
-  for (const name of requested) {
+  for (const name of names) {
     if (!discoverable.has(name)) {
       unavailable.push(name);
       continue;
@@ -44,7 +56,9 @@ export function analyze(
 
   const generatedAt = options.generatedAt ?? new Date().toISOString();
   const runId = options.runId ?? `${generatedAt}#${dataset}`;
-  const source: Record<string, string> = { dataset, producer: "frame" };
+  const producerRaw = input.artifacts["__producer__"];
+  const producer = typeof producerRaw === "string" ? producerRaw : "frame";
+  const source: Record<string, string> = { dataset, producer };
   if (unavailable.length > 0) source["unavailable"] = unavailable.join(",");
 
   return {
@@ -57,4 +71,48 @@ export function analyze(
     narrative: null,
     analyzers_run: ran,
   };
+}
+
+/**
+ * Run `analyzers` over `rows` and return a single `AnalysisReport`. `analyzers`
+ * omitted defaults to every frame-compatible analyzer. Names requested but not
+ * discoverable land in `source.unavailable`.
+ */
+export function analyze(
+  rows: FrameRows,
+  analyzers?: readonly string[],
+  options: AnalyzeOptions = {},
+): AnalysisReport {
+  const dataset = options.dataset ?? "frame";
+  const input: AnalyzerInput = { dataset, frame: rows, artifacts: {} };
+  const requested = analyzers ?? frameCompatibleAnalyzers();
+  return assembleReport(input, requested, options);
+}
+
+/** Discoverable analyzers at least one of whose `consumes` keys is present in
+ * `input.artifacts` — the fan-out selector for `analyzePipeline` (sorted order). */
+export function artifactCompatibleAnalyzers(input: AnalyzerInput): string[] {
+  const present = new Set(Object.keys(input.artifacts));
+  return availableAnalyzers().filter((name) =>
+    loadAnalyzer(name).info.consumes.some((key) => present.has(key)),
+  );
+}
+
+/**
+ * Analyze a GoldenMatch `DedupeResult`-like object: `match.rates` + `cluster.distribution`.
+ * `certificate` (optional) is a recall certificate (`{estimate, safe_bound}` or a
+ * `{recall, recall_lower}` shape); absent → the recall metrics are omitted.
+ */
+export function analyzeMatch(result: unknown, options: AnalyzeMatchOptions = {}): AnalysisReport {
+  const input = matchArtifacts(result, options);
+  return assembleReport(input, ["match.rates", "cluster.distribution"], options);
+}
+
+/**
+ * Analyze a GoldenPipe `PipeResult`-like object, fanning out to every analyzer whose
+ * consumed artifacts are present in `result.artifacts`.
+ */
+export function analyzePipeline(result: unknown, options: AnalyzeOptions = {}): AnalysisReport {
+  const input = pipeArtifacts(result, options);
+  return assembleReport(input, artifactCompatibleAnalyzers(input), options);
 }

--- a/packages/typescript/goldenanalysis/src/core/analyzers/clusterDist.ts
+++ b/packages/typescript/goldenanalysis/src/core/analyzers/clusterDist.ts
@@ -1,0 +1,97 @@
+/**
+ * `cluster.distribution` — cluster-size shape from a GoldenMatch result.
+ *
+ * Reads `clusters` (and optionally `match_stats` for the record count) from
+ * `AnalyzerInput.artifacts`. Parity with
+ * `packages/python/goldenanalysis/goldenanalysis/analyzers/cluster_dist.py`.
+ */
+
+import { quantile } from "../aggregate.js";
+import type {
+  AnalysisTable,
+  Analyzer,
+  AnalyzerInfo,
+  AnalyzerInput,
+  AnalyzerResult,
+  Metric,
+} from "../types.js";
+
+const PRODUCES = [
+  "cluster.count",
+  "cluster.record_count",
+  "cluster.singleton_ratio",
+  "cluster.size_p50",
+  "cluster.size_p95",
+  "cluster.size_max",
+  "cluster.reduction_ratio",
+];
+
+/** A cluster is `{size}` / `{members:[...]}` (dict) or a bare size (int). */
+function clusterSize(c: unknown): number {
+  if (c !== null && typeof c === "object") {
+    const obj = c as Record<string, unknown>;
+    if (typeof obj["size"] === "number") return obj["size"];
+    const members = obj["members"];
+    return Array.isArray(members) ? members.length : 0;
+  }
+  return Number(c);
+}
+
+export class ClusterDistributionAnalyzer implements Analyzer {
+  readonly info: AnalyzerInfo = {
+    name: "cluster.distribution",
+    consumes: ["clusters"],
+    produces: PRODUCES,
+  };
+
+  run(input: AnalyzerInput): AnalyzerResult {
+    const clusters = input.artifacts["clusters"];
+    // NOTE: an empty object `{}` is truthy in JS — guard on key count, not falsiness.
+    if (clusters === null || clusters === undefined || typeof clusters !== "object") {
+      return { metrics: [], tables: [] };
+    }
+    const values = Object.values(clusters as Record<string, unknown>);
+    if (values.length === 0) return { metrics: [], tables: [] };
+
+    const sizes = values.map(clusterSize);
+    const count = values.length;
+    const stats = (input.artifacts["match_stats"] as Record<string, unknown> | undefined) ?? {};
+    const sumSizes = sizes.reduce((a, b) => a + b, 0);
+    // Prefer the engine's own record total; fall back to summed cluster sizes.
+    const recordCount = typeof stats["total_records"] === "number" ? stats["total_records"] : sumSizes;
+    const singletons = sizes.filter((s) => s === 1).length;
+
+    const metrics: Metric[] = [
+      { key: "cluster.count", value: count, unit: "clusters", direction: "neutral" },
+      { key: "cluster.record_count", value: recordCount, unit: "rows", direction: "neutral" },
+      { key: "cluster.singleton_ratio", value: count ? singletons / count : 0, unit: "ratio", direction: "neutral" },
+      { key: "cluster.size_p50", value: quantile(sizes, 0.5), unit: "rows", direction: "neutral" },
+      { key: "cluster.size_p95", value: quantile(sizes, 0.95), unit: "rows", direction: "neutral" },
+      { key: "cluster.size_max", value: sizes.length ? Math.max(...sizes) : 0, unit: "rows", direction: "neutral" },
+      {
+        key: "cluster.reduction_ratio",
+        value: recordCount ? 1 - count / recordCount : 0,
+        unit: "ratio",
+        direction: "neutral",
+      },
+    ];
+
+    // Discrete size histogram, buckets 1 / 2 / 3 / "4+".
+    const n1 = sizes.filter((s) => s === 1).length;
+    const n2 = sizes.filter((s) => s === 2).length;
+    const n3 = sizes.filter((s) => s === 3).length;
+    const n4 = sizes.filter((s) => s >= 4).length;
+    const table: AnalysisTable = {
+      name: "cluster_size_histogram",
+      columns: ["size", "count"],
+      rows: [
+        [1, n1],
+        [2, n2],
+        [3, n3],
+        ["4+", n4],
+      ],
+    };
+
+    return { metrics, tables: [table] };
+  }
+}

--- a/packages/typescript/goldenanalysis/src/core/analyzers/matchRates.ts
+++ b/packages/typescript/goldenanalysis/src/core/analyzers/matchRates.ts
@@ -1,0 +1,91 @@
+/**
+ * `match.rates` — match metrics from a GoldenMatch result's artifacts.
+ *
+ * Reads `scored_pairs` / `match_stats` (+ optional `recall_certificate` and
+ * `match_threshold`) from `AnalyzerInput.artifacts` — the SAME snake_case keys the
+ * Python sibling reads, so a serialized `PipeResult.artifacts` feeds this identically.
+ * Degrades: emits the metrics its present artifacts support and omits the rest.
+ * Parity with `packages/python/goldenanalysis/goldenanalysis/analyzers/match_rates.py`.
+ */
+
+import { histogram } from "../aggregate.js";
+import type {
+  AnalysisTable,
+  Analyzer,
+  AnalyzerInfo,
+  AnalyzerInput,
+  AnalyzerResult,
+  Metric,
+} from "../types.js";
+
+const PRODUCES = [
+  "match.pair_count",
+  "match.match_rate",
+  "match.threshold",
+  "match.recall_estimate",
+  "match.recall_safe_bound",
+  "match.mean_pair_score",
+];
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+/** Normalize a certificate (dict-ish) to [estimate, safeBound]; either may be null. */
+function certValues(cert: unknown): [number | null, number | null] {
+  if (cert === null || cert === undefined || typeof cert !== "object") return [null, null];
+  const c = cert as Record<string, unknown>;
+  return [asNumber(c["estimate"] ?? c["recall"]), asNumber(c["safe_bound"] ?? c["recall_lower"])];
+}
+
+export class MatchRatesAnalyzer implements Analyzer {
+  readonly info: AnalyzerInfo = {
+    name: "match.rates",
+    consumes: ["scored_pairs", "match_stats"],
+    produces: PRODUCES,
+  };
+
+  run(input: AnalyzerInput): AnalyzerResult {
+    const art = input.artifacts;
+    const scoredPairs = Array.isArray(art["scored_pairs"]) ? (art["scored_pairs"] as unknown[]) : [];
+    const stats = (art["match_stats"] as Record<string, unknown> | undefined) ?? {};
+
+    const metrics: Metric[] = [
+      { key: "match.pair_count", value: scoredPairs.length, unit: "pairs", direction: "neutral" },
+    ];
+    if ("match_rate" in stats) {
+      metrics.push({ key: "match.match_rate", value: Number(stats["match_rate"]), unit: "ratio", direction: "neutral" });
+    }
+    const threshold = art["match_threshold"];
+    if (threshold !== null && threshold !== undefined) {
+      metrics.push({ key: "match.threshold", value: Number(threshold), unit: "score", direction: "neutral" });
+    }
+
+    const [estimate, safeBound] = certValues(art["recall_certificate"]);
+    if (estimate !== null) {
+      metrics.push({ key: "match.recall_estimate", value: estimate, unit: "ratio", direction: "higher_better" });
+    }
+    if (safeBound !== null) {
+      metrics.push({ key: "match.recall_safe_bound", value: safeBound, unit: "ratio", direction: "higher_better" });
+    }
+
+    const tables: AnalysisTable[] = [];
+    if (scoredPairs.length > 0) {
+      // Each pair is (...ids, score) — the score is the last element.
+      const scores = scoredPairs.map((p) => {
+        const arr = p as unknown[];
+        return Number(arr[arr.length - 1]);
+      });
+      const meanScore = scores.reduce((a, b) => a + b, 0) / scores.length;
+      metrics.push({ key: "match.mean_pair_score", value: meanScore, unit: "score", direction: "neutral" });
+      const hist = histogram(scores, 10);
+      tables.push({
+        name: "score_histogram",
+        columns: ["bin_left", "count"],
+        rows: hist.map(([edge, count]) => [edge, count]),
+      });
+    }
+
+    return { metrics, tables };
+  }
+}

--- a/packages/typescript/goldenanalysis/src/core/analyzers/qualityRollup.ts
+++ b/packages/typescript/goldenanalysis/src/core/analyzers/qualityRollup.ts
@@ -1,0 +1,128 @@
+/**
+ * `quality.rollup` — a single "is the data healthy" view rolling up both GoldenCheck
+ * (findings + profile) and GoldenFlow (manifest).
+ *
+ * Reads `findings` / `profile` / `manifest` from `AnalyzerInput.artifacts`, degrading
+ * per-producer: the `quality.*` keys need `findings`; the `flow.*` keys need
+ * `manifest`; either can be absent. Parity with
+ * `packages/python/goldenanalysis/goldenanalysis/analyzers/quality_rollup.py`.
+ */
+
+import type {
+  AnalysisTable,
+  Analyzer,
+  AnalyzerInfo,
+  AnalyzerInput,
+  AnalyzerResult,
+  Metric,
+} from "../types.js";
+
+const PRODUCES = [
+  "quality.findings_total",
+  "quality.columns_with_findings",
+  "quality.score",
+  "flow.rows_changed",
+  "flow.rules_fired",
+];
+
+/** Read `key` from a dict/object (Finding/TransformRecord either way). */
+function get(obj: unknown, key: string, fallback: unknown = undefined): unknown {
+  if (obj !== null && typeof obj === "object") {
+    const v = (obj as Record<string, unknown>)[key];
+    return v === undefined ? fallback : v;
+  }
+  return fallback;
+}
+
+/** Normalize a severity (enum-ish / int / str) to an upper-case name. */
+function severityName(value: unknown): string {
+  if (value !== null && typeof value === "object") {
+    const name = (value as Record<string, unknown>)["name"];
+    if (name) return String(name).toUpperCase();
+  }
+  if (typeof value === "number") {
+    return ({ 1: "INFO", 2: "WARNING", 3: "ERROR" } as Record<number, string>)[value] ?? String(value);
+  }
+  return String(value).toUpperCase();
+}
+
+/** Counter.most_common(): count desc, ties in first-appearance order (stable sort). */
+function mostCommon(counts: Map<string, number>): Array<[string, number]> {
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+}
+
+/**
+ * GoldenCheck `DatasetProfile.health_score` normalized to a 0-1 ratio. Duck-typed:
+ * if `profile` exposes a `healthScore`/`health_score` function, it is called with the
+ * per-column `{errors,warnings}` map; the return is read as `[grade, score]` or a
+ * bare `score` and divided by 100. Returns null if absent or it throws.
+ */
+function healthScore(profile: unknown, findings: readonly unknown[]): number | null {
+  if (profile === null || typeof profile !== "object") return null;
+  const fn = (profile as Record<string, unknown>)["healthScore"] ?? (profile as Record<string, unknown>)["health_score"];
+  if (typeof fn !== "function") return null;
+  const byCol: Record<string, { errors: number; warnings: number }> = {};
+  for (const f of findings) {
+    const col = get(f, "column");
+    if (col === null || col === undefined) continue;
+    const sev = severityName(get(f, "severity"));
+    const bucket = (byCol[String(col)] ??= { errors: 0, warnings: 0 });
+    if (sev === "ERROR") bucket.errors += 1;
+    else if (sev === "WARNING") bucket.warnings += 1;
+  }
+  try {
+    const out = (fn as (arg: unknown) => unknown)(byCol);
+    const score = Array.isArray(out) ? Number(out[1]) : Number(out);
+    return Number.isNaN(score) ? null : score / 100;
+  } catch {
+    return null;
+  }
+}
+
+export class QualityRollupAnalyzer implements Analyzer {
+  readonly info: AnalyzerInfo = {
+    name: "quality.rollup",
+    consumes: ["findings", "manifest"],
+    produces: PRODUCES,
+  };
+
+  run(input: AnalyzerInput): AnalyzerResult {
+    const art = input.artifacts;
+    const metrics: Metric[] = [];
+    const tables: AnalysisTable[] = [];
+
+    const findings = art["findings"];
+    if (Array.isArray(findings)) {
+      const byClass = new Map<string, number>();
+      const columns = new Set<string>();
+      for (const f of findings) {
+        const cls = String(get(f, "check", "unknown"));
+        byClass.set(cls, (byClass.get(cls) ?? 0) + 1);
+        const col = get(f, "column");
+        if (col !== null && col !== undefined) columns.add(String(col));
+      }
+      metrics.push({ key: "quality.findings_total", value: findings.length, unit: "findings", direction: "lower_better" });
+      metrics.push({
+        key: "quality.columns_with_findings",
+        value: columns.size,
+        unit: "columns",
+        direction: "lower_better",
+      });
+      const score = healthScore(art["profile"], findings);
+      if (score !== null) {
+        metrics.push({ key: "quality.score", value: score, unit: "ratio", direction: "higher_better" });
+      }
+      tables.push({ name: "findings_by_class", columns: ["class", "count"], rows: mostCommon(byClass) });
+    }
+
+    const manifest = art["manifest"];
+    if (manifest !== null && manifest !== undefined) {
+      const records = (get(manifest, "records", []) as unknown[]) ?? [];
+      const rowsChanged = records.reduce((acc: number, r) => acc + Number(get(r, "affected_rows", 0) ?? 0), 0);
+      metrics.push({ key: "flow.rows_changed", value: rowsChanged, unit: "rows", direction: "neutral" });
+      metrics.push({ key: "flow.rules_fired", value: records.length, unit: "count", direction: "neutral" });
+    }
+
+    return { metrics, tables };
+  }
+}

--- a/packages/typescript/goldenanalysis/src/core/index.ts
+++ b/packages/typescript/goldenanalysis/src/core/index.ts
@@ -1,12 +1,22 @@
 // GoldenAnalysis core — edge-safe (no node: imports).
 
-export { analyze } from "./analyze.js";
-export type { AnalyzeOptions } from "./analyze.js";
+export { analyze, analyzeMatch, analyzePipeline, artifactCompatibleAnalyzers } from "./analyze.js";
+export type { AnalyzeMatchOptions, AnalyzeOptions } from "./analyze.js";
 export { toJson, toMarkdown } from "./render.js";
 export { availableAnalyzers, loadAnalyzer, frameCompatibleAnalyzers } from "./registry.js";
 export { FrameSummaryAnalyzer } from "./analyzers/frameSummary.js";
+export { MatchRatesAnalyzer } from "./analyzers/matchRates.js";
+export { ClusterDistributionAnalyzer } from "./analyzers/clusterDist.js";
+export { QualityRollupAnalyzer } from "./analyzers/qualityRollup.js";
 export * as aggregate from "./aggregate.js";
 export { SCHEMA_VERSION } from "./types.js";
+
+// Suite artifact adapters (edge-safe; duck-typed producer normalizers).
+export { matchArtifacts, normalizeCert } from "./adapters/match.js";
+export type { MatchAdapterOptions } from "./adapters/match.js";
+export { flowArtifacts } from "./adapters/flow.js";
+export { checkArtifacts } from "./adapters/check.js";
+export { pipeArtifacts } from "./adapters/pipe.js";
 
 // Cross-run (edge-safe): regression decision logic, report-level queries, narrative.
 export {

--- a/packages/typescript/goldenanalysis/src/core/registry.ts
+++ b/packages/typescript/goldenanalysis/src/core/registry.ts
@@ -1,10 +1,17 @@
-/** Analyzer registry — a hard-coded map (no entry-points in TS). */
+/** Analyzer registry — a hard-coded map (no entry-points in TS). Mirrors the Python
+ * registry's fallback table (`registry.py`). */
 
+import { ClusterDistributionAnalyzer } from "./analyzers/clusterDist.js";
 import { FrameSummaryAnalyzer } from "./analyzers/frameSummary.js";
+import { MatchRatesAnalyzer } from "./analyzers/matchRates.js";
+import { QualityRollupAnalyzer } from "./analyzers/qualityRollup.js";
 import type { Analyzer } from "./types.js";
 
 const FACTORIES: Record<string, () => Analyzer> = {
   "frame.summary": () => new FrameSummaryAnalyzer(),
+  "match.rates": () => new MatchRatesAnalyzer(),
+  "cluster.distribution": () => new ClusterDistributionAnalyzer(),
+  "quality.rollup": () => new QualityRollupAnalyzer(),
 };
 
 export function availableAnalyzers(): string[] {

--- a/packages/typescript/goldenanalysis/tests/unit/adapters.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/adapters.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { checkArtifacts } from "../../src/core/adapters/check.js";
+import { flowArtifacts } from "../../src/core/adapters/flow.js";
+import { matchArtifacts } from "../../src/core/adapters/match.js";
+import { pipeArtifacts } from "../../src/core/adapters/pipe.js";
+
+describe("matchArtifacts", () => {
+  it("normalizes a DedupeResult-like object + an explicit certificate", () => {
+    const result = {
+      clusters: { 0: { members: [0], size: 1 } },
+      scored_pairs: [[0, 1, 0.9]],
+      stats: { total_records: 2, match_rate: 0.5 },
+      config: null,
+    };
+    const inp = matchArtifacts(result, { dataset: "customers", certificate: { estimate: 0.94, safe_bound: 0.89 } });
+    expect(inp.dataset).toBe("customers");
+    expect(inp.artifacts["__producer__"]).toBe("goldenmatch");
+    expect(inp.artifacts["clusters"]).toEqual(result.clusters);
+    expect(inp.artifacts["scored_pairs"]).toEqual(result.scored_pairs);
+    expect(inp.artifacts["match_stats"]).toEqual(result.stats);
+    expect(inp.artifacts["recall_certificate"]).toEqual({ estimate: 0.94, safe_bound: 0.89 });
+  });
+
+  it("reads + normalizes a producer-attached certificate (RecallEstimate, no safe bound)", () => {
+    const result = { clusters: {}, scored_pairs: [], stats: {}, config: null, recall_certificate: { recall: 0.94, recall_lower: null } };
+    const inp = matchArtifacts(result);
+    expect(inp.artifacts["recall_certificate"]).toEqual({ estimate: 0.94, safe_bound: null });
+  });
+});
+
+describe("flowArtifacts", () => {
+  it("normalizes a TransformResult-like object (frame + manifest)", () => {
+    const df = [{ a: 1 }];
+    const manifest = { records: [] };
+    const inp = flowArtifacts({ df, manifest }, { dataset: "d" });
+    expect(inp.artifacts["__producer__"]).toBe("goldenflow");
+    expect(inp.artifacts["manifest"]).toBe(manifest);
+    expect(inp.frame).toBe(df);
+  });
+});
+
+describe("checkArtifacts", () => {
+  it("is a pure from-scan seam", () => {
+    const inp = checkArtifacts([{ check: "x" }], null, { dataset: "d" });
+    expect(inp.artifacts["__producer__"]).toBe("goldencheck");
+    expect(inp.artifacts["findings"]).toEqual([{ check: "x" }]);
+    expect(inp.artifacts["profile"]).toBeNull();
+  });
+});
+
+describe("pipeArtifacts", () => {
+  it("passes artifacts through, derives the dataset from the source stem, normalizes the cert", () => {
+    const result = {
+      artifacts: {
+        clusters: { 0: { members: [0], size: 1 } },
+        scored_pairs: [[0, 1, 0.9]],
+        match_stats: { match_rate: 0.5 },
+        findings: [{ check: "x", column: "a", severity: "WARNING" }],
+        manifest: { records: [] },
+        recall_certificate: { recall: 0.94, recall_lower: 0.89 },
+      },
+      source: "customers.parquet",
+      input_rows: 4000,
+    };
+    const inp = pipeArtifacts(result);
+    expect(inp.dataset).toBe("customers");
+    expect(inp.artifacts["__producer__"]).toBe("goldenpipe");
+    expect(inp.artifacts["clusters"]).toEqual(result.artifacts.clusters);
+    expect(inp.artifacts["recall_certificate"]).toEqual({ estimate: 0.94, safe_bound: 0.89 });
+  });
+
+  it("falls back to 'frame' for a non-file source", () => {
+    const inp = pipeArtifacts({ artifacts: {}, source: "<DataFrame>" });
+    expect(inp.dataset).toBe("frame");
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/unit/analyzeSuite.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/analyzeSuite.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { analyzeMatch, analyzePipeline } from "../../src/core/analyze.js";
+
+describe("analyzeMatch", () => {
+  it("runs match.rates + cluster.distribution over a DedupeResult-like object", () => {
+    const result = {
+      clusters: { 0: { members: [0], size: 1 }, 1: { members: [1, 2], size: 2 } },
+      scored_pairs: [[1, 2, 0.9]],
+      stats: { total_records: 3, match_rate: 0.66 },
+      config: null,
+    };
+    const report = analyzeMatch(result, { dataset: "customers" });
+    expect(new Set(report.analyzers_run)).toEqual(new Set(["match.rates", "cluster.distribution"]));
+    const keys = new Set(report.metrics.map((m) => m.key));
+    expect(keys.has("match.pair_count")).toBe(true);
+    expect(keys.has("cluster.count")).toBe(true);
+    expect(report.source["dataset"]).toBe("customers");
+    expect(report.source["producer"]).toBe("goldenmatch");
+  });
+});
+
+describe("analyzePipeline", () => {
+  it("fans out to the analyzers whose consumed artifacts are present", () => {
+    const result = {
+      artifacts: {
+        findings: [{ check: "x", column: "a", severity: "WARNING" }],
+        manifest: { records: [] },
+        clusters: { 0: { members: [0], size: 1 } },
+        scored_pairs: [],
+        match_stats: { match_rate: 0.5 },
+      },
+      source: "customers.parquet",
+    };
+    const ran = new Set(analyzePipeline(result).analyzers_run);
+    expect(ran.has("quality.rollup")).toBe(true);
+    expect(ran.has("cluster.distribution")).toBe(true);
+    expect(ran.has("match.rates")).toBe(true);
+    // frame.summary needs a `frame` artifact, which a PipeResult doesn't expose.
+    expect(ran.has("frame.summary")).toBe(false);
+  });
+
+  it("omits absent analyzers (manifest only -> just quality.rollup)", () => {
+    const report = analyzePipeline({ artifacts: { manifest: { records: [] } }, source: "d.csv" });
+    expect(report.analyzers_run).toEqual(["quality.rollup"]);
+    expect(report.source["producer"]).toBe("goldenpipe");
+    expect(report.source["dataset"]).toBe("d");
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/unit/clusterDist.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/clusterDist.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { ClusterDistributionAnalyzer } from "../../src/core/analyzers/clusterDist.js";
+import type { AnalyzerInput, Metric } from "../../src/core/types.js";
+
+// 4 clusters, sizes [1, 1, 3, 2] -> 7 records.
+const CLUSTERS = {
+  0: { members: [0], size: 1 },
+  1: { members: [1], size: 1 },
+  2: { members: [2, 3, 4], size: 3 },
+  3: { members: [5, 6], size: 2 },
+};
+
+function run(artifacts: Record<string, unknown>) {
+  const inp: AnalyzerInput = { dataset: "customers", artifacts };
+  return new ClusterDistributionAnalyzer().run(inp);
+}
+
+function byKey(metrics: readonly Metric[]): Map<string, Metric> {
+  return new Map(metrics.map((m) => [m.key, m]));
+}
+
+describe("cluster.distribution", () => {
+  it("core metrics", () => {
+    const m = byKey(run({ clusters: CLUSTERS }).metrics);
+    expect(m.get("cluster.count")!.value).toBe(4);
+    expect(m.get("cluster.record_count")!.value).toBe(7);
+    expect(m.get("cluster.singleton_ratio")!.value).toBe(0.5);
+    expect(m.get("cluster.size_max")!.value).toBe(3);
+    expect(Number(m.get("cluster.reduction_ratio")!.value)).toBeCloseTo(1 - 4 / 7, 9);
+  });
+
+  it("discrete size histogram buckets", () => {
+    const tbl = run({ clusters: CLUSTERS }).tables.find((t) => t.name === "cluster_size_histogram")!;
+    expect(tbl.rows).toEqual([
+      [1, 2],
+      [2, 1],
+      [3, 1],
+      ["4+", 0],
+    ]);
+  });
+
+  it("prefers match_stats.total_records for the record count", () => {
+    const m = byKey(run({ clusters: CLUSTERS, match_stats: { total_records: 20 } }).metrics);
+    expect(m.get("cluster.record_count")!.value).toBe(20);
+    expect(Number(m.get("cluster.reduction_ratio")!.value)).toBeCloseTo(1 - 4 / 20, 9);
+  });
+
+  it("emits nothing for an empty clusters object (truthy {} guard)", () => {
+    const r = run({ clusters: {} });
+    expect(r.metrics).toEqual([]);
+    expect(r.tables).toEqual([]);
+  });
+
+  it("emits nothing when clusters is absent", () => {
+    const r = run({});
+    expect(r.metrics).toEqual([]);
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/unit/matchRates.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/matchRates.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { MatchRatesAnalyzer } from "../../src/core/analyzers/matchRates.js";
+import type { AnalyzerInput, Metric } from "../../src/core/types.js";
+
+function input(artifacts: Record<string, unknown>): AnalyzerInput {
+  return { dataset: "customers", artifacts };
+}
+
+function byKey(metrics: readonly Metric[]): Map<string, Metric> {
+  return new Map(metrics.map((m) => [m.key, m]));
+}
+
+describe("match.rates", () => {
+  it("core metrics; recall omitted without a certificate", () => {
+    const r = new MatchRatesAnalyzer().run(
+      input({
+        scored_pairs: [
+          [0, 1, 0.9],
+          [1, 2, 0.8],
+          [3, 4, 0.95],
+        ],
+        match_stats: { total_records: 10, match_rate: 0.3, total_clusters: 2 },
+        match_threshold: 0.82,
+      }),
+    );
+    const m = byKey(r.metrics);
+    expect(m.get("match.pair_count")!.value).toBe(3);
+    expect(m.get("match.match_rate")!.value).toBe(0.3);
+    expect(m.get("match.threshold")!.value).toBe(0.82);
+    expect(Number(m.get("match.mean_pair_score")!.value)).toBeCloseTo((0.9 + 0.8 + 0.95) / 3, 9);
+    expect(m.has("match.recall_estimate")).toBe(false);
+    expect(m.has("match.recall_safe_bound")).toBe(false);
+  });
+
+  it("recall from a {estimate, safe_bound} certificate (both higher_better)", () => {
+    const r = new MatchRatesAnalyzer().run(
+      input({
+        scored_pairs: [[0, 1, 0.9]],
+        match_stats: { total_records: 4, match_rate: 0.5 },
+        recall_certificate: { estimate: 0.94, safe_bound: 0.89 },
+      }),
+    );
+    const m = byKey(r.metrics);
+    expect(m.get("match.recall_estimate")!.value).toBe(0.94);
+    expect(m.get("match.recall_estimate")!.direction).toBe("higher_better");
+    expect(m.get("match.recall_safe_bound")!.value).toBe(0.89);
+    expect(m.get("match.recall_safe_bound")!.direction).toBe("higher_better");
+  });
+
+  it("estimate-only certificate omits the safe bound", () => {
+    const r = new MatchRatesAnalyzer().run(
+      input({ scored_pairs: [[0, 1, 0.9]], match_stats: { match_rate: 0.5 }, recall_certificate: { estimate: 0.94, safe_bound: null } }),
+    );
+    const m = byKey(r.metrics);
+    expect(m.get("match.recall_estimate")!.value).toBe(0.94);
+    expect(m.has("match.recall_safe_bound")).toBe(false);
+  });
+
+  it("emits a score_histogram table when pairs are present", () => {
+    const r = new MatchRatesAnalyzer().run(
+      input({ scored_pairs: [[0, 1, 0.1], [2, 3, 0.9]], match_stats: { match_rate: 0.5 } }),
+    );
+    expect(r.tables.map((t) => t.name)).toContain("score_histogram");
+  });
+
+  it("degrades on empty pairs (no mean_pair_score)", () => {
+    const r = new MatchRatesAnalyzer().run(input({ scored_pairs: [], match_stats: { total_records: 5, match_rate: 0.0 } }));
+    const m = byKey(r.metrics);
+    expect(m.get("match.pair_count")!.value).toBe(0);
+    expect(m.has("match.mean_pair_score")).toBe(false);
+    expect(r.tables.length).toBe(0);
+  });
+});

--- a/packages/typescript/goldenanalysis/tests/unit/qualityRollup.test.ts
+++ b/packages/typescript/goldenanalysis/tests/unit/qualityRollup.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { QualityRollupAnalyzer } from "../../src/core/analyzers/qualityRollup.js";
+import type { AnalyzerInput, Metric } from "../../src/core/types.js";
+
+const FINDINGS = [
+  { severity: "WARNING", column: "email", check: "email_blanked" },
+  { severity: "WARNING", column: "email", check: "email_blanked" },
+  { severity: "ERROR", column: "phone", check: "phone_unparseable" },
+];
+const MANIFEST = {
+  records: [
+    { column: "email", transform: "blank_malformed", affected_rows: 1188, total_rows: 4000 },
+    { column: "phone", transform: "e164", affected_rows: 12, total_rows: 4000 },
+  ],
+};
+
+function run(artifacts: Record<string, unknown>) {
+  const inp: AnalyzerInput = { dataset: "customers", artifacts };
+  return new QualityRollupAnalyzer().run(inp);
+}
+
+function byKey(metrics: readonly Metric[]): Map<string, Metric> {
+  return new Map(metrics.map((m) => [m.key, m]));
+}
+
+describe("quality.rollup", () => {
+  it("quality + flow metrics, findings_by_class table", () => {
+    const r = run({ findings: FINDINGS, manifest: MANIFEST });
+    const m = byKey(r.metrics);
+    expect(m.get("quality.findings_total")!.value).toBe(3);
+    expect(m.get("quality.findings_total")!.direction).toBe("lower_better");
+    expect(m.get("quality.columns_with_findings")!.value).toBe(2);
+    expect(m.get("flow.rows_changed")!.value).toBe(1200);
+    expect(m.get("flow.rules_fired")!.value).toBe(2);
+    expect(m.has("quality.score")).toBe(false); // no profile
+    const tbl = r.tables.find((t) => t.name === "findings_by_class")!;
+    const rows = new Map(tbl.rows.map((row) => [row[0], row[1]]));
+    expect(rows.get("email_blanked")).toBe(2);
+    expect(rows.get("phone_unparseable")).toBe(1);
+  });
+
+  it("quality.score from a duck-typed profile.healthScore", () => {
+    const profile = { healthScore: () => ["B", 80] };
+    const m = byKey(run({ findings: FINDINGS, profile }).metrics);
+    expect(m.get("quality.score")!.value).toBe(0.8);
+    expect(m.get("quality.score")!.direction).toBe("higher_better");
+  });
+
+  it("degrades to findings-only", () => {
+    const m = byKey(run({ findings: FINDINGS }).metrics);
+    expect(m.has("quality.findings_total")).toBe(true);
+    expect(m.has("flow.rows_changed")).toBe(false);
+  });
+
+  it("degrades to manifest-only", () => {
+    const m = byKey(run({ manifest: MANIFEST }).metrics);
+    expect(m.has("flow.rules_fired")).toBe(true);
+    expect(m.has("quality.findings_total")).toBe(false);
+  });
+});


### PR DESCRIPTION
Ports the GoldenAnalysis **suite analyzers** to TypeScript (parity with Python Phase 2a). Builds on Phase 3a/3b (merged): the `AnalysisReport`/`Metric` types, `analyze`, `aggregate`, registry.

## What's here (all edge-safe `src/core`, no `node:`)
- **3 analyzers** reading the SAME snake_case artifact keys the Python sibling reads (so a serialized Python `PipeResult.artifacts` feeds them identically):
  - `match.rates` — `scored_pairs`/`match_stats` (+ `match_threshold`/`recall_certificate`) → pair count, match rate, threshold, recall estimate/safe-bound, mean score + `score_histogram`.
  - `cluster.distribution` — `clusters` (+ `match_stats`) → count, record count, singleton ratio, size p50/p95/max, reduction ratio + `cluster_size_histogram`.
  - `quality.rollup` — `findings`/`manifest` (+ `profile`) → findings total, columns-with-findings, health score + `flow.rows_changed`/`rules_fired` + `findings_by_class`.
- **4 duck-typed adapters** (`matchArtifacts`/`flowArtifacts`/`checkArtifacts`/`pipeArtifacts`) — normalize a producer's result-like object into an `AnalyzerInput`; no goldenmatch/goldenflow/goldencheck/goldenpipe import. Shared `normalizeCert`; pipe dataset = `Path(source).stem`.
- **Entry points**: `analyzeMatch(result, {dataset, certificate})` → `match.rates` + `cluster.distribution`; `analyzePipeline(result)` → fans out to every analyzer whose consumed artifacts are present (sorted; `frame.summary` skipped — a PipeResult exposes no `frame`).
- `analyze.ts` refactored to share one `assembleReport` across the frame + suite paths (producer read from `artifacts.__producer__`).

## Parity gotchas handled
- Empty `clusters` `{}` is **truthy** in JS → guarded on `Object.keys().length` (Python `if not clusters`).
- `findings_by_class` follows `Counter.most_common()` (count desc, ties first-appearance — stable sort).
- `cluster.record_count` prefers `match_stats.total_records`, else `sum(sizes)`.
- Frame path stays **byte-identical** (empty artifacts → producer `"frame"`) — the 3a cross-surface parity test is green.

## Test plan
- `npx vitest run` — 80 passed (23 new: 3 analyzers, adapters, `analyzeMatch`/`analyzePipeline`; mirrors the Python 2a unit scenarios). The 3a parity + all 3b cross-run tests stay green.
- `npx tsc --noEmit` clean; `npx tsup` builds all 4 entries; built `core` export smoke-tested (`analyzeMatch`/`analyzePipeline`).
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)