### PR TITLE
feat(goldenpipe): Phase 5C — goldenanalysis.report terminal reporting stage

### DIFF
--- a/packages/python/goldenpipe/goldenpipe/adapters/analysis.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/analysis.py
@@ -1,0 +1,74 @@
+"""GoldenAnalysis terminal reporting stage -- Phase 5.
+
+Runs goldenanalysis over the pipeline's accumulated artifacts (clusters /
+scored_pairs / match_stats / findings / manifest -- the SAME keys the upstream
+stages already surface, so no remapping is needed) and attaches a unified
+``analysis_report``. READ-ONLY: it writes only that one artifact and never mutates
+the data or any store. Optional -- ships behind ``goldenpipe[analysis]`` and
+degrades to a clear error when goldenanalysis isn't installed.
+
+Makes "one CLI runs Check -> Flow -> Match -> Identity -> Analysis" literally true.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+from goldenpipe.models.context import PipeContext, StageResult, StageStatus
+from goldenpipe.models.stage import StageInfo
+
+logger = logging.getLogger(__name__)
+
+try:
+    from goldenanalysis import analyze_pipeline
+
+    HAS_ANALYSIS = True
+except ImportError:
+    HAS_ANALYSIS = False
+    analyze_pipeline = None  # type: ignore[assignment]
+
+
+class AnalysisReportStage:
+    info = StageInfo(
+        name="goldenanalysis.report",
+        produces=["analysis_report"],
+        # Only `df` is hard-required (always present, so wiring never fails).
+        # clusters / scored_pairs / match_stats / findings / manifest /
+        # identity_summary are read opportunistically from ctx.artifacts --
+        # goldenanalysis degrades to whatever is present, so the stage works on
+        # any pipeline (check-only, full dedupe, etc.). Place it LAST in the
+        # config to report over every upstream artifact.
+        consumes=["df"],
+    )
+    rollback = None
+
+    def validate(self, ctx: PipeContext) -> None:
+        if not HAS_ANALYSIS:
+            raise RuntimeError(
+                "goldenanalysis not available. Install it with "
+                "`pip install goldenpipe[analysis]`."
+            )
+
+    def run(self, ctx: PipeContext) -> StageResult:
+        # A PipeResult-like view over the accumulated artifacts. goldenanalysis's
+        # pipe adapter reads `.artifacts` + `.source`; it fans out to every analyzer
+        # whose consumed artifacts are present and skips the rest.
+        result_like = SimpleNamespace(
+            artifacts=dict(ctx.artifacts),
+            source=ctx.metadata.get("source"),
+        )
+        try:
+            report = analyze_pipeline(result_like)
+        except Exception as e:  # noqa: BLE001 - a reporting stage must never break the run
+            logger.warning("Analysis reporting failed: %s", e)
+            return StageResult(status=StageStatus.FAILED, error=str(e))
+
+        # Attach as a plain JSON dict (read-only; never written back to the data).
+        ctx.artifacts["analysis_report"] = json.loads(report.to_json())
+        logger.info(
+            "Analysis report: %d metric(s) from [%s]",
+            len(report.metrics),
+            ",".join(report.analyzers_run) or "no analyzers",
+        )
+        return StageResult(status=StageStatus.SUCCESS)

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -30,7 +30,11 @@ dependencies = [
 check = ["goldencheck>=0.5.0"]
 flow = ["goldenflow>=0.1.0"]
 match = ["goldenmatch>=1.2.0"]
-golden-suite = ["goldencheck>=0.5.0", "goldenflow>=0.1.0", "goldenmatch>=1.2.0"]
+# Optional terminal reporting stage (goldenanalysis.report) -- read-only metrics
+# over the run's artifacts. goldenanalysis is a workspace member (root uv.sources),
+# so dev/CI resolve it locally; the published wheel resolves it from PyPI.
+analysis = ["goldenanalysis>=0.1.0"]
+golden-suite = ["goldencheck>=0.5.0", "goldenflow>=0.1.0", "goldenmatch>=1.2.0", "goldenanalysis>=0.1.0"]
 tui = ["textual>=1.0"]
 api = ["fastapi>=0.110", "uvicorn>=0.30"]
 mcp = ["mcp>=1.0"]
@@ -54,6 +58,7 @@ Author = "https://bensevern.dev"
 "goldenflow.transform" = "goldenpipe.adapters.flow:TransformStage"
 "goldenmatch.dedupe" = "goldenpipe.adapters.match:DedupeStage"
 "goldenmatch.identity_resolve" = "goldenpipe.adapters.identity:IdentityResolveStage"
+"goldenanalysis.report" = "goldenpipe.adapters.analysis:AnalysisReportStage"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/python/goldenpipe/tests/test_analysis_stage.py
+++ b/packages/python/goldenpipe/tests/test_analysis_stage.py
@@ -1,0 +1,65 @@
+"""GoldenAnalysis terminal reporting stage (goldenanalysis.report).
+
+The stage is read-only: it attaches an `analysis_report` artifact built from the
+run's accumulated artifacts and never mutates data. The integration cases skip
+cleanly when goldenanalysis isn't installed; the info + guard cases always run.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenpipe.adapters import analysis
+from goldenpipe.adapters.analysis import AnalysisReportStage
+from goldenpipe.models.context import PipeContext, StageStatus
+
+
+def test_stage_info() -> None:
+    info = AnalysisReportStage.info
+    assert info.name == "goldenanalysis.report"
+    assert info.produces == ["analysis_report"]
+    # Only df is hard-required; the rest are read opportunistically (degrade).
+    assert info.consumes == ["df"]
+
+
+def test_validate_requires_goldenanalysis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(analysis, "HAS_ANALYSIS", False)
+    with pytest.raises(RuntimeError, match="goldenanalysis"):
+        AnalysisReportStage().validate(PipeContext())
+
+
+def test_run_attaches_report_from_artifacts() -> None:
+    pytest.importorskip("goldenanalysis")
+    ctx = PipeContext(
+        artifacts={
+            "clusters": {0: {"members": [0], "size": 1}, 1: {"members": [1, 2], "size": 2}},
+            "scored_pairs": [(1, 2, 0.9)],
+            "match_stats": {"total_records": 3, "match_rate": 0.66},
+        },
+        metadata={"source": "customers.parquet"},
+    )
+    result = AnalysisReportStage().run(ctx)
+    assert result.status == StageStatus.SUCCESS
+    report = ctx.artifacts["analysis_report"]
+    keys = {m["key"] for m in report["metrics"]}
+    assert "cluster.count" in keys
+    assert "match.pair_count" in keys
+    assert report["source"]["producer"] == "goldenpipe"
+    # Read-only: nothing else was added to the data artifacts.
+    assert "clusters" in ctx.artifacts  # untouched
+
+
+def test_run_degrades_with_no_artifacts() -> None:
+    pytest.importorskip("goldenanalysis")
+    ctx = PipeContext(metadata={"source": "empty.csv"})
+    result = AnalysisReportStage().run(ctx)
+    # A reporting stage must never break the run: no artifacts -> empty report.
+    assert result.status == StageStatus.SUCCESS
+    assert ctx.artifacts["analysis_report"]["analyzers_run"] == []
+
+
+def test_registered_as_entry_point() -> None:
+    pytest.importorskip("goldenanalysis")
+    from goldenpipe.engine.registry import StageRegistry
+
+    reg = StageRegistry()
+    reg.discover()
+    assert "goldenanalysis.report" in reg.list_all()

