### PR TITLE
feat(layer2): flip GOLDENMATCH_CLUSTER_FRAMES_OUT default ON + close frames-out parity gaps

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -516,17 +516,16 @@ def build_clusters(
     )
 
 
-def _cluster_frames_out_enabled() -> bool:  # pyright: ignore[reportUnusedFunction]
-    """SP-A frames-out path gate. When ``GOLDENMATCH_CLUSTER_FRAMES_OUT`` is set
-    (non-``0``), ``build_cluster_frames`` returns the two-frame ``ClusterFrames``
-    columnar representation directly, WITHOUT materializing the per-cluster
-    ``dict[int, dict]`` for non-oversized clusters. Default OFF. Independent of
-    ``build_clusters`` and all its consumers, which are untouched.
+def _cluster_frames_out_enabled() -> bool:
+    """Frames-out path gate. When enabled, ``build_cluster_frames`` returns the
+    two-frame ``ClusterFrames`` columnar representation directly, WITHOUT
+    materializing the per-cluster ``dict[int, dict]`` for non-oversized clusters.
 
-    Not consumed in SP-A; the pipeline wires this gate in SP-B to choose
-    build_cluster_frames vs build_clusters. The pyright-ignore drops the
-    reportUnusedFunction false-positive until then."""
-    return os.environ.get("GOLDENMATCH_CLUSTER_FRAMES_OUT", "0").strip() != "0"
+    Default ON; set ``GOLDENMATCH_CLUSTER_FRAMES_OUT=0`` to force the legacy dict
+    path. Independent of ``build_clusters`` and all its consumers, which are
+    untouched. The pipeline wires this gate to choose ``build_cluster_frames``
+    vs ``build_clusters``."""
+    return os.environ.get("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1").strip() != "0"
 
 
 def build_cluster_frames(
@@ -740,16 +739,20 @@ def build_cluster_frames(
         .alias("confidence"),
     )
 
-    _emit_cluster_profile_frames(metadata, assignments)
+    _emit_cluster_profile_frames(metadata, assignments, pairs_list)
     return ClusterFrames(assignments=assignments, metadata=metadata)
 
 
-def _emit_cluster_profile_frames(metadata: Any, assignments: Any) -> None:
+def _emit_cluster_profile_frames(
+    metadata: Any, assignments: Any, pairs: Any = None,
+) -> None:
     """Frames-path twin of ``_emit_cluster_profile``. Telemetry only -- no-op
     when no capture is active. Builds the ``ClusterProfile`` from the metadata +
-    assignments frames as closely as the columnar shape allows (no per-cluster
-    pair_scores on this path, so the transitivity threshold falls back to 0.5,
-    same as ``_emit_cluster_profile`` when ``aggregated_scores`` is empty)."""
+    assignments frames as closely as the columnar shape allows. The within-cluster
+    edge scores (which the frames path doesn't carry on the cluster dict) are
+    reconstructed from ``pairs`` + ``assignments`` so ``transitivity_rate`` matches
+    the dict path's value -- the auto-config controller iterates on this signal,
+    so a frames-path 0.0 would change its behaviour vs the dict path."""
     import math
 
     if not _emitter_stack.get():
@@ -782,10 +785,22 @@ def _emit_cluster_profile_frames(metadata: Any, assignments: Any) -> None:
         ):
             members_by_cluster.setdefault(int(cid), []).append(int(mid))
 
-    # No per-cluster pair_scores on the frames path -> empty aggregate ->
-    # transitivity threshold falls back to 0.5 (same as _emit_cluster_profile).
+    # Reconstruct the within-cluster edge scores from the raw pairs + final
+    # assignments (the frames path keeps no per-cluster pair_scores). Mirrors the
+    # dict path's aggregate: canonical (min,max) keys, last-wins by input order,
+    # restricted to pairs whose endpoints landed in the SAME cluster. Threshold
+    # proxy = min observed within-cluster score, same as _emit_cluster_profile.
+    member_to_cid: dict[int, int] = {}
+    for cid, mids in members_by_cluster.items():
+        for m in mids:
+            member_to_cid[m] = cid
     aggregated_scores: dict[tuple[int, int], float] = {}
-    threshold = 0.5
+    if pairs is not None:
+        for a, b, s in pairs:
+            ca = member_to_cid.get(a)
+            if ca is not None and ca == member_to_cid.get(b):
+                aggregated_scores[(min(a, b), max(a, b))] = s
+    threshold = min(aggregated_scores.values()) if aggregated_scores else 0.5
 
     oversized_count = int(
         metadata.filter(_pl.col("oversized")).height

--- a/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
@@ -125,8 +125,13 @@ class ClusterPairScores:
             a_col.append(a)
             b_col.append(b)
             s_col.append(s)
+        # Explicit schema so an EMPTY pair list yields Int64 ``a``/``b`` columns
+        # (not null-typed) -- otherwise the join below blows up with a
+        # SchemaError against the i64 ``member_id`` key when a dedupe run
+        # produces no scored pairs (small/degenerate inputs).
         pairs_df = pl.DataFrame(
-            {"a": a_col, "b": b_col, "s": s_col}
+            {"a": a_col, "b": b_col, "s": s_col},
+            schema={"a": pl.Int64, "b": pl.Int64, "s": pl.Float64},
         ).with_row_index("__i__")
         amap_a = assignments.select(
             "member_id", pl.col("cluster_id").alias("cid_a")

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -1124,6 +1124,7 @@ def build_golden_records_from_frames(
     rules: GoldenRulesConfig,
     quality_scores: dict[tuple[int, str], float] | None = None,
     provenance: bool = False,
+    cluster_pair_scores: dict[int, dict[tuple[int, int], float]] | None = None,
 ) -> tuple[pl.DataFrame | None, list[dict]]:
     """Phase 4 entry point: build golden records from a Phase-2
     ``ClusterFrames`` plus the source DataFrame.
@@ -1142,6 +1143,12 @@ def build_golden_records_from_frames(
             selection ``size > 1 and not oversized``.
         rules: forwarded to the golden builder unchanged.
         quality_scores, provenance: forwarded unchanged.
+        cluster_pair_scores: optional ``{cluster_id: {(row_a, row_b): score}}``
+            forwarded to the slow batch builder so the ``confidence_majority``
+            strategy can weight survivorship by edge confidence. The frames-out
+            cluster dict carries no pair_scores, so the caller sources these from
+            the ``ClusterPairScores`` view. Dropped on the fast path (which never
+            consults pair scores).
 
     Returns:
         A ``(golden_df, golden_records)`` tuple. Exactly one slot is
@@ -1199,6 +1206,7 @@ def build_golden_records_from_frames(
         rules,
         quality_scores=quality_scores,
         provenance=provenance,
+        cluster_pair_scores=cluster_pair_scores,
     )
     return None, golden_records
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1690,13 +1690,41 @@ def _run_dedupe_pipeline(
     # path (stats + dupes) never calls it -- those read the metadata/assignments
     # frames directly -- so golden + stats + dupes stay dict-free.
     _clusters_cache: list[dict[int, dict]] = []
+    _pair_score_view_cache: list[ClusterPairScores | None] = []
+
+    def _pair_score_view() -> ClusterPairScores | None:
+        # The per-cluster pair scores for the frames-out path, sourced from the
+        # raw scored pairs + final assignments. Built AT MOST ONCE and cached.
+        # None on the dict/columnar paths (their `clusters` dict already carries
+        # real pair_scores). Used to (a) restore pair_scores on the rebuilt
+        # results["clusters"] dict and (b) feed the confidence_majority golden
+        # slow path -- both of which the frames-out cluster dict leaves empty.
+        if cluster_frames is None:
+            return None
+        if not _pair_score_view_cache:
+            from goldenmatch.core.cluster_pairscores import ClusterPairScores
+            _pair_score_view_cache.append(
+                ClusterPairScores.from_frames(cluster_frames.assignments, all_pairs)
+            )
+        return _pair_score_view_cache[0]
 
     def _clusters_dict() -> dict[int, dict]:
         if cluster_frames is None:
             # Gate-OFF / columnar paths bound `clusters` eagerly above.
             return clusters
         if not _clusters_cache:
-            _clusters_cache.append(cluster_frames_to_dict(cluster_frames))
+            d = cluster_frames_to_dict(cluster_frames)
+            # cluster_frames_to_dict leaves pair_scores={} on every cluster;
+            # restore the real per-pair scores from the view so the returned
+            # dict matches the legacy path's contract (unmerge, lineage, and
+            # callers that read clusters[cid]["pair_scores"] all depend on it).
+            psv = _pair_score_view()
+            if psv is not None:
+                for cid, edges in psv.iter_clusters():
+                    info = d.get(cid)
+                    if info is not None:
+                        info["pair_scores"] = {(a, b): s for (a, b, s) in edges}
+            _clusters_cache.append(d)
         return _clusters_cache[0]
 
     if cluster_frames is not None:
@@ -1817,12 +1845,29 @@ def _run_dedupe_pipeline(
                     c for c in collected_df.columns
                     if not any(c.startswith(p) for p in _internal_prefixes)
                 ])
+            # Source per-cluster pair scores from the view so the slow builder's
+            # confidence_majority survivorship weights by edge confidence instead
+            # of degrading to count-majority (the frames-out cluster dict carries
+            # pair_scores={}). The fast builder ignores it; only built once here
+            # if the slow path needs it.
+            _frames_pair_scores: dict[int, dict[tuple[int, int], float]] | None = None
+            if not (
+                not _provenance_on
+                and _polars_native_eligible(golden_rules, quality_scores=quality_scores)
+            ):
+                _psv = _pair_score_view()
+                if _psv is not None:
+                    _frames_pair_scores = {
+                        cid: {(a, b): s for (a, b, s) in edges}
+                        for cid, edges in _psv.iter_clusters()
+                    }
             golden_df, golden_records = build_golden_records_from_frames(
                 _golden_source,
                 cluster_frames,
                 golden_rules,
                 quality_scores=quality_scores,
                 provenance=_provenance_on,
+                cluster_pair_scores=_frames_pair_scores,
             )
     else:
         with stage("golden"):
@@ -2092,12 +2137,7 @@ def _run_dedupe_pipeline(
     # input pairs (input-order last-wins) against the final cluster membership.
     # The gate-OFF branch is UNCHANGED: it leaves the view None and passes the
     # real-pair_scores dict.
-    pair_score_view: ClusterPairScores | None = None
-    if cluster_frames is not None:
-        from goldenmatch.core.cluster_pairscores import ClusterPairScores
-        pair_score_view = ClusterPairScores.from_frames(
-            cluster_frames.assignments, all_pairs
-        )
+    pair_score_view: ClusterPairScores | None = _pair_score_view()
     with stage("identity_resolve"):
         identity_summary = _resolve_identities(
             clusters if cluster_frames is None else None,

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -138,7 +138,7 @@ def _run(monkeypatch, *, frames_out: str, max_cluster_size: int, provenance: boo
     if frames_out == "1":
         monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
     else:
-        monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+        monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "0")
     cfg = _config(max_cluster_size=max_cluster_size, provenance=provenance)
     return run_dedupe_df(_fixture_df(), cfg, source_name="t")
 
@@ -341,7 +341,7 @@ def test_frames_out_identity_parity(monkeypatch, tmp_path, native):
 
     # Gate OFF: identity off the dict path (real per-cluster pair_scores).
     off_db = str(tmp_path / "identity_off.db")
-    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "0")
     off = run_dedupe_df(
         df, _identity_config(off_db, "off"), source_name=source,
     )
@@ -442,7 +442,7 @@ def test_frames_out_identity_consumes_cluster_frames_directly(
     # Gate OFF -> dict path.
     captured["leg"] = "off"
     off_db = str(tmp_path / "sp_c_off.db")
-    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "0")
     off = run_dedupe_df(df, _identity_config(off_db, "off"), source_name=source)
 
     # Gate ON -> frames-out path.
@@ -530,7 +530,7 @@ def test_frames_out_output_on_deferred_dict_parity(monkeypatch, tmp_path, native
     off_dir.mkdir()
     on_dir.mkdir()
 
-    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "0")
     off = run_dedupe_df(
         _fixture_df(),
         _config_with_output(str(off_dir), max_cluster_size=4),


### PR DESCRIPTION
## Phase 4 decision = FLIP

Makes the frames-out cluster -> golden -> identity path the default
(`GOLDENMATCH_CLUSTER_FRAMES_OUT` default `"0"` -> `"1"`; set `=0` to force the
legacy dict path). Records the resolution of the one pending decision from the
PR #838 handoff (verdict: ~2.1x wall win at 25M/100M, RSS converges to noise at
scale, no OOM divergence -> delete off the table, FLIP over HOLD).

## Why this is more than a 3-line flip

The handoff framed this as a default sentinel change covered by the existing
parity tests. Flipping the default surfaced **four real frames-out path defects**
the parity suites did not catch -- they compared curated multi-cluster fixtures
and stripped `pair_scores`, so neither the degenerate-input crash nor the
output-contract divergences were exercised. All four are fixed here.

| # | Defect (only visible once frames-out is the default) | Fix |
|---|------------------------------------------------------|-----|
| 1 | Hard crash: an empty scored-pair list gives a null-typed `a` column, so `ClusterPairScores.from_frames`'s join against the i64 `member_id` key raised `SchemaError` on small/degenerate dedupes | `from_frames` builds `pairs_df` with an explicit Int64/Float64 schema |
| 2 | `results["clusters"][cid]["pair_scores"]` came back `{}` (the frames dict carries no scores), breaking `unmerge` + scored-pair consumers | Build the `ClusterPairScores` view once, lazily; enrich the rebuilt clusters dict from it |
| 3 | `confidence_majority` golden survivorship silently degraded to count-majority on the frames path | `build_golden_records_from_frames` gains a `cluster_pair_scores` param, fed from the view (ignored on the fast path) |
| 4 | The cluster `ComplexityProfile.transitivity_rate` was emitted as 0.0 (no within-cluster scores), changing the auto-config controller's iteration behaviour vs the dict path | `_emit_cluster_profile_frames` reconstructs within-cluster edge scores from `pairs` + `assignments` so transitivity matches the dict path |

Plus the flip itself (`cluster.py` default + docstring scrub, drop the stale
pyright `reportUnusedFunction` ignore) and pinning the four legacy "gate OFF"
arms in `test_pipeline_frames_out_parity` to `GOLDENMATCH_CLUSTER_FRAMES_OUT=0`
so they keep comparing frames-vs-dict now that the default is ON.

## Validation

The full test suite is **byte-identical with the gate ON vs OFF**: 98 failed /
3714 passed either way, with **zero** tests differing in either direction
(diffed the complete FAILED + ERROR sets, not just counts). The 98 failures are
all pre-existing optional-dependency / environment failures (torch, mcp,
fastapi, ray, datafusion) that fail the same regardless of the gate.

- All four frames-out parity suites green (cluster / golden / identity / pipeline),
  plus the DataFusion-spine and pairscore-view parity suites.
- The native cluster kernel (`build_clusters_arrow`) was installed and exercised
  locally, so the native frames-out path is covered, not just pending CI.

The DataFusion-spine invariant is preserved: `build_cluster_frames`,
`build_golden_records_from_frames`, `cluster_frames_to_dict`, and
`ClusterPairScores.from_frames` all remain.

## Not included

- No version bump / CHANGELOG entry -- this is an internal default flip, not a
  release.
- The handoff's verdict-roadmap doc lives under `docs/superpowers/` (gitignored,
  local-only), so the Phase 3 verdict table is recorded here in the PR body
  rather than in a tracked doc.

https://claude.ai/code/session_01Xx2KE2vLjkn43CZZpqv71b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xx2KE2vLjkn43CZZpqv71b)_