### PR TITLE
feat(goldenanalysis): Phase 5A — MCP server + goldensuite-mcp surfacing

### DIFF
--- a/docs/superpowers/plans/2026-06-08-goldenanalysis-phase5-pipe-mcp-publish.md
+++ b/docs/superpowers/plans/2026-06-08-goldenanalysis-phase5-pipe-mcp-publish.md
@@ -1,0 +1,52 @@
+# GoldenAnalysis Phase 5 — GoldenPipe stage + MCP + publish Plan
+
+> Use superpowers:executing-plans. Phase 5 is three independent subsystems → **three focused PRs** (the repo SOP + the design, which flags the GoldenPipe stage as "a separate follow-up PR"). Each PR is green on its own.
+
+**Goal:** Finish GoldenAnalysis's suite integration + shipping surface: (A) an MCP server + goldensuite-mcp surfacing, (B) the PyPI + npm + MCP-registry publish workflows, (C) the optional GoldenPipe terminal reporting stage.
+
+**Reference:** design `docs/superpowers/specs/2026-06-08-goldenanalysis-cross-cutting-analysis-engine-design.md` §Phase 5 + §"CI + publish wiring". Templates: `goldenpipe/mcp/server.py`, `goldensuite_mcp/server.py`, `publish-goldenpipe.yml` / `publish-goldenpipe-js.yml`, `goldenpipe/stages/` + `goldenpipe/adapters/`.
+
+---
+
+## PR A — MCP server + goldensuite-mcp surfacing  (branch `feat/goldenanalysis-p5` → first PR)
+
+The package already ships `server.json` (registry manifest, `uvx` stdio) but has no MCP server backing it. Mirror goldenpipe's module-level `TOOLS` + `HANDLERS` so the aggregator surfaces it transitively.
+
+### A.0 — `goldenanalysis/mcp/{__init__.py,server.py}`
+- [ ] `server.py` mirrors `goldenpipe/mcp/server.py`: `HAS_MCP` guard; tool fns `list_analyzers()`, `analyze_frame(path, analyzers?, output_format?)`, `get_trend(history, metric, dataset, last?)`, `detect_regressions(history, dataset, baseline?, window?, policy?)` — each lazy-imports polars/the package internals so module import stays light; `_build_tools()`; module-level `TOOLS` + `HANDLERS` (name→`lambda args: fn(**args)`); `create_server()`/`run_server()`/`run_server_http(port=8300)` (A2A convention: Check 8100 / Flow 8150 / Match 8200 / Pipe 8250 → Analysis 8300).
+- [ ] Test `tests/test_mcp_server.py`: `TOOLS` non-empty + names; `HANDLERS["list_analyzers"]({})` returns the 4 analyzers; `analyze_frame` on a tmp CSV returns a report dict with `frame.row_count`; `get_trend`/`detect_regressions` over a tmp jsonl seeded via `ReportHistory`. (`create_server` only if mcp installed.)
+- [ ] Commit `feat(goldenanalysis): MCP server (analyze_frame / get_trend / detect_regressions / list_analyzers)`
+
+### A.1 — CLI `mcp-serve`
+- [ ] `cli/main.py`: add `mcp-serve` (`--transport stdio|http`, `--host`, `--port 8300`) calling `run_server()` / `run_server_http()`; lazy-import the server. Test: command registered (introspect the Typer app — do NOT scrape `--help`, per the narrow-terminal-wrap flake).
+- [ ] Commit `feat(goldenanalysis): goldenanalysis mcp-serve command`
+
+### A.2 — goldensuite-mcp surfacing
+- [ ] `goldensuite_mcp/server.py`: add `_adapt_goldenanalysis()` (HANDLERS dispatch, like `_adapt_goldenpipe`) + append `("goldenanalysis", _adapt_goldenanalysis)` to `_SUITE_ORDER`.
+- [ ] `goldensuite-mcp/pyproject.toml`: add `goldenanalysis[mcp]` to `dependencies` + `goldenanalysis = { workspace = true }` to `[tool.uv.sources]`.
+- [ ] `tests/test_aggregator_smoke.py`: add `_adapt_goldenanalysis` to the adapter loop; assert a goldenanalysis tool (e.g. `analyze_frame`) surfaces through `_adapt_goldenanalysis`.
+- [ ] Commit `feat(goldensuite-mcp): surface goldenanalysis tools`
+
+### A.3 — verify + PR
+- [ ] Local (targeted, `POLARS_SKIP_CPU_CHECK=1`): import the mcp server, assert `TOOLS`/`HANDLERS`, run `list_analyzers` (no polars). ruff clean. Heavy tools (analyze_frame/trend) verified in CI.
+- [ ] Push (auth dance); PR vs main; babysit (`ci-required` + `CodeQL` + the `python (goldenanalysis)` + `python (goldensuite-mcp)` lanes); merge.
+
+## PR B — publish workflows  (off main after A merges)
+- [ ] `.github/workflows/publish-goldenanalysis.yml` — mirror `publish-goldenpipe.yml`: `release: published` on `goldenanalysis-v*` (skip the other tag prefixes), PyPI via `PYPI_TOKEN`, version from the git tag (the #167 duplicate-version race), `skip-existing: true`.
+- [ ] `.github/workflows/publish-goldenanalysis-js.yml` — mirror `publish-goldenpipe-js.yml`: npm on `goldenanalysis-js-v*`, `NPM_TOKEN`, `pnpm publish --no-git-checks`.
+- [ ] `publish-mcp.yml` — add `goldenanalysis` to the `package` enum + the sync mapping so `server.json` syncs under `io.github.benseverndev-oss/goldenanalysis` (version from the git tag, not PyPI).
+- [ ] Verify the three workflow files parse (YAML); confirm tag-prefix guards don't cross-trigger. Push; PR; babysit; merge.
+
+## PR C — GoldenPipe terminal reporting stage  (off main after B)
+- [ ] `goldenpipe`: a `goldenanalysis.report` stage (register at `goldenpipe.stages`), `consumes=["df","clusters","identity_summary"]`, `produces=["analysis_report"]`, appends `PipeResult.artifacts["analysis_report"]`, writes nothing back. Optional `[analysis]` extra on goldenpipe → `goldenanalysis`. Degrades when goldenanalysis absent (HAS_ANALYSIS guard, like HAS_CHECK/FLOW/MATCH).
+- [ ] Test: the stage runs after a dedupe and attaches an `analysis_report` artifact; a config omitting it still works; goldenpipe without `[analysis]` skips gracefully.
+- [ ] Verify; push; PR; babysit; merge.
+
+## Acceptance
+- [ ] A: `goldenanalysis.mcp.server.TOOLS`/`HANDLERS` exist; `mcp-serve` runs; goldensuite-mcp surfaces the tools (aggregator smoke green); `python (goldenanalysis)` + `python (goldensuite-mcp)` lanes green.
+- [ ] B: three publish workflows parse + tag-guarded; MCP-registry enum includes goldenanalysis.
+- [ ] C: GoldenPipe can run Check→Flow→Match→Identity→**Analysis** as one chain; the stage is read-only + optional; absent-dep path degrades.
+
+### Notes
+- snake_case wire types stay snake_case across the JSON the MCP tools emit (the `AnalysisReport`/`Metric` exception). MCP tools are file-path based (stdio-friendly).
+- Don't scrape Typer/Rich `--help` in tests (CI narrow-terminal wrap flake) — introspect the Typer app's registered commands.

--- a/packages/python/goldenanalysis/goldenanalysis/cli/main.py
+++ b/packages/python/goldenanalysis/goldenanalysis/cli/main.py
@@ -134,5 +134,27 @@ def regressions(
         raise typer.Exit(1)
 
 
+@app.command(name="mcp-serve")
+def mcp_serve(
+    transport: str = typer.Option("stdio", "--transport", help="stdio | http"),
+    host: str = typer.Option("0.0.0.0", "--host"),
+    port: int = typer.Option(8300, "--port", help="HTTP port (A2A convention: Analysis = 8300)."),
+) -> None:
+    """Start the GoldenAnalysis MCP server (requires the [mcp] extra)."""
+    try:
+        from goldenanalysis.mcp import server as mcp_server
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        typer.echo(f"MCP not available: {exc} (install goldenanalysis[mcp])", err=True)
+        raise typer.Exit(1) from exc
+
+    if transport == "http":
+        mcp_server.run_server_http(host=host, port=port)
+    elif transport == "stdio":
+        mcp_server.run_server()
+    else:
+        typer.echo(f"unknown --transport {transport!r} (want stdio|http)", err=True)
+        raise typer.Exit(2)
+
+
 if __name__ == "__main__":  # pragma: no cover
     app()

--- a/packages/python/goldenanalysis/goldenanalysis/mcp/__init__.py
+++ b/packages/python/goldenanalysis/goldenanalysis/mcp/__init__.py
@@ -1,0 +1,6 @@
+"""Optional MCP server for GoldenAnalysis (the ``[mcp]`` extra).
+
+``goldenanalysis.mcp.server`` exposes module-level ``TOOLS`` + ``HANDLERS`` so the
+in-process ``goldensuite-mcp`` aggregator surfaces them transitively, plus a
+stdio / Streamable-HTTP server for standalone use (``goldenanalysis mcp-serve``).
+"""

--- a/packages/python/goldenanalysis/goldenanalysis/mcp/server.py
+++ b/packages/python/goldenanalysis/goldenanalysis/mcp/server.py
@@ -1,0 +1,260 @@
+"""MCP server with read-only GoldenAnalysis tools.
+
+Mirrors ``goldenpipe/mcp/server.py``: module-level ``TOOLS`` (list of
+``mcp.types.Tool``) + ``HANDLERS`` (tool name -> callable taking the args dict),
+which ``goldensuite-mcp`` imports to surface these transitively. Every tool
+lazy-imports the heavy bits (polars, ``ReportHistory``) so importing this module
+stays light -- the aggregator + smoke tests only touch ``TOOLS`` / ``HANDLERS``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp.types import Prompt, Resource, TextContent, Tool
+
+    HAS_MCP = True
+except ImportError:
+    HAS_MCP = False
+
+
+def _open_history(history: str):
+    from goldenanalysis.history import ReportHistory
+
+    p = Path(history)
+    backend = "sqlite" if p.suffix.lower() in (".db", ".sqlite") else "jsonl"
+    return ReportHistory(backend=backend, path=p)
+
+
+def list_analyzers_tool() -> dict[str, Any]:
+    """List the discoverable analyzers."""
+    from goldenanalysis.registry import available_analyzers
+
+    return {"analyzers": available_analyzers()}
+
+
+def analyze_frame_tool(path: str, analyzers: str | None = None, output_format: str = "json") -> dict[str, Any]:
+    """Analyze a .parquet/.csv frame (or re-render a saved .json AnalysisReport)."""
+    from goldenanalysis import analyze
+    from goldenanalysis.models import AnalysisReport
+
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        rep = AnalysisReport.from_json(p.read_text(encoding="utf-8"))
+    else:
+        import polars as pl
+
+        if suffix == ".parquet":
+            df = pl.read_parquet(p)
+        elif suffix == ".csv":
+            df = pl.read_csv(p)
+        else:
+            return {"error": f"unsupported input type: {p.suffix!r} (want .parquet/.csv/.json)"}
+        names = (
+            None if not analyzers or analyzers == "all" else [a.strip() for a in analyzers.split(",") if a.strip()]
+        )
+        rep = analyze(df, analyzers=names, dataset=p.stem)
+
+    if output_format == "markdown":
+        return {"markdown": rep.to_markdown()}
+    return json.loads(rep.to_json())
+
+
+def get_trend_tool(history: str, metric: str, dataset: str, last: int = 30) -> dict[str, Any]:
+    """Trend a metric over a ReportHistory (.jsonl/.db)."""
+    series = _open_history(history).trend(metric, dataset, last_n=last)
+    return {
+        "metric_key": series.metric_key,
+        "dataset": series.dataset,
+        "points": [[run_id, value] for run_id, value in series.points],
+    }
+
+
+def detect_regressions_tool(
+    history: str,
+    dataset: str,
+    baseline: str = "rolling_median",
+    window: int = 7,
+    policy: dict | None = None,
+) -> dict[str, Any]:
+    """Detect metric regressions vs a baseline over a ReportHistory."""
+    from goldenanalysis.models import RegressionPolicy
+
+    pol = (
+        RegressionPolicy(
+            default_pct=policy.get("default_pct", 10.0), per_metric=policy.get("per_metric", {})
+        )
+        if policy
+        else RegressionPolicy()
+    )
+    flagged = _open_history(history).detect_regressions(dataset, baseline=baseline, window=window, policy=pol)
+    return {
+        "flagged": [
+            {
+                "metric": r.metric,
+                "baseline": r.baseline,
+                "current": r.current,
+                "delta_pct": r.delta_pct,
+                "direction": r.direction,
+            }
+            for r in flagged
+        ]
+    }
+
+
+def _build_tools() -> list:
+    """Build the Tool list. Lazy so import doesn't fail without mcp installed."""
+    return [
+        Tool(
+            name="list_analyzers",
+            description="List the discoverable GoldenAnalysis analyzers",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="analyze_frame",
+            description="Analyze a .parquet/.csv frame (or re-render a .json AnalysisReport) into a metrics report",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "A .parquet/.csv frame or a .json AnalysisReport"},
+                    "analyzers": {"type": "string", "description": "Comma-separated analyzer names, or 'all'"},
+                    "output_format": {"type": "string", "enum": ["json", "markdown"]},
+                },
+                "required": ["path"],
+            },
+        ),
+        Tool(
+            name="get_trend",
+            description="Trend a metric over a run history (.jsonl/.db ReportHistory)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "history": {"type": "string"},
+                    "metric": {"type": "string"},
+                    "dataset": {"type": "string"},
+                    "last": {"type": "integer"},
+                },
+                "required": ["history", "metric", "dataset"],
+            },
+        ),
+        Tool(
+            name="detect_regressions",
+            description="Detect metric regressions vs a baseline over a run history",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "history": {"type": "string"},
+                    "dataset": {"type": "string"},
+                    "baseline": {"type": "string"},
+                    "window": {"type": "integer"},
+                    "policy": {"type": "object"},
+                },
+                "required": ["history", "dataset"],
+            },
+        ),
+    ]
+
+
+# Module-level surfaces for goldensuite-mcp (the in-process aggregator).
+# TOOLS is a list of mcp.types.Tool; HANDLERS maps tool name -> callable taking the
+# arguments dict and returning a JSON-serializable result.
+TOOLS = _build_tools() if HAS_MCP else []
+HANDLERS = {
+    "list_analyzers": lambda args: list_analyzers_tool(),
+    "analyze_frame": lambda args: analyze_frame_tool(**args),
+    "get_trend": lambda args: get_trend_tool(**args),
+    "detect_regressions": lambda args: detect_regressions_tool(**args),
+}
+
+
+def create_server() -> Server:
+    """Create and configure the MCP server instance."""
+    if not HAS_MCP:
+        raise ImportError("MCP not installed. Run: pip install goldenanalysis[mcp]")
+
+    server = Server("GoldenAnalysis")
+
+    @server.list_tools()
+    async def handle_list_tools():
+        return TOOLS
+
+    @server.list_resources()
+    async def handle_list_resources() -> list[Resource]:
+        return []
+
+    @server.list_prompts()
+    async def handle_list_prompts() -> list[Prompt]:
+        return []
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict):
+        handler = HANDLERS.get(name)
+        if handler is None:
+            result = {"error": f"Unknown tool: {name}"}
+        else:
+            try:
+                result = handler(arguments)
+            except Exception as exc:  # noqa: BLE001 — surface a structured error, never crash the call
+                result = {"error": str(exc)}
+        return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+
+    return server
+
+
+def run_server() -> None:
+    """Start the MCP server over stdio transport."""
+    import asyncio
+
+    server = create_server()
+
+    async def main():
+        async with stdio_server() as (read, write):
+            await server.run(read, write, server.create_initialization_options())
+
+    asyncio.run(main())
+
+
+def run_server_http(host: str = "0.0.0.0", port: int = 8300) -> None:
+    """Start the MCP server over Streamable HTTP transport (A2A port 8300)."""
+    import contextlib
+    from collections.abc import AsyncIterator
+
+    import uvicorn
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse
+    from starlette.routing import Mount, Route
+
+    server = create_server()
+    session_manager = StreamableHTTPSessionManager(app=server, json_response=False, stateless=False)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app: Starlette) -> AsyncIterator[None]:
+        async with session_manager.run():
+            yield
+
+    async def server_card(request):
+        return JSONResponse(
+            {
+                "name": "GoldenAnalysis",
+                "description": "Read-only cross-cutting analysis, metrics, and reporting across the Golden Suite. 4 MCP tools: list analyzers, analyze a frame, trend a metric over a run history, and detect regressions vs a baseline.",
+                "homepage": "https://github.com/benseverndev-oss/goldenmatch/tree/main/packages/python/goldenanalysis",
+                "iconUrl": "https://avatars.githubusercontent.com/u/192581748",
+            }
+        )
+
+    starlette_app = Starlette(
+        debug=False,
+        routes=[
+            Route("/.well-known/mcp/server-card.json", server_card),
+            Mount("/mcp", app=session_manager.handle_request),
+        ],
+        lifespan=lifespan,
+    )
+
+    uvicorn.run(starlette_app, host=host, port=port)

