### PR TITLE
feat(sail): S5 identity-on-Sail — distributed create + edge-emit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1372,8 +1372,14 @@ jobs:
       - name: Sail golden parity gate (blocking)
         run: |
           .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_golden_parity.py -v --timeout=300
-      # GATE (blocking): the full Sail pipeline (load->...->golden) runs
-      # end-to-end on Sail (S4).
+      # GATE (blocking): identity create + edge-emit parity vs the one-box
+      # resolve_clusters on a fresh store (S5) -- same_as edge-set + record->
+      # entity partition equivalence + count + determinism.
+      - name: Sail identity parity gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_identity_parity.py -v --timeout=300
+      # GATE (blocking): the full Sail pipeline (load->...->golden[->identity])
+      # runs end-to-end on Sail (S4 + S5 emit_identity).
       - name: Sail end-to-end pipeline gate (blocking)
         run: |
           .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_pipeline.py -v --timeout=300

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -516,7 +516,7 @@ def build_clusters(
     )
 
 
-def _cluster_frames_out_enabled() -> bool:
+def _cluster_frames_out_enabled() -> bool:  # pyright: ignore[reportUnusedFunction]  # used cross-module: pipeline.py imports + calls this; pyright's private-symbol unused check misses the call site
     """Frames-out path gate. When enabled, ``build_cluster_frames`` returns the
     two-frame ``ClusterFrames`` columnar representation directly, WITHOUT
     materializing the per-cluster ``dict[int, dict]`` for non-oversized clusters.

--- a/packages/python/goldenmatch/goldenmatch/sail/identity.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/identity.py
@@ -1,0 +1,316 @@
+"""S5: identity-on-Sail — distributed create + edge-emit (Stage S5).
+
+Re-expresses Layer 1 of one-box ``identity.resolve.resolve_clusters`` (create +
+``same_as`` edges — entity-independent + content-deterministic) as relational
+Spark ops + scalar pandas-UDFs. The stateful incremental layer (absorb/merge
+against an existing store) is DEFERRED, honest-null: it stays driver-side, as
+the Ray path left it. Spec: docs/superpowers/specs/2026-06-10-sail-tier-stage
+-s5-identity-design.md.
+
+pyspark is imported lazily INSIDE the builder functions so this module imports
+without the [sail] extra (mirrors sail/golden.py).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+_ENT_PREFIX = "ent:h1:"
+_ENT_HASH_LEN = 16  # 64 bits of hex; collision-safe for entity populations.
+
+
+# --- pure helpers (no pyspark; locally testable, parity-by-construction) ---
+
+
+def record_id_for_row(
+    payload: dict[str, Any], source: str, source_pk_col: str | None
+) -> str:
+    """Primary record_id for a row, mirroring one-box ``_record_id_candidates``
+    PRIMARY path. PK -> ``{source}:{pk}``. No PK -> canonical fingerprint
+    ``{source}:h1:{fingerprint[:12]}``; un-fingerprintable rows fall to the
+    legacy ``{source}:hash:{12}`` (same as the one-box ``except`` branch). The
+    legacy id is NOT emitted as a separate lookup candidate here — candidate
+    resolution is the deferred Layer-2 (overlap) concern.
+    """
+    if source_pk_col and source_pk_col in payload and payload[source_pk_col] is not None:
+        return f"{source}:{payload[source_pk_col]}"
+    clean = {k: v for k, v in payload.items() if not str(k).startswith("__")}
+    from goldenmatch.core._hashing import record_fingerprint
+    from goldenmatch.identity.fingerprint_batch import _canonical_payload
+
+    try:
+        full_h1 = record_fingerprint(_canonical_payload(clean))
+    except (TypeError, ValueError):
+        blob = json.dumps(clean, sort_keys=True, default=str)
+        return f"{source}:hash:{hashlib.sha256(blob.encode('utf-8')).hexdigest()[:12]}"
+    return f"{source}:h1:{full_h1[:12]}"
+
+
+def entity_id_for_members(record_ids: list[str]) -> str:
+    """Deterministic content-derived entity_id: SHA-256 of the cluster's
+    canonical (sorted) member record_ids. Order-independent, reproducible, no
+    worker coordination. Sail-create-only scheme (``ent:h1:``).
+    """
+    canonical = "\n".join(sorted(record_ids))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"{_ENT_PREFIX}{digest[:_ENT_HASH_LEN]}"
+
+
+def _id_scheme() -> str:
+    """``h1`` (deterministic content hash, default) or ``uuid7`` (per-worker
+    UUIDv7, matches the one-box scheme but non-deterministic output).
+    """
+    return os.environ.get("GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME", "h1").strip().lower()
+
+
+# --- Spark frame builders (lazy pyspark imports) ---
+
+
+def derive_record_ids(
+    source_df: Any,
+    *,
+    source_col: str = "__source__",
+    source_pk_col: str | None = None,
+    id_col: str = "__row_id__",
+) -> Any:
+    """Add a ``record_id`` column to ``source_df``. PK path is a pure column
+    expression; the no-PK h1 path runs ``record_id_for_row`` in a struct
+    pandas_udf over the payload columns (parity with one-box by construction).
+    """
+    from pyspark.sql import functions as F
+    from pyspark.sql.types import StringType
+
+    has_source = source_col in source_df.columns
+    src_expr = F.col(source_col) if has_source else F.lit("dataframe")
+
+    if source_pk_col is not None:
+        return source_df.withColumn(
+            "record_id",
+            F.concat(src_expr, F.lit(":"), F.col(source_pk_col).cast("string")),
+        )
+
+    payload_cols = [c for c in source_df.columns if not c.startswith("__")]
+    # Thread the row's REAL __source__ through to the helper (one-box uses the
+    # row's source, not a constant) -- pass it as an extra struct column so the
+    # no-PK h1 id matches one-box per-row. Falls back to "dataframe" per row
+    # when __source__ is absent (matches one-box row.get default).
+    udf_cols = payload_cols + ([source_col] if has_source else [])
+
+    @F.pandas_udf(StringType())
+    def _rid(*cols):
+        import pandas as pd
+
+        frame = pd.concat(cols, axis=1)
+        frame.columns = udf_cols
+        out = []
+        for _, row in frame.iterrows():
+            payload = {c: row[c] for c in payload_cols}
+            source = str(row[source_col]) if has_source else "dataframe"
+            out.append(record_id_for_row(payload, source, None))
+        return pd.Series(out)
+
+    return source_df.withColumn("record_id", _rid(*[F.col(c) for c in udf_cols]))
+
+
+def mint_entity_ids(assignments_with_recid: Any) -> Any:
+    """``(cluster_id, record_id)`` -> ``(cluster_id, entity_id)``: collect each
+    cluster's member record_ids and hash them deterministically. ``uuid7``
+    scheme mints a per-cluster UUIDv7 instead (non-deterministic; matches the
+    one-box scheme).
+    """
+    from pyspark.sql import functions as F
+    from pyspark.sql.types import StringType
+
+    grouped = assignments_with_recid.groupBy("cluster_id").agg(
+        F.collect_list("record_id").alias("__rids__")
+    )
+
+    if _id_scheme() == "uuid7":
+        from goldenmatch.identity.store import new_entity_id
+
+        @F.pandas_udf(StringType())
+        def _eid(col):
+            import pandas as pd
+
+            return pd.Series([new_entity_id() for _ in col])
+    else:
+
+        @F.pandas_udf(StringType())
+        def _eid(col):
+            import pandas as pd
+
+            return pd.Series([entity_id_for_members(list(v)) for v in col])
+
+    return grouped.withColumn("entity_id", _eid(F.col("__rids__"))).select(
+        "cluster_id", "entity_id"
+    )
+
+
+def build_same_as_edges(
+    pairs: Any,
+    assignments: Any,
+    recid_map: Any,
+    entity_ids: Any,
+    *,
+    run_meta: dict[str, Any],
+) -> Any:
+    """``same_as`` evidence edges, one per scored within-cluster pair. Join each
+    pair's endpoints to their cluster (via assignments) and entity, map member
+    ids to record_ids. Entity-independent content; every post-dedup pair is
+    within-cluster by WCC construction.
+    """
+    from pyspark.sql import functions as F
+
+    # member_id -> cluster_id (a's cluster == b's cluster by construction).
+    a_cl = assignments.select(
+        F.col("member_id").alias("a"), F.col("cluster_id")
+    )
+    ra = recid_map.select(
+        F.col("member_id").alias("a"), F.col("record_id").alias("record_a_id")
+    )
+    rb = recid_map.select(
+        F.col("member_id").alias("b"), F.col("record_id").alias("record_b_id")
+    )
+
+    e = (
+        pairs.join(a_cl, on="a", how="inner")
+        .join(entity_ids, on="cluster_id", how="inner")
+        .join(ra, on="a", how="inner")
+        .join(rb, on="b", how="inner")
+    )
+    return e.select(
+        "entity_id",
+        "record_a_id",
+        "record_b_id",
+        F.lit("same_as").alias("kind"),
+        F.col("score"),
+        F.lit(run_meta.get("matchkey_name")).alias("matchkey_name"),
+        F.lit(run_meta["run_name"]).alias("run_name"),
+        F.lit(run_meta.get("dataset")).alias("dataset"),
+        F.lit(run_meta["recorded_at"]).alias("recorded_at"),
+    )
+
+
+def build_identity_nodes(
+    entity_ids: Any,
+    golden_df: Any,
+    *,
+    run_meta: dict[str, Any],
+) -> Any:
+    """One node per entity (incl. singletons). ``golden_record`` LEFT-joins
+    ``build_golden`` (multi-member only); SINGLETON ``golden_record`` is NULL by
+    design -- node *count* (one per cluster) is the gate invariant, content is
+    not. (One-box populates singleton golden from the single row; S5 leaves it
+    NULL, a documented gate-neutral simplification -- populating it is a deferred
+    polish, not needed for the create-path graph.)
+    """
+    from pyspark.sql import functions as F
+    from pyspark.sql.types import StringType
+
+    # entity -> golden JSON for multi-member clusters.
+    gcols = [c for c in golden_df.columns if c != "cluster_id"]
+
+    @F.pandas_udf(StringType())
+    def _as_json(*cols):
+        import pandas as pd
+
+        frame = pd.concat(cols, axis=1)
+        frame.columns = gcols
+        out = []
+        for _, row in frame.iterrows():
+            rec = {c: (None if pd.isna(row[c]) else row[c]) for c in gcols}
+            out.append(json.dumps(rec, default=str))
+        return pd.Series(out)
+
+    golden_json = (
+        golden_df.join(entity_ids, on="cluster_id", how="inner")
+        .withColumn("golden_record", _as_json(*[F.col(c) for c in gcols]))
+        .select("entity_id", "golden_record")
+    )
+
+    # LEFT join keeps EVERY entity (singletons get NULL golden_record).
+    nodes = entity_ids.select("cluster_id", "entity_id").join(
+        golden_json, on="entity_id", how="left"
+    )
+    return nodes.select(
+        "entity_id",
+        F.lit("active").alias("status"),
+        F.lit(None).cast("string").alias("merged_into"),
+        F.col("golden_record"),
+        F.lit(None).cast("double").alias("confidence"),
+        F.lit(run_meta.get("dataset")).alias("dataset"),
+        F.lit(run_meta["recorded_at"]).alias("created_at"),
+        F.lit(run_meta["recorded_at"]).alias("updated_at"),
+    )
+
+
+def build_source_records(
+    assignments: Any,
+    recid_map: Any,
+    entity_ids: Any,
+    *,
+    run_meta: dict[str, Any],
+) -> Any:
+    """record_id -> entity assignment (the record->entity partition)."""
+    from pyspark.sql import functions as F
+
+    return (
+        assignments.join(recid_map, on="member_id", how="inner")
+        .join(entity_ids, on="cluster_id", how="inner")
+        .select(
+            "record_id",
+            "entity_id",
+            F.lit(run_meta.get("dataset")).alias("dataset"),
+            F.lit(run_meta["recorded_at"]).alias("first_seen_at"),
+            F.lit(run_meta["recorded_at"]).alias("last_seen_at"),
+        )
+    )
+
+
+@dataclass
+class IdentityGraphFrames:
+    nodes: Any
+    records: Any
+    edges: Any
+
+
+def build_identity_graph(
+    pairs: Any,
+    assignments: Any,
+    source_df: Any,
+    golden_df: Any,
+    *,
+    run_meta: dict[str, Any],
+    source_col: str = "__source__",
+    source_pk_col: str | None = None,
+    id_col: str = "__row_id__",
+) -> IdentityGraphFrames:
+    """Produce the create-path identity graph as distributed Spark frames.
+    Layer 1 only (create + same_as edges); incremental absorb/merge is the
+    deferred Layer 2 (honest-null).
+    """
+    from pyspark.sql import functions as F
+
+    src_rid = derive_record_ids(
+        source_df, source_col=source_col, source_pk_col=source_pk_col, id_col=id_col
+    )
+    # member_id -> record_id
+    recid_map = src_rid.select(
+        F.col(id_col).alias("member_id"), F.col("record_id")
+    )
+    assign_rid = assignments.join(recid_map, on="member_id", how="inner").select(
+        "cluster_id", "record_id"
+    )
+    entity_ids = mint_entity_ids(assign_rid)
+
+    edges = build_same_as_edges(
+        pairs, assignments, recid_map, entity_ids, run_meta=run_meta
+    )
+    nodes = build_identity_nodes(entity_ids, golden_df, run_meta=run_meta)
+    records = build_source_records(
+        assignments, recid_map, entity_ids, run_meta=run_meta
+    )
+    return IdentityGraphFrames(nodes=nodes, records=records, edges=edges)

