### PR TITLE
feat(goldenanalysis): P4 gate-flip — histogram + quantile go native (measured 5.8-9.9x on Linux)

### DIFF
--- a/packages/python/goldenanalysis/README.md
+++ b/packages/python/goldenanalysis/README.md
@@ -113,17 +113,20 @@ like `goldenmatch[native]` / `goldencheck[native]`:
 pip install goldenanalysis[native]   # pulls the separate goldenanalysis-native wheel
 ```
 
-The pure-Python/Polars path stays the **default and the byte-identical reference**.
-The compiled kernel (`analysis-core` pyo3-free + `analysis-native` abi3 wheel)
-mirrors `core/aggregate.py`'s `histogram` / `quantile` value-for-value, reading
-input as a Float64 Arrow array (zero-copy). The loader gate
-(`core/_native_loader.py`, `GOLDENANALYSIS_NATIVE=auto|0|1`) only uses a primitive
-once it's in `_GATED_ON` — which is **empty by design**: a primitive is added only
-after `tests/core/test_native_parity.py` proves byte-identical output **and**
-`benchmarks/aggregate_benchmark.py` shows the wall actually moved on a real shape
-(the pure loops are tight and the native path pays an Arrow-marshalling cost, so
-"it's Rust" is not enough). In-tree dev build:
-`uv run python scripts/build_analysis_native.py`.
+The pure-Python path stays the **default and the byte-identical reference**. The
+compiled kernel (`analysis-core` pyo3-free + `analysis-native` abi3 wheel) mirrors
+`core/aggregate.py`'s `histogram` / `quantile` value-for-value, reading input as a
+Float64 Arrow array (zero-copy). The loader gate (`core/_native_loader.py`,
+`GOLDENANALYSIS_NATIVE=auto|0|1`) uses a primitive only once it's in `_GATED_ON` —
+which holds **`histogram` and `quantile`**: both proved byte-identical
+(`tests/core/test_native_parity.py`) **and** measured **5.8–9.9x faster** than the
+pure Python loop on Linux x86_64 at 1M–10M rows, *including* the list→Arrow
+conversion the dispatch pays (`benchmarks/aggregate_benchmark.py` +
+`bench-analysis-native.yml`). A new primitive joins only after the same two gates
+clear — "it's Rust" is never enough (the goldencheck composite-key kernel was 2.5x
+*slower* until the gate caught it). With `goldenanalysis[native]` installed, the
+`auto` default uses the native path automatically; `GOLDENANALYSIS_NATIVE=0` forces
+pure. In-tree dev build: `uv run python scripts/build_analysis_native.py`.
 
 ## License
 

--- a/packages/python/goldenanalysis/goldenanalysis/core/_native_loader.py
+++ b/packages/python/goldenanalysis/goldenanalysis/core/_native_loader.py
@@ -31,10 +31,13 @@ except Exception:  # noqa: BLE001 - any import/load failure falls back below
 
 
 # Components whose native path has cleared parity and may run under
-# ``GOLDENANALYSIS_NATIVE=auto``. EMPTY until Phase 4 — a primitive joins this set
-# only after a parity test proves byte-identical output AND the wall is measured to
-# move (heed the goldenmatch-native footguns in the root CLAUDE.md).
-_GATED_ON: frozenset[str] = frozenset()
+# ``GOLDENANALYSIS_NATIVE=auto``. ``histogram`` / ``quantile`` joined after
+# ``test_native_parity.py`` proved byte-identical output AND the wall was measured to
+# move on the target env: 5.8-9.9x faster than the pure Python loop on Linux x86_64
+# at 1M-10M rows, INCLUDING the list->Arrow conversion the dispatch pays (the
+# ``bench-analysis-native.yml`` A/B harness). A new primitive joins only after the
+# same two gates clear (heed the goldenmatch-native footguns in the root CLAUDE.md).
+_GATED_ON: frozenset[str] = frozenset({"histogram", "quantile"})
 
 
 def native_module() -> Any:

--- a/packages/python/goldenanalysis/goldenanalysis/core/aggregate.py
+++ b/packages/python/goldenanalysis/goldenanalysis/core/aggregate.py
@@ -1,8 +1,15 @@
 """Pure-Python/Polars aggregation primitives.
 
-This module is the **byte-identical reference** for the optional Rust accelerator
-(``analysis-core``, Phase 4). Keep it deterministic: stable bin edges, no reliance
-on float-key dict ordering, linear-interpolation quantiles (numpy default).
+The ``_*_pure`` helpers are the **byte-identical reference** for the optional Rust
+accelerator (``analysis-core``, Phase 4). Keep them deterministic: stable bin edges,
+no reliance on float-key dict ordering, linear-interpolation quantiles (numpy
+default).
+
+``histogram`` / ``quantile`` dispatch to the native kernel when it has cleared the
+gate (``_native_loader._GATED_ON``); both were measured **5.8-9.9x faster** than the
+pure Python loop on Linux x86_64 at 1M-10M rows, INCLUDING the list->Arrow conversion
+(see ``benchmarks/aggregate_benchmark.py`` + ``bench-analysis-native.yml``). The
+native output is byte-identical to ``_*_pure`` (``tests/core/test_native_parity.py``).
 """
 
 from __future__ import annotations
@@ -10,6 +17,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import polars as pl
+
+from goldenanalysis.core._native_loader import native_enabled, native_module
 
 
 def null_ratio_per_column(df: pl.DataFrame) -> dict[str, float]:
@@ -38,7 +47,15 @@ def histogram(values: Sequence[float], bins: int) -> list[tuple[float, int]]:
     Returns ``[(left_edge, count), ...]`` with ``bins`` entries. The right edge is
     inclusive (the max lands in the last bin). All-equal input collapses to a
     single ``[(value, count)]`` bin. Empty input or ``bins < 1`` => ``[]``.
+
+    Dispatches to the native kernel when gated (byte-identical to ``_histogram_pure``).
     """
+    if native_enabled("histogram"):
+        return _histogram_native(values, bins)
+    return _histogram_pure(values, bins)
+
+
+def _histogram_pure(values: Sequence[float], bins: int) -> list[tuple[float, int]]:
     vals = [float(v) for v in values if v is not None]
     if not vals or bins < 1:
         return []
@@ -55,8 +72,26 @@ def histogram(values: Sequence[float], bins: int) -> list[tuple[float, int]]:
     return [(lo + i * width, counts[i]) for i in range(bins)]
 
 
+def _histogram_native(values: Sequence[float], bins: int) -> list[tuple[float, int]]:
+    import pyarrow as pa
+
+    vals = [float(v) for v in values if v is not None]
+    arr = pa.array(vals, type=pa.float64())
+    # pyo3 returns a list of (float, int) tuples -- the same shape as the pure path.
+    return native_module().histogram(arr, bins)
+
+
 def quantile(values: Sequence[float], q: float) -> float:
-    """Linear-interpolation quantile (numpy default). Empty input => 0.0."""
+    """Linear-interpolation quantile (numpy default). Empty input => 0.0.
+
+    Dispatches to the native kernel when gated (byte-identical to ``_quantile_pure``).
+    """
+    if native_enabled("quantile"):
+        return _quantile_native(values, q)
+    return _quantile_pure(values, q)
+
+
+def _quantile_pure(values: Sequence[float], q: float) -> float:
     vals = sorted(float(v) for v in values if v is not None)
     if not vals:
         return 0.0
@@ -68,3 +103,11 @@ def quantile(values: Sequence[float], q: float) -> float:
     if lo_idx + 1 < len(vals):
         return vals[lo_idx] + (vals[lo_idx + 1] - vals[lo_idx]) * frac
     return vals[lo_idx]
+
+
+def _quantile_native(values: Sequence[float], q: float) -> float:
+    import pyarrow as pa
+
+    vals = [float(v) for v in values if v is not None]
+    arr = pa.array(vals, type=pa.float64())
+    return native_module().quantile(arr, q)

--- a/packages/python/goldenanalysis/tests/core/test_native_parity.py
+++ b/packages/python/goldenanalysis/tests/core/test_native_parity.py
@@ -1,7 +1,9 @@
 """Parity: the native ``histogram`` / ``quantile`` kernels must produce
-byte-identical output to the pure-Python reference in
-``goldenanalysis.core.aggregate``. This is the gate that lets a primitive sit in
-``_native_loader._GATED_ON`` (run under ``GOLDENANALYSIS_NATIVE=auto``).
+byte-identical output to the pure-Python reference (``aggregate._*_pure``). This is
+the gate that let them sit in ``_native_loader._GATED_ON`` (run under
+``GOLDENANALYSIS_NATIVE=auto``). The reference is the ``_*_pure`` helpers, NOT the
+public ``aggregate.histogram`` / ``quantile`` -- those now DISPATCH to native when
+gated, so comparing against them would be native-vs-native.
 
 Skips cleanly when the native extension isn't built (pure-Python-only env). The
 loader-gate tests at the bottom run WITHOUT the wheel (they don't import polars).
@@ -23,30 +25,28 @@ native_only = pytest.mark.skipif(
 )
 
 
-def _f64(values):
+def _f64(values: list):
     import pyarrow as pa
 
     return pa.array(values, type=pa.float64())
 
 
-def _assert_histogram_parity(values, bins) -> None:
+def _assert_histogram_parity(values: list, bins: int) -> None:
     from goldenanalysis.core import aggregate
 
     native = native_module().histogram(_f64(values), bins)
-    pure = aggregate.histogram(values, bins)
-    assert native == pure
+    assert native == aggregate._histogram_pure(values, bins)
 
 
-def _assert_quantile_parity(values, q) -> None:
+def _assert_quantile_parity(values: list, q: float) -> None:
     from goldenanalysis.core import aggregate
 
     native = native_module().quantile(_f64(values), q)
-    pure = aggregate.quantile(values, q)
-    assert native == pure
+    assert native == aggregate._quantile_pure(values, q)
 
 
 # ---------------------------------------------------------------------------
-# Parity (native present)
+# Parity (native present) -- native kernel vs the pure reference helpers
 # ---------------------------------------------------------------------------
 
 
@@ -88,12 +88,12 @@ def test_parity_adversarial_magnitudes() -> None:
 def test_parity_drops_nulls() -> None:
     # Null slots must be dropped (their backing f64 is undefined), matching the
     # pure path which only sees the non-null values.
-    arr = _f64([1.5, None, 200.0, None, 9.9, None])
-    non_null = [1.5, 200.0, 9.9]
     from goldenanalysis.core import aggregate
 
-    assert native_module().histogram(arr, 10) == aggregate.histogram(non_null, 10)
-    assert native_module().quantile(arr, 0.5) == aggregate.quantile(non_null, 0.5)
+    arr = _f64([1.5, None, 200.0, None, 9.9, None])
+    non_null = [1.5, 200.0, 9.9]
+    assert native_module().histogram(arr, 10) == aggregate._histogram_pure(non_null, 10)
+    assert native_module().quantile(arr, 0.5) == aggregate._quantile_pure(non_null, 0.5)
 
 
 @native_only
@@ -102,6 +102,25 @@ def test_parity_empty_and_all_equal() -> None:
     _assert_quantile_parity([], 0.5)
     _assert_histogram_parity([2.0, 2.0, 2.0], 4)
     _assert_quantile_parity([7.0], 0.5)
+
+
+@native_only
+@pytest.mark.parametrize("seed", range(4))
+def test_public_dispatch_matches_pure(monkeypatch: pytest.MonkeyPatch, seed: int) -> None:
+    """The PUBLIC ``aggregate.histogram`` / ``quantile`` dispatch (native, gated, =1)
+    is byte-identical to the pure path (=0) -- the end-to-end gate guarantee."""
+    from goldenanalysis.core import aggregate
+
+    rng = random.Random(seed)
+    values = [rng.uniform(-100.0, 1000.0) for _ in range(5000)]
+
+    monkeypatch.setenv("GOLDENANALYSIS_NATIVE", "1")  # force native dispatch
+    native_hist = aggregate.histogram(values, 10)
+    native_q = aggregate.quantile(values, 0.95)
+
+    monkeypatch.setenv("GOLDENANALYSIS_NATIVE", "0")  # force pure
+    assert native_hist == aggregate.histogram(values, 10)
+    assert native_q == aggregate.quantile(values, 0.95)
 
 
 # ---------------------------------------------------------------------------
@@ -117,12 +136,13 @@ def test_disabled_env_forces_python(monkeypatch: pytest.MonkeyPatch) -> None:
     assert native_enabled("quantile") is False
 
 
-def test_auto_with_empty_gated_on_uses_python(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_GATED_ON is empty until a wall-verified flip, so `auto` is always pure --
-    even when a wheel is importable."""
+def test_auto_gates_histogram_and_quantile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """histogram/quantile are gated, so under `auto` they use native iff a wheel is
+    importable. A non-gated component always stays pure."""
     monkeypatch.setenv("GOLDENANALYSIS_NATIVE", "auto")
-    assert native_enabled("histogram") is False
-    assert native_enabled("quantile") is False
+    assert native_enabled("histogram") is native_available()
+    assert native_enabled("quantile") is native_available()
+    assert native_enabled("frame.row_count") is False  # not in _GATED_ON
 
 
 @pytest.mark.skipif(native_available(), reason="wheel present -> =1 does not raise")

--- a/packages/python/goldenanalysis/tests/test_native_loader.py
+++ b/packages/python/goldenanalysis/tests/test_native_loader.py
@@ -1,4 +1,4 @@
-"""Native-loader gate contract (Phase 1: pure fallback, _GATED_ON empty)."""
+"""Native-loader gate contract (pure fallback; histogram/quantile gated since P4)."""
 
 from __future__ import annotations
 
@@ -26,5 +26,7 @@ def test_require_native_raises_when_absent(monkeypatch: pytest.MonkeyPatch) -> N
             nl.native_enabled("anything")
 
 
-def test_gated_on_is_empty() -> None:
-    assert nl._GATED_ON == frozenset()
+def test_gated_on_holds_the_measured_primitives() -> None:
+    # histogram + quantile joined _GATED_ON after the P4 measured flip (5.8-9.9x on
+    # Linux, byte-identical parity). A new primitive joins only after the same gates.
+    assert nl._GATED_ON == frozenset({"histogram", "quantile"})


### PR DESCRIPTION
The measured `_GATED_ON` flip the P4 scaffold was built for. The bench harness (#820) ran on ubuntu-latest and the data was decisive.

## The measurement (`bench-analysis-native.yml`, Linux x86_64)
`native+conv` is the **realistic dispatch** — Python list → Arrow → native kernel, exactly what `aggregate.py` receives (both pure and native pay the same `[float(v) ...]` comprehension, so the honest comparison is bucket-loop / C-`sorted` vs Arrow-build + Rust-kernel):

| | 1M rows | 10M rows |
|---|---|---|
| histogram | pure 197ms → **native+conv 20ms (9.9x)** | pure 1911ms → **209ms (9.2x)** |
| quantile | pure 303ms → **native+conv 53ms (5.8x)** | pure 3962ms → **604ms (6.6x)** |

`pyarrow.array()` conversion is far cheaper than the pure-Python loops, so native wins big **even including the conversion**. My initial worry (that the shared comprehension would wash out the gain) was wrong — measured, not reasoned. Both `histogram` (match.rates' score histogram) and `quantile` (cluster.distribution's size quantiles) are real hot paths over millions of pairs/clusters.

## The flip
- `aggregate.histogram`/`quantile` now **dispatch** to the native kernel when `native_enabled()`; the pure logic moves to `_histogram_pure`/`_quantile_pure` (the byte-identical reference).
- `_GATED_ON = {"histogram", "quantile"}` — under `auto` with the wheel, both run native; `GOLDENANALYSIS_NATIVE=0` forces pure; **no behavior change without the wheel** (`auto` → `native_enabled` False → pure).
- Parity test now references the `_*_pure` helpers (not the dispatching public fns), plus a new `test_public_dispatch_matches_pure` asserting the public dispatch (`=1`) is byte-identical to pure (`=0`) end-to-end.

## Test plan
- Local: ruff clean; pure fallback verified (no wheel → pure path intact, public == `_*_pure`).
- CI: the `goldenanalysis_native` lane builds the abi3 wheel + runs the parity suite (native vs `_*_pure`) + the end-to-end dispatch test under `GOLDENANALYSIS_NATIVE=1` — proving byte-identical on Linux. The `python (goldenanalysis)` matrix lane (no wheel) exercises the pure-fallback gate tests.

This closes the last open GoldenAnalysis item: the Rust accelerator is now **live**, not just scaffolded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)