--- a/packages/python/goldenanalysis/tests/test_mcp_server.py
+++ b/packages/python/goldenanalysis/tests/test_mcp_server.py
@@ -1,0 +1,84 @@
+"""MCP server smoke tests for goldenanalysis.
+
+The tool HANDLERS are plain callables (no `mcp` dependency), so they run in the
+default matrix lane (which installs goldenanalysis without the [mcp] extra). The
+`TOOLS` list + `create_server` need `mcp`, so those are gated on `HAS_MCP`.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from goldenanalysis.mcp import server
+
+
+def test_handlers_cover_the_tool_set() -> None:
+    assert set(server.HANDLERS) == {"list_analyzers", "analyze_frame", "get_trend", "detect_regressions"}
+
+
+def test_list_analyzers_handler() -> None:
+    out = server.HANDLERS["list_analyzers"]({})
+    assert "frame.summary" in out["analyzers"]
+    assert "match.rates" in out["analyzers"]
+
+
+def test_analyze_frame_handler(tmp_path: Path) -> None:
+    csv = tmp_path / "customers.csv"
+    csv.write_text("a,b\n1,x\n1,x\n2,y\n", encoding="utf-8")
+    out = server.HANDLERS["analyze_frame"]({"path": str(csv)})
+    keys = {m["key"] for m in out["metrics"]}
+    assert "frame.row_count" in keys
+    assert out["source"]["dataset"] == "customers"
+
+
+def test_analyze_frame_rejects_unknown_suffix(tmp_path: Path) -> None:
+    bad = tmp_path / "data.txt"
+    bad.write_text("nope", encoding="utf-8")
+    out = server.HANDLERS["analyze_frame"]({"path": str(bad)})
+    assert "error" in out
+
+
+def _seed_history(path: Path):
+    from goldenanalysis.history import ReportHistory
+    from goldenanalysis.models import AnalysisReport, Metric
+
+    def _rep(run_id: str, val: float) -> AnalysisReport:
+        return AnalysisReport(
+            run_id=run_id,
+            generated_at=datetime(2026, 6, 8, tzinfo=UTC),
+            source={"dataset": "customers"},
+            metrics=[Metric(key="cluster.singleton_ratio", value=val, unit="ratio", direction="neutral")],
+        )
+
+    hist = ReportHistory(backend="jsonl", path=path)
+    for i in range(7):
+        hist.append(_rep(f"r{i}", 0.58))
+    hist.append(_rep("r7", 0.71))
+
+
+def test_trend_handler(tmp_path: Path) -> None:
+    path = tmp_path / "a.jsonl"
+    _seed_history(path)
+    series = server.HANDLERS["get_trend"](
+        {"history": str(path), "metric": "cluster.singleton_ratio", "dataset": "customers"}
+    )
+    assert series["metric_key"] == "cluster.singleton_ratio"
+    assert series["points"][-1] == ["r7", 0.71]
+
+
+def test_detect_regressions_handler(tmp_path: Path) -> None:
+    path = tmp_path / "a.jsonl"
+    _seed_history(path)
+    out = server.HANDLERS["detect_regressions"](
+        {"history": str(path), "dataset": "customers", "policy": {"default_pct": 10}}
+    )
+    flagged = {r["metric"] for r in out["flagged"]}
+    assert "cluster.singleton_ratio" in flagged  # +22.4% clears the 10% gate
+
+
+@pytest.mark.skipif(not server.HAS_MCP, reason="mcp extra not installed")
+def test_tools_and_server_build() -> None:
+    names = {t.name for t in server.TOOLS}
+    assert names == {"list_analyzers", "analyze_frame", "get_trend", "detect_regressions"}
+    assert server.create_server() is not None

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
@@ -106,6 +106,20 @@ def _adapt_infermap() -> tuple[list[Tool], Callable[[str, dict], dict]]:
     return _normalize_tools(list(im.TOOLS)), dispatch
 
 
+def _adapt_goldenanalysis() -> tuple[list[Tool], Callable[[str, dict], dict]]:
+    from goldenanalysis.mcp import server as ga
+
+    handlers = ga.HANDLERS
+
+    def dispatch(name: str, args: dict) -> dict:
+        h = handlers.get(name)
+        if h is None:
+            return {"error": f"goldenanalysis: unknown tool {name!r}"}
+        return h(args)
+
+    return _normalize_tools(list(ga.TOOLS)), dispatch
+
+
 # Order determines first-wins precedence on tool-name collisions.
 # Goldenmatch is the headline package, so its tools win; the others register
 # only their unshadowed names. Adjust this order to change precedence.
@@ -115,6 +129,7 @@ _SUITE_ORDER: list[tuple[str, Callable[[], tuple[list[Tool], Callable[[str, dict
     ("goldenflow", _adapt_goldenflow),
     ("goldenpipe", _adapt_goldenpipe),
     ("infermap", _adapt_infermap),
+    ("goldenanalysis", _adapt_goldenanalysis),
 ]
 
 

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "goldenflow[mcp]",
     "goldenpipe[mcp]",
     "infermap[mcp]",
+    "goldenanalysis[mcp]",
     "uvicorn>=0.30",
     "starlette>=1.0.1",
 ]
@@ -52,6 +53,7 @@ goldencheck = { workspace = true }
 goldenflow = { workspace = true }
 goldenpipe = { workspace = true }
 infermap = { workspace = true }
+goldenanalysis = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["goldensuite_mcp"]

--- a/packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py
+++ b/packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py
@@ -28,6 +28,7 @@ def test_aggregator_imports():
 def test_each_subpackage_adapter_loads():
     """Each adapter returns (tools, dispatch) without raising."""
     from goldensuite_mcp.server import (
+        _adapt_goldenanalysis,
         _adapt_goldencheck,
         _adapt_goldenflow,
         _adapt_goldenmatch,
@@ -41,12 +42,27 @@ def test_each_subpackage_adapter_loads():
         _adapt_goldenflow,
         _adapt_goldenpipe,
         _adapt_infermap,
+        _adapt_goldenanalysis,
     ):
         tools, dispatch = adapter()
         assert isinstance(tools, list)
         # Tools normalize to mcp.types.Tool; at minimum each adapter ships >=1
         assert len(tools) >= 1, f"{adapter.__name__} returned no tools"
         assert callable(dispatch)
+
+
+def test_goldenanalysis_tools_surface_through_aggregator():
+    """GoldenAnalysis's read-only tools must flow through its adapter."""
+    from goldensuite_mcp.server import _adapt_goldenanalysis
+
+    tools, dispatch = _adapt_goldenanalysis()
+    names = {t.name for t in tools}
+    expected = {"list_analyzers", "analyze_frame", "get_trend", "detect_regressions"}
+    missing = expected - names
+    assert not missing, f"GoldenAnalysis tools missing from aggregator: {missing}"
+    # list_analyzers needs no fixture -> routes cleanly through dispatch.
+    out = dispatch("list_analyzers", {})
+    assert "frame.summary" in out["analyzers"]
 
 
 def test_identity_tools_surface_through_aggregator():