--- a/packages/python/goldenmatch/goldenmatch/sail/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/pipeline.py
@@ -4,7 +4,18 @@ a single pre-existing column (S1 scope); the scorer is the rapidfuzz pandas UDF;
 WCC defaults to the chain-robust pointer-jumping algorithm (scale)."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
+
+
+@dataclass
+class SailPipelineResult:
+    """Returned by ``run_sail_pipeline`` ONLY when ``emit_identity=True``. The
+    default path (``emit_identity=False``) returns the bare golden DataFrame
+    unchanged (back-compat)."""
+
+    golden: Any
+    identity: Any  # IdentityGraphFrames
 
 
 def run_sail_pipeline(
@@ -18,6 +29,10 @@ def run_sail_pipeline(
     threshold: float = 0.85,
     strategy: str = "most_complete",
     wcc: str = "scale",
+    emit_identity: bool = False,
+    source_col: str = "__source__",
+    source_pk_col: str | None = None,
+    run_meta: dict[str, Any] | None = None,
 ) -> Any:
     """Run the full Sail pipeline. Returns the golden DataFrame
     ``(cluster_id, *golden_cols)`` (one per multi-member cluster). ``wcc``:
@@ -25,6 +40,13 @@ def run_sail_pipeline(
 
     ``source_df`` must carry ``id_col`` (int), ``block_col``, ``value_col``,
     and the ``golden_cols``.
+
+    When ``emit_identity=True`` (S5), ALSO builds the create-path identity graph
+    (distributed) and returns a ``SailPipelineResult(golden, identity)`` instead
+    of the bare golden frame. ``run_meta`` (run_name/dataset/recorded_at/
+    matchkey_name) is passed in for deterministic output; a default is
+    synthesized when omitted. Default ``emit_identity=False`` is byte-for-byte
+    the prior behavior.
     """
     from goldenmatch.sail.clustering import (
         connected_components,
@@ -46,10 +68,32 @@ def run_sail_pipeline(
         connected_components_scale if wcc == "scale" else connected_components
     )
     assignments = wcc_fn(pairs, ids_df, id_col=id_col)
-    return build_golden(
+    golden = build_golden(
         assignments,
         source_df,
         value_cols=golden_cols,
         source_id_col=id_col,
         strategy=strategy,
     )
+    if not emit_identity:
+        return golden
+
+    from goldenmatch.sail.identity import build_identity_graph
+
+    meta = run_meta or {
+        "run_name": "sail",
+        "dataset": None,
+        "recorded_at": "1970-01-01T00:00:00",
+        "matchkey_name": scorer_name,
+    }
+    identity = build_identity_graph(
+        pairs,
+        assignments,
+        source_df,
+        golden,
+        run_meta=meta,
+        source_col=source_col,
+        source_pk_col=source_pk_col,
+        id_col=id_col,
+    )
+    return SailPipelineResult(golden=golden, identity=identity)

--- a/packages/python/goldenmatch/tests/test_sail_identity_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_identity_parity.py
@@ -1,0 +1,287 @@
+"""S5 gate: identity-on-Sail (distributed create + edge-emit) parity vs the
+one-box ``resolve_clusters`` create path on a fresh store.
+
+Two test tiers:
+  * PURE-HELPER unit tests (``record_id_for_row`` / ``entity_id_for_members``)
+    need no Sail server -- they run anywhere (incl. the normal python lane).
+  * SERVER tests (the builders, the 3-part parity gate, determinism) use an
+    in-process Sail Spark Connect server; the ``spark`` fixture ``importorskip``s
+    ``pysail``/``pyspark`` so they SKIP without the [sail] extra and run in the
+    `sail` CI lane.
+
+Parity gate (entity-id-INDEPENDENT, since one-box mints UUIDv7 while S5 mints
+deterministic ``ent:h1:`` ids): (1) ``same_as`` edge SET, (2) record->entity
+PARTITION equivalence, (3) node/edge counts. Spec:
+docs/superpowers/specs/2026-06-10-sail-tier-stage-s5-identity-design.md.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+import pytest
+from goldenmatch.sail.identity import entity_id_for_members, record_id_for_row
+
+# --------------------------------------------------------------------------
+# Tier 1: pure-helper unit tests (no Sail server needed).
+# --------------------------------------------------------------------------
+
+
+def test_record_id_pk_path():
+    # PK present -> "{source}:{pk}" (mirrors one-box _record_id_candidates).
+    assert record_id_for_row({"id": 42, "name": "x"}, "people", "id") == "people:42"
+
+
+def test_record_id_h1_path_matches_one_box():
+    # No PK -> "{source}:h1:{fingerprint[:12]}", byte-identical to the one-box
+    # primary id (parity by construction: same record_fingerprint call).
+    from goldenmatch.core._hashing import record_fingerprint
+    from goldenmatch.identity.fingerprint_batch import _canonical_payload
+
+    payload = {"first_name": "Jon", "email": "jon@x.com"}
+    expected = f"dataframe:h1:{record_fingerprint(_canonical_payload(payload))[:12]}"
+    assert record_id_for_row(payload, "dataframe", None) == expected
+
+
+def test_entity_id_order_independent():
+    a = entity_id_for_members(["people:1", "people:2", "people:3"])
+    b = entity_id_for_members(["people:3", "people:1", "people:2"])
+    assert a == b
+    assert a.startswith("ent:h1:")
+
+
+def test_entity_id_distinct_for_distinct_members():
+    a = entity_id_for_members(["people:1", "people:2"])
+    b = entity_id_for_members(["people:1", "people:3"])
+    assert a != b
+
+
+# --------------------------------------------------------------------------
+# Tier 2: server-backed tests (in-process Sail Spark Connect server).
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def spark():
+    pytest.importorskip("pysail")
+    pytest.importorskip("pyspark")
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def test_derive_record_ids_pk(spark):
+    from goldenmatch.sail.identity import derive_record_ids
+
+    df = spark.createDataFrame(
+        [(0, "people", 10, "Jon"), (1, "people", 11, "Marg")],
+        ["__row_id__", "__source__", "pk", "first_name"],
+    )
+    out = {
+        r["__row_id__"]: r["record_id"]
+        for r in derive_record_ids(df, source_pk_col="pk").collect()
+    }
+    assert out == {0: "people:10", 1: "people:11"}
+
+
+def test_mint_entity_ids(spark):
+    from goldenmatch.sail.identity import entity_id_for_members, mint_entity_ids
+
+    rows = [(0, "people:10"), (0, "people:11"), (5, "people:15")]
+    df = spark.createDataFrame(rows, ["cluster_id", "record_id"])
+    got = {r["cluster_id"]: r["entity_id"] for r in mint_entity_ids(df).collect()}
+    assert got[0] == entity_id_for_members(["people:10", "people:11"])
+    assert got[5] == entity_id_for_members(["people:15"])
+
+
+def _run_meta():
+    return {
+        "run_name": "r1",
+        "dataset": None,
+        "recorded_at": "2026-06-10T00:00:00",
+        "matchkey_name": "mk",
+    }
+
+
+def test_same_as_edges_set(spark):
+    from goldenmatch.sail.identity import build_same_as_edges
+
+    pairs = spark.createDataFrame([(0, 1, 0.97), (2, 3, 0.91)], ["a", "b", "score"])
+    assignments = spark.createDataFrame(
+        [(0, 0), (0, 1), (2, 2), (2, 3)], ["cluster_id", "member_id"]
+    )
+    recid = spark.createDataFrame(
+        [(0, "p:0"), (1, "p:1"), (2, "p:2"), (3, "p:3")], ["member_id", "record_id"]
+    )
+    entity_ids = spark.createDataFrame(
+        [(0, "ent:A"), (2, "ent:B")], ["cluster_id", "entity_id"]
+    )
+    edges = build_same_as_edges(
+        pairs, assignments, recid, entity_ids, run_meta=_run_meta()
+    )
+    collected = edges.collect()
+    got = {(r["record_a_id"], r["record_b_id"], r["entity_id"]) for r in collected}
+    assert got == {("p:0", "p:1", "ent:A"), ("p:2", "p:3", "ent:B")}
+    assert all(r["kind"] == "same_as" for r in collected)
+
+
+def test_nodes_include_singletons_and_records(spark):
+    from goldenmatch.sail.identity import build_identity_nodes, build_source_records
+
+    assignments = spark.createDataFrame(
+        [(0, 0), (0, 1), (5, 5)], ["cluster_id", "member_id"]
+    )
+    recid = spark.createDataFrame(
+        [(0, "p:0"), (1, "p:1"), (5, "p:5")], ["member_id", "record_id"]
+    )
+    entity_ids = spark.createDataFrame(
+        [(0, "ent:A"), (5, "ent:S")], ["cluster_id", "entity_id"]
+    )
+    # build_golden emits cluster 0 only (multi-member); cluster 5 is a singleton.
+    golden = spark.createDataFrame([(0, "Jonathan")], ["cluster_id", "first_name"])
+
+    nodes = build_identity_nodes(entity_ids, golden, run_meta=_run_meta())
+    node_ids = {r["entity_id"] for r in nodes.collect()}
+    assert node_ids == {"ent:A", "ent:S"}  # singleton node MUST exist
+
+    records = build_source_records(assignments, recid, entity_ids, run_meta=_run_meta())
+    rec_to_ent = {r["record_id"]: r["entity_id"] for r in records.collect()}
+    assert rec_to_ent == {"p:0": "ent:A", "p:1": "ent:A", "p:5": "ent:S"}
+
+
+# --------------------------------------------------------------------------
+# The 3-part parity gate + determinism.
+# --------------------------------------------------------------------------
+
+
+def _fixture():
+    # rows: (__row_id__, __source__, pk, name). Clusters by design:
+    #   chain 0-1-2 (a-b 0.96, b-c 0.95), junction-multimerge 5-6,6-7 (two pairs
+    #   share member 6), singleton 9.
+    rows = [
+        (0, "p", 100, "Ann"), (1, "p", 101, "Anne"), (2, "p", 102, "Annie"),
+        (5, "p", 105, "Bob"), (6, "p", 106, "Bobby"), (7, "p", 107, "Robert"),
+        (9, "p", 109, "Zed"),
+    ]
+    pairs = [(0, 1, 0.96), (1, 2, 0.95), (5, 6, 0.93), (6, 7, 0.92)]
+    # assignments via union-find over pairs (cluster_id = min member id).
+    assignments = [(0, 0), (0, 1), (0, 2), (5, 5), (5, 6), (5, 7), (9, 9)]
+    return rows, pairs, assignments
+
+
+def _partition_sig(rec_to_ent):
+    # Entity-id-independent signature: frozenset of frozensets of record_ids.
+    groups = defaultdict(set)
+    for rid, eid in rec_to_ent.items():
+        groups[eid].add(rid)
+    return frozenset(frozenset(g) for g in groups.values())
+
+
+def _one_box_graph(rows, pairs, assignments, db_path):
+    """Run the one-box resolver on a fresh SQLite store; return
+    (canonical edge_set, record->entity partition signature)."""
+    import polars as pl
+    from goldenmatch.identity.resolve import resolve_clusters
+    from goldenmatch.identity.store import IdentityStore
+
+    df = pl.DataFrame(
+        {
+            "__row_id__": [r[0] for r in rows],
+            "__source__": [r[1] for r in rows],
+            "pk": [r[2] for r in rows],
+            "name": [r[3] for r in rows],
+        }
+    )
+    members: dict[int, list[int]] = {}
+    for cid, mid in assignments:
+        members.setdefault(cid, []).append(mid)
+    pair_scores: dict[int, dict[tuple[int, int], float]] = {}
+    for a, b, s in pairs:
+        cid = next(c for c, ms in members.items() if a in ms)
+        pair_scores.setdefault(cid, {})[(min(a, b), max(a, b))] = s
+    clusters = {
+        cid: {
+            "members": ms,
+            "confidence": 1.0,
+            "bottleneck_pair": None,
+            "pair_scores": pair_scores.get(cid, {}),
+        }
+        for cid, ms in members.items()
+    }
+    store = IdentityStore(backend="sqlite", path=str(db_path))
+    resolve_clusters(
+        clusters, df, [(a, b, s) for a, b, s in pairs], "mk", store, "r1",
+        source_pk_col="pk",
+    )
+    edges, partition = set(), {}
+    for node in store.list_identities(limit=10000):
+        eid = node.entity_id
+        for rec in store.get_records_for_entity(eid):
+            partition[rec.record_id] = eid
+        for edge in store.edges_for_entity(eid):
+            if edge.kind == "same_as":
+                edges.add(tuple(sorted((edge.record_a_id, edge.record_b_id))))
+    return edges, _partition_sig(partition)
+
+
+def _clusters(assignments):
+    return {cid for cid, _ in assignments}
+
+
+def test_identity_graph_parity(spark, tmp_path):
+    from goldenmatch.sail.identity import build_identity_graph
+
+    rows, pairs, assignments = _fixture()
+    edges_ref, part_ref = _one_box_graph(
+        rows, pairs, assignments, tmp_path / "identity.db"
+    )
+
+    source = spark.createDataFrame(rows, ["__row_id__", "__source__", "pk", "name"])
+    pairs_df = spark.createDataFrame(pairs, ["a", "b", "score"])
+    assign_df = spark.createDataFrame(assignments, ["cluster_id", "member_id"])
+    golden_df = spark.createDataFrame(
+        [(0, "Annie"), (5, "Robert")], ["cluster_id", "name"]  # multi-member only
+    )
+
+    g = build_identity_graph(
+        pairs_df, assign_df, source, golden_df, run_meta=_run_meta(),
+        source_pk_col="pk",
+    )
+
+    edges_got = {
+        tuple(sorted((r["record_a_id"], r["record_b_id"])))
+        for r in g.edges.collect()
+    }
+    part_got = _partition_sig(
+        {r["record_id"]: r["entity_id"] for r in g.records.collect()}
+    )
+    node_count = g.nodes.count()
+
+    assert edges_got == edges_ref                  # (1) edge-set parity
+    assert part_got == part_ref                    # (2) partition equivalence
+    assert node_count == len(_clusters(assignments))  # (3) count parity
+
+
+def test_identity_graph_deterministic(spark, tmp_path):
+    from goldenmatch.sail.identity import build_identity_graph
+
+    rows, pairs, assignments = _fixture()
+    source = spark.createDataFrame(rows, ["__row_id__", "__source__", "pk", "name"])
+    pairs_df = spark.createDataFrame(pairs, ["a", "b", "score"])
+    assign_df = spark.createDataFrame(assignments, ["cluster_id", "member_id"])
+    golden_df = spark.createDataFrame([(0, "Annie"), (5, "Robert")], ["cluster_id", "name"])
+
+    def run():
+        g = build_identity_graph(
+            pairs_df, assign_df, source, golden_df, run_meta=_run_meta(),
+            source_pk_col="pk",
+        )
+        return sorted((r["record_id"], r["entity_id"]) for r in g.records.collect())
+
+    assert run() == run()  # content-hash entity_ids -> deterministic

--- a/packages/python/goldenmatch/tests/test_sail_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_sail_pipeline.py
@@ -42,3 +42,38 @@ def test_run_sail_pipeline_end_to_end(spark):
     )
     got = {int(r["cluster_id"]): r["first_name"] for r in golden.collect()}
     assert got == {0: "Jon", 2: "Ann"}
+
+
+def test_run_sail_pipeline_emit_identity(spark):
+    from goldenmatch.sail.identity import IdentityGraphFrames
+    from goldenmatch.sail.pipeline import SailPipelineResult, run_sail_pipeline
+
+    # same clustering shape as above, with __source__ + pk for record ids.
+    rows = [
+        (0, "s", "10001", "Smith", "Jon"),
+        (1, "s", "10001", "Smith", None),   # cluster {0,1}
+        (2, "s", "20002", "Brown", "Ann"),
+        (3, "s", "20002", "Brown", None),   # cluster {2,3}
+        (4, "s", "30003", "Solo", "Zed"),   # singleton
+    ]
+    df = spark.createDataFrame(
+        rows, ["__row_id__", "__source__", "zip", "last_name", "first_name"]
+    )
+    run_meta = {
+        "run_name": "r1", "dataset": None,
+        "recorded_at": "2026-06-10T00:00:00", "matchkey_name": "jaro_winkler",
+    }
+    out = run_sail_pipeline(
+        df, id_col="__row_id__", block_col="zip", value_col="last_name",
+        golden_cols=["first_name"], threshold=0.85, wcc="scale",
+        emit_identity=True, source_pk_col="__row_id__", run_meta=run_meta,
+    )
+    assert isinstance(out, SailPipelineResult)
+    assert isinstance(out.identity, IdentityGraphFrames)
+    # one node per cluster (2 multi-member + 1 singleton); 2 same_as edges.
+    assert out.identity.nodes.count() == 3
+    assert out.identity.edges.count() == 2
+    rec_to_ent = {r["record_id"]: r["entity_id"] for r in out.identity.records.collect()}
+    # 5 records partitioned into 3 entities; the two pairs share an entity.
+    assert len(rec_to_ent) == 5
+    assert len(set(rec_to_ent.values())) == 3


### PR DESCRIPTION
Stage S5 of the Sail tier: re-expresses **Layer 1** of one-box `identity.resolve.resolve_clusters` (create + `same_as` edge-emit) as distributed Spark ops on Sail, producing the durable identity graph as frames written distributed — removing the driver-side identity island for the fresh-store case.

## Scope (the honest cut)
`resolve_clusters` splits into:
- **Layer 1 (relational, distributable):** `same_as` edge-emit (entity-independent) + brand-new-cluster **create** (already a special-cased batch path on a fresh store).
- **Layer 2 (stateful, NOT relational):** absorb/**merge** against an existing store — order-dependent, transactional. **The Ray path never distributed this either** (`distributed/identity.py` collects driver-side then runs the same resolver), so it's intrinsic, not a Sail gap.

S5 = **Layer 1 only**. Layer 2 (incremental) is **deferred = honest-null**, the same call S3 made for order-dependent golden strategies. Ray is **not** retired (still gates on the real 100M bench).

## What's here
- `sail/identity.py`: pure helpers (`record_id_for_row`, `entity_id_for_members` — reused verbatim by the parity reference and the UDFs → parity by construction) + frame builders (`derive_record_ids`, `mint_entity_ids`, `build_same_as_edges`, `build_identity_nodes`, `build_source_records`) + `build_identity_graph` → `IdentityGraphFrames(nodes, records, edges)`.
- **Deterministic** content-derived entity_ids (`ent:h1:` = sha256 of sorted member record_ids; kill-switch `GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME`, `=uuid7` for the one-box scheme). Output is byte-identical on re-run.
- `run_sail_pipeline(emit_identity=...)` opt-in (keyword-only, defaulted; default path unchanged).
- **7th `sail` CI gate** — structural parity vs one-box `resolve_clusters` on a fresh SQLite store: `same_as` edge-set parity (exact, entity-independent) + record→entity **partition** equivalence (literal entity_ids differ; one-box mints UUIDv7) + node count + determinism.

## Verification
The binding gate is the `sail` CI lane (in-process Sail Spark Connect server). Pure-helper unit tests also run in the normal python lane. Local Windows runs of the Sail stack are not reliable, so CI is authoritative.

Spec + plan: `docs/superpowers/specs/2026-06-10-sail-tier-stage-s5-identity-design.md` (gitignored, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)