### PR TITLE
docs: record the Rust test-coverage arc (context network + mintlify)

### DIFF
--- a/context-network/architecture/rust-test-coverage.md
+++ b/context-network/architecture/rust-test-coverage.md
@@ -1,0 +1,87 @@
+# Rust Test Coverage (the extensions tree)
+
+How the `packages/rust/extensions/` crates are tested in CI, what each lane
+covers, and the measured per-crate baseline. This is the cross-cutting result of
+the 2026-06-08/09 Rust-coverage arc (audit → close the structural gaps → measure).
+
+**Status:** SHIPPED — graph-core/score-core CI wiring + native unit tests + the
+pgrx SQL surface (#827); the bloom CLK kernel's own Rust tests (#826); the
+bridge marshalling tests (#830, 6 silent no-ops → 42 real tests); and the
+measured-coverage job (#832).
+
+## The crates and how each is actually tested
+
+The extensions workspace's `cargo test --workspace` is misleadingly named — the
+workspace is `members = ["bridge"]`, so it tests ONE crate. Every other crate is
+its own standalone `[workspace]` and needs an explicit lane. The real map:
+
+| Crate | Rust unit tests | How it runs in CI | Lane |
+|---|---|---|---|
+| `bridge` (pyo3, embeds CPython) | 42 | `cargo test --workspace` + goldenmatch installed into the embedded interpreter | `rust` |
+| `graph-core` / `score-core` | 7 / 5 | explicit `cargo test --manifest-path` (standalone workspaces) | `rust` |
+| `fingerprint-core` | 3 | `cargo test` + 3-surface parity | `native` |
+| `native` (pyo3 extension-module) | 18 | `cargo test --no-default-features` + Python parity suite | `native` |
+| `goldenembed` (ort) | 11 | `cargo test --release` | `goldenembed` |
+| `postgres` (pgrx) | 5 `#[pg_test]` (DEAD) | psql smoke vs real `CREATE EXTENSION` | `rust_pgrx` |
+| `datafusion-udf` | 0 | Python FFI tests (`test_datafusion_ffi_udf.py`) | `python` |
+
+## Three load-bearing facts (each was a trap)
+
+1. **`cargo pgrx test` cannot run for `goldenmatch_pg`.** It depends on pgrx SQL
+   schema generation (installs each `#[pg_test]` into a `tests` schema), which is
+   broken for this crate — the exact reason its SQL is hand-maintained and it's
+   excluded from the workspace. So the 5 `#[pg_test]`s are dead; the pgrx SQL
+   surface is asserted via the `rust_pgrx` **psql smoke** against a real
+   `CREATE EXTENSION` (stronger: it tests the shipped SQL, not auto-generated
+   wrappers). See [0009](../decisions/0009-rust-test-coverage.md).
+
+2. **The bridge tests were a silent false-green.** `bridge/api.rs` (the JSON
+   marshalling boundary for the whole Postgres + Rust surface) had 6 tests that
+   all self-skipped (`Err -> eprintln -> pass`) because the `rust` job never
+   installed goldenmatch — so the largest Rust file was effectively untested.
+   Fix: install goldenmatch into the bridge's embedded interpreter (`setup-python`
+   clean interp + pinned `PYO3_PYTHON`/`LD_LIBRARY_PATH`) and gate the skip behind
+   `GOLDENMATCH_BRIDGE_REQUIRE_PY=1` (CI → a Python failure HARD-fails; unset
+   locally → skip, so `cargo test` still works without the package).
+
+3. **`native`'s low measured coverage is a measurement artifact, not a gap.**
+   native is a pyo3 boundary crate: its 18 Rust tests cover the pure helpers
+   (soundex, featurizer, pairs-math, C-ABI), but the bulk of its lines live in
+   `#[pyfunction]` wrappers + Arrow/rayon paths exercised by the **Python parity**
+   suite, which `cargo-llvm-cov` can't see (it only instruments `cargo test`).
+
+## Measured coverage (`rust_coverage` lane, baseline 2026-06-09)
+
+`cargo-llvm-cov` per crate, posted to the job summary + grep-able
+`COVERAGE_RESULT` log markers. Informational baseline (no floor gate yet) +
+tolerant per-crate (a crate that won't instrument degrades to "(failed)").
+
+| Crate | Line coverage |
+|---|---:|
+| `score-core` | 95.7% |
+| `fingerprint-core` | 83.9% |
+| `graph-core` | 76.4% |
+| `bridge` | 74.7% |
+| `goldenembed` | 71.8% |
+| `native` | 25.8% (measurement artifact — Python-parity-tested) |
+
+The well-tested crates are 76–96%; the bridge marshalling layer is 75% (uncovered
+≈ error/edge paths); the one "low" crate is low only because its real coverage is
+via Python parity. There is no compelling remaining Rust gap — the work is done,
+now provable and regression-guardable.
+
+## Entry points
+
+- `.github/workflows/ci.yml`: jobs `rust`, `native`, `native_wheel`, `goldenembed`,
+  `embed_wheel`, `rust_pgrx` (PG 15/16/17), and `rust_coverage`.
+- The bridge CPython-in-CI install dance is the canonical pattern for any future
+  pyo3-embedding crate that calls goldenmatch (reused by `rust_coverage`).
+
+## Related
+
+- [sql-native-extensions.md](sql-native-extensions.md) — the graph/embed UDF
+  surfaces these crates expose (its Verification section is the #509-scoped view).
+- [0009 — Rust test coverage strategy](../decisions/0009-rust-test-coverage.md).
+
+---
+**Classification:** architecture/active • **Last updated:** 2026-06-09

--- a/context-network/architecture/sql-native-extensions.md
+++ b/context-network/architecture/sql-native-extensions.md
@@ -64,12 +64,18 @@ to that one wheel and keeping `goldenembed` pyo3-free. Postgres + DataFusion cal
   `core/pairs.py` primitives (behavior-exact ports, CI parity-gated).
 
 ## Verification
-- **Local:** `graph-core` `cargo test` (pyo3-free, 7 tests); DuckDB graph + cross-backend
-  parity pytest (DuckDB value == native kernel).
-- **CI-only (Windows can't link `ort`/libclang):** Postgres PG 15/16/17 (`cargo pgrx` +
-  `CREATE EXTENSION` on the 0.6.0 surface + `pg_test`); `embed_wheel` lane (maturin build +
+- **Local:** `graph-core` `cargo test` (pyo3-free, 7 tests — now also run in CI by the
+  `rust` job, see [rust-test-coverage.md](rust-test-coverage.md)); DuckDB graph +
+  cross-backend parity pytest (DuckDB value == native kernel).
+- **CI-only (Windows can't link `ort`/libclang):** Postgres PG 15/16/17 (`cargo pgrx
+  install` + `CREATE EXTENSION` + a **psql smoke** that asserts the graph/fingerprint
+  SQL functions against the real extension); `embed_wheel` lane (maturin build +
   load/embed the `tiny_model` fixture + best-effort in-house cosine parity); the
   datafusion FFI lane (`test_datafusion_ffi_udf.py`).
+- **NOT `cargo pgrx test`:** the crate's `#[pg_test]`s cannot run — pgrx schema
+  generation is broken for it (the reason its SQL is hand-maintained). The psql
+  smoke is the mechanism. See [rust-test-coverage.md](rust-test-coverage.md) +
+  [0009](../decisions/0009-rust-test-coverage.md).
 
 ## Known follow-ups (non-blocking, not part of #509 acceptance)
 - DataFusion `_str` (string-id) graph variants — int64-only this pass.

--- a/context-network/decisions/0009-rust-test-coverage.md
+++ b/context-network/decisions/0009-rust-test-coverage.md
@@ -1,0 +1,53 @@
+# 0009 — Rust test coverage: make the tests real, route around the dead-ends, then measure
+
+**Status:** accepted (2026-06-09, Ben) • **Shipped:** PRs #827 / #830 / #832 (+ #826 bloom tests) • **Architecture:** [../architecture/rust-test-coverage.md](../architecture/rust-test-coverage.md)
+
+## Context
+A coverage audit of `packages/rust/extensions/` found the Rust tree's CI claims
+were partly fictional. Standalone-workspace crates (`graph-core`, `score-core`)
+had unit tests that never ran (`cargo test --workspace` only builds the `bridge`
+member). The `postgres` crate's `#[pg_test]`s never executed (`cargo pgrx test`
+appears nowhere). The `bridge` — the largest Rust file and the JSON marshalling
+boundary for the whole SQL surface — had 6 tests that all self-skipped in CI,
+making it an effective 0% false-green. And nothing was measured, so "what's left"
+was guesswork.
+
+## Decision
+1. **Close the structural gaps where the mechanism works; route around it where
+   it doesn't.** Wire the standalone crates' `cargo test` into a real lane; add
+   native unit tests behind an `extension-module` feature-gate so `cargo test
+   --no-default-features` links. But **don't chase `cargo pgrx test`** — it needs
+   pgrx schema-gen, which is structurally broken for this crate (the same reason
+   the SQL is hand-maintained). Assert the pgrx SQL surface via the psql smoke
+   against a real `CREATE EXTENSION` instead; it tests the shipped SQL, which is
+   stronger than auto-generated test wrappers.
+2. **A test that doesn't run is worse than no test — make it loud.** The bridge's
+   `Err -> eprintln -> pass` skip was the anti-pattern the whole audit was about.
+   Replace it with an env-gated require (`GOLDENMATCH_BRIDGE_REQUIRE_PY=1` in CI →
+   hard fail; unset locally → skip) and install goldenmatch into the bridge's
+   embedded interpreter so the tests actually exercise the path.
+3. **Stage CI-only changes behind a de-risk gate.** The bridge/native/pgrx work
+   can only be verified by pushing (local Windows can't link pgrx, and the
+   embedded interpreter imports polars → WMI-hangs). Prove the embedded-CPython
+   path on the 6 existing bridge tests BEFORE writing 26 more; the staging caught
+   the debian-`typing_extensions` install conflict (→ use `setup-python`) and the
+   marshalling-assertion shape (structural, not strict `serde_json::from_str` —
+   goldenmatch's reports embed control chars).
+4. **Measure, don't assume — but keep it honest.** Add a `cargo-llvm-cov` job as
+   an informational baseline, not a hard gate. Read the numbers as cargo-test
+   coverage: `native`'s 26% is correct-but-misleading (it's Python-parity-tested),
+   so a low number is not automatically a gap.
+
+## Consequence
+- The standalone crates run in CI; native has 18 Rust unit tests; the pgrx graph/
+  fingerprint surface is psql-asserted; the bridge went 6 silent no-ops → 42 real
+  marshalling tests; coverage is measured per crate.
+- The bridge CPython-in-CI install dance (`setup-python` + pinned `PYO3_PYTHON`/
+  `LD_LIBRARY_PATH` + `REQUIRE_PY`) is the reusable pattern for any pyo3-embedding
+  crate; `rust_coverage` already reuses it.
+- The data says there is no compelling remaining Rust gap — a per-crate floor
+  gate on the measured baseline is the natural (optional) next step.
+- `cargo pgrx test` is documented as a structural dead-end so it isn't retried.
+
+---
+**Classification:** decision • **Last updated:** 2026-06-09

--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -15,6 +15,7 @@ links rather than reading everything.
 - [architecture/goldencheck-native-kernel.md](architecture/goldencheck-native-kernel.md) — GoldenCheck's Arrow-native runtime (`goldencheck-native`) + deep-profiling expansion (Benford / composite-key / FD / fuzzy / approx-FD kernels, `--deep`, `refs`, freshness) + the `cell_quality` / `functional_dependencies` bridge APIs; SHIPPED (#793, 2026-06-07).
 - [architecture/goldencheck-goldenmatch-integration.md](architecture/goldencheck-goldenmatch-integration.md) — data quality feeds entity resolution: four fail-open, default-OFF doors (survivorship, blocking, FD negative-evidence, quality-gated review); #794/#795/#798 shipped, #797 open.
 - [architecture/fellegi-sunter-splink-parity.md](architecture/fellegi-sunter-splink-parity.md) — the `type: probabilistic` matchkey from scorer to Splink-class engine: model lifecycle, supervised m, match-weight waterfall, calibration, accuracy analysis, bucket/native scale-out. FS auto-config v2 (#823, v1.29.0) now beats hand-rolled Splink on every dataset Splink scores (pairwise F1, shared evaluator), made reproducible by the #829 EM-sampling determinism fix; the deterministic three-engine bake-off is at [`docs/benchmarks/2026-06-09-splink-bakeoff.md`](../docs/benchmarks/2026-06-09-splink-bakeoff.md).
+- [architecture/rust-test-coverage.md](architecture/rust-test-coverage.md) — how the `packages/rust/extensions/` crates are tested in CI: per-crate map, the bridge CPython-in-CI dance, the `cargo pgrx test` structural dead-end, and the measured per-crate baseline; SHIPPED (#827/#830/#832, 2026-06-09).
 
 ## Decisions (records with no other home)
 - [decisions/0001-gate-reframe-engine-portability.md](decisions/0001-gate-reframe-engine-portability.md) — retire one-box RSS as the gate; engine portability is the destination.
@@ -25,6 +26,7 @@ links rather than reading everything.
 - [decisions/0006-goldenflow-native-nanp-gating.md](decisions/0006-goldenflow-native-nanp-gating.md) — GoldenFlow: vectorize in Polars first; gate the native phone kernel to NANP-only (parity-safe by construction).
 - [decisions/0007-goldencheck-goldenmatch-integration.md](decisions/0007-goldencheck-goldenmatch-integration.md) — GoldenCheck→GoldenMatch: fail-open quality bridges, additive, default-OFF + benchmark-gated; hold the DQ↔ER boundary.
 - [decisions/0008-fellegi-sunter-splink-parity.md](decisions/0008-fellegi-sunter-splink-parity.md) — Fellegi-Sunter: close the Splink engine gap in dependency order, reuse the scale substrate, keep defaults reproducible (new power opt-in), measure the scale gate on a real runner.
+- [decisions/0009-rust-test-coverage.md](decisions/0009-rust-test-coverage.md) — Rust coverage: make the tests real (de-skip the bridge, run the standalone crates), route around the `cargo pgrx test` dead-end (psql smoke), then measure — informational baseline, not a hard gate.
 
 ## Processes (how work is done here)
 - [processes/development-workflow.md](processes/development-workflow.md) — spec → plan → execute → review → CI → merge, plus the hard environment constraints.
@@ -39,4 +41,4 @@ links rather than reading everything.
 - [meta/maintenance.md](meta/maintenance.md) — how to keep nodes accurate and small.
 
 ---
-**Classification:** navigation • **Last updated:** 2026-06-07
+**Classification:** navigation • **Last updated:** 2026-06-09

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,26 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-09 — Rust test-coverage arc: make the tests real, then measure (#827/#830/#832)
+- New nodes: [../architecture/rust-test-coverage.md](../architecture/rust-test-coverage.md)
+  (per-crate testing map + the measured baseline) and
+  [../decisions/0009-rust-test-coverage.md](../decisions/0009-rust-test-coverage.md).
+- An audit found the Rust tree's CI claims were partly fictional. Closed the real
+  gaps: standalone `graph-core`/`score-core` tests now run (#827); `native` got 18
+  Rust unit tests behind an `extension-module` feature-gate (#827); the pgrx graph/
+  fingerprint surface is psql-asserted vs a real `CREATE EXTENSION` (#827); the
+  `bridge` went from **6 silent self-skipping no-ops to 42 real marshalling tests**
+  (#830, install goldenmatch into the embedded interpreter + a `REQUIRE_PY` gate);
+  and a `cargo-llvm-cov` `rust_coverage` job posts a per-crate baseline (#832).
+- Two load-bearing facts recorded so they aren't re-litigated: **`cargo pgrx test`
+  is a structural dead-end** for `goldenmatch_pg` (schema-gen broken → psql smoke
+  instead), and **`native`'s 26% measured coverage is an artifact** (it's
+  Python-parity-tested; llvm-cov only sees `cargo test`). Fixed the now-stale
+  `cargo pgrx test`/`pg_test` claim in
+  [../architecture/sql-native-extensions.md](../architecture/sql-native-extensions.md).
+- Verdict: no compelling remaining Rust gap; the structural work is done and now
+  measurable + regression-guardable.
+
 ## 2026-06-09 — FS auto-config v2: GoldenMatch now BEATS Splink on accuracy (#823)
 - Updated the architecture node + decision:
   [../architecture/fellegi-sunter-splink-parity.md](../architecture/fellegi-sunter-splink-parity.md)

--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -47,6 +47,8 @@ The same engine is implemented across languages so you can run it wherever your 
 | dbt | `dbt-goldencheck` data-quality tests as a dbt package. |
 | GitHub Actions | `goldencheck-action` gates pull requests on data-quality regressions. |
 
+Every surface is exercised in CI: the Python test matrix (3.11 to 3.13), the TypeScript parity suite (scorer outputs matched to four decimals), and the Rust extension crates. The Postgres extension is built and smoke-tested against PostgreSQL 15, 16, and 17, the native acceleration kernels are parity-checked against the pure-Python path, and per-crate Rust line coverage is measured in CI.
+
 ## AI-native surface
 
 Every package ships an MCP server, a REST API, and an agent surface. Across the suite there are 35+ MCP tools. The `AutoConfigController` is visible from every interface: the web `ControllerPanel`, the TUI (`Ctrl+A`), the CLI, REST endpoints, Postgres functions, DuckDB UDFs, and MCP/agent tools.


### PR DESCRIPTION
Documents this session's Rust test-coverage work (#827 / #830 / #832, + #826's bloom tests) in both knowledge surfaces.

## Context network
- **New** [`architecture/rust-test-coverage.md`](../blob/docs/rust-test-coverage/context-network/architecture/rust-test-coverage.md) — the per-crate testing map (which crate runs where), the three load-bearing facts (the `cargo pgrx test` dead-end, the bridge false-green fix, native's measurement artifact), and the measured per-crate line-coverage baseline.
- **New** ADR `decisions/0009-rust-test-coverage.md` — make the tests real, route around the dead-ends, then measure (informational baseline, not a hard gate).
- `meta/updates.md` entry + `discovery.md` registration.
- **Fix** the now-stale `cargo pgrx test` / `pg_test` claim in `sql-native-extensions.md` — the crate's `#[pg_test]`s can't run (schema-gen broken); the pgrx surface is a psql smoke.

## Mintlify
- A factual CI/testing note on `concepts/architecture.mdx`: every surface is exercised in CI — the Postgres extension across PG 15/16/17, the native kernels parity-checked, and per-crate Rust line coverage measured. `mint validate` + `mint broken-links` both pass.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)