--- a/uv.lock
+++ b/uv.lock
@@ -1481,6 +1481,7 @@ name = "goldensuite-mcp"
 version = "0.2.0"
 source = { editable = "packages/python/goldensuite-mcp" }
 dependencies = [
+    { name = "goldenanalysis", extra = ["mcp"] },
     { name = "goldencheck", extra = ["mcp"] },
     { name = "goldenflow", extra = ["mcp"] },
     { name = "goldenmatch", extra = ["mcp"] },
@@ -1499,6 +1500,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "goldenanalysis", extras = ["mcp"], editable = "packages/python/goldenanalysis" },
     { name = "goldencheck", extras = ["mcp"], editable = "packages/python/goldencheck" },
     { name = "goldenflow", extras = ["mcp"], editable = "packages/python/goldenflow" },
     { name = "goldenmatch", extras = ["mcp"], editable = "packages/python/goldenmatch" },


### PR DESCRIPTION
First of three focused Phase 5 PRs (the repo SOP + the design, which flags the GoldenPipe stage as a separate follow-up). This one gives GoldenAnalysis its **agent surface** — backing the `server.json` that already ships.

## What's here
- **`goldenanalysis/mcp/server.py`** — mirrors `goldenpipe/mcp/server.py`: module-level `TOOLS` + `HANDLERS` (so `goldensuite-mcp` surfaces them transitively) + stdio/Streamable-HTTP server. Four read-only tools:
  - `list_analyzers` — the discoverable analyzers
  - `analyze_frame` — analyze a `.parquet`/`.csv` (or re-render a `.json` report) → metrics report
  - `get_trend` — trend a metric over a `ReportHistory` (`.jsonl`/`.db`)
  - `detect_regressions` — flag metric regressions vs a baseline
  - Tools lazy-import polars/`ReportHistory` so module import stays light; handlers are **mcp-free** (run in the matrix lane without the `[mcp]` extra), `TOOLS`/`create_server` gated on `HAS_MCP`.
- **`goldenanalysis mcp-serve`** CLI (`--transport stdio|http`, A2A port 8300: Check 8100 / Flow 8150 / Match 8200 / Pipe 8250 → Analysis 8300).
- **goldensuite-mcp** surfaces the tools: `_adapt_goldenanalysis()` + `_SUITE_ORDER` entry (last, so existing tools keep first-wins precedence) + `goldenanalysis[mcp]` dep + uv workspace source. `uv lock` adds one edge (2-line diff).

## Test plan
- `tests/test_mcp_server.py` — handlers verified (list_analyzers + analyze_frame on a tmp CSV + seeded trend/regressions over a tmp jsonl); `TOOLS`/`create_server` gated on `HAS_MCP`. Verified locally (trend `['r7', 0.71]`, regression `cluster.singleton_ratio` flagged, `create_server` builds).
- `goldensuite-mcp` aggregator smoke test covers the new adapter + asserts the 4 tools surface + route.
- ruff clean. CI: path-filtered to `python (goldenanalysis)` + `python (goldensuite-mcp)` + pyright + CodeQL.

Follow-ups (Phase 5): **B** publish workflows (PyPI + npm + MCP-registry enum); **C** the optional GoldenPipe terminal reporting stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)