### PR TITLE
perf(cluster): drop always-true per-pair guard in compute_cluster_confidence

### DIFF
--- a/.github/workflows/profile-hotspots.yml
+++ b/.github/workflows/profile-hotspots.yml
@@ -25,7 +25,7 @@ on:
         required: false
         default: "100000 1000000"
       targets:
-        description: "Space-separated paths to profile: list columnar"
+        description: "Space-separated paths to profile: list columnar full"
         required: false
         default: "list columnar"
       profilers:

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -1193,8 +1193,16 @@ def compute_cluster_confidence(
         Dict with: min_edge, avg_edge, connectivity, bottleneck_pair, confidence.
     """
     if native_enabled("clustering"):
-        edges = [(k[0], k[1], v) for k, v in pair_scores.items()
-                 if isinstance(k, tuple) and len(k) == 2]
+        # pair_scores keys are ALWAYS canonical (min, max) 2-tuples by
+        # construction -- every writer in this module builds them that way
+        # (_build_clusters_dict_path, add_to_cluster, unmerge, the split/merge
+        # paths) per the project-wide pair-canonicalization invariant. The old
+        # `if isinstance(k, tuple) and len(k) == 2` filter therefore re-confirmed
+        # a guaranteed invariant on EVERY pair and dropped nothing: at 1M / 131M
+        # pairs that was ~132M isinstance + ~132M len calls (~19s, profiled as
+        # 18% of the cluster stage / 5% of the whole-pipeline wall). Build the
+        # edge list directly; output is byte-identical for valid input.
+        edges = [(k[0], k[1], v) for k, v in pair_scores.items()]
         min_e, avg_e, conn, bn, conf = native_module().cluster_confidence(edges, size)
         return {
             "min_edge": min_e,

--- a/packages/python/goldenmatch/scripts/profile_hotspots.py
+++ b/packages/python/goldenmatch/scripts/profile_hotspots.py
@@ -19,7 +19,7 @@ Two profilers, depending on what you want to see:
   cumtime that's authoritative when you want to compare specific
   function-call counts.
 
-Two targets you can profile:
+Three targets you can profile:
 
 - ``list``: legacy ``score_blocks_parallel`` -> ``build_clusters``
   path. The pre-Phase-1c baseline against which the columnar
@@ -27,6 +27,16 @@ Two targets you can profile:
 - ``columnar``: Phase 1c-real ``score_blocks_columnar`` ->
   ``build_clusters_columnar`` path. The post-#639 winner that
   measured 22.7% faster at 1M.
+- ``full``: the whole ``run_dedupe`` engine via ``dedupe_df`` under
+  ``bench_capture``, emitting the per-stage wall split (collect /
+  exact / fuzzy build+score / cluster / golden / identity). This is
+  the stage breakdown the ``list``/``columnar`` micro-targets don't
+  surface -- golden, the input collect, etc. Uses the explicit
+  single-matchkey config (NOT zero-config) so it stays offline-safe
+  and deterministic; the auto-config controller is a separate,
+  sample-based cost already measured by
+  ``scripts/bench_phase2_controller.py`` (``bench-phase2-controller``
+  workflow), so it is deliberately out of scope here.
 
 Run via the ``profile-hotspots`` workflow on ``large-new-64GB``.
 Don't run locally past 100K -- memory/feedback_avoid_full_suite_oom
@@ -100,8 +110,16 @@ def _prepare_blocks(df: pl.DataFrame, cfg: GoldenMatchConfig) -> tuple[list, lis
 # ── Profile targets ─────────────────────────────────────────────────
 
 
-def _profile_list_path(blocks: list, cfg: GoldenMatchConfig, all_ids: list[int]) -> tuple[int, int, float]:
-    """Returns (n_pairs, n_clusters, wall_s)."""
+# Each target returns (n_pairs, n_clusters, wall_s, extra) where ``extra`` is a
+# JSON-serializable dict merged into the per-combo summary (empty for the micro-
+# targets; the per-stage bench split for ``full``). ``df`` is the prepared
+# fixture frame; the micro-targets ignore it (they consume pre-built ``blocks``).
+
+
+def _profile_list_path(
+    df: pl.DataFrame, blocks: list, cfg: GoldenMatchConfig, all_ids: list[int],
+) -> tuple[int, int, float, dict]:
+    """Returns (n_pairs, n_clusters, wall_s, extra)."""
     mk = cfg.matchkeys[0]
     matched: set[tuple[int, int]] = set()
     t0 = time.perf_counter()
@@ -111,10 +129,12 @@ def _profile_list_path(blocks: list, cfg: GoldenMatchConfig, all_ids: list[int])
     pairs = score_blocks_parallel(blocks, mk, matched, track_matched=False)
     clusters = build_clusters(pairs, all_ids=all_ids)
     wall = time.perf_counter() - t0
-    return len(pairs), len(clusters), wall
+    return len(pairs), len(clusters), wall, {}
 
 
-def _profile_columnar_path(blocks: list, cfg: GoldenMatchConfig, all_ids: list[int]) -> tuple[int, int, float]:
+def _profile_columnar_path(
+    df: pl.DataFrame, blocks: list, cfg: GoldenMatchConfig, all_ids: list[int],
+) -> tuple[int, int, float, dict]:
     mk = cfg.matchkeys[0]
     matched: set[tuple[int, int]] = set()
     t0 = time.perf_counter()
@@ -124,12 +144,55 @@ def _profile_columnar_path(blocks: list, cfg: GoldenMatchConfig, all_ids: list[i
     pairs_df = score_blocks_columnar(blocks, mk, matched, track_matched=False)
     clusters = build_clusters_columnar(pairs_df, all_ids=all_ids)
     wall = time.perf_counter() - t0
-    return pairs_df.height, len(clusters), wall
+    return pairs_df.height, len(clusters), wall, {}
+
+
+def _profile_full_pipeline(
+    df: pl.DataFrame, blocks: list, cfg: GoldenMatchConfig, all_ids: list[int],
+) -> tuple[int, int, float, dict]:
+    """Whole-``run_dedupe`` engine stage split (offline, explicit-config).
+
+    Runs the real ``_run_dedupe_pipeline`` via ``dedupe_df`` under
+    ``bench_capture`` so the per-stage wall (combined_lf_collect / exact /
+    fuzzy build+score / cluster / golden / identity) is captured -- the stages
+    the ``list``/``columnar`` micro-targets never exercise. Uses the explicit
+    single-matchkey ``cfg`` (NOT zero-config) so it stays offline-safe and
+    deterministic: no controller iterations, no HuggingFace rerank download,
+    no ``ControllerNotConfidentError``. The ``extra`` dict carries the stage
+    timings + bench metrics into the summary JSON.
+    """
+    from goldenmatch import dedupe_df
+    from goldenmatch.core.bench import bench_capture
+
+    # The worker pre-adds the internal ``__row_id__`` (the micro-targets need it
+    # for ``_prepare_blocks``); ``run_dedupe_df`` assigns its own, so a frame that
+    # already carries it triggers a Polars DuplicateError. Hand the full pipeline
+    # a clean frame and let it own the internal columns.
+    clean = df.drop([c for c in ("__row_id__", "__source__") if c in df.columns])
+
+    t0 = time.perf_counter()
+    with bench_capture() as rec:
+        res = dedupe_df(clean, config=cfg)
+    wall = time.perf_counter() - t0
+
+    bench = rec.to_dict()
+    metrics = bench.get("metrics", {})
+    n_pairs = int(metrics.get("scored_pair_count", 0) or 0)
+    n_clusters = int(
+        metrics.get("cluster_count", 0) or len(getattr(res, "clusters", {}) or {}),
+    )
+    extra = {
+        "stage_timings_seconds": bench.get("stage_timings_seconds", {}),
+        "stage_peak_rss_kb": bench.get("stage_peak_rss_kb", {}),
+        "bench_metrics": metrics,
+    }
+    return n_pairs, n_clusters, wall, extra
 
 
 _TARGETS = {
     "list": _profile_list_path,
     "columnar": _profile_columnar_path,
+    "full": _profile_full_pipeline,
 }
 
 
@@ -157,7 +220,12 @@ def _worker_main(n: int, target: str, profiler: str, out_dir: Path) -> int:
             pl.col("__row_id__").cast(pl.Int64),
         )
     cfg = _make_config()
-    blocks, all_ids = _prepare_blocks(df, cfg)
+    # The micro-targets consume pre-built blocks; the `full` target re-runs the
+    # whole pipeline (which blocks internally), so skip the redundant build.
+    if target == "full":
+        blocks, all_ids = [], []
+    else:
+        blocks, all_ids = _prepare_blocks(df, cfg)
 
     out_dir.mkdir(parents=True, exist_ok=True)
     base = out_dir / f"{target}_n{n}_{profiler}"
@@ -181,7 +249,7 @@ def _worker_main(n: int, target: str, profiler: str, out_dir: Path) -> int:
 
         prof = Profiler(interval=0.001)
         prof.start()
-        n_pairs, n_clusters, wall = target_fn(blocks, cfg, all_ids)
+        n_pairs, n_clusters, wall, extra = target_fn(df, blocks, cfg, all_ids)
         prof.stop()
 
         # Console output (human readable) -- shows the top frame chain
@@ -199,11 +267,12 @@ def _worker_main(n: int, target: str, profiler: str, out_dir: Path) -> int:
             "console_path": str(base.with_suffix(".txt").name),
             "html_path": str(base.with_suffix(".html").name),
         })
+        summary.update(extra)
 
     elif profiler == "cprofile":
         prof = cProfile.Profile()
         prof.enable()
-        n_pairs, n_clusters, wall = target_fn(blocks, cfg, all_ids)
+        n_pairs, n_clusters, wall, extra = target_fn(df, blocks, cfg, all_ids)
         prof.disable()
 
         # Dump pstats binary AND a human-readable cumtime-sorted dump.
@@ -242,6 +311,7 @@ def _worker_main(n: int, target: str, profiler: str, out_dir: Path) -> int:
             "text_path": str(base.with_suffix(".txt").name),
             "top_cumtime": top_funcs,
         })
+        summary.update(extra)
 
     else:
         print(f"unknown profiler: {profiler}", file=sys.stderr, flush=True)
@@ -321,6 +391,25 @@ def _summarize(out_dir: Path) -> None:
             f"`{report}` |",
             flush=True,
         )
+
+    # full-target: show the per-stage wall split for the largest shape. This is
+    # the whole-run_dedupe breakdown (collect / exact / fuzzy / cluster / golden
+    # / identity) that the list/columnar micro-targets don't surface.
+    full = [s for s in summaries if s.get("stage_timings_seconds")]
+    if full:
+        biggest = max(full, key=lambda s: s.get("n", 0))
+        stages = biggest.get("stage_timings_seconds", {})
+        if stages:
+            total = sum(stages.values()) or 1.0
+            print(
+                f"\n### Stage wall split (full run_dedupe @ "
+                f"n={biggest['n']:,}, {biggest.get('profiler', '?')})\n",
+                flush=True,
+            )
+            print("| stage | wall_s | % of staged |", flush=True)
+            print("|---|---:|---:|", flush=True)
+            for name, secs in sorted(stages.items(), key=lambda kv: kv[1], reverse=True):
+                print(f"| `{name}` | {secs:.2f} | {100 * secs / total:.1f}% |", flush=True)
 
     # cProfile-only: show top hotspots for the largest shape.
     cprof = [s for s in summaries if s.get("profiler") == "cprofile"]

--- a/packages/python/goldenmatch/scripts/profile_hotspots.py
+++ b/packages/python/goldenmatch/scripts/profile_hotspots.py
@@ -195,6 +195,11 @@ _TARGETS = {
     "full": _profile_full_pipeline,
 }
 
+# Above this row count, the `full` target refuses cProfile (call-graph retention
+# over the whole pipeline OOMs a 64GB host). pyinstrument + the bench stage split
+# cover the same ground safely.
+_FULL_CPROFILE_MAX_N = 200_000
+
 
 # ── Worker (one (shape, target, profiler) at a time, subprocess-isolated) ──
 
@@ -213,6 +218,22 @@ def _worker_main(n: int, target: str, profiler: str, out_dir: Path) -> int:
         print(f"unknown target: {target}", file=sys.stderr, flush=True)
         return 2
     target_fn = _TARGETS[target]
+
+    # Guard: the `full` target under cProfile retains a per-call graph over the
+    # ENTIRE pipeline (input collect + 131M-pair scoring + per-cluster pair_scores
+    # dicts + golden). At 1M that OOM-killed the 64GB runner host (run
+    # 27246143342). The per-stage split comes from bench_capture, which is
+    # profiler-independent, so pyinstrument -- a sampling profiler with a
+    # fixed-size call tree -- yields the same wall breakdown at a fraction of the
+    # memory. Skip the dangerous combo instead of crashing the whole job.
+    if target == "full" and profiler == "cprofile" and n > _FULL_CPROFILE_MAX_N:
+        print(
+            f"  full@{n:,} [cprofile]: SKIPPED -- cProfile call-graph retention "
+            f"OOMs the whole-pipeline target above {_FULL_CPROFILE_MAX_N:,} rows; "
+            f"use pyinstrument (the bench stage split is profiler-independent).",
+            file=sys.stderr, flush=True,
+        )
+        return 0
 
     df = realistic_person_df(n)
     if "__row_id__" not in df.columns:

--- a/packages/python/goldenmatch/tests/test_cluster_confidence_guard.py
+++ b/packages/python/goldenmatch/tests/test_cluster_confidence_guard.py
@@ -1,0 +1,104 @@
+"""Contract/parity tests for ``compute_cluster_confidence`` after the
+native-path edge-list guard removal.
+
+The native branch used to filter ``pair_scores`` items with
+``if isinstance(k, tuple) and len(k) == 2`` on EVERY pair before handing the
+edge list to the Rust kernel. ``pair_scores`` keys are always canonical
+``(min, max)`` 2-tuples by construction (every writer in ``core/cluster.py``
+builds them that way), so the filter re-confirmed a guaranteed invariant and
+dropped nothing -- ~132M isinstance + ~132M len calls at 1M / 131M pairs
+(~19s, 18% of the cluster stage on the profiled 1M run). The guard was removed;
+these tests pin the exact confidence contract so the removal is provably
+output-preserving on valid (canonical-key) input.
+
+confidence = 0.4*min_edge + 0.3*avg_edge + 0.3*connectivity
+connectivity = len(pair_scores) / (size*(size-1)/2)
+
+Path-independent: the native kernel and the pure-Python fallback are
+parity-validated to the same numbers, so these assertions hold whichever path
+``native_enabled("clustering")`` selects in the test env.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core.cluster import compute_cluster_confidence
+
+_ABS = 1e-9
+
+
+def test_triangle_full_connectivity():
+    """3 members, all 3 edges present -> connectivity 1.0."""
+    ps = {(0, 1): 0.9, (0, 2): 0.8, (1, 2): 0.7}
+    out = compute_cluster_confidence(ps, size=3)
+    assert out["min_edge"] == pytest.approx(0.7, abs=_ABS)
+    assert out["avg_edge"] == pytest.approx(0.8, abs=_ABS)
+    assert out["connectivity"] == pytest.approx(1.0, abs=_ABS)
+    assert out["bottleneck_pair"] == (1, 2)
+    # 0.4*0.7 + 0.3*0.8 + 0.3*1.0 = 0.82
+    assert out["confidence"] == pytest.approx(0.82, abs=_ABS)
+
+
+def test_chain_partial_connectivity():
+    """3 members, only 2 of 3 possible edges -> connectivity 2/3."""
+    ps = {(0, 1): 0.9, (1, 2): 0.6}
+    out = compute_cluster_confidence(ps, size=3)
+    assert out["min_edge"] == pytest.approx(0.6, abs=_ABS)
+    assert out["avg_edge"] == pytest.approx(0.75, abs=_ABS)
+    assert out["connectivity"] == pytest.approx(2.0 / 3.0, abs=_ABS)
+    assert out["bottleneck_pair"] == (1, 2)
+    # 0.4*0.6 + 0.3*0.75 + 0.3*(2/3) = 0.665
+    assert out["confidence"] == pytest.approx(0.665, abs=_ABS)
+
+
+def test_two_member():
+    ps = {(0, 1): 0.85}
+    out = compute_cluster_confidence(ps, size=2)
+    assert out["min_edge"] == pytest.approx(0.85, abs=_ABS)
+    assert out["avg_edge"] == pytest.approx(0.85, abs=_ABS)
+    assert out["connectivity"] == pytest.approx(1.0, abs=_ABS)
+    assert out["bottleneck_pair"] == (0, 1)
+    # 0.4*0.85 + 0.3*0.85 + 0.3*1.0 = 0.895
+    assert out["confidence"] == pytest.approx(0.895, abs=_ABS)
+
+
+def test_singleton():
+    out = compute_cluster_confidence({}, size=1)
+    assert out["connectivity"] == pytest.approx(1.0, abs=_ABS)
+    assert out["confidence"] == pytest.approx(1.0, abs=_ABS)
+    assert out["bottleneck_pair"] is None
+
+
+def test_empty_pairs_multi_member():
+    """size>1 with no edges -> connectivity 0, confidence 0."""
+    out = compute_cluster_confidence({}, size=2)
+    assert out["connectivity"] == pytest.approx(0.0, abs=_ABS)
+    assert out["confidence"] == pytest.approx(0.0, abs=_ABS)
+    assert out["bottleneck_pair"] is None
+
+
+def test_bottleneck_is_first_minimum():
+    """Ties resolve to the first minimum key in dict-insertion order (the
+    contract the native + Python paths share)."""
+    ps = {(0, 1): 0.5, (0, 2): 0.5, (1, 2): 0.9}
+    out = compute_cluster_confidence(ps, size=3)
+    assert out["min_edge"] == pytest.approx(0.5, abs=_ABS)
+    assert out["bottleneck_pair"] == (0, 1)
+
+
+def test_larger_cluster_matches_formula():
+    """Exercise the comprehension path over many pairs and check the result
+    against the formula computed independently."""
+    n = 60
+    ps = {(i, j): 0.6 + ((i + j) % 5) * 0.05
+          for i in range(n) for j in range(i + 1, n)}
+    out = compute_cluster_confidence(ps, size=n)
+    scores = list(ps.values())
+    exp_min = min(scores)
+    exp_avg = sum(scores) / len(scores)
+    exp_conn = len(ps) / (n * (n - 1) / 2)  # fully connected -> 1.0
+    assert out["min_edge"] == pytest.approx(exp_min, abs=_ABS)
+    assert out["avg_edge"] == pytest.approx(exp_avg, abs=_ABS)
+    assert out["connectivity"] == pytest.approx(exp_conn, abs=_ABS)
+    assert out["confidence"] == pytest.approx(
+        0.4 * exp_min + 0.3 * exp_avg + 0.3 * exp_conn, abs=_ABS,
+    )


### PR DESCRIPTION
## What

Whole-pipeline perf-audit finding **F1**: the native path of `compute_cluster_confidence` filtered `pair_scores` items with `if isinstance(k, tuple) and len(k) == 2` before building the edge list for the Rust kernel. `pair_scores` keys are **always** canonical `(min, max)` 2-tuples by construction — every writer in `core/cluster.py` builds them that way per the project-wide pair-canonicalization invariant — so the filter re-confirmed a guaranteed invariant on every pair and dropped nothing.

At 1M / ~131M scored pairs that was ~132M `isinstance` + ~132M `len` calls. This commit builds the edge list directly; **output is byte-identical for valid input.**

## Measured (1M, `large-new-64GB`, `list` target, cProfile)

Before = post-#840 baseline (run 27243162275); after = this branch (run 27249159224). Identical output on both: 131,166,381 pairs / 5,407 clusters.

| | before | after | Δ |
|---|---:|---:|---:|
| list-path wall | 243.6s | **198.5s** | **−45.1s (−18.5%)** |
| `compute_cluster_confidence` tottime | 38.10s | **14.54s** | −23.6s |
| `compute_cluster_confidence` cumtime | 61.1s | **18.3s** | −42.8s |
| `isinstance` calls | 132,218,899 | **0** | gone |
| `len` calls | 132,236,139 | **2,270** | gone |

The drop exceeds the isolated `isinstance`+`len` tottime (~19s) because evaluating the `if` condition over 131M items also carried the boolean-`and` + `== 2` + branch overhead inside the comprehension (the 23.6s drop in the function's own tottime).

Whole-pipeline context: in the full `run_dedupe` profile `compute_cluster_confidence` was 63.6s of the 353.7s wall, so this is ~12% of the entire pipeline for deleting always-true work.

## Tests

`tests/test_cluster_confidence_guard.py` pins the exact confidence contract (min/avg/connectivity/bottleneck/confidence) across full/partial connectivity, 2-member, singleton, empty, tie-break, and a 60-member cluster — path-independent (native + pure-Python parity), so the removal is provably output-preserving. Native clustering is active in CI, so the changed branch is exercised. 34 cluster + 12 parity/guard tests green locally.

## Also included (audit tooling)

Two commits that produced the measurement above, kept with F1 rather than on the scorer-guard PR:
- `add full target for the whole-run_dedupe stage split` — the `profile-hotspots.yml` `full` target that runs the real `_run_dedupe_pipeline` under `bench_capture` and emits the per-stage wall split.
- `skip cProfile for the full target above 200K rows (OOM guard)` — the `full`+cProfile combo OOM-killed the 64GB runner; the stage split is profiler-independent, so the worker skips that combo and uses pyinstrument.

https://claude.ai/code/session_011PU7UrNxRsy2aTwyPeMWuz

---
_Generated by [Claude Code](https://claude.ai/code/session_011PU7UrNxRsy2aTwyPeMWuz)_