--- a/uv.lock
+++ b/uv.lock
@@ -1406,12 +1406,16 @@ agent = [
 all = [
     { name = "aiohttp" },
     { name = "fastapi" },
+    { name = "goldenanalysis" },
     { name = "goldencheck" },
     { name = "goldenflow" },
     { name = "goldenmatch" },
     { name = "mcp" },
     { name = "textual" },
     { name = "uvicorn" },
+]
+analysis = [
+    { name = "goldenanalysis" },
 ]
 api = [
     { name = "fastapi" },
@@ -1432,6 +1436,7 @@ flow = [
     { name = "goldenflow" },
 ]
 golden-suite = [
+    { name = "goldenanalysis" },
     { name = "goldencheck" },
     { name = "goldenflow" },
     { name = "goldenmatch" },
@@ -1450,6 +1455,8 @@ tui = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'agent'", specifier = ">=3.14.0" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.110" },
+    { name = "goldenanalysis", marker = "extra == 'analysis'", editable = "packages/python/goldenanalysis" },
+    { name = "goldenanalysis", marker = "extra == 'golden-suite'", editable = "packages/python/goldenanalysis" },
     { name = "goldencheck", marker = "extra == 'check'", editable = "packages/python/goldencheck" },
     { name = "goldencheck", marker = "extra == 'golden-suite'", editable = "packages/python/goldencheck" },
     { name = "goldencheck-types", editable = "packages/python/goldencheck-types" },
@@ -1474,7 +1481,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.30" },
 ]
-provides-extras = ["check", "flow", "match", "golden-suite", "tui", "api", "mcp", "agent", "all", "dev"]
+provides-extras = ["check", "flow", "match", "analysis", "golden-suite", "tui", "api", "mcp", "agent", "all", "dev"]
 
 [[package]]
 name = "goldensuite-mcp"


### PR DESCRIPTION
Final Phase 5 PR: the optional GoldenPipe terminal reporting stage. Makes "one CLI runs Check → Flow → Match → Identity → **Analysis**" literally true. This completes the GoldenAnalysis roadmap (P1–P5).

## What's here
- **`goldenpipe/adapters/analysis.py:AnalysisReportStage`** — registered as `goldenanalysis.report` at `goldenpipe.stages`. Runs `goldenanalysis.analyze_pipeline` over the run's accumulated artifacts (`clusters` / `scored_pairs` / `match_stats` / `findings` / `manifest` — the SAME keys the upstream stages already surface, so **no remapping**) and attaches an `analysis_report`. **Read-only**: writes only that one artifact, never mutates the data or any store.
- **Robust wiring**: `consumes=["df"]` (always present, so it never fails the resolver), `produces=["analysis_report"]`. Reads clusters/findings/manifest/identity_summary **opportunistically** — `analyze_pipeline` fans out to whatever analyzers' artifacts are present and skips the rest, so the stage works on any pipeline (check-only → just quality.rollup; full dedupe → match.rates + cluster.distribution). Place it **last** in the config to report over everything upstream.
- **Optional + degrades**: ships behind `goldenpipe[analysis]` (+ folded into `golden-suite`); `HAS_ANALYSIS` guard raises a clear install hint when goldenanalysis is absent. A reporting failure returns `FAILED` for the stage but never crashes the run.

## Why `consumes=["df"]` and not the design's literal `["df","clusters","identity_summary"]`
The resolver validates each `consumes` is produced by an **earlier** stage (config order) or raises `WiringError`. Hard-requiring `clusters`/`identity_summary` would break check-only pipelines and pipelines without an identity stage. Consuming only `df` + reading the rest opportunistically matches goldenanalysis's degrade-gracefully philosophy and keeps the stage usable everywhere.

## Test plan
- `tests/test_analysis_stage.py`: stage info; `validate()` raises without goldenanalysis (monkeypatched guard); end-to-end `run()` over a hand-built clusters+scored_pairs+match_stats context attaches a report with `cluster.count` + `match.pair_count` and `source.producer == "goldenpipe"`; no-artifacts degrades to an empty-analyzer report; entry-point registered. Integration cases `importorskip("goldenanalysis")`.
- Verified locally end-to-end: producer=goldenpipe, fans out to `cluster.distribution` + `match.rates`; degrade path → `analyzers_run == []`. `uv lock` resolves the circular *optional* dep (goldenanalysis[pipe] ↔ goldenpipe[analysis]) cleanly. ruff clean.
- CI: `python (goldenpipe)` lane (uv sync --all-packages installs goldenanalysis, so the integration runs, not skips) + CodeQL.

Completes the GoldenAnalysis roadmap: P1 Python core → 2a/2b suite+cross-run → 3a/3b/3c TS port → P4 Rust accelerator → **P5 GoldenPipe stage + MCP + publish**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)