### PR TITLE
docs(context-network): record publish-containers flake hardening (decision 0010)

### DIFF
--- a/context-network/decisions/0010-publish-containers-ghcr-mirror.md
+++ b/context-network/decisions/0010-publish-containers-ghcr-mirror.md
@@ -1,0 +1,25 @@
+# 0010 — publish-containers: mirror BuildKit/binfmt into ghcr (off anonymous Docker Hub)
+
+**Status:** accepted (2026-06-10, PR #846)
+**Evidence:** 30-day audit — 11 fails across 6 different packages, all transient registry timeouts, zero code bugs; verified `main` run `27284102426` (8/8 jobs green, no retry twin fired).
+
+## Context
+`publish-containers` (7-image matrix, every push to `main`) went red ~1 run in 18 over 30 days. Every failure was a transient network/registry timeout, never a code bug. Dominant mode: `docker/setup-buildx-action` bootstraps BuildKit by pulling `moby/buildkit:buildx-stable-1` from Docker Hub **anonymously** (the workflow logged into ghcr but never Docker Hub). On GitHub's shared runner egress IPs Docker Hub throttles anonymous pulls into timeouts (`context deadline exceeded`); 7 legs pulling buildkit in parallel each push meant a random leg raced into a throttled window. Secondary modes: transient ghcr 502s and GHA-cache (`actions-cache`) blob copy errors at `Build and push`.
+
+## Decision
+1. **Mirror the helper images into ghcr.** A prerequisite `mirror` job copies `moby/buildkit:buildx-stable-1` + `tonistiigi/binfmt:latest` into `ghcr.io/<owner>/{buildkit,binfmt}` once per run (retried); the 7 legs pull them from ghcr via `setup-buildx` `driver-opts:` / `setup-qemu` `image:`. ghcr login moved **ahead** of the buildx bootstrap so the private mirror is pullable. Net: Docker Hub off the hot path; 7 unguarded parallel pulls become 1 retried read.
+2. **Retry-once backstop** (`continue-on-error` + `outcome == 'failure'` guard) on QEMU / Buildx / Build-and-push, for the residual ghcr/cache blips.
+3. **`publish` runs even if `mirror` fails** (`needs.mirror.result == 'success' || 'failure'`): a stale-but-present ghcr copy still unblocks all images; only a cancelled mirror skips it.
+
+### Rejected alternatives
+- **Docker Hub login (`docker/login-action` for `docker.io`).** Raises anonymous limits but needs a Docker Hub username + token as new repo secrets, and the failure was a *timeout* not a hard 429. Preferred removing Docker Hub from the hot path over negotiating its limits — zero new secrets.
+- **A third-party retry action (`Wandalen/wretry`, `nick-fields/retry`).** The repo SHA-pins everything and uses native `--retry` only; a new third-party action on the publish critical path is a supply-chain cost. Used native retry-once (a duplicated guarded step) instead.
+- **A separate scheduled mirror workflow.** Creates an ordering trap (a brand-new workflow can't be `workflow_dispatch`-ed off a feature branch until it lands on the default branch, so the mirror couldn't be bootstrapped pre-merge). The in-workflow prereq job is self-bootstrapping and cuts Docker Hub pulls 7 to 1.
+
+## Consequences
+- Operational detail lives in root `CLAUDE.md` (`## publish-containers flakes`) — point, don't duplicate.
+- A red `publish-containers` is cosmetic (content-addressed images, prior `:latest` stays valid, next push self-heals); don't chase it as a build break.
+- One new small dependency, the `mirror` job, mitigated by 3x retry + the `if:` that lets `publish` proceed on a stale ghcr copy.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-06-10

--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -27,6 +27,7 @@ links rather than reading everything.
 - [decisions/0007-goldencheck-goldenmatch-integration.md](decisions/0007-goldencheck-goldenmatch-integration.md) — GoldenCheck→GoldenMatch: fail-open quality bridges, additive, default-OFF + benchmark-gated; hold the DQ↔ER boundary.
 - [decisions/0008-fellegi-sunter-splink-parity.md](decisions/0008-fellegi-sunter-splink-parity.md) — Fellegi-Sunter: close the Splink engine gap in dependency order, reuse the scale substrate, keep defaults reproducible (new power opt-in), measure the scale gate on a real runner.
 - [decisions/0009-rust-test-coverage.md](decisions/0009-rust-test-coverage.md) — Rust coverage: make the tests real (de-skip the bridge, run the standalone crates), route around the `cargo pgrx test` dead-end (psql smoke), then measure — informational baseline, not a hard gate.
+- [decisions/0010-publish-containers-ghcr-mirror.md](decisions/0010-publish-containers-ghcr-mirror.md) — publish-containers flakes were anonymous-Docker-Hub buildkit-pull timeouts; mirror buildkit/binfmt into ghcr (off the hot path) + native retry-once, no new secrets/actions.
 
 ## Processes (how work is done here)
 - [processes/development-workflow.md](processes/development-workflow.md) — spec → plan → execute → review → CI → merge, plus the hard environment constraints.
@@ -41,4 +42,4 @@ links rather than reading everything.
 - [meta/maintenance.md](meta/maintenance.md) — how to keep nodes accurate and small.
 
 ---
-**Classification:** navigation • **Last updated:** 2026-06-09
+**Classification:** navigation • **Last updated:** 2026-06-10

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,27 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-10 — publish-containers flake hardening (ghcr buildkit mirror, #846)
+- New decision: [../decisions/0010-publish-containers-ghcr-mirror.md](../decisions/0010-publish-containers-ghcr-mirror.md).
+- **Audit:** `publish-containers` went red ~1 run in 18 over 30 days (11 fails,
+  6 different packages) — every one a transient registry timeout, never a code
+  bug. Dominant: `setup-buildx` pulls `moby/buildkit:buildx-stable-1` from Docker
+  Hub *anonymously*; 7 legs pulling in parallel each main push race into Docker
+  Hub's shared-runner-IP throttle → `context deadline exceeded`. Secondary: ghcr
+  502s + GHA-cache blob copy errors at `Build and push`.
+- **Fix (PR #846, merged):** a prereq `mirror` job republishes buildkit + binfmt
+  into `ghcr.io/<owner>/{buildkit,binfmt}` once per run (retried); the legs pull
+  the helper images from ghcr via `setup-buildx driver-opts:` / `setup-qemu
+  image:` (ghcr login moved ahead of buildx). Docker Hub off the hot path: 7
+  unguarded parallel pulls → 1 retried read. Native retry-once twins
+  (`continue-on-error` + `outcome=='failure'`, no third-party action) backstop
+  the residual ghcr/cache blips; `publish` still runs on a stale ghcr copy if
+  `mirror` flakes.
+- **Verified on `main`:** run `27284102426` — 8/8 jobs green, zero retry twin
+  fired (the mirror eliminated the Docker Hub pulls outright, not just retried
+  them). Operational detail recorded in root `CLAUDE.md` (`## publish-containers
+  flakes`); a red leg is cosmetic (content-addressed, self-heals next push).
+
 ## 2026-06-09 — Rust test-coverage arc: make the tests real, then measure (#827/#830/#832)
 - New nodes: [../architecture/rust-test-coverage.md](../architecture/rust-test-coverage.md)
   (per-crate testing map + the measured baseline) and
@@ -236,4 +257,4 @@ Newest first. One entry per meaningful change to the network.
 - Committed to git on branch `chore/context-network`.
 
 ---
-**Classification:** meta/log • **Last updated:** 2026-06-09
+**Classification:** meta/log • **Last updated:** 2026-06-10


### PR DESCRIPTION
## What

Records the `publish-containers` flake-hardening work (PR #846) in the context network.

- **New decision** `decisions/0010-publish-containers-ghcr-mirror.md` — context (the 30-day audit: 11 fails / 6 packages / all transient registry timeouts), the 3-part decision (ghcr mirror job, native retry-once, publish-runs-on-stale-mirror), the **rejected alternatives** (Docker Hub login + secrets, third-party retry action, separate scheduled mirror workflow), and consequences. Points to root `CLAUDE.md` for operational detail rather than duplicating it.
- **discovery.md** — new 0010 entry under Decisions; footer to 2026-06-10.
- **meta/updates.md** — new top entry (audit to fix to verified `main` run `27284102426`); footer to 2026-06-10.

Numbered 0010 (0009 is the rust-test-coverage decision); purely additive, nothing else touched.

## Why

Follows the network's `maintenance.md`: a decision with real "why we didn't" trade-offs and no code home gets a numbered record + a discovery link + an updates entry.
