### PR TITLE
feat(bench): Splink-hand-rolled vs GoldenMatch-autoconfig bake-off (accuracy + perf)

### DIFF
--- a/.github/workflows/bench-probabilistic.yml
+++ b/.github/workflows/bench-probabilistic.yml
@@ -35,6 +35,11 @@ on:
         type: boolean
         required: false
         default: false
+      run_bakeoff:
+        description: "Run the 3-engine bake-off lane (gm_zeroconfig + gm_probabilistic + Splink)"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -151,4 +156,63 @@ jobs:
             prob_panel_v1/
             prob_panel_v2/
             compare/
+          retention-days: 90
+
+  # ── 3-engine bake-off lane ────────────────────────────────────────────────
+  # Runs scripts/bench_er_headtohead/run_bakeoff.py: gm_zeroconfig +
+  # gm_probabilistic + a hand-rolled Splink spec, scored by the SAME evaluator,
+  # across 4 datasets (historical_50k, febrl3, synthetic_person, dblp_acm).
+  # Each engine is a subprocess (run_bakeoff already passes --allow-pure-python
+  # to the GM side, so no native build is needed). Measurement lane only — not a
+  # gate. Toggled by the run_bakeoff input; the toggle takes effect once this
+  # workflow is on the default branch.
+  bake-off:
+    if: ${{ inputs.run_bakeoff }}
+    runs-on: large-new-64GB
+    timeout-minutes: 180
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install goldenmatch[bench] (pulls splink + duckdb + pyarrow)
+        run: pip install -e packages/python/goldenmatch[bench]
+
+      - name: Install recordlinkage (for the febrl3 dataset loader)
+        run: pip install recordlinkage
+
+      # DBLP-ACM is gitignored; fetch the Leipzig benchmark best-effort. On any
+      # failure the bake-off records dblp_acm as skipped (never fatal), so the
+      # lane still measures the other datasets.
+      - name: Fetch DBLP-ACM (Leipzig, best-effort)
+        continue-on-error: true
+        run: |
+          DEST=packages/python/goldenmatch/tests/benchmarks/datasets/DBLP-ACM
+          mkdir -p "$DEST"
+          if curl -fsSL --retry 3 -o /tmp/dblp-acm.zip https://dbs.uni-leipzig.de/file/DBLP-ACM.zip; then
+            mkdir -p /tmp/dblp-acm && unzip -o /tmp/dblp-acm.zip -d /tmp/dblp-acm
+            for f in DBLP2.csv ACM.csv DBLP-ACM_perfectMapping.csv; do
+              found=$(find /tmp/dblp-acm -name "$f" | head -1)
+              if [ -n "$found" ]; then cp "$found" "$DEST/$f"; else echo "::warning::DBLP-ACM file $f not in archive"; fi
+            done
+            ls -la "$DEST"
+          else
+            echo "::warning::DBLP-ACM download failed; dblp_acm will be skipped in the bake-off"
+          fi
+
+      - name: Run bake-off
+        run: python scripts/bench_er_headtohead/run_bakeoff.py --out-dir bakeoff_out
+
+      - name: Upload bake-off results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bakeoff
+          path: |
+            bakeoff_out/bakeoff.md
+            bakeoff_out/bakeoff.json
           retention-days: 90

