### PR TITLE
docs(goldenanalysis): document GoldenAnalysis in the Mintlify suite docs

### DIFF
--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -69,9 +69,9 @@ The suite is a single monorepo:
 
 ```text
 packages/
-├── python/       goldenmatch, goldencheck, goldenflow, goldenpipe, infermap, goldensuite-mcp
-├── typescript/   goldenmatch, goldencheck, goldenflow, infermap
-├── rust/         extensions (Postgres pgrx + DuckDB UDFs)
+├── python/       goldenmatch, goldencheck, goldenflow, goldenpipe, goldenanalysis, infermap, goldensuite-mcp
+├── typescript/   goldenmatch, goldencheck, goldenflow, goldenanalysis, infermap
+├── rust/         extensions (Postgres pgrx + DuckDB UDFs, incl. analysis-core/native)
 ├── dbt/          dbt-goldencheck
 └── actions/      goldencheck GitHub Action
 examples/         Python, TypeScript, and Airflow DAG demos

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -104,6 +104,14 @@
             ]
           },
           {
+            "group": "GoldenAnalysis",
+            "pages": [
+              "goldenanalysis/overview",
+              "goldenanalysis/cross-run",
+              "goldenanalysis/native"
+            ]
+          },
+          {
             "group": "InferMap",
             "pages": [
               "infermap/overview"

--- a/docs-site/goldenanalysis/cross-run.mdx
+++ b/docs-site/goldenanalysis/cross-run.mdx
@@ -1,0 +1,75 @@
+---
+title: "Cross-run analysis"
+description: "Trend metrics across a run history and flag regressions versus a baseline, with a deterministic narrative."
+keywords: ["goldenanalysis", "cross-run", "trend", "regression detection", "report history", "drift"]
+---
+
+A single report tells you about one run. The cross-run layer answers "how did this run compare to last week?" — trend, drift, and regression detection over a stored history of reports.
+
+## ReportHistory
+
+`ReportHistory` is an append-only store of `AnalysisReport`s, keyed by `(analysis_name, dataset, run_id)`. It defaults to **JSONL** (a reports log is the natural fit) with **SQLite** optional — both stdlib, no new dependencies.
+
+```python
+from goldenanalysis import ReportHistory
+
+hist = ReportHistory(path=".golden/analysis.jsonl")   # backend inferred from suffix
+hist.append(report)                                    # after each run
+
+series = hist.trend("cluster.singleton_ratio", "customers", last_n=30)
+flagged = hist.detect_regressions("customers")
+```
+
+## Regression detection
+
+Regression flags are **direction-aware** and **per-metric**. The baseline is a *strategy*, not just "the previous value":
+
+- `rolling_median` (default) — the median of the last *window* runs; immune to one noisy night, where `previous` would alternately flag and un-flag.
+- `previous` / `last_known_good` — the most recent historical value.
+- a pinned `run_id`.
+
+Thresholds come from a `RegressionPolicy` and respect each metric's `direction`: a `higher_better` metric (recall) flags only on a **drop**, a `lower_better` metric (finding counts) only on a **rise**, `neutral` either way.
+
+```python
+from goldenanalysis import RegressionPolicy
+
+policy = RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+flagged = hist.detect_regressions("customers", baseline="rolling_median", policy=policy)
+```
+
+The worked example: a per-metric **2% gate on `match.recall_safe_bound`** catches a 0.97 → 0.89 recall drop that a global 10% gate would miss — exactly the kind of quiet quality regression a nightly pipeline should alert on.
+
+## Narrative
+
+`build_narrative(report, regressions)` produces a deterministic, ASCII-clean one-paragraph summary: it names the largest-magnitude flagged regression, lists co-moving metrics across analyzers, and surfaces the most common quality finding. Because root cause is often only visible by crossing analyzers, the narrative sees the full metric set.
+
+## CLI
+
+```bash
+# trend one metric across the run history
+goldenanalysis trend --metric cluster.singleton_ratio --dataset customers \
+  --history .golden/analysis.jsonl
+
+# detect regressions vs a baseline; exit 1 on any flag (a CI gate)
+goldenanalysis regressions --dataset customers --history .golden/analysis.jsonl \
+  --policy "match.recall_safe_bound=2" --fail-on-regression
+```
+
+<Note>
+  `--fail-on-regression` makes GoldenAnalysis a drop-in nightly-pipeline gate: store a report after each run, then fail the job when a direction-aware, per-metric threshold trips.
+</Note>
+
+## TypeScript
+
+The cross-run layer is ported to TypeScript too. The decision logic (`detectRegressions`, `buildTrend`, `buildNarrative`) is edge-safe in `goldenanalysis/core`; the file-backed `ReportHistory` (JSONL) lives in `goldenanalysis/node`.
+
+```ts
+import { ReportHistory } from "goldenanalysis/node";
+
+const hist = new ReportHistory({ path: ".golden/analysis.jsonl" });
+hist.append(report);
+const flagged = hist.detectRegressions("customers", {
+  baseline: "rolling_median",
+  policy: { defaultPct: 10, perMetric: { "match.recall_safe_bound": 2 } },
+});
+```

--- a/docs-site/goldenanalysis/native.mdx
+++ b/docs-site/goldenanalysis/native.mdx
@@ -1,0 +1,38 @@
+---
+title: "Native accelerator"
+description: "An optional Rust kernel for the heavy aggregation primitives, gated only after a measured wall-clock win."
+keywords: ["goldenanalysis", "native", "rust", "pyo3", "histogram", "quantile", "performance"]
+---
+
+The heavy aggregation primitives — `histogram` and `quantile`, run over the score and cluster-size arrays of large results — have an optional Rust kernel, gated exactly like `goldenmatch[native]` / `goldencheck[native]`.
+
+```bash
+pip install goldenanalysis[native]   # pulls the separate goldenanalysis-native wheel
+```
+
+The pure-Python path stays the **default and the byte-identical reference**. The compiled kernel (`analysis-core`, a pyo3-free crate, plus the `analysis-native` abi3 wheel) mirrors `core/aggregate.py` value-for-value, reading input as a Float64 Arrow array (zero-copy). With the wheel installed, `GOLDENANALYSIS_NATIVE=auto` (the default) uses the native path automatically; `GOLDENANALYSIS_NATIVE=0` forces pure.
+
+## Gate on the measured wall, not "it's Rust"
+
+A primitive is used only once it is in `_native_loader._GATED_ON`, which it joins after **two** gates clear: a parity test proves byte-identical output, **and** the wall-clock is measured to actually move on the target environment. The pure loops are tight, and the native path pays a list→Arrow conversion cost, so "it's compiled" is never enough — the goldencheck composite-key kernel was once 2.5x *slower* than its baseline, and the gate caught it.
+
+`histogram` and `quantile` cleared both gates. The A/B harness (`bench-analysis-native.yml`, on Linux x86_64) measured the **realistic dispatch** — a Python list converted to Arrow, then the kernel, exactly what the call sites pay:
+
+| Primitive | 1M rows | 10M rows |
+|-----------|---------|----------|
+| `histogram` | 9.9x faster | 9.2x faster |
+| `quantile` | 5.8x faster | 6.6x faster |
+
+The Arrow conversion turns out to be far cheaper than the pure-Python loops, so the native path wins decisively even including it.
+
+## How it stays honest
+
+- **Two crates, mirrored.** `analysis-core` (pyo3-free) holds the kernel logic so it can later back a SQL surface; `analysis-native` is the thin abi3 PyO3 + Arrow shim over it.
+- **Parity is a CI gate.** A dedicated lane builds the wheel and runs the parity suite under `GOLDENANALYSIS_NATIVE=1`, including an end-to-end test that the public `aggregate.histogram` / `quantile` dispatch is byte-identical to the pure path.
+- **No behavior change without the wheel.** With no native extension installed, `auto` resolves to the pure path; results are identical whether or not native is present.
+
+In-tree dev build (no maturin needed):
+
+```bash
+uv run python scripts/build_analysis_native.py
+```

--- a/docs-site/goldenanalysis/overview.mdx
+++ b/docs-site/goldenanalysis/overview.mdx
@@ -1,0 +1,127 @@
+---
+title: "GoldenAnalysis overview"
+description: "Read-only, cross-cutting analysis, metrics, and reporting across the Golden Suite. Consumes any stage's artifacts and emits one unified report."
+keywords: ["goldenanalysis", "analysis", "metrics", "reporting", "regression detection", "cross-run"]
+---
+
+GoldenAnalysis is the suite's read-only **analysis, metrics, and reporting** layer. It sits *beside* the pipeline rather than inside it: it consumes the typed artifacts any other package produces (a GoldenMatch dedupe result, a GoldenCheck scan, a GoldenFlow manifest, a whole GoldenPipe run) and emits one unified, comparable, exportable `AnalysisReport`. It never transforms data, mutates a store, or makes a pipeline decision.
+
+It answers questions *about* a run that previously meant hand-writing a notebook against each package's bespoke output: "what was the match rate?", "how did the cluster-size distribution shift versus last week?", "did quality-finding counts regress after the GoldenFlow rule change?", "roll all five stage outputs into one report for the data steward."
+
+## Install
+
+```bash
+pip install goldenanalysis              # the generic frame path; zero suite deps
+pip install goldenanalysis[suite]       # + adapters for match/check/flow/pipe
+pip install goldenanalysis[native]      # + the Rust accelerator (histogram/quantile)
+pip install goldenanalysis[mcp]         # + the MCP server
+```
+
+The generic path works on any Polars DataFrame even with no other Golden package installed.
+
+## Quickstart
+
+Analyze a frame directly:
+
+```python
+from goldenanalysis import analyze
+
+report = analyze(df, analyzers=["frame.summary"], dataset="customers")
+print(report.to_markdown())
+report.metrics   # row_count, column_count, null_ratio_mean, duplicate_row_ratio, ...
+```
+
+Or analyze a producer's result and let the right analyzers fan out:
+
+```python
+import goldenanalysis as ga
+
+# A GoldenMatch dedupe result -> match.rates + cluster.distribution
+report = ga.analyze_match(dedupe_result, dataset="customers")
+
+# A whole GoldenPipe run -> every analyzer whose artifacts are present
+report = ga.analyze_pipeline(pipe_result)
+```
+
+On the CLI:
+
+```bash
+goldenanalysis report customers.parquet              # analyze a frame
+goldenanalysis report report.json --format markdown  # re-render a saved report
+```
+
+## Analyzers
+
+Analyzers are a registry (mirroring GoldenPipe's stage entry-points). Each computes a typed `Metric` set plus optional tables, and **degrades gracefully** — it emits what its present artifacts support and records what it could not compute in `report.source`.
+
+| Analyzer | Consumes | Emits |
+|----------|----------|-------|
+| `frame.summary` | a generic frame | row/column counts, null-ratio mean, duplicate-row ratio, a `per_column` table |
+| `match.rates` | `scored_pairs`, `match_stats` (+ a recall certificate) | pair count, match rate, threshold, recall estimate + safe bound, mean score, a score histogram |
+| `cluster.distribution` | `clusters` | cluster count, singleton ratio, size p50/p95/max, reduction ratio, a size histogram |
+| `quality.rollup` | `findings`, `manifest` (+ a profile) | findings total, columns-with-findings, a health score, GoldenFlow rows-changed / rules-fired, a `findings_by_class` table |
+
+The **recall certificate** is a first-class input: `match.rates` emits `recall_safe_bound`, the alerting metric for unsupervised runs. Attach it with `dedupe_df(..., certify=True)`.
+
+## The report
+
+Every analyze entrypoint returns one `AnalysisReport`:
+
+```python
+report.schema_version   # cross-surface contract anchor
+report.run_id
+report.source           # {"dataset": ..., "producer": ..., "unavailable": ...}
+report.metrics          # list[Metric] — key, value, unit, direction
+report.tables           # list[AnalysisTable]
+report.narrative        # one-paragraph NL summary (cross-run)
+report.analyzers_run    # which analyzers actually ran
+report.to_markdown()    # / .to_json()
+```
+
+`AnalysisReport` / `Metric` are **wire types** kept in `snake_case` on every surface, so a report crosses the JSON wire between Python and TypeScript without remapping.
+
+## GoldenCheck vs GoldenAnalysis
+
+They are easy to confuse and deliberately distinct:
+
+| | GoldenCheck | GoldenAnalysis |
+|---|---|---|
+| **Scope** | Profiles a *single input dataset at ingest* | *Cross-cutting* over any stage's outputs |
+| **Direction** | A **producer** of artifacts (scan findings) | A **consumer** of artifacts (including GoldenCheck's) |
+| **Across runs?** | No — one dataset, one scan | Yes — trend / drift / regression over a run history |
+| **Writes data?** | Suggests/applies fixes | **Never** — read-only by construction |
+
+The hard line: **GoldenAnalysis depends on other packages' types; never the reverse.**
+
+## More
+
+<CardGroup cols={2}>
+  <Card title="Cross-run analysis" icon="chart-line" href="/goldenanalysis/cross-run">
+    Trend metrics over a run history and detect regressions vs a baseline.
+  </Card>
+  <Card title="Native accelerator" icon="bolt" href="/goldenanalysis/native">
+    The optional Rust kernel for the heavy aggregation primitives.
+  </Card>
+</CardGroup>
+
+## In a GoldenPipe run
+
+Register the read-only `goldenanalysis.report` terminal stage so one pipeline runs Check → Flow → Match → Identity → **Analysis**:
+
+```bash
+pip install goldenpipe[analysis]
+```
+
+The stage runs `analyze_pipeline` over the run's accumulated artifacts and attaches an `analysis_report`. It writes nothing back to the data.
+
+## TypeScript
+
+`goldenanalysis` ships a TypeScript port (`goldenanalysis` on npm) with the same `AnalysisReport` wire types, the frame analyzer, the suite analyzers, and the cross-run layer. The core is edge-safe (no `node:` imports); file-backed `ReportHistory` lives in the Node entry.
+
+```ts
+import { analyze, analyzeMatch, analyzePipeline, toMarkdown } from "goldenanalysis";
+```
+
+## MCP
+
+`goldenanalysis mcp-serve` exposes four read-only tools — `list_analyzers`, `analyze_frame`, `get_trend`, `detect_regressions` — and they surface transitively through the aggregated `goldensuite-mcp` server.

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -42,6 +42,7 @@ flowchart LR
 | [GoldenFlow](/goldenflow/overview) | Standardize and transform. Phone, date, address, categorical normalization. |
 | [GoldenMatch](/goldenmatch/overview) | Dedupe, cluster, and survivorship. Fuzzy, exact, probabilistic, and LLM scoring. |
 | [GoldenPipe](/goldenpipe/overview) | Orchestrator. Wires the tools into one adaptive pipeline. |
+| [GoldenAnalysis](/goldenanalysis/overview) | Cross-cutting reporting. Read-only metrics, trend, and regression detection over any stage's outputs. |
 
 ## Packages
 
@@ -57,6 +58,9 @@ flowchart LR
   </Card>
   <Card title="GoldenPipe" icon="diagram-project" href="/goldenpipe/overview">
     One call to chain Check, Flow, and Match.
+  </Card>
+  <Card title="GoldenAnalysis" icon="chart-line" href="/goldenanalysis/overview">
+    Read-only metrics, trend, and regression reporting over any run.
   </Card>
   <Card title="InferMap" icon="arrows-left-right" href="/infermap/overview">
     Inference-driven schema mapping with confidence scores.


### PR DESCRIPTION
Adds the 6th package to the public Mintlify docs (`docs-site/`). GoldenAnalysis shipped across P1–P5 + the native gate-flip but had no docs page.

## What's here
- **`docs-site/goldenanalysis/overview.mdx`** — what it is (read-only, cross-cutting), install/extras, `analyze` / `analyze_match` / `analyze_pipeline`, the analyzer table, the `AnalysisReport` wire type, the **GoldenCheck vs GoldenAnalysis** distinction, the GoldenPipe terminal stage, TypeScript, and MCP.
- **`docs-site/goldenanalysis/cross-run.mdx`** — `ReportHistory`, `trend`, direction-aware per-metric regression detection (the 2%-recall-gate worked example), the narrative, the `--fail-on-regression` CI gate, and the TS port.
- **`docs-site/goldenanalysis/native.mdx`** — the optional Rust accelerator and the *measured* gate: the Linux A/B numbers (histogram 9.2–9.9x, quantile 5.8–6.6x) and the "gate on the wall, not 'it's Rust'" discipline.
- **Nav + landing**: a GoldenAnalysis group in `docs.json`; a tools-table row + Packages card on `index.mdx`; the `goldenanalysis` Python/TS packages + `analysis-core`/`analysis-native` crates added to the architecture repo-layout.

## Test plan
- `docs.json` is valid JSON; all 72 nav page IDs resolve to `.mdx` files (the 3 new pages included); the cross-link targets (`/goldenanalysis/{overview,cross-run,native}`) all exist.
- Docs-only change to `docs-site/` — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)