### PR TITLE
fix(probabilistic): deterministic EM training-pair sampling

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -452,7 +452,15 @@ def _sample_blocked_pairs(
     block-stratified sample. Deterministic (fixed ``seed``).
     """
     rng = random.Random(seed)
-    order = list(range(len(blocks)))
+    # Determinism: `blocks` can arrive in a non-deterministic order (parallel /
+    # hash-bucketed construction; varies by machine/core-count), so a seeded
+    # shuffle of bare indices still draws a different training sample run-to-run.
+    # Sort by the stable, already-computed block_key FIRST so the seeded shuffle
+    # permutes a canonical order -> reproducible sample (no extra collect; block_key
+    # is a string attribute set at construction). Ties (rare cross-pass key
+    # collisions) fall back to the original index, adjacent same-key blocks being
+    # near-equivalent anyway.
+    order = sorted(range(len(blocks)), key=lambda i: (str(getattr(blocks[i], "block_key", "")), i))
     rng.shuffle(order)
     # Headroom over n_pairs so the post-dedup downsample still has enough to
     # draw from even when blocks overlap or are tiny.
@@ -462,7 +470,7 @@ def _sample_blocked_pairs(
     for bi in order:
         block = blocks[bi]
         block_df = block.df.collect() if hasattr(block.df, 'collect') else block.df
-        row_ids = block_df["__row_id__"].to_list()
+        row_ids = sorted(block_df["__row_id__"].to_list())  # canonical order before the seeded sample
         if len(row_ids) < 2:
             continue
         # Limit per-block pairs for large blocks

--- a/packages/python/goldenmatch/tests/test_probabilistic_determinism.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic_determinism.py
@@ -1,0 +1,34 @@
+import polars as pl
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.blocker import build_blocks
+from goldenmatch.core.probabilistic import _sample_blocked_pairs
+
+
+def _person_df():
+    # several soundex-distributed surnames so blocks are non-trivial
+    import itertools
+    first = ["ann","bob","cara","dan","eve","fay","gus","hal"]
+    sur = ["lee","kim","ng","ono","poe","qua","rae","sol"]
+    rows = []
+    for i, (f, s) in enumerate(itertools.product(first, sur)):
+        rows.append({"first_name": f, "surname": s, "dob": f"19{50+(i%40):02d}-01-01"})
+        rows.append({"first_name": f, "surname": s, "dob": f"19{50+(i%40):02d}-01-01"})  # a dup
+    return pl.DataFrame({"__row_id__": list(range(len(rows))),
+                         "first_name": [r["first_name"] for r in rows],
+                         "surname": [r["surname"] for r in rows],
+                         "dob": [r["dob"] for r in rows]})
+
+def test_sample_blocked_pairs_is_order_independent():
+    df = _person_df()
+    cfg = BlockingConfig(keys=[BlockingKeyConfig(fields=["surname"])])
+    blocks = build_blocks(df.lazy(), cfg)
+    import random
+    # same blocks, two DIFFERENT input orders (simulating non-deterministic construction)
+    b1 = list(blocks)
+    b2 = list(blocks); random.Random(1).shuffle(b2)
+    b3 = list(blocks); random.Random(2).shuffle(b3)
+    s1 = _sample_blocked_pairs(b1, n_pairs=200, seed=42)
+    s2 = _sample_blocked_pairs(b2, n_pairs=200, seed=42)
+    s3 = _sample_blocked_pairs(b3, n_pairs=200, seed=42)
+    assert set(s1) == set(s2) == set(s3), "sample must be invariant to block input order"
+    assert len(s1) > 0


### PR DESCRIPTION
A bake-off (GM autoconfig vs hand-rolled Splink) surfaced that GoldenMatch's probabilistic
(Fellegi-Sunter) results are NOT reproducible run-to-run: historical_50k F1 swung ~0.77-0.83
(0.64 on a 16-core runner) with the SAME seed. Root cause: `_sample_blocked_pairs` shuffled
bare block INDICES (seeded), but `blocks[bi]` depends on the order blocks were constructed,
which is non-deterministic (parallel / hash-bucketed block scoring; varies by machine and
core count). The seeded per-block `rng.sample` was also fed row_ids in non-deterministic
df order.

## Fix

Two cheap STABLE sorts in `_sample_blocked_pairs` (no extra block collection -- preserves the
#803 early-stop; `block_key` is an already-set string attribute):
- sort blocks by `block_key` BEFORE the seeded shuffle (canonical order -> reproducible sample);
- `sorted(row_ids)` before the seeded per-block sample.

Now `_sample_blocked_pairs` is invariant to block input order, so EM training pairs ->
m-probabilities -> match weights are reproducible run-to-run and machine-to-machine. Covers
both `train_em` and `train_em_continuous` (and the per-rule EM path that routes through them).

## Verification

- New `test_probabilistic_determinism.py`: sample is identical across 3 different block input
  orders (was different pre-fix).
- 132 passed / 4 skipped across the probabilistic suites; no exact-value assertion shifted.
- The fix is NOT tuned toward any F1 -- it produces one canonical deterministic draw.

Found via the bake-off harness (#828). A re-run of the bake-off on this fix will give the
stable historical_50k number; the v1.29.0 "beats Splink on historical_50k" doc claim will be
reconciled against that reproducible value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)