### PR TITLE
bench(goldenanalysis): native A/B harness (Linux) for the P4 gate decision

### DIFF
--- a/.github/workflows/bench-analysis-native.yml
+++ b/.github/workflows/bench-analysis-native.yml
@@ -1,0 +1,58 @@
+name: Bench analysis-native (A/B)
+
+# A/B harness for the GoldenAnalysis native aggregation kernels (histogram /
+# quantile). Builds the abi3 ext into the package + runs the bench at scale,
+# printing pure vs native_raw vs native+conv to the step summary. This is the
+# measurement that decides the _native_loader._GATED_ON flip -- Linux is the
+# target env for goldenanalysis[native] users (the #688 "measure on the target
+# env" lesson). workflow_dispatch only; never runs on push/PR.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch/commit to build + bench (default: the dispatch ref)"
+        required: false
+        default: ""
+      rows:
+        description: "Comma-separated row counts to bench"
+        required: false
+        default: "1000000,10000000"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/analysis-native
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Build the native ext into the package
+        run: uv run python scripts/build_analysis_native.py
+      - name: Bench (pure vs native_raw vs native+conv)
+        env:
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: |
+          {
+            echo '## analysis-native A/B bench (histogram / quantile)'
+            echo ''
+            echo '```'
+            IFS=',' read -ra ROWS <<< "${{ inputs.rows }}"
+            for n in "${ROWS[@]}"; do
+              uv run python packages/python/goldenanalysis/benchmarks/aggregate_benchmark.py --rows "$n"
+              echo ''
+            done
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/packages/python/goldenanalysis/benchmarks/aggregate_benchmark.py
+++ b/packages/python/goldenanalysis/benchmarks/aggregate_benchmark.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 """A/B bench for the GoldenAnalysis native aggregation kernels.
 
-Measures the 5-run median wall of ``histogram`` / ``quantile``, pure-Python vs the
-native ``analysis-native`` kernel, over a large Float64 array. This is the
-measurement that decides the ``_native_loader._GATED_ON`` flip: a primitive joins
-the gated set ONLY after the WALL is shown to move on a real shape.
+Measures the 5-run median wall of ``histogram`` / ``quantile`` over a large array,
+three ways, to decide the ``_native_loader._GATED_ON`` flip:
 
-Don't gate on "it's Rust". The pure ``histogram`` / ``quantile`` are tight Python
-loops, and the native path pays an Arrow-marshalling cost; the goldencheck
-composite-key kernel was *2.5x slower* than the vectorized baseline until it was
-rewritten, and the gate caught it. Run under the native ext (built via
-``scripts/build_analysis_native.py``) so ``native_module()`` resolves; otherwise it
-reports pure-only.
+- ``pure``         -- the pure-Python reference (``core/aggregate``), a Python list in.
+- ``native_raw``   -- the native kernel with the Arrow array ALREADY materialized.
+                      This is the *frames-out ceiling*: what the kernel is worth when
+                      a caller hands it Arrow directly (the #663 columnar world).
+- ``native+conv``  -- the REALISTIC dispatch for the current call convention: a Python
+                      list in, converted to Arrow, then the native kernel. This is what
+                      ``aggregate.histogram`` would pay today (it receives a list).
+
+GATE: flip ``_GATED_ON`` for a primitive ONLY if ``native+conv`` comfortably beats
+``pure``. Don't gate on ``native_raw`` -- the current call sites pass Python lists, so
+the conversion is real. And don't gate on "it's Rust": the pure ``histogram`` is a
+tight loop and ``quantile`` leans on C ``sorted``; the goldencheck composite-key kernel
+was 2.5x SLOWER than its baseline until the gate caught it. Build the ext first
+(``scripts/build_analysis_native.py``); otherwise this reports pure-only.
 
     POLARS_SKIP_CPU_CHECK=1 uv run python \
         packages/python/goldenanalysis/benchmarks/aggregate_benchmark.py --rows 1000000
@@ -19,8 +25,10 @@ reports pure-only.
 from __future__ import annotations
 
 import argparse
+import platform
 import random
 import statistics
+import sys
 import time
 from collections.abc import Callable
 
@@ -47,41 +55,41 @@ def main() -> int:
 
     rng = random.Random(args.seed)
     values = [rng.uniform(-1000.0, 1000.0) for _ in range(args.rows)]
+    print(f"# {platform.system()} {platform.machine()} | python {sys.version.split()[0]}")
     print(f"rows={args.rows:,} bins={args.bins} runs={args.runs}")
 
     nm = None
     arr = None
+    pa = None
     if native_available():
-        import pyarrow as pa
+        import pyarrow as pa  # noqa: F811
 
         arr = pa.array(values, type=pa.float64())
         nm = native_module()
     else:
         print("native ext NOT built -> pure-only (run scripts/build_analysis_native.py to A/B)")
 
-    def _report(name: str, pure: Callable[[], object], native: Callable[[], object]) -> None:
+    def bench(name: str, pure: Callable[[], object], native_on_arr: Callable[[object], object]) -> None:
         pure_ms = _median_wall(pure, args.runs) * 1e3
-        line = f"{name:<10} pure={pure_ms:8.2f} ms"
-        if nm is not None:
-            nat_ms = _median_wall(native, args.runs) * 1e3
-            speedup = pure_ms / nat_ms if nat_ms else float("inf")
-            line += f"  native={nat_ms:8.2f} ms  speedup={speedup:5.2f}x"
+        line = f"{name:<10} pure={pure_ms:9.2f} ms"
+        if nm is not None and pa is not None:
+            raw_ms = _median_wall(lambda: native_on_arr(arr), args.runs) * 1e3
+            conv_ms = _median_wall(
+                lambda: native_on_arr(pa.array(values, type=pa.float64())), args.runs
+            ) * 1e3
+            line += (
+                f"  native_raw={raw_ms:9.2f} ms ({pure_ms / raw_ms:5.2f}x)"
+                f"  native+conv={conv_ms:9.2f} ms ({pure_ms / conv_ms:5.2f}x)"
+            )
         print(line)
 
-    _report(
-        "histogram",
-        lambda: aggregate.histogram(values, args.bins),
-        lambda: nm.histogram(arr, args.bins),
-    )
-    _report(
-        "quantile",
-        lambda: aggregate.quantile(values, 0.95),
-        lambda: nm.quantile(arr, 0.95),
-    )
+    bench("histogram", lambda: aggregate.histogram(values, args.bins), lambda a: nm.histogram(a, args.bins))
+    bench("quantile", lambda: aggregate.quantile(values, 0.95), lambda a: nm.quantile(a, 0.95))
 
     if nm is not None:
-        print("\nGATE: add a primitive to _native_loader._GATED_ON only if its speedup is")
-        print("comfortably > 1x here AND parity holds (tests/core/test_native_parity.py).")
+        print("\nGATE: flip _GATED_ON only if native+conv (Python list in -> the current")
+        print("aggregate.py call convention) comfortably beats pure. native_raw is the")
+        print("frames-out ceiling (Arrow already materialized), NOT the current dispatch.")
     return 0
 
 


### PR DESCRIPTION
The measurement step for the P4 `_GATED_ON` flip. Adds nothing to the runtime path — a bench script + a `workflow_dispatch` harness that never runs on push/PR.

## What's here
- **`benchmarks/aggregate_benchmark.py`** now reports three numbers: `pure`, `native_raw` (Arrow already materialized — the frames-out ceiling), and **`native+conv`** (Python list → Arrow → kernel — the REALISTIC dispatch for `aggregate.py`'s current call convention, since both the pure path and a native dispatch pay the same `[float(v) for v in values if v is not None]` comprehension).
- **`bench-analysis-native.yml`** (`workflow_dispatch`, ubuntu-latest) builds the abi3 ext + prints the table to the step summary. Linux is the target env for `goldenanalysis[native]` users (the #688 "measure on the target env" lesson).

## Why land first, then dispatch
A `workflow_dispatch` workflow must be on the default branch to be dispatchable. Merging this lets me run the bench on main (the P4 kernel is already there) and read the Linux numbers. The actual gate-flip — wiring the dispatch in `aggregate.py` + adding to `_GATED_ON` — only follows **if `native+conv` comfortably beats `pure`** (the goldencheck "measure, the naive kernel LOST" discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)