--- a/scripts/bench_er_headtohead/run_bakeoff.py
+++ b/scripts/bench_er_headtohead/run_bakeoff.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python
+"""Unified accuracy+perf bake-off orchestrator for the ER head-to-head.
+
+Runs THREE engines per benchmark dataset on one machine and emits a single
+comparison table (bakeoff.md / bakeoff.json):
+
+  * gm_zeroconfig    -- GoldenMatch's zero-config controller (auto_configure_df)
+  * gm_probabilistic -- GoldenMatch's Fellegi-Sunter probabilistic auto-config
+  * splink           -- a hand-rolled Splink spec (compound blocking + EM)
+
+Each engine runs as a SUBPROCESS (run_goldenmatch.py / run_splink.py), so the OS
+reclaims its memory on exit and one engine's failure can never poison another's
+measurement. Both GoldenMatch modes write STRING-record_id predictions; Splink
+writes real-record_id predictions. All three are scored by the SAME evaluator
+(evaluate.evaluate), so accuracy numbers are directly comparable.
+
+Robustness contract (mirrors run_panel.py): a missing dataset/dep, a refused
+config, a non-zero exit, or a subprocess timeout becomes a `skipped`/`refused`/
+`error`/`timeout` row -- NEVER fatal to the whole bake-off.
+
+build_rows() and render_md() are PURE assembly functions (no I/O) so the table
+math + null-tolerant formatting are unit-testable against stubbed engine
+results, independent of the live engines.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+RUN_GM = _HERE / "run_goldenmatch.py"
+RUN_SPLINK = _HERE / "run_splink.py"
+
+ENGINES = ["gm_zeroconfig", "gm_probabilistic", "splink"]
+DATASETS = ["historical_50k", "febrl3", "synthetic_person", "dblp_acm"]
+
+# Maps a GoldenMatch bake-off engine name to run_goldenmatch.py's --mode value.
+_GM_MODE = {"gm_zeroconfig": "zeroconfig", "gm_probabilistic": "probabilistic"}
+
+# Generous per-engine subprocess cap; Splink EM + clustering and the GM
+# zero-config controller can be slow on a shared runner. A timeout records
+# `timeout`, never hangs the bake-off.
+_ENGINE_TIMEOUT_S = 3600
+
+
+def _import_sibling(name: str):
+    """Import a sibling bench module whether run as a script or imported."""
+    if str(_HERE) not in sys.path:
+        sys.path.insert(0, str(_HERE))
+    try:
+        return __import__(name)
+    except ImportError:
+        path = _HERE / f"{name}.py"
+        spec = importlib.util.spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+
+def build_rows(
+    per_engine_results: dict[str, dict[str, tuple[dict, dict | None]]],
+) -> list[dict]:
+    """Flatten per-(dataset, engine) (result, metrics) tuples into table rows.
+
+    PURE function -- no I/O. `per_engine_results` is
+        {dataset: {engine: (result_dict, metrics_dict|None)}}
+    where result_dict carries at least `status` plus optional perf fields
+    (dedupe_wall_seconds, peak_rss_mb, scored_pairs, rows) and metrics_dict is
+    the evaluate.evaluate output (or None for skipped/refused/error/timeout).
+
+    Each row:
+        {dataset, engine, status, precision, recall, f1, bcubed_f1,
+         dedupe_wall_seconds, peak_rss_mb, scored_pairs,
+         throughput_pairs_per_s, rows}
+
+    throughput_pairs_per_s = round(scored_pairs / wall) only when BOTH are
+    present and wall > 0, else None. Accuracy fields are None when metrics is
+    None. peak_rss_mb=None is tolerated verbatim (Windows has no rusage).
+    """
+    rows: list[dict] = []
+    for dataset, engines in per_engine_results.items():
+        for engine, (result, metrics) in engines.items():
+            result = result or {}
+            wall = result.get("dedupe_wall_seconds")
+            scored_pairs = result.get("scored_pairs")
+            throughput = None
+            if (
+                scored_pairs is not None
+                and wall is not None
+                and wall > 0
+            ):
+                throughput = round(scored_pairs / wall)
+
+            row: dict = {
+                "dataset": dataset,
+                "engine": engine,
+                "status": result.get("status", "error"),
+                "precision": None,
+                "recall": None,
+                "f1": None,
+                "bcubed_f1": None,
+                "dedupe_wall_seconds": wall,
+                "peak_rss_mb": result.get("peak_rss_mb"),
+                "scored_pairs": scored_pairs,
+                "throughput_pairs_per_s": throughput,
+                "rows": result.get("rows") or result.get("rows_loaded")
+                or result.get("rows_requested"),
+            }
+            if metrics is not None:
+                pw = metrics.get("pairwise", {}) or {}
+                bc = metrics.get("bcubed", {}) or {}
+                row["precision"] = pw.get("precision")
+                row["recall"] = pw.get("recall")
+                row["f1"] = pw.get("f1")
+                row["bcubed_f1"] = bc.get("f1")
+            # Carry an error/reason note through for transparency in the table.
+            note = result.get("reason") or result.get("error")
+            if note:
+                row["note"] = note
+            rows.append(row)
+    return rows
+
+
+def _fmt(v) -> str:
+    """Render a cell. None -> '-' so null RSS / skipped cells never crash."""
+    if v is None:
+        return "-"
+    if isinstance(v, float):
+        return f"{v:.4f}"
+    return str(v)
+
+
+def _ratio(a, b) -> str:
+    """a/b as a 2-dp ratio string, or '-' if either is missing / b == 0."""
+    if a is None or b is None or b == 0:
+        return "-"
+    return f"{a / b:.2f}x"
+
+
+def _delta(a, b) -> str:
+    """a-b as a signed 4-dp delta string, or '-' if either is missing."""
+    if a is None or b is None:
+        return "-"
+    return f"{a - b:+.4f}"
+
+
+def render_md(rows: list[dict]) -> str:
+    """Markdown report: a per-dataset accuracy+perf table (rows = engines) plus a
+    per-dataset GM-vs-Splink delta block, plus an honest-framing footer.
+
+    Uses _fmt() so any None cell (null RSS, skipped accuracy) renders as '-'.
+    """
+    # Group rows by dataset, preserving first-seen order.
+    by_dataset: dict[str, list[dict]] = {}
+    for r in rows:
+        by_dataset.setdefault(r["dataset"], []).append(r)
+
+    header = (
+        "| Engine | Status | P | R | F1 | B3-F1 | wall(s) | peak RSS(MB) "
+        "| throughput pairs/s |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+    )
+
+    lines: list[str] = ["# ER bake-off: GoldenMatch (zero-config + probabilistic) vs hand-rolled Splink", ""]
+
+    for dataset, drows in by_dataset.items():
+        lines.append(f"## {dataset}")
+        lines.append("")
+        lines.append(header)
+        for r in drows:
+            status = r.get("status", "-")
+            note = r.get("note")
+            if note and status in ("skipped", "error", "refused", "timeout"):
+                status = f"{status} ({note})"
+            lines.append(
+                "| {engine} | {st} | {p} | {rcl} | {f1} | {b3} | {wall} "
+                "| {rss} | {tput} |".format(
+                    engine=r.get("engine", "-"),
+                    st=status,
+                    p=_fmt(r.get("precision")),
+                    rcl=_fmt(r.get("recall")),
+                    f1=_fmt(r.get("f1")),
+                    b3=_fmt(r.get("bcubed_f1")),
+                    wall=_fmt(r.get("dedupe_wall_seconds")),
+                    rss=_fmt(r.get("peak_rss_mb")),
+                    tput=_fmt(r.get("throughput_pairs_per_s")),
+                )
+            )
+        lines.append("")
+
+        # Per-dataset GM-vs-Splink delta block (wall ratio, RSS ratio, F1 delta).
+        splink = next((r for r in drows if r.get("engine") == "splink"), None)
+        gm_rows = [r for r in drows if r.get("engine", "").startswith("gm_")]
+        if splink is not None and splink.get("dedupe_wall_seconds") is not None:
+            lines.append(
+                "**GoldenMatch vs Splink (ratio = GM / Splink; F1 delta = GM - Splink):**"
+            )
+            lines.append("")
+            lines.append(
+                "| GM mode | wall ratio | RSS ratio | F1 delta |\n"
+                "| --- | --- | --- | --- |"
+            )
+            for gm in gm_rows:
+                if gm.get("dedupe_wall_seconds") is None:
+                    continue
+                lines.append(
+                    "| {mode} | {wall} | {rss} | {f1d} |".format(
+                        mode=gm.get("engine", "-"),
+                        wall=_ratio(
+                            gm.get("dedupe_wall_seconds"),
+                            splink.get("dedupe_wall_seconds"),
+                        ),
+                        rss=_ratio(gm.get("peak_rss_mb"), splink.get("peak_rss_mb")),
+                        f1d=_delta(gm.get("f1"), splink.get("f1")),
+                    )
+                )
+            lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append("**Honest framing:**")
+    lines.append("")
+    lines.append(
+        "- Pairwise P/R/F1 and B-cubed F1 come from ONE shared evaluator "
+        "(`evaluate.evaluate`), so all three engines are judged by identical code."
+    )
+    lines.append(
+        "- The ~0.97 Splink figure quoted for `historical_50k` in Splink's own "
+        "docs is a CLUSTER-level metric; the F1 here is pairwise under the shared "
+        "evaluator, so it will not match that number 1:1."
+    )
+    lines.append(
+        "- Splink skips `dblp_acm` honestly (bibliographic settings are out of "
+        "scope for the hand-rolled spec); that row is `skipped`, not a 0."
+    )
+    lines.append(
+        "- Perf (wall / peak RSS / throughput) is SINGLE-RUN per engine and "
+        "subject to runner variance; treat ratios as directional, not exact. "
+        "`peak RSS` is null on Windows (no rusage) and renders as `-`."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _run_gm(name, mode, ds_dir, records_parquet, rows_n, truth_path, threshold):
+    """Run run_goldenmatch.py in zeroconfig/probabilistic mode as a subprocess.
+
+    Returns (result_dict, metrics|None). status=ok + pred present -> metrics
+    from the shared evaluator; refused/error/timeout -> metrics None.
+    """
+    res_path = ds_dir / f"gm_{mode}_res.json"
+    pred_path = ds_dir / f"gm_{mode}_pred.parquet"
+    cmd = [
+        sys.executable,
+        str(RUN_GM),
+        "--input", str(records_parquet),
+        "--rows", str(rows_n),
+        "--mode", mode,
+        "--allow-pure-python",
+        "--pred-out", str(pred_path),
+        "--out", str(res_path),
+        "--threshold", str(threshold),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_ENGINE_TIMEOUT_S
+        )
+    except subprocess.TimeoutExpired:
+        return ({"status": "timeout", "error": f"timed out after {_ENGINE_TIMEOUT_S}s"}, None)
+
+    if proc.stdout:
+        print(proc.stdout.rstrip())
+
+    result: dict = {}
+    if res_path.exists():
+        try:
+            result = json.loads(res_path.read_text())
+        except Exception as e:  # noqa: BLE001
+            result = {"status": "error", "error": f"unreadable result json: {e}"}
+
+    if proc.returncode != 0 and result.get("status") not in ("ok", "refused"):
+        err = (proc.stderr or "").strip()[-400:]
+        result = {"status": "error", "error": f"run_goldenmatch exited {proc.returncode}: {err}"}
+        return result, None
+
+    if result.get("status") != "ok":
+        # refused / error / unknown -> no metrics.
+        return result, None
+
+    if not pred_path.exists():
+        result["status"] = "error"
+        result["error"] = "goldenmatch reported ok but wrote no pred parquet"
+        return result, None
+
+    try:
+        evaluate_mod = _import_sibling("evaluate")
+        metrics = evaluate_mod.evaluate(pred_path, truth_path)
+    except Exception as e:  # noqa: BLE001 - eval failure -> error row, never fatal
+        result["status"] = "error"
+        result["error"] = f"evaluate failed: {type(e).__name__}: {e}"
+        return result, None
+    return result, metrics
+
+
+def _run_splink(name, ds_dir, truth_path, threshold):
+    """Run run_splink.py --dataset <name> as a subprocess; return (result, metrics).
+
+    Mirrors run_panel.py::_run_splink: a dataset Splink declines -> status
+    `skipped` (metrics None); a non-zero exit/timeout -> `error`/`timeout`.
+    """
+    res_path = ds_dir / "splink_res.json"
+    pred_path = ds_dir / "splink_pred.parquet"
+    cmd = [
+        sys.executable,
+        str(RUN_SPLINK),
+        "--dataset", name,
+        "--out", str(res_path),
+        "--pred-out", str(pred_path),
+        "--threshold", str(threshold),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_ENGINE_TIMEOUT_S
+        )
+    except subprocess.TimeoutExpired:
+        return ({"status": "timeout", "error": f"timed out after {_ENGINE_TIMEOUT_S}s"}, None)
+
+    if proc.stdout:
+        print(proc.stdout.rstrip())
+
+    result: dict = {}
+    if res_path.exists():
+        try:
+            result = json.loads(res_path.read_text())
+        except Exception as e:  # noqa: BLE001
+            result = {"status": "error", "error": f"unreadable result json: {e}"}
+
+    status = result.get("status")
+    if proc.returncode != 0 and status not in ("skipped", "ok"):
+        err = (proc.stderr or "").strip()[-400:]
+        return ({"status": "error", "error": f"run_splink exited {proc.returncode}: {err}"}, None)
+
+    if status == "skipped":
+        return result, None
+    if status != "ok":
+        if "error" not in result:
+            result["error"] = f"splink status={status}"
+        result["status"] = "error"
+        return result, None
+
+    if not pred_path.exists():
+        result["status"] = "error"
+        result["error"] = "splink reported ok but wrote no pred parquet"
+        return result, None
+
+    try:
+        evaluate_mod = _import_sibling("evaluate")
+        metrics = evaluate_mod.evaluate(pred_path, truth_path)
+    except Exception as e:  # noqa: BLE001
+        result["status"] = "error"
+        result["error"] = f"evaluate failed: {type(e).__name__}: {e}"
+        return result, None
+    return result, metrics
+
+
+def _print_progress(dataset, engine, result, metrics) -> None:
+    f1 = None
+    if metrics is not None:
+        f1 = (metrics.get("pairwise", {}) or {}).get("f1")
+    print(
+        f"[bakeoff] {dataset} {engine}: status={result.get('status')} "
+        f"F1={f1} wall={result.get('dedupe_wall_seconds')}s "
+        f"peak_rss={result.get('peak_rss_mb')}MB"
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", default="bakeoff_out", type=Path)
+    ap.add_argument(
+        "--datasets",
+        default=",".join(DATASETS),
+        help="comma-separated dataset names",
+    )
+    ap.add_argument("--threshold", type=float, default=0.85)
+    args = ap.parse_args(argv)
+
+    out_dir: Path = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    names = [n.strip() for n in args.datasets.split(",") if n.strip()]
+
+    datasets = _import_sibling("datasets")
+
+    import polars as pl
+
+    per_engine_results: dict[str, dict[str, tuple[dict, dict | None]]] = {}
+    for name in names:
+        print(f"\n=== dataset: {name} ===")
+        per_engine_results[name] = {}
+        try:
+            records, truth = datasets.load_dataset(name)
+        except getattr(datasets, "DatasetUnavailable", Exception) as e:
+            reason = f"{type(e).__name__}: {e}"
+            print(f"[bakeoff] {name}: unavailable -> skipping all engines ({reason})")
+            for eng in ENGINES:
+                per_engine_results[name][eng] = ({"status": "skipped", "reason": reason}, None)
+            continue
+        except Exception as e:  # noqa: BLE001 - load failure -> error, never fatal
+            reason = f"{type(e).__name__}: {e}"
+            print(f"[bakeoff] {name}: load error -> skipping all engines ({reason})")
+            for eng in ENGINES:
+                per_engine_results[name][eng] = ({"status": "error", "error": reason}, None)
+            continue
+
+        ds_dir = out_dir / name
+        ds_dir.mkdir(parents=True, exist_ok=True)
+
+        # Records: preserve the REAL record_id verbatim for the engine subprocess.
+        records_parquet = ds_dir / "records.parquet"
+        records.write_parquet(records_parquet)
+        # Truth in STRING record_id space so it joins both GM (string preds) and
+        # Splink (real-id preds) under the shared evaluator.
+        truth_path = ds_dir / "truth.parquet"
+        truth.with_columns(pl.col("record_id").cast(pl.Utf8)).write_parquet(truth_path)
+
+        rows_n = records.height
+
+        for eng in ("gm_zeroconfig", "gm_probabilistic"):
+            result, metrics = _run_gm(
+                name, _GM_MODE[eng], ds_dir, records_parquet, rows_n,
+                truth_path, args.threshold,
+            )
+            per_engine_results[name][eng] = (result, metrics)
+            _print_progress(name, eng, result, metrics)
+
+        result, metrics = _run_splink(name, ds_dir, truth_path, args.threshold)
+        per_engine_results[name]["splink"] = (result, metrics)
+        _print_progress(name, "splink", result, metrics)
+
+    rows = build_rows(per_engine_results)
+    (out_dir / "bakeoff.json").write_text(json.dumps(rows, indent=2))
+    md = render_md(rows)
+    (out_dir / "bakeoff.md").write_text(md)
+    print("\n" + md)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -14,9 +14,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import resource
 import time
 from pathlib import Path
+
+try:
+    import resource  # Unix-only; absent on Windows dev boxes (CI/bench runs on Linux)
+except ImportError:  # pragma: no cover - Windows fallback path
+    resource = None
 
 # Must be set BEFORE importing goldenmatch so the native loader + planner see them.
 os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")  # clean, reproducible CI runs
@@ -24,8 +28,10 @@ os.environ.setdefault("GOLDENMATCH_PLANNER_BUCKET", "1")  # prefer bucket scorer
 # GOLDENMATCH_NATIVE is set from --require-native below, before the heavy imports.
 
 
-def _peak_rss_mb() -> float:
+def _peak_rss_mb() -> float | None:
     # Linux ru_maxrss is in KiB; this is the process high-water mark (load + dedupe).
+    if resource is None:  # Windows dev box: no rusage, perf RSS only meaningful on CI.
+        return None
     return round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0, 1)
 
 
@@ -44,6 +50,11 @@ def main() -> None:
     ap.add_argument("--pred-out", type=Path, default=None,
                     help="write {record_id, pred_cluster_id} parquet for accuracy eval")
     ap.add_argument("--threshold", type=float, default=0.85)
+    ap.add_argument("--mode", choices=["hand_built", "zeroconfig", "probabilistic"],
+                    default="hand_built",
+                    help="hand_built = explicit bucket+native config (default); "
+                         "zeroconfig = auto_configure_df controller; "
+                         "probabilistic = Fellegi-Sunter auto-config")
     ap.add_argument("--require-native", action="store_true", default=True)
     ap.add_argument("--allow-pure-python", dest="require_native", action="store_false")
     args = ap.parse_args()
@@ -56,14 +67,11 @@ def main() -> None:
         "rows_requested": args.rows,
         "status": "error",
         "threshold": args.threshold,
+        "mode": args.mode,
     }
     t_start = time.perf_counter()
     try:
         import polars as pl
-
-        from goldenmatch.core._native_loader import native_enabled, native_module
-        from goldenmatch.core.bench import bench_capture
-
         from goldenmatch.config.schemas import (
             BlockingConfig,
             BlockingKeyConfig,
@@ -71,6 +79,8 @@ def main() -> None:
             MatchkeyConfig,
             MatchkeyField,
         )
+        from goldenmatch.core._native_loader import native_enabled, native_module
+        from goldenmatch.core.bench import bench_capture
 
         try:
             from goldenmatch import dedupe_df
@@ -80,7 +90,14 @@ def main() -> None:
         native_loaded = native_module() is not None
         result["native_loaded"] = native_loaded
         result["native_block_scoring"] = bool(native_enabled("block_scoring"))
-        if args.require_native and not (native_loaded and native_enabled("block_scoring")):
+        # The native gate only applies to the hand_built optimized-path claim. The
+        # autoconfig modes let the controller pick the backend, so a missing native
+        # runtime is recorded for info but does NOT refuse the run.
+        if (
+            args.mode == "hand_built"
+            and args.require_native
+            and not (native_loaded and native_enabled("block_scoring"))
+        ):
             raise RuntimeError(
                 "Native Arrow block-scorer is NOT active; refusing to report a "
                 "pure-Python number as the optimized backend. Build it with "
@@ -92,70 +109,135 @@ def main() -> None:
         result["rows_loaded"] = df.height
         load_wall = time.perf_counter() - t0
 
-        # GoldenMatch's MOST-OPTIMIZED path: explicit bucket+native config (not the
-        # zero-config controller, which adds 30s+ overhead and can commit a RED
-        # config on off-distribution data). Mirrors Splink's hand-built spec —
-        # compound blocking + native Jaro-Winkler scoring — for a fair head-to-head.
-        # NOTE: the bucket backend does SINGLE-KEY blocking (one eager bucket pass
-        # — it ignores multi_pass `passes`); that's how it stays fast at scale.
-        # So we give it its best single key. On this fixture, blocking on the
-        # stable, rarely-corrupted `postcode` covers ~0.94 of true pairs with small
-        # blocks, vs ~0.48 for surname+dob (surnames get typo'd). Splink, by
-        # contrast, unions 3 blocking rules (~0.99 coverage) — a real engine
-        # difference the benchmark surfaces rather than hides.
-        config = GoldenMatchConfig(
-            backend="bucket",
-            n_buckets=256,
-            blocking=BlockingConfig(
-                max_block_size=5000,
-                skip_oversized=False,  # rely on the bucket scorer's hot-block split
-                keys=[BlockingKeyConfig(fields=["postcode"], transforms=["strip"])],
-            ),
-            matchkeys=[
-                MatchkeyConfig(
-                    name="person",
-                    type="weighted",
-                    threshold=args.threshold,
-                    rerank=False,  # no cross-encoder -> no HuggingFace download
-                    fields=[
-                        MatchkeyField(field="first_name", scorer="jaro_winkler", weight=0.3, transforms=["lowercase"]),
-                        MatchkeyField(field="surname", scorer="jaro_winkler", weight=0.4, transforms=["lowercase"]),
-                        MatchkeyField(field="dob", scorer="jaro_winkler", weight=0.3),
-                    ],
-                )
-            ],
-        )
+        if args.mode == "hand_built":
+            # GoldenMatch's MOST-OPTIMIZED path: explicit bucket+native config (not
+            # the zero-config controller, which adds 30s+ overhead and can commit a
+            # RED config on off-distribution data). Mirrors Splink's hand-built spec
+            # — compound blocking + native Jaro-Winkler scoring — for a fair
+            # head-to-head. NOTE: the bucket backend does SINGLE-KEY blocking (one
+            # eager bucket pass — it ignores multi_pass `passes`); that's how it
+            # stays fast at scale. So we give it its best single key. On this
+            # fixture, blocking on the stable, rarely-corrupted `postcode` covers
+            # ~0.94 of true pairs with small blocks, vs ~0.48 for surname+dob
+            # (surnames get typo'd). Splink, by contrast, unions 3 blocking rules
+            # (~0.99 coverage) — a real engine difference the benchmark surfaces
+            # rather than hides.
+            config = GoldenMatchConfig(
+                backend="bucket",
+                n_buckets=256,
+                blocking=BlockingConfig(
+                    max_block_size=5000,
+                    skip_oversized=False,  # rely on bucket scorer's hot-block split
+                    keys=[BlockingKeyConfig(fields=["postcode"], transforms=["strip"])],
+                ),
+                matchkeys=[
+                    MatchkeyConfig(
+                        name="person",
+                        type="weighted",
+                        threshold=args.threshold,
+                        rerank=False,  # no cross-encoder -> no HuggingFace download
+                        fields=[
+                            MatchkeyField(field="first_name", scorer="jaro_winkler", weight=0.3, transforms=["lowercase"]),
+                            MatchkeyField(field="surname", scorer="jaro_winkler", weight=0.4, transforms=["lowercase"]),
+                            MatchkeyField(field="dob", scorer="jaro_winkler", weight=0.3),
+                        ],
+                    )
+                ],
+            )
 
-        t0 = time.perf_counter()
-        with bench_capture() as bench:
-            ded = dedupe_df(df, config=config)
-        dedupe_wall = time.perf_counter() - t0
+            t0 = time.perf_counter()
+            with bench_capture() as bench:
+                ded = dedupe_df(df, config=config)
+            dedupe_wall = time.perf_counter() - t0
+        elif args.mode == "zeroconfig":
+            # ControllerNotConfidentError lives in autoconfig_controller (NOT
+            # autoconfig); it only fires at df.height >= 100K on a RED commit, so it
+            # won't trigger on the panel datasets — it's a defensive guard.
+            from goldenmatch.core.autoconfig_controller import (
+                ControllerNotConfidentError,
+            )
+
+            t0 = time.perf_counter()
+            try:
+                with bench_capture() as bench:
+                    ded = dedupe_df(df)
+            except ControllerNotConfidentError as e:
+                dedupe_wall = time.perf_counter() - t0
+                result.update(status="refused", error=str(e),
+                              dedupe_wall_seconds=round(dedupe_wall, 2))
+                result["total_wall_seconds"] = round(time.perf_counter() - t_start, 2)
+                result["peak_rss_mb"] = _peak_rss_mb()
+                _atomic_write(args.out, result)
+                print(
+                    f"[goldenmatch] rows={args.rows:,} mode={args.mode} "
+                    f"status=refused error={e}"
+                )
+                return
+            dedupe_wall = time.perf_counter() - t0
+        else:  # probabilistic
+            from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
+            cfg = auto_configure_probabilistic_df(df)
+            # Force rerank off so a 3+ field weighted matchkey can't pull a
+            # cross-encoder model down from HuggingFace at dedupe time.
+            for mk in cfg.get_matchkeys():
+                if getattr(mk, "type", None) == "weighted":
+                    mk.rerank = False
+            t0 = time.perf_counter()
+            with bench_capture() as bench:
+                ded = dedupe_df(df, config=cfg)
+            dedupe_wall = time.perf_counter() - t0
 
         # Per-record cluster assignment for accuracy eval. clusters is
-        # {cid: {"members": [__row_id__...]}} over ALL records; the fixture's
-        # record_id IS the input row index, and GoldenMatch preserves it as
-        # __row_id__, so member row-ids are record-ids directly.
+        # {cid: {"members": [__row_id__...]}} over ALL records.
         if args.pred_out is not None:
             import numpy as np
             import pyarrow as pa
             import pyarrow.parquet as pq
 
             clusters = getattr(ded, "clusters", None) or {}
-            rids, cids = [], []
-            for cid, c in clusters.items():
-                members = c["members"] if isinstance(c, dict) else c.members
-                rids.extend(members)
-                cids.extend([cid] * len(members))
-            pq.write_table(
-                pa.table(
-                    {
-                        "record_id": pa.array(np.asarray(rids, dtype=np.int64)),
-                        "pred_cluster_id": pa.array(np.asarray(cids, dtype=np.int64)),
-                    }
-                ),
-                args.pred_out,
-                compression="zstd",
-            )
+            if args.mode == "hand_built":
+                # The optimized-path benchmark's truth join is int64 (orchestrate.py
+                # back-compat): the fixture's record_id IS the input row index, and
+                # GoldenMatch preserves it as __row_id__, so member row-ids are
+                # record-ids directly.
+                rids, cids = [], []
+                for cid, c in clusters.items():
+                    members = c["members"] if isinstance(c, dict) else c.members
+                    rids.extend(members)
+                    cids.extend([cid] * len(members))
+                pq.write_table(
+                    pa.table(
+                        {
+                            "record_id": pa.array(np.asarray(rids, dtype=np.int64)),
+                            "pred_cluster_id": pa.array(np.asarray(cids, dtype=np.int64)),
+                        }
+                    ),
+                    args.pred_out,
+                    compression="zstd",
+                )
+            else:
+                # Autoconfig modes: remap internal __row_id__ back to the input df's
+                # REAL record_id as a STRING column (mirrors run_panel.py:83-108).
+                # The real benchmark datasets carry STRING record_ids (historical_50k
+                # Q-ids, dblp_acm 'dblp:123', febrl3 'rec-123-org').
+                rid = df["record_id"].to_list()
+                rids, cids = [], []
+                for cid, c in clusters.items():
+                    members = c["members"] if isinstance(c, dict) else c.members
+                    for m in members:
+                        rids.append(str(rid[m]))
+                        cids.append(cid)
+                pq.write_table(
+                    pa.table(
+                        {
+                            "record_id": pa.array(rids, pa.string()),
+                            "pred_cluster_id": pa.array(np.asarray(cids, dtype=np.int64)),
+                        }
+                    ),
+                    args.pred_out,
+                    compression="zstd",
+                )
 
         bench_blob = bench.to_dict()
         metrics = bench_blob.get("metrics", {}) if isinstance(bench_blob, dict) else {}
@@ -184,7 +266,8 @@ def main() -> None:
         result["peak_rss_mb"] = _peak_rss_mb()
         _atomic_write(args.out, result)
         print(
-            f"[goldenmatch] rows={args.rows:,} status={result['status']} "
+            f"[goldenmatch] rows={args.rows:,} mode={args.mode} "
+            f"status={result['status']} "
             f"dedupe={result.get('dedupe_wall_seconds')}s "
             f"peak_rss={result['peak_rss_mb']}MB pairs={result.get('scored_pairs')}"
         )

--- a/scripts/bench_er_headtohead/test_bakeoff.py
+++ b/scripts/bench_er_headtohead/test_bakeoff.py
@@ -1,0 +1,65 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import polars as pl
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+HERE = Path(__file__).resolve().parent
+RUN_GM = HERE / "run_goldenmatch.py"
+
+def _tiny_parquet(tmp_path):
+    df = pl.DataFrame({
+        "record_id": ["r0","r1","r2","r3","r4","r5"],
+        "first_name": ["ann","ann","bob","bob","cara","dan"],
+        "surname":    ["lee","lee","kim","kim","ng","ono"],
+        "dob":        ["1990-01-01","1990-01-01","1985-02-02","1985-02-02","1972-03-03","1965-04-04"],
+        "postcode":   ["AA1","AA1","BB2","BB2","CC3","DD4"],
+    })
+    p = tmp_path / "tiny.parquet"; df.write_parquet(p); return p, df
+
+def _run(p, mode, tmp_path):
+    out = tmp_path / "res.json"; pred = tmp_path / "pred.parquet"
+    proc = subprocess.run(
+        [sys.executable, str(RUN_GM), "--input", str(p), "--rows", "6",
+         "--mode", mode, "--out", str(out), "--pred-out", str(pred),
+         "--allow-pure-python", "--threshold", "0.85"],
+        capture_output=True, text=True, timeout=300,
+        env={**os.environ, "POLARS_SKIP_CPU_CHECK": "1", "PYTHONIOENCODING": "utf-8"},
+    )
+    return proc, out, pred
+
+def test_zeroconfig_emits_string_record_id_preds(tmp_path):
+    p, df = _tiny_parquet(tmp_path)
+    proc, out, pred = _run(p, "zeroconfig", tmp_path)
+    assert out.exists(), proc.stderr
+    res = json.loads(out.read_text())
+    assert res["mode"] == "zeroconfig"
+    assert res["status"] in ("ok", "refused")
+    if res["status"] == "ok":
+        t = pq.read_table(pred)
+        assert t.column_names == ["record_id", "pred_cluster_id"]
+        rids = set(t.column("record_id").to_pylist())
+        assert rids <= set(df["record_id"].to_list())
+        assert all(isinstance(x, str) for x in rids)
+
+def test_probabilistic_mode_runs_and_string_preds(tmp_path):
+    p, df = _tiny_parquet(tmp_path)
+    proc, out, pred = _run(p, "probabilistic", tmp_path)
+    assert out.exists(), proc.stderr
+    res = json.loads(out.read_text())
+    assert res["mode"] == "probabilistic" and res["status"] == "ok", res.get("error")
+    t = pq.read_table(pred)
+    assert all(isinstance(x, str) for x in t.column("record_id").to_pylist())
+
+def test_hand_built_mode_unchanged_int_ids(tmp_path):
+    p, df = _tiny_parquet(tmp_path)
+    proc, out, pred = _run(p, "hand_built", tmp_path)
+    res = json.loads(out.read_text())
+    assert res["mode"] == "hand_built"
+    if res["status"] == "ok":
+        t = pq.read_table(pred)
+        assert pa.types.is_integer(t.schema.field("record_id").type)

--- a/scripts/bench_er_headtohead/test_bakeoff.py
+++ b/scripts/bench_er_headtohead/test_bakeoff.py
@@ -63,3 +63,46 @@ def test_hand_built_mode_unchanged_int_ids(tmp_path):
     if res["status"] == "ok":
         t = pq.read_table(pred)
         assert pa.types.is_integer(t.schema.field("record_id").type)
+
+
+def test_bakeoff_table_assembly_and_missing_engine():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("run_bakeoff", HERE / "run_bakeoff.py")
+    rb = importlib.util.module_from_spec(spec); spec.loader.exec_module(rb)
+    stub = {
+      "febrl3": {
+        "gm_zeroconfig": ({"status":"ok","dedupe_wall_seconds":3.1,"peak_rss_mb":900.0,"scored_pairs":12000},
+                          {"pairwise":{"precision":0.99,"recall":0.98,"f1":0.985},"bcubed":{"f1":0.97}}),
+        "gm_probabilistic": ({"status":"ok","dedupe_wall_seconds":4.0,"peak_rss_mb":950.0,"scored_pairs":15000},
+                          {"pairwise":{"precision":0.99,"recall":0.99,"f1":0.991},"bcubed":{"f1":0.98}}),
+        "splink": ({"status":"ok","dedupe_wall_seconds":8.0,"peak_rss_mb":1200.0,"scored_pairs":20000},
+                          {"pairwise":{"precision":0.97,"recall":0.96,"f1":0.965},"bcubed":{"f1":0.95}}),
+      },
+      "dblp_acm": {
+        "gm_zeroconfig": ({"status":"ok","dedupe_wall_seconds":2.0,"peak_rss_mb":800.0,"scored_pairs":9000},
+                          {"pairwise":{"precision":0.9,"recall":0.86,"f1":0.879},"bcubed":{"f1":0.86}}),
+        "gm_probabilistic": ({"status":"ok","dedupe_wall_seconds":2.2,"peak_rss_mb":810.0,"scored_pairs":9100},
+                          {"pairwise":{"precision":0.9,"recall":0.86,"f1":0.879},"bcubed":{"f1":0.86}}),
+        "splink": ({"status":"skipped","error":"bibliographic out of scope"}, None),
+      },
+    }
+    rows = rb.build_rows(stub)
+    skips = [r for r in rows if r["dataset"]=="dblp_acm" and r["engine"]=="splink"]
+    assert skips and skips[0]["status"]=="skipped" and skips[0].get("f1") in (None,"")
+    # throughput computed when wall+pairs present
+    febrl_gm = [r for r in rows if r["dataset"]=="febrl3" and r["engine"]=="gm_zeroconfig"][0]
+    assert febrl_gm["throughput_pairs_per_s"] == round(12000/3.1)
+    md = rb.render_md(rows)
+    assert "febrl3" in md and "peak" in md.lower() and ("throughput" in md.lower() or "pairs/s" in md.lower())
+    assert "ratio" in md.lower() or "delta" in md.lower()  # GM-vs-Splink delta block
+
+
+def test_bakeoff_tolerates_null_rss(tmp_path):
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("run_bakeoff", HERE / "run_bakeoff.py")
+    rb = importlib.util.module_from_spec(spec); spec.loader.exec_module(rb)
+    stub = {"febrl3": {"gm_zeroconfig": ({"status":"ok","dedupe_wall_seconds":3.0,"peak_rss_mb":None,"scored_pairs":100},
+                       {"pairwise":{"precision":1.0,"recall":1.0,"f1":1.0},"bcubed":{"f1":1.0}})}}
+    rows = rb.build_rows(stub)
+    md = rb.render_md(rows)  # must not crash on null RSS
+    assert "febrl3" in md


### PR DESCRIPTION
Adds the bake-off harness pitting hand-rolled expert Splink against GoldenMatch's two
zero-tuning autoconfig modes, capturing accuracy AND performance per benchmark dataset.

## What

- **`run_goldenmatch.py --mode {hand_built,zeroconfig,probabilistic}`** -- `hand_built`
  byte-unchanged (orchestrate.py back-compat); `zeroconfig` = `dedupe_df(df)` (catches
  `ControllerNotConfidentError` -> status=refused, exit 0); `probabilistic` =
  `auto_configure_probabilistic_df` (+ rerank forced off). Bake-off modes remap preds to
  the real STRING `record_id` (so the real datasets eval correctly); hand_built keeps int64.
  Also wrapped the Unix-only `import resource` so the script imports on Windows (no-op on Linux).
- **`run_bakeoff.py`** -- unified orchestrator: per dataset (historical_50k, febrl3,
  synthetic_person, dblp_acm), runs all 3 engines as isolated subprocesses, evals each via
  the shared `evaluate.py` (Utf8-truth + string-record_id, lifted from run_panel.py), emits
  `bakeoff.md`/`.json` with P/R/F1 + B3 + wall + peak RSS + throughput + GM-vs-Splink deltas.
  Pure `build_rows`/`render_md` (stub-unit-tested); tolerates null RSS / skipped / refused / timeout.
- **`bench-probabilistic.yml` bake-off lane** -- `workflow_dispatch` (`run_bakeoff` toggle),
  `large-new-64GB`, mirrors the panel setup (DBLP-ACM fetch etc.), uploads the artifacts.
  Non-gating measurement lane.

## Verification

- `test_bakeoff.py`: 5 passed (3 GM-mode tests incl. string-vs-int pred ids per mode; 2 pure
  table-assembly tests incl. null-RSS + skipped-engine). ruff clean; YAML valid.
- Local febrl3 smoke: gm_probabilistic F1=0.991, gm_zeroconfig F1=0.967 (Splink errors only on
  Windows's missing `resource`; runs on the Linux CI lane).

The actual bake-off RUN (+ committing the results doc) is the post-merge step -- the
`workflow_dispatch` lane only registers once this is on the default branch.

Spec: docs/superpowers/specs/2026-06-09-splink-bakeoff-design.md (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)