### PR TITLE
ci(goldenanalysis): Phase 5B — PyPI + npm + MCP-registry publish workflows

### DIFF
--- a/.github/workflows/publish-goldenanalysis-js.yml
+++ b/.github/workflows/publish-goldenanalysis-js.yml
@@ -1,0 +1,75 @@
+name: Publish goldenanalysis to npm
+
+on:
+  push:
+    tags:
+      - "goldenanalysis-js-v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      dry-run:
+        description: "Pack and validate without publishing"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/typescript/goldenanalysis
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
+
+      # goldenanalysis-js is standalone (only `commander`; no workspace deps), so
+      # there is nothing to pre-build — go straight to typecheck/test/build.
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify version matches tag
+        if: startsWith(github.ref, 'refs/tags/goldenanalysis-js-v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/goldenanalysis-js-v}"
+          PKG_VERSION=$(jq -r .version package.json)
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - name: Pack (dry-run validation)
+        if: github.event.inputs.dry-run == 'true'
+        run: pnpm pack
+
+      - name: Publish to npm
+        if: github.event.inputs.dry-run != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --provenance --no-git-checks

--- a/.github/workflows/publish-goldenanalysis.yml
+++ b/.github/workflows/publish-goldenanalysis.yml
@@ -1,0 +1,40 @@
+name: Publish goldenanalysis to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    # Only run for goldenanalysis-v* tags. `startsWith` excludes goldenanalysis-js-v*
+    # and goldenanalysis-native-v* (the char after `goldenanalysis-` is j / n, not v).
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenanalysis-v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    defaults:
+      run:
+        working-directory: packages/python/goldenanalysis
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: packages/python/goldenanalysis/dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -35,6 +35,7 @@ on:
           - goldenflow
           - goldenpipe
           - infermap
+          - goldenanalysis
         default: all
 
 permissions:
@@ -71,11 +72,14 @@ jobs:
             elif [[ "$TAG" == goldenmatch-duckdb-v* ]]; then : noop  # not on registry
             elif [[ "$TAG" == goldenmatch-pg-v* ]];     then : noop  # not on registry
             elif [[ "$TAG" == goldensuite-mcp-v* ]];    then : noop  # aggregator -- transitively exposes sub-package tools
+            elif [[ "$TAG" == goldenanalysis-native-v* ]]; then : noop  # not on registry
+            elif [[ "$TAG" == goldenanalysis-js-v* ]];  then : noop
+            elif [[ "$TAG" == goldenanalysis-v* ]];     then PKGS+=(goldenanalysis)
             elif [[ "$TAG" == v* ]];                    then PKGS+=(goldenmatch)
             fi
           else
             if [ "$DISPATCH_PKG" = "all" ]; then
-              PKGS=(goldenmatch goldencheck goldenflow goldenpipe infermap)
+              PKGS=(goldenmatch goldencheck goldenflow goldenpipe infermap goldenanalysis)
             else
               PKGS=("$DISPATCH_PKG")
             fi


### PR DESCRIPTION
Second of three Phase 5 PRs: the publish surface so `goldenanalysis` (PyPI), `goldenanalysis-js` (npm), and the MCP-registry listing can actually ship. Workflow files only — no package code changes.

## What's here
- **`publish-goldenanalysis.yml`** — PyPI on `goldenanalysis-v*` (mirrors `publish-goldenpipe.yml`): `python -m build` in the package dir, `PYPI_TOKEN`, `skip-existing: true`. The `startsWith(tag, 'goldenanalysis-v')` guard cleanly excludes `goldenanalysis-js-v*` / `goldenanalysis-native-v*` (the char after `goldenanalysis-` is `j`/`n`, not `v`).
- **`publish-goldenanalysis-js.yml`** — npm on `goldenanalysis-js-v*` (mirrors `publish-goldenpipe-js.yml`): typecheck + vitest + build + version-vs-tag guard + `pnpm publish --provenance --no-git-checks`. goldenanalysis-js is standalone (only `commander`), so the workspace-deps prebuild step is dropped.
- **`publish-mcp.yml`** — add `goldenanalysis` to the dispatch enum + the `all` list + the release tag→package mapping (`goldenanalysis-v*` → sync under `io.github.benseverndev-oss/goldenanalysis`; `-native-v*`/`-js-v*` → noop). `server.json` already ships; version derived from the git tag (the #167 duplicate-version race).

## Test plan
- All three YAML files parse; the tag-dispatch routing verified by replaying the `resolve` bash against `goldenanalysis-v` / `-native-v` / `-js-v` / `v` / `goldenpipe-v` (routes to goldenanalysis / noop / noop / goldenmatch / goldenpipe respectively).
- Publish workflows don't run on PRs (release/tag/dispatch-triggered), so this is low-risk; the `--native` workflow already landed in P4.

Follow-up: **C** the optional GoldenPipe terminal reporting stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)