### PR TITLE
docs(superpowers): commit pending design specs/plans (44 files)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-columnar-view-frame-backed.md
+++ b/docs/superpowers/plans/2026-06-02-columnar-view-frame-backed.md
@@ -1,0 +1,232 @@
+# Columnar Pair-Score View (opt #3b) Implementation Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development. Steps use
+> checkbox (`- [ ]`) syntax. CI-validated posture: the dev box HANGS on
+> `import goldenmatch`/`import polars`. Subagents validate Python via `ruff
+> check` + `python -m py_compile` ONLY — NEVER `import`, `pytest`, `pyright`,
+> or `uv`. The real parity tests run in CI's `python (goldenmatch)` lane
+> (native=1 parity included). Run pyright yourself (the controller), bounded.
+
+**Goal:** Make `ClusterPairScores.from_frames` cheap + low-RSS at 100M pairs via
+a vectorized Polars join (Stage 1) then a frame-backed view with no resident
+100M-entry dict-of-dicts (Stage 2), byte-identical to the dict path.
+
+**Architecture:** Stage 1 replaces the `_bucket_pairs` Python loop in
+`from_frames` with a join+group_by that produces a `view_df`, then materializes
+the same `_by_cid` dict (byte-identical, parity-gated, NO 100M bench). Stage 2
+backs the view with `_partitions = view_df.partition_by("cid", as_dict=True)`
+and makes `for_cluster`/`score_for`/`iter_clusters` serve per-cid slices on
+demand — killing the global dict-of-dicts. Identity consumption unchanged.
+
+**Tech Stack:** Polars, pytest (CI only), Rust native kernel (unaffected).
+
+**Spec:** `docs/superpowers/specs/2026-06-02-columnar-view-frame-backed-design.md`
+
+**Branch/auth:** off `main`; benzsevern (`GH_TOKEN=$(gh auth token --user
+benzsevern)`); NEVER benzsevern-mjh. `docs/superpowers/` is gitignored — do NOT
+`git add` the spec/plan.
+
+---
+
+## Byte-identical invariants (every task must hold these — from the spec)
+
+1. Keep pair iff both endpoints map to same cid; either endpoint absent → drop.
+2. Key `(a,b)` AS GIVEN (not canonicalized); `(7,3)` ≠ `(3,7)`.
+3. Key insertion order within a cid = FIRST-occurrence order.
+4. Value = LAST-occurrence score. `last_score = pl.col("s").sort_by("__i__").last()`
+   — **NEVER `pl.col("s").max()`**.
+5. `score_for` canonicalizes ONLY the query `(min,max)`; stored keys stay
+   as-given → the reversed-orientation MISS (→ `None`) is PRESERVED.
+6. `assignments` is unique on `member_id` (join fan-out guard).
+
+---
+
+### Task 1: Stage 1 parity fixture + test (RED first)
+
+**Files:**
+- Test: `packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py`
+
+- [ ] **Step 1: Write the failing parity test.** Build a small fixture
+  `pairs` list + final `clusters` dict + matching `assignments` frame that
+  INCLUDES, by construction:
+  - a cascading auto-split clique (cluster that splits, then a child re-splits);
+  - a duplicate `(a,b)` where the LATER occurrence's score is LOWER than the
+    earlier (so MAX≠LAST);
+  - cross-cut edges (a pair with one endpoint in a different final cid);
+  - a reversed pair `(7,3)` and `(3,7)` both present;
+  - a self-pair `(a,a)` with `a` in a cid (must be KEPT — join+filter passes it);
+  - at least one singleton (member with no kept pair).
+  Assert `assignments["member_id"].is_unique().all()`. Then assert, for every
+  cid: `ClusterPairScores.from_frames(assignments, pairs).for_cluster(cid)` ==
+  `ClusterPairScores.from_pairs(pairs, clusters).for_cluster(cid)` — EXACT dict
+  equality (keys, key order via `list(d.items())`, values). Also assert
+  `list(view_frames.iter_clusters())` == `list(view_pairs.iter_clusters())`.
+
+- [ ] **Step 2: Validate the test file** — `ruff check <file>` +
+  `python -m py_compile <file>`. (No pytest locally.) The test will run RED in
+  CI until Task 2 lands; that's expected — note it in the commit.
+
+- [ ] **Step 3: Commit.** `feat(test): Stage-1 from_frames join parity fixture
+  (cascading split, MAX≠LAST dup, cross-cut, reversed pair)`
+
+### Task 2: Stage 1 — vectorized `from_frames` (GREEN)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py`
+
+- [ ] **Step 1: Rewrite `from_frames`** to build the view via Polars from the
+  RAW `all_pairs` list (AS-GIVEN orientation — NEVER source from
+  `_columnar_pairs_df`, which is canonicalized `id_a<id_b` and would break the
+  as-given invariant + the F3 miss). Keep the `_by_cid` dict output
+  (byte-identical). Algorithm — note the EXPLICIT cid column naming:
+  ```
+  # all_pairs is the raw list[(a,b,s)] (as-given); build the frame here.
+  pairs_df = pl.DataFrame({"a":[...], "b":[...], "s":[...]}).with_row_index("__i__")
+  amap_a = assignments.select("member_id", pl.col("cluster_id").alias("cid_a"))
+  amap_b = assignments.select("member_id", pl.col("cluster_id").alias("cid_b"))
+  j = (pairs_df
+        .join(amap_a, left_on="a", right_on="member_id", how="left")   # member_id key dropped
+        .join(amap_b, left_on="b", right_on="member_id", how="left")
+        .filter(pl.col("cid_a").is_not_null()
+                & pl.col("cid_b").is_not_null()
+                & (pl.col("cid_a")==pl.col("cid_b")))
+        .with_columns(pl.col("cid_a").alias("cid")))
+  g = (j.group_by("cid","a","b")
+        .agg(pl.col("__i__").min().alias("first_i"),
+             pl.col("s").sort_by("__i__").last().alias("last_score"))  # NEVER .max()
+        .sort("cid","first_i"))   # REQUIRED: group_by output order is undefined
+  by_cid: dict = {}
+  for cid,a,b,s in g.select("cid","a","b","last_score").iter_rows():
+      by_cid.setdefault(cid, {})[(a,b)] = s
+  return cls(by_cid=by_cid)
+  ```
+  Pre-aliasing `cluster_id`→`cid_a`/`cid_b` in the two `amap` selects avoids any
+  suffix/collision ambiguity (the `right_on="member_id"` key column is dropped
+  by the join, so it never collides). Keep the existing `from_frames` docstring
+  caveat (RAW pairs, not max-score). `from_pairs`/`from_cluster_dict`/
+  `_bucket_pairs` UNCHANGED (legacy paths; `_bucket_pairs` still used by
+  `from_pairs`). The `(assignments, all_pairs)` signature is UNCHANGED — no
+  pipeline edit (see dropped Task 4).
+
+- [ ] **Step 2: Validate** — `ruff check` + `py_compile` on the module.
+  Controller runs bounded `pyright` on the file.
+
+- [ ] **Step 3: Commit.** `perf(cluster): Stage-1 vectorize from_frames via
+  polars join (byte-identical _by_cid; no 100M bench)`
+
+### Task 3: Stage 2 — frame-backed partitions + accessors
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py`
+- Test: `packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py`
+
+- [ ] **Step 1: Extend the parity test** to also exercise the frame-backed
+  accessors directly: after Task-3 Step-2, `from_frames` returns a
+  `_partitions`-backed view; assert `for_cluster`, `score_for` (including the
+  reversed-orientation MISS → `None`), and `iter_clusters` ordering are all
+  byte-identical to `from_pairs`. (Independent of Task 4 — Task 4 is dropped.)
+  Validate (ruff + py_compile).
+
+- [ ] **Step 2: Add `_partitions` backing.** Add `"_partitions"` to
+  `__slots__`; `__init__(self, by_cid=None, partitions=None)` MUST set BOTH
+  `self._by_cid = by_cid` (default None) AND `self._partitions = partitions`
+  (slots raises on unset attribute access). `from_frames` builds `view_df` (the
+  `g` frame from Task 2, selected to columns `cid,a,b` + `last_score` aliased to
+  `s`) and sets `_partitions = view_df.partition_by("cid", as_dict=True)` (ONCE),
+  passing `partitions=` to `__init__` and leaving `by_cid=None`. The legacy
+  `from_pairs`/`from_cluster_dict` set `by_cid=` and leave `partitions=None`.
+
+- [ ] **Step 2b: Make accessors backing-aware** (O(cid) per call, no per-call
+  `partition_by`):
+  ```
+  for_cluster(cid):
+      if _partitions is not None:
+          f = _partitions.get((cid,)) ; if None: return {}
+          d = {}
+          for a,b,s in f.select("a","b","s").iter_rows(): d[(a,b)] = s  # frame already last-wins+ordered
+          return d
+      return _by_cid.get(cid, {})
+  score_for(cid,a,b):
+      key=(min(a,b),max(a,b))
+      if _partitions is not None:
+          f=_partitions.get((cid,)); if None: return None
+          # compare key against AS-GIVEN stored (a,b): preserve reversed MISS
+          return for_cluster(cid).get(key)     # lookup uses canonical query vs as-given keys -> same miss as today
+      return _by_cid.get(cid,{}).get(key)
+  iter_clusters():
+      if _partitions is not None:
+          for (cid,),f in _partitions.items():
+              yield cid, [(a,b,s) for a,b,s in f.select("a","b","s").iter_rows()]
+      else:
+          for cid,ps in _by_cid.items(): yield cid,[(a,b,s) for (a,b),s in ps.items()]
+  ```
+  NOTE: confirm `partition_by(..., as_dict=True)` key shape on the installed
+  Polars — current Polars keys by a 1-tuple `(cid,)`; older (≤0.19) keyed by
+  scalar `cid`. **CI failure mode: if `for_cluster` returns `{}` for EVERY cid,
+  the key shape is wrong — flip `_partitions.get((cid,))` ↔ `_partitions.get(cid)`.**
+  The parity gate catches this loudly. `partition_by` preserves the input frame's
+  row order within each partition (current Polars), so the prior
+  `.sort("cid","first_i")` yields first-occurrence order per slice; drop the
+  `first_i` helper column before/at partition so slices carry only `a,b,s`.
+
+- [ ] **Step 3: Validate** (ruff + py_compile); controller runs bounded pyright.
+
+- [ ] **Step 4: Commit.** `perf(cluster): Stage-2 frame-backed ClusterPairScores
+  (partition_by view; kills resident 100M dict-of-dicts; byte-identical)`
+
+### Task 4: DROPPED
+
+Original "thread `_columnar_pairs_df` into `from_frames`" is removed: plan review
+proved `_columnar_pairs_df` is `None` at the `from_frames` call site
+(pipeline.py:1906 fires only on the frames-out branch, mutually exclusive with
+the columnar pair-stream branch) AND it is canonicalized `id_a<id_b` (would
+break the as-given invariant + F3 miss). `from_frames(assignments, all_pairs)`
+builds its own `pairs_df` from the raw list (Task 2). No pipeline.py change. The
+call site stays exactly as-is.
+
+### Task 5: Identity-level parity test
+
+**Files:**
+- Test: `packages/python/goldenmatch/tests/test_identity_from_frames_parity.py`
+
+- [ ] **Step 1:** Extend the identity parity test: resolve once with the
+  dict-backed view (`from_pairs`) and once with the frame-backed view
+  (`from_frames`), assert identical evidence-edge set (entity partition + per-
+  edge scores) AND that a weak cluster whose `bottleneck_pair` is stored in the
+  REVERSE orientation of the `score_for` query still emits a conflict edge with
+  `score=None` (preserves the F3 miss). Validate (ruff + py_compile).
+
+- [ ] **Step 2: Commit.** `test(identity): frame-backed view evidence-edge
+  parity + reversed-bottleneck score=None`
+
+### Task 6: Bench — confirm it exercises the new path
+
+**Files:**
+- `packages/python/goldenmatch/scripts/bench_pipeline_complete_path.py` (~212)
+
+- [ ] **Step 1:** The columnar `id_prep` leg already calls
+  `ClusterPairScores.from_frames(frames.assignments, pairs_list)` — which now
+  builds the frame + partitions internally (Tasks 2-3), so it ALREADY measures
+  the Stage-2 path. Verify no code change is needed; if the `_keepalive` tuple
+  (line 218) references `view._by_cid`-shaped internals, leave it (it just holds
+  the view object for peak-RSS). Likely NO edit — confirm + note in the commit,
+  or make the minimal touch if the leg constructs the view differently.
+
+- [ ] **Step 2: Commit (if changed).** `bench: confirm columnar id_prep
+  measures the Stage-2 frame-backed from_frames`
+
+---
+
+## Execution order & gates
+
+1. Tasks 1→2 (Stage 1): land, push, CI `python (goldenmatch)` parity GREEN.
+   NO 100M bench on Stage 1.
+2. Tasks 3→5 (Stage 2 + identity parity): land, push, CI parity GREEN.
+3. Task 6 + dispatch the 100M complete-path bench (`np=100000000`) ONCE.
+   Report `id_prep` + peak RSS delta vs legacy. The bench is DATA.
+
+## Final review
+
+After all tasks: dispatch a final code-reviewer over the whole diff (byte-
+identical focus + the F1-F6 landmines), then finish the branch (PR off main,
+benzsevern auth, CI parity gate is the verifier).

--- a/docs/superpowers/plans/2026-06-03-autoconfig-identifier-pincer.md
+++ b/docs/superpowers/plans/2026-06-03-autoconfig-identifier-pincer.md
@@ -1,0 +1,430 @@
+# Auto-config Identifier Pincer (#715) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let high-cardinality identifier columns (npi/email/phone) back exact matchkeys in zero-config auto-config, so healthcare-provider-shape data stops collapsing to a fuzzy-only, mega-block, over-merging config.
+
+**Architecture:** One root cause (the exact-matchkey cost model in `build_matchkeys`). Replace the blanket row-count "Guard 1" with a cardinality band `0.5 <= card < 1.0`, and stop skipping `col_type="identifier"` outright. Blocking already self-corrects once the config is healthy (verification only). Add a regression assertion, docs, and a hard DQbench/quality-gate pre-merge check.
+
+**Tech Stack:** Python 3.12, polars, pytest. Module: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`. Tests: `packages/python/goldenmatch/tests/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-autoconfig-identifier-pincer-design.md`
+
+**Precondition — branch from latest `main`.** PR #718 (merge commit `b2a5914`) already landed BOTH `packages/python/goldenmatch/scripts/repro_issue_715.py` (the synthetic generator + `make_healthcare_df`) and `.github/workflows/repro-issue-715.yml` (the `workflow_dispatch` harness whose "Run #715 repro" step already tees stdout to `repro715.log`). Create the implementation branch off current `main` so both exist. Do NOT branch from any in-flight feature branch (e.g. `chore/sail-*`), which predates the #718 merge and will be missing the workflow.
+
+**Run environment note:** the local Windows box hangs on polars' WMI CPU check and chokes on Unicode console output. For ANY local python run in this plan, prefix with `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8` and run via `.venv/Scripts/python.exe`. Per repo policy, run the FULL pytest suite in CI, not locally; targeted single-file `pytest` runs are fine locally. Kill zombie python with `powershell.exe -Command "Get-Process python | Stop-Process -Force"` if the box starves.
+
+---
+
+## File Structure
+
+- **Modify:** `goldenmatch/core/autoconfig.py`
+  - `build_matchkeys` (~`:550-697`): drop Guard 1 (`:644-655`), add the `card >= 1.0` upper-bound surrogate-key skip, remove `"identifier"` from the `:566` skip tuple, update the `_exact_eligible` warning set (`:672-697`).
+- **Create:** `tests/test_autoconfig_pincer_715.py` — unit tests for the band + identifier admission + regression assertion + `_healthcare_df` fixture.
+- **Modify:** `scripts/repro_issue_715.py` — fix the too-strict verdict (matchkey pincer is the primary signal; blocking is secondary).
+- **Modify:** `.github/workflows/repro-issue-715.yml` — add a post-fix assertion step.
+- **Create:** `packages/python/goldenmatch/docs/autoconfig-cost-model.md` — user-facing cost-model doc.
+
+---
+
+## Task 1: Cardinality-band exact-matchkey admission in `build_matchkeys`
+
+**Files:**
+- Modify: `goldenmatch/core/autoconfig.py:550-697`
+- Test: `tests/test_autoconfig_pincer_715.py`
+
+Drive the tests with directly-constructed `ColumnProfile` objects (deterministic `cardinality_ratio`) plus a tiny `df` carrying the same column names. `ColumnProfile(name, dtype, col_type, confidence, sample_values=[], null_rate=0.0, cardinality_ratio=0.0, avg_len=0.0)`.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/test_autoconfig_pincer_715.py
+import polars as pl
+from goldenmatch.core.autoconfig import ColumnProfile, build_matchkeys
+
+
+def _df_with(cols):
+    # Minimal df so build_matchkeys' df-dependent paths have real columns.
+    return pl.DataFrame({c: ["a", "b", "c"] for c in cols})
+
+
+def _exact_fields(matchkeys):
+    return {
+        f.field
+        for mk in matchkeys if mk.type == "exact"
+        for f in mk.fields
+    }
+
+
+def test_email_high_card_large_n_gets_exact_matchkey():
+    """email at card 0.7 must back an exact matchkey regardless of row count
+    (Guard 1 / df.height > 10000 must no longer fire)."""
+    profiles = [
+        ColumnProfile("email", "Utf8", "email", 0.9,
+                      null_rate=0.3, cardinality_ratio=0.7),
+    ]
+    df = _df_with(["email"])
+    df = pl.concat([df] * 4000)  # ~12000 rows, would trip old Guard 1
+    mks = build_matchkeys(profiles, df=df)
+    assert "email" in _exact_fields(mks)
+
+
+def test_identifier_high_card_gets_exact_matchkey():
+    """npi-shaped identifier at card 0.62 must back an exact matchkey
+    (col_type='identifier' must no longer be skipped outright)."""
+    profiles = [
+        ColumnProfile("npi", "Utf8", "identifier", 0.9,
+                      null_rate=0.38, cardinality_ratio=0.62),
+    ]
+    mks = build_matchkeys(profiles, df=_df_with(["npi"]))
+    assert "npi" in _exact_fields(mks)
+
+
+def test_surrogate_key_card_1_excluded():
+    """matching_id at card 1.0 is a per-record surrogate key -> NO exact
+    matchkey (upper bound of the band)."""
+    profiles = [
+        ColumnProfile("matching_id", "Utf8", "identifier", 0.9,
+                      null_rate=0.0, cardinality_ratio=1.0),
+    ]
+    mks = build_matchkeys(profiles, df=_df_with(["matching_id"]))
+    assert "matching_id" not in _exact_fields(mks)
+
+
+def test_low_card_still_excluded_megacluster_guard_intact():
+    """A low-card column (0.3) must STILL be excluded (mega-cluster guard)."""
+    profiles = [
+        ColumnProfile("status", "Utf8", "identifier", 0.9,
+                      null_rate=0.0, cardinality_ratio=0.3),
+    ]
+    mks = build_matchkeys(profiles, df=_df_with(["status"]))
+    assert "status" not in _exact_fields(mks)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `POLARS_SKIP_CPU_CHECK=1 .venv/Scripts/python.exe -m pytest tests/test_autoconfig_pincer_715.py -v` (from `packages/python/goldenmatch`)
+Expected: `test_email_*`, `test_identifier_*` FAIL (no exact matchkey produced); `test_surrogate_*`, `test_low_card_*` may already pass.
+
+- [ ] **Step 3: Remove `"identifier"` from the matchkey skip**
+
+At `autoconfig.py:566`, change:
+```python
+        if p.col_type in ("numeric", "date", "identifier", "year"):
+            continue  # skip non-matchable columns (year is blocking-only)
+```
+to:
+```python
+        if p.col_type in ("numeric", "date", "year"):
+            continue  # skip non-matchable columns (year is blocking-only).
+            # identifier columns ARE matchable: a real shared identifier
+            # (NPI/SSN/MRN) backs an exact matchkey, gated below by the
+            # cardinality band. Per-record surrogate keys (card==1.0) are
+            # excluded by the upper bound. See #715.
+```
+
+- [ ] **Step 4: Replace Guard 1 with the surrogate-key upper bound**
+
+At `autoconfig.py:644-655`, DELETE the row-count guard block:
+```python
+        # Skip exact matchkeys for large datasets — exact matchkeys do a full
+        # self-join which is O(N^2) without blocking. ...
+        if scorer == "exact" and df is not None and df.height > 10000:
+            reason = f"dataset has {df.height} rows; exact self-join is O(N^2)"
+            logger.warning(...)
+            skipped_exact.append((p.name, reason))
+            continue
+```
+and REPLACE with the upper-bound surrogate-key skip:
+```python
+        # Exact matchkeys are a Polars hash self-join (find_exact_matches),
+        # not a nested loop, and do not pass through fuzzy blocking. Their
+        # cost is the number of emitted equal-pairs, bounded by cardinality:
+        # a high-cardinality column emits few pairs and is both cheap and
+        # mega-cluster-safe. So there is NO row-count guard here (the old
+        # df.height > 10000 guard mismodeled the cost and orphaned real
+        # identifiers -- see #715). The mega-cluster risk is the OPPOSITE
+        # shape (low cardinality), already caught by the >= 0.5 gate above.
+        #
+        # Upper bound: a perfectly-unique column (card == 1.0) is a
+        # per-record surrogate key (e.g. a row PK). It is never shared, so an
+        # exact match emits zero pairs and asserts no real identity. Exclude
+        # it for config hygiene.
+        if scorer == "exact" and p.cardinality_ratio >= 1.0:
+            reason = (
+                f"cardinality_ratio={p.cardinality_ratio:.4f} >= 1.0 "
+                f"— perfectly-unique surrogate key, no shared identity to match"
+            )
+            logger.info(
+                "Skipping exact matchkey for '%s' (%s).", p.name, reason,
+            )
+            skipped_exact.append((p.name, reason))
+            continue
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `POLARS_SKIP_CPU_CHECK=1 .venv/Scripts/python.exe -m pytest tests/test_autoconfig_pincer_715.py -v`
+Expected: all four PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig.py packages/python/goldenmatch/tests/test_autoconfig_pincer_715.py
+git commit -m "fix(autoconfig): admit high-card identifiers to exact matchkeys (#715)
+
+Drop the blanket df.height>10000 Guard 1 (mismodeled a hash self-join as
+O(N^2)) and the col_type=='identifier' skip. Admit exact matchkeys on the
+cardinality band 0.5 <= card < 1.0: lower bound = existing mega-cluster
+guard, upper bound excludes perfectly-unique surrogate keys.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Update the "all exact-eligible excluded" aggregate warning
+
+**Files:**
+- Modify: `goldenmatch/core/autoconfig.py:672-697`
+- Test: `tests/test_autoconfig_pincer_715.py`
+
+The `_exact_eligible` set (`:672-676`) currently excludes `identifier`, so the degradation warning under-counts. Since identifier now backs exact matchkeys, include it.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_aggregate_warning_counts_identifier(caplog):
+    """When every exact-eligible column (incl. identifier) is excluded, the
+    aggregate warning must count identifier columns too."""
+    import logging
+    profiles = [
+        # low-card identifier -> excluded by the >=0.5 gate
+        ColumnProfile("npi", "Utf8", "identifier", 0.9,
+                      null_rate=0.0, cardinality_ratio=0.2),
+        ColumnProfile("name", "Utf8", "name", 0.9,
+                      null_rate=0.0, cardinality_ratio=0.5),
+    ]
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.core.autoconfig"):
+        build_matchkeys(profiles, df=_df_with(["npi", "name"]))
+    msgs = " ".join(r.message for r in caplog.records)
+    assert "exact-eligible" in msgs and "npi" in msgs
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `POLARS_SKIP_CPU_CHECK=1 .venv/Scripts/python.exe -m pytest tests/test_autoconfig_pincer_715.py::test_aggregate_warning_counts_identifier -v`
+Expected: FAIL (npi not in the eligible set, so warning omits it).
+
+- [ ] **Step 3: Include identifier in the eligible set**
+
+At `autoconfig.py:672-676`, change the exclusion tuple:
+```python
+    _exact_eligible = [
+        p for p in profiles
+        if p.col_type not in ("numeric", "date", "identifier", "description")
+        and _SCORER_MAP.get(p.col_type, (None,))[0] == "exact"
+    ]
+```
+to:
+```python
+    _exact_eligible = [
+        p for p in profiles
+        if p.col_type not in ("numeric", "date", "description")
+        and _SCORER_MAP.get(p.col_type, (None,))[0] == "exact"
+    ]
+```
+(`identifier` maps to `exact` in `_SCORER_MAP`, so removing it from the exclusion makes it counted.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `POLARS_SKIP_CPU_CHECK=1 .venv/Scripts/python.exe -m pytest tests/test_autoconfig_pincer_715.py::test_aggregate_warning_counts_identifier -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig.py packages/python/goldenmatch/tests/test_autoconfig_pincer_715.py
+git commit -m "fix(autoconfig): count identifier columns in exact-eligible warning (#715)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: End-to-end regression — healthcare shape commits a healthy config (Component 3 + Component 2 verification)
+
+**Files:**
+- Modify: `tests/test_autoconfig_pincer_715.py`
+
+This is the load-bearing behavioral assertion: the full `auto_configure_df` path on healthcare shape must produce >= 1 exact matchkey on an identifier column AND retain a bounded blocking key, at a row count above the old Guard 1 threshold but small enough to run in unit-test time (~15K rows). Use `confidence_required=False` so the test exercises the committed config directly without the REFUSE_AT_N raise (which only triggers at >= 100K anyway).
+
+Reuse the synthetic generator already in `scripts/repro_issue_715.py` (`make_healthcare_df`). Import it, or copy it into a `_healthcare_df` helper in the test module (sibling to `_person_df`/`_gate_test_df` in `test_autoconfig_regressions.py`). Prefer importing to stay DRY:
+
+- [ ] **Step 1: Write the failing regression test**
+
+```python
+def test_healthcare_shape_commits_exact_matchkey_and_blocking():
+    """#715 regression: healthcare-provider shape must auto-configure to a
+    config with >= 1 exact matchkey on an identifier-ish column AND a bounded
+    blocking key — not the fuzzy-only, mega-block collapse."""
+    import sys
+    from pathlib import Path
+    sys.path.insert(
+        0, str(Path(__file__).parent.parent / "scripts"),
+    )
+    from repro_issue_715 import make_healthcare_df
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    df = make_healthcare_df(15_000)  # above old Guard 1 (10000), fast
+    cfg = auto_configure_df(df, confidence_required=False)
+
+    mks = cfg.get_matchkeys()
+    exact_fields = {
+        f.field for mk in mks if mk.type == "exact" for f in mk.fields
+    }
+    assert exact_fields & {"npi", "email", "phone_number"}, (
+        f"expected an exact matchkey on an identifier column, got {exact_fields}"
+    )
+
+    # Blocking retained and bounded (Component 2 verification).
+    blocking = cfg.blocking
+    assert blocking is not None and blocking.keys, (
+        "expected blocking to be retained, got none"
+    )
+```
+
+- [ ] **Step 2: Run to verify it fails (pre-fix) or passes (post-Task-1)**
+
+Run: `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 .venv/Scripts/python.exe -m pytest tests/test_autoconfig_pincer_715.py::test_healthcare_shape_commits_exact_matchkey_and_blocking -v`
+Expected after Tasks 1-2: PASS. If the blocking assertion FAILS, that confirms the controller-commit gap (spec Component 2) — STOP and surface it; do not patch `build_blocking` blindly.
+
+Note: `auto_configure_df` may enable `rerank=True` on weighted matchkeys, which loads a HF cross-encoder. If the test errors on a model download, follow the offline pattern in `tests/test_autoconfig_regressions.py::test_dedupe_df_interaction_all_three_fixes_together` (build config, set `mk.rerank = False`). The assertions here only read matchkeys/blocking, so a download is unlikely to trigger, but guard if it does.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/tests/test_autoconfig_pincer_715.py
+git commit -m "test(autoconfig): #715 regression — healthcare shape gets exact MK + blocking
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Fix the repro script verdict + add post-fix assertion to the workflow
+
+**Files:**
+- Modify: `scripts/repro_issue_715.py`
+- Modify: `.github/workflows/repro-issue-715.yml`
+
+The script's verdict required BOTH zero exact matchkeys AND zero blocking; the matchkey pincer is the primary signal. Reframe it to report the matchkey-side pincer (no exact matchkeys) as the verdict, and show blocking separately.
+
+- [ ] **Step 1: Reframe the verdict in `scripts/repro_issue_715.py`**
+
+Replace the `# -- Verdict --` block so the primary signal is "zero exact matchkeys despite identifier-eligible columns present" and blocking is reported as context, not part of the pass/fail. Post-fix, the script should print `PINCER RESOLVED` when exact matchkeys ARE produced.
+
+```python
+    print("=== VERDICT ===")
+    print(f"  exact matchkeys produced: {len(exact_mks)}  fields={sorted(_exact_fields(matchkeys))}")
+    print(f"  blocking keys: {has_blocking}")
+    identifier_eligible = [
+        p.name for p in profiles
+        if p.col_type in ("identifier", "email", "phone")
+        and 0.5 <= p.cardinality_ratio < 1.0
+    ]
+    print(f"  identifier-eligible (0.5<=card<1.0): {identifier_eligible}")
+    if identifier_eligible and len(exact_mks) == 0:
+        print("  >>> PINCER PRESENT: identifier-eligible columns produced ZERO exact matchkeys.")
+    elif identifier_eligible and exact_mks:
+        print("  >>> PINCER RESOLVED: identifier columns now back exact matchkeys.")
+    else:
+        print("  >>> inconclusive at this shape.")
+```
+(Add a small `_exact_fields(matchkeys)` helper mirroring the test's.)
+
+- [ ] **Step 2: Add a post-fix assertion step to `.github/workflows/repro-issue-715.yml`**
+
+The workflow already exists on `main` (from #718) and its "Run #715 repro" step already tees stdout to `repro715.log`. Add a NEW step immediately after it (do not recreate the workflow or the run step) that fails the job if the pincer is still present:
+```yaml
+      - name: Assert pincer resolved
+        working-directory: packages/python/goldenmatch
+        run: |
+          if grep -q "PINCER PRESENT" repro715.log; then
+            echo "::error::#715 pincer still present — identifier columns produced no exact matchkeys"
+            exit 1
+          fi
+          grep -q "PINCER RESOLVED" repro715.log && echo "pincer resolved" || echo "::warning::inconclusive verdict"
+```
+
+- [ ] **Step 3: Run the repro locally to confirm RESOLVED**
+
+Run: `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 .venv/Scripts/python.exe packages/python/goldenmatch/scripts/repro_issue_715.py 20000`
+Expected: `PINCER RESOLVED` (email/npi now back exact matchkeys).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/python/goldenmatch/scripts/repro_issue_715.py .github/workflows/repro-issue-715.yml
+git commit -m "test(autoconfig): repro #715 verdict reframed to matchkey pincer + CI assert
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: User-facing cost-model doc (Component 4)
+
+**Files:**
+- Create: `packages/python/goldenmatch/docs/autoconfig-cost-model.md`
+
+- [ ] **Step 1: Write the doc**
+
+Cover, in plain prose with a short example:
+- Why exact matchkeys are gated by **cardinality**, not row count (hash self-join, cost = emitted equal-pairs).
+- The admission band `0.5 <= card < 1.0` and what each bound protects against (mega-clusters below 0.5; useless surrogate keys at 1.0).
+- That high-cardinality identifiers (NPI/email/phone) anchor exact matchkeys and do NOT need blocking.
+- The blocking block-size cap (`max_safe_block`) + compound fallback for the fuzzy matchkey.
+- Override env vars: `GOLDENMATCH_BLOCKING_MAX_RATIO`, `POLARS_SKIP_CPU_CHECK` (Windows local-run note).
+- ASCII only (repo convention; no em dashes).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/python/goldenmatch/docs/autoconfig-cost-model.md
+git commit -m "docs(autoconfig): add exact-matchkey cardinality cost-model page (#715)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Pre-merge validation — DQbench + in-house quality gate (HARD GATE)
+
+**Files:** none (validation run)
+
+Dropping Guard 1 changes behavior for ANY large dataset with a high-card email/identifier column. This is the primary mega-cluster risk. It MUST be measured before merge.
+
+- [ ] **Step 1: Run the in-house backend-parity quality gate (#528)**
+
+This runs in CI on the PR (the `python (goldenmatch)` lane / quality gate). Confirm it stays green. If a local run is needed, use the gate entry point referenced in `project_bucket_native_scoring_win` / `#528`.
+
+- [ ] **Step 2: Run DQbench T1/T2/T3**
+
+DQbench datasets are local at `~/.dqbench`; the CLI runs under system Python312 (see `project_issue_489_zerolabel_gate`). Capture the composite + per-tier F1 before and after the change. The adversarial same-email/same-id collision shape (T3) is the closest analog to the mega-cluster risk — watch T3 precision specifically.
+
+- [ ] **Step 3: Record the verdict in the PR description**
+
+Paste the before/after DQbench composite + T1/T2/T3 and the quality-gate result. **Do not merge if T3 precision regresses materially** — if it does, the cardinality band alone is insufficient and the band's upper/lower bounds (or a collision-rate check) need revisiting before merge.
+
+---
+
+## Task 7: Open PR, run full CI, land
+
+**Files:** none
+
+- [ ] **Step 1: Push branch + open PR** to `benseverndev-oss/goldenmatch` base `main` (auth: `gh auth switch --user benzsevern` before push; switch back to `benzsevern-mjh` after). PR body links #715 and pastes the repro `PINCER RESOLVED` output + Task 6 DQbench numbers.
+- [ ] **Step 2: Wait for `python (goldenmatch)` lane + `ci-required` green** (the lane runs ~14 min). Poll robustly (treat empty `gh` output as "keep waiting").
+- [ ] **Step 3: Dispatch `repro-issue-715.yml` on the PR branch** to confirm the at-scale post-fix assertion passes.
+- [ ] **Step 4: Squash-merge `--delete-branch`** once green (branch must be up to date with main; `gh pr update-branch` if behind).
+- [ ] **Step 5: Comment on #715** with the root-cause summary (the pincer + hash-join cost model) and the fix, and close it.

--- a/docs/superpowers/plans/2026-06-03-datafusion-cluster-edges.md
+++ b/docs/superpowers/plans/2026-06-03-datafusion-cluster-edges.md
@@ -1,0 +1,322 @@
+# DataFusion Cluster-Edge Stream (scale-substrate SP1) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development.
+> Steps use checkbox (`- [ ]`) syntax. **CI-validated posture:** the dev box HANGS
+> on `import goldenmatch`/`import polars`/`import datafusion`. Subagents validate
+> Python via `ruff check` + `python -m py_compile` ONLY — NEVER `import`, `pytest`,
+> `uv`, or `pyright`. Real tests + the bench run in CI. The controller runs
+> bounded `pyright` itself. Branch off `main`; benzsevern auth
+> (`GH_TOKEN=$(gh auth token --user benzsevern)`), NEVER benzsevern-mjh.
+> `docs/superpowers/` is gitignored — do NOT `git add` the spec/plan.
+
+**Goal:** Replace the per-pair `dict[int,dict]` edge view (the 566s `id_prep`)
+with an embedded-DataFusion cid-sorted edge stream that spills to disk, and
+measure it 3-way (legacy/datafusion/polars) at 25M/100M/OOM-seeking — the first
+clean test of whether the columnar substrate kills the limiter and survives where
+the dict OOMs.
+
+**Architecture:** A new `cluster_edges_datafusion(pairs, assignments, *,
+memory_limit)` returns `(edges_reader, rollup_table)`: MAX-dedup → join+filter →
+external-sort edge stream (PRIMARY, spills) + an assignments-driven rollup
+(SECONDARY, parity only). Gated behind scale mode; `datafusion` is an optional
+extra. Parity is SEMANTIC (edge sets + rollup), not bit-identical.
+
+**Tech Stack:** Apache DataFusion (Python pkg), PyArrow, Polars, pytest (CI only).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-datafusion-scale-substrate-design.md`
+
+---
+
+## File structure
+
+- Create `packages/python/goldenmatch/goldenmatch/core/cluster_edges_df.py` —
+  the `cluster_edges_datafusion` function + helpers. One responsibility: the
+  DataFusion edge-stream + rollup. No identity/pipeline wiring (out of scope).
+- Create `packages/python/goldenmatch/tests/fixtures/cluster_edges_shapes.py` —
+  a realistic-shaped fixture builder (sparse, singleton, oversized/split, dup
+  pairs) returning `(pairs, assignments, expected_per_cluster)`.
+- Create `packages/python/goldenmatch/tests/test_cluster_edges_df.py` — edge-set
+  parity, rollup parity (incl. singleton/edgeless), dedup, determinism.
+- Create `packages/python/goldenmatch/scripts/bench_df_cluster_edges.py` — 3-way
+  bench + realistic input (heavy-tailed generator).
+- Create `.github/workflows/bench-df-cluster-edges.yml` — `workflow_dispatch`.
+- Modify `packages/python/goldenmatch/pyproject.toml` — `[project.optional-
+  dependencies] datafusion = ["datafusion>=43"]` (pin a current major at impl).
+
+## Reference semantics (the parity target — from the spec + code)
+
+- `_bucket_pairs` (`core/cluster_pairscores.py:12-26`): keep pair iff
+  `member_to_cid[a]==member_to_cid[b]`; key `(a,b)` as-given; INPUT-order
+  LAST-WINS. Scale mode replaces last-wins with **MAX** (signed-off R1).
+- `compute_cluster_confidence` (`core/cluster.py:1244-1261`): `size<=1 →
+  confidence 1.0`; `min_edge=min(scores)`; `avg_edge=sum/len`;
+  `connectivity=len(pair_scores)/(size*(size-1)/2)`;
+  `confidence=0.4*min+0.3*avg+0.3*conn`; bottleneck=argmin (scale mode: lexicographic
+  `(a,b)` tie-break); weak iff `avg-min>0.3`.
+- The legacy view the bench compares against: `ClusterPairScores.from_frames(
+  assignments, pairs).for_cluster(cid)` (`core/cluster_pairscores.py`).
+
+---
+
+### Task 1: Optional `datafusion` extra + zero-copy ingest smoke
+
+**Files:**
+- Modify: `packages/python/goldenmatch/pyproject.toml`
+- Create: `packages/python/goldenmatch/tests/test_cluster_edges_df.py`
+
+- [ ] **Step 1: Pin the version FIRST, then add the extra.** Check the latest
+  released `datafusion` Python major on PyPI (it tracks the Rust crate but is NOT
+  identical — recent Python releases are in the ~40s). Write ALL subsequent API
+  calls against THAT version's docs. Add to `pyproject.toml`
+  `[project.optional-dependencies]`: `datafusion = ["datafusion>=N,<N+1"]` (the
+  confirmed major). Do NOT add to core deps. `datafusion` is on PyPI, so no
+  `uv.sources` workspace trap (unlike `goldenmatch-native`).
+
+- [ ] **Step 2: Wire CI to actually RUN the tests (the #1 hazard).** The tests
+  are `importorskip("datafusion")`-gated, so they SILENTLY SKIP unless the lane
+  installs the extra. Add to the `python (goldenmatch)` lane in
+  `.github/workflows/ci.yml`: `uv pip install datafusion` (or add the extra to
+  that lane's sync). AND add a guard so a silent-skip is a loud failure — one
+  test (below) that imports datafusion WITHOUT importorskip and is expected to
+  run; plus verify via the raw pytest summary (CLAUDE.md: per-step JSON lies on
+  `continue-on-error`; grep the log for the expected `passed` count).
+
+- [ ] **Step 3: Write the failing zero-copy smoke test** (prefer `from_arrow`,
+  the stable ingest across recent releases; `register_record_batches` partition
+  nesting drifts by version):
+
+```python
+import pytest
+pa = pytest.importorskip("pyarrow")
+datafusion = pytest.importorskip("datafusion")
+
+def test_datafusion_from_arrow_ingest():
+    from datafusion import SessionContext
+    ctx = SessionContext()
+    tbl = pa.table({"x": pa.array([1, 2, 3], pa.int64())})
+    df = ctx.from_arrow(tbl, name="t")          # confirm signature vs pinned ver
+    out = ctx.sql("SELECT sum(x) AS s FROM t").to_arrow_table()
+    assert out.column("s")[0].as_py() == 6
+```
+
+- [ ] **Step 4: Validate** `ruff check` + `py_compile` the test file.
+
+- [ ] **Step 5: Commit.** `feat(datafusion): optional extra (version-pinned) + CI install + from_arrow smoke`
+
+### Task 2: Realistic-shaped parity fixture
+
+**Files:**
+- Create: `packages/python/goldenmatch/tests/fixtures/cluster_edges_shapes.py`
+
+- [ ] **Step 1: Write the fixture builder.** `build_cluster_edges_fixture() ->
+  (pairs, assignments, expected)` where `pairs: list[tuple[int,int,float]]`,
+  `assignments: pl.DataFrame{member_id,cluster_id}`, `expected: dict[cid ->
+  {members:set, edges:dict[(a,b)->score_MAX], size:int, min_edge, avg_edge,
+  connectivity, confidence, quality, bottleneck:(a,b)}]`. Construct BY HAND so
+  it's verifiable, INCLUDING:
+  - a fully-connected triangle (cid A: 3 members, 3 edges);
+  - a **sparse** cluster (cid B: 4 members, only 3 edges → connectivity<1);
+  - a **singleton** (cid C: 1 member, 0 edges, confidence 1.0);
+  - an **edgeless** multi-member cluster is N/A under WCC (members imply ≥1 edge),
+    so instead include a cluster whose only dup pair makes `edge_count` differ
+    from naive count — i.e. a **duplicate canonical pair with a LOWER later score**
+    (cid A: `(1,2,0.9)` then `(1,2,0.4)` → MAX keeps 0.9, last-wins would keep 0.4;
+    pins MAX≠LAST);
+  - a **reversed** pair `(7,3)` and a separate non-canonical-only pair to exercise
+    as-given keys and the lexicographic bottleneck tie-break;
+  - a cross-cut edge (one endpoint in another cid → dropped).
+  Compute `expected` per the reference semantics above (MAX dedup; lexicographic
+  bottleneck). Assert `assignments["member_id"].is_unique().all()` inside.
+
+- [ ] **Step 2: Validate** `ruff check` + `py_compile`.
+
+- [ ] **Step 3: Commit.** `test(datafusion): realistic cluster-edges parity fixture (sparse/singleton/dup/reversed/cross-cut)`
+
+### Task 3: `cluster_edges_datafusion` — dedup + join + edge stream + rollup
+
+**Files:**
+- Create: `packages/python/goldenmatch/goldenmatch/core/cluster_edges_df.py`
+- Test: `packages/python/goldenmatch/tests/test_cluster_edges_df.py`
+
+- [ ] **Step 1: Write the failing parity tests** (use the Task-2 fixture):
+
+```python
+def test_edge_sets_match_legacy():
+    pairs, assignments, expected = build_cluster_edges_fixture()
+    edges_reader, rollup = cluster_edges_datafusion(
+        _pairs_to_arrow(pairs), _assign_to_arrow(assignments), memory_limit=None)
+    # consume the cid-sorted stream into per-cid edge SETS
+    by_cid = _collect_runs(edges_reader)        # {cid: {(a,b): score}}
+    for cid, exp in expected.items():
+        assert by_cid.get(cid, {}) == exp["edges"], f"cid {cid} edges"
+
+def test_rollup_matches_legacy_incl_singleton_and_sparse():
+    pairs, assignments, expected = build_cluster_edges_fixture()
+    _, rollup = cluster_edges_datafusion(...)
+    got = {r["cluster_id"]: r for r in rollup.to_pylist()}
+    for cid, exp in expected.items():
+        assert got[cid]["size"] == exp["size"]
+        assert got[cid]["edge_count"] == len(exp["edges"])
+        assert got[cid]["min_edge"] == pytest.approx(exp["min_edge"], abs=1e-12)
+        assert got[cid]["avg_edge"] == pytest.approx(exp["avg_edge"], abs=1e-12)
+        conf = _confidence(got[cid])            # size<=1 -> 1.0 else 0.4min+0.3avg+0.3conn
+        assert conf == pytest.approx(exp["confidence"], abs=1e-9)
+        assert (got[cid]["bottleneck_a"], got[cid]["bottleneck_b"]) == exp["bottleneck"]
+
+def test_max_dedup_not_last_wins():
+    # cid A has (1,2,0.9) then (1,2,0.4): MAX keeps 0.9
+    ...
+    assert by_cid[A][(1, 2)] == 0.9
+```
+
+- [ ] **Step 2: Implement `cluster_edges_datafusion`** per the spec's Steps 0-4.
+  **The four API calls below are Context7-verified corrections — use them, not
+  the spec's looser sketch:**
+  - **Context build + spilling (memory lives on the RUNTIME ENV, not config):**
+    ```python
+    from datafusion import SessionContext, SessionConfig, RuntimeEnvBuilder
+    cfg = SessionConfig()
+    if memory_limit is not None:
+        runtime = RuntimeEnvBuilder().with_memory_limit(memory_limit, 0.8).build()  # NOTE .build()
+        ctx = SessionContext(config=cfg, runtime=runtime)
+    else:
+        ctx = SessionContext(config=cfg)
+    ```
+    (Confirm `RuntimeEnvBuilder` vs the older `RuntimeConfig` name on the pinned
+    version — renamed ~40.x. There is NO `ctx.set_memory_limit()`.)
+  - Step 0: `SELECT a, b, max(score) AS score FROM pairs GROUP BY a, b` (MAX dedup,
+    as-given keys — do NOT canonicalize).
+  - Step 1: `JOIN` deduped pairs to `assignments` on `a=member_id` (→ `cid_a`) and
+    on `b=member_id` (→ `cid_b`); `WHERE cid_a IS NOT NULL AND cid_b IS NOT NULL
+    AND cid_a = cid_b`; project `cid=cid_a, a, b, score`.
+  - **Step 2 (PRIMARY) — streaming sorted edges:** `ctx.sql("... ORDER BY cid")`
+    then `.execute_stream()` (NOT `to_arrow_table_reader` — that does not exist).
+    Iterate the stream incrementally; if the consumer needs a `pa.RecordBatchReader`
+    object, wrap via `pa.RecordBatchReader.from_batches(schema, batch_iter)`.
+  - **Step 3 (SECONDARY) — rollup; bottleneck = TWO scalar `first_value`s, NOT a
+    struct:**
+    ```sql
+    size_t: SELECT cluster_id, count(*) AS size FROM assignments GROUP BY cluster_id
+    agg:    SELECT cid,
+                   min(score) AS min_edge, avg(score) AS avg_edge, count(*) AS edge_count,
+                   first_value(a ORDER BY score ASC, a ASC, b ASC) AS bottleneck_a,
+                   first_value(b ORDER BY score ASC, a ASC, b ASC) AS bottleneck_b
+            FROM edges GROUP BY cid
+    rollup: size_t LEFT JOIN agg ON cluster_id = cid     -- singletons/edgeless survive
+            -> coalesce(edge_count,0), coalesce(min_edge,0.0), coalesce(avg_edge,0.0)
+    ```
+    If the pinned build does NOT support `first_value(... ORDER BY ...)` as an
+    aggregate, use the PRE-COMMITTED fallback: two-pass — compute `min_edge` per
+    cid, then `SELECT cid, min(a) , min(b)` over rows where `score = min_edge`
+    (lexicographic). Do NOT discover this at impl; wire the fallback behind a
+    capability check.
+  - Step 4: the spilling is already wired via the runtime env above (covers both
+    the external sort in Step 2 and `GroupByHashExec` in Step 3).
+  Add `_pairs_to_arrow`, `_assign_to_arrow`, `_collect_runs` (consumes the
+  `execute_stream` into `{cid: {(a,b): score}}` by same-cid runs), `_confidence`
+  helpers (shared with tests — put them in the module).
+
+- [ ] **Step 3: Validate** `ruff check` + `py_compile`. Controller runs bounded
+  `pyright` on the module.
+
+- [ ] **Step 4: Commit.** `feat(datafusion): cluster_edges_datafusion — dedup+join+sorted edge stream+rollup`
+
+### Task 4: Determinism gate
+
+**Files:**
+- Test: `packages/python/goldenmatch/tests/test_cluster_edges_df.py`
+
+- [ ] **Step 1: Write the determinism test.** Run `cluster_edges_datafusion` at
+  `target_partitions ∈ {1, 4, 17}` (17 > typical core count) — the impl must
+  accept a `target_partitions` arg and attach it explicitly via
+  `SessionContext(config=SessionConfig().with_target_partitions(n))` (not a
+  post-hoc setter); assert identical `cluster_id`,
+  `size`, `edge_count`, `bottleneck`, and edge SETS across all three, and
+  `avg_edge` equal to `abs=1e-12`. If `avg_edge` drifts, the impl must pin the
+  reduction (e.g. `avg` over a `sort`ed input, or sum-then-divide on a sorted
+  partition) — note this in the test's failure message.
+
+- [ ] **Step 2: Validate** `ruff check` + `py_compile`.
+
+- [ ] **Step 3: Commit.** `test(datafusion): cross-target_partitions determinism (>=3, eps 1e-12)`
+
+### Task 5: Heavy-tailed bench input + 3-way bench script
+
+**Files:**
+- Create: `packages/python/goldenmatch/scripts/bench_df_cluster_edges.py`
+
+- [ ] **Step 1: Write the input generator.** `make_heavytailed(n_pairs, seed) ->
+  (pairs_arrow, assignments_arrow)`: a heavy-tailed cluster-size distribution
+  (most size 2-5, a long tail incl. a few oversized >100), partial connectivity
+  (NOT fully connected), varied scores, and a small fraction of duplicate
+  canonical pairs. Vectorized (numpy) so it scales to 200M pairs. (Mirror the
+  vectorization style of `bench_pipeline_complete_path.py:_make_pairs_df`.)
+
+- [ ] **Step 2: Write the 3-way bench.** `--np "25000000,100000000"`,
+  `--memory-limit` (bytes, optional, for the OOM-seeking leg), `--variants
+  legacy,datafusion,polars`. Per variant per scale, measure wall + peak RSS
+  (RSS via the same harness as the complete-path bench) and catch the legacy
+  OOM (record "legacy OOM" rather than crashing):
+  - `legacy`: `ClusterPairScores.from_frames(assignments, pairs)` + per-cid iter.
+    NOTE: `from_frames` is LAST-WINS on dup canonical pairs; DataFusion is MAX. To
+    keep the bottleneck-divergence number clean (tie-break only, not muddied by
+    MAX-vs-last-wins on dups), **pre-dedup the bench input to one row per `(a,b)`
+    by MAX before feeding the legacy leg too** — OR report the two divergence
+    sources separately. Pick one; state it in the bench output.
+  - `datafusion`: `cluster_edges_datafusion(..., memory_limit=...)` + consume the
+    stream in cid-runs.
+  - `polars`: `pairs.join(assignments...).filter(...).sort("cid")` collected
+    streaming + group-by rollup.
+  Peak RSS via the complete-path bench's `_peak_rss_mb` (`resource.getrusage`,
+  **Linux/CI-only** — returns 0 on Windows; don't add a Windows path). Also print
+  the **bottleneck-divergence rate** (datafusion vs legacy) + a one-time check
+  that DataFusion ingest didn't double input RSS (the spec's zero-copy risk).
+  Emit a markdown table.
+
+- [ ] **Step 3: Validate** `ruff check` + `py_compile`.
+
+- [ ] **Step 4: Commit.** `bench(datafusion): 3-way cluster-edges bench + heavy-tailed generator`
+
+### Task 6: Bench workflow
+
+**Files:**
+- Create: `.github/workflows/bench-df-cluster-edges.yml`
+
+- [ ] **Step 1: Write the workflow.** `workflow_dispatch` inputs `np`
+  (default `25000000,100000000`), `memory_limit` (default empty), `variants`
+  (default `legacy,datafusion,polars`). `runs-on: large-new-64GB`,
+  `timeout-minutes: 85`. Mirror `bench-pipeline-complete-path.yml`: checkout,
+  rust-toolchain, setup-uv (cache), `uv sync --all-packages`, **`uv pip install
+  datafusion`** (the extra), `uv run python scripts/build_native.py`, then run
+  `bench_df_cluster_edges.py` piping to `$GITHUB_STEP_SUMMARY`. Upload the JSON
+  artifact.
+
+- [ ] **Step 2: Validate** the YAML (yamllint if available, else inspect).
+
+- [ ] **Step 3: Commit.** `ci(datafusion): bench-df-cluster-edges workflow`
+
+---
+
+## Execution order & gates
+
+1. Tasks 1→4 (lib + tests): land on a branch off main, push (benzsevern), open PR.
+   CI `python (goldenmatch)` must run the new tests GREEN (parity + determinism).
+   **HARD REQUIREMENT (Task 1 Step 2): the lane MUST install `datafusion` AND the
+   run must prove the new tests did not silently skip** — grep the raw pytest log
+   for the expected `passed` count (per CLAUDE.md, the per-step JSON reports
+   `success` on `continue-on-error` regardless). A green-by-skip is a false pass
+   and the whole parity gate is decorative without this.
+2. Task 5→6 (bench): land, then dispatch `bench-df-cluster-edges.yml` at
+   `np=25000000,100000000` AND an OOM-seeking run (`np=200000000` or a low
+   `memory_limit`). Commit the 3-way table into the roadmap doc
+   (`2026-06-01-arrow-native-finish-line-design.md`).
+3. The verdict is DATA: it answers (a) does DataFusion kill the 566s, (b) is the
+   win DataFusion-specific vs polars, (c) does it spill+survive where the dict
+   OOMs (binding-vs-non-binding). No default flip; no further sub-project until
+   reviewed.
+
+## Final review
+
+After Tasks 1-6: dispatch a final code-reviewer over the whole diff (DataFusion
+API correctness, parity-semantics, the spilling/determinism claims), then finish
+the branch (PR off main, benzsevern, CI green).

--- a/docs/superpowers/plans/2026-06-03-datafusion-spine-stage-b.md
+++ b/docs/superpowers/plans/2026-06-03-datafusion-spine-stage-b.md
@@ -1,0 +1,188 @@
+# DataFusion Spine — Stage B: scorer as FFI ScalarUDF Implementation Plan
+
+> **For agentic workers:** REQUIRED: superpowers:subagent-driven-development.
+> Checkbox (`- [ ]`) steps. **CI-validated posture:** dev box HANGS on Python
+> `import` of goldenmatch/polars/datafusion. Subagents validate Python via `ruff
+> check` + `python -m py_compile` ONLY, Rust via `cargo check` (long timeout; the
+> local rustc sysroot may be corrupted — if `cargo check` ICEs on deps, defer to
+> CI and say so). NEVER import/pytest/uv/pyright. Real tests in CI. Branch off
+> the Stage-A branch `feat/datafusion-ffi-udf` (the proven FFI scaffold);
+> benzsevern auth, NEVER benzsevern-mjh. `docs/superpowers/` gitignored.
+
+**Goal:** Replace the Stage-A `add_one` FFI UDF with the real native string
+scorers (jaro_winkler / token_sort / levenshtein) as `FFI_ScalarUDF`s over
+`(Utf8, Utf8) -> Float64`, with the scorer algorithms in a SHARED crate so the
+FFI UDF score equals the in-process native score BY CONSTRUCTION.
+
+**Architecture:** Extract `score.rs`'s pure scorer fns into a new
+`goldenmatch-score-core` lib crate; `_native` and `datafusion-udf` both depend on
+it (single source of truth). The FFI UDFs downcast two `StringArray` args, call
+score-core per row, return a `Float64Array`.
+
+**Tech Stack:** Rust (rapidfuzz 0.5.0, datafusion-ffi 53.x, arrow 58, pyo3 0.28),
+Python datafusion 53, PyArrow.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-datafusion-spine-design.md` (Stage B).
+**Stage A (DONE, GREEN #698):** the FFI boundary works on v53.
+
+---
+
+## Reference (the native scorers being shared — `packages/rust/extensions/native/src/score.rs`)
+
+- `jaro_winkler_similarity(a:&str,b:&str)->f64` (:81), `levenshtein_similarity` (:87),
+  `token_sort_ratio` (:94), `token_sort_string(s)` (:71), `score_one(scorer_id:u8,
+  a,b)->f64` (:104) — all pure, backed by `rapidfuzz = "0.5.0"`. These MOVE to the
+  shared crate; `_native` re-imports them (its public behavior + parity tests
+  unchanged).
+
+## File structure
+
+- Create `packages/rust/extensions/score-core/` — lib crate, `crate-type=["lib"]`,
+  NO pyo3. `Cargo.toml` (rapidfuzz 0.5.0, own empty `[workspace]` for isolation),
+  `src/lib.rs` = the pure scorer fns moved verbatim from `native/src/score.rs`.
+- Modify `packages/rust/extensions/native/Cargo.toml` — add
+  `goldenmatch-score-core = { path = "../score-core" }`.
+- Modify `packages/rust/extensions/native/src/score.rs` — `score_one` becomes
+  `use goldenmatch_score_core::score_one;` (pure re-import); the three pyo3
+  scorers keep `#[pyfunction]` SHIMS delegating to score-core (so
+  `lib.rs:32-34`'s `wrap_pyfunction!` still resolves); the arrow/batch wrappers
+  (`score_block_pairs`, `score_block_pairs_arrow`, `score_field_matrix`) stay and
+  call the shared `score_one`. `token_sort_string` moves entirely (private in
+  score-core); zero hits remain in `native/src/`.
+- Modify `packages/rust/extensions/datafusion-udf/Cargo.toml` — add the path dep.
+- Modify `packages/rust/extensions/datafusion-udf/src/scalar_udf.rs` — replace
+  `AddOneUDF` with the scorer UDFs.
+- Modify `packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py` — the
+  scorer parity test (FFI UDF == native scorer).
+
+---
+
+### Task B1: Extract `goldenmatch-score-core` (single source of truth)
+
+**Files:**
+- Create: `packages/rust/extensions/score-core/Cargo.toml`, `src/lib.rs`
+- Modify: `packages/rust/extensions/native/Cargo.toml`, `src/score.rs`
+
+- [ ] **Step 1: Create the lib crate.** `Cargo.toml`: `[package] name=
+  "goldenmatch-score-core"`, `edition="2021"`, `[lib]`, `[dependencies] rapidfuzz
+  = "0.5.0"` (same pin as `native/Cargo.toml:31` — no skew), empty `[workspace]`.
+  **NO `rust-toolchain.toml`** (path deps compile under each PARENT's toolchain;
+  score-core must inherit, not pin). `src/lib.rs` MOVES from `native/src/score.rs`:
+  - the three scorers `jaro_winkler_similarity`/`levenshtein_similarity`/
+    `token_sort_ratio` — **as plain `pub fn`, STRIPPING the `#[pyfunction]`
+    attribute + any `use pyo3::...`** (score-core has no pyo3 → `#[pyfunction]`
+    won't compile).
+  - `score_one` — `pub fn`, **VERBATIM including the id=2 UNSCALED `fuzz::ratio`**
+    ([0,1], NOT `*100`). Do NOT reconcile with `token_sort_ratio`'s `*100` —
+    `score_field_matrix` depends on the unscaled form (see score.rs:491-493
+    comment). This is the silent-drift trap (CLAUDE.md "2 bugs survived review").
+  - `token_sort_string` — keep PRIVATE in score-core (both its callers,
+    `token_sort_ratio` + `score_one`, move with it). Do NOT export/re-import it.
+  - the `use rapidfuzz::...` the moved fns need.
+
+- [ ] **Step 2: Point `_native` at the shared crate.** `native/Cargo.toml`:
+  `goldenmatch-score-core = { path = "../score-core" }`. In `native/src/score.rs`:
+  - `score_one` → `use goldenmatch_score_core::score_one;` (pure re-import; it's
+    called by `score_block_pairs`:188, `score_block_pairs_arrow`:335,
+    `score_field_matrix`:494 which STAY in `_native`).
+  - the three pyo3 scorers → KEEP a `#[pyfunction]` SHIM in `score.rs` delegating
+    to score-core, e.g. `#[pyfunction] pub fn jaro_winkler_similarity(a:&str,
+    b:&str)->f64 { goldenmatch_score_core::jaro_winkler_similarity(a,b) }`. A bare
+    `use` re-export does NOT satisfy `lib.rs:32-34`'s `wrap_pyfunction!(
+    score::jaro_winkler_similarity)` — it needs a `#[pyfunction]` in the `score`
+    module. Leave `lib.rs` UNCHANGED.
+  - `grep token_sort_string native/src/` MUST return zero hits post-move.
+
+- [ ] **Step 3: Validate.** `cargo check` in `score-core` and in `native` (long
+  timeout; if the local rustc ICEs on deps, note it and defer to CI). Confirm no
+  other `native/src/*.rs` referenced the moved fns by their old path (grep).
+
+- [ ] **Step 4: Commit.** `refactor(score): extract scorers to goldenmatch-score-core (shared by _native + datafusion-udf)`.
+  NOTE the GATE: `_native`'s existing scorer/bucket parity tests in CI MUST stay
+  GREEN (they prove the extraction didn't change native behavior — `build_native.py`
+  builds `_native` which now pulls score-core).
+
+### Task B2: Scorer FFI UDFs in `datafusion-udf`
+
+**Files:**
+- Modify: `packages/rust/extensions/datafusion-udf/Cargo.toml`
+- Modify: `packages/rust/extensions/datafusion-udf/src/scalar_udf.rs` (+ `lib.rs`)
+
+- [ ] **Step 1: Add the dep.** `datafusion-udf/Cargo.toml`:
+  `goldenmatch-score-core = { path = "../score-core" }`.
+
+- [ ] **Step 2: Implement the scorer UDFs.** Replace `AddOneUDF` with one
+  `#[pyclass]` `ScalarUDFImpl` per scorer: `JaroWinklerUDF` (name `"jaro_winkler"`),
+  `TokenSortUDF` (`"token_sort"`), `LevenshteinUDF` (`"levenshtein"`). Each:
+  `signature() = Signature::exact(vec![DataType::Utf8, DataType::Utf8],
+  Volatility::Immutable)`, `return_type() -> Float64`,
+  `invoke_with_args(args)`: use `ColumnarValue::values_to_arrays(&args.args)?`
+  (v53 helper — collapses Scalar→Array of len `args.number_rows`, removing the
+  hand-rolled Array/Scalar broadcast + its null edges), downcast both to
+  `StringArray`, build via `Float64Array::from_iter(a.iter().zip(b.iter()).map(
+  |(oa,ob)| ...))`. **Null convention (pin it + test in B3): match the in-memory
+  path — `None`→`""` then score** (the in-memory `native.py:47` maps `None→""`),
+  so FFI ≡ in-process; do NOT null-propagate unless you assert that divergence in
+  B3. `goldenmatch_score_core::jaro_winkler_similarity(a,b)` etc.; return
+  `ColumnarValue::Array(Arc::new(out))`. Mirror Stage A's
+  `__datafusion_scalar_udf__` PyCapsule export verbatim per UDF. Register all
+  three in the `#[pymodule]`. Named UDFs (not a generic scorer-name arg) — cleaner
+  for the spine's SQL.
+
+- [ ] **Step 3: Validate** `cargo check` (defer to CI if rustc ICEs). Commit.
+  `feat(df-udf): jaro_winkler/token_sort/levenshtein scorers as FFI ScalarUDFs`
+
+### Task B3: Parity test (FFI UDF == native scorer) + CI
+
+**Files:**
+- Modify: `packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py`
+
+- [ ] **Step 1: Write the parity test.** Add a scorer-parity test: a fixture of
+  string pairs (identical, typo'd, reordered tokens, empty, **a null/None**,
+  unicode, disjoint). At the TOP assert
+  `goldenmatch.core._native_loader.native_available() is True` (NOT importorskip —
+  if `_native` isn't built in this job the test must FAIL, not silently fall back).
+  Register the scorer UDFs into a `SessionContext`, run `SELECT jaro_winkler(a,b),
+  token_sort(a,b), levenshtein(a,b) FROM pairs`, assert each == the per-pair native
+  scorer `goldenmatch._native.jaro_winkler_similarity(a,b)` /
+  `.levenshtein_similarity(a,b)` / `.token_sort_ratio(a,b)` (these ARE exported,
+  per `lib.rs:32-34`, already tested vs rapidfuzz in `test_native_parity.py`).
+  **CRITICAL: native `token_sort_ratio` returns 0-100; the FFI `token_sort` UDF
+  returns 0-1** → assert `ffi_token_sort == native.token_sort_ratio(a,b)/100.0`
+  (a 100× silent failure if missed). jaro_winkler/levenshtein are both 0-1 on both
+  sides. Null row: assert FFI matches the `None→""` convention (B2). Use
+  `pytest.approx(abs=1e-6)` (f32-origin; NOT 1e-12). Both paths call
+  `goldenmatch-score-core` → parity is by construction; this is the drift guard.
+
+- [ ] **Step 2: CI.** The `datafusion-udf` wheel step (Stage A) builds score-core
+  transitively. The parity test now ALSO needs `goldenmatch._native` importable in
+  the same job — confirm the goldenmatch lane builds `_native` (`build_native.py`)
+  before pytest (it does for the in-tree native path); if not, add it. Add
+  `packages/rust/extensions/score-core/**` to BOTH paths-filters: the
+  `datafusion-udf`/`python_goldenmatch` filter AND whatever filter gates the
+  `_native` build + `test_native_parity.py` (else a score-core-only PR skips the
+  native regression gate that is the whole point of B1).
+
+- [ ] **Step 3: Validate** `ruff` + `py_compile` the test. Commit.
+  `test(df-udf): scorer FFI UDF parity vs native (eps 1e-6, by-construction guard)`
+
+---
+
+## Execution order & gates
+
+1. B1 → B2 → B3 on a branch off `feat/datafusion-ffi-udf`. Push (benzsevern), PR.
+2. CI gates (both must be GREEN):
+   - `_native`'s scorer/bucket parity tests (B1 didn't change native behavior).
+   - the new FFI scorer-parity test (FFI UDF == native, ε 1e-6) — actually RUNS
+     (hard import guard from Stage A; datafusion installed).
+3. If GREEN: Stage B done → re-plan Stage C (spine orchestration). The shared
+   `score-core` + the scorer UDFs are the substrate Stage C's score stage uses.
+
+No default flips (nothing wires into the pipeline until Stage C, behind
+`mode="scale"`).
+
+## Final review
+
+After B1-B3: a code-reviewer over the diff (the score.rs extraction correctness —
+did any native caller break? — the FFI UDF arrow array handling + null/scalar
+cases, the parity fixture coverage), then declare Stage B done.

--- a/docs/superpowers/plans/2026-06-03-datafusion-spine-stage-c.md
+++ b/docs/superpowers/plans/2026-06-03-datafusion-spine-stage-c.md
@@ -1,0 +1,197 @@
+# DataFusion Spine — Stage C: spine orchestration Implementation Plan
+
+> **For agentic workers:** REQUIRED: superpowers:subagent-driven-development.
+> Checkbox (`- [ ]`). **CI-validated posture:** box HANGS on Python `import` of
+> goldenmatch/polars/datafusion. Validate Python via `ruff check` + `py_compile`
+> ONLY (and the goldenmatch lane enforces `I001` import-ordering — run `ruff
+> check` and fix BEFORE pushing). NEVER import/pytest/uv/pyright. Real tests in
+> CI. Branch off `main` (which now has Stage A+B merged: the FFI scorer UDFs +
+> `goldenmatch-score-core`). benzsevern auth, NEVER benzsevern-mjh.
+> `docs/superpowers/` gitignored.
+
+**Goal:** Thread `score → dedup → [UF break] → id_prep → golden` on ONE Python
+`datafusion` `SessionContext` with out-of-core spill, behind `mode="scale"`,
+producing the SAME partition + golden as the in-memory pipeline (semantic parity,
+not bit-identical).
+
+**PRECONDITION (gate on this):** Stage A/B must be MERGED to main first (the
+`goldenmatch_datafusion_udf` crate, `goldenmatch-score-core`, the CI wheel step,
+and the `datafusion>=53,<54` pin). Until then they live only on
+`feat/datafusion-ffi-udf`. If A/B is not yet merged, either wait, or scope C to
+**B1** (`datafusion_backend.py::_make_score_udf`, the Python UDF, already on main)
+and defer the B2/FFI seam — `_register_scorers` falls to B1 when
+`goldenmatch_datafusion_udf` is absent, so state that, don't present FFI as live.
+
+**Architecture (corrected after review — the spine REUSES the proven frames-out
+path; only score+dedup is new DataFusion):** `run_spine(blocked_candidates,
+config, *, memory_limit) -> (golden_df, assignments_df)`.
+- **New DataFusion stages (ride the spilling ctx):** `score` (block self-join +
+  scorer UDF) → `dedup` (in-ctx `max(score) GROUP BY a,b`). Output: the scored
+  pairs.
+- **Clustering → id_prep → golden = MIRROR the in-memory frames-out path
+  (`pipeline.py:1503-1647` under `GOLDENMATCH_CLUSTER_FRAMES_OUT=1`), which is
+  Ray-free + frames-native:** `build_cluster_frames(RAW all_pairs, all_ids, ...)`
+  → `ClusterFrames` (the genuine one-box WCC; NOT `build_clusters_distributed`,
+  which is Ray-only) → `from_frames(assignments, RAW all_pairs)` (id_prep) +
+  `build_golden_records_from_frames(source, cluster_frames, rules)` (golden).
+  No Ray, no `materialize_cluster_dict`, no DIY metadata assembly.
+- Written against the SCORER-UDF interface so B1 (Python UDF) ↔ B2 (FFI UDF) is a
+  swap. **RAW pairs (not the deduped frame) feed `build_cluster_frames` AND
+  `from_frames`** — the in-memory path does exactly this (`pipeline.py:1505,1906`);
+  the deduped set is only for the `scored_pairs` result field.
+
+**Tech Stack:** Python datafusion 53, PyArrow, the Stage-B FFI scorer UDFs
+(`goldenmatch_datafusion_udf`), `goldenmatch.distributed.clustering`,
+`goldenmatch.core.golden`/`cluster_pairscores`.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-datafusion-spine-design.md` (Stage C).
+
+---
+
+## Stage entry-points (grounded — read these before wiring)
+
+- **score:** `backends/datafusion_backend.py::score_blocks_datafusion` (block
+  self-join + scorer UDF). `_make_score_udf` is B1 (Python). For B2 register the
+  Stage-B FFI UDFs (`goldenmatch_datafusion_udf.{JaroWinklerUDF,TokenSortUDF,
+  LevenshteinUDF}` via `datafusion.udf(...)`). Wire BOTH behind one interface.
+- **dedup:** **in-ctx** `SELECT a,b,max(score) AS score GROUP BY a,b` (rides the
+  spill pool — do NOT use `dedup_pairs_max_score_arrow`, which pulls the full
+  scored set to the driver as a Polars frame, defeating spill at this stage).
+- **UF (clustering):** `core/cluster.py::build_cluster_frames(all_pairs, all_ids,
+  *, max_cluster_size, weak_cluster_threshold, auto_split)` → `ClusterFrames`
+  (assignments `cluster_id,member_id` + the 9-col metadata `cluster_id,size,
+  confidence,quality,oversized,bottleneck_pair_a,bottleneck_pair_b,min_edge,
+  avg_edge`). **Ray-free, one-box, the in-memory path's clustering** (`pipeline.py
+  :1505`). NOT `build_clusters_distributed` (Ray-only). `all_ids` Arrow-derived
+  (not a Python `list[int]`). RAW `all_pairs` (it dedups internally via
+  `_columnar_presplit`).
+- **id_prep:** `core/cluster_pairscores.py::ClusterPairScores.from_frames(
+  cluster_frames.assignments, RAW all_pairs)` (#696 group-by.agg; RAW pairs per
+  its docstring contract — last-wins, NOT the max-deduped set).
+- **golden:** `core/golden.py::build_golden_records_from_frames(source_df,
+  cluster_frames, rules, ...)` — pass the `ClusterFrames` from
+  `build_cluster_frames` STRAIGHT through (it carries `size`/`oversized` that
+  `_multi_df_from_frames` filters on). No assembly. Mirror `pipeline.py:1641-1647`.
+
+## File structure
+
+- Create `packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py`
+  — `run_spine(...)` + helpers (one `SessionContext`, stage threading, the UF
+  break). One responsibility: the spine orchestration. Reuses
+  `datafusion_backend` for the score stage.
+- Create `packages/python/goldenmatch/tests/test_datafusion_spine_parity.py`
+  — run_spine vs in-memory parity.
+- Modify `.github/workflows/ci.yml` if the spine test needs the datafusion-udf
+  wheel + datafusion runtime (it does — the Stage A/B build step already wires
+  this for the goldenmatch lane; confirm it covers the new test path).
+
+---
+
+### Task C1: spine skeleton — ctx + score + dedup
+
+**Files:**
+- Create: `goldenmatch/backends/datafusion_spine.py`
+- Test: `tests/test_datafusion_spine_parity.py`
+
+- [ ] **Step 1: Write a failing skeleton test.** On a tiny fixture (a few blocked
+  candidate rows), `run_spine(candidates, config, memory_limit=None)` returns
+  `(golden_df, assignments_df)` that are non-empty pyarrow/polars frames with the
+  expected columns (`assignments`: `member_id, cluster_id`). (Full parity is C4.)
+
+- [ ] **Step 2: Build the ctx + spill.** `_make_spine_ctx(memory_limit,
+  target_partitions=None)`: `SessionConfig()` (+ `.with_target_partitions(n)` if
+  given); if `memory_limit`: `RuntimeEnvBuilder().with_disk_manager_os()
+  .with_fair_spill_pool(memory_limit)` passed as `SessionContext(config=cfg,
+  runtime=builder)` (the Stage-A/B confirmed v53 API). Register the scorer UDFs:
+  an `_register_scorers(ctx, config, *, use_ffi)` that registers either the FFI
+  UDFs (B2, default when `goldenmatch_datafusion_udf` importable) or falls back
+  to B1 (`_make_score_udf`). This is the UDF-interface seam.
+
+- [ ] **Step 3: score + dedup.** Register `blocked_candidates` (Arrow) on the
+  ctx. Score: a block-self-join SQL using the scorer UDF(s) (mirror
+  `score_blocks_datafusion`'s self-join shape `a.block_key=b.block_key AND
+  a.id<b.id`; reuse `_materialize_blocks_to_arrow` for the `__block_key__/
+  __row_id__/__value__` shape; if registering FFI token_sort, replicate the
+  `/100.0` normalization `_make_score_udf` applies), threshold-filter →
+  **RAW scored pairs** `(a,b,score)`. KEEP the raw scored pairs (for
+  `build_cluster_frames` + `from_frames`). Dedup (in-ctx, rides spill): `SELECT
+  a,b,max(score) GROUP BY a,b` → the deduped set, used ONLY for the
+  `scored_pairs` result field — NOT fed to clustering/id_prep.
+
+- [ ] **Step 4: Validate** (`ruff check` incl I001 + `py_compile`). Commit.
+  `feat(spine): datafusion_spine ctx + score(UDF) + dedup stages`
+
+### Task C2: clustering via build_cluster_frames (one-box, Ray-free)
+
+- [ ] **Step 1:** Collect the RAW scored pairs to the driver as `all_pairs`
+  (`list[(a,b,score)]` or the Arrow it accepts) and derive `all_ids` as an Arrow
+  array (NOT a Python `list[int]` rehydration). Call `build_cluster_frames(
+  all_pairs, all_ids, max_cluster_size=config..., weak_cluster_threshold=...,
+  auto_split=...)` → `cluster_frames` (`ClusterFrames`). This is exactly what
+  `pipeline.py:1503-1509` does under frames-out. NO Ray,
+  `build_clusters_distributed`, or `materialize_cluster_dict`. (The driver-side
+  collect here is the "in-memory island" the spec scopes — bound below scipy's
+  ~50M envelope in Stage E.)
+
+- [ ] **Step 2: Validate + commit.** `feat(spine): clustering via build_cluster_frames (Ray-free ClusterFrames)`
+
+### Task C3: id_prep + golden (mirror pipeline.py:1641)
+
+- [ ] **Step 1:** id_prep: `pair_score_view = ClusterPairScores.from_frames(
+  cluster_frames.assignments, RAW all_pairs)` (RAW pairs per the docstring
+  contract). golden: `golden_df = build_golden_records_from_frames(source_df,
+  cluster_frames, golden_rules, quality_scores=None, provenance=...)` — pass
+  `cluster_frames` straight through (NO assembly; its 9-col metadata carries
+  `size`/`oversized` golden filters on). Return `(golden_df,
+  cluster_frames.assignments)`.
+
+- [ ] **Step 2: Validate + commit.** `feat(spine): id_prep view + golden from cluster_frames (mirror frames-out)`
+
+### Task C4: parity harness (the gate)
+
+**Files:**
+- Test: `tests/test_datafusion_spine_parity.py`
+
+- [ ] **Step 1: Write the parity test.** A representative fixture (realistic-
+  person shape, small N). Comparand: run the in-memory pipeline with
+  `GOLDENMATCH_CLUSTER_FRAMES_OUT=1` so BOTH sides derive the partition the SAME
+  way — the in-memory `cluster_frames.assignments` vs the spine's
+  `assignments_df` (both from `build_cluster_frames`, so this should be near-
+  identical; the only difference is the DataFusion score/dedup feeding it). Assert
+  SEMANTIC parity (NOT bit-identical):
+  - **cluster partition: Rand index 1.0** — frozenset of `__row_id__` per cluster,
+    SINGLETONS handled CONSISTENTLY on both sides (`build_cluster_frames` emits
+    size-1 clusters for singletons, so include them on both, or exclude on both).
+  - **golden content:** same surviving values per multi-member non-oversized
+    cluster (golden's scope; the partition check is broader — keep the scopes
+    distinct).
+  - **id_prep edge sets:** per-cluster `for_cluster(cid)` edge sets match (set
+    equality) — passes only if RAW pairs fed `from_frames` (C3), not deduped.
+  `confidence_required=False`. Entity-ids are not literal-comparable (use the
+  partition). Confidence as ε.
+
+- [ ] **Step 2: Validate (ruff I001 + py_compile) + commit.**
+  `test(spine): run_spine vs in-memory semantic parity (Rand 1.0 + golden + edges)`
+
+---
+
+## Execution order & gates
+
+1. C1 → C2 → C3 → C4 on a branch off main. Push (benzsevern), PR.
+2. CI gate: the spine parity test GREEN (Rand 1.0 partition + golden + edge sets).
+   The datafusion-udf wheel + datafusion runtime build in the goldenmatch lane
+   (Stage A/B wiring) — confirm the spine test runs (hard deps present), not skip.
+3. If GREEN: Stage C done → Stage D (scale-mode contract: determinism across
+   `target_partitions`, feature-gating LLM/rerank/boost/NE/exotic → error) and
+   Stage E (out-of-core spill bench: relational stages survive where in-memory
+   OOMs; bound the UF collection below scipy's ~50M envelope).
+
+No default flips (run_spine is behind `mode="scale"`, default standard; nothing
+in the default pipeline path changes until a later cutover).
+
+## Final review
+
+After C1-C4: a code-reviewer over the diff (the UF-break frame-native round-trip —
+no `list[int]`/`materialize_cluster_dict` rehydration; the `ClusterFrames`
+contract golden needs; the parity harness's partition comparison correctness),
+then declare Stage C done.

--- a/docs/superpowers/plans/2026-06-03-datafusion-spine-stage-d.md
+++ b/docs/superpowers/plans/2026-06-03-datafusion-spine-stage-d.md
@@ -1,0 +1,474 @@
+# DataFusion Spine — Stage D: scale-mode contract (Implementation Plan)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `mode="scale"` an explicit, opt-in, deterministic contract on the DataFusion spine: a `mode` config field, a hard feature-gate that errors (never silently ignores) on every unsupported surface, and a determinism gate proving identical pair set / cluster partition / id_prep edges across `target_partitions`.
+
+**Architecture:** Add `mode: Literal["standard","scale"]` to `GoldenMatchConfig`. `run_spine` (the spine entry) calls a new `_validate_scale_mode_supported(config)` guard before doing any work: it requires `config.mode == "scale"` and raises `NotImplementedError` for LLM scorer/cluster, LLM boost, LLM auto, rerank/cross-encoder, negative-evidence, domain extraction, and any non-single-weighted matchkey surface. A new determinism test runs `run_spine` at `target_partitions ∈ {1,3,17}` and asserts the emitted pair SET, the cluster PARTITION, the id_prep edge sets, and `avg_edge` are identical/ε-equal. Sign-off content (feature matrix, customer statement, MAX-vs-last) is finalized in the parent roadmap doc.
+
+**Tech Stack:** Python 3.12, pydantic v2, polars, Python `datafusion>=53,<54`, pytest. The spine's relational stages run inside one `datafusion.SessionContext`; clustering/id_prep/golden mirror the in-memory frames-out path.
+
+---
+
+## Critical context for the executor (read before starting)
+
+- **This box HANGS on `import goldenmatch` / `import polars` / `import datafusion`.** You CANNOT run pytest locally. Validate every Python change with `ruff check` (exit 0) and `python -m py_compile` ONLY. **CI is the only test verifier.** Each task's "run the test" step means: push the branch and read the `python (goldenmatch)` lane result. Batch tasks, then push once and watch CI.
+- **The `python (goldenmatch)` CI lane** installs `datafusion>=53,<54` and builds the `goldenmatch_datafusion_udf` FFI wheel, so `run_spine` runs there with the real FFI scorers. New tests under `packages/python/goldenmatch/tests/` are picked up automatically — no CI YAML change needed for Stage D.
+- **`ruff check` (I001 import ordering) is enforced.** Run `uv run ruff check packages/python/goldenmatch` — or if `uv` hangs, `ruff check packages/python/goldenmatch` — to **exit 0** before EVERY commit. Never pipe through `tail` (masks the exit code). `ruff check --fix` if it fires.
+- **GitHub auth:** `GH_TOKEN=$(gh auth token --user benzsevern)` for every push/PR/merge. NEVER `benzsevern-mjh`. Repo is `benseverndev-oss/goldenmatch`.
+- **Branch off `origin/main`, NOT local `main`** — local `main` is stale (it predates the whole DataFusion-spine series; `datafusion_spine.py`/`datafusion_backend.py` are NOT on local `main`). Stage C (PR #700) is only reachable from `origin/main`. Do `git fetch origin && git checkout -b feat/datafusion-spine-stage-d origin/main`. (See Task 0.)
+- Subagents may NOT import/pytest/pyright/uv (zombie-python box pathology). Static checks only; the parent runs pyright bounded if needed.
+
+## Grounding references (all on `main`)
+
+- `goldenmatch/backends/datafusion_spine.py` — `run_spine(blocked_candidates, config, *, memory_limit=None, target_partitions=None)`; `_resolve_single_weighted_matchkey`; imports `_validate_matchkey` from `datafusion_backend`.
+- `goldenmatch/backends/datafusion_backend.py:62` — `_validate_matchkey` is the NotImplementedError-on-out-of-scope pattern to mirror. `_SUPPORTED_SCORERS = ("jaro_winkler","levenshtein","token_sort")` at line 32.
+- `goldenmatch/config/schemas.py` — `GoldenMatchConfig` top-level fields (~line 709). Feature-gate signals (verified):
+  - `llm_boost: bool = False` — boost.
+  - `llm_scorer: LLMScorerConfig | None = None` — `.enabled` flag.
+  - `llm_auto: bool = False` — LLM auto.
+  - `domain: DomainConfig | None = None` — `.enabled` flag (exotic/domain matchkeys).
+  - per-matchkey (`MatchkeyConfig`): `rerank: bool = False`; `negative_evidence: list | None = None`; `type ∈ {"exact","weighted","probabilistic"}` (only single-field weighted w/ supported scorer is in scope).
+  - `get_matchkeys()` (~line 797) returns top-level `matchkeys` or `match_settings.matchkeys` or `[]`.
+- `tests/test_datafusion_spine_parity.py` — `_fixture_df`, `_config(*, max_cluster_size)`, `_prepared_blocks(df, config)`, `_partition(assignments)`, `_edge_sets_by_partition(assignments, raw_pairs)`, `_run_spine`. The Stage D determinism test ADDS to this file and reuses these helpers.
+- `tests/test_config.py` — where `mode`-field schema tests go.
+- Parent roadmap: `docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md` — §"The scale-mode contract" (~line 324), §"Feature matrix … DRAFT for sign-off" (~line 392), §sign-off (~line 431). Already lists APPROVED customer statement + MAX-vs-last decision; Stage D finalizes/links them.
+- Local gating notes: `docs/superpowers/plans/_stage-d-gating-notes.md` (delete after Stage D lands).
+- Spec: `docs/superpowers/specs/2026-06-03-datafusion-spine-design.md` §"Stage D".
+
+---
+
+## File Structure
+
+- **Modify** `goldenmatch/config/schemas.py` — add `mode: Literal["standard","scale"] = "standard"` to `GoldenMatchConfig`.
+- **Modify** `goldenmatch/backends/datafusion_spine.py` — add `_validate_scale_mode_supported(config)`; call it first in `run_spine`.
+- **Modify** `tests/test_datafusion_spine_parity.py` — set `mode="scale"` in `_config`; add the determinism test reusing existing helpers.
+- **Create** `tests/test_datafusion_spine_scale_mode.py` — feature-gate tests (self-contained; assert each unsupported surface raises).
+- **Modify** `tests/test_config.py` — `mode`-field schema tests.
+- **Modify** `docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md` — finalize feature matrix + customer statement + MAX-vs-last sign-off, cross-link to Stage D.
+
+---
+
+## Task 0: Setup — branch off `origin/main`
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Fetch and branch off the REMOTE main** (local `main` is stale and lacks the spine files):
+
+```bash
+git fetch origin
+git checkout -b feat/datafusion-spine-stage-d origin/main
+```
+
+- [ ] **Step 2: Verify Stage C is present** (so the Modify steps have files to touch):
+
+```bash
+test -f packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py && \
+test -f packages/python/goldenmatch/tests/test_datafusion_spine_parity.py && echo OK
+```
+Expected: `OK`. If not, you branched off the wrong ref — redo Step 1.
+
+---
+
+## Task 1: Add `mode` field to `GoldenMatchConfig`
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/config/schemas.py` (the `GoldenMatchConfig` class, ~line 709)
+- Test: `packages/python/goldenmatch/tests/test_config.py`
+
+- [ ] **Step 1: Write the failing tests** in `tests/test_config.py` (append; ensure `from goldenmatch.config.schemas import GoldenMatchConfig` and `import pytest` / `from pydantic import ValidationError` are imported — reuse existing imports, add only what's missing):
+
+```python
+def test_config_mode_defaults_to_standard():
+    cfg = GoldenMatchConfig()
+    assert cfg.mode == "standard"
+
+
+def test_config_mode_accepts_scale():
+    cfg = GoldenMatchConfig(mode="scale")
+    assert cfg.mode == "scale"
+
+
+def test_config_mode_rejects_unknown_value():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        GoldenMatchConfig(mode="turbo")
+
+
+def test_config_mode_round_trips_through_model_dump():
+    cfg = GoldenMatchConfig(mode="scale")
+    assert GoldenMatchConfig(**cfg.model_dump()).mode == "scale"
+```
+
+- [ ] **Step 2: Add the field.** In `schemas.py`, `GoldenMatchConfig`, add next to the other top-level mode-like flags (e.g. right after `backend: str | None = None`):
+
+```python
+    # Execution mode. "standard" (default) = the in-memory/Ray pipeline,
+    # bit-identical artifacts. "scale" = the DataFusion spine
+    # (out-of-core, deterministic + semantically correct but NOT
+    # bit-identical to standard; MAX dedup, reduced feature surface).
+    # The spine entry (backends/datafusion_spine.run_spine) enforces the
+    # scale-mode feature gate; this field is the opt-in signal.
+    mode: Literal["standard", "scale"] = "standard"
+```
+
+  `Literal` is already imported in `schemas.py` (used by `MatchkeyConfig.type`). Verify the import line — do NOT add a duplicate.
+
+- [ ] **Step 3: Static-validate.** `ruff check packages/python/goldenmatch/goldenmatch/config/schemas.py` (exit 0) and `python -m py_compile packages/python/goldenmatch/goldenmatch/config/schemas.py packages/python/goldenmatch/tests/test_config.py`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/config/schemas.py packages/python/goldenmatch/tests/test_config.py
+git commit -m "feat(spine): add mode={standard,scale} field to GoldenMatchConfig (Stage D)"
+```
+
+---
+
+## Task 2: Scale-mode feature-gate at the spine entry
+
+The gate raises `NotImplementedError` for every unsupported surface and `ValueError` when invoked on a non-scale config. It mirrors `_validate_matchkey`'s message style. Errors are explicit — NEVER silently ignore an unsupported feature.
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py`
+- Test (gate): `packages/python/goldenmatch/tests/test_datafusion_spine_scale_mode.py` (create)
+- Test (parity fixup): `packages/python/goldenmatch/tests/test_datafusion_spine_parity.py`
+
+- [ ] **Step 1: Write the failing gate tests** — create `tests/test_datafusion_spine_scale_mode.py`. These assert raises only; they build configs and call `run_spine([], config)` (empty blocks is fine — the gate runs BEFORE any block work, so it raises before touching DataFusion; an FFI/datafusion install is not required for the gate tests to pass, but the lane has it anyway). Helper `_base_config()` builds a valid single-weighted scale config; each test mutates one surface.
+
+```python
+"""Stage D: scale-mode feature-gate. ``run_spine`` must raise an explicit
+error (never silently ignore) when ``mode="scale"`` is paired with an
+unsupported surface, and must refuse a non-scale config."""
+from __future__ import annotations
+
+import pytest
+
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+
+
+def _base_config(**overrides) -> GoldenMatchConfig:
+    """Valid single-field weighted scale-mode config (the supported shape).
+    ``overrides`` patch top-level fields; matchkey-level surfaces are set by
+    mutating the returned config's matchkey in the test."""
+    cfg = GoldenMatchConfig(
+        mode="scale",
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["zip"])],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="fuzzy_last",
+                fields=[MatchkeyField(
+                    column="last_name", scorer="jaro_winkler", weight=1.0,
+                )],
+                comparison="weighted",
+                threshold=0.85,
+            ),
+        ],
+    )
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _run(cfg):
+    from goldenmatch.backends.datafusion_spine import run_spine
+    return run_spine([], cfg)
+
+
+def test_gate_rejects_non_scale_mode():
+    cfg = _base_config()
+    cfg.mode = "standard"
+    with pytest.raises(ValueError, match="mode='scale'"):
+        _run(cfg)
+
+
+def test_gate_rejects_llm_boost():
+    with pytest.raises(NotImplementedError, match="boost"):
+        _run(_base_config(llm_boost=True))
+
+
+def test_gate_rejects_llm_auto():
+    with pytest.raises(NotImplementedError, match="LLM"):
+        _run(_base_config(llm_auto=True))
+
+
+def test_gate_rejects_llm_scorer_enabled():
+    from goldenmatch.config.schemas import LLMScorerConfig
+    with pytest.raises(NotImplementedError, match="LLM"):
+        _run(_base_config(llm_scorer=LLMScorerConfig(enabled=True)))
+
+
+def test_gate_allows_llm_scorer_present_but_disabled():
+    # A disabled LLM scorer is inert -> must NOT trip the gate. (It will
+    # proceed past the gate and hit the empty-blocks no-op path, returning
+    # normally.)
+    from goldenmatch.config.schemas import LLMScorerConfig
+    _run(_base_config(llm_scorer=LLMScorerConfig(enabled=False)))
+
+
+def test_gate_rejects_domain_enabled():
+    from goldenmatch.config.schemas import DomainConfig
+    with pytest.raises(NotImplementedError, match="domain"):
+        _run(_base_config(domain=DomainConfig(enabled=True)))
+
+
+def test_gate_rejects_rerank():
+    cfg = _base_config()
+    cfg.get_matchkeys()[0].rerank = True
+    with pytest.raises(NotImplementedError, match="rerank"):
+        _run(cfg)
+
+
+def test_gate_rejects_negative_evidence():
+    cfg = _base_config()
+    cfg.get_matchkeys()[0].negative_evidence = [
+        NegativeEvidenceField(
+            field="phone", scorer="exact", threshold=0.9, penalty=0.5,
+        )
+    ]
+    with pytest.raises(NotImplementedError, match="negative.evidence"):
+        _run(cfg)
+
+
+def test_gate_rejects_probabilistic_matchkey():
+    cfg = _base_config()
+    cfg.matchkeys.append(
+        MatchkeyConfig(
+            name="prob_mk",
+            fields=[MatchkeyField(column="last_name", scorer="jaro_winkler")],
+            comparison="probabilistic",
+        )
+    )
+    with pytest.raises(NotImplementedError, match="weighted"):
+        _run(cfg)
+```
+
+- [ ] **Step 2: Verify the tests fail** (in CI). Expected: all fail because `run_spine` does not gate yet (currently `_resolve_single_weighted_matchkey` would pick the weighted mk and proceed; several would raise the wrong error type or none).
+
+- [ ] **Step 3: Implement `_validate_scale_mode_supported`** in `datafusion_spine.py`. Add the function above `run_spine`, and call it as the FIRST statement in `run_spine` (before `_resolve_single_weighted_matchkey`).
+
+```python
+def _validate_scale_mode_supported(config) -> None:
+    """Hard-gate the scale-mode feature surface. Raise EXPLICITLY (never
+    silently ignore) when ``mode="scale"`` is paired with an unsupported
+    feature, so a customer never gets a silently-degraded result. Mirrors
+    ``datafusion_backend._validate_matchkey``'s NotImplementedError-on-
+    out-of-scope contract.
+
+    Supported scale-mode surface: a single-field ``weighted`` matchkey
+    with a supported scorer (jaro_winkler / levenshtein / token_sort),
+    static blocking, golden rules. Everything below is OUT and errors.
+    """
+    if getattr(config, "mode", "standard") != "scale":
+        raise ValueError(
+            "DataFusion spine requires mode='scale' (the opt-in to the "
+            "out-of-core, MAX-dedup, reduced-feature path). Set "
+            "config.mode='scale' to use run_spine; standard mode runs the "
+            "in-memory pipeline."
+        )
+
+    if getattr(config, "llm_boost", False):
+        raise NotImplementedError(
+            "DataFusion spine (mode='scale') does not support LLM boost "
+            "(config.llm_boost=True). Drop it or use standard mode."
+        )
+    if getattr(config, "llm_auto", False):
+        raise NotImplementedError(
+            "DataFusion spine (mode='scale') does not support LLM auto "
+            "(config.llm_auto=True). Drop it or use standard mode."
+        )
+    llm_scorer = getattr(config, "llm_scorer", None)
+    if llm_scorer is not None and getattr(llm_scorer, "enabled", False):
+        raise NotImplementedError(
+            "DataFusion spine (mode='scale') does not support the LLM "
+            "scorer/cluster (config.llm_scorer.enabled=True). Drop it or "
+            "use standard mode."
+        )
+    domain = getattr(config, "domain", None)
+    if domain is not None and getattr(domain, "enabled", False):
+        raise NotImplementedError(
+            "DataFusion spine (mode='scale') does not support domain "
+            "extraction / exotic domain matchkeys (config.domain.enabled="
+            "True). Drop it or use standard mode."
+        )
+
+    for mk in config.get_matchkeys():
+        if getattr(mk, "type", None) != "weighted":
+            raise NotImplementedError(
+                "DataFusion spine (mode='scale') supports only single-field "
+                f"weighted matchkeys; matchkey {mk.name!r} has "
+                f"type={mk.type!r} (probabilistic/exact/exotic out of scope)."
+            )
+        if getattr(mk, "rerank", False):
+            raise NotImplementedError(
+                "DataFusion spine (mode='scale') does not support "
+                f"rerank/cross-encoder (matchkey {mk.name!r} rerank=True)."
+            )
+        if getattr(mk, "negative_evidence", None):
+            raise NotImplementedError(
+                "DataFusion spine (mode='scale') does not support "
+                f"negative-evidence post-filters (matchkey {mk.name!r})."
+            )
+```
+
+  Then in `run_spine`, immediately after the docstring / before `mk = _resolve_single_weighted_matchkey(config)`:
+
+```python
+    _validate_scale_mode_supported(config)
+```
+
+  Note: the gate iterates ALL matchkeys (so a stray probabilistic/rerank matchkey errors even though `_resolve_single_weighted_matchkey` would pick a different one) — that's the point: never silently ignore.
+
+- [ ] **Step 4: Fix the Stage C parity fixture.** In `tests/test_datafusion_spine_parity.py`, `_config(...)`, add `mode="scale"` to the `GoldenMatchConfig(...)` constructor (otherwise the gate's `mode='scale'` check fails the now-passing parity tests):
+
+```python
+    return GoldenMatchConfig(
+        mode="scale",
+        blocking=BlockingConfig(
+        ...
+```
+
+- [ ] **Step 5: Static-validate.** `ruff check packages/python/goldenmatch` (exit 0); `python -m py_compile` on all three changed files.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py \
+        packages/python/goldenmatch/tests/test_datafusion_spine_scale_mode.py \
+        packages/python/goldenmatch/tests/test_datafusion_spine_parity.py
+git commit -m "feat(spine): scale-mode feature gate at run_spine entry (Stage D)"
+```
+
+---
+
+## Task 3: Determinism across `target_partitions`
+
+Prove the scale-mode output is identical across partition counts. Compare SETS/PARTITIONS (label- and order-independent), NOT raw f32 float equality. The fixture (`_fixture_df`) is all-identical-strings-within-block → every pair scores exactly 1.0, threshold 0.85 → 0.15 margin, so NO pair is within ε(1e-6) of the cutoff: the gate measures partition determinism, not threshold flapping (spec §Stage D, lines 90-92). The multi-member blocks (5-dense, 3-chain) exercise multi-partition join + GROUP-BY aggregation; tp=17 over-partitions the tiny input deliberately.
+
+**Files:**
+- Test: `packages/python/goldenmatch/tests/test_datafusion_spine_parity.py` (add; reuse `_fixture_df`, `_config`, `_prepared_blocks`, `_partition`, `_edge_sets_by_partition`)
+
+- [ ] **Step 1: Add a `target_partitions`-aware spine runner + the determinism test** to `test_datafusion_spine_parity.py`. Paste EXACTLY this (no `monkeypatch` param, no `_avg_edge_by_partition` helper — see the avg_edge note below for why it's omitted):
+
+```python
+def _run_spine_tp(blocks, config, target_partitions):
+    from goldenmatch.backends.datafusion_spine import run_spine
+    return run_spine(blocks, config, target_partitions=target_partitions)
+
+
+def test_spine_deterministic_across_target_partitions():
+    """Stage D gate: the emitted pair SET, the cluster PARTITION, and the
+    id_prep edge sets are identical across target_partitions {1,3,17}.
+
+    Compared as SETS/PARTITIONS (label- and order-independent), NOT raw f32
+    float equality. The fixture's within-block strings are identical, so every
+    pair scores exactly 1.0 (threshold 0.85 -> 0.15 margin): no pair is within
+    1e-6 of the cutoff, so this measures partition determinism, not threshold
+    flapping (spec Stage D). avg_edge is intentionally NOT asserted: run_spine
+    does not return cluster metadata, and with uniform 1.0 scores avg_edge is a
+    deterministic function of the (proven-identical) edge sets, so it cannot
+    drift independently.
+    """
+    df = _fixture_df()
+    config = _config(max_cluster_size=100)
+
+    results = {}
+    for tp in (1, 3, 17):
+        # Rebuild blocks per run so each run is independent (build_blocks may
+        # yield a lazy frame consumed once).
+        blocks_tp = _prepared_blocks(df, config)
+        _golden, assign, raw_pairs = _run_spine_tp(blocks_tp, config, tp)
+        results[tp] = {
+            "pairset": frozenset((min(a, b), max(a, b)) for a, b, _ in raw_pairs),
+            "partition": _partition(assign),
+            "edges": _edge_sets_by_partition(assign, raw_pairs),
+        }
+
+    base = results[1]
+    for tp in (3, 17):
+        assert results[tp]["pairset"] == base["pairset"], (
+            f"pair set diverged at target_partitions={tp}"
+        )
+        assert results[tp]["partition"] == base["partition"], (
+            f"cluster partition diverged at target_partitions={tp}"
+        )
+        assert results[tp]["edges"] == base["edges"], (
+            f"id_prep edge sets diverged at target_partitions={tp}"
+        )
+```
+
+  **Why avg_edge is omitted:** `run_spine` returns only `(golden_df, assignments, raw_pairs)` — not `cluster_frames.metadata` — so `avg_edge` is not observable from the return without changing the API. With the all-1.0 fixture it is a deterministic function of the proven-identical edge sets, so a separate avg_edge assert adds no coverage. If a reviewer later insists on an explicit avg_edge gate, derive it test-side via `build_cluster_frames(raw_pairs, sorted({i for p in raw_pairs for i in p[:2]}), ...)` and compare per-cluster — but do NOT add that unless asked (keeps the test free of an unused helper).
+
+- [ ] **Step 2: Verify in CI** the determinism test passes at all three partition counts. If it FAILS (pair set or partition diverges), that's a real nondeterminism bug — STOP and apply the spec's contingency: pin the reduction (e.g. sort the score self-join output deterministically before the GROUP BY, or add `ORDER BY id_a, id_b` to the dedup SQL) and re-run. Surface to the human if a pin doesn't resolve it.
+
+- [ ] **Step 3: Static-validate** + **Commit.**
+
+```bash
+git add packages/python/goldenmatch/tests/test_datafusion_spine_parity.py
+git commit -m "test(spine): determinism gate across target_partitions {1,3,17} (Stage D)"
+```
+
+---
+
+## Task 4: Finalize scale-mode sign-off in the parent roadmap
+
+The roadmap already drafts the feature matrix + APPROVED customer statement + MAX-vs-last decision. Stage D promotes "DRAFT for sign-off" to "shipped" and cross-links the enforcing code.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md`
+
+- [ ] **Step 1:** In the "Feature matrix (scale mode supported / dropped) — DRAFT for sign-off" section (~line 392), change the heading to drop "DRAFT for sign-off" → "(SHIPPED Stage D — enforced by `datafusion_spine._validate_scale_mode_supported`)". Verify each DROPPED row matches the actual gate (LLM boost/auto/scorer, domain, rerank, negative-evidence, non-weighted matchkeys). Add any gated surface the matrix is missing.
+
+- [ ] **Step 2:** In the sign-off section (~line 431-448), under the customer-facing statement, add a one-line pointer: the statement now lives in code as the `ValueError`/`NotImplementedError` messages in `_validate_scale_mode_supported`, and the `mode` field's docstring in `schemas.py`. Confirm the MAX-vs-last note (R1=0 on the default single-weighted path) is stated as the dedup contract for scale mode.
+
+- [ ] **Step 3: Commit** (specs are gitignored — use `-f`).
+
+```bash
+git add -f docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md
+git commit -m "docs(spine): finalize scale-mode sign-off + feature matrix (Stage D)"
+```
+
+---
+
+## Task 5: Push, green CI, merge
+
+- [ ] **Step 1:** Delete the scratch gating notes: `git rm -f docs/superpowers/plans/_stage-d-gating-notes.md` (or `rm` if untracked) — it was a working aid.
+
+- [ ] **Step 2: Push the branch and open the PR.**
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) git push -u origin feat/datafusion-spine-stage-d
+GH_TOKEN=$(gh auth token --user benzsevern) gh pr create --base main \
+  --title "feat(spine): scale-mode contract — mode field, feature gate, determinism gate (Stage D)" \
+  --body "Stage D of the DataFusion spine. Adds the mode={standard,scale} config field, a hard feature-gate at run_spine entry (errors on LLM boost/auto/scorer, domain, rerank, negative-evidence, non-weighted matchkeys, and non-scale mode), and a determinism gate across target_partitions {1,3,17}. Finalizes the scale-mode sign-off in the roadmap. Spec: docs/superpowers/specs/2026-06-03-datafusion-spine-design.md (Stage D)."
+```
+
+- [ ] **Step 3: Watch the `python (goldenmatch)` lane go green** (and `ci-required`). Poll: `while gh pr checks <N> | grep -qE "\bpending\b|in_progress"; do sleep 30; done`. If the branch falls behind main, `gh pr update-branch <N>` and re-poll.
+
+- [ ] **Step 4: Merge** once green: `gh pr merge <N> --squash --delete-branch` (the worktree-delete cosmetic failure is expected and safe to ignore).
+
+---
+
+## Definition of done
+
+- `GoldenMatchConfig.mode` exists, defaults `"standard"`, rejects unknown values, round-trips.
+- `run_spine` raises `ValueError` on non-scale mode and `NotImplementedError` (explicit, matched message) on every unsupported surface; a disabled LLM scorer does NOT trip the gate.
+- Determinism test green at `target_partitions ∈ {1,3,17}` (pair set + partition + id_prep edges identical).
+- Stage C parity tests still green (fixture sets `mode="scale"`).
+- Roadmap feature matrix + sign-off finalized and cross-linked to the enforcing code.
+- `python (goldenmatch)` + `ci-required` green; PR merged.
+
+## Out of scope (Stage E and beyond)
+
+- The out-of-core spill bench (Stage E — separate plan).
+- Flipping the `mode` default to `"scale"` (do NOT — gated on Stage E's spill verdict + the recorded sign-off).
+- Sail / distributed routing; view-elimination; multi-field weighted; the in-memory golden custom-field-rules fallback.

--- a/docs/superpowers/plans/2026-06-03-datafusion-spine-stage-e.md
+++ b/docs/superpowers/plans/2026-06-03-datafusion-spine-stage-e.md
@@ -1,0 +1,544 @@
+# DataFusion Spine — Stage E: out-of-core spill bench (Implementation Plan)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure whether the DataFusion spine's relational stages SPILL and SURVIVE where the in-memory pipeline OOMs — the binding "out-of-core" proof — via a `workflow_dispatch` bench on `large-new-64GB`, and record the verdict (binding or honest-null) in the roadmap.
+
+**Architecture:** A single-file driver `bench_datafusion_spine_spill.py` generates one shared person-shape dataset per scale, then runs three variants — `bucket` (in-memory production winner), `spine_nospill` (`run_spine`, no memory cap), `spine_spill` (`run_spine` with a low `fair_spill_pool` cap) — each in a SUBPROCESS so a Linux OOM-kill of one variant is recorded (non-zero exit) rather than crashing the bench. Each child self-reports peak RSS via `getrusage(RUSAGE_SELF).ru_maxrss`. The bench keeps scale below the ~50M-pair scipy/UF envelope (the UF break collects pairs to the driver — an in-memory island the spill pool does NOT cover; pushing past it would OOM at the UF boundary and falsely read as "spine doesn't survive"). A workflow on `large-new-64GB` builds the Stage-B FFI UDF wheel + installs `datafusion>=53`, runs the driver, uploads the JSON + posts a markdown table. The verdict (incl. the honest-null outcome where nothing OOMs at reachable scale) lands in the roadmap.
+
+**Tech Stack:** Python 3.12, polars, `datafusion>=53,<54`, the `goldenmatch_datafusion_udf` FFI wheel, `goldenmatch._native` (bucket backend kernel), GitHub Actions `large-new-64GB` (16c/64GB).
+
+---
+
+## Critical context for the executor (read before starting)
+
+- **This box HANGS on `import goldenmatch`/`polars`/`datafusion`, and the bench scale OOMs Ben's Windows machine.** Do NOT run the driver locally at any non-trivial scale. Validate Python with `ruff check` + `python -m py_compile` ONLY. The smoke test runs in CI; the real bench runs on `large-new-64GB`. CI is the only verifier.
+- **Branch off `origin/main`** (Stage D #702 is merged: `mode` field + `_validate_scale_mode_supported` are on `origin/main`). This plan's branch is `feat/datafusion-spine-stage-e` (already created off `origin/main`).
+- **GitHub auth:** `GH_TOKEN=$(gh auth token --user benzsevern)` for every push/PR/merge/`gh run`/`gh workflow run`. NEVER `benzsevern-mjh`. Repo `benseverndev-oss/goldenmatch`.
+- **`ruff check packages/python/goldenmatch` must exit 0** before EVERY commit (I001 import order enforced). Never pipe through `tail`.
+- **`run_spine` requires `config.mode == "scale"`** (Stage D gate) — the driver MUST set `mode="scale"` on the spine config or the gate raises `ValueError`.
+- **The bench is billable** (`large-new-64GB`, up to ~85 min). Land + smoke-green the harness in the PR FIRST, then dispatch the bench from the branch via `gh workflow run --ref feat/datafusion-spine-stage-e`, THEN commit the verdict to the same PR, THEN merge.
+- **Honest-null is a valid outcome** (spec Risk: "Spill may still not bind"): if nothing OOMs at reachable sub-50M-pair scale on 64GB, record that — the spine's value is then engine-portability/Sail, not one-box survival. Do NOT manufacture an OOM by pushing past 50M pairs (that OOMs the UF island, not the relational stages — a false negative).
+
+## Grounding references (all on `origin/main`)
+
+- `backends/datafusion_spine.py::run_spine(blocked_candidates, config, *, memory_limit=None, target_partitions=None)` → `(golden_df, assignments, raw_pairs)`. `memory_limit` (bytes) sizes the `RuntimeEnvBuilder().with_disk_manager_os().with_fair_spill_pool(memory_limit)` so score+dedup spill. `None` = no pool cap.
+- `tests/test_datafusion_spine_parity.py::_prepared_blocks(df, config)` — the canonical block-build for the spine (add `__row_id__`, `precompute_matchkey_transforms`, `build_blocks` over static blocking, returns LazyFrame blocks). Mirror it.
+- `tests/fixtures/realistic_person.py::realistic_person_df(n, seed=42)` — deterministic person-shape data with real fuzzy dupes; ~5K+ distinct surnames, soundex-distributed blocks, dupe count scales with N.
+- `scripts/bench_datafusion_vs_bucket.py` — the existing datafusion bench: `_make_config(backend)` (single-field weighted jaro_winkler on `last_name`, soundex static blocking), the JSON/markdown/decision-gate structure to mirror.
+- `.github/workflows/bench-pipeline-complete-path.yml` — the subprocess-per-variant + "catch the child's non-zero exit and record OOM" pattern + `large-new-64GB` + `np` input + step-summary + artifact upload.
+- `.github/workflows/bench-datafusion-vs-bucket.yml` — `large-new-64GB`, `uv sync`, `scripts/build_native.py`, JSON artifact, markdown step summary.
+- FFI UDF build recipe (from `ci.yml:269-280`):
+  ```
+  uv pip install 'datafusion>=53,<54'
+  uv run --with maturin maturin build --release \
+    --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml --out dist-dfudf
+  uv pip install dist-dfudf/*.whl
+  ```
+- Bucket = current in-memory winner: 25M rows → 57.7 GB peak RSS on `large-new-64GB` (near the 64 GB ceiling); ~8.3M pairs at 25M rows (well under the 50M UF envelope). So the OOM-seeking zone is ~25–40M records.
+
+---
+
+## File Structure
+
+- **Create** `packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py` — the driver (parent orchestrator + `--worker` child entrypoint).
+- **Create** `packages/python/goldenmatch/tests/test_bench_spine_spill_smoke.py` — a tiny-scale smoke test that runs in the goldenmatch CI lane (validates the driver end-to-end before the billable dispatch).
+- **Create** `.github/workflows/bench-datafusion-spine-spill.yml` — `workflow_dispatch` bench on `large-new-64GB`.
+- **Modify** `docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md` — record the Stage E spill verdict (numbers table + binding/honest-null call). Commit with `git add -f` (tracked doc).
+
+---
+
+## Task 1: The spill-bench driver
+
+**Files:**
+- Create: `packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py`
+
+- [ ] **Step 1: Write the driver.** Single file; parent orchestrates, `--worker` runs one variant in a child process. Peak RSS via the child's own `getrusage(RUSAGE_SELF).ru_maxrss` (Linux KB); OOM detected by the parent as a non-zero/killed child exit.
+
+```python
+"""Stage E: out-of-core spill bench for the DataFusion spine.
+
+Measures whether the spine's RELATIONAL stages (score self-join + dedup
+GROUP BY, inside one DataFusion ctx with a fair-spill pool) SPILL and
+SURVIVE where the in-memory pipeline OOMs. Three variants per scale:
+
+    bucket         -- dedupe_df(df, backend="bucket"): the in-memory
+                      production winner (holds within-block score state
+                      in RAM); the OOM comparand.
+    spine_nospill  -- run_spine(blocks, cfg, memory_limit=None): the
+                      spine with NO pool cap.
+    spine_spill    -- run_spine(blocks, cfg, memory_limit=POOL): the
+                      spine with a low fair-spill pool so score+dedup
+                      spill to disk.
+
+Each variant runs in a SUBPROCESS (this script re-invoked with --worker)
+so a Linux OOM-kill of one variant is recorded as a non-zero exit, not a
+bench crash (mirrors bench-pipeline-complete-path.yml). The child
+self-reports peak RSS via getrusage(RUSAGE_SELF).ru_maxrss.
+
+SCOPE (honest): the spill-survival claim is for the relational stages
+ONLY. The spine's UF break (build_cluster_frames) collects raw pairs to
+the driver -- an in-memory island the spill pool does NOT cover. Keep
+scale below the ~50M-pair scipy/UF envelope (person-shape data yields
+~8.3M pairs at 25M rows, so 25-40M rows is the OOM-seeking-yet-safe
+zone). Pushing past 50M pairs OOMs the UF island, not the relational
+stages -- a FALSE negative. If nothing OOMs at reachable scale, that's a
+valid HONEST-NULL result (the spine's value is then engine portability).
+
+Usage (CI / large-new-64GB only -- OOMs a laptop):
+    python scripts/bench_datafusion_spine_spill.py \
+        --rows 5000000,25000000 --pool-mb 8192 --out result.json
+    python scripts/bench_datafusion_spine_spill.py --smoke   # tiny, CI
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import resource
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import polars as pl
+
+# realistic_person_df lives under tests/fixtures (same sys.path dance as
+# bench_datafusion_vs_bucket.py).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests"))
+from fixtures.realistic_person import realistic_person_df  # noqa: E402
+from goldenmatch import dedupe_df  # noqa: E402
+from goldenmatch.config.schemas import (  # noqa: E402
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+
+VARIANTS = ("bucket", "spine_nospill", "spine_spill")
+
+
+def _spine_config() -> GoldenMatchConfig:
+    """Scale-mode spine config: single-field weighted jaro_winkler on
+    last_name, soundex static blocking -- the supported spine surface
+    (mode='scale' is REQUIRED by the Stage D gate)."""
+    return GoldenMatchConfig(
+        mode="scale",
+        matchkeys=[
+            MatchkeyConfig(
+                name="last_name_fuzzy",
+                type="weighted",
+                fields=[MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0)],
+                threshold=0.85,
+            )
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["last_name"], transforms=["soundex"])],
+        ),
+    )
+
+
+def _bucket_config() -> GoldenMatchConfig:
+    """Same matchkey/blocking as the spine, backend=bucket (standard
+    mode) -- the in-memory comparand on an identical workload."""
+    cfg = _spine_config()
+    cfg.mode = "standard"
+    cfg.backend = "bucket"
+    return cfg
+
+
+def _build_blocks(df: pl.DataFrame, config: GoldenMatchConfig):
+    """Mirror tests/test_datafusion_spine_parity.py::_prepared_blocks."""
+    from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.core.matchkey import precompute_matchkey_transforms
+
+    with_ids = df.with_row_index("__row_id__")
+    augmented = precompute_matchkey_transforms(with_ids, config.get_matchkeys())
+    return build_blocks(augmented.lazy(), config.blocking)
+
+
+def _worker(variant: str, data_path: str, pool_mb: int) -> int:
+    """Run ONE variant in this (child) process. Print a JSON result line
+    to stdout and exit 0; on OOM the OS kills us and the parent records
+    it. Peak RSS is self-reported via getrusage."""
+    df = pl.read_parquet(data_path)
+    t0 = time.perf_counter()
+
+    if variant == "bucket":
+        result = dedupe_df(df, config=_bucket_config())
+        pairs = result.dupes.height if result.dupes is not None else 0
+        clusters = len(result.clusters) if result.clusters else 0
+    else:
+        from goldenmatch.backends.datafusion_spine import run_spine
+
+        cfg = _spine_config()
+        blocks = _build_blocks(df, cfg)
+        pool = None if variant == "spine_nospill" else pool_mb * 1024 * 1024
+        _golden, assign, raw_pairs = run_spine(blocks, cfg, memory_limit=pool)
+        pairs = len(raw_pairs)
+        clusters = assign["cluster_id"].n_unique() if assign is not None and assign.height else 0
+
+    wall = time.perf_counter() - t0
+    # ru_maxrss: Linux = KB, macOS = bytes. CI is Linux -> KB -> MB.
+    peak_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+    print(json.dumps({
+        "variant": variant, "wall_s": wall, "peak_rss_mb": peak_mb,
+        "pairs": int(pairs), "clusters": int(clusters), "status": "ok",
+    }))
+    return 0
+
+
+def _run_variant_subprocess(variant: str, data_path: str, pool_mb: int) -> dict:
+    """Spawn a child for one variant; capture its JSON or record OOM."""
+    proc = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()),
+         "--worker", variant, "--data", data_path, "--pool-mb", str(pool_mb)],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        # 137 = 128+9 (SIGKILL, the OOM-killer signature).
+        oom = proc.returncode in (137, -9)
+        return {
+            "variant": variant,
+            "status": "OOM" if oom else "ERROR",
+            "returncode": proc.returncode,
+            "stderr_tail": proc.stderr[-2000:],
+        }
+    # The child may emit warnings before the JSON line; take the last
+    # non-empty stdout line as the result.
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    if not lines:
+        return {"variant": variant, "status": "ERROR", "returncode": 0,
+                "stderr_tail": "no JSON emitted; stderr: " + proc.stderr[-1500:]}
+    return json.loads(lines[-1])
+
+
+def _bench_scale(rows: int, pool_mb: int, seed: int, tmp: Path) -> dict:
+    data_path = tmp / f"spine_spill_{rows}.parquet"
+    df = realistic_person_df(rows, seed=seed)
+    df.write_parquet(data_path)
+    del df  # free the parent's copy before spawning children
+    print(f"\n=== rows={rows:,} pool={pool_mb}MB (data={data_path.name}) ===", flush=True)
+    out: dict[str, dict] = {}
+    for variant in VARIANTS:
+        r = _run_variant_subprocess(variant, str(data_path), pool_mb)
+        out[variant] = r
+        if r.get("status") == "ok":
+            print(f"  {variant}: wall={r['wall_s']:.1f}s peak_rss={r['peak_rss_mb']:.0f}MB "
+                  f"pairs={r['pairs']} clusters={r['clusters']}", flush=True)
+        else:
+            print(f"  {variant}: {r['status']} (rc={r.get('returncode')})", flush=True)
+    try:
+        data_path.unlink()
+    except OSError:
+        pass
+    return {"rows": rows, "pool_mb": pool_mb, "results": out}
+
+
+def _markdown(scales: list[dict]) -> str:
+    lines = ["## bench-datafusion-spine-spill", "",
+             "| rows | variant | wall_s | peak_rss_MB | pairs | status |",
+             "|---|---|---|---|---|---|"]
+    for s in scales:
+        for variant in VARIANTS:
+            r = s["results"][variant]
+            if r.get("status") == "ok":
+                lines.append(f"| {s['rows']:,} | {variant} | {r['wall_s']:.1f} | "
+                             f"{r['peak_rss_mb']:.0f} | {r['pairs']} | ok |")
+            else:
+                lines.append(f"| {s['rows']:,} | {variant} | - | - | - | "
+                             f"**{r['status']}** (rc={r.get('returncode')}) |")
+    # Verdict line: binding iff at the largest scale bucket OOMs/errors
+    # AND spine_spill is ok.
+    top = scales[-1]["results"] if scales else {}
+    bucket_dead = top.get("bucket", {}).get("status") in ("OOM", "ERROR")
+    spill_ok = top.get("spine_spill", {}).get("status") == "ok"
+    verdict = ("BINDING: in-memory (bucket) OOM/errored while spine_spill survived"
+               if bucket_dead and spill_ok else
+               "HONEST-NULL: nothing OOMed at this scale -- spine value is "
+               "engine-portability, not one-box survival (push scale or lower pool "
+               "to seek the binding point, staying < 50M pairs)")
+    lines += ["", f"**Verdict:** {verdict}"]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--worker", choices=VARIANTS, help="internal: run one variant")
+    ap.add_argument("--data", help="internal: parquet path for --worker")
+    ap.add_argument("--rows", default="5000000,25000000",
+                    help="comma-separated row counts (OOM-seeking; keep < 50M pairs)")
+    ap.add_argument("--pool-mb", type=int, default=8192,
+                    help="fair-spill pool size (MB) for spine_spill")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--smoke", action="store_true",
+                    help="tiny scale for CI validation (rows=2000, pool=128MB)")
+    ap.add_argument("--out", default=None, help="JSON output path")
+    args = ap.parse_args()
+
+    if args.worker:
+        return _worker(args.worker, args.data, args.pool_mb)
+
+    rows_list = [2000] if args.smoke else [int(x) for x in args.rows.split(",")]
+    pool_mb = 128 if args.smoke else args.pool_mb
+    tmp = Path(os.environ.get("RUNNER_TEMP", "/tmp")) / "spine-spill-bench"
+    tmp.mkdir(parents=True, exist_ok=True)
+
+    scales = [_bench_scale(n, pool_mb, args.seed, tmp) for n in rows_list]
+    payload = {"scales": scales, "pool_mb": pool_mb, "smoke": args.smoke}
+    md = _markdown(scales)
+    print("\n" + md)
+    if args.out:
+        Path(args.out).write_text(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Static-validate.** `ruff check packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py` (exit 0); `python -m py_compile` it.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py
+git commit -m "feat(spine): Stage E out-of-core spill bench driver"
+```
+
+---
+
+## Task 2: CI smoke test (validate the driver before the billable dispatch)
+
+**Files:**
+- Create: `packages/python/goldenmatch/tests/test_bench_spine_spill_smoke.py`
+
+- [ ] **Step 1: Write the smoke test.** It imports the driver's `_worker`/`_build_blocks` and runs the `spine_spill` variant in-process at a trivial scale, asserting it produces pairs+clusters. Runs in the `python (goldenmatch)` lane (datafusion + FFI wheel present). Self-contained.
+
+```python
+"""Stage E smoke: the spill-bench driver runs end-to-end at a trivial
+scale (validates the driver before the billable large-new-64GB dispatch).
+Runs in the goldenmatch CI lane (datafusion + FFI UDF wheel present)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("datafusion")
+pytest.importorskip("goldenmatch_datafusion_udf")
+
+_DRIVER = (
+    Path(__file__).resolve().parents[1] / "scripts" / "bench_datafusion_spine_spill.py"
+)
+
+
+def _load_driver():
+    spec = importlib.util.spec_from_file_location("spine_spill_bench", _DRIVER)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["spine_spill_bench"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_spine_spill_driver_runs_tiny():
+    drv = _load_driver()
+    import polars as pl
+
+    df = drv.realistic_person_df(400, seed=7)
+    cfg = drv._spine_config()
+    blocks = drv._build_blocks(df, cfg)
+
+    from goldenmatch.backends.datafusion_spine import run_spine
+
+    # Low pool to exercise the spill runtime construction path on tiny data.
+    _golden, assign, raw_pairs = run_spine(blocks, cfg, memory_limit=128 * 1024 * 1024)
+    assert isinstance(raw_pairs, list)
+    assert assign is not None
+    # NOTE: build_blocks drops soundex-singleton surnames (blocks with < 2
+    # records), so `assign` covers only the post-height>=2 block universe,
+    # NOT all 400 source rows. Assert the path produced a non-empty
+    # assignment with at least one cluster -- the end-to-end "it ran" check.
+    assert assign.height >= 1
+    assert assign["cluster_id"].n_unique() >= 1
+
+
+def test_spine_spill_config_is_scale_mode():
+    # The Stage D gate requires mode='scale'; a regression here would make
+    # every spine variant ValueError at bench time.
+    drv = _load_driver()
+    assert drv._spine_config().mode == "scale"
+    assert drv._bucket_config().backend == "bucket"
+```
+
+- [ ] **Step 2: Static-validate** + **Step 3: Commit.**
+
+```bash
+git add packages/python/goldenmatch/tests/test_bench_spine_spill_smoke.py
+git commit -m "test(spine): Stage E spill-bench driver smoke (tiny-scale, CI lane)"
+```
+
+---
+
+## Task 3: The workflow_dispatch bench on large-new-64GB
+
+**Files:**
+- Create: `.github/workflows/bench-datafusion-spine-spill.yml`
+
+- [ ] **Step 1: Write the workflow.** Mirror `bench-datafusion-vs-bucket.yml` (large-new-64GB, native build) + the FFI UDF build recipe + `bench-pipeline-complete-path.yml` inputs/summary.
+
+```yaml
+# Stage E: out-of-core spill bench for the DataFusion spine
+# (workflow_dispatch only). Runs scripts/bench_datafusion_spine_spill.py
+# on large-new-64GB (16c/64GB) -- the same box the bucket 25M numbers
+# were measured on. Builds the Stage-B FFI UDF wheel + installs
+# datafusion>=53 (the spine's scorers), and the native ext (bucket's
+# kernel). Uploads the JSON artifact and posts the markdown verdict to
+# the step summary.
+#
+# Scope (honest): the spill-survival claim is for the relational stages
+# only; keep `rows` below the ~50M-pair UF/scipy envelope (person-shape
+# ~8.3M pairs at 25M rows). A HONEST-NULL verdict (nothing OOMs) is a
+# valid outcome -- do NOT push past 50M pairs to manufacture an OOM.
+#
+# Spec: docs/superpowers/specs/2026-06-03-datafusion-spine-design.md (Stage E)
+# Roadmap: docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md
+
+name: bench-datafusion-spine-spill
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Comma-separated row counts (OOM-seeking; keep < 50M pairs)"
+        default: "5000000,25000000"
+      pool_mb:
+        description: "fair-spill pool size (MB) for the spine_spill variant"
+        default: "8192"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: large-new-64GB
+    timeout-minutes: 85
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+
+      - name: Build + install the FFI UDF wheel (spine scorers) + datafusion runtime
+        run: |
+          uv pip install 'datafusion>=53,<54'
+          uv run --with maturin maturin build --release \
+            --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml --out dist-dfudf
+          uv pip install dist-dfudf/*.whl
+
+      - name: Build native extension (bucket backend kernel)
+        run: uv run python scripts/build_native.py
+
+      - name: Verify spine + bucket deps importable
+        run: |
+          uv run python -c "import datafusion, goldenmatch_datafusion_udf; import goldenmatch._native as n; assert hasattr(n,'score_block_pairs_arrow'); print('deps ok')"
+
+      - name: Run spill bench
+        run: |
+          set -o pipefail
+          mkdir -p .profile_tmp
+          uv run python packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py \
+            --rows "${{ inputs.rows }}" --pool-mb "${{ inputs.pool_mb }}" \
+            --out .profile_tmp/spine_spill.json | tee /tmp/spine_spill.txt
+          { echo '## bench-datafusion-spine-spill (raw stdout)'; echo '```'; cat /tmp/spine_spill.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: spine-spill-bench
+          path: .profile_tmp/spine_spill.json
+          if-no-files-found: warn
+          retention-days: 30
+```
+
+- [ ] **Step 2:** A workflow-file change to `ci.yml` is NOT needed (this is a standalone `workflow_dispatch` file). Confirm the path-filter `changes` job in `ci.yml` does not REQUIRE every new workflow to be registered (new bench workflows are added without a filter entry — verify by checking an existing `bench-*.yml` has no `ci.yml` filter entry). If the repo gates on workflow presence, no action; bench workflows are dispatch-only and unfiltered.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add .github/workflows/bench-datafusion-spine-spill.yml
+git commit -m "ci(spine): Stage E spill-bench workflow (workflow_dispatch, large-new-64GB)"
+```
+
+---
+
+## Task 4: Push, smoke-green the harness PR
+
+- [ ] **Step 1: Push + open PR.**
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) git push -u origin feat/datafusion-spine-stage-e
+GH_TOKEN=$(gh auth token --user benzsevern) gh pr create --base main \
+  --title "feat(spine): Stage E out-of-core spill bench (driver + workflow + smoke)" \
+  --body "Stage E harness: the spill-bench driver, a tiny-scale CI smoke, and the large-new-64GB workflow_dispatch bench. The binding spill verdict is dispatched from this branch and committed here once measured. Spec: docs/superpowers/specs/2026-06-03-datafusion-spine-design.md (Stage E)."
+```
+
+- [ ] **Step 2: Watch the `python (goldenmatch)` lane go green** (it runs the smoke test). Poll: `while gh pr checks <N> | grep -qE "\bpending\b|in_progress"; do sleep 30; done`. If behind main, `gh pr update-branch <N>`. Confirm the pytest summary includes the 2 smoke tests passing (grep the raw log).
+
+---
+
+## Task 5: Dispatch the bench, record the verdict, merge
+
+- [ ] **Step 1: Dispatch the bench from the branch** (reads the workflow from the branch ref):
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) gh workflow run bench-datafusion-spine-spill.yml \
+  --ref feat/datafusion-spine-stage-e -f rows=5000000,25000000 -f pool_mb=8192
+```
+
+- [ ] **Step 2: Wait for it** (`large-new-64GB` provisioning can take minutes; the run up to ~85 min). Find the run id (`gh run list --workflow=bench-datafusion-spine-spill.yml --branch feat/datafusion-spine-stage-e -L 1`), then `gh run watch <id> --exit-status` or poll. Download the artifact + read the step summary for the verdict table.
+
+  **Interpretation:**
+  - **BINDING** if at the top scale `bucket` is OOM/ERROR (rc 137) AND `spine_spill` is `ok` → the spine survived where in-memory died.
+  - **HONEST-NULL** if nothing OOMed → record it plainly; consider one re-dispatch with a larger `rows` (staying < 50M pairs — person-shape stays ~1/3 row-count in pairs, so ≤ ~40M rows) and/or a lower `pool_mb`. Do NOT exceed the 50M-pair envelope.
+  - If `spine_spill` OOMs while `spine_nospill` doesn't, or pairs ≳ 50M, the UF island (not the relational stages) is the OOM — note it; lower the scale.
+
+- [ ] **Step 3: Record the verdict in the roadmap.** Add a Stage E section to `docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md` (near the scale-mode sign-off): the per-variant numbers table (rows / wall / peak RSS / pairs / status), the binding-or-honest-null call, the run id, and the runner. Keep ASCII (no em-dashes).
+
+```bash
+git add -f docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md
+git commit -m "docs(spine): record Stage E out-of-core spill verdict (run <id>)"
+GH_TOKEN=$(gh auth token --user benzsevern) git push
+```
+
+- [ ] **Step 4: Re-green + merge.** Poll PR CI; `gh pr update-branch <N>` if behind; merge once green:
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) gh pr merge <N> --squash --delete-branch
+```
+
+- [ ] **Step 5: Do NOT flip the `mode` default.** Stage E's verdict (binding or honest-null) is recorded; the default-flip decision is a separate, explicit follow-up the human owns. Surface the recommendation in the PR/summary, do not implement it here.
+
+---
+
+## Definition of done
+
+- Driver `bench_datafusion_spine_spill.py` runs the 3-variant subprocess bench, records OOM as a non-zero child exit, self-reports peak RSS, emits JSON + markdown verdict.
+- Smoke test green in the `python (goldenmatch)` lane.
+- `bench-datafusion-spine-spill.yml` dispatched on `large-new-64GB`; the spill verdict (binding or honest-null) recorded in the roadmap with the numbers, run id, and runner.
+- PR merged. `mode` default NOT flipped (separate human decision).
+
+## Out of scope
+
+- Flipping `mode` to `"scale"` by default.
+- Sail / distributed UF (removing the in-memory pair-collection island) — that's the tier that would let Stage E exceed 50M pairs.
+- Fixing the pre-existing empty-input `SchemaError` in the frames-out tail (flagged in Stage D).

--- a/docs/superpowers/plans/2026-06-03-datafusion-spine.md
+++ b/docs/superpowers/plans/2026-06-03-datafusion-spine.md
@@ -1,0 +1,238 @@
+# DataFusion Spine (SP2) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development.
+> Steps use checkbox (`- [ ]`). **CI-validated posture:** the dev box HANGS on
+> `import goldenmatch`/`import polars`/`import datafusion`. Subagents validate
+> Python via `ruff check` + `python -m py_compile` ONLY, and Rust via `cargo
+> check`/`cargo build` (NOT a long `cargo test` if it hangs — push to CI). NEVER
+> `import`, `pytest`, `uv`, `pyright`. Real tests run in CI. Branch off `main`;
+> benzsevern auth (`GH_TOKEN=$(gh auth token --user benzsevern)`), NEVER
+> benzsevern-mjh. `docs/superpowers/` is gitignored — don't `git add` spec/plan.
+
+**Goal:** Stand up the DataFusion spine over score→dedup→[UF]→id_prep→golden with
+out-of-core spill and a Rust scorer `ScalarUDF` (B2). **This plan fully details
+Stage A (the FFI hard gate); Stages B-E are outlined and re-planned after A.**
+
+**Architecture:** A separate maturin crate exports a native `ScalarUDF` via
+`datafusion-ffi` as a PyCapsule; the Python `datafusion` 53 `SessionContext`
+registers it and threads the relational stages with a fair-spill pool; UF routes
+to the existing scipy/label-prop path. Stage A proves ONLY the cross-crate FFI
+boundary on v53 with a trivial UDF.
+
+**Tech Stack:** Rust (datafusion 53.x, datafusion-ffi 53.x, pyo3/arrow-ffi),
+maturin, Python datafusion 53, PyArrow.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-datafusion-spine-design.md`
+
+---
+
+## Stage A is a HARD GATE
+
+Stage A proves a Rust-crate `ScalarUDF` can be registered into the Python
+`datafusion` 53 `SessionContext` via `datafusion-ffi` (PyCapsule). **If it cannot
+be made to work on v53 after a bounded effort, STOP and escalate to the human**
+(fall back: B1 Python UDF in `datafusion_backend.py` for the spine). Do NOT start
+Stages B-E until A is GREEN in CI.
+
+### CANONICAL REFERENCE (mirror this verbatim — it solves the FFI shape)
+
+Clone `apache/datafusion-python` at tag **`53.0.0`** and mirror
+`examples/datafusion-ffi-example/`:
+- `src/scalar_udf.rs` → the `#[pyclass]` + `__datafusion_scalar_udf__` + FFI export
+  pattern (Tasks A1/A2).
+- `python/tests/_test_scalar_udf.py` → the `udf(MyUDF())` + `ctx.register_udf(...)`
+  registration (Task A3).
+Swap their `IsNullUDF` (Any→Bool) for our `AddOneUDF` (Int64→Int64). This reference
+resolves every FFI-API question below; do NOT hand-roll from memory.
+
+### Verified FFI facts (from datafusion-python 53 source + the example)
+
+- The protocol object is a `#[pyclass]` with a `__datafusion_scalar_udf__(&self,
+  py) -> PyResult<Bound<PyCapsule>>` method (NOT a bare pyfunction returning a
+  capsule). Capsule name: `cr"datafusion_scalar_udf"`.
+- FFI build: `FFI_ScalarUDF::from(Arc::new(ScalarUDF::from(impl)))` — needs `Arc`
+  (`From<Arc<ScalarUDF>>` only).
+- `ScalarUDFImpl` v53 method is `invoke_with_args(&self, args: ScalarFunctionArgs)
+  -> Result<ColumnarValue>` (NOT `invoke_batch`/`invoke`).
+- Python registration: `from datafusion import udf; ctx.register_udf(udf(
+  AddOneUDF()))` — `udf()` detects the dunder + calls `from_pycapsule` internally.
+  Do NOT pass a raw capsule to `from_pycapsule`.
+- Arrow major: datafusion 53 pins **arrow 58** (NOT 53). New crate uses `arrow =
+  "58"` with `features=["ffi"]`; this differs from `_native`'s arrow 55 — the
+  reason the crate MUST be separate (separate cdylibs tolerate it).
+
+## File structure (Stage A)
+
+- Create `packages/rust/extensions/datafusion-udf/` — a NEW, standalone maturin
+  crate (own `Cargo.toml` with `[workspace]` to isolate it, own
+  `pyproject.toml`). One responsibility: export native ScalarUDFs over the FFI
+  boundary. Do NOT touch the existing `native` crate or `scripts/build_native.py`.
+  - `Cargo.toml` (mirror the example's dep set — sub-crates, not the umbrella):
+    `datafusion-ffi = "=53.x"`, `datafusion-expr = "=53.x"` (for `ScalarUDF`/
+    `ScalarUDFImpl`), `datafusion-common = "=53.x"`, `arrow = { version="58",
+    features=["ffi"] }`, `arrow-array`, `arrow-schema`, `pyo3 = { features=[
+    "extension-module","abi3-py311"] }`. `[lib] crate-type=["cdylib"]`. (datafusion-ffi's
+    own Cargo.toml says do NOT add the umbrella `datafusion` crate.)
+  - `src/lib.rs`: an `AddOneUDF` `#[pyclass]` implementing `ScalarUDFImpl`
+    (`invoke_with_args`) with a `__datafusion_scalar_udf__` method exporting
+    `FFI_ScalarUDF::from(Arc::new(ScalarUDF::from(...)))` as a `PyCapsule` named
+    `cr"datafusion_scalar_udf"`. Registered in the `#[pymodule]`.
+- Create `packages/rust/extensions/datafusion-udf/pyproject.toml` — maturin build
+  (mirror `packages/rust/extensions/native/`'s maturin pyproject).
+- Create `packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py` — the
+  Python registration + `SELECT add_one(x)` test.
+- Modify `.github/workflows/ci.yml` — a step (goldenmatch lane) that builds the
+  new crate (`maturin develop` / `pip install`) + installs `datafusion>=53,<54`,
+  so the FFI test actually runs (loud guard, no silent skip).
+
+---
+
+### Task A1: The maturin crate skeleton + version pins
+
+**Files:**
+- Create: `packages/rust/extensions/datafusion-udf/Cargo.toml`
+- Create: `packages/rust/extensions/datafusion-udf/pyproject.toml`
+- Create: `packages/rust/extensions/datafusion-udf/src/lib.rs` (stub)
+
+- [ ] **Step 1: Confirm the exact 53 minor.** Check crates.io for the latest
+  `datafusion-ffi` 53.x and the matching `datafusion` 53.x + the `arrow` major
+  datafusion 53 pins. Pin all three EXACTLY (`=53.x`) in `Cargo.toml`. Read
+  `packages/rust/extensions/native/Cargo.toml` for the pyo3/abi3 + `[workspace]`
+  isolation pattern to mirror.
+
+- [ ] **Step 2: Write `Cargo.toml`** — `[package]`, `[lib] crate-type=["cdylib"]`,
+  `[workspace]` (empty, to isolate from the bridge workspace like `native`), the
+  sub-crate dep set above (`datafusion-ffi`/`datafusion-expr`/`datafusion-common`
+  `=53.x`, `arrow=58` `features=["ffi"]`, `pyo3` extension-module+abi3-py311).
+  `pyproject.toml` — maturin backend mirroring `native/pyproject.toml` (module
+  name `goldenmatch_datafusion_udf`).
+
+- [ ] **Step 3: Write a stub `src/lib.rs`** — empty `#[pymodule]` so the crate
+  compiles. Validate: `cargo check` in the crate dir (if it doesn't hang; else
+  push to CI). Do NOT `cargo build --release` locally if it's slow — CI builds it.
+
+- [ ] **Step 4: Commit.** `feat(df-udf): maturin crate skeleton (datafusion 53.x, ffi) — isolated`
+
+### Task A2: The `add_one` ScalarUDF + FFI PyCapsule export
+
+**Files:**
+- Modify: `packages/rust/extensions/datafusion-udf/src/lib.rs`
+
+- [ ] **Step 1: Mirror the canonical example** `examples/datafusion-ffi-example/
+  src/scalar_udf.rs` @ tag 53.0.0, swapping `IsNullUDF` → `AddOneUDF`. Implement
+  `AddOneUDF` as a `#[pyclass]` AND `impl ScalarUDFImpl for AddOneUDF`:
+  `name()->"add_one"`, `signature()=Signature::exact(vec![Int64], Immutable)`,
+  `return_type()->Int64`, `invoke_with_args(&self, args: ScalarFunctionArgs) ->
+  Result<ColumnarValue>` adding 1 to the Int64 array.
+
+- [ ] **Step 2: The FFI export METHOD on the pyclass** (NOT a bare pyfunction):
+  ```rust
+  #[pymethods]
+  impl AddOneUDF {
+      #[new]
+      fn new() -> Self { Self { signature: Signature::exact(vec![DataType::Int64], Volatility::Immutable) } }
+      fn __datafusion_scalar_udf__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyCapsule>> {
+          let name = cr"datafusion_scalar_udf";
+          let func = Arc::new(ScalarUDF::from(self.clone()));   // Arc REQUIRED
+          let provider = FFI_ScalarUDF::from(func);
+          PyCapsule::new(py, provider, Some(name.into()))
+      }
+  }
+  ```
+  Register `AddOneUDF` in the `#[pymodule]` (`m.add_class::<AddOneUDF>()?`).
+
+- [ ] **Step 3: Validate** `cargo check` (the crate compiles + FFI types line up).
+  Do NOT run Python. Commit. `feat(df-udf): AddOneUDF pyclass + __datafusion_scalar_udf__ FFI export`
+
+### Task A3: Python registration test + CI wiring (the GATE)
+
+**Files:**
+- Create: `packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py`
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Write the failing test.**
+
+```python
+import pytest
+pa = pytest.importorskip("pyarrow")
+datafusion = pytest.importorskip("datafusion")
+# HARD import (NOT importorskip) — the lane BUILDS this crate; a build failure
+# must FAIL, not skip (the loud guard).
+import goldenmatch_datafusion_udf  # noqa: E402
+
+def test_ffi_scalar_udf_registers_and_evaluates():
+    from datafusion import SessionContext, udf
+    from goldenmatch_datafusion_udf import AddOneUDF
+    ctx = SessionContext()
+    ctx.register_udf(udf(AddOneUDF()))     # udf() detects __datafusion_scalar_udf__ + from_pycapsule
+    ctx.from_arrow(pa.table({"x": pa.array([1, 2, 3], pa.int64())}), name="t")
+    batches = ctx.sql("SELECT add_one(x) AS y FROM t ORDER BY x").collect()
+    got = [v for b in batches for v in b.column(0).to_pylist()]
+    assert got == [2, 3, 4]
+```
+
+- [ ] **Step 2: Wire CI to build the crate + run the test (no silent skip).** In
+  the `python (goldenmatch)` lane: build/install the new crate (`maturin develop
+  -m packages/rust/extensions/datafusion-udf/pyproject.toml` or `pip install` the
+  built wheel) AND `uv pip install 'datafusion>=53,<54'`. Add a non-importorskip
+  guard test asserting `goldenmatch_datafusion_udf` imports, so a build failure
+  fails loudly (per CLAUDE.md the per-step JSON lies on continue-on-error — the
+  guard test is the real signal).
+
+- [ ] **Step 3: Validate** `ruff` + `py_compile` the test; inspect the ci.yml diff.
+  Commit. `test(df-udf): FFI ScalarUDF registration gate + CI build/install`
+
+- [ ] **Step 4: THE GATE — push, open PR, confirm CI GREEN.** The test must
+  actually RUN and PASS in CI (not skip). If it fails on an API-name mismatch
+  (`from_pycapsule` / capsule name / `invoke_*`), fix against the v53 source and
+  re-push. If the FFI boundary fundamentally cannot be made to work on v53 after a
+  bounded effort (a few iterations), STOP and escalate with the exact error —
+  recommend the B1 fallback. **Do NOT proceed to Stage B until this is GREEN.**
+
+---
+
+## Stages B-E (OUTLINE — detailed in a follow-on plan AFTER Stage A is GREEN)
+
+Each becomes its own fully-detailed plan once the prior gate passes. Listed so the
+arc is visible; do NOT execute from these outlines.
+
+- **Stage B — scorer as FFI ScalarUDF.** Replace `add_one` with the native string
+  scorers (jaro_winkler/token_sort/...) as `FFI_ScalarUDF`(s) over `(Utf8, Utf8)
+  -> Float64`. Gate: UDF score == in-process native scorer (ε 1e-6, f32-origin)
+  on a string-pair fixture. Reuses the native scorer Rust already in `_native`
+  (may need to vendor/share the scorer code into the new crate).
+- **Stage C — spine orchestration.** `run_spine(blocked_candidates, config, *,
+  memory_limit) -> (golden_df, assignments_df)` threading score (block-self-join
+  + UDF) → dedup (`max(score) GROUP BY a,b`) → UF (scipy via
+  `build_clusters_distributed`, frame-native `all_ids`, no `materialize_cluster_
+  dict`) → id_prep (group_by edges, #695/#696 shape) + golden (group_by
+  representative) on ONE ctx with `with_fair_spill_pool`. Written against the UDF
+  INTERFACE (B1↔B2 swap). Gate: Rand-1.0 partition + golden content + id_prep
+  edge-set parity vs the in-memory pipeline.
+- **Stage D — scale-mode contract.** Determinism across `target_partitions`
+  {1,3,N} on the emitted PAIR-SET/PARTITION (not f32 float; fixture with no pair
+  within 1e-6 of threshold); MAX dedup; feature-gating (LLM/rerank/boost/NE/exotic
+  → explicit error). D doesn't block on C.
+- **Stage E — out-of-core spill bench.** Full spine at an OOM-seeking scale →
+  spill-survival for the RELATIONAL stages (bound the UF-collection pair-frame
+  below scipy's ~50M envelope so the UF island doesn't OOM and misread as failure).
+  3-way (in-memory / DataFusion / bucket). Commit numbers to the roadmap doc.
+
+---
+
+## Execution order & gates
+
+1. Tasks A1→A3 on a branch off main; push (benzsevern); PR. **CI must run the FFI
+   test GREEN (not skip).** This is the hard gate.
+2. If GREEN: re-invoke writing-plans for Stage B (then C, D, E) — each its own
+   plan + review, executed via subagent-driven-development, gated on the prior.
+3. If the FFI boundary fails on v53: STOP, escalate, recommend B1.
+
+No defaults flip in this plan (Stage A is a feasibility spike; nothing wires into
+the pipeline until Stage C, which is itself behind `mode="scale"`).
+
+## Final review
+
+After Stage A: the gate IS the review (CI green = FFI works). Then a code-reviewer
+over the crate (FFI types, capsule name, version pins) before declaring A done and
+planning B.

--- a/docs/superpowers/plans/2026-06-03-sail-tier-stage-s1.md
+++ b/docs/superpowers/plans/2026-06-03-sail-tier-stage-s1.md
@@ -1,0 +1,437 @@
+# Sail Tier — Stage S1: harness + scorer UDF + score/dedup (Implementation Plan)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up `goldenmatch.sail` on Sail (Spark Connect): connect to a local Sail server, score a block self-join with a rapidfuzz Arrow/pandas UDF, dedup with a distributed GROUP BY, and prove the emitted pair SET matches a python-rapidfuzz reference on a fixture — the first Sail-native gate.
+
+**Architecture:** A new optional `goldenmatch[sail]` extra (`pysail` + `pyspark[connect]`). A pytest fixture starts an in-process Sail Spark Connect server (`pysail.spark.SparkConnectServer`) and hands tests a `SparkSession`. `sail/scoring.py` builds the block self-join, applies a rapidfuzz `pandas_udf` scorer, threshold-filters, and dedups via `groupBy(a,b).max(score)`. Parity is gated against a python-rapidfuzz brute-force comparand (NOT the datafusion one-box spine — that keeps the Sail CI lane free of datafusion/native; both sides use rapidfuzz, so parity is exact). A new path-filtered `sail` CI job runs it.
+
+**Tech Stack:** Python 3.12, `pysail>=0.6`, `pyspark[connect]`, rapidfuzz, polars, pytest. Sail = Spark Connect (PySpark DataFrame/SQL), NOT datafusion-python.
+
+---
+
+## Critical context for the executor (read before starting)
+
+- **This box HANGS on `import goldenmatch`/`polars`, and Sail/pyspark are NOT installed locally.** Do NOT run anything locally. Validate Python with `ruff check` + `python -m py_compile` ONLY. **The new `sail` CI lane is the only verifier.** Every "run test" step below means: push, read the `sail` lane result.
+- **Sail is brand-new to this repo's CI.** The dep stack (pysail + pyspark[connect] + Spark Connect handshake + pandas_udf on Sail) is UNPROVEN here. **Task 1 is a pure connectivity de-risk** — prove the harness runs a trivial query before building the pipeline on it (mirrors how the spine de-risked the FFI boundary at Stage A). If Task 1's CI run fails on dep/version compat, pin `pyspark` to the version `pysail` requires (`pip show pysail` / pysail PyPI metadata) before proceeding.
+- **Branch off `origin/main`** (the Sail spec is merged there). Branch `feat/sail-tier-s1`.
+- **`ruff check packages/python/goldenmatch` must exit 0** before EVERY commit (I001). Never pipe through `tail`.
+- **GitHub auth:** `GH_TOKEN=$(gh auth token --user benzsevern)`. NEVER `benzsevern-mjh`. Repo `benseverndev-oss/goldenmatch`.
+- pyright slice does NOT cover `goldenmatch/sail/` or `tests/` — diagnostics there don't gate CI.
+- Scope: S1 uses the **pure-Python rapidfuzz** scorer UDF (the spec's decision-2 floor + parity reference). The native-kernel Arrow UDF is a later perf task — NOT in S1. Keep the fixture small (≤ a few hundred rows); S1 proves correctness + the harness, not scale.
+
+## Grounding references
+- Spec: `docs/superpowers/specs/2026-06-03-sail-tier-design.md` (S1 = "Sail harness + score/dedup").
+- The one-box parity shape to mirror: `tests/test_datafusion_spine_parity.py::_fixture_df` (5-dense / 2-member / 3-chain / 2-singleton on `last_name`, block on `zip`) + `_inmemory_comparand` (python `rapidfuzz` `JaroWinkler.normalized_similarity` brute-force within block, canonical `(min,max)` pairs, MAX dedup). S1 re-implements that comparand inline (self-contained; do NOT import the datafusion test module).
+- CI job template: `.github/workflows/ci.yml::distributed` (lines ~838-890) — an optional-extra goldenmatch lane: `uv sync` → `uv pip install <extra>` → `.venv/bin/python -m pytest` (NOT `uv run` — server-subprocess/venv mismatch risk, same lesson as ray).
+- pysail API (verified): `from pysail.spark import SparkConnectServer; s=SparkConnectServer(); s.start(); _,port=s.listening_address; SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()`. `start()` is background by default; `s.stop()` to tear down.
+
+## File Structure
+- **Create** `packages/python/goldenmatch/goldenmatch/sail/__init__.py`
+- **Create** `packages/python/goldenmatch/goldenmatch/sail/session.py` — connect helper.
+- **Create** `packages/python/goldenmatch/goldenmatch/sail/scorers.py` — rapidfuzz `pandas_udf` by scorer name.
+- **Create** `packages/python/goldenmatch/goldenmatch/sail/scoring.py` — block self-join → score → dedup.
+- **Create** `packages/python/goldenmatch/tests/test_sail_connectivity.py` — Task 1 de-risk.
+- **Create** `packages/python/goldenmatch/tests/test_sail_score_parity.py` — Task 4 gate (+ the shared server fixture).
+- **Modify** `packages/python/goldenmatch/pyproject.toml` — add the `[sail]` extra.
+- **Modify** `.github/workflows/ci.yml` — `sail` path filter + job + `ci-required` wiring.
+
+---
+
+## Task 0: Branch + the `[sail]` optional extra
+
+**Files:** `pyproject.toml`
+
+- [ ] **Step 1:** `git fetch origin && git checkout -b feat/sail-tier-s1 origin/main`.
+
+- [ ] **Step 2:** In `packages/python/goldenmatch/pyproject.toml`, under `[project.optional-dependencies]`, add:
+
+```toml
+sail = [
+  "pysail>=0.6",
+  "pyspark[connect]>=3.5",
+]
+```
+
+  (If CI Task 1 reveals a version mismatch, pin `pyspark` to the version `pysail` declares — pysail bundles/targets a specific Spark Connect protocol version. The connectivity test is where this is nailed down.)
+
+- [ ] **Step 3:** Commit.
+
+```bash
+git add packages/python/goldenmatch/pyproject.toml
+git commit -m "build(sail): add goldenmatch[sail] optional extra (pysail + pyspark connect)"
+```
+
+---
+
+## Task 1: Sail connectivity de-risk (prove the harness before building on it)
+
+**Files:**
+- Create: `goldenmatch/sail/__init__.py` (empty / docstring), `goldenmatch/sail/session.py`
+- Test: `tests/test_sail_connectivity.py`
+- Modify: `.github/workflows/ci.yml` (the `sail` job — so this can RUN)
+
+- [ ] **Step 1: Write `sail/session.py`** — the connect helper used everywhere.
+
+```python
+"""Sail (Spark Connect) session helpers. Sail is programmed via PySpark /
+Spark Connect, NOT the datafusion Python API -- this is a re-expression of
+the one-box spine's algorithm, not a port."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def connect(remote: str | None = None) -> Any:
+    """Return a SparkSession connected to a Sail server.
+
+    ``remote`` (or ``SAIL_REMOTE``) is an ``sc://host:port`` URL. Raises if
+    neither is set -- S1 has no implicit cluster bootstrap (BYO)."""
+    from pyspark.sql import SparkSession
+
+    url = remote or os.environ.get("SAIL_REMOTE")
+    if not url:
+        raise RuntimeError(
+            "No Sail remote: pass remote='sc://host:port' or set SAIL_REMOTE."
+        )
+    return SparkSession.builder.remote(url).getOrCreate()
+```
+
+- [ ] **Step 2: Write the connectivity test** `tests/test_sail_connectivity.py` — starts an in-process Sail server and runs a trivial query. This is the infra gate.
+
+```python
+"""S1 de-risk: prove the Sail (Spark Connect) harness runs in CI before any
+pipeline is built on it. Skips where the sail extra is absent."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+
+
+def test_sail_local_server_runs_trivial_query():
+    from pyspark.sql import SparkSession
+    from pysail.spark import SparkConnectServer
+
+    server = SparkConnectServer()
+    server.start()  # background
+    try:
+        _, port = server.listening_address
+        spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+        rows = spark.sql("SELECT 1 + 1 AS two").collect()
+        assert rows[0]["two"] == 2
+        spark.stop()
+    finally:
+        server.stop()
+```
+
+- [ ] **Step 3: Add the `sail` CI lane** so Task 1 can run. In `.github/workflows/ci.yml`:
+  - **In the `changes` job's `outputs:` map (lines ~20-36), add** (REQUIRED — without this, `needs.changes.outputs.sail` resolves to empty and the lane only ever runs via the `ci_workflow` fallback, silently skipping the gate on a sail-only change in later S-stages; every other area here has this line):
+    ```yaml
+          sail: ${{ steps.filter.outputs.sail }}
+    ```
+  - In the `changes` job's `filters:` block (mirror the `distributed` filter), add:
+    ```yaml
+            sail:
+              - 'packages/python/goldenmatch/goldenmatch/sail/**'
+              - 'packages/python/goldenmatch/tests/test_sail_*.py'
+    ```
+  - Add a `sail` job (mirror `distributed`, lines ~838-890):
+    ```yaml
+      sail:
+        needs: changes
+        if: needs.changes.outputs.sail == 'true' || needs.changes.outputs.ci_workflow == 'true'
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+          - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+            with:
+              enable-cache: true
+              cache-dependency-glob: |
+                uv.lock
+                **/pyproject.toml
+          - run: uv sync --all-packages
+          # Sail (Spark Connect) optional stack. NO Java: pyspark[connect] is a
+          # pure-gRPC client (no py4j/JVM launch) and the Sail server is Rust.
+          # Install VIA THE EXTRA so the pyproject [sail] entry is exercised.
+          - name: Install sail extra
+            run: uv pip install -e 'packages/python/goldenmatch[sail]'
+          # Run with the venv python directly (NOT `uv run`): the Sail server
+          # spawns in-process; mirror the ray lane's venv-python discipline.
+          - name: Sail connectivity gate (blocking)
+            run: |
+              .venv/bin/python -c "import pysail, pyspark; print('pyspark', pyspark.__version__)"
+              .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_connectivity.py -v --timeout=300
+    ```
+  - Register `sail` in the `ci-required` job's `needs:` list (find the `ci-required` aggregator job and add `sail` so the gate waits on it). If `ci-required` uses a result-checking step, add `sail` there too.
+  - **Note:** a change to `ci.yml` forces all jobs (incl. `sail`) to run via the `ci_workflow` filter — expected (this is also why the missing `outputs:` line would stay hidden in S1; fix it now).
+
+- [ ] **Step 4: Static-validate + push the connectivity slice EARLY.** `ruff check` + `py_compile` the new py files; `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` to confirm the YAML parses. Commit:
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/sail/__init__.py \
+        packages/python/goldenmatch/goldenmatch/sail/session.py \
+        packages/python/goldenmatch/tests/test_sail_connectivity.py \
+        .github/workflows/ci.yml
+git commit -m "feat(sail): session connect helper + Spark Connect connectivity gate + CI lane"
+```
+
+- [ ] **Step 5: Push, open the PR, and CONFIRM the `sail` lane goes green on connectivity** before building further. This isolates the novel-infra risk. **If it fails on the Spark Connect handshake (a gRPC/protobuf version error won't name the fix):** Sail v0.6.x targets a SPECIFIC Spark Connect protocol version, so read pysail's declared `pyspark` constraint FIRST — `uv pip show pysail` (Requires) or the PyPI metadata — and pin `pyspark` in the `[sail]` extra to that compatible version, rather than guessing. Then re-push. Do NOT proceed to Task 2 until the connectivity gate is green.
+
+---
+
+## Task 2: rapidfuzz scorer as a pandas UDF
+
+**Files:**
+- Create: `goldenmatch/sail/scorers.py`
+- Test: add `test_sail_scorer_udf_matches_rapidfuzz` to `tests/test_sail_score_parity.py` (create the file + the shared server fixture here).
+
+- [ ] **Step 1: Write the shared server fixture + scorer.** First `sail/scorers.py`:
+
+```python
+"""Scorers as Spark pandas UDFs (S1: pure-Python rapidfuzz -- the floor +
+parity reference; the native-kernel Arrow UDF is a later perf task)."""
+from __future__ import annotations
+
+from typing import Any
+
+# SQL-callable names (match the matchkey scorer names the spine supports).
+_SUPPORTED = ("jaro_winkler", "levenshtein", "token_sort")
+
+
+def make_scorer_udf(scorer_name: str) -> Any:
+    """Return a Spark ``pandas_udf`` (double) scoring two string columns in
+    [0,1] via rapidfuzz -- the same library the one-box spine's FFI scorer
+    delegates to (rapidfuzz==rust-rapidfuzz at 1e-9), so this is the exact
+    parity reference."""
+    if scorer_name not in _SUPPORTED:
+        raise NotImplementedError(
+            f"Sail S1 supports scorers {_SUPPORTED}; got {scorer_name!r}."
+        )
+    from pyspark.sql.functions import pandas_udf
+
+    @pandas_udf("double")
+    def _udf(a, b):  # a, b: pandas Series[str]
+        import pandas as pd
+        from rapidfuzz.distance import JaroWinkler, Levenshtein
+
+        def score(x: str, y: str) -> float:
+            x = x or ""
+            y = y or ""
+            if scorer_name == "jaro_winkler":
+                return JaroWinkler.normalized_similarity(x, y)
+            if scorer_name == "levenshtein":
+                return Levenshtein.normalized_similarity(x, y)
+            # token_sort: rapidfuzz fuzz.token_sort_ratio / 100
+            from rapidfuzz import fuzz
+            return fuzz.token_sort_ratio(x, y) / 100.0
+
+        return pd.Series([score(x, y) for x, y in zip(a, b)])
+
+    return _udf
+```
+
+- [ ] **Step 2: Write the fixture + scorer test** in `tests/test_sail_score_parity.py`:
+
+```python
+"""S1 gate: the Sail score/dedup pipeline's emitted pair SET matches a
+python-rapidfuzz reference. Self-contained (no datafusion). Skips where the
+sail extra is absent; runs in the `sail` CI lane."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+pytest.importorskip("polars")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pyspark.sql import SparkSession
+    from pysail.spark import SparkConnectServer
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def _fixture_rows():
+    """Mirror the one-box parity fixture: dense / 2-member / 3-chain /
+    singletons on last_name, block on zip. Returns list of (row_id, last, zip)."""
+    last = (["Aaaa"] * 5 + ["Brown", "Brown"]
+            + ["Carter", "Carter", "Carter"] + ["Dixon", "Ellis"])
+    zips = (["10001"] * 5 + ["20002"] * 2 + ["30003"] * 3 + ["40004", "50005"])
+    return [(i, last[i], zips[i]) for i in range(len(last))]
+
+
+def test_sail_scorer_udf_matches_rapidfuzz(spark):
+    from goldenmatch.sail.scorers import make_scorer_udf
+    from rapidfuzz.distance import JaroWinkler
+
+    df = spark.createDataFrame([("Aaaa", "Aaaa"), ("Brown", "Browne")], ["a", "b"])
+    udf = make_scorer_udf("jaro_winkler")
+    got = {(r["a"], r["b"]): r["s"] for r in df.select("a", "b", udf("a", "b").alias("s")).collect()}
+    for (a, b), s in got.items():
+        assert abs(s - JaroWinkler.normalized_similarity(a, b)) < 1e-9
+```
+
+- [ ] **Step 3: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/sail/scorers.py \
+        packages/python/goldenmatch/tests/test_sail_score_parity.py
+git commit -m "feat(sail): rapidfuzz scorer pandas UDF + parity-fixture scaffold"
+```
+
+---
+
+## Task 3: block self-join → score → dedup
+
+**Files:**
+- Create: `goldenmatch/sail/scoring.py`
+
+- [ ] **Step 1: Write `sail/scoring.py`** — the relational score+dedup, the S1 core.
+
+```python
+"""S1 score+dedup on Sail (Spark Connect): a block self-join scored by a
+rapidfuzz pandas UDF, threshold-filtered, then deduped via GROUP BY max.
+Returns the RAW above-threshold canonical (a<b) pair set."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def score_and_dedup(
+    df: Any,
+    *,
+    block_col: str,
+    value_col: str,
+    id_col: str,
+    scorer_name: str,
+    threshold: float,
+):
+    """``df`` is a Spark DataFrame with ``id_col`` (int), ``value_col`` (the
+    scored field) and ``block_col`` (the blocking key). Returns a Spark
+    DataFrame of ``(a, b, score)`` with ``a < b``, score >= threshold,
+    deduped to max(score) per pair. The self-join + UDF + GROUP BY are all
+    Spark ops Sail distributes."""
+    from pyspark.sql import functions as F
+
+    from goldenmatch.sail.scorers import make_scorer_udf
+
+    udf = make_scorer_udf(scorer_name)
+    a = df.alias("a")
+    b = df.alias("b")
+    pairs = (
+        a.join(
+            b,
+            (F.col(f"a.{block_col}") == F.col(f"b.{block_col}"))
+            & (F.col(f"a.{id_col}") < F.col(f"b.{id_col}")),
+        )
+        .select(
+            F.col(f"a.{id_col}").alias("a"),
+            F.col(f"b.{id_col}").alias("b"),
+            udf(F.col(f"a.{value_col}"), F.col(f"b.{value_col}")).alias("score"),
+        )
+        .where(F.col("score") >= F.lit(threshold))
+    )
+    # Dedup: max(score) per canonical (a,b) -- the scale-mode MAX contract.
+    return pairs.groupBy("a", "b").agg(F.max("score").alias("score"))
+```
+
+- [ ] **Step 2: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/sail/scoring.py
+git commit -m "feat(sail): block self-join score + GROUP BY max dedup (score_and_dedup)"
+```
+
+---
+
+## Task 4: the S1 parity gate
+
+**Files:**
+- Modify: `tests/test_sail_score_parity.py` (add the gate test).
+
+- [ ] **Step 1: Add the parity gate** — Sail pipeline's pair SET == python-rapidfuzz brute-force reference.
+
+```python
+def _reference_pairs(rows, threshold):
+    """python-rapidfuzz brute-force within block (mirror _inmemory_comparand):
+    canonical (min,max) above-threshold pairs. The SAME rapidfuzz the Sail
+    UDF uses -> exact set parity is the gate."""
+    from collections import defaultdict
+
+    from rapidfuzz.distance import JaroWinkler
+
+    by_block = defaultdict(list)
+    for rid, last, z in rows:
+        by_block[z].append((rid, last))
+    out = set()
+    for members in by_block.values():
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                (ida, va), (idb, vb) = members[i], members[j]
+                if JaroWinkler.normalized_similarity(va, vb) >= threshold:
+                    out.add((min(ida, idb), max(ida, idb)))
+    return out
+
+
+def test_sail_score_dedup_pair_set_parity(spark):
+    from goldenmatch.sail.scoring import score_and_dedup
+
+    rows = _fixture_rows()
+    threshold = 0.85
+    sdf = spark.createDataFrame(rows, ["__row_id__", "last_name", "zip"])
+    out = score_and_dedup(
+        sdf, block_col="zip", value_col="last_name", id_col="__row_id__",
+        scorer_name="jaro_winkler", threshold=threshold,
+    )
+    sail_pairs = {(min(r["a"], r["b"]), max(r["a"], r["b"])) for r in out.collect()}
+    assert sail_pairs == _reference_pairs(rows, threshold)
+```
+
+- [ ] **Step 2: Add the parity test to the `sail` CI lane.** In the `sail` job, extend the blocking step (or add one) to run the parity file:
+
+```yaml
+          - name: Sail score/dedup parity gate (blocking)
+            run: |
+              .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_score_parity.py -v --timeout=300
+```
+
+- [ ] **Step 3: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/tests/test_sail_score_parity.py .github/workflows/ci.yml
+git commit -m "test(sail): S1 score/dedup pair-set parity gate vs rapidfuzz reference"
+```
+
+---
+
+## Task 5: push, green the `sail` lane, merge
+
+- [ ] **Step 1: Push** (PR already opened in Task 1; otherwise open it). Body: "Sail tier Stage S1 — harness + rapidfuzz scorer UDF + score/dedup, parity-gated vs a python-rapidfuzz reference on the spine fixture. First Sail-native gate. Spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md (S1)."
+
+- [ ] **Step 2: Watch the `sail` lane** (connectivity gate + parity gate). Poll `while gh pr checks <N> | grep -qE "\bpending\b|in_progress"; do sleep 30; done`. If behind main, `gh pr update-branch <N>`. Grep the raw log for the pytest summary (`passed`/`failed,`) — `continue-on-error` lies in per-step JSON.
+
+- [ ] **Step 3: Merge** once the `sail` lane + `ci-required` are green: `gh pr merge <N> --squash --delete-branch`.
+
+---
+
+## Definition of done
+- `goldenmatch[sail]` extra installs; the `sail` CI lane connects to a local Sail Spark Connect server and runs a trivial query (connectivity gate green).
+- `score_and_dedup` on Sail produces a pair SET byte-identical to the python-rapidfuzz brute-force reference on the spine fixture (parity gate green).
+- The `sail` lane is wired into `ci-required`. PR merged.
+
+## Out of scope (later S-stages)
+- WCC on Sail (S2 — the gate that follows). Golden + identity (S3). The binding 100M+ multi-node bench + Ray retirement (S4).
+- The native-kernel Arrow UDF (a perf task; S1 uses pure-Python rapidfuzz).
+- Multi-field weighted matchkeys, soundex/other blocking transforms (S1 blocks on a raw column to match the parity fixture).

--- a/docs/superpowers/plans/2026-06-03-sail-tier-stage-s2.md
+++ b/docs/superpowers/plans/2026-06-03-sail-tier-stage-s2.md
@@ -1,0 +1,340 @@
+# Sail Tier — Stage S2: connected components on Sail (Implementation Plan)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compute weakly-connected components (the Union-Find holdout) distributed on Sail (Spark Connect), parity-gated to an identical cluster PARTITION (Rand 1.0) vs a reference on fixtures including a chain and a multi-merge archetype — closing the make-or-break "can WCC be done correctly + distributed on Sail" risk.
+
+**Architecture:** `goldenmatch/sail/clustering.py::connected_components(pairs_df, ids_df, *, id_col)` runs **min-label propagation** over symmetric edges as pure Spark Connect DataFrame joins/aggregations to a fixpoint: each node starts labeled with its own id (seeded from a DISTRIBUTED `ids_df`, NOT a driver `list[int]`), then repeatedly adopts the minimum label among itself and its neighbors until no label changes. Each component converges to a stable label = its min member id. Returns an `assignments` DataFrame (`cluster_id`, `member_id`) matching `core.cluster.build_cluster_frames`'s shape. Singletons (ids with no edge) surface as their own component.
+
+**Tech Stack:** Python 3.12, `pysail` + `pyspark[connect]` (the `[sail]` extra from S1), PySpark DataFrame API, pytest. Runs in the existing `sail` CI lane.
+
+---
+
+## CRITICAL: algorithm choice + the deliberate deviation from the spec (read first)
+
+The spec (`2026-06-03-sail-tier-design.md` §Decision 1) ordered **two-phase WCC** first
+(chain-robust; `mapInArrow` partition-UF + driver boundary merge) with large-star/small-star
+as the fallback. **This plan deliberately leads with min-label propagation instead, for S2.**
+Rationale (the receiving-code-review discipline — explain, don't blindly follow):
+
+- **S2's gate is CORRECTNESS at small fixture scale**, not scale. The spec's reason for
+  preferring two-phase over label-prop is purely about SCALE — "chains are label-prop's worst
+  case" means label-prop takes O(chain-length) iterations on long chains. At S2's fixture scale
+  (a 3-chain, a few components) that's 2-3 iterations. The chain concern does not bite here.
+- **Min-label propagation's correctness is trivially sound** (monotone min-propagation bounded
+  below by the component min → reaches the fixpoint where every node = its component's min id).
+  Under the no-local-testing constraint (this box can't run anything; CI is the only verifier),
+  the simplest provably-correct algorithm minimizes CI churn. Two-phase's `mapInArrow`
+  partition-UF + driver merge is far more code and far easier to get subtly wrong with no local
+  REPL.
+- **It is genuinely Sail-native** (pure Spark Connect DataFrame joins — no `mapInArrow` UDTF, the
+  very risk the spec flagged as the trigger for falling back from two-phase). So it satisfies the
+  "Sail-native everything" decision.
+- **It closes the EXISTENTIAL make-or-break risk** — "can connected-components (a non-relational
+  op) be computed correctly + distributed on Sail at all?" — decisively. That is S2's job.
+
+**What this DEFERS (and where):** the chain-SCALE-robust algorithm (large-star/small-star,
+O(log n) iterations — the spec's pure-relational option) is a **REQUIRED prerequisite for S4's
+100M chain-heavy binding bench**, because label-prop's O(diameter) iterations won't bind there.
+S2 proves WCC-on-Sail works correctly; **S4's plan MUST swap in / add large-star/small-star (or
+two-phase) before the binding bench** — this is recorded as an S4 entry, not silently dropped.
+If a reviewer wants the scale algorithm in S2, that's a defensible alternative — but it trades
+higher first-cut bug risk (under no local testing) for scale-readiness S2's gate doesn't measure.
+
+## Critical context for the executor
+- **This box HANGS on imports; Sail isn't installed locally.** Validate with `ruff check` +
+  `python -m py_compile` ONLY. The `sail` CI lane is the only verifier. Every "run test" = push,
+  read the `sail` lane.
+- **Branch off `origin/main`** (S1 is merged: `goldenmatch.sail` + the `sail` lane exist). Branch `feat/sail-tier-s2`.
+- `ruff check packages/python/goldenmatch` exit 0 before EVERY commit (I001; `ruff check --fix` if it fires — note ruff sorts `pysail` before `pyspark`). Never pipe through `tail`.
+- GitHub auth: `GH_TOKEN=$(gh auth token --user benzsevern)`. Push may hit a cosmetic `.git/config` permission error — re-run `git push` and verify `git ls-remote` HEAD matches local.
+- pyright slice does NOT cover `goldenmatch/sail/` or `tests/`.
+- **The isolated-node TRAP (spec Decision 1):** seed labels from the DISTRIBUTED `ids_df`, NEVER a
+  driver-side `list[int]` of every record id (the WCC-rehydration OOM). The driver must never hold
+  a per-record Python list. S2 enforces this by construction (`ids_df` is a Spark DataFrame).
+
+## Grounding references
+- Spec: `docs/superpowers/specs/2026-06-03-sail-tier-design.md` (S2 = "WCC on Sail — the gate").
+- `distributed/clustering.py::two_phase_wcc(pairs_ds, all_ids) -> {id, label}` — the Ray algorithm
+  being conceptually replaced; output label = min-id member of each component (S2 matches that
+  labeling so `cluster_id` is the component's min id).
+- `core/cluster.py::build_cluster_frames` → `ClusterFrames.assignments` is a polars DataFrame with
+  `cluster_id` + `member_id` columns. S2's `connected_components` returns the Spark analog.
+- S1: `goldenmatch/sail/scoring.py::score_and_dedup` returns `(a, b, score)` — the edge source.
+  `tests/test_sail_score_parity.py` — the server fixture + fixture-row pattern to mirror.
+
+## File Structure
+- **Create** `packages/python/goldenmatch/goldenmatch/sail/clustering.py` — `connected_components`.
+- **Create** `packages/python/goldenmatch/tests/test_sail_clustering_parity.py` — the WCC gate (reuses the in-process Sail server fixture).
+- **Modify** `.github/workflows/ci.yml` — add the clustering parity test to the `sail` lane.
+
+---
+
+## Task 1: `connected_components` (min-label propagation)
+
+**Files:**
+- Create: `goldenmatch/sail/clustering.py`
+
+- [ ] **Step 1: Write `sail/clustering.py`.**
+
+```python
+"""Weakly-connected components on Sail (Spark Connect) -- the Union-Find
+holdout, computed distributed via min-label propagation.
+
+S2 uses min-label propagation (pure Spark DataFrame joins to a fixpoint):
+each node starts labeled with its own id (seeded from a DISTRIBUTED ids
+frame -- NEVER a driver list[int], the WCC-rehydration OOM trap), then
+adopts the min label among itself + its neighbors until nothing changes.
+Each component converges to label = its min member id. Correct + genuinely
+Sail-native; the chain-SCALE-robust large-star/small-star is an S4
+prerequisite (label-prop is O(diameter) iterations on long chains -- fine
+at S2's correctness-gate scale, not at 100M)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def connected_components(
+    pairs_df: Any,
+    ids_df: Any,
+    *,
+    id_col: str = "__row_id__",
+) -> Any:
+    """Distributed weakly-connected components.
+
+    Args:
+        pairs_df: Spark DataFrame of edges with ``a`` and ``b`` (int) columns
+            (canonical ``a < b`` from ``score_and_dedup``; not required).
+        ids_df: Spark DataFrame of the FULL node universe with ``id_col``
+            (every record id, singletons included). DISTRIBUTED -- never a
+            driver list. Singletons surface as their own component.
+        id_col: the id column name in ``ids_df``.
+
+    Returns:
+        Spark DataFrame ``(cluster_id, member_id)`` -- one row per node;
+        ``cluster_id`` is the component's min member id (a stable, label-
+        independent partition). Matches ``build_cluster_frames.assignments``.
+    """
+    from pyspark.sql import functions as F
+
+    # Symmetric edges so labels flow both ways: (src, dst) for both
+    # orientations. Self-loops are harmless (a < b avoids them anyway).
+    fwd = pairs_df.select(F.col("a").alias("src"), F.col("b").alias("dst"))
+    rev = pairs_df.select(F.col("b").alias("src"), F.col("a").alias("dst"))
+    edges = fwd.unionByName(rev)
+
+    # Seed: every node labeled with itself (from the DISTRIBUTED universe).
+    labels = ids_df.select(F.col(id_col).cast("long").alias("node")).withColumn(
+        "label", F.col("node")
+    )
+
+    # Iterate to fixpoint. Bounded by component diameter; at S2 fixture scale
+    # this is 2-3 rounds. The convergence count is a driver scalar (cheap).
+    # NOTE for S4: cache/checkpoint `labels` each round + swap in large-star/
+    # small-star -- label-prop's O(diameter) won't bind at 100M chains.
+    #
+    # Spark Connect discipline: every join is on a SHARED COLUMN NAME (auto-
+    # coalesced, no duplicate-column ambiguity), and the other side is RENAMED
+    # before the join so no two inputs share a non-key name. We NEVER reference
+    # a column via the `df["col"]` handle across a self-similar join (the
+    # AMBIGUOUS_REFERENCE / CANNOT_RESOLVE footgun across iterations).
+    max_rounds = 100
+    for _ in range(max_rounds):
+        # Each node's neighbor-min label. Join edges.dst == labels.node by
+        # renaming labels -> (dst, dst_label) and joining on the shared "dst".
+        lab_for_nbr = labels.select(
+            F.col("node").alias("dst"), F.col("label").alias("dst_label")
+        )
+        nbr_min = (
+            edges.join(lab_for_nbr, on="dst", how="inner")
+            .groupBy("src")
+            .agg(F.min("dst_label").alias("nbr_min"))
+            .select(F.col("src").alias("node"), F.col("nbr_min"))
+        )
+        # Update: node adopts min(own label, neighbor-min). Left join on the
+        # shared "node"; nodes with no neighbor keep their label (coalesce).
+        new_labels = labels.join(nbr_min, on="node", how="left").select(
+            F.col("node"),
+            F.least(
+                F.col("label"), F.coalesce(F.col("nbr_min"), F.col("label"))
+            ).alias("label"),
+        )
+        # Convergence: compare new vs old on the shared "node"; old renamed.
+        old_for_cmp = labels.select(
+            F.col("node"), F.col("label").alias("old_label")
+        )
+        changed = (
+            new_labels.join(old_for_cmp, on="node", how="inner")
+            .where(F.col("label") != F.col("old_label"))
+            .limit(1)
+            .count()
+        )
+        labels = new_labels
+        if changed == 0:
+            break
+
+    return labels.select(
+        F.col("label").alias("cluster_id"), F.col("node").alias("member_id")
+    )
+```
+
+- [ ] **Step 2: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/sail/clustering.py
+git commit -m "feat(sail): connected_components via min-label propagation (S2 WCC)"
+```
+
+---
+
+## Task 2: the S2 WCC parity gate
+
+**Files:**
+- Create: `tests/test_sail_clustering_parity.py`
+
+- [ ] **Step 1: Write the gate.** Fixtures stress what WCC must get right: a 3-chain (transitive
+  merge across hops — the label-prop concern's correctness analog), a separate 2-member component,
+  and a singleton (isolated-node seeding). Reference = inline Python Union-Find over the same edges
+  + id universe (the canonical connected-components partition). Compare partitions (sets of
+  frozensets of member ids) — label-independent.
+
+```python
+"""S2 gate: Sail connected_components produces a cluster PARTITION identical
+to a reference Union-Find on fixtures including a chain + a singleton. Self-
+contained; skips where the sail extra is absent; runs in the `sail` lane."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def _reference_partition(ids, edges):
+    """Canonical connected components via plain Union-Find -> set of
+    frozensets of member ids (singletons included)."""
+    parent = {i: i for i in ids}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in edges:
+        parent[find(a)] = find(b)
+    comp = {}
+    for i in ids:
+        comp.setdefault(find(i), set()).add(i)
+    return {frozenset(v) for v in comp.values()}
+
+
+def _sail_partition(out_df):
+    """assignments DataFrame -> set of frozensets of member ids per cluster_id."""
+    from collections import defaultdict
+
+    by_cid = defaultdict(set)
+    for r in out_df.collect():
+        by_cid[r["cluster_id"]].add(int(r["member_id"]))
+    return {frozenset(v) for v in by_cid.values()}
+
+
+def test_sail_wcc_partition_parity(spark):
+    from goldenmatch.sail.clustering import connected_components
+
+    # ids 0..6: chain {0-1-2}, pair {3-4}, singletons {5},{6}.
+    ids = list(range(7))
+    edges = [(0, 1), (1, 2), (3, 4)]  # canonical a<b
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+
+    out = connected_components(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == _reference_partition(ids, edges)
+
+
+def test_sail_wcc_deep_chain_converges(spark):
+    """A longer chain 0-1-2-...-9 must collapse to ONE component (label-prop
+    across many hops -- the correctness analog of the chain concern)."""
+    from goldenmatch.sail.clustering import connected_components
+
+    ids = list(range(10))
+    edges = [(i, i + 1) for i in range(9)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+
+    out = connected_components(pairs_df, ids_df, id_col="__row_id__")
+    part = _sail_partition(out)
+    assert part == {frozenset(range(10))}
+
+
+def test_sail_wcc_junction_multimerge(spark):
+    """The spec-named multi-merge archetype: branches 0,1,2 all merge at a
+    junction node 3 (min-propagation arrives from multiple neighbors in one
+    round), a separate pair {4,5}, and a singleton {6}. Stresses the case
+    most likely to surface a subtle min-propagation bug."""
+    from goldenmatch.sail.clustering import connected_components
+
+    ids = list(range(7))
+    edges = [(0, 3), (1, 3), (2, 3), (4, 5)]  # canonical a<b
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+
+    out = connected_components(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == _reference_partition(ids, edges)
+```
+
+- [ ] **Step 2: Add the gate to the `sail` CI lane.** In `.github/workflows/ci.yml`, after the
+  S1 parity step, add:
+
+```yaml
+      - name: Sail WCC parity gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_clustering_parity.py -v --timeout=300
+```
+
+- [ ] **Step 3: Static-validate** (`ruff check`, `py_compile`, `yaml.safe_load` ci.yml) **+ commit.**
+
+```bash
+git add packages/python/goldenmatch/tests/test_sail_clustering_parity.py .github/workflows/ci.yml
+git commit -m "test(sail): S2 WCC partition-parity gate (chain + singleton fixtures)"
+```
+
+---
+
+## Task 3: push, green the `sail` lane, merge
+
+- [ ] **Step 1: Push + open the PR.** Body: "Sail tier Stage S2 — connected components on Sail via min-label propagation (the Union-Find holdout, computed distributed), partition-parity-gated vs a reference UF on chain + singleton fixtures. Closes the make-or-break 'WCC-on-Sail' existential risk. Leads with label-prop (correctness gate); the chain-scale-robust algorithm is an S4 prerequisite. Spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md (S2)."
+
+- [ ] **Step 2: Watch the `sail` lane** (connectivity + S1 score/dedup + S2 WCC gates). Poll `while gh pr checks <N> | grep -qE "\bpending\b|in_progress"; do sleep 30; done`. **This is the make-or-break gate** — if the WCC parity fails, the min-label-prop logic is wrong (likely the join-aliasing or the convergence check); debug from the CI pytest output (grep the raw log) and iterate. If behind main, `gh pr update-branch <N>`. Note: a `ci.yml` change forces the full matrix — wait for it before the policy allows merge.
+
+- [ ] **Step 3: Merge** once the `sail` lane + `ci-required` are green: `gh pr merge <N> --squash --delete-branch`.
+
+---
+
+## Definition of done
+- `connected_components` computes WCC distributed on Sail; the cluster PARTITION is identical to a
+  reference Union-Find on chain + multi-component + singleton fixtures (Rand 1.0). The `sail` lane's
+  WCC gate is green. PR merged.
+- The existential "WCC-on-Sail correctly + distributed" risk is CLOSED.
+
+## Out of scope (later stages — explicitly recorded)
+- **S4 prerequisite (REQUIRED before the 100M bench):** the chain-SCALE-robust algorithm
+  (large-star/small-star, O(log n) iterations, or two-phase WCC) + `labels` checkpointing — min-
+  label-prop's O(diameter) iterations + growing Spark Connect lineage won't bind at 100M chains.
+- Oversized-cluster auto-split / cluster-quality (the spine's post-WCC `build_cluster_frames`
+  step) — separate from pure connected-components; an S3/golden concern if needed on Sail.
+- golden + identity on Sail (S3); the binding multi-node bench + Ray retirement (S4).

--- a/docs/superpowers/plans/2026-06-03-sail-tier-stage-s3.md
+++ b/docs/superpowers/plans/2026-06-03-sail-tier-stage-s3.md
@@ -1,0 +1,317 @@
+# Sail Tier — Stage S3: golden survivorship on Sail (Implementation Plan)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build golden records (survivorship) distributed on Sail (Spark Connect), parity-gated to identical per-cluster golden field values vs the one-box `merge_field` primitive — proving the distributed group-and-merge assembles the right per-cluster inputs.
+
+**Architecture:** `goldenmatch/sail/golden.py::build_golden(assignments_df, source_df, *, value_cols, strategy)` joins the S2 `assignments` (`cluster_id`, `member_id`) to the source records, filters to multi-member clusters, `groupBy(cluster_id).agg(collect_list(field))` per field, then a scalar `pandas_udf` per field calls the **one-box `core.golden.merge_field`** over each collected value list → the survivor value. Reusing the exact one-box primitive guarantees semantic parity; Sail only distributes the grouping. Pure-relational (collect_list + scalar UDF — builds on S1's proven `pandas_udf`, NOT the riskier grouped-map `applyInPandas`).
+
+**Tech Stack:** Python 3.12, `pysail` + `pyspark[connect]` (the `[sail]` extra), PySpark DataFrame API, `goldenmatch.core.golden.merge_field`, pytest. Runs in the existing `sail` CI lane.
+
+---
+
+## Scope decision (read first): S3 = golden ONLY; identity is split out
+
+The spec's S3 bullet says "golden + identity." This plan scopes S3 to **golden survivorship**
+and defers **identity** to its own later stage. Reason (writing-plans scope-check): identity is a
+**stateful graph subsystem** (durable entity store, `resolve_clusters` overlap detection, evidence
+edges) — even the existing Ray distributed path resolves it DRIVER-SIDE against a pooled Postgres
+connection (`distributed/identity.py`, Phase 6), not as a relational op. It is a different beast
+from golden's clean grouped-aggregation and does not belong in the same plan. Golden ships a real,
+cleanly parity-gateable distributed win on its own.
+
+**S3 golden scope (YAGNI):** the uniform-strategy, order-INDEPENDENT case — the default
+`most_complete` strategy over multi-member clusters. Explicitly DEFERRED (consistent with the Ray
+distributed golden's "custom field-rules + quality_scores always fall back to in-memory"):
+order-DEPENDENT strategies (`most_recent`/`source_priority` need collected dates/sources),
+custom plugin strategies, oversized-cluster exclusion, and provenance. These are follow-ons, not S3.
+
+## Critical context for the executor
+- **This box HANGS on imports; Sail isn't installed locally.** Validate with `ruff check` +
+  `python -m py_compile` ONLY. The `sail` CI lane is the only verifier.
+- **Branch off `origin/main`** (S1+S2 merged: `goldenmatch.sail.{session,scorers,scoring,clustering}`
+  + the `sail` lane exist). Branch `feat/sail-tier-s3`.
+- `ruff check packages/python/goldenmatch` exit 0 before EVERY commit (I001; `ruff check --fix`;
+  ruff sorts `pysail` before `pyspark`). Never pipe through `tail`.
+- GitHub auth: `GH_TOKEN=$(gh auth token --user benzsevern)`. Push may hit a cosmetic
+  `.git/config` permission error — re-run `git push` and verify `git ls-remote` HEAD == local.
+- **Spark Connect discipline (the S2 lesson):** join on a SHARED COLUMN NAME + rename-before-join;
+  NEVER reference a column via the `df["col"]` handle across a self-similar join (AMBIGUOUS_REFERENCE).
+- pyright slice does NOT cover `goldenmatch/sail/` or `tests/`.
+
+## Grounding references
+- `core/golden.py::merge_field(values, rule, ...) -> (value, confidence, source_index)` — the per-
+  FIELD survivorship primitive. `rule` is a `config.schemas.GoldenFieldRule` (`GoldenFieldRule(strategy="most_complete")`).
+  When all non-null values are identical it returns the value at confidence 1.0; `most_complete`
+  picks the most-complete/longest value (order-independent given a unique winner).
+- `core/golden.py::build_golden_records_from_frames(source_df, frames, rules, ...)` — the one-box
+  whole-frame golden (the conceptual reference; S3's testable reference is `merge_field` directly,
+  since both the Sail path and the reference call it → parity by construction).
+- S2: `sail/clustering.py::connected_components` → `assignments` (`cluster_id`, `member_id`).
+- S1: `tests/test_sail_score_parity.py` — the in-process Sail server fixture pattern to mirror.
+
+## File Structure
+- **Create** `packages/python/goldenmatch/goldenmatch/sail/golden.py` — `build_golden` + `make_merge_udf`.
+- **Create** `packages/python/goldenmatch/tests/test_sail_golden_parity.py` — the golden gate.
+- **Modify** `.github/workflows/ci.yml` — add the golden parity test to the `sail` lane.
+
+---
+
+## Task 1: `build_golden` (collect_list + merge_field UDF)
+
+**Files:**
+- Create: `goldenmatch/sail/golden.py`
+
+- [ ] **Step 1: Write `sail/golden.py`.**
+
+```python
+"""Golden-record survivorship on Sail (Spark Connect), distributed.
+
+Joins the S2 ``assignments`` (cluster_id, member_id) to the source records,
+filters to multi-member clusters, then for each field collects the cluster's
+values (``collect_list``) and merges them with the ONE-BOX
+``core.golden.merge_field`` primitive via a scalar pandas UDF -- reusing the
+exact survivorship logic guarantees semantic parity; Sail distributes the
+group-and-merge. Pure-relational (collect_list + scalar UDF), building on S1's
+proven pandas_udf mechanism (not grouped-map applyInPandas).
+
+S3 scope: the uniform, order-INDEPENDENT case (default ``most_complete`` over
+multi-member clusters). Order-dependent strategies (most_recent/source_priority),
+custom plugin strategies, oversized exclusion, and provenance are deferred
+(mirrors the Ray distributed golden's in-memory fallback for those)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def make_merge_udf(strategy: str) -> Any:
+    """A scalar pandas UDF mapping an array-of-values column (one cluster's
+    collected field values) to the survivor value via ``merge_field``."""
+    from pyspark.sql.functions import pandas_udf
+
+    @pandas_udf("string")
+    def _udf(col):  # col: pandas Series where each element is a list of values
+        import pandas as pd
+
+        from goldenmatch.config.schemas import GoldenFieldRule
+        from goldenmatch.core.golden import merge_field
+
+        rule = GoldenFieldRule(strategy=strategy)
+        out = []
+        for vals in col:
+            values = list(vals) if vals is not None else []
+            merged, _conf, _src = merge_field(values, rule)
+            out.append(None if merged is None else str(merged))
+        return pd.Series(out)
+
+    return _udf
+
+
+def build_golden(
+    assignments_df: Any,
+    source_df: Any,
+    *,
+    value_cols: list[str],
+    source_id_col: str = "__row_id__",
+    strategy: str = "most_complete",
+) -> Any:
+    """Build one golden record per multi-member cluster, distributed.
+
+    Args:
+        assignments_df: Spark DataFrame ``(cluster_id, member_id)`` (from S2).
+        source_df: Spark DataFrame with ``source_id_col`` + the ``value_cols``.
+        value_cols: the fields to survivor-merge.
+        source_id_col: the id column in ``source_df`` (joined to ``member_id``).
+        strategy: survivorship strategy (S3: order-independent, default
+            ``most_complete``).
+
+    Returns:
+        Spark DataFrame ``(cluster_id, *value_cols)`` -- one golden row per
+        multi-member cluster, each field survivor-merged.
+    """
+    from pyspark.sql import functions as F
+
+    # Join on a SHARED name (rename source's id col -> member_id); no df["col"]
+    # cross-handle refs (the S2 AMBIGUOUS_REFERENCE lesson).
+    src = source_df.withColumnRenamed(source_id_col, "member_id")
+    joined = assignments_df.join(src, on="member_id", how="inner")
+
+    # Multi-member clusters only (golden is the multi-member rollup; singletons
+    # are "unique", not golden).
+    multi = (
+        assignments_df.groupBy("cluster_id")
+        .count()
+        .where(F.col("count") > 1)
+        .select("cluster_id")
+    )
+    joined = joined.join(multi, on="cluster_id", how="inner")
+
+    # Collect each field's values per cluster, then merge via the UDF.
+    agg = joined.groupBy("cluster_id").agg(
+        *[F.collect_list(c).alias(c) for c in value_cols]
+    )
+    merge_udf = make_merge_udf(strategy)
+    for c in value_cols:
+        agg = agg.withColumn(c, merge_udf(F.col(c)))
+    return agg
+```
+
+- [ ] **Step 2: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/sail/golden.py
+git commit -m "feat(sail): golden survivorship via collect_list + merge_field UDF (S3)"
+```
+
+---
+
+## Task 2: the S3 golden parity gate
+
+**Files:**
+- Create: `tests/test_sail_golden_parity.py`
+
+- [ ] **Step 1: Write the gate.** Fixture: source records with a clear `most_complete` winner per
+  field (one full value + nulls/shorter values, so the result is order-independent), assigned to a
+  2-member and a 3-member cluster plus a singleton (excluded). Reference = `merge_field` over the
+  same per-cluster member values (multi-member only). Compare `{cluster_id -> {field -> value}}`.
+
+```python
+"""S3 gate: Sail build_golden produces per-cluster golden field values
+identical to the one-box merge_field over the same members (multi-member
+clusters only). Both call merge_field -> parity by construction; the gate
+proves the Sail join/group/collect_list plumbing assembles the right per-
+cluster inputs. Skips where the sail extra is absent; runs in the `sail` lane."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+_VALUE_COLS = ["first_name", "email"]
+
+
+def _source_rows():
+    """(row_id, first_name, email). Each multi-member cluster has a clear
+    most_complete winner per field (one full value, others null/shorter), so
+    the survivor is order-independent."""
+    return [
+        # cluster A (members 0,1): first_name winner "Jonathan" (vs null),
+        #   email winner "jon@x.com" (vs null).
+        (0, "Jonathan", None),
+        (1, None, "jon@x.com"),
+        # cluster B (members 2,3,4): first_name "Margaret" (vs "Marg", None),
+        #   email "marg@y.com" (vs None, None).
+        (2, "Marg", None),
+        (3, "Margaret", "marg@y.com"),
+        (4, None, None),
+        # singleton (member 5): excluded from golden.
+        (5, "Solo", "solo@z.com"),
+    ]
+
+
+def _assignments():
+    # (cluster_id, member_id). cluster_id = min member id (S2 convention).
+    return [(0, 0), (0, 1), (2, 2), (2, 3), (2, 4), (5, 5)]
+
+
+def _reference_golden(rows, assignments, value_cols, strategy):
+    from collections import defaultdict
+
+    from goldenmatch.config.schemas import GoldenFieldRule
+    from goldenmatch.core.golden import merge_field
+
+    by_id = {r[0]: dict(zip(["__row_id__", *value_cols], r)) for r in rows}
+    members = defaultdict(list)
+    for cid, mid in assignments:
+        members[cid].append(mid)
+    rule = GoldenFieldRule(strategy=strategy)
+    out = {}
+    for cid, mids in members.items():
+        if len(mids) < 2:
+            continue
+        rec = {}
+        for c in value_cols:
+            merged, _c, _s = merge_field([by_id[m][c] for m in mids], rule)
+            rec[c] = None if merged is None else str(merged)
+        out[cid] = rec
+    return out
+
+
+def _sail_golden(out_df, value_cols):
+    return {
+        int(r["cluster_id"]): {c: r[c] for c in value_cols}
+        for r in out_df.collect()
+    }
+
+
+def test_sail_golden_content_parity(spark):
+    from goldenmatch.sail.golden import build_golden
+
+    rows = _source_rows()
+    assignments = _assignments()
+    source_df = spark.createDataFrame(rows, ["__row_id__", *_VALUE_COLS])
+    assign_df = spark.createDataFrame(assignments, ["cluster_id", "member_id"])
+
+    out = build_golden(assign_df, source_df, value_cols=_VALUE_COLS)
+    got = _sail_golden(out, _VALUE_COLS)
+    expected = _reference_golden(rows, assignments, _VALUE_COLS, "most_complete")
+    assert got == expected
+    # Singleton cluster 5 excluded.
+    assert 5 not in got
+```
+
+- [ ] **Step 2: Add the gate to the `sail` CI lane.** In `.github/workflows/ci.yml`, after the
+  S2 WCC step, add:
+
+```yaml
+      - name: Sail golden parity gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_golden_parity.py -v --timeout=300
+```
+
+- [ ] **Step 3: Static-validate** (`ruff check`, `py_compile`, `yaml.safe_load` ci.yml) **+ commit.**
+
+```bash
+git add packages/python/goldenmatch/tests/test_sail_golden_parity.py .github/workflows/ci.yml
+git commit -m "test(sail): S3 golden content-parity gate vs merge_field reference"
+```
+
+---
+
+## Task 3: push, green the `sail` lane, merge
+
+- [ ] **Step 1: Push + open the PR.** Body: "Sail tier Stage S3 — golden survivorship on Sail (collect_list + merge_field UDF), content-parity-gated per multi-member cluster vs the one-box merge_field. Reuses the exact one-box survivorship primitive -> parity by construction. Scope: uniform most_complete; identity split to its own stage. Spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md (S3, golden half)."
+
+- [ ] **Step 2: Watch the `sail` lane** (connectivity + S1 + S2 + S3 golden gates). Poll `while gh pr checks <N> | grep -qE "\bpending\b|in_progress"; do sleep 30; done`. If the golden gate fails: likely `collect_list` array-typed `pandas_udf` input handling, or the multi-member filter join. Debug from the CI pytest output (grep the raw log). **Contingency:** if a scalar `pandas_udf` over a `collect_list` (array) column isn't supported on Sail v0.6.x, fall back to grouped-map `applyInPandas` (one StructType-schema'd row per cluster). If behind main, `gh pr update-branch <N>`. A `ci.yml` change forces the full matrix — wait before the policy allows merge.
+
+- [ ] **Step 3: Merge** once the `sail` lane + `ci-required` are green: `gh pr merge <N> --squash --delete-branch`.
+
+---
+
+## Definition of done
+- `build_golden` produces one golden record per multi-member cluster on Sail; per-cluster golden
+  field values are identical to the one-box `merge_field` reference (singletons excluded). The
+  `sail` lane's golden gate is green. PR merged.
+
+## Out of scope (later stages — explicitly recorded)
+- **Identity on Sail** — a separate stage (stateful entity store + `resolve_clusters` overlap,
+  resolved driver-side; not a relational op).
+- Order-DEPENDENT golden strategies (most_recent/source_priority — need collected dates/sources),
+  custom plugin strategies, oversized-cluster exclusion, provenance (in-memory fallback, like Ray).
+- S4: the binding 100M+ multi-node bench + the large-star/small-star WCC scale swap + Ray retirement.

--- a/docs/superpowers/plans/2026-06-03-sail-tier-stage-s4-harness.md
+++ b/docs/superpowers/plans/2026-06-03-sail-tier-stage-s4-harness.md
@@ -1,0 +1,501 @@
+# Sail Tier — Stage S4 harness: scale-WCC + end-to-end pipeline + bench scaffold (Implementation Plan)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build everything S4 needs EXCEPT the actual cluster run: the chain-scale-robust large-star/small-star WCC (so 100M chains bind), the end-to-end `run_sail_pipeline` (load → block → score → dedup → WCC → golden), and a `workflow_dispatch` 100M bench scaffold wired to a `SAIL_REMOTE` secret. Ray is NOT retired (that waits for the binding run).
+
+**Architecture:** `goldenmatch/sail/clustering.py` gains `connected_components_large_star` — the Kiveris alternating-star connected-components (O(log n) iterations vs label-prop's O(diameter)), pure Spark Connect DataFrame ops, parity-gated to the same reference Union-Find as S2. `goldenmatch/sail/pipeline.py::run_sail_pipeline` threads the S1-S3 pieces + the chosen WCC into one end-to-end run. `.github/workflows/bench-sail-100m.yml` is a `workflow_dispatch` scaffold that connects to `SAIL_REMOTE`, runs the pipeline on a parquet, and times it — fail-fast if `SAIL_REMOTE` is unset (no real run in this plan).
+
+**Tech Stack:** Python 3.12, `pysail` + `pyspark[connect]`, PySpark DataFrame API, pytest. Algorithm + pipeline are CI-gated on the in-process `sail` lane; the bench workflow is scaffold-only.
+
+---
+
+## Critical context for the executor
+- **This box HANGS on imports; Sail isn't installed locally.** Validate with `ruff check` +
+  `python -m py_compile` ONLY. The `sail` CI lane is the only verifier. The **large-star algorithm
+  is the highest-risk piece** — if its parity gate fails, the per-row star logic or the convergence
+  read-off is wrong; debug from the CI pytest output and iterate. The gate is the safety net.
+- **Branch off `origin/main`** (S1-S3 merged). Branch `feat/sail-tier-s4-harness`.
+- `ruff check packages/python/goldenmatch` exit 0 before EVERY commit (I001; `ruff check --fix`).
+  Never pipe through `tail`.
+- GitHub auth: `GH_TOKEN=$(gh auth token --user benzsevern)`. Push may hit a cosmetic
+  `.git/config` permission error — re-run `git push`, verify `git ls-remote` HEAD == local.
+- **Spark Connect discipline:** join on a SHARED COLUMN NAME + rename-before-join; NEVER a
+  `df["col"]` handle ref across a self-similar join (the S2 AMBIGUOUS_REFERENCE lesson).
+- pyright slice does NOT cover `goldenmatch/sail/` or `tests/`.
+- **Ray is NOT retired here.** Retirement is gated on the real binding run (out of scope).
+
+## Grounding references
+- Spec: `docs/superpowers/specs/2026-06-03-sail-tier-design.md` (S4). S2's plan recorded
+  large-star/small-star as a REQUIRED S4 prerequisite.
+- `sail/clustering.py::connected_components` (S2, min-label-prop) — the proven baseline + the
+  `(cluster_id, member_id)` output shape the large-star version must match.
+- `tests/test_sail_clustering_parity.py` (S2) — the reference Union-Find `_reference_partition` +
+  `_sail_partition` helpers + `spark` fixture to reuse for the large-star gate.
+- `sail/scoring.py::score_and_dedup` (S1), `sail/golden.py::build_golden` (S3) — pipeline stages.
+- Algorithm: Kiveris et al., "Connected Components in MapReduce and Beyond" — alternating
+  large-star / small-star, each re-points neighbors to the local min; star per component in O(log n).
+
+## File Structure
+- **Modify** `goldenmatch/sail/clustering.py` — add `connected_components_large_star`.
+- **Create** `goldenmatch/sail/pipeline.py` — `run_sail_pipeline`.
+- **Modify** `tests/test_sail_clustering_parity.py` — large-star parity (reuse helpers; add a long chain).
+- **Create** `tests/test_sail_pipeline.py` — end-to-end pipeline test.
+- **Create** `.github/workflows/bench-sail-100m.yml` + `scripts/bench_sail_100m.py` — the scaffold.
+- **Modify** `.github/workflows/ci.yml` — add the pipeline test to the `sail` lane.
+
+---
+
+## Task 1: chain-robust O(log n) WCC (pointer-jumping) — the scale algorithm
+
+**Files:** Modify `goldenmatch/sail/clustering.py`
+
+**ALGORITHM NOTE (honest naming):** the spec/S2-plan said "large-star/small-star." A first
+blind attempt at literal Kiveris large-star/small-star was WRONG (it read labels off a
+collapsing edge set → returned singletons; caught by hand-trace in plan review). This task
+ships the **chain-robust O(log n) WCC via min-label propagation with pointer-jumping
+(Shiloach-Vishkin-style shortcutting)** instead — same goal (O(log n), beats label-prop's
+O(diameter) on chains), but **provably correct and hand-verifiable** under the no-local-
+testing constraint. Both are standard O(log n) connected-components; this one is the one we
+can verify. **Hand-traced** below on the 2-node and 3-node chains (converge in 1 round).
+
+- [ ] **Step 1: Add `connected_components_scale`** to `clustering.py`.
+
+```python
+def connected_components_scale(
+    pairs_df: Any,
+    ids_df: Any,
+    *,
+    id_col: str = "__row_id__",
+    max_rounds: int = 40,
+) -> Any:
+    """Chain-robust O(log n) weakly-connected components via min-label
+    propagation with POINTER-JUMPING (Shiloach-Vishkin shortcutting). Pure
+    Spark Connect. The scale algorithm for the 100M bench (label-prop is
+    O(diameter) on long chains; the pointer-jump halves the distance to the
+    root each round -> O(log n)).
+
+    Same output as ``connected_components``: ``(cluster_id, member_id)`` where
+    cluster_id is the component's min member id. Isolated nodes (singletons)
+    seeded from the DISTRIBUTED ``ids_df`` (the rehydration-OOM trap).
+
+    Each round: (1) PROPAGATE -- each node adopts min(own label, min neighbor
+    label); (2) SHORTCUT -- ``label[v] = label[label[v]]`` (jump to the label's
+    label). Early-exit when labels stop changing. NOTE for the real run:
+    cache/checkpoint ``labels`` each round (Spark Connect lineage grows) + a
+    cheaper change-counter; the gate runs tiny fixtures.
+
+    HAND TRACE (2-node, edges=[(0,1)], seed {0:0,1:1}):
+      r1 propagate: node0 min(0,lbl[1]=1)=0; node1 min(1,lbl[0]=0)=0 -> {0:0,1:0}
+         shortcut: lbl[0]=lbl[0]=0; lbl[1]=lbl[lbl[1]=0]=0 -> {0:0,1:0}
+      r2: no change -> CONVERGED {0:0,1:0}.  ONE component. CORRECT.
+    HAND TRACE (3-chain, edges=[(0,1),(1,2)], seed {0:0,1:1,2:2}):
+      r1 propagate: 0->min(0,1)=0; 1->min(1,min(0,2)=0)=0; 2->min(2,1)=1 -> {0:0,1:0,2:1}
+         shortcut: 0->lbl[0]=0; 1->lbl[0]=0; 2->lbl[1]=0 -> {0:0,1:0,2:0}
+      r2: no change -> CONVERGED all 0.  ONE component. CORRECT.
+    """
+    from pyspark.sql import functions as F
+
+    # Symmetric edges (node, nbr) so labels flow both ways.
+    fwd = pairs_df.select(F.col("a").alias("node"), F.col("b").alias("nbr"))
+    rev = pairs_df.select(F.col("b").alias("node"), F.col("a").alias("nbr"))
+    edges = fwd.unionByName(rev)
+
+    # Labels seeded from the DISTRIBUTED universe (singletons -> own label).
+    labels = ids_df.select(
+        F.col(id_col).cast("long").alias("node")
+    ).withColumn("label", F.col("node"))
+
+    # Spark Connect discipline: join on a SHARED NAME, other side renamed; no
+    # df["col"] cross-handle refs (the S2 AMBIGUOUS_REFERENCE lesson).
+    for _ in range(max_rounds):
+        # (1) PROPAGATE: each node adopts min(own, min neighbor label).
+        lab_for_nbr = labels.select(
+            F.col("node").alias("nbr"), F.col("label").alias("nbr_label")
+        )
+        nbr_min = (
+            edges.join(lab_for_nbr, on="nbr", how="inner")
+            .groupBy("node")
+            .agg(F.min("nbr_label").alias("nbr_min"))
+        )
+        propagated = labels.join(nbr_min, on="node", how="left").select(
+            F.col("node"),
+            F.least(
+                F.col("label"), F.coalesce(F.col("nbr_min"), F.col("label"))
+            ).alias("label"),
+        )
+        # (2) SHORTCUT (pointer-jump): label[v] = label[label[v]].
+        # Join propagated(label) to a copy keyed by node (renamed to the shared
+        # "label" join key); grandlabel = label of node `label[v]`.
+        lab_target = propagated.select(
+            F.col("node").alias("label"), F.col("label").alias("grandlabel")
+        )
+        jumped = propagated.join(lab_target, on="label", how="left").select(
+            F.col("node"),
+            F.coalesce(F.col("grandlabel"), F.col("label")).alias("label"),
+        )
+        # Convergence: any label changed vs the previous round?
+        prev_r = labels.select(
+            F.col("node"), F.col("label").alias("prev_label")
+        )
+        changed = (
+            jumped.join(prev_r, on="node", how="inner")
+            .where(F.col("label") != F.col("prev_label"))
+            .limit(1)
+            .count()
+        )
+        labels = jumped
+        if changed == 0:
+            break
+
+    return labels.select(
+        F.col("label").alias("cluster_id"), F.col("node").alias("member_id")
+    )
+```
+
+  **Spark Connect self-join risk (the shortcut):** `propagated.join(lab_target, on="label")`
+  is a self-join (both derive from `propagated`). It uses the shared-name `on="label"` form
+  (auto-coalesced) with the other side's non-key column renamed to `grandlabel` (no overlap),
+  which is the robust pattern. **If CI raises a self-join AMBIGUOUS_REFERENCE here,** the fix
+  is to break lineage before the join (e.g. round-trip `propagated` through
+  `spark.createDataFrame(propagated.collect())` is NOT acceptable at scale — instead use
+  `.checkpoint()` / `.localCheckpoint()` if Sail supports it, else `.cache()` + an action).
+  Note this in the debug step.
+
+- [ ] **Step 2: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/sail/clustering.py
+git commit -m "feat(sail): chain-robust O(log n) WCC via pointer-jumping (S4 scale)"
+```
+
+---
+
+## Task 2: scale-WCC parity gate (2-node minimal + long chain)
+
+**Files:** Modify `tests/test_sail_clustering_parity.py` (reuse `_reference_partition`/`_sail_partition`/`spark`)
+
+- [ ] **Step 1: Add `connected_components_scale` parity tests** — the 2-node minimal case (the
+  fastest-failing case per the review), chain+pair+singleton, a 30-node chain (stresses O(log n)
+  where label-prop needs ~30 rounds), and the junction.
+
+```python
+def test_sail_wcc_scale_two_node(spark):
+    """Minimal case: edges=[(0,1)] -> one component {0,1}. The fastest-failing
+    case for a wrong WCC (it returned two singletons in the blind attempt)."""
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = [0, 1]
+    edges = [(0, 1)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == {frozenset({0, 1})}
+
+
+def test_sail_wcc_scale_partition_parity(spark):
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = list(range(7))
+    edges = [(0, 1), (1, 2), (3, 4)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == _reference_partition(ids, edges)
+
+
+def test_sail_wcc_scale_long_chain(spark):
+    """A 30-node chain: pointer-jumping converges in O(log 30) rounds where
+    label-prop would need ~30. Must collapse to ONE component."""
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = list(range(30))
+    edges = [(i, i + 1) for i in range(29)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == {frozenset(range(30))}
+
+
+def test_sail_wcc_scale_junction(spark):
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = list(range(7))
+    edges = [(0, 3), (1, 3), (2, 3), (4, 5)]  # singleton 6
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == _reference_partition(ids, edges)
+```
+
+- [ ] **Step 2: Static-validate + commit.** (The `sail` lane's WCC step already runs this file.)
+
+```bash
+git add packages/python/goldenmatch/tests/test_sail_clustering_parity.py
+git commit -m "test(sail): scale-WCC (pointer-jump) partition parity (2-node + 30-node chain)"
+```
+
+---
+
+## Task 3: `run_sail_pipeline` (end-to-end) + a small gate
+
+**Files:** Create `goldenmatch/sail/pipeline.py` + `tests/test_sail_pipeline.py`; Modify `ci.yml`
+
+- [ ] **Step 1: Write `sail/pipeline.py`.**
+
+```python
+"""End-to-end Sail pipeline: load -> block -> score -> dedup -> WCC -> golden,
+all distributed on Sail (Spark Connect). The bench entrypoint (S4). Blocking is
+a single pre-existing column (S1 scope); the scorer is the rapidfuzz pandas UDF;
+WCC defaults to large-star/small-star (chain-robust at scale)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def run_sail_pipeline(
+    source_df: Any,
+    *,
+    id_col: str,
+    block_col: str,
+    value_col: str,
+    golden_cols: list[str],
+    scorer_name: str = "jaro_winkler",
+    threshold: float = 0.85,
+    strategy: str = "most_complete",
+    wcc: str = "scale",
+) -> Any:
+    """Run the full Sail pipeline. Returns the golden DataFrame
+    ``(cluster_id, *golden_cols)`` (one per multi-member cluster). ``wcc``:
+    ``"scale"`` (pointer-jumping, chain-robust O(log n)) or ``"label_prop"``."""
+    from goldenmatch.sail.clustering import (
+        connected_components,
+        connected_components_scale,
+    )
+    from goldenmatch.sail.golden import build_golden
+    from goldenmatch.sail.scoring import score_and_dedup
+
+    pairs = score_and_dedup(
+        source_df, block_col=block_col, value_col=value_col, id_col=id_col,
+        scorer_name=scorer_name, threshold=threshold,
+    )
+    ids_df = source_df.select(id_col)
+    wcc_fn = (
+        connected_components_scale if wcc == "scale"
+        else connected_components
+    )
+    assignments = wcc_fn(pairs, ids_df, id_col=id_col)
+    return build_golden(
+        assignments, source_df, value_cols=golden_cols,
+        source_id_col=id_col, strategy=strategy,
+    )
+```
+
+- [ ] **Step 2: Write `tests/test_sail_pipeline.py`** (reuse the server fixture).
+
+```python
+"""S4 end-to-end gate: run_sail_pipeline runs on Sail and produces golden per
+multi-member cluster. Skips where the sail extra is absent; runs in the `sail`
+lane."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def test_run_sail_pipeline_end_to_end(spark):
+    from goldenmatch.sail.pipeline import run_sail_pipeline
+
+    rows = [
+        (0, "10001", "Smith", "Jon"),
+        (1, "10001", "Smith", None),     # cluster {0,1}: first_name "Jon"
+        (2, "20002", "Brown", "Ann"),
+        (3, "20002", "Brown", None),     # cluster {2,3}: first_name "Ann"
+        (4, "30003", "Solo", "Zed"),     # singleton (excluded)
+    ]
+    df = spark.createDataFrame(
+        rows, ["__row_id__", "zip", "last_name", "first_name"]
+    )
+    golden = run_sail_pipeline(
+        df, id_col="__row_id__", block_col="zip", value_col="last_name",
+        golden_cols=["first_name"], threshold=0.85, wcc="scale",
+    )
+    got = {int(r["cluster_id"]): r["first_name"] for r in golden.collect()}
+    assert got == {0: "Jon", 2: "Ann"}
+```
+
+- [ ] **Step 3: Add the pipeline test to the `sail` lane.** In `ci.yml`, after the golden gate:
+
+```yaml
+      - name: Sail end-to-end pipeline gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_pipeline.py -v --timeout=300
+```
+
+- [ ] **Step 4: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/sail/pipeline.py \
+        packages/python/goldenmatch/tests/test_sail_pipeline.py .github/workflows/ci.yml
+git commit -m "feat(sail): run_sail_pipeline end-to-end (load->...->golden) + e2e gate"
+```
+
+---
+
+## Task 4: the 100M bench scaffold (workflow_dispatch, no real run)
+
+**Files:** Create `scripts/bench_sail_100m.py` + `.github/workflows/bench-sail-100m.yml`
+
+- [ ] **Step 1: Write the bench driver** `packages/python/goldenmatch/scripts/bench_sail_100m.py`.
+
+```python
+"""S4 binding bench DRIVER (scaffold). Connects to a REAL Sail cluster via
+SAIL_REMOTE, runs run_sail_pipeline over a parquet at scale, times it, writes
+JSON. No in-process server -- needs a real BYO cluster (not run in this plan).
+Usage: SAIL_REMOTE=sc://host:port python bench_sail_100m.py --input <parquet>."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="parquet path/URI on the cluster")
+    ap.add_argument("--id-col", default="__row_id__")
+    ap.add_argument("--block-col", default="last_name_soundex")
+    ap.add_argument("--value-col", default="last_name")
+    ap.add_argument("--golden-cols", default="first_name,email")
+    ap.add_argument("--out", default=".profile_tmp/sail_100m.json")
+    args = ap.parse_args()
+
+    remote = os.environ.get("SAIL_REMOTE")
+    if not remote:
+        print(
+            "::error::SAIL_REMOTE unset -- this bench needs a real BYO Sail cluster.",
+            file=sys.stderr,
+        )
+        return 2
+
+    from goldenmatch.sail.pipeline import run_sail_pipeline
+    from goldenmatch.sail.session import connect
+
+    spark = connect(remote)
+    src = spark.read.parquet(args.input)
+    t0 = time.perf_counter()
+    golden = run_sail_pipeline(
+        src, id_col=args.id_col, block_col=args.block_col,
+        value_col=args.value_col, golden_cols=args.golden_cols.split(","),
+        wcc="scale",
+    )
+    n_golden = golden.count()  # forces the full pipeline
+    wall = time.perf_counter() - t0
+
+    payload = {
+        "wall_s": wall, "golden_count": n_golden,
+        "remote": remote, "input": args.input,
+    }
+    print(json.dumps(payload, indent=2))
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Write `.github/workflows/bench-sail-100m.yml`** (workflow_dispatch only).
+
+```yaml
+# Sail tier S4 binding bench (workflow_dispatch only). Runs the full Sail
+# pipeline over a parquet on a REAL BYO Sail cluster (SAIL_REMOTE secret), the
+# binding "beats one-box / scales out" proof. SCAFFOLD: without SAIL_REMOTE the
+# driver exits 2 (fail-fast). Mirrors the Ray phase5 BYO-cluster posture (docs
+# not bootstrap). Ray is NOT retired until this binds.
+# Spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md (S4).
+name: bench-sail-100m
+on:
+  workflow_dispatch:
+    inputs:
+      input:
+        description: "parquet path/URI reachable from the Sail cluster"
+        required: true
+permissions:
+  contents: read
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+      - run: uv sync --all-packages
+      - name: Install sail extra
+        run: uv pip install -e 'packages/python/goldenmatch[sail]'
+      - name: Run Sail bench (real cluster via SAIL_REMOTE)
+        env:
+          SAIL_REMOTE: ${{ secrets.SAIL_REMOTE }}
+        run: |
+          .venv/bin/python packages/python/goldenmatch/scripts/bench_sail_100m.py \
+            --input "${{ inputs.input }}" --out .profile_tmp/sail_100m.json
+          { echo '## bench-sail-100m'; echo '```'; cat .profile_tmp/sail_100m.json; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sail-100m-bench
+          path: .profile_tmp/sail_100m.json
+          if-no-files-found: warn
+```
+
+- [ ] **Step 3: Static-validate** (`ruff` the driver, `yaml.safe_load` the workflow) **+ commit.**
+
+```bash
+git add packages/python/goldenmatch/scripts/bench_sail_100m.py .github/workflows/bench-sail-100m.yml
+git commit -m "ci(sail): S4 100M bench scaffold (workflow_dispatch, BYO cluster via SAIL_REMOTE)"
+```
+
+---
+
+## Task 5: push, green the `sail` lane, merge
+
+- [ ] **Step 1: Push + open the PR.** Body: large-star WCC parity (incl. 30-node chain);
+  run_sail_pipeline e2e; 100M bench scaffold (no real run); Ray NOT retired.
+- [ ] **Step 2: Watch the `sail` lane** (6 gates now). **The large-star gate is the risk** — if it
+  fails, the star per-row logic or convergence read-off is wrong; debug from CI pytest output and
+  iterate. If behind main, `gh pr update-branch <N>`. A `ci.yml` change forces the full matrix.
+- [ ] **Step 3: Merge** once `sail` + `ci-required` green: `gh pr merge <N> --squash --delete-branch`.
+
+---
+
+## Definition of done
+- `connected_components_large_star` partition-parity-green incl. a 30-node chain.
+- `run_sail_pipeline` runs end-to-end on Sail and produces correct golden.
+- `bench-sail-100m.yml` + driver exist (workflow_dispatch, SAIL_REMOTE, fail-fast) — NO real run.
+- PR merged. Ray NOT retired.
+
+## Out of scope
+- The actual 100M multi-node run (real BYO Sail cluster + `SAIL_REMOTE` + 100M parquet) → the
+  binding verdict + Ray retirement.
+- Identity on Sail (its own stage). Per-node RSS instrumentation (cluster-side metrics). Distributed
+  soundex/other blocking transforms (the driver assumes a pre-computed block column on the parquet).

--- a/docs/superpowers/plans/2026-06-04-autoconfig-491-lever-coverage.md
+++ b/docs/superpowers/plans/2026-06-04-autoconfig-491-lever-coverage.md
@@ -1,0 +1,192 @@
+# Auto-config lever coverage: probabilistic + qgram + ANN (#491) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make three unreachable auto-config levers selectable from the auto surface — the `probabilistic` matchkey type (controller heuristic + optimizer candidate), the `qgram` scorer (heuristic + optimizer), and `ann` blocking (heuristic gate).
+
+**Architecture:** Three independent levers. Lever A (probabilistic) reuses the existing `MatchkeyTypeSwap` edit in the optimizer (A1) and adds a conservative, quality-gated controller refit rule (A2, ship-or-defer). Lever B (qgram) adds a short-code shape refinement in `build_matchkeys` (B1) + the optimizer scorer family (B2). Lever C (ann) adds a strictly-gated branch in `build_blocking`.
+
+**Tech Stack:** Python 3.12, polars, pytest. Files in `packages/python/goldenmatch/goldenmatch/core/`: `autoconfig.py`, `autoconfig_rules.py`, `config_optimizer.py`, `config_edits.py`, `config/schemas.py`.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-autoconfig-491-lever-coverage-design.md`
+
+**Precondition — branch from latest `main`** (has #715/#720/#723, and #678/#458 once merged). Create `feat/491-lever-coverage` off `origin/main`.
+
+**Run environment:** prefix every local python/pytest with `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8` and use the worktree `.venv/Scripts/python.exe`. `uv` lives at `C:/Users/bsevern/AppData/Local/Programs/Python/Python312/Scripts/uv.exe` (not on PATH — use the absolute path for `uv sync`). Run ONLY targeted test files locally (full suite OOMs; CI runs it). Kill zombie python: `powershell.exe -Command "Get-Process python | Stop-Process -Force"`. pyright reporting "polars could not be resolved" is env noise — judge NEW errors vs baseline.
+
+---
+
+## File Structure
+- **Modify** `goldenmatch/core/autoconfig.py`: `build_matchkeys` scorer-selection (B1 short-code → qgram, via a refinement near the `_refdata_refine_matchkey_field` hook ~592-609); `build_blocking` (C: new `ann` branch).
+- **Modify** `goldenmatch/core/config_optimizer.py`: `CoordinateDescentProposer` scorer family (~334, add `qgram` for B2) + a new `mktype` family wiring `MatchkeyTypeSwap` (A1).
+- **Modify** `goldenmatch/core/autoconfig_rules.py`: new `rule_select_probabilistic_matchkey` + `DEFAULT_RULES` (A2).
+- **Modify** `goldenmatch/config/schemas.py` (NOT under `core/`): `VALID_SCORERS` (~21-25, add `qgram` — Task 0).
+- **Read-only ref** `goldenmatch/core/config_edits.py:167` (`MatchkeyTypeSwap`), `goldenmatch/config/schemas.py:~380` (`BlockingConfig.ann_column/ann_model/ann_top_k`, `strategy="ann"` Literal ~366).
+- **Create** `tests/test_autoconfig_491_levers.py` (all lever unit + reachability tests).
+
+---
+
+## Task 0: B0 — implement the qgram scorer (PREREQUISITE for Task 1/2)
+
+**Files:** Modify `goldenmatch/core/scorer.py` (single dispatch ~89, matrix dispatch ~419, + two new helpers); Modify `goldenmatch/config/schemas.py` (`VALID_SCORERS` ~21-25); Test `tests/test_autoconfig_491_levers.py`
+
+**Why:** `qgram` is not a scorer today (it's a lossy `qgram:N` transform; dice/jaccard are bloom-only). Must add a real char-n-gram similarity scorer before Tasks 1/2 can route to it.
+
+- [ ] **Step 1: failing test**
+```python
+def test_qgram_scorer_similarity():
+    from goldenmatch.core.scorer import score_pair  # or the single-score entry; READ scorer.py:80-95 for the real entry
+    # identical -> 1.0; disjoint -> 0.0; transposition-ish -> high but < 1
+    assert score_pair("ABC123", "ABC123", scorer="qgram") == 1.0
+    assert score_pair("ABC123", "XYZ789", scorer="qgram") < 0.2
+    assert 0.4 < score_pair("ABC123", "ABC132", scorer="qgram") < 1.0
+```
+(READ `scorer.py:80-95` to find the actual single-score function name + signature; adapt the import/call. The `_dice_score_single`/`_jaccard_score_single` pair at ~526-536 is the structural template — but those read bloom hex; yours reads raw strings.)
+- [ ] **Step 2:** run, confirm FAIL (qgram not a valid scorer → ValueError, or unknown scorer).
+- [ ] **Step 3: implement**
+  - Add `"qgram"` to `VALID_SCORERS` in `goldenmatch/config/schemas.py` (~21-25).
+  - Add `_qgram_score_single(val_a, val_b, n=3)`: pad each with `##...##`, build the FULL set of length-n substrings (NOT the transform's `[:5]` truncation), return `len(A & B)/len(A | B)` (0.0 if both empty / union empty). Wire into the single dispatch (`scorer.py` ~89, beside dice/jaccard).
+  - Add `_qgram_score_matrix(values)`: NxN, same metric (can be a straightforward loop or vectorized set ops). Wire into the matrix dispatch (~419).
+  - Confirm no native/Rust dispatch hijacks `qgram` (the note at ~317-319 shows dice/jaccard matrix stays Python; keep qgram Python too).
+- [ ] **Step 4:** run, pass.
+- [ ] **Step 5: commit** `feat(scorer): add qgram char-n-gram similarity scorer (#491)`.
+
+---
+
+## Task 1: B1 — route short-code columns to qgram (heuristic)
+
+**Files:** Modify `goldenmatch/core/autoconfig.py` (`build_matchkeys` scorer path); Test `tests/test_autoconfig_491_levers.py`
+
+READ `build_matchkeys` (~550-700), `_SCORER_MAP` (~503), and the `_refdata_refine_matchkey_field` refinement hook (~592-609) first. The short-code refinement slots in alongside that hook: after col_type/scorer is chosen, if the column matches a short-code shape, override the matchkey field's scorer to `qgram` (now a valid scorer from Task 0).
+
+- [ ] **Step 1: failing test** — construct `ColumnProfile`s for a short-code column (e.g. `sku`, `col_type="string"` or `"identifier"`, `avg_len≈6`, `cardinality_ratio≈0.7`, alphanumeric `sample_values` like `"A1B2C3"`) and a name column. Assert `build_matchkeys` produces a matchkey field with `scorer="qgram"` for `sku` and NOT for the name column.
+```python
+def test_short_code_column_gets_qgram():
+    profiles = [
+        ColumnProfile("sku","Utf8","string",0.9, sample_values=["A1B2C3","X9Y8Z7","Q2W3E4"],
+                      null_rate=0.0, cardinality_ratio=0.7, avg_len=6.0),
+        ColumnProfile("first_name","Utf8","name",0.9, sample_values=["james","mary"],
+                      null_rate=0.0, cardinality_ratio=0.02, avg_len=5.0),
+    ]
+    mks = build_matchkeys(profiles, df=_df_with(["sku","first_name"]))
+    scorers = {f.field: f.scorer for mk in mks for f in mk.fields}
+    assert scorers.get("sku") == "qgram"
+    assert scorers.get("first_name") != "qgram"
+```
+- [ ] **Step 2:** run, confirm FAIL (qgram never emitted today).
+- [ ] **Step 3: implement** a `_is_short_code(p: ColumnProfile) -> bool` helper (avg_len in ~3..12, cardinality_ratio >= a threshold e.g. 0.3, col_type in {"string","identifier"} and NOT name/email/phone/zip/date, sample_values look alphanumeric/code-like — check a mix of letters+digits or uniform short length). In `build_matchkeys`, after the scorer is resolved for a fuzzy field, if `_is_short_code(p)` and scorer is a generic string scorer (token_sort/ensemble), set scorer to `"qgram"` (valid as of Task 0). Add a comment tagging `#491`.
+- [ ] **Step 4:** run, pass. Re-run a couple of existing `build_matchkeys` tests (`tests/test_refdata_autoconfig.py`) to confirm no regression on name/address columns.
+- [ ] **Step 5: commit** `feat(autoconfig): emit qgram for short-code columns (#491)`.
+
+---
+
+## Task 2: B2 — qgram in the optimizer scorer family
+
+**Files:** Modify `goldenmatch/core/config_optimizer.py` (~334); Test `tests/test_autoconfig_491_levers.py`
+
+- [ ] **Step 1: failing test** — assert `qgram` is in `CoordinateDescentProposer`'s scorer family / appears as a candidate scorer. Inspect the family constant directly:
+```python
+def test_optimizer_scorer_family_includes_qgram():
+    from goldenmatch.core.config_optimizer import CoordinateDescentProposer
+    # the scorer family is the `scorers` tuple (instance attr `_scorers`, default
+    # literal at config_optimizer.py:328-335) -- READ to confirm and assert against
+    # the real symbol (NOT `_SCORER_FAMILY`, which does not exist).
+    assert "qgram" in CoordinateDescentProposer()._scorers
+```
+(READ config_optimizer.py:328-376 to confirm the exact attribute/local name; adapt the test + the constructor call to the real signature.)
+- [ ] **Step 2:** run, confirm FAIL.
+- [ ] **Step 3: implement** — add `"qgram"` to the scorer family list (~334), with the same `#491` comment style as the levenshtein/soundex entries.
+- [ ] **Step 4:** run, pass.
+- [ ] **Step 5: commit** `feat(optimizer): add qgram to scorer candidate family (#491)`.
+
+---
+
+## Task 3: A1 — probabilistic candidate in the deterministic optimizer
+
+**Files:** Modify `goldenmatch/core/config_optimizer.py` (`CoordinateDescentProposer` `_FAMILIES`/`_edits`); ref `config_edits.py:167` (`MatchkeyTypeSwap`); Test `tests/test_autoconfig_491_levers.py`
+
+READ `config_optimizer.py:307-446` (`CoordinateDescentProposer`, its `_FAMILIES`, `_edits`, `propose`) and `config_edits.py:167` (`MatchkeyTypeSwap`, `_PERTURBABLE_TYPES = ("weighted","probabilistic")`, its `.apply`). `MatchkeyTypeSwap` is already LLM-deserialized but not imported into the optimizer.
+
+- [ ] **Step 1: failing test** — given a `SearchState` whose config has a `weighted` matchkey, assert `CoordinateDescentProposer.propose` yields at least one candidate whose matchkey type is `probabilistic`.
+```python
+def test_optimizer_proposes_probabilistic_candidate():
+    # build a minimal SearchState with a weighted matchkey (read SearchState shape first)
+    cands = CoordinateDescentProposer(...).propose(state)
+    types = {mk.type for _label, cfg in cands for mk in cfg.get_matchkeys()}
+    assert "probabilistic" in types
+```
+(READ `SearchState` + how existing families construct candidates to build the fixture correctly.)
+- [ ] **Step 2:** run, confirm FAIL.
+- [ ] **Step 3: implement** — import `MatchkeyTypeSwap`; add a `mktype` family to `CoordinateDescentProposer` that, for each `weighted` matchkey in the state, emits a `MatchkeyTypeSwap(...weighted→probabilistic)` candidate (and optionally the reverse for a probabilistic matchkey). Apply via the same `edit.apply(base)` path the other families use. Label candidates so the report attributes the move (e.g. `"mktype:probabilistic"`).
+- [ ] **Step 4:** run, pass.
+- [ ] **Step 5: commit** `feat(optimizer): propose weighted↔probabilistic matchkey-type swaps (#491)`.
+
+---
+
+## Task 4: A2 — conservative controller rule (ship-or-defer)
+
+**Files:** Modify `goldenmatch/core/autoconfig_rules.py` (new rule + `DEFAULT_RULES` ~1086); Test `tests/test_autoconfig_491_levers.py`
+
+READ an existing rule (e.g. `rule_unimodal_scoring` ~240 or `rule_recall_gap_suspected` ~656) for the exact signature `(profile, current, history) -> proposal | None` and how a rule edits matchkeys + returns its proposal/decision. Read `ComplexityProfile.scoring` for `dip_statistic` / `mass_above_threshold`.
+
+- [ ] **Step 1: failing tests** —
+  - FIRES: profile with a weighted matchkey of ≥3 graded fuzzy fields + recall-limited scoring (low `dip_statistic`/`mass_above_threshold`) + no exact-anchor matchkey → rule returns a proposal converting the weighted matchkey to `probabilistic`.
+  - DOES NOT FIRE: (a) a config with an exact-anchor matchkey present (DQbench-like), (b) a 2-field weighted matchkey (below the ≥3 threshold), (c) healthy scoring.
+```python
+def test_rule_selects_probabilistic_on_target_shape(): ...
+def test_rule_skips_when_exact_anchor_present(): ...
+def test_rule_skips_small_weighted_or_healthy(): ...
+```
+- [ ] **Step 2:** run, confirm FAIL (no such rule).
+- [ ] **Step 3: implement** `rule_select_probabilistic_matchkey(profile, current, history) -> tuple[GoldenMatchConfig, PolicyDecision] | None` (READ an existing rule for the exact 2-tuple return + `PolicyDecision` shape): guard on the three trigger conditions (≥3 graded fuzzy fields in a weighted mk; recall-limited scoring via `profile.scoring.dip_statistic` / `mass_above_threshold`; no exact matchkey in `current`); when all hold, return `(new_config, PolicyDecision(...))` swapping that weighted matchkey to `type="probabilistic"` (m/u train at dedupe time). **INSERT the rule into `DEFAULT_RULES` BEFORE `rule_recall_gap_suspected`** — do NOT append: `test_autoconfig_policy.py:1182` asserts `idx_recall_gap == len(DEFAULT_RULES) - 2` ("recall_gap second-to-last, sparse_match_expand last"), which a tail append breaks. Tag `#491`.
+  - **Bump ALL SIX `len(DEFAULT_RULES) == 15` assertions to `== 16`** in `tests/test_autoconfig_policy.py` (lines ~439, 622, 838, 1162, 1303, 1551 — grep `len(DEFAULT_RULES)` to find them all), and confirm the positional invariant at ~1182 still holds after the insert.
+- [ ] **Step 4:** run the new tests + `tests/test_autoconfig_policy.py` + `tests/test_autoconfig_rules.py`, all pass.
+- [ ] **Step 5: commit** `feat(autoconfig): rule_select_probabilistic_matchkey (conservative, #491)`.
+
+---
+
+## Task 5: C — ANN blocking branch (strictly gated)
+
+**Files:** Modify `goldenmatch/core/autoconfig.py` (`build_blocking` ~1309); ref `config/schemas.py:362` (`BlockingConfig.ann_column/ann_model/ann_top_k`); Test `tests/test_autoconfig_491_levers.py`
+
+READ `build_blocking` (signature takes `n_rows_full`), the embedding-column/scorer detection already used for embedding scorers, and `BlockingConfig` ann_* fields. `ANNBlocker` raises if `ann_column` unset (`blocker.py:658`).
+
+- [ ] **Step 1: failing tests** —
+  - EMITS ann: profiles include an embedding-bearing column/scorer AND `n_rows_full >= ANN_MIN_ROWS` → `build_blocking` returns `strategy="ann"` with `ann_column` set.
+  - NEVER ann without embeddings: profiles with no embedding column → strategy is the normal one, never `"ann"` (the safety invariant).
+  - below scale: embeddings present but `n_rows_full < ANN_MIN_ROWS` → not ann.
+- [ ] **Step 2:** run, confirm FAIL.
+- [ ] **Step 3: implement** — add an early branch in `build_blocking`: detect embedding presence (an embedding/record_embedding matchkey field, or an embedding-designated column — reuse the existing detection); define `ANN_MIN_ROWS` (default ~100_000, env-overridable `GOLDENMATCH_ANN_MIN_ROWS`); when both hold, return `BlockingConfig(strategy="ann", ann_column=<the embedding column>, ann_model=<default>, ann_top_k=<default>, ...)`. The gate MUST be conjunctive — no embeddings ⇒ never ann. Tag `#491`.
+- [ ] **Step 4:** run, pass. Re-run `tests/test_autoconfig.py` blocking tests for no regression.
+- [ ] **Step 5: commit** `feat(autoconfig): auto-select ANN blocking with embeddings at scale (#491)`.
+
+---
+
+## Task 6: Reachability tests (the #491 acceptance)
+
+**Files:** Test `tests/test_autoconfig_491_levers.py`
+
+- [ ] **Step 1:** add explicit reachability assertions tying back to #491's acceptance: qgram reachable via `build_matchkeys` (Task 1 covers); probabilistic reachable via BOTH the controller rule (Task 4) AND the optimizer candidate set (Task 3); ann reachable via `build_blocking` (Task 5). A small grouped test module-docstring referencing #491.
+- [ ] **Step 2:** run the whole `tests/test_autoconfig_491_levers.py` — all green.
+- [ ] **Step 3: commit** `test(autoconfig): #491 lever-reachability assertions`.
+
+---
+
+## Task 7: Quality gate + ship-or-defer decision (HARD GATE)
+
+**Files:** none (validation) — may revert Task 4.
+
+A2 (and B1) change default zero-config selection. This is the central risk.
+
+- [ ] **Step 1:** run the in-house #528 quality gate (CI lane on the PR) — confirm green.
+- [ ] **Step 2:** run DQbench T1/T2/T3 (local `~/.dqbench`, system Python312 dqbench CLI per `project_issue_489_zerolabel_gate`) + the NCVR + Febrl3 benchmarks. Capture before/after.
+- [ ] **Step 3: DECISION** — if NCVR/Febrl3/DQbench regress vs baseline: **revert Task 4** (`rule_select_probabilistic_matchkey` + its `DEFAULT_RULES` entry + the `len(DEFAULT_RULES)` assert), leaving probabilistic reachable via the optimizer only (A1) — still satisfies #491. Record the numbers + the decision in the PR. If no regression: keep A2.
+
+---
+
+## Task 8: PR + CI + land
+
+- [ ] **Step 1:** ruff clean + pyright (no NEW errors) on all changed files.
+- [ ] **Step 2:** push (`benzsevern` auth dance), open PR to `main` linking #491; paste reachability test results + Task 7 benchmark numbers + the A2 keep/defer decision.
+- [ ] **Step 3:** wait `python (goldenmatch)` + `ci-required` green; merge `--squash --delete-branch` (update-branch if behind).
+- [ ] **Step 4:** comment on #491 mapping each lever to its delivery (qgram heuristic+optimizer, probabilistic controller-rule[kept/deferred]+optimizer, ann gate); close #491 if all acceptance met (or re-scope to any deferred piece).

--- a/docs/superpowers/plans/2026-06-04-autoconfig-blocking-cost-guard-refuse-red.md
+++ b/docs/superpowers/plans/2026-06-04-autoconfig-blocking-cost-guard-refuse-red.md
@@ -1,0 +1,149 @@
+# Auto-config Blocking Cost Guard + Refuse-on-RED (#715 reopened) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Stop auto-config from committing an unbounded `soundex(name)` blocking pass that explodes candidate pairs at scale, and refuse (instead of running) when it commits a RED give-up config.
+
+**Architecture:** Three blocking-side changes in `build_blocking`/`_build_compound_blocking` (bound every emitted pass by projected full-N block size; let the compound search use sparse/identifier-typed numeric columns; scale the iteration budget), plus a new `allow_red_config` flag that makes a RED commit raise by default. Closed by an at-scale CI repro (the gap that let #715 reopen) + DQbench validation.
+
+**Tech Stack:** Python 3.12, polars, pytest. Files: `goldenmatch/core/autoconfig.py`, `goldenmatch/core/autoconfig_controller.py`, `goldenmatch/core/blocking_candidates.py`, `goldenmatch/_api.py`.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-autoconfig-blocking-cost-guard-refuse-red-design.md`
+
+**Precondition — branch from latest `main`** (has #720). Create `fix/715-blocking-cost-guard` off `origin/main`.
+
+**Run environment:** prefix every local python/pytest with `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8` and use the worktree `.venv/Scripts/python.exe`. Run ONLY targeted test files locally (full suite OOMs the box; it runs in CI). Kill zombie python with `powershell.exe -Command "Get-Process python | Stop-Process -Force"`.
+
+---
+
+## File Structure
+
+- **Modify** `goldenmatch/core/blocking_candidates.py`: add `project_max_block_size(sample_max_block, sample_n, full_n)` (Chao1-style on group sizes; NEW — distinct from the existing cardinality projection and `estimate_avg_block_size`).
+- **Modify** `goldenmatch/core/autoconfig.py`: `build_blocking` (per-pass block-size gate, B1) and `_build_compound_blocking` (candidate pool, B2).
+- **Modify** `goldenmatch/core/autoconfig_controller.py`: `ControllerBudget.for_dataset` (iteration scaling) + the commit/raise path (A, reconciled with the #417 guard at `:879-937`).
+- **Modify** `goldenmatch/_api.py` + `core/autoconfig.py::auto_configure_df`: thread `allow_red_config`.
+- **Create** `tests/test_autoconfig_blocking_cost_715.py`, `tests/test_allow_red_config.py`.
+- **Create/Modify** `.github/workflows/repro-issue-715.yml`: add an at-scale sparse-zip blocking-bound assertion (or a new `repro-issue-715-blocking.yml`).
+
+---
+
+## Task 1: Block-size projection helper (B1 foundation)
+
+**Files:** Modify `goldenmatch/core/blocking_candidates.py`; Test `tests/test_autoconfig_blocking_cost_715.py`
+
+- [ ] **Step 1: failing test**
+```python
+from goldenmatch.core.blocking_candidates import project_max_block_size
+
+def test_project_max_block_size_scales_with_full_n():
+    # A key with max block 250 in a 5K sample projects up toward full N.
+    proj = project_max_block_size(sample_max_block=250, sample_n=5_000, full_n=1_000_000)
+    assert proj > 250  # must grow toward full scale
+    # identity when sample IS full data
+    assert project_max_block_size(4055, 200_000, 200_000) == 4055
+```
+- [ ] **Step 2:** run, confirm ImportError/fail.
+- [ ] **Step 3: implement** `project_max_block_size`. Block size for a fixed-cardinality key scales ~linearly with N (a key's block holds a fixed *fraction* of rows): `projected = sample_max_block * (full_n / sample_n)`, clamped to `[sample_max_block, full_n]`. Return `sample_max_block` when `full_n <= sample_n`. Document why linear (not sqrt): block size is a fraction of N, unlike distinct-count which is sublinear. Mirror the env-opt-out / clamp style of `scale_cardinality_ratio_to_full_population`.
+- [ ] **Step 4:** run, pass.
+- [ ] **Step 5: commit** `feat(autoconfig): add project_max_block_size for full-N blocking cost (#715)`.
+
+---
+
+## Task 2: B1 — gate every emitted blocking key/pass by projected block size
+
+**Files:** Modify `goldenmatch/core/autoconfig.py` (`build_blocking`, ~1387-1503); Test same file.
+
+Context: v0 runs `build_blocking` on the full df (non-distributed), so `_max_block_size(cols)` is exact; for safety/distributed reuse `project_max_block_size(_max_block_size(cols), df.height, n_rows_full)`. The name-fallback emits `keys=[soundex(best_name)]` + soundex/substring passes with NO per-pass size gate — that's the bug.
+
+- [ ] **Step 1: failing test** — sparse-zip healthcare profiles (use the generator from `scripts/repro_issue_715.py::make_healthcare_df`, with zip5 ~50% present) at N where `soundex(name)`/single-name passes exceed `max_safe_block`. Assert: every key in `blocking.keys` AND every pass in `blocking.passes` has projected max block size `<= blocking.max_block_size` (i.e., no oversized pass emitted).
+```python
+def _proj(df, cols, full_n):
+    from goldenmatch.core.blocking_candidates import project_max_block_size
+    mb = int(df.group_by(cols).len().get_column("len").max() or 0)
+    return project_max_block_size(mb, df.height, full_n)
+
+def test_no_emitted_blocking_pass_exceeds_cap_on_sparse_zip():
+    # build sparse-zip df at, say, 30K; n_rows_full simulates 1M
+    ...
+    blk = build_blocking(profiles, df, n_rows_full=1_000_000)
+    cap = blk.max_block_size
+    for k in (blk.keys or []):
+        assert _proj(df, k.fields, 1_000_000) <= cap, (k.fields, "key oversized")
+    for p in (blk.passes or []):
+        # single-column soundex passes are the offenders
+        assert _proj(df, p.fields, 1_000_000) <= cap, (p.fields, "pass oversized")
+```
+- [ ] **Step 2:** run, confirm FAIL (an oversized `soundex(name)` pass is currently emitted).
+- [ ] **Step 3: implement.** After constructing the candidate pass list in the name-fallback branches (both the geo-compound branch ~1448-1475 and the no-geo branch ~1477-1503), FILTER passes: drop any pass whose `project_max_block_size(_max_block_size(p.fields), df.height, n_rows_full)` exceeds `max_safe_block`. The primary `keys=` must also be bounded — if the chosen `best_name`/soundex key is oversized, prefer a bounded compound (from Task 3 / `_build_compound_blocking`) or, if none survives, return a config the controller will read as degenerate (empty `keys` -> existing `#417` guard / new RED path handles it). Add an INFO log naming dropped oversized passes. Keep `skip_oversized=True`/`max_block_size` runtime filter as-is (defense in depth).
+- [ ] **Step 4:** run, pass. Also re-run with DENSE zip5 and assert the bounded `zip5+last_name` compound is still chosen (no regression on the good shape).
+- [ ] **Step 5: commit** `fix(autoconfig): drop oversized blocking passes by projected full-N block size (#715)`.
+
+---
+
+## Task 3: B2 — compound search uses sparse/identifier-typed numeric columns
+
+**Files:** Modify `goldenmatch/core/autoconfig.py` (`_build_compound_blocking`, ~872-895); Test same file.
+
+- [ ] **Step 1: failing test** — sparse zip5 (reclassified `identifier`, ~50% null) profiles; assert `_build_compound_blocking` returns a config whose primary key includes `zip5` (e.g. `zip5+last_name`) with projected max block `<= max_safe_block`.
+- [ ] **Step 2:** run, confirm FAIL (zip5 excluded today: `col_type=="identifier"` and null>20%).
+- [ ] **Step 3: implement.** In the candidate pool (`:890-895`): (a) stop excluding `col_type == "identifier"`; instead include a column when its single-column block size is non-singleton (`_max_block_size > 1`) AND `cardinality_ratio < 1.0` (exclude surrogate keys). (b) For the null ceiling: a high-null column is admissible as a compound *component* in a multi_pass set (other passes cover the null rows), so relax the `_null_rate <= max_null_rate` gate for the compound-component role only — keep it for single-key blocking. Keep `numeric`/`date` excluded. Keep `_check_source_overlap > 0`. NOTE: `_build_compound_blocking(profiles, df, max_safe_block, max_null_rate)` has no `n_rows_full` param; block-size checks here use `_max_block_size` on the build `df` directly, exact at the v0-on-full-df path. Threading `n_rows_full` in is OUT OF SCOPE unless a distributed/sample caller needs it.
+- [ ] **Step 4:** run, pass. Re-run Task 2's dense-zip no-regression check.
+- [ ] **Step 5: commit** `fix(autoconfig): admit sparse/identifier numeric cols to compound blocking (#715)`.
+
+---
+
+## Task 4: Iteration-budget scaling (add-on)
+
+**Files:** Modify `goldenmatch/core/autoconfig_controller.py` (`ControllerBudget.for_dataset`, ~419-440); Test `tests/test_autoconfig_blocking_cost_715.py`.
+
+- [ ] **Step 1: failing test**
+```python
+from goldenmatch.core.autoconfig_controller import ControllerBudget
+def test_max_iterations_scales_with_size():
+    assert ControllerBudget.for_dataset(2_000_000).max_iterations > \
+           ControllerBudget.for_dataset(10_000).max_iterations
+```
+- [ ] **Step 2:** run, confirm FAIL (fixed at 3).
+- [ ] **Step 3: implement.** In each size tier of `for_dataset`, set `max_iterations`: `<100K -> 3` (default), `100K-1M -> 4`, `>=1M -> 5`. Update the docstring tier table. Add an inline note that this is non-load-bearing for #715 (sample masks at-scale blocking blow-up) per the spec.
+- [ ] **Step 4:** run, pass.
+- [ ] **Step 5: commit** `feat(autoconfig): scale controller max_iterations with dataset size (#715)`.
+
+---
+
+## Task 5: A — allow_red_config default-raise
+
+**Files:** Modify `goldenmatch/core/autoconfig_controller.py` (commit/raise path ~843-937, 1067-1078), `goldenmatch/core/autoconfig.py::auto_configure_df`, `goldenmatch/_api.py` (`dedupe_df`/`match_df`); Test `tests/test_allow_red_config.py`.
+
+- [ ] **Step 1: failing tests** (mirror `tests/test_api_confidence_required_kwarg.py` patterns — monkeypatch a forced-RED history):
+  - default (`allow_red_config=False`): `auto_configure_df` on a RED commit RAISES — **including a small-N (<100K) case** (default-raise is independent of REFUSE_AT_N).
+  - `allow_red_config=True`: returns the config (today's warn-and-run).
+  - `confidence_required` default unchanged otherwise.
+- [ ] **Step 2:** run, confirm FAIL (no such kwarg; small-N RED runs today).
+- [ ] **Step 3: implement.**
+  - Add `allow_red_config: bool = False` to `AutoConfigController.run`, `auto_configure_df`, `dedupe_df`, `match_df`; thread through.
+  - In the commit path: when committed health is RED with `stop_reason` set, and `not allow_red_config`, raise. Reconcile with the existing #417 guard (`:879-937`) and the confidence gate (`:857`): compute the raise decision ONCE, choose the most specific `failing_sub_profile`/message (blocking-degenerate if that's it, else generic RED), and raise a single error. Reuse `ControllerNotConfidentError` (extend its message to mention `allow_red_config=True`) rather than a second exception type.
+  - `allow_red_config=True` short-circuits all RED-refuse paths to warn-and-run.
+- [ ] **Step 4:** run, pass.
+- [ ] **Step 5: commit** `feat(autoconfig): allow_red_config — refuse RED configs by default (#715)`.
+
+---
+
+## Task 6: At-scale CI repro (the mandatory gap-closer) + verdict reframe
+
+**Files:** Modify `.github/workflows/repro-issue-715.yml` (or add `repro-issue-715-blocking.yml`); Modify `scripts/repro_issue_715.py`.
+
+A sample-sized unit test cannot catch the at-scale blocking blow-up — that is why #715 reopened. This CI job is mandatory.
+
+- [ ] **Step 1:** extend `scripts/repro_issue_715.py` (or add a sibling) to: generate the sparse-zip healthcare shape at a `--rows` count (default 500K), run the FULL `auto_configure_df(df, allow_red_config=True)` (so it doesn't raise) AND inspect the committed config's blocking; compute each emitted key/pass's max block size on the full df; print `BLOCKING BOUNDED` if all `<= max_safe_block`, else `BLOCKING UNBOUNDED: <fields>=<size>`.
+- [ ] **Step 2:** workflow step asserts the log contains `BLOCKING BOUNDED` and fails on `BLOCKING UNBOUNDED`. Run at >= 500K on `large-new-64GB` (per the bench-runner default).
+- [ ] **Step 3: commit** `test(autoconfig): at-scale sparse-zip blocking-bound CI assertion (#715)`.
+
+---
+
+## Task 7: Validation + PR + land
+
+- [ ] **Step 1:** Full targeted test files green locally; ruff clean on all changed files.
+- [ ] **Step 2:** `#528` quality gate (CI) + DQbench T1/T2/T3 (per `project_issue_489_zerolabel_gate`): confirm no recall regression from dropping oversized recall passes / changed blocking selection. Record before/after in the PR. **Hard gate** — the blocking-selection change is the recall risk.
+- [ ] **Step 3:** Push (`benzsevern` auth dance), open PR to `main` linking #715; paste the at-scale `BLOCKING BOUNDED` output + DQbench numbers.
+- [ ] **Step 4:** Wait `python (goldenmatch)` + `ci-required` green; dispatch the at-scale repro workflow on the PR branch and confirm `BLOCKING BOUNDED`.
+- [ ] **Step 5:** Squash-merge `--delete-branch`; comment on #715 with the reproduced root cause (unbounded soundex pass + sparse-zip->identifier drop + fixed iterations + runs-on-RED) and the four-part fix; confirm closed.

--- a/docs/superpowers/plans/2026-06-04-cluster-split-budget-661-726.md
+++ b/docs/superpowers/plans/2026-06-04-cluster-split-budget-661-726.md
@@ -1,0 +1,562 @@
+# Cluster split efficiency + edge-work budget (#661 + #726) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split an oversized cluster all the way down to `max_cluster_size` from a SINGLE max-spanning-tree build (kills the O(E·k) re-MST pathology, #661), scale the auto-split edge-work budget to dataset size + make it config-tunable, and turn the budget-exhaustion path into a loud, actionable warning that keeps the oversized clusters in the output flagged rather than silently losing them (#726).
+
+**Architecture:** A new pure-Python `split_oversized_cluster_to_size(members, pair_scores, max_size)` builds the MST once, then repeatedly cuts the weakest tree edge of any still-oversized component (a sub-tree of a max spanning tree IS the max spanning tree of its induced sub-graph — proven below — so cutting original tree edges reproduces today's per-component re-MST cut decisions, yielding the **identical membership partition**). The two callers (`_finalize_clusters` dict/columnar path and the `build_cluster_frames` inline loop) drop their per-pass re-MST loop and call the batch function once per top-level oversized cluster, charging `edge_work` once per top-level cluster. The budget becomes `max(5_000_000, n_rows * C)` with precedence config-field > env > auto-scaled.
+
+**What "byte-identical" means here (read carefully — this scopes the whole plan).** The BINDING invariant is the **membership partition** (which records co-cluster) — that is what the cycle-property proof guarantees and what the #528 quality gate + the columnar/dict parity gate enforce. Integer **cluster-id labels** for split clusters are NOT a cross-version durability contract: identity entity_ids are content-based stable record fingerprints (the `:h1:` scheme), not the ephemeral `cluster_id`, so a label reshuffle for split clusters does not move entity_ids. What IS required for labels: (a) **run-to-run determinism** (guaranteed by sort-by-min-member), and (b) **the dict path and the columnar/frames path produce the SAME labels as each other** (the existing `test_columnar_drop_pairscores_byte_identical` gate, which both paths satisfy because both adopt the same batch function and the same caller labeling). To keep (b) and (a) intact, both callers MUST iterate top-level oversized clusters in the same order and the batch function MUST emit sub-clusters deterministically (specified in Task 2). The plan does NOT claim — and does not need — label equality against the pre-#661 release.
+
+**Tech Stack:** Python 3.12, polars, numpy, pytest; optional Rust native kernel (`mst_split_components`) stays available but is no longer on the oversized-split hot path. uv workspace; run tests via `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest` (Windows local) per `packages/python/CLAUDE.md`.
+
+---
+
+## Why the single-MST batch split is byte-identical (read before coding)
+
+Today (`split_oversized_cluster`, `core/cluster.py:157`): for each oversized cluster the caller filters that cluster's induced pairs (`ps = {(a,b):s for a,b,s in pairs_list if a in ms and b in ms}`, O(E)), builds the max spanning tree from `ps` (`_build_mst`, Kruskal score-desc + stable sort, O(E log E)), removes the SINGLE weakest tree edge (`min(mst, key=e[2])`, first-minimum tie-break), and re-unions. The caller re-enqueues each still-oversized sub-cluster and **repeats the whole filter + MST build** — O(E·k) for k cuts (#661).
+
+**Key theorem (cycle property):** Let `T` be a maximum spanning tree of `G`. Remove an edge of `T`, splitting it into components `C1, C2`. Then `T` restricted to `C1` is a maximum spanning tree of the induced sub-graph `G[C1]`. Proof: if some edge `e=(u,v)` with both endpoints in `C1`, `e ∉ T`, were heavier than the lightest edge on the `T`-path between `u` and `v` (a path lying entirely in `C1`), then `T` would not be a maximum spanning tree of `G` (cycle property violated). No such `e` exists, so `T[C1]` is already maximum for `G[C1]`. □
+
+Therefore cutting weakest **tree edges of the one original MST** produces the SAME components, with the SAME first-minimum tie-break, as today's per-component re-MST. Tie-break order is preserved because the induced edge sort is a subsequence of the full edge sort (same relative order), Kruskal selects the identical tree-edge set, so iteration order — and thus `min(...)`'s first-minimum — matches. The batch function reuses the existing `compute_cluster_confidence` / pair-partition code per final sub-cluster, so confidence + bottleneck_pair are unchanged. This guarantees the **membership partition** is identical to the old loop's; see the Architecture note above for why cluster-id label equality vs the old release is NOT claimed.
+
+**The automated backstops:**
+- NEW old-vs-new MEMBERSHIP equivalence test (Task 1): a faithful reference that runs the REAL old algorithm (repeated single-edge `split_oversized_cluster` + re-enqueue) and asserts the batch function returns the SAME set of `frozenset(members)` with the same per-component confidence/bottleneck. This locks the partition against the actual pre-#661 behavior (NOT tautological — the reference uses the unchanged single-edge function, a genuinely different code path from the batch loop).
+- `tests/test_columnar_drop_pairscores_parity.py::test_columnar_drop_pairscores_byte_identical` (columnar vs dict path: members-as-set, size, oversized, confidence EXACT float, bottleneck_pair, cluster_quality, AND cluster ids byte-identical) — this enforces label invariant (b): the two live paths agree. Extend with fixtures that have ≥2 oversized top-level clusters and a ≥3-component split (Task 3).
+- `tests/test_native_parity.py::test_split_oversized_cluster_parity` (single-edge `split_oversized_cluster` native-vs-python) — must still pass; `split_oversized_cluster` is NOT removed.
+- The #528 in-house quality gate (CI) — the co-clustering / F1 backstop on real benchmark data.
+
+## Out of scope (per spec)
+- Min-cut quality upgrade (#661 optional). Changes co-clustering, breaks invariance gate. Deferred.
+- EM non-convergence (#726 hypothesis 3). Parked as a follow-up note on #726.
+
+## File structure
+
+- `packages/python/goldenmatch/goldenmatch/core/cluster.py` — add `split_oversized_cluster_to_size`; change `_split_edge_work_budget` signature; rewrite the two split loops in `_finalize_clusters` (`:873-923`) and `build_cluster_frames` (`:588-669`) to call it once per top-level oversized cluster; thread `n_rows` + budget override; upgrade the WARNING text. `split_oversized_cluster` (`:157`) STAYS.
+- `packages/python/goldenmatch/goldenmatch/config/schemas.py` — add `split_edge_budget: int | None = None` to `GoldenRulesConfig` (`:439`).
+- `packages/python/goldenmatch/goldenmatch/core/pipeline.py` — unpack `split_edge_budget` from `config.golden_rules` (`:1455-1461`) and pass it + `n_rows=len(all_ids)` to the three build call sites (`:1497`, `:1504`, `:1519`).
+- `packages/python/goldenmatch/goldenmatch/core/cluster.py` build-function signatures — the FULL dispatch chain gains `split_edge_budget: int | None = None` (keyword, default None → unchanged behavior): public `build_clusters` (`:361`), `build_cluster_frames` (`:463`), `build_clusters_columnar` (`:1568`); AND the private wrappers `build_clusters` dispatches into — `_build_clusters_dict_path` (`:756`, calls `_finalize_clusters` at `:831`) and `_build_clusters_via_frames` (`:967`, calls `_finalize_clusters` at `:1044`); AND `_finalize_clusters` (`:836`) itself. `build_clusters_v2_columnar` (`:1849`) and `build_clusters_arrow_native` (`:1903`) forward into `build_clusters` and are NOT on the pipeline cluster-step path; leave them at the auto-scale default (do not thread the field) — note this in the plan so it's a deliberate omission, not a miss.
+- Tests: extend `tests/test_columnar_drop_pairscores_parity.py`; new `tests/test_cluster_split_to_size.py` (equivalence + perf + budget + failure-mode).
+
+---
+
+### Task 1: `split_oversized_cluster_to_size` — single-MST batch split (#661 root fix)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py` (add function after `split_oversized_cluster`, ~`:224`)
+- Test: `packages/python/goldenmatch/tests/test_cluster_split_to_size.py` (create)
+
+The function runs the SAME cut decisions the callers run today, but builds the MST ONCE and filters pairs ONCE. It returns final sub-clusters in a deterministic order (sort-by-min-member at each cut, oversized re-enqueued LIFO) so the two live callers assign labels consistently. Global `next_cid` labeling stays with the caller — this function only produces the partition + per-sub confidence/bottleneck.
+
+- [ ] **Step 1: Write the membership-equivalence test (failing) — faithful OLD reference via the unchanged single-edge function**
+
+```python
+# tests/test_cluster_split_to_size.py
+"""#661: split_oversized_cluster_to_size builds the MST once and splits all the
+way to max_size, producing the SAME membership partition (and per-component
+confidence/bottleneck) as the old repeated single-weakest-edge loop. The
+reference below drives the UNCHANGED single-edge split_oversized_cluster, so it
+is a genuinely different code path from the batch loop (not tautological)."""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core.cluster import (
+    split_oversized_cluster,
+    split_oversized_cluster_to_size,
+)
+
+
+def _old_partition(members, pair_scores, max_size):
+    """Reference: the pre-#661 algorithm. Repeatedly call the unchanged
+    single-edge split_oversized_cluster on any still-oversized component,
+    re-filtering that component's induced pairs each pass (exactly what
+    _finalize_clusters:880-915 did). Returns the FINAL list of sub-cluster
+    dicts. No cluster-id labeling here — this test locks the PARTITION, not
+    labels (label parity across the two live paths is locked separately by
+    test_columnar_drop_pairscores_byte_identical)."""
+    work = [list(members)]
+    final = []
+    while work:
+        comp = work.pop()
+        if len(comp) <= max_size:
+            final.append(comp)
+            continue
+        ms = set(comp)
+        ps = {(a, b): s for (a, b), s in pair_scores.items() if a in ms and b in ms}
+        subs = split_oversized_cluster(comp, ps)
+        if len(subs) <= 1:
+            final.append(comp)        # unsplittable: stays as-is, oversized
+            continue
+        for sc in subs:
+            work.append(sc["members"])
+    return final
+
+
+def _dense_clique(nodes, score=0.99):
+    return {(a, b): score for i, a in enumerate(nodes) for b in nodes[i + 1:]}
+
+
+@pytest.mark.parametrize("native", ["0", "1"])
+def test_batch_split_membership_matches_old(monkeypatch, native):
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    # Splits into 3 components at max_size=2: three cliques joined by 2 weak bridges.
+    members = list(range(10, 19))
+    ps = {}
+    ps.update(_dense_clique([10, 11, 12]))
+    ps.update(_dense_clique([13, 14, 15]))
+    ps.update(_dense_clique([16, 17, 18]))
+    ps[(12, 13)] = 0.30   # weak bridge 1
+    ps[(15, 16)] = 0.25   # weak bridge 2
+    got = split_oversized_cluster_to_size(members, ps, max_size=2)
+    want = _old_partition(members, ps, max_size=2)
+    # Membership partition is the binding invariant: compare as a set of frozensets.
+    assert {frozenset(s["members"]) for s in got} == {frozenset(c) for c in want}
+    # Per-sub confidence/bottleneck must match the single-edge path too. Index by
+    # frozenset(members) since order is not the contract here.
+    from goldenmatch.core.cluster import compute_cluster_confidence
+    for s in got:
+        ms = set(s["members"])
+        induced = {(a, b): v for (a, b), v in ps.items() if a in ms and b in ms}
+        ref = compute_cluster_confidence(induced, len(ms))
+        assert round(s["confidence"], 12) == round(ref["confidence"], 12)
+        assert s["bottleneck_pair"] == ref["bottleneck_pair"]
+```
+
+- [ ] **Step 2: Run it to confirm it fails (function undefined)**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_cluster_split_to_size.py -v`
+Expected: FAIL — `ImportError: cannot import name 'split_oversized_cluster_to_size'`.
+
+- [ ] **Step 3: Implement `split_oversized_cluster_to_size`**
+
+Build the MST once, run the loop over tree-edge subsets (NOT re-filtered pairs), partition pair_scores once at the end per final component. Reuse `_build_mst`, `UnionFind`, `compute_cluster_confidence`.
+
+```python
+def split_oversized_cluster_to_size(
+    members: list[int],
+    pair_scores: dict[tuple[int, int], float],
+    max_size: int,
+) -> list[dict]:
+    """Split a cluster down to ``max_size`` from a SINGLE MST build (#661).
+
+    Repeatedly cuts the weakest tree edge of any component still larger than
+    ``max_size``. A sub-tree of a maximum spanning tree IS the maximum spanning
+    tree of its induced sub-graph (cycle property), so cutting original tree
+    edges reproduces the old per-component re-MST cut decisions (same membership
+    partition, same first-minimum tie-break). Returns final sub-clusters in a
+    DETERMINISTIC order (sort-by-min-member at each cut, oversized components
+    re-enqueued LIFO) so the two live callers label consistently and run-to-run.
+
+    Components that cannot be cut further (no remaining cuttable tree edge) are
+    returned still oversized (``oversized=True``)."""
+    if len(members) <= max_size or len(members) <= 1 or not pair_scores:
+        size = len(members)
+        return [{"members": sorted(members), "size": size,
+                 "oversized": size > max_size, "pair_scores": pair_scores,
+                 **_confidence_fields(pair_scores, size)}]
+
+    # Build the MST ONCE. Native single-edge kernel is NOT used here (it does one
+    # cut per call); the proven sub-tree property lets us do all cuts on the one
+    # Python MST. split_oversized_cluster (single-edge) stays for its callers.
+    tree_edges = _build_mst(members, pair_scores)
+    if not tree_edges:
+        size = len(members)
+        return [{"members": sorted(members), "size": size,
+                 "oversized": size > max_size, "pair_scores": pair_scores,
+                 **_confidence_fields(pair_scores, size)}]
+
+    # Loop mirrors _finalize_clusters:877-915. A "work item" = (member set, its
+    # tree-edge list). Cut the weakest tree edge; the two resulting components'
+    # tree edges are the partition of the remaining tree edges (the cut edge is
+    # dropped). sort-by-min-member + LIFO re-enqueue reproduce creation order.
+    out_order: list[tuple[frozenset[int], list]] = []
+    work: list[tuple[set[int], list]] = [(set(members), list(tree_edges))]
+    while work:
+        node_set, edges = work.pop()
+        if len(node_set) <= max_size or not edges:
+            out_order.append((frozenset(node_set), edges))
+            continue
+        weakest = min(edges, key=lambda e: e[2])  # first-minimum, same as today
+        remaining = [e for e in edges if e is not weakest]
+        uf = UnionFind()
+        uf.add_many(list(node_set))
+        for a, b, _s in remaining:
+            uf.union(a, b)
+        comps = uf.get_clusters()           # 2 components
+        # bucket remaining tree edges to their component
+        rep_to_edges: dict[int, list] = {}
+        node_to_rep = {n: uf.find(n) for n in node_set}
+        for e in remaining:
+            rep_to_edges.setdefault(node_to_rep[e[0]], []).append(e)
+        sub_items = [(c, rep_to_edges.get(uf.find(next(iter(c))), [])) for c in comps]
+        # creation order: sort by min member; oversized ones go back on the stack
+        sub_items.sort(key=lambda ci: min(ci[0]))
+        for c, ce in sub_items:
+            if len(c) > max_size:
+                work.append((set(c), ce))
+            else:
+                out_order.append((frozenset(c), ce))
+
+    # Partition pair_scores once across the final components (single O(E) pass).
+    final_sets = [s for s, _e in out_order]
+    member_to_idx: dict[int, int] = {}
+    for idx, s in enumerate(final_sets):
+        for m in s:
+            member_to_idx[m] = idx
+    sub_pairs: list[dict] = [{} for _ in final_sets]
+    for (a, b), sc in pair_scores.items():
+        ia = member_to_idx.get(a)
+        if ia is not None and ia == member_to_idx.get(b):
+            sub_pairs[ia][(a, b)] = sc
+
+    result = []
+    for idx, s in enumerate(final_sets):
+        sc_list = sorted(s)
+        size = len(sc_list)
+        result.append({
+            "members": sc_list, "size": size, "oversized": size > max_size,
+            "pair_scores": sub_pairs[idx],
+            **_confidence_fields(sub_pairs[idx], size),
+        })
+    return result
+
+
+def _confidence_fields(pair_scores: dict, size: int) -> dict:
+    conf = compute_cluster_confidence(pair_scores, size)
+    return {"confidence": conf["confidence"], "bottleneck_pair": conf["bottleneck_pair"]}
+```
+
+> NOTE for implementer: `_DEFAULT_SPLIT_EDGE_WORK_BUDGET` (`:34`) and `compute_cluster_confidence` (`:1211`) are retained — do not delete them. The batch function MUST route confidence through `compute_cluster_confidence` (no alternate recompute), or the EXACT-float assertion in `test_columnar_drop_pairscores_byte_identical` breaks. The membership-equivalence test (Step 1) is the binding partition lock; if it fails, the cut decisions diverged — do NOT "fix" by changing tie-break or enqueue order to chase it, debug the MST sub-tree handling.
+
+- [ ] **Step 4: Run the membership-equivalence test — expect PASS (native=0 and native=1)**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_cluster_split_to_size.py::test_batch_split_membership_matches_old -v`
+Expected: PASS for both `native` params.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/cluster.py packages/python/goldenmatch/tests/test_cluster_split_to_size.py
+git commit -m "feat(cluster): single-MST batch split_oversized_cluster_to_size (#661)"
+```
+
+---
+
+### Task 2: Wire both split loops to the batch function (once per top-level cluster)
+
+Replace the per-pass re-MST + re-enqueue in `_finalize_clusters` (`:877-915`) and `build_cluster_frames` (`:588-669`) with a single `split_oversized_cluster_to_size` call per top-level oversized cluster, charging `edge_work` once per top-level cluster. The global `next_cid` labeling stays in the caller, assigned over the batch function's returned order.
+
+**Label-parity requirement (BOTH callers MUST match each other — gated by `test_columnar_drop_pairscores_byte_identical`):**
+- Iterate top-level oversized clusters in a SINGLE fixed order in BOTH callers. The old `_finalize_clusters` drained `to_split` LIFO; to keep new-dict == new-columnar, pick ONE order and use it in both — recommended: iterate `sorted(oversized_cids)` ascending (simplest, deterministic, identical in both callers). Whatever you choose, it MUST be the same in `_finalize_clusters` and `build_cluster_frames`.
+- For each top-level oversized cluster, after `subs = split_oversized_cluster_to_size(...)`, assign sequential cids to `subs` IN THE ORDER THE BATCH FUNCTION RETURNS THEM (it is already sorted-by-min-member deterministic), starting at `max(live_cids, default=0) + 1`. Do this identically in both callers.
+- The parity gate (Task 3) is the proof these two paths agree; if it fails, the two callers' iteration/labeling diverged.
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py:877-915` (`_finalize_clusters` split loop; warning `:916-923`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py:588-669` (`build_cluster_frames` inline loop)
+
+- [ ] **Step 1: Rewrite `_finalize_clusters` split loop**
+
+Build `oversized_cids = sorted(cid for cid, c in result.items() if c["oversized"])` (when `auto_split`). For each cid in that order: materialize its `pair_scores` (dict path already has them; columnar path materializes from `raw_pairs` as today), charge `edge_work += len(pair_scores)` ONCE, check budget (break, leaving this + remaining cids oversized in `result`), then `subs = split_oversized_cluster_to_size(cinfo["members"], cinfo["pair_scores"], max_cluster_size)`. If `len(subs) <= 1` leave intact (`cinfo["oversized"] = cinfo["size"] > max_cluster_size`; keep in `result`). Else `result.pop(cid)`, then `next_cid = max(result.keys(), default=0) + 1` and emit each sub in returned order: `sc["_was_split"] = True`, `result[next_cid] = sc`, `next_cid += 1`. NO re-enqueue — the batch function already split fully; a sub returned `oversized=True` (uncuttable dense blob) stays flagged and is NOT re-enqueued.
+
+- [ ] **Step 2: Rewrite `build_cluster_frames` inline loop (`:588-669`) the same way**
+
+Same shape and SAME top-level order (`sorted(oversized)`): per top-level oversized cid, filter `ps` once, charge once, call the batch function, then label sequentially via `next_cid` over `live_cids` in the batch function's returned order. Preserve `quality="split"`, the `drop_cids` set, and the materialize-rows-at-end structure. A returned-oversized sub stays in `split_result` flagged (its metadata row carries `oversized=True`). Drop the inner `while to_split` re-enqueue (the batch function owns the full split now).
+
+- [ ] **Step 3: Run the byte-identical parity test (the hard backstop)**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_columnar_drop_pairscores_parity.py -v`
+Expected: PASS (native 1 and 0). This asserts cluster ids + all fields byte-identical across paths after the rewrite.
+
+- [ ] **Step 4: Run the columnar cluster-build + pipeline parity suites**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py packages/python/goldenmatch/tests/test_columnar_pipeline_parity.py packages/python/goldenmatch/tests/test_native_parity.py -v`
+Expected: PASS — partition + labels + native-vs-python all unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/cluster.py
+git commit -m "refactor(cluster): both split loops call batch split once per top-level cluster (#661)"
+```
+
+---
+
+### Task 3: Add ≥2-oversized-top-level + ≥3-component fixtures to the byte-identical parity test
+
+The existing `_adversarial_pairs` has a dense clique that can't split and a barbell that splits once. Add (a) a cluster that splits into ≥3 components, and (b) a SECOND oversized top-level cluster, so the parity gate exercises the batch loop's repeated cuts AND the two callers' top-level iteration/labeling order agreement (the Task 2 label-parity requirement).
+
+**Files:**
+- Modify: `packages/python/goldenmatch/tests/test_columnar_drop_pairscores_parity.py` (`_adversarial_pairs`)
+
+- [ ] **Step 1: Add two new oversized groups to `_adversarial_pairs`**
+
+First check the `max_cluster_size` the test passes to `build_clusters` (read the test body; the parametrized call sets it — likely 5). Add, sized to exceed it:
+- Group A (nodes 40..48): three dense cliques `{40,41,42}`, `{43,44,45}`, `{46,47,48}` joined by weak bridges `(42,43)=0.30`, `(45,46)=0.25` — splits into 3.
+- Group B (nodes 50..57): two dense cliques `{50,51,52,53}`, `{54,55,56,57}` joined by weak bridge `(53,54)=0.28` — a SECOND oversized top-level cluster that splits into 2.
+
+Append `list(range(40,49)) + list(range(50,58))` to `all_ids`. Two oversized top-level clusters means the test now catches any divergence in top-level iteration order / cid assignment between the dict and columnar paths.
+
+- [ ] **Step 2: Run it — expect PASS (columnar == dict, native 1 and 0)**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_columnar_drop_pairscores_parity.py -v`
+Expected: PASS — the 3-way split has byte-identical members/ids/confidence across paths.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/tests/test_columnar_drop_pairscores_parity.py
+git commit -m "test(cluster): dense 3-component split fixture in byte-identical parity gate (#661)"
+```
+
+---
+
+### Task 4: Perf guard — MST built once per top-level oversized cluster (#661)
+
+Lock the #661 fix: on a dense cluster that peels into many components, `_build_mst` must be called ONCE per top-level oversized cluster, not once per cut.
+
+**Files:**
+- Test: `packages/python/goldenmatch/tests/test_cluster_split_to_size.py` (extend)
+
+- [ ] **Step 1: Write the perf-invariant test (failing if loop re-MSTs)**
+
+```python
+def test_single_mst_build_per_top_level_cluster(monkeypatch):
+    """#661: a dense cluster peeling into k components builds the MST ONCE,
+    not k times. Instrument _build_mst call count."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    import goldenmatch.core.cluster as cl
+    calls = {"n": 0}
+    orig = cl._build_mst
+    monkeypatch.setattr(cl, "_build_mst",
+                        lambda m, ps: (calls.__setitem__("n", calls["n"] + 1), orig(m, ps))[1])
+    members = list(range(100, 130))           # 30-node dense-ish cluster
+    ps = {(a, b): 0.99 for i, a in enumerate(members) for b in members[i + 1:]}
+    # add a few weak bridges so it actually peels into several components
+    subs = cl.split_oversized_cluster_to_size(members, ps, max_size=5)
+    assert calls["n"] == 1                     # ONE MST build, not O(k)
+    assert all(s["size"] <= 5 or s["oversized"] for s in subs)
+
+
+def test_caller_invokes_batch_once_per_top_level_cluster(monkeypatch):
+    """#661: the build path calls split_oversized_cluster_to_size exactly once
+    per oversized TOP-LEVEL cluster (no per-pass re-call)."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    import goldenmatch.core.cluster as cl
+    calls = {"n": 0}
+    orig = cl.split_oversized_cluster_to_size
+    monkeypatch.setattr(cl, "split_oversized_cluster_to_size",
+                        lambda *a, **k: (calls.__setitem__("n", calls["n"] + 1), orig(*a, **k))[1])
+    # ONE oversized top-level cluster (15-node clique) -> exactly ONE batch call.
+    members = list(range(100, 115))
+    pairs = [(a, b, 0.99) for i, a in enumerate(members) for b in members[i + 1:]]
+    cl.build_clusters(pairs, all_ids=members, max_cluster_size=5)
+    assert calls["n"] == 1
+```
+
+- [ ] **Step 2: Run both — expect PASS**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_cluster_split_to_size.py -k "single_mst_build or caller_invokes" -v`
+Expected: PASS — one `_build_mst` per batch call, one batch call per top-level oversized cluster.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/tests/test_cluster_split_to_size.py
+git commit -m "test(cluster): assert single MST build + one batch call per oversized cluster (#661)"
+```
+
+---
+
+### Task 5: Budget scaling + config field (#726)
+
+`_split_edge_work_budget` becomes `_split_edge_work_budget(n_rows, override=None)` with precedence **override (config field) > `GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET` env > `max(5_000_000, n_rows * C)`** (C=5). Thread `split_edge_budget` + `n_rows` through the build functions.
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py:37-45` (`_split_edge_work_budget`)
+- Modify: `packages/python/goldenmatch/goldenmatch/config/schemas.py:443-446` (`GoldenRulesConfig`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py` build-fn signatures + `_finalize_clusters` calls
+- Modify: `packages/python/goldenmatch/goldenmatch/core/pipeline.py:1455-1524`
+- Test: `packages/python/goldenmatch/tests/test_cluster_split_to_size.py` (extend)
+
+- [ ] **Step 1: Write budget tests (failing)**
+
+```python
+def test_budget_autoscales_with_n_rows():
+    from goldenmatch.core.cluster import _split_edge_work_budget
+    assert _split_edge_work_budget(1000) == 5_000_000           # floor
+    assert _split_edge_work_budget(2_000_000) == 10_000_000     # n_rows * 5
+
+def test_budget_env_overrides_autoscale(monkeypatch):
+    from goldenmatch.core.cluster import _split_edge_work_budget
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "777")
+    assert _split_edge_work_budget(2_000_000) == 777
+
+def test_budget_config_override_beats_env(monkeypatch):
+    from goldenmatch.core.cluster import _split_edge_work_budget
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "777")
+    assert _split_edge_work_budget(2_000_000, override=12345) == 12345
+```
+
+- [ ] **Step 2: Run — expect FAIL (signature takes no args)**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_cluster_split_to_size.py -k budget -v`
+Expected: FAIL — `TypeError: _split_edge_work_budget() takes 0 positional arguments`.
+
+- [ ] **Step 3: Implement the new budget function**
+
+```python
+_SPLIT_EDGE_BUDGET_PER_ROW = 5  # C: linear edge-work allowance per input row
+
+def _split_edge_work_budget(n_rows: int, override: int | None = None) -> int:
+    """Cumulative-edge-work cap for the auto-split loop.
+
+    Precedence: explicit ``override`` (GoldenRulesConfig.split_edge_budget) >
+    GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET env > max(5M, n_rows * C). With the
+    single-MST batch split (#661) exhaustion is rare; this makes the rare case
+    scale-appropriate and tunable."""
+    if override is not None:
+        return max(1, int(override))
+    raw = os.environ.get("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET")
+    if raw is not None:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return max(_DEFAULT_SPLIT_EDGE_WORK_BUDGET, int(n_rows) * _SPLIT_EDGE_BUDGET_PER_ROW)
+```
+
+- [ ] **Step 4: Add `split_edge_budget` to `GoldenRulesConfig`**
+
+In `schemas.py` after `weak_cluster_threshold` (`:446`):
+```python
+    # #726: cap on cumulative auto-split edge-work. None => auto-scaled
+    # max(5_000_000, n_rows * 5). Raise this (or set
+    # GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET) if a loud "clusters left oversized"
+    # warning fires on a legitimately dense dataset. Precedence: this field >
+    # env > auto-scaled.
+    split_edge_budget: int | None = None
+```
+
+- [ ] **Step 5: Thread `n_rows` + `split_edge_budget` through the FULL dispatch chain**
+
+`build_clusters` does NOT call `_finalize_clusters` directly — it dispatches to `_build_clusters_dict_path` / `_build_clusters_via_frames`. Thread through every hop or the field silently collapses to the 5M floor (`n_rows=0`):
+- `build_clusters` (`:361`): add keyword `split_edge_budget: int | None = None`; pass it on BOTH dispatch calls — `_build_clusters_via_frames(..., split_edge_budget=split_edge_budget)` (`:427`) and `_build_clusters_dict_path(..., split_edge_budget=split_edge_budget)` (`:431`).
+- `_build_clusters_dict_path` (`:756`): add keyword `split_edge_budget: int | None = None`; at the `_finalize_clusters` call (`:831`) pass `n_rows=len(all_ids), split_edge_budget=split_edge_budget`.
+- `_build_clusters_via_frames` (`:967`): add keyword `split_edge_budget: int | None = None`; at the `_finalize_clusters` call (`:1044`) pass `n_rows=len(all_ids), split_edge_budget=split_edge_budget`.
+- `_finalize_clusters` (`:836`): add keyword params `n_rows: int = 0` and `split_edge_budget: int | None = None`; change `edge_budget = _split_edge_work_budget()` (`:875`) → `_split_edge_work_budget(n_rows, split_edge_budget)`.
+- `build_cluster_frames` (`:463`): add keyword `split_edge_budget: int | None = None`; in its inline loop `edge_budget = _split_edge_work_budget(len(all_ids), split_edge_budget)` (`all_ids` is in scope, derived at `:494`).
+- `build_clusters_columnar` (`:1568`): add keyword `split_edge_budget: int | None = None`; forward it on the `build_clusters(...)` call (`:1617`).
+- `pipeline.py`: in the unpack block (`:1455-1461`) read `split_edge_budget = getattr(config.golden_rules, "split_edge_budget", None)`; pass `split_edge_budget=split_edge_budget` to the three build call sites (`:1497` columnar, `:1504` frames, `:1519` dict).
+- Do NOT thread it into `build_clusters_v2_columnar` / `build_clusters_arrow_native` (off the pipeline cluster-step path; auto-scale default is correct there).
+
+- [ ] **Step 6: Run budget tests + a full-pipeline smoke**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_cluster_split_to_size.py -k budget packages/python/goldenmatch/tests/test_columnar_drop_pairscores_parity.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/cluster.py packages/python/goldenmatch/goldenmatch/config/schemas.py packages/python/goldenmatch/goldenmatch/core/pipeline.py packages/python/goldenmatch/tests/test_cluster_split_to_size.py
+git commit -m "feat(cluster): scale + config-tune auto-split edge budget (#726)"
+```
+
+---
+
+### Task 6: Loud, non-silent budget-exhaustion failure (#726 DX)
+
+The clusters are already KEPT and flagged oversized today; the gap is the warning doesn't name the knob. Upgrade both warnings (`_finalize_clusters:916-923` and `build_cluster_frames:638-640`) to name the count + the exact knobs (config field + env). No exception, no silent drop.
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py` (both `_clog.warning` call sites)
+- Test: `packages/python/goldenmatch/tests/test_cluster_split_to_size.py` (extend)
+
+- [ ] **Step 1: Write the failure-mode test (failing)**
+
+```python
+def test_budget_exhaustion_warns_and_keeps_clusters(monkeypatch, caplog):
+    """#726: tiny budget + a dense cluster -> WARNING names the knob AND the
+    oversized clusters stay in the output, flagged (NOT dropped)."""
+    import logging
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "1")  # exhaust immediately
+    from goldenmatch.core.cluster import build_clusters
+    members = list(range(200, 215))
+    pairs = [(a, b, 0.99) for i, a in enumerate(members) for b in members[i + 1:]]
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.cluster"):
+        clusters = build_clusters(pairs, all_ids=members, max_cluster_size=5)
+    # cluster(s) present and flagged oversized — not silently dropped
+    assert any(c["oversized"] for c in clusters.values())
+    assert sum(c["size"] for c in clusters.values()) == len(members)
+    msg = " ".join(r.message for r in caplog.records)
+    assert "split_edge_budget" in msg and "GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET" in msg
+```
+
+- [ ] **Step 2: Run — expect FAIL on the knob-name assertion**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_cluster_split_to_size.py::test_budget_exhaustion_warns_and_keeps_clusters -v`
+Expected: FAIL — current warning lacks `split_edge_budget` / env name.
+
+- [ ] **Step 3: Upgrade both warnings**
+
+```python
+_clog.warning(
+    "build_clusters: auto-split edge-work budget (%d) exhausted; %d cluster(s) "
+    "left OVERSIZED and flagged (kept in output, excluded from golden "
+    "downstream). Raise GoldenRulesConfig.split_edge_budget or env "
+    "GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET to split them.",
+    edge_budget, n_oversized,
+)
+```
+(and the `build_cluster_frames` twin, with its `n_oversized` count computed from the metadata frame.)
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_cluster_split_to_size.py::test_budget_exhaustion_warns_and_keeps_clusters -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/cluster.py packages/python/goldenmatch/tests/test_cluster_split_to_size.py
+git commit -m "feat(cluster): loud budget-exhaustion warning names the knob, keeps clusters flagged (#726)"
+```
+
+---
+
+### Task 7: Targeted regression run, dense-pathology check, PR
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Run the cluster + golden + pipeline test files locally**
+
+Run: `D:/show_case/gm-661/.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_cluster_split_to_size.py packages/python/goldenmatch/tests/test_columnar_drop_pairscores_parity.py packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py packages/python/goldenmatch/tests/test_columnar_pipeline_parity.py packages/python/goldenmatch/tests/test_native_parity.py -v`
+Expected: ALL PASS. (Per memory `feedback_avoid_full_suite_oom`: run targeted files locally; the FULL suite runs in GitHub Actions, never locally.)
+
+- [ ] **Step 2: Verify the known dense-split pathology no longer hangs**
+
+The `project_build_clusters_dense_split_pathology` fixture (auto-split peeling 1 node/pass on a large dense cluster) should now finish from one MST build. If a dedicated fixture exists, run it; otherwise the Task 4 perf test + Task 6 dense fixture cover the regression. Confirm no test exceeds the CI `--timeout=120`.
+
+- [ ] **Step 3: Push branch + open PR (auth dance per memory)**
+
+```bash
+git push -u origin feat/661-726-cluster-split
+# gh auth switch --user benzsevern  (benseverndev-oss uses personal account)
+# gh pr create against main; body references #661 + #726
+```
+PR body: single-MST batch split (#661 root), auto-scaled+config edge budget (#726), loud-warn-keep-flagged failure mode (#726). Note byte-identical clustering invariant held (parity gates green). Switch auth back to `benzsevern-mjh` after push.
+
+- [ ] **Step 4: Poll CI to green; ensure `python (goldenmatch)` + `synthetic_benchmarks` (#528) + `ci-required` pass**
+
+Use the poll loop from CLAUDE.md: `while gh pr checks <N> | grep -qE "pending|in_progress"; do sleep 30; done`. The #528 in-house quality gate is the co-clustering invariance backstop — it MUST be green (any drop means the split partition changed).
+
+- [ ] **Step 5: Merge on green (squash, delete branch), close #661 + #726**
+
+---
+
+## Risks (carried from spec)
+- **Component 1 silently changes co-clustering** (primary). Backstops: the cycle-property proof above, the membership-equivalence test against the real single-edge path (Task 1), the columnar/dict parity gate + new ≥2-oversized / ≥3-component fixtures (Tasks 2-3), and the #528 quality gate (Task 7).
+- **The two live callers (dict vs columnar/frames) assign DIFFERENT cluster-id labels for split clusters.** Mitigation: identical top-level iteration order (`sorted(oversized)`) + identical sequential labeling over the batch function's deterministic return order in both callers; `test_columnar_drop_pairscores_byte_identical` (extended with two oversized top-level clusters) is the proof. Note: label equality vs the PRE-#661 release is NOT a requirement (entity_ids are content-based fingerprints, not cluster_id; run-to-run determinism + cross-path parity + membership are the binding invariants).
+- **Native/Python divergence.** Mitigation: batch path is pure Python; `test_split_oversized_cluster_parity` keeps the single-edge native kernel honest; the parity gate runs native 1 and 0.
+- **Genuinely huge dense cluster still expensive.** Mitigation: one MST build bounds the cost; the scaled budget + loud-warn-and-keep handle the residual pathological case without a hang.

--- a/docs/superpowers/plans/2026-06-04-goldenembed-rs-finish-line.md
+++ b/docs/superpowers/plans/2026-06-04-goldenembed-rs-finish-line.md
@@ -1,0 +1,1101 @@
+# goldenembed-rs finish-line (#508) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish issue #508 by giving the standalone `goldenembed` Rust crate a persistent embedding cache, a throughput bench, and a real non-CPython caller (a DataFusion SQL embed UDF).
+
+**Architecture:** Three independently-shippable stages on top of the existing `packages/rust/extensions/goldenembed/` crate. A redb-backed two-tier cache keyed by a Python-parity `model_id + sha256(normalize_text)`; a `bench` CLI verb plus a Python side-by-side comparison harness; and a `goldenmatch_embed` DataFusion FFI ScalarUDF in the sibling `datafusion-udf` crate that depends on `goldenembed` by Cargo path (no FFI boundary). model_id parity is reproduced in Rust by parsing `weights.npz` — zero Python change.
+
+**Tech Stack:** Rust (`ort` 2.0-rc.10 onnxruntime, `redb`, `sha2`, `zip`, `blake2`), DataFusion 53 / Arrow 58 FFI ScalarUDFs (pyo3 abi3), Python (numpy) for fixtures + bench comparison.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-goldenembed-rs-finish-line-design.md`
+
+**Sequencing:** PR 1 = Stage A′ + A (model_id + cache). PR 2 = Stage B (bench). PR 3 = Stage C (UDF, spike-gated). B and C are independent once A′ lands.
+
+**Branch/auth note:** This work is in `packages/rust/extensions/` which uses the **personal** `benzsevern` GitHub account. Per repo SOP, branch `feature/goldenembed-finish-508`, squash-merge via PR, `gh auth switch --user benzsevern` before push and switch back after. `docs/superpowers/` is gitignored — do NOT `git add` the spec or this plan.
+
+**Rust bash preamble (prepend to every cargo command):**
+```bash
+export PATH="/c/Users/bsevern/.cargo/bin:$PATH" && export RUSTUP_HOME="C:/Users/bsevern/.rustup" && export CARGO_HOME="C:/Users/bsevern/.cargo"
+```
+
+**Crate dir for Stage A/B:** `packages/rust/extensions/goldenembed`
+**Crate dir for Stage C:** `packages/rust/extensions/datafusion-udf`
+
+---
+
+## Stage A′ — model_id parity (npz parse)
+
+### Task 1: Add deps + hex helper + model_id module skeleton
+
+**Files:**
+- Modify: `packages/rust/extensions/goldenembed/Cargo.toml`
+- Create: `packages/rust/extensions/goldenembed/src/model_id.rs`
+- Modify: `packages/rust/extensions/goldenembed/src/lib.rs`
+
+- [ ] **Step 1: Add dependencies**
+
+In `Cargo.toml` `[dependencies]`, add:
+```toml
+redb = "2"
+sha2 = "0.10"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+```
+(`zip` `deflate` feature covers both stored and deflated entries; `np.savez` uses stored, but enabling deflate is harmless and future-proofs against `savez_compressed`.)
+
+- [ ] **Step 2: Write the failing test for model_id npz parsing**
+
+Append to `src/model_id.rs`:
+```rust
+//! Reproduce the Python `GoldenEmbedModel.model_id` from a saved model dir,
+//! by hashing the raw array bytes inside `weights.npz` exactly as numpy's
+//! `ndarray.tobytes()` would — so the Rust runtime computes the same cache
+//! namespace as Python without a Python dependency.
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use blake2::digest::{Update, VariableOutput};
+use blake2::Blake2bVar;
+
+/// Lowercase hex of a byte slice (matches Python `hexdigest()`).
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Extract the raw data section of a `.npy` blob (skip magic + header).
+fn npy_data(buf: &[u8]) -> Result<&[u8]> {
+    if buf.len() < 10 || &buf[0..6] != b"\x93NUMPY" {
+        return Err(anyhow!("not a .npy buffer"));
+    }
+    let major = buf[6];
+    let data_start = if major >= 2 {
+        if buf.len() < 12 {
+            return Err(anyhow!("truncated v2 .npy header"));
+        }
+        12 + u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]) as usize
+    } else {
+        10 + u16::from_le_bytes([buf[8], buf[9]]) as usize
+    };
+    buf.get(data_start..).ok_or_else(|| anyhow!("truncated .npy"))
+}
+
+fn read_zip_entry(zip_path: &Path, name: &str) -> Result<Option<Vec<u8>>> {
+    let file = std::fs::File::open(zip_path)
+        .with_context(|| format!("opening {}", zip_path.display()))?;
+    let mut archive = zip::ZipArchive::new(file)?;
+    match archive.by_name(name) {
+        Ok(mut entry) => {
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf)?;
+            Ok(Some(buf))
+        }
+        Err(zip::result::ZipError::FileNotFound) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Reproduce `inhouse:d{dim}:{blake2b8(weights[+bias])}` from `<dir>/weights.npz`.
+pub fn compute_model_id(dir: &Path, dim: usize) -> Result<String> {
+    let zip_path = dir.join("weights.npz");
+    let weights = read_zip_entry(&zip_path, "weights.npy")?
+        .ok_or_else(|| anyhow!("weights.npy missing from {}", zip_path.display()))?;
+    let mut hasher = Blake2bVar::new(8).expect("blake2b-8 is valid");
+    hasher.update(npy_data(&weights)?);
+    if let Some(bias) = read_zip_entry(&zip_path, "bias.npy")? {
+        hasher.update(npy_data(&bias)?);
+    }
+    let mut out = [0u8; 8];
+    hasher.finalize_variable(&mut out).expect("8-byte output fits");
+    Ok(format!("inhouse:d{dim}:{}", hex(&out)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures")
+            .join(name)
+    }
+
+    #[test]
+    fn model_id_matches_python_no_bias() {
+        // EXPECTED_NO_BIAS is the model_id printed by the Python fixture
+        // generator (see Task 2). Paste the real value there.
+        let got = compute_model_id(&fixture("tiny_model"), 8).unwrap();
+        assert_eq!(got, EXPECTED_NO_BIAS);
+    }
+
+    #[test]
+    fn model_id_matches_python_with_bias() {
+        let got = compute_model_id(&fixture("tiny_model_bias"), 8).unwrap();
+        assert_eq!(got, EXPECTED_BIAS);
+    }
+
+    const EXPECTED_NO_BIAS: &str = "PLACEHOLDER_NO_BIAS";
+    const EXPECTED_BIAS: &str = "PLACEHOLDER_BIAS";
+}
+```
+
+Register the module in `src/lib.rs` after the `mod featurizer;` line:
+```rust
+pub mod model_id;
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cargo test -p goldenembed model_id --manifest-path packages/rust/extensions/goldenembed/Cargo.toml
+```
+Expected: FAIL — fixtures don't exist yet / PLACEHOLDER mismatch.
+
+### Task 2: Generate the fixture models + lock expected model_ids
+
+**Files:**
+- Create: `packages/rust/extensions/goldenembed/tests/fixtures/tiny_model/{config.json,weights.npz,model.onnx}`
+- Create: `packages/rust/extensions/goldenembed/tests/fixtures/tiny_model_bias/{config.json,weights.npz,model.onnx}`
+- Modify: `packages/rust/extensions/goldenembed/src/model_id.rs` (paste real expected ids)
+
+- [ ] **Step 1: Generate the fixtures with Python**
+
+> Run with the repo's Python that has `goldenmatch` + numpy installed. Set
+> `POLARS_SKIP_CPU_CHECK=1` is not needed (no polars import here). This imports
+> only numpy + the featurizer (no torch/polars).
+
+```bash
+python - <<'PY'
+import numpy as np
+from pathlib import Path
+from goldenmatch.embeddings.inhouse.model import GoldenEmbedModel, EmbedModelConfig
+from goldenmatch.embeddings.inhouse.featurizer import FeaturizerConfig
+
+base = Path("packages/rust/extensions/goldenembed/tests/fixtures")
+fc = FeaturizerConfig(n_features=256, ngram_min=2, ngram_max=3, lowercase=True, boundary="", seed=0)
+
+# no-bias model, dim=8, deterministic seed
+m = GoldenEmbedModel(EmbedModelConfig(dim=8, use_bias=False, featurizer=fc), seed=7)
+m.save(base / "tiny_model")
+print("EXPECTED_NO_BIAS =", m.model_id)
+
+# bias model, dim=8
+mb = GoldenEmbedModel(EmbedModelConfig(dim=8, use_bias=True, featurizer=fc), seed=7)
+mb.save(base / "tiny_model_bias")
+print("EXPECTED_BIAS =", mb.model_id)
+PY
+```
+
+- [ ] **Step 2: Paste the printed ids into `model_id.rs`**
+
+Replace `PLACEHOLDER_NO_BIAS` / `PLACEHOLDER_BIAS` with the two printed values.
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+```bash
+cargo test -p goldenembed model_id --manifest-path packages/rust/extensions/goldenembed/Cargo.toml
+```
+Expected: PASS (both cases). If FAIL, the npy header parse or hash order is wrong — verify `npy_data` offset and that weights-then-bias matches `model.py:82-85`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/rust/extensions/goldenembed/Cargo.toml \
+        packages/rust/extensions/goldenembed/src/model_id.rs \
+        packages/rust/extensions/goldenembed/src/lib.rs \
+        packages/rust/extensions/goldenembed/tests/fixtures
+git commit -m "feat(goldenembed): reproduce Python model_id from weights.npz"
+```
+
+### Task 3: Wire model_id into GoldenEmbed::load + CLI
+
+**Files:**
+- Modify: `packages/rust/extensions/goldenembed/src/lib.rs`
+- Modify: `packages/rust/extensions/goldenembed/src/main.rs`
+
+- [ ] **Step 1: Add a `model_id` field + accessor to `GoldenEmbed`**
+
+In `lib.rs`, add `model_id: Option<String>` to the struct. In `load`, after reading the config, compute it (non-fatal — ONNX-only dirs have no npz):
+```rust
+let model_id = crate::model_id::compute_model_id(dir, cfg.dim).ok();
+```
+Store it; add:
+```rust
+/// The Python-parity cache namespace, or an onnx-bytes fallback when
+/// `weights.npz` is absent (see `model_id_or_fallback`).
+pub fn model_id(&self) -> Option<&str> {
+    self.model_id.as_deref()
+}
+```
+
+- [ ] **Step 2: Print model_id in the CLI smoke path**
+
+In `main.rs`, the no-input branch currently prints `model loaded: dim={}`. Change to also print the id:
+```rust
+println!(
+    "model loaded: dim={} model_id={}",
+    model.dim(),
+    model.model_id().unwrap_or("<onnx-only>")
+);
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+cargo build -p goldenembed --manifest-path packages/rust/extensions/goldenembed/Cargo.toml
+```
+Expected: clean build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/rust/extensions/goldenembed/src/lib.rs packages/rust/extensions/goldenembed/src/main.rs
+git commit -m "feat(goldenembed): expose model_id on load + CLI smoke output"
+```
+
+---
+
+## Stage A — redb embedding cache
+
+### Task 4: normalize_text + text_hash parity helpers
+
+**Files:**
+- Create: `packages/rust/extensions/goldenembed/src/cache.rs`
+- Modify: `packages/rust/extensions/goldenembed/src/lib.rs` (add `pub mod cache;`)
+
+- [ ] **Step 1: Write the failing parity tests**
+
+Create `src/cache.rs`:
+```rust
+//! redb-backed two-tier embedding cache keyed by Python-parity
+//! `(model_id, text_hash)`. Rust-only on-disk format by design (edge runtime);
+//! cross-language sharing with the Python SQLite cache is a non-goal.
+use sha2::{Digest, Sha256};
+
+/// Port of Python `goldenmatch.embeddings.normalize_text`:
+/// collapse all whitespace runs to single spaces, then lowercase.
+/// `split_whitespace` uses Unicode `White_Space`; Python `str.split` uses
+/// `str.isspace` — they agree on ASCII + common Unicode whitespace. Known
+/// divergence (documented, non-critical: a mismatch only forces a cache miss):
+/// Python treats C0 separators `\x1c`–`\x1f` and `\x85` as whitespace; Rust
+/// does not.
+pub fn normalize_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+}
+
+/// Port of Python `text_hash`: lowercase hex SHA-256 of the UTF-8 bytes.
+pub fn text_hash(normalized: &str) -> String {
+    let digest = Sha256::digest(normalized.as_bytes());
+    let mut s = String::with_capacity(64);
+    for b in digest {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_collapses_and_lowercases() {
+        assert_eq!(normalize_text("Acme  Corp"), "acme corp");
+        assert_eq!(normalize_text("  John\tSmith\n"), "john smith");
+        assert_eq!(normalize_text(""), "");
+    }
+
+    #[test]
+    fn text_hash_matches_python_sha256() {
+        // Digests computed independently via `printf '<t>' | sha256sum`.
+        assert_eq!(
+            text_hash("acme corp"),
+            "ea6f9c07a2f95c788a1645cf557f58aa63c5fa3ad7d749b9db4fce435deef64e"
+        );
+        assert_eq!(
+            text_hash("john smith"),
+            "32ddaf65cc3aa8d3e6eda3ca2da7c18b71e169e9aa444cccb479c9ca759dd095"
+        );
+        assert_eq!(
+            text_hash(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}
+```
+Add `pub mod cache;` to `lib.rs`.
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+cargo test -p goldenembed cache::tests --manifest-path packages/rust/extensions/goldenembed/Cargo.toml
+```
+Expected: PASS (these helpers are self-contained; this task is parity-locking, not red-green).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/rust/extensions/goldenembed/src/cache.rs packages/rust/extensions/goldenembed/src/lib.rs
+git commit -m "feat(goldenembed): normalize_text + text_hash cache-key parity"
+```
+
+### Task 5: EmbedCache (mem + redb tiers)
+
+**Files:**
+- Modify: `packages/rust/extensions/goldenembed/src/cache.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cache.rs` (above the existing `tests` mod, add the impl; add cases to `tests`):
+```rust
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Result;
+use redb::{Database, ReadableTable, TableDefinition};
+
+const TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("embeddings");
+
+/// Two-tier cache: in-memory HashMap front + optional redb disk tier.
+pub struct EmbedCache {
+    mem: HashMap<String, Vec<f32>>,
+    db: Option<Database>,
+}
+
+fn key(model_id: &str, text_hash: &str) -> String {
+    // `\u{0}` cannot appear in a hex hash or the model_id format, so this is a
+    // collision-free composite key.
+    format!("{model_id}\u{0}{text_hash}")
+}
+
+fn to_bytes(vec: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vec.len() * 4);
+    for v in vec {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+fn from_bytes(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+impl EmbedCache {
+    /// Ephemeral mem-only cache.
+    pub fn in_memory() -> Self {
+        Self { mem: HashMap::new(), db: None }
+    }
+
+    /// Open/create a redb-backed cache at `path`.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let db = Database::create(path.as_ref())?;
+        // Ensure the table exists so first-read on a fresh db doesn't error.
+        let w = db.begin_write()?;
+        { let _ = w.open_table(TABLE)?; }
+        w.commit()?;
+        Ok(Self { mem: HashMap::new(), db: Some(db) })
+    }
+
+    pub fn get(&mut self, model_id: &str, text_hash: &str) -> Option<Vec<f32>> {
+        let k = key(model_id, text_hash);
+        if let Some(hit) = self.mem.get(&k) {
+            return Some(hit.clone());
+        }
+        let db = self.db.as_ref()?;
+        let r = db.begin_read().ok()?;
+        let t = r.open_table(TABLE).ok()?;
+        let v = t.get(k.as_str()).ok().flatten()?;
+        let vec = from_bytes(v.value());
+        self.mem.insert(k, vec.clone()); // promote to mem tier
+        Some(vec)
+    }
+
+    pub fn put(&mut self, model_id: &str, text_hash: &str, vec: Vec<f32>) -> Result<()> {
+        let k = key(model_id, text_hash);
+        if let Some(db) = self.db.as_ref() {
+            let w = db.begin_write()?;
+            { let mut t = w.open_table(TABLE)?; t.insert(k.as_str(), to_bytes(&vec).as_slice())?; }
+            w.commit()?;
+        }
+        self.mem.insert(k, vec);
+        Ok(())
+    }
+}
+```
+Add tests to the `tests` mod:
+```rust
+    #[test]
+    fn mem_roundtrip() {
+        let mut c = EmbedCache::in_memory();
+        assert!(c.get("m", "h").is_none());
+        c.put("m", "h", vec![1.0, 2.0, 3.0]).unwrap();
+        assert_eq!(c.get("m", "h"), Some(vec![1.0, 2.0, 3.0]));
+    }
+
+    #[test]
+    fn redb_persists_across_reopen() {
+        let dir = std::env::temp_dir().join(format!("gec_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("cache.redb");
+        {
+            let mut c = EmbedCache::open(&path).unwrap();
+            c.put("m", "h", vec![0.5, -0.5]).unwrap();
+        }
+        let mut c2 = EmbedCache::open(&path).unwrap();
+        assert_eq!(c2.get("m", "h"), Some(vec![0.5, -0.5]));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+```bash
+cargo test -p goldenembed cache --manifest-path packages/rust/extensions/goldenembed/Cargo.toml
+```
+Expected: PASS. (redb API: if `ReadableTable`/method names differ in the resolved 2.x, fix imports — `table.get` returns `Result<Option<AccessGuard>>`, `.value()` yields `&[u8]`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/rust/extensions/goldenembed/src/cache.rs
+git commit -m "feat(goldenembed): EmbedCache mem+redb two-tier store"
+```
+
+### Task 6: GoldenEmbed::embed_cached
+
+**Files:**
+- Modify: `packages/rust/extensions/goldenembed/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a `#[cfg(test)] mod tests` to `lib.rs` (or extend if present):
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tiny() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/tiny_model")
+    }
+
+    #[test]
+    fn embed_cached_equals_uncached() {
+        let mut m = GoldenEmbed::load(tiny()).unwrap();
+        let texts = ["Acme Corp", "acme  corp", "Zebra Inc"];
+        let direct = m.embed(&texts).unwrap();
+        let mut cache = crate::cache::EmbedCache::in_memory();
+        let cached = m.embed_cached(&texts, &mut cache).unwrap();
+        assert_eq!(direct.len(), cached.len());
+        for (a, b) in direct.iter().zip(&cached) {
+            for (x, y) in a.iter().zip(b) {
+                assert!((x - y).abs() < 1e-6, "{x} vs {y}");
+            }
+        }
+        // "Acme Corp" and "acme  corp" normalize identically -> one cache entry.
+        assert_eq!(cache.len(), 2);
+    }
+}
+```
+(Add a `pub fn len(&self) -> usize { self.mem.len() }` to `EmbedCache` for the assertion.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cargo test -p goldenembed embed_cached --manifest-path packages/rust/extensions/goldenembed/Cargo.toml
+```
+Expected: FAIL — `embed_cached` / `len` not defined.
+
+- [ ] **Step 3: Implement `embed_cached`**
+
+Add to `impl GoldenEmbed` in `lib.rs`:
+```rust
+/// Embed `texts` with cache lookups keyed by `(model_id, sha256(normalize_text))`.
+/// Unique misses (deduped by text_hash) are embedded in one batched ONNX run,
+/// chunked to bound memory. Output is in input order.
+pub fn embed_cached(
+    &mut self,
+    texts: &[&str],
+    cache: &mut crate::cache::EmbedCache,
+) -> anyhow::Result<Vec<Vec<f32>>> {
+    use crate::cache::{normalize_text, text_hash};
+    const MISS_CHUNK: usize = 4096;
+
+    let model_id = self
+        .model_id()
+        .map(str::to_owned)
+        .unwrap_or_else(|| self.onnx_fallback_namespace());
+
+    let normalized: Vec<String> = texts.iter().map(|t| normalize_text(t)).collect();
+    let hashes: Vec<String> = normalized.iter().map(|n| text_hash(n)).collect();
+
+    // Resolve hits; collect unique miss hashes preserving first-seen normalized text.
+    let mut resolved: std::collections::HashMap<String, Vec<f32>> = std::collections::HashMap::new();
+    let mut miss_order: Vec<String> = Vec::new();
+    let mut miss_text: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for (norm, h) in normalized.iter().zip(&hashes) {
+        if resolved.contains_key(h) || miss_text.contains_key(h) {
+            continue;
+        }
+        if let Some(v) = cache.get(&model_id, h) {
+            resolved.insert(h.clone(), v);
+        } else {
+            miss_order.push(h.clone());
+            miss_text.insert(h.clone(), norm.clone());
+        }
+    }
+
+    // Embed misses in bounded chunks.
+    for chunk in miss_order.chunks(MISS_CHUNK) {
+        let batch_texts: Vec<&str> = chunk.iter().map(|h| miss_text[h].as_str()).collect();
+        let vecs = self.embed(&batch_texts)?;
+        for (h, vec) in chunk.iter().zip(vecs) {
+            cache.put(&model_id, h, vec.clone())?;
+            resolved.insert(h.clone(), vec);
+        }
+    }
+
+    Ok(hashes.iter().map(|h| resolved[h].clone()).collect())
+}
+
+/// Deterministic cache namespace when `weights.npz` is absent: blake2b-8 over
+/// the raw `model.onnx` bytes. Will NOT match Python's `inhouse:…` id (parity
+/// needs the weights) — fine, since Python doesn't share this redb file.
+fn onnx_fallback_namespace(&self) -> String {
+    format!("onnx:d{}:{}", self.dim, self.onnx_digest.clone())
+}
+```
+To support the fallback deterministically, in `load` compute and store an
+`onnx_digest: String` field = blake2b-8 hex over the bytes read from
+`<dir>/model.onnx` (read them once; you already pass the path to
+`commit_from_file`). Reuse the `hex` helper pattern from `model_id.rs` (make it
+`pub(crate)` there and import, to stay DRY).
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+cargo test -p goldenembed --manifest-path packages/rust/extensions/goldenembed/Cargo.toml
+```
+Expected: PASS (whole crate green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/extensions/goldenembed/src/lib.rs packages/rust/extensions/goldenembed/src/model_id.rs
+git commit -m "feat(goldenembed): embed_cached with deduped batched misses"
+```
+
+### Task 7: fmt/clippy + open PR 1
+
+- [ ] **Step 1: Format + lint**
+
+```bash
+cd packages/rust/extensions/goldenembed && cargo fmt && cargo clippy --all-targets -- -D warnings
+```
+Expected: clean. Fix any clippy findings.
+
+- [ ] **Step 2: Push + PR** (auth dance — see header)
+
+```bash
+gh auth switch --user benzsevern
+git push -u origin feature/goldenembed-finish-508
+GH_TOKEN=$(gh auth token --user benzsevern) gh pr create --repo benseverndev-oss/goldenmatch \
+  --title "feat(goldenembed): model_id parity + redb embedding cache (#508 a)" \
+  --body "Stage A′+A of #508. Reproduces Python model_id from weights.npz; adds redb two-tier embedding cache keyed by model_id + sha256(normalize_text). Non-goal: Python cache sharing."
+gh auth switch --user benzsevern-mjh
+```
+
+- [ ] **Step 3: Watch CI green, then merge** (see root CLAUDE.md poll-loop + merge patterns)
+
+---
+
+## Stage B — throughput bench
+
+### Task 8: `goldenembed bench` CLI verb
+
+**Files:**
+- Modify: `packages/rust/extensions/goldenembed/src/main.rs`
+
+- [ ] **Step 1: Add the bench subcommand (hand-rolled arg parse, no new deps)**
+
+Detect a leading `bench` verb in `main`. Implement:
+```rust
+fn run_bench(model_dir: &str, rows: usize, batches: &[usize]) -> anyhow::Result<()> {
+    use std::time::Instant;
+    let mut model = goldenembed::GoldenEmbed::load(model_dir)?;
+    // Deterministic synthetic corpus (vary by index; no RNG dep).
+    let corpus: Vec<String> = (0..rows).map(|i| format!("record number {i} acme corp")).collect();
+    println!("rows={rows} dim={} model_id={}", model.dim(),
+             model.model_id().unwrap_or("<onnx-only>"));
+    for &b in batches {
+        let refs: Vec<&str> = corpus.iter().map(String::as_str).collect();
+        let mut latencies: Vec<f64> = Vec::new();
+        let start = Instant::now();
+        for chunk in refs.chunks(b) {
+            let t = Instant::now();
+            let _ = model.embed(chunk)?;
+            latencies.push(t.elapsed().as_secs_f64() * 1000.0);
+        }
+        let wall = start.elapsed().as_secs_f64();
+        latencies.sort_by(|a, c| a.partial_cmp(c).unwrap());
+        let p = |q: f64| latencies[((latencies.len() as f64 * q) as usize).min(latencies.len() - 1)];
+        println!(
+            "batch={b:>6} rows/sec={:>10.0} p50={:>7.2}ms p95={:>7.2}ms",
+            rows as f64 / wall, p(0.50), p(0.95)
+        );
+    }
+    Ok(())
+}
+```
+Parse `--rows` (default 50_000) and `--batch` (comma list, default `64,256,1024,4096`). Keep the existing embed/no-input paths intact.
+
+- [ ] **Step 2: Build + smoke-run against a fixture**
+
+```bash
+cargo build --release -p goldenembed --manifest-path packages/rust/extensions/goldenembed/Cargo.toml
+./packages/rust/extensions/goldenembed/target/release/goldenembed bench \
+  --model packages/rust/extensions/goldenembed/tests/fixtures/tiny_model --rows 2000 --batch 64,512
+```
+Expected: prints a rows/sec table, no panic.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/rust/extensions/goldenembed/src/main.rs
+git commit -m "feat(goldenembed): bench CLI verb (rows/sec + p50/p95 by batch)"
+```
+
+### Task 9: Python side-by-side comparison harness
+
+**Files:**
+- Create: `packages/python/goldenmatch/scripts/bench_goldenembed.py`
+
+- [ ] **Step 1: Write the harness**
+
+```python
+"""Side-by-side throughput: Python GoldenEmbedModel.embed vs the Rust
+`goldenembed bench` CLI, on identical synthetic text. Prints rows/sec per side
++ a cosine parity spot-check. Reports the ratio (env-dependent), does not assert.
+"""
+from __future__ import annotations
+import argparse, subprocess, time
+from pathlib import Path
+import numpy as np
+from goldenmatch.embeddings.inhouse.model import GoldenEmbedModel
+
+
+def synthetic(rows: int) -> list[str]:
+    return [f"record number {i} acme corp" for i in range(rows)]
+
+
+def py_throughput(model_dir: str, rows: int, batch: int, backend: str) -> float:
+    m = GoldenEmbedModel.load(model_dir)
+    texts = synthetic(rows)
+    start = time.perf_counter()
+    for i in range(0, rows, batch):
+        m.embed(texts[i : i + batch], backend=backend)
+    return rows / (time.perf_counter() - start)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--rows", type=int, default=50_000)
+    ap.add_argument("--batch", type=int, default=1024)
+    ap.add_argument("--rust-bin", default="goldenembed")
+    args = ap.parse_args()
+
+    for backend in ("auto", "onnx"):
+        rps = py_throughput(args.model, args.rows, args.batch, backend)
+        print(f"python[{backend}] rows/sec={rps:,.0f}")
+
+    print("--- rust ---")
+    subprocess.run(
+        [args.rust_bin, "bench", "--model", args.model,
+         "--rows", str(args.rows), "--batch", str(args.batch)],
+        check=True,
+    )
+
+    # Parity spot-check on a small sample.
+    m = GoldenEmbedModel.load(args.model)
+    sample = synthetic(8)
+    v = m.embed(sample, backend="auto")
+    # cosine of each row with itself via the onnx backend == ~1.0
+    v2 = m.embed(sample, backend="onnx")
+    cos = (v * v2).sum(1) / (np.linalg.norm(v, axis=1) * np.linalg.norm(v2, axis=1) + 1e-9)
+    print(f"parity cosine min={cos.min():.6f} (expect ~1.0)")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Smoke-run**
+
+```bash
+python packages/python/goldenmatch/scripts/bench_goldenembed.py \
+  --model packages/rust/extensions/goldenembed/tests/fixtures/tiny_model \
+  --rows 2000 --batch 512 \
+  --rust-bin packages/rust/extensions/goldenembed/target/release/goldenembed
+```
+Expected: prints python + rust rows/sec and a parity cosine ~1.0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/scripts/bench_goldenembed.py
+git commit -m "feat(goldenembed): python<->rust throughput comparison harness"
+```
+
+### Task 10: workflow_dispatch bench CI job
+
+**Files:**
+- Create: `.github/workflows/bench-goldenembed.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: bench-goldenembed
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "rows to embed"
+        default: "200000"
+      runner:
+        description: "runner label"
+        default: "large-new-64GB"
+jobs:
+  bench:
+    runs-on: ${{ github.event.inputs.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build goldenembed (release)
+        working-directory: packages/rust/extensions/goldenembed
+        run: cargo build --release
+      - name: Bench
+        working-directory: packages/rust/extensions/goldenembed
+        run: |
+          ./target/release/goldenembed bench \
+            --model tests/fixtures/tiny_model \
+            --rows ${{ github.event.inputs.rows }} \
+            --batch 64,256,1024,4096 | tee bench.txt
+      - name: Summary
+        working-directory: packages/rust/extensions/goldenembed
+        run: |
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat bench.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+```
+(Per `feedback_bench_default_runner`: default to `large-new-64GB`. This job is dispatch-only — NOT added to the default `needs:` aggregate gate.)
+
+- [ ] **Step 2: Commit + push + dispatch a smoke run**
+
+```bash
+git add .github/workflows/bench-goldenembed.yml
+git commit -m "ci(goldenembed): workflow_dispatch throughput bench job"
+# after merge to main (workflow must exist on the ref):
+# gh workflow run bench-goldenembed.yml --ref main -f rows=50000
+```
+
+- [ ] **Step 3: Open PR 2, watch CI, merge** (auth dance + poll-loop as in Task 7)
+
+PR title: `feat(goldenembed): throughput bench + comparison harness (#508 b)`
+
+---
+
+## Stage C — datafusion-udf embed UDF (spike-gated)
+
+### Task 11: SPIKE — ort Session thread-safety + onnxruntime-in-cdylib
+
+**Files:** none committed (investigation). Record findings in the PR description.
+
+- [ ] **Step 1: Determine the `ort` 2.0-rc.10 `Session::run` receiver**
+
+```bash
+grep -rn "fn run" ~/.cargo/registry/src/*/ort-2.0.0-rc.10/src/session/ 2>/dev/null | head
+```
+Or read docs.rs for `ort` 2.0.0-rc.10 `Session`. Record: is `run` `&self` or `&mut self`?
+- If `&self` → model can be `Arc<GoldenEmbed>` (lock-free). BUT `GoldenEmbed::embed` currently takes `&mut self`; refactor `embed` to `&self` if the underlying `session.run` allows, else keep `&mut` and use a `Mutex`.
+- If `&mut self` → wrap as `Arc<Mutex<GoldenEmbed>>` in the UDF struct (correctness over throughput for v1; note contention in a comment).
+
+> **Expected outcome:** `ort` 2.x `Session::run` is `&mut self`, and
+> `GoldenEmbed::embed` is already `&mut self` (`lib.rs:54`), so the
+> `Arc<Mutex<GoldenEmbed>>` branch in Task 12 is almost certainly the survivor.
+> Don't over-invest in the lock-free path unless the spike surprises you.
+
+- [ ] **Step 2: Confirm onnxruntime binary loads from within an abi3 cdylib**
+
+The `datafusion-udf` cdylib is imported by CPython. Confirm `ort`'s default
+`download-binaries` (or chosen feature) resolves the onnxruntime shared lib at
+load time in that context. Quick check: add `goldenembed` as a path dep
+(Task 12 step 1) and write a throwaway `#[test]` in the datafusion-udf crate
+that does `goldenembed::GoldenEmbed::load(fixture)?.embed(&["x"])?` and run
+`cargo test`. If onnxruntime fails to load, evaluate `ort` features
+(`load-dynamic` + a bundled lib path) before proceeding.
+
+- [ ] **Step 3: Decision gate**
+
+Write the verdict in the PR/issue: GREEN (proceed with Arc or Arc<Mutex>) or
+RED (surface to the user; do not force the UDF). Only continue to Task 12 on
+GREEN.
+
+### Task 12: goldenmatch_embed ScalarUDF
+
+**Files:**
+- Modify: `packages/rust/extensions/datafusion-udf/Cargo.toml`
+- Create: `packages/rust/extensions/datafusion-udf/src/embed_udf.rs`
+- Modify: `packages/rust/extensions/datafusion-udf/src/lib.rs`
+
+- [ ] **Step 1: Add the path dep**
+
+In `datafusion-udf/Cargo.toml` `[dependencies]`:
+```toml
+goldenembed = { path = "../goldenembed" }
+```
+No other Cargo change needed — `arrow-array 58` already provides the
+`FixedSizeListBuilder` / `Float32Builder` used below. (This dep pulls `ort` +
+`redb`/`zip`/`sha2` into the cdylib; the Task 11 spike confirms onnxruntime
+loads in that context before you rely on this.)
+
+- [ ] **Step 2: Write the UDF (shape mirrors scalar_udf.rs, single-arg)**
+
+Create `embed_udf.rs`:
+```rust
+//! goldenmatch_embed(text: Utf8) -> FixedSizeList<Float32, dim>. Loads a saved
+//! GoldenEmbedModel from GOLDENEMBED_MODEL_DIR once at construction and runs the
+//! pure-Rust featurize + ONNX projection per batch — a zero-CPython SQL embed
+//! path. NULL Utf8 -> empty string -> zero-then-normalized vector (matches the
+//! Python None convention).
+use std::any::Any;
+use std::sync::{Arc, Mutex};   // drop Mutex if the spike says Session::run is &self
+
+use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+use arrow_array::cast::AsArray;
+use arrow_schema::{DataType, Field};
+use datafusion_common::error::{DataFusionError, Result as DataFusionResult};
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_ffi::udf::FFI_ScalarUDF;
+use goldenembed::GoldenEmbed;
+use pyo3::types::PyCapsule;
+use pyo3::{Bound, PyResult, Python, pyclass, pymethods};
+
+#[pyclass(from_py_object, name = "EmbedUDF", module = "goldenmatch_datafusion_udf", subclass)]
+#[derive(Clone)]
+pub(crate) struct EmbedUDF {
+    signature: Signature,
+    dim: i32,
+    model: Arc<Mutex<GoldenEmbed>>,
+}
+
+// ScalarUDFImpl requires Eq/Hash/PartialEq; compare on dim + model_id only.
+impl PartialEq for EmbedUDF {
+    fn eq(&self, other: &Self) -> bool { self.dim == other.dim }
+}
+impl Eq for EmbedUDF {}
+impl std::hash::Hash for EmbedUDF {
+    fn hash<H: std::hash::Hasher>(&self, s: &mut H) { self.dim.hash(s); }
+}
+impl std::fmt::Debug for EmbedUDF {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EmbedUDF{{dim:{}}}", self.dim)
+    }
+}
+
+#[pymethods]
+impl EmbedUDF {
+    #[new]
+    fn new() -> PyResult<Self> {
+        let dir = std::env::var("GOLDENEMBED_MODEL_DIR").map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("GOLDENEMBED_MODEL_DIR not set")
+        })?;
+        let model = GoldenEmbed::load(&dir)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        let dim = model.dim() as i32;
+        Ok(Self {
+            signature: Signature::exact(vec![DataType::Utf8], Volatility::Immutable),
+            dim,
+            model: Arc::new(Mutex::new(model)),
+        })
+    }
+
+    fn __datafusion_scalar_udf__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyCapsule>> {
+        let name = cr"datafusion_scalar_udf".into();
+        let func = Arc::new(ScalarUDF::from(self.clone()));
+        let provider = FFI_ScalarUDF::from(func);
+        PyCapsule::new(py, provider, Some(name))
+    }
+}
+
+impl ScalarUDFImpl for EmbedUDF {
+    fn as_any(&self) -> &dyn Any { self }
+    fn name(&self) -> &str { "goldenmatch_embed" }
+    fn signature(&self) -> &Signature { &self.signature }
+    fn return_type(&self, _: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Float32, false)),
+            self.dim,
+        ))
+    }
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
+        let arrs = ColumnarValue::values_to_arrays(&args.args)?;
+        let texts = arrs[0].as_string::<i32>();
+        let texts_ref: Vec<&str> = texts.iter().map(|o| o.unwrap_or("")).collect();
+        let vecs = {
+            let mut m = self.model.lock().unwrap();
+            m.embed(&texts_ref).map_err(|e| DataFusionError::Execution(e.to_string()))?
+        };
+        let mut b = FixedSizeListBuilder::new(Float32Builder::new(), self.dim);
+        for row in vecs {
+            b.values().append_slice(&row);
+            b.append(true);
+        }
+        Ok(ColumnarValue::Array(Arc::new(b.finish())))
+    }
+}
+```
+
+Register in `lib.rs`:
+```rust
+pub(crate) mod embed_udf;
+use crate::embed_udf::EmbedUDF;
+// inside #[pymodule]:
+m.add_class::<EmbedUDF>()?;
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+cargo build -p goldenmatch-datafusion-udf --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml
+```
+Expected: clean (adjust FixedSizeList builder/Field API to the resolved arrow 58 if names differ).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/rust/extensions/datafusion-udf/Cargo.toml \
+        packages/rust/extensions/datafusion-udf/src/embed_udf.rs \
+        packages/rust/extensions/datafusion-udf/src/lib.rs
+git commit -m "feat(datafusion-udf): goldenmatch_embed ScalarUDF over goldenembed"
+```
+
+### Task 13: Python smoke + parity test for the UDF
+
+**Files:**
+- Create: `packages/python/goldenmatch/tests/test_embed_udf.py`
+
+> **Where this runs:** the `datafusion-udf` crate is built into the goldenmatch
+> `.venv` by the existing CI step (`ci.yml:277-288`, `matrix.pkg == 'goldenmatch'`)
+> and the FFI tests live in `packages/python/goldenmatch/tests/`. So the embed
+> test goes **there**, next to `test_datafusion_ffi_udf.py`, and is collected by
+> the existing goldenmatch pytest lane automatically — **no new CI job and no
+> `ci.yml` edit** (the crate already builds the new `EmbedUDF` class into the
+> same wheel; `GOLDENEMBED_MODEL_DIR` is set by the test via `monkeypatch`).
+> Registration API is `ctx.register_udf(udf(EmbedUDF()))` — copied verbatim from
+> `test_datafusion_ffi_udf.py:46-52`.
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""goldenmatch_embed FFI UDF: shape + determinism + parity vs Python embed.
+
+Mirrors test_datafusion_ffi_udf.py: pyarrow/datafusion are soft deps; the crate
+is a HARD import (CI builds it into .venv). GOLDENEMBED_MODEL_DIR points at the
+committed tiny fixture, set before EmbedUDF() is constructed (the Rust ctor reads
+the env var at construction).
+"""
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+datafusion = pytest.importorskip("datafusion")
+import goldenmatch_datafusion_udf  # noqa: E402,F401  HARD import (loud guard)
+from goldenmatch.embeddings.inhouse.model import GoldenEmbedModel  # noqa: E402
+
+# tests -> goldenmatch -> python -> packages -> <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURE = _REPO_ROOT / "packages/rust/extensions/goldenembed/tests/fixtures/tiny_model"
+
+
+def test_embed_udf_shape_and_parity(monkeypatch):
+    monkeypatch.setenv("GOLDENEMBED_MODEL_DIR", str(FIXTURE))
+    from datafusion import SessionContext, udf
+    from goldenmatch_datafusion_udf import EmbedUDF
+
+    ctx = SessionContext()
+    ctx.register_udf(udf(EmbedUDF()))
+    ctx.from_arrow(
+        pa.table({"t": pa.array(["acme corp", "acme corp"], pa.string())}), name="rows"
+    )
+    batches = ctx.sql("SELECT goldenmatch_embed(t) AS e FROM rows").collect()
+    out = batches[0].column(0).to_pylist()
+
+    assert len(out) == 2
+    assert len(out[0]) == 8  # dim
+    assert out[0] == out[1]  # determinism: identical input -> identical vector
+
+    py = GoldenEmbedModel.load(str(FIXTURE)).embed(["acme corp"], backend="onnx")[0]
+    v = np.asarray(out[0], dtype=np.float32)
+    cos = float(np.dot(v, py) / (np.linalg.norm(v) * np.linalg.norm(py) + 1e-9))
+    assert cos > 0.999, f"UDF vs python embed cosine {cos}"
+```
+
+- [ ] **Step 2: Build the crate into .venv (mirror CI) + run the test locally**
+
+`maturin develop` installs into an ephemeral overlay env, NOT the project `.venv`
+(see the `ci.yml:281-288` comment) — so build a wheel and install it, exactly as
+CI does:
+```bash
+cd packages/python/goldenmatch
+uv pip install 'datafusion>=53,<54'
+uv run --with maturin maturin build --release \
+  --manifest-path ../../rust/extensions/datafusion-udf/Cargo.toml --out dist-dfudf
+uv pip install dist-dfudf/*.whl --reinstall
+uv run pytest tests/test_embed_udf.py -v
+```
+Expected: PASS. If onnxruntime load fails here, that's the Task 11 spike failing
+in practice — stop and surface to the user.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/tests/test_embed_udf.py
+git commit -m "test(goldenmatch): goldenmatch_embed UDF shape + parity smoke"
+```
+
+### Task 14: fmt/clippy + open PR 3
+
+- [ ] **Step 1: Format + lint both crates**
+
+```bash
+cd packages/rust/extensions/datafusion-udf && cargo fmt && cargo clippy --all-targets -- -D warnings
+cd ../goldenembed && cargo fmt --check
+```
+
+- [ ] **Step 2: PR 3** (auth dance)
+
+PR title: `feat(datafusion-udf): SQL embed UDF over goldenembed (#508 c)`
+Body: include the Task 11 spike verdict (ort receiver, onnxruntime-load result).
+
+- [ ] **Step 3: Watch CI, merge.**
+
+---
+
+## Close-out
+
+- [ ] **Update issue #508** with a comment: cache (Stage A), bench (Stage B), and the DataFusion SQL embed UDF (Stage C) shipped; postgres `gm_embed` tracked as the remaining follow-up. Close #508 if the follow-up is filed separately.
+- [ ] **File the postgres follow-up issue**: `gm_embed(text) -> float4[]` pgrx pg_extern over `goldenembed` (Linux/CI-only).
+- [ ] **Memory:** update `project_arrow_native_finish_line` or add a note that the goldenembed crate now has a cache + a real SQL caller, if it materially changes the roadmap state.
+```

--- a/docs/superpowers/plans/2026-06-04-spine-spill-capped-sparse-bench.md
+++ b/docs/superpowers/plans/2026-06-04-spine-spill-capped-sparse-bench.md
@@ -1,0 +1,263 @@
+# DataFusion Spine — capped sparse-block spill bench (Implementation Plan)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the Stage E HONEST-NULL into a real measurement: under a fixed per-process cgroup memory cap, on a LARGE-but-SPARSE block, show that the in-memory `bucket` backend (which materializes an M×M `rapidfuzz.cdist` score matrix) OOMs while the spilling DataFusion spine (which STREAMS the self-join through a threshold filter) survives — the binding spill-survival proof the dense soundex workload precluded.
+
+**Architecture:** Extend the existing `bench_datafusion_spine_spill.py` with (1) a sparse-block dataset (one block of N distinct, mutually-dissimilar surnames → most pairs below threshold), and (2) a per-variant **cgroup cap** via `sudo systemd-run --scope -p MemoryMax=.. -p MemorySwapMax=0` so a variant that exceeds the cap is **cgroup-OOM-killed (SIGKILL, rc 137) cleanly and in isolation** — the driver records it; the other variants + the runner survive (fixing the exit-143-kills-the-whole-job flaw). A new `workflow_dispatch` on **`ubuntu-latest`** (the cap bounds RSS → no billable large runner) runs it.
+
+**Tech Stack:** Python 3.12, polars, numpy, `datafusion>=53`, the FFI UDF wheel, `goldenmatch._native` (bucket kernel), `systemd-run` (cgroup v2 on the GH runner), pytest.
+
+---
+
+## Critical context for the executor
+- **Box HANGS on imports; the bench OOMs a laptop.** Validate Python with `ruff check` +
+  `python -m py_compile` ONLY. The bench runs in CI (the new workflow). CI is the verifier.
+- **Branch off `origin/main`**. Branch `feat/spine-spill-capped-bench`.
+- `ruff check packages/python/goldenmatch` exit 0 before EVERY commit. Never pipe through `tail`.
+- GitHub auth: `GH_TOKEN=$(gh auth token --user benzsevern)`. Push may hit a cosmetic
+  `.git/config` permission error — re-run `git push`, verify `git ls-remote` HEAD == local.
+- **`run_spine` requires `config.mode == "scale"`** (Stage D gate) — the sparse spine config MUST set it.
+- The original `bench_datafusion_spine_spill.py` + `bench-datafusion-spine-spill.yml` stay as-is (the
+  unbounded version). This plan ADDS a capped+sparse path + a NEW workflow.
+
+## Grounding references
+- `scripts/bench_datafusion_spine_spill.py` — the existing driver: `_worker(variant, data_path, pool_mb)`,
+  `_run_variant_subprocess`, `_bench_scale`, `_spine_config`/`_bucket_config` (soundex-on-last_name),
+  `VARIANTS=("bucket","spine_nospill","spine_spill")`, the `_markdown` verdict. Extend it.
+- `.github/workflows/bench-datafusion-spine-spill.yml` — the existing workflow to mirror (FFI wheel +
+  datafusion + native build steps), but target `ubuntu-latest` + add the cap smoke.
+- Stage E verdict (`docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md`) named these
+  two follow-ups: cgroup-capped relational-only bench + large-but-sparse-block workload. This is both.
+- Why it can bind: `bucket` uses `rapidfuzz.process.cdist` → an M×M matrix in RAM (CLAUDE.md:
+  "Fuzzy matching uses rapidfuzz.process.cdist for vectorized NxN scoring"). The spine's
+  `_score_and_dedup` self-join streams + `collect()`s only the FILTERED (small) above-threshold set.
+
+## Parameters (defaults; tunable via workflow inputs)
+| Knob | Default | Rationale |
+|---|---|---|
+| `--sparse-rows` N | 30000 | bucket float32 matrix = 30000² × 4B ≈ 3.6 GB |
+| `--mem-cap-mb` | 2560 | 3.6 GB matrix > 2.5 GB → bucket OOMs; spine streamed set < 2.5 GB → survives |
+| `--pool-mb` (spine_spill) | 1024 | fair-spill pool < cap → score+dedup spill |
+| runner | `ubuntu-latest` | cap bounds RSS; ~450M Rust UDF evals (FFI) ≈ tens of sec |
+
+---
+
+## Task 1: sparse-block dataset + config
+
+**Files:** Modify `packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py`
+
+- [ ] **Step 1: Add the sparse dataset + sparse config builders.** A block of N distinct random
+  8-char lowercase surnames (pairwise jaro_winkler well below 0.85 → sparse) all forced into ONE
+  block via a constant `block` column.
+
+```python
+def _sparse_block_df(rows: int, seed: int) -> "pl.DataFrame":
+    """One large block of distinct, mutually-DISSIMILAR surnames (constant
+    block key). bucket materializes the rows x rows cdist matrix (OOM under a
+    tight cap); the spine streams the self-join + threshold-filter (few pairs
+    pass -> survives). first_name/email carried so golden has fields."""
+    import numpy as np
+    import polars as pl
+
+    rng = np.random.default_rng(seed)
+    alphabet = np.array(list("abcdefghijklmnopqrstuvwxyz"))
+    last = ["".join(r) for r in alphabet[rng.integers(0, 26, size=(rows, 8))]]
+    first = ["".join(r) for r in alphabet[rng.integers(0, 26, size=(rows, 5))]]
+    return pl.DataFrame({
+        "last_name": last,
+        "first_name": first,
+        "email": [f"{i}@x.com" for i in range(rows)],
+        "block": ["B0"] * rows,  # one forced block
+    })
+```
+
+  Then add sparse config builders (block on the constant `block` column, NO transform; score
+  `last_name` with jaro_winkler, threshold 0.85). Parameterize the existing `_spine_config` /
+  `_bucket_config` OR add `_sparse_spine_config()` / `_sparse_bucket_config()`:
+
+```python
+def _sparse_spine_config():
+    from goldenmatch.config.schemas import (
+        BlockingConfig, BlockingKeyConfig, GoldenMatchConfig,
+        MatchkeyConfig, MatchkeyField,
+    )
+    return GoldenMatchConfig(
+        mode="scale",
+        matchkeys=[MatchkeyConfig(
+            name="last_name_fuzzy", type="weighted",
+            fields=[MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0)],
+            threshold=0.85,
+        )],
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["block"])],
+        ),
+    )
+
+
+def _sparse_bucket_config():
+    cfg = _sparse_spine_config()
+    cfg.mode = "standard"
+    cfg.backend = "bucket"
+    return cfg
+```
+
+  Wire a `--sparse` flag + a `--mem-cap-mb` arg into `main`'s argparse and thread them: in `--sparse`
+  mode, `_bench_scale` generates via `_sparse_block_df` and the worker uses the sparse configs +
+  `block_col="block"`. The `_worker` needs to know the mode (pass `--sparse` to the child too).
+
+- [ ] **Step 2: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py
+git commit -m "feat(bench): sparse-block workload for the spill bench (large block, dissimilar)"
+```
+
+---
+
+## Task 2: the cgroup cap in the variant runner
+
+**Files:** Modify `bench_datafusion_spine_spill.py` (`_run_variant_subprocess`)
+
+- [ ] **Step 1: Wrap the child in a cgroup cap** when `mem_cap_mb > 0`. A cgroup-OOM SIGKILLs the
+  child (rc 137) cleanly, isolated to its scope — the parent + sibling variants + runner survive.
+
+```python
+def _run_variant_subprocess(variant, data_path, pool_mb, *, mem_cap_mb=0, sparse=False):
+    child = [sys.executable, str(Path(__file__).resolve()),
+             "--worker", variant, "--data", data_path, "--pool-mb", str(pool_mb)]
+    if sparse:
+        child.append("--sparse")
+    if mem_cap_mb:
+        # cgroup v2 cap: a transient scope, swap off so it OOM-kills (not swaps).
+        # --scope runs synchronously and propagates the child's exit/signal.
+        cmd = ["sudo", "-n", "systemd-run", "--scope", "--quiet",
+               "-p", f"MemoryMax={mem_cap_mb}M", "-p", "MemorySwapMax=0",
+               "--"] + child
+    else:
+        cmd = child
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        oom = proc.returncode in (137, -9)  # SIGKILL == cgroup OOM-kill
+        return {"variant": variant,
+                "status": "OOM" if oom else "ERROR",
+                "returncode": proc.returncode,
+                "stderr_tail": proc.stderr[-2000:]}
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    if not lines:
+        return {"variant": variant, "status": "ERROR", "returncode": 0,
+                "stderr_tail": "no JSON; stderr: " + proc.stderr[-1500:]}
+    return json.loads(lines[-1])
+```
+
+  Thread `mem_cap_mb` + `sparse` from `_bench_scale` (which gets them from `main`'s args). The
+  worker self-reports peak RSS via `getrusage` as today.
+
+- [ ] **Step 2: Update the verdict** in `_markdown` for the capped sparse run: BINDING iff under the
+  cap `bucket` is OOM AND `spine_spill` is ok (the spilling spine survives where in-memory OOMs).
+  (Keep the existing honest-null branch for the uncapped path.)
+
+- [ ] **Step 3: Static-validate + commit.**
+
+```bash
+git add packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py
+git commit -m "feat(bench): per-variant cgroup MemoryMax cap (clean isolated OOM, not exit-143)"
+```
+
+---
+
+## Task 3: the capped-bench workflow (ubuntu-latest)
+
+**Files:** Create `.github/workflows/bench-spine-spill-capped.yml`
+
+- [ ] **Step 1: Write the workflow.** Mirror `bench-datafusion-spine-spill.yml`'s build steps (FFI
+  wheel + datafusion + native) but on `ubuntu-latest`, add a **cgroup-cap smoke** (de-risk the
+  load-bearing harness mechanism before the real run), then run the sparse+capped bench.
+
+```yaml
+name: bench-spine-spill-capped
+on:
+  workflow_dispatch:
+    inputs:
+      sparse_rows: { description: "rows in the one sparse block", default: "30000" }
+      mem_cap_mb:  { description: "per-variant cgroup MemoryMax (MB)", default: "2560" }
+      pool_mb:     { description: "spine_spill fair-spill pool (MB)", default: "1024" }
+permissions:
+  contents: read
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+      - run: uv sync --all-packages
+      - name: Build + install the FFI UDF wheel + datafusion runtime
+        run: |
+          uv pip install 'datafusion>=53,<54'
+          uv run --with maturin maturin build --release \
+            --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml --out dist-dfudf
+          uv pip install dist-dfudf/*.whl
+      - name: Build native extension (bucket kernel)
+        run: uv run python scripts/build_native.py
+      # DE-RISK: confirm the cgroup cap actually OOM-kills (the harness premise).
+      - name: cgroup cap smoke (must OOM-kill -> rc 137)
+        run: |
+          set +e
+          sudo -n systemd-run --scope --quiet -p MemoryMax=128M -p MemorySwapMax=0 -- \
+            python3 -c "x=bytearray(512*1024*1024)"
+          rc=$?
+          echo "cap smoke rc=$rc (expect 137)"
+          [ "$rc" = "137" ] || { echo '::error::cgroup cap did not OOM-kill; harness premise broken'; exit 1; }
+      - name: Run capped sparse spill bench
+        run: |
+          set -o pipefail
+          mkdir -p .profile_tmp
+          uv run python packages/python/goldenmatch/scripts/bench_datafusion_spine_spill.py \
+            --sparse --sparse-rows "${{ inputs.sparse_rows }}" \
+            --mem-cap-mb "${{ inputs.mem_cap_mb }}" --pool-mb "${{ inputs.pool_mb }}" \
+            --out .profile_tmp/spine_spill_capped.json | tee /tmp/capped.txt
+          { echo '## bench-spine-spill-capped'; echo '```'; cat /tmp/capped.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: spine-spill-capped
+          path: .profile_tmp/spine_spill_capped.json
+          if-no-files-found: warn
+```
+
+- [ ] **Step 2: Validate** (`yaml.safe_load`) **+ commit.**
+
+```bash
+git add .github/workflows/bench-spine-spill-capped.yml
+git commit -m "ci(bench): capped sparse-block spill bench (ubuntu-latest, cgroup cap)"
+```
+
+---
+
+## Task 4: push, merge the harness, dispatch the bench, record the verdict
+
+- [ ] **Step 1: Push + open the PR + green the goldenmatch lane** (the driver is a script; the
+  `python (goldenmatch)` lane doesn't run it, but ruff + the workflow-file change run). Merge once
+  green (the new workflow must be on `main` to be dispatchable — the workflow-trigger-ordering gotcha).
+- [ ] **Step 2: Dispatch** `gh workflow run bench-spine-spill-capped.yml --ref main` (defaults), watch it.
+- [ ] **Step 3: Read the verdict.** BINDING if `bucket`=OOM (rc 137) and `spine_spill`=ok under the
+  cap. **If inconclusive:** if bucket did NOT OOM, re-dispatch with larger `sparse_rows` or smaller
+  `mem_cap_mb`; if spine_spill ALSO OOMed, that's a cleaner honest-null (the spine's self-join
+  materializes rather than streams — record it, it's a real finding about the engine). The capped run
+  is cheap → iterate.
+- [ ] **Step 4: Record the verdict** in the roadmap (update the Stage E section) + the context network
+  `architecture/datafusion-spine.md` / memory. Keep ASCII.
+
+---
+
+## Definition of done
+- The cap smoke proves cgroup OOM-kill works on the runner (rc 137).
+- The capped sparse bench runs on `ubuntu-latest` and records a clean 3-way result.
+- A recorded verdict: BINDING (bucket OOMs, spine_spill survives under the same cap) or a cleaner
+  honest-null (both OOM → the spine's join materializes). Either is a real measured outcome.
+
+## Out of scope
+- The full pipeline / golden / identity (this bench is score+dedup spill-survival).
+- The unbounded large-new-64GB bench (stays as-is). Flipping the `mode` default (separate decision).

--- a/docs/superpowers/plans/2026-06-05-security-alerts-remediation.md
+++ b/docs/superpowers/plans/2026-06-05-security-alerts-remediation.md
@@ -1,0 +1,693 @@
+# Security Alerts Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close all 7 open Dependabot alerts and all 35 open code-scanning alerts on `benseverndev-oss/goldenmatch` via 5 sequential PRs plus one verify-and-dismiss task (fix where real, dismiss-with-justification where the flagged behavior is required by design or already remediated).
+
+**Architecture:** Five independent PRs, each branched off `origin/main`, merged one at a time (cheapest first), plus a no-code task for the Dockerfile-pinning alerts already remediated by PR #742. Two new shared helpers land in `goldenmatch/core/`: `_logging.py` (`sanitize_for_log`) and `_paths.py` (`safe_path`), then get applied at every CodeQL-flagged call site. Config-only PRs (workflows, Dockerfiles, lockfile, Cargo) carry no new tests; the two helper PRs are TDD.
+
+**Tech Stack:** GitHub Actions workflows, Docker, npm lockfile, pyo3/maturin, Python stdlib (`logging`, `pathlib`), pytest, CodeQL + StepSecurity/Scorecard alerts API.
+
+---
+
+## Ground rules (read before any task)
+
+- **Branching/auth SOP:** every task = fresh branch off `origin/main` (NOT off the current `chore/sail-s4-network` checkout, which is dirty). Push as `benzsevern`: run `gh auth switch --user benzsevern` before push, and `gh auth switch --user benzsevern-mjh` immediately after the PR is opened. If `gh pr create` 401s after the switch, prefix with `GH_TOKEN=$(gh auth token --user benzsevern)`.
+- **Worktrees:** create each branch in an isolated worktree under `.worktrees/` (gitignored), e.g. `git worktree add .worktrees/sec-pr1 -b chore/sec-workflow-permissions origin/main`.
+- **Tests:** NEVER run the full pytest suite locally (OOMs the box — repo rule). Run only the specific test files you create: `python -m pytest packages/python/goldenmatch/tests/unit/test_<name>.py -v` from the package dir. Full-suite verification happens in CI on the PR.
+- **Merging:** `main` requires `ci-required` + strict up-to-date head. After approval, `gh pr merge <N> --squash --delete-branch --auto`, then babysit: if a previously merged PR made the branch stale, run `gh pr update-branch <N>` and re-poll. CI poll: `while gh pr checks <N> | grep -qE "pending|in_progress"; do sleep 30; done`.
+- **Alert verification:** after each PR merges, re-query the relevant alerts (commands given per task) and confirm they auto-close (CodeQL/Scorecard alerts close on the next default-branch scan; Dependabot closes on lockfile/manifest merge). Dismissals are explicit API calls given inline.
+- **Alert API base:** `export GH_TOKEN=$(gh auth token --user benzsevern)` then `gh api repos/benseverndev-oss/goldenmatch/...`.
+- **Local Python on this Windows box:** any command that imports polars needs `POLARS_SKIP_CPU_CHECK=1` (and `PYTHONIOENCODING=utf-8`) in the env or it hangs on a WMI query.
+
+### Alert inventory (state as of 2026-06-05)
+
+**Dependabot (7):** #14 vitest critical, #5/#4 fast-uri high, #3 postcss med, #2 vite med, #1 esbuild med — all in `packages/python/infermap/benchmark/runners/ts/package-lock.json` (lockfile resolves vitest **1.6.1** while `package.json` already declares `^4.1.0`; lockfile is stale). #6 pyo3 low — `packages/rust/extensions/bridge/Cargo.toml` pins `>=0.23.3, <0.24`; advisory fixed in 0.24.1.
+
+**Code scanning (35):**
+- `TokenPermissionsID` (3, high): #373 `bench-df-cluster-edges.yml` (no top-level `permissions:` at all), #372 `generate-bench-dataset.yml` (job-level `contents: write` — REQUIRED for release upload → dismiss), #312 `benchmarks.yml` (job-level `actions: write` — NOT actually needed → remove).
+- `PinnedDependenciesID` (4, med): #376 `Dockerfile.bench:17`, #375 `Dockerfile.qis:23`, #374 `Dockerfile.embprov:18`, #320 `dbt-goldensuite/spcs/Dockerfile:30` — **already remediated on main by PR #742 (merged 2026-06-05 06:15 UTC: digest-pinned base images, exact pip versions, qis pinned to commit SHA)**; alerts remain open only because Scorecard hasn't rescanned and/or wants pip hash-pinning. Verify-then-dismiss, no code change (Task 2).
+- `py/log-injection` (9, med): #396-#399 `mcp/agent_tools.py`, #402/#403 `core/match_one.py`, #404 `core/rollback.py`, #401 `core/lineage.py`, #400 `core/domain_registry.py`.
+- `py/path-injection` (19, high): #377/#388-#392 `mcp/server.py`, #383-#387 `core/rollback.py`, #393-#395 `core/smart_ingest.py`, #381/#382 `core/lineage.py`, #378/#379 `core/domain_registry.py`, #380 `core/ingest.py`.
+
+Alert line numbers refer to `main`; this plan references **functions**, which are stable.
+
+---
+
+### Task 1: PR 1 — workflow token permissions (closes #373, #312; dismisses #372)
+
+**Files:**
+- Modify: `.github/workflows/bench-df-cluster-edges.yml` (add top-level permissions block after `name:`)
+- Modify: `.github/workflows/benchmarks.yml` (remove job-level `actions: write`)
+- No change: `.github/workflows/generate-bench-dataset.yml` (dismiss instead)
+
+- [ ] **Step 1: Create worktree + branch**
+
+```bash
+git fetch origin main
+git worktree add .worktrees/sec-pr1 -b chore/sec-workflow-permissions origin/main
+cd .worktrees/sec-pr1
+```
+
+- [ ] **Step 2: Add top-level permissions to bench-df-cluster-edges.yml**
+
+The file currently has NO `permissions:` block. Insert immediately after the `name: bench-df-cluster-edges` line (line 1, before the comment block):
+
+```yaml
+name: bench-df-cluster-edges
+
+permissions:
+  contents: read
+```
+
+Verify nothing in the workflow writes via GITHUB_TOKEN first: `grep -nE "GITHUB_TOKEN|GH_TOKEN|gh api|gh release" .github/workflows/bench-df-cluster-edges.yml` — expect only checkout/upload-artifact usage (neither needs write). If a write usage appears, scope a job-level grant instead and note it in the PR body.
+
+- [ ] **Step 3: Remove `actions: write` from benchmarks.yml**
+
+In the `benchmarks` job (~line 49 on main), the job-level permissions block is:
+
+```yaml
+    permissions:
+      contents: read
+      # Allows the job to comment on the workflow summary + upload artifacts.
+      actions: write
+```
+
+Replace with:
+
+```yaml
+    permissions:
+      contents: read
+```
+
+Rationale for the PR body: `actions/upload-artifact` and `$GITHUB_STEP_SUMMARY` require no token permission; the comment in the workflow was wrong. Confirmed nothing else in the workflow calls the Actions API (`grep -nE "gh api|actions/cache|workflow" .github/workflows/benchmarks.yml` shows only checkout/upload-artifact and the cron comment).
+
+- [ ] **Step 4: Validate YAML parses**
+
+```bash
+python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/bench-df-cluster-edges.yml')); yaml.safe_load(open('.github/workflows/benchmarks.yml')); print('OK')"
+```
+
+Expected: `OK`
+
+- [ ] **Step 5: Commit, push, PR**
+
+```bash
+git add .github/workflows/bench-df-cluster-edges.yml .github/workflows/benchmarks.yml
+git commit -m "chore(ci): least-privilege GITHUB_TOKEN permissions on bench workflows
+
+Closes code-scanning TokenPermissionsID alerts 373 (no top-level
+permissions on bench-df-cluster-edges) and 312 (unneeded job-level
+actions:write on benchmarks -- upload-artifact and step summaries
+need no token permission)."
+gh auth switch --user benzsevern
+git push -u origin chore/sec-workflow-permissions
+gh pr create --title "chore(ci): least-privilege token permissions on bench workflows" --body "..."
+gh auth switch --user benzsevern-mjh
+```
+
+Note: workflow-file changes force ALL CI jobs to run (path-filter rule) — expect a longer CI run than a doc PR.
+
+- [ ] **Step 6: Merge (auto-merge + babysit), then dismiss #372**
+
+`generate-bench-dataset.yml` already follows least privilege (top-level `contents: read`, job-level `contents: write` only on the job that uploads release assets). Scorecard scores any job-level `write` as 0 regardless. Dismiss:
+
+```bash
+export GH_TOKEN=$(gh auth token --user benzsevern)
+gh api -X PATCH repos/benseverndev-oss/goldenmatch/code-scanning/alerts/372 \
+  -f state=dismissed -f dismissed_reason="won't fix" \
+  -f dismissed_comment="contents:write is required for this job to upload bench-dataset release assets; already scoped to job level with top-level contents:read. Least privilege for this workflow's purpose."
+```
+
+- [ ] **Step 7: Verify #373 and #312 close after the next default-branch scan**
+
+```bash
+gh api repos/benseverndev-oss/goldenmatch/code-scanning/alerts/373 -q .state
+gh api repos/benseverndev-oss/goldenmatch/code-scanning/alerts/312 -q .state
+```
+
+Expected: `dismissed`/`fixed` (Scorecard runs on a schedule — if still `open` hours later, don't block; note it and continue. Check the schedule with `gh api repos/benseverndev-oss/goldenmatch/actions/workflows --paginate -q '.workflows[].path' | grep -iE "scorecard|step"`).
+
+---
+
+### Task 2: Dockerfile pinning alerts — verify-then-dismiss, NO PR (targets #376, #375, #374, #320)
+
+**Files:** none. The remediation already landed on main as **PR #742** (merged 2026-06-05 06:15 UTC): all four Dockerfiles have digest-pinned `FROM` lines, exact pip versions (`polars==1.41.2`, `numpy==2.4.6`, `recordlinkage==0.16`, `cryptography==48.0.0`, etc.), and `Dockerfile.qis` pins a commit SHA instead of the git branch. Do NOT create a branch or PR for this task.
+
+The 4 alerts remain open for one (or both) of two reasons: Scorecard hasn't rescanned main since #742, and/or Scorecard's pinned-dependencies check additionally demands pip `--require-hashes` pinning, which is disproportionate for these internal one-shot bench/Railway images.
+
+- [ ] **Step 1: Confirm main really carries the #742 pinning (guard against revert)**
+
+```bash
+git fetch origin main
+git show "origin/main:packages/python/goldenmatch/Dockerfile.bench" | grep -E "^FROM|=="
+git show "origin/main:Dockerfile.qis" | grep -E "^FROM|git\+"
+git show "origin/main:Dockerfile.embprov" | grep -E "^FROM|=="
+git show "origin/main:packages/python/goldenmatch/dbt-goldensuite/spcs/Dockerfile" | grep -E "^FROM|=="
+```
+
+(On this Windows box the Bash tool mangles `origin/main:path` args unless quoted — keep the quotes, or use the PowerShell tool.)
+
+Expected: every `FROM` carries `@sha256:`, every pip dep is `==`-pinned, qis installs from a 40-char commit SHA. If any of that is missing, STOP — main moved again; re-inventory before acting.
+
+- [ ] **Step 2: Check whether Scorecard has rescanned since #742 and whether the alerts closed**
+
+```bash
+export GH_TOKEN=$(gh auth token --user benzsevern)
+for n in 376 375 374 320; do gh api repos/benseverndev-oss/goldenmatch/code-scanning/alerts/$n -q '[.number,.state,.most_recent_instance.commit_sha[0:8]] | @tsv'; done
+```
+
+If `most_recent_instance.commit_sha` predates the #742 merge commit, the scan is stale — find and trigger the scanning workflow (`gh api repos/benseverndev-oss/goldenmatch/actions/workflows --paginate -q '.workflows[] | [.path,.state] | @tsv' | grep -iE "scorecard|step|codeql"`, then `gh workflow run <file> --ref main` if it supports dispatch; otherwise wait for its schedule and continue with Task 3 in the meantime — revisit in the Task 7 sweep).
+
+- [ ] **Step 3: Dismiss whatever survives a post-#742 scan**
+
+Alerts still open against the pinned Dockerfiles are the no-hashes complaint. Dismiss:
+
+```bash
+gh api -X PATCH repos/benseverndev-oss/goldenmatch/code-scanning/alerts/<n> \
+  -f state=dismissed -f dismissed_reason="won't fix" \
+  -f dismissed_comment="Base image digest-pinned and all pip deps exact-version-pinned (PR #742). Full --require-hashes pinning is disproportionate for this internal one-shot bench/Railway image (no production traffic, rebuilt deliberately)."
+```
+
+---
+
+### Task 3: PR 3 — infermap TS runner lockfile regen (closes Dependabot #14, #5, #4, #3, #2, #1)
+
+**Files:**
+- Modify: `packages/python/infermap/benchmark/runners/ts/package-lock.json` (regenerated)
+- Possibly modify: `packages/python/infermap/benchmark/runners/ts/package.json` (only if vitest 4.x needs a config tweak)
+
+**Context:** the lockfile resolves vitest **1.6.1** but `package.json` already declares `^4.1.0` — the lockfile predates the devDep bump. A regen pulls vitest 4.1.x and current vite/esbuild/postcss/fast-uri transitively, clearing all 6 alerts. This is a standalone npm project (NOT part of the pnpm/turbo workspace — it lives under a python package), so plain `npm` is correct here.
+
+- [ ] **Step 1: Create worktree + branch**
+
+```bash
+git worktree add .worktrees/sec-pr3 -b chore/sec-infermap-ts-lockfile origin/main
+cd .worktrees/sec-pr3/packages/python/infermap/benchmark/runners/ts
+```
+
+- [ ] **Step 2: Regenerate the lockfile**
+
+```bash
+rm -rf node_modules package-lock.json
+npm install
+```
+
+Note: `infermap` resolves via `file:../../../../typescript/infermap` — that path must exist in the worktree (it does; it's in-repo).
+
+- [ ] **Step 3: Verify the vulnerable packages moved**
+
+```bash
+python -c "
+import json
+lock = json.load(open('package-lock.json'))
+for name in ['vitest','vite','esbuild','postcss','fast-uri']:
+    for k,v in lock['packages'].items():
+        if k.endswith('node_modules/'+name):
+            print(k, '=>', v.get('version'))
+"
+```
+
+Expected: vitest >= 4.1.0, vite >= 6.x/7.x (no <= 6.4.1), esbuild > 0.24.2 everywhere (watch for a NESTED old `node_modules/vite/node_modules/esbuild` — the current lockfile has 0.21.5 there), postcss >= 8.5.10, fast-uri > 3.1.1.
+
+- [ ] **Step 4: Run the runner's own checks**
+
+```bash
+npm run typecheck
+npm run build
+npm test
+```
+
+Expected: all pass. vitest 1.x → 4.x is a major jump: if tests fail on config/API changes (e.g. `vitest.config` workspace options, `test.poolOptions`), fix minimally and include in the PR. If the failures are deep, STOP and report — do not park a broken runner.
+
+- [ ] **Step 5: Commit (lockfile + any config fixes), push, PR (auth dance)**
+
+```bash
+git add package-lock.json package.json
+git commit -m "chore(deps): regenerate infermap TS bench runner lockfile (vitest 1.6 -> 4.1)
+
+Clears Dependabot alerts 14 (vitest critical), 4/5 (fast-uri),
+1 (esbuild), 2 (vite), 3 (postcss) -- all transitive of the stale
+lockfile; package.json already declared vitest ^4.1.0."
+```
+
+- [ ] **Step 6: After merge, verify Dependabot alerts auto-closed**
+
+```bash
+gh api repos/benseverndev-oss/goldenmatch/dependabot/alerts -q '.[] | select(.state=="open") | [.number,.dependency.package.name] | @tsv'
+```
+
+Expected: only #6 (pyo3) remains.
+
+---
+
+### Task 4: PR 4 — pyo3 bump in bridge crate (closes Dependabot #6)
+
+**Files:**
+- Modify: `packages/rust/extensions/bridge/Cargo.toml` (version range + the stale advisory comment above it)
+- Possibly modify: `packages/rust/extensions/bridge/src/*.rs` (~2k lines total: `api.rs`, `convert.rs`, `error.rs`, `lib.rs`) if 0.24 API changes bite
+
+**Context:** advisory = buffer overflow in `PyString::from_object`, fixed in pyo3 0.24.1. Current pin `>=0.23.3, <0.24` with a comment saying the 0.24 bump is a separate task. The 0.23→0.24 migration is small compared to 0.22→0.23 (the `IntoPyObject` rework already happened in 0.23). The `native` crate already allows `<0.25` and `datafusion-udf` is on 0.28 — only `bridge` is stuck.
+
+**Local-box constraint:** `cargo check` is fine locally; do NOT run `cargo build`/`cargo test` locally (OOM risk — repo rule). Functional verification happens in CI.
+
+- [ ] **Step 1: Create worktree + branch**
+
+```bash
+git worktree add .worktrees/sec-pr4 -b chore/sec-pyo3-bump origin/main
+cd .worktrees/sec-pr4/packages/rust/extensions/bridge
+```
+
+- [ ] **Step 2: Bump the pin**
+
+In `Cargo.toml`, replace:
+
+```toml
+pyo3 = { version = ">=0.23.3, <0.24", features = ["auto-initialize"] }
+```
+
+with:
+
+```toml
+pyo3 = { version = ">=0.24.1, <0.25", features = ["auto-initialize"] }
+```
+
+Also rewrite the comment block above it (it references the old 0.23 GHSA and says "Bumping to 0.24+ is a separate task") to: pinned `>=0.24.1` for RUSTSEC/GHSA buffer-overflow fix in `PyString::from_object`; `<0.25` to stay on the same API line as the `native` crate.
+
+- [ ] **Step 3: Check compile**
+
+```bash
+cargo check 2>&1 | tail -30
+```
+
+Expected: clean, or a small set of deprecation/API errors. Known 0.24 changes to watch for: `pyo3::prelude` item moves, `Bound<'_, T>` signature tightening, `PyAnyMethods` trait imports. Fix minimally; do not refactor.
+
+- [ ] **Step 4: Check whether the `native` crate's lockfile floor needs the same nudge**
+
+```bash
+grep -rn "name = \"pyo3\"" -A1 ../native/Cargo.lock 2>/dev/null | head
+```
+
+The `native` range `>=0.23.3, <0.25` already *permits* 0.24.1+, but if its `Cargo.lock` pins a vulnerable resolve (<0.24.1), run `cargo update -p pyo3` in `../native` and include the lockfile in this PR. (Dependabot only flagged `bridge`, so this is belt-and-braces.)
+
+- [ ] **Step 5: Commit, push, PR (auth dance); CI is the real verifier**
+
+```bash
+git add Cargo.toml Cargo.lock src/ 2>/dev/null
+git commit -m "chore(deps): bump bridge pyo3 to >=0.24.1 (GHSA PyString::from_object overflow)"
+```
+
+PR body must note: verified via `cargo check` locally + full CI; local cargo build/test skipped by repo policy.
+
+- [ ] **Step 6: Watch the rust CI lane specifically; after merge, confirm Dependabot #6 closed**
+
+```bash
+gh api repos/benseverndev-oss/goldenmatch/dependabot/alerts/6 -q .state
+```
+
+Expected: `fixed`.
+
+---
+
+### Task 5: PR 5 — log-injection sanitizer (closes #396-#404, 9 alerts)
+
+**Files:**
+- Create: `packages/python/goldenmatch/goldenmatch/core/_logging.py`
+- Test: `packages/python/goldenmatch/tests/unit/test_log_sanitize.py`
+- Modify: `packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py` (3 `logger.info` sites in `_dispatch`: scan_quality, fix_quality, run_transforms)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/match_one.py` (2 sites: `match_one`, `_match_one_brute`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/rollback.py` (1 site in `rollback_run`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/lineage.py` (1 site in `save_lineage`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/domain_registry.py` (1 site in `save_rulebook`)
+
+- [ ] **Step 1: Create worktree + branch**
+
+```bash
+git worktree add .worktrees/sec-pr5 -b feat/sec-log-sanitize origin/main
+cd .worktrees/sec-pr5/packages/python/goldenmatch
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/test_log_sanitize.py`:
+
+```python
+"""Tests for goldenmatch.core._logging.sanitize_for_log."""
+
+from goldenmatch.core._logging import sanitize_for_log
+
+
+def test_strips_newlines_and_carriage_returns():
+    assert sanitize_for_log("a\nb\rc") == "a b c"
+
+
+def test_strips_ansi_and_control_chars():
+    assert sanitize_for_log("ok\x1b[31mred\x07") == "okred"
+
+
+def test_truncates_long_values():
+    out = sanitize_for_log("x" * 5000)
+    assert len(out) <= 1000
+    assert out.endswith("...")
+
+
+def test_non_string_values_coerced():
+    assert sanitize_for_log(0.85) == "0.85"
+    from pathlib import Path
+    assert sanitize_for_log(Path("a/b")) in ("a/b", "a\\b")
+
+
+def test_plain_string_unchanged():
+    assert sanitize_for_log("normal_file.csv") == "normal_file.csv"
+```
+
+- [ ] **Step 3: Run it, verify it fails**
+
+```bash
+python -m pytest tests/unit/test_log_sanitize.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: goldenmatch.core._logging`. (Remember `POLARS_SKIP_CPU_CHECK=1` if the package import chain pulls polars.)
+
+- [ ] **Step 4: Implement the helper**
+
+Create `goldenmatch/core/_logging.py`:
+
+```python
+"""Log-output sanitization (CodeQL py/log-injection mitigation).
+
+User-supplied values (file paths, run ids, config strings) flow into
+log lines. Strip control characters so a crafted value can't forge
+log records or smuggle ANSI escapes into terminals tailing the log.
+"""
+
+from __future__ import annotations
+
+import re
+
+_CONTROL_CHARS = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+_MAX_LEN = 1000
+
+
+def sanitize_for_log(value: object, max_length: int = _MAX_LEN) -> str:
+    """Return a log-safe string: newlines collapsed, ANSI/control chars
+    stripped, truncated to *max_length*."""
+    s = str(value)
+    s = s.replace("\r", " ").replace("\n", " ")
+    s = _CONTROL_CHARS.sub("", s)
+    if len(s) > max_length:
+        s = s[: max_length - 3] + "..."
+    return s
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+```bash
+python -m pytest tests/unit/test_log_sanitize.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 6: Apply at the 9 flagged sites**
+
+Pattern — wrap ONLY the tainted argument, leave the format string and untainted args alone. The sites (function-anchored; find each `logger.info` with grep, line numbers drift):
+
+1. `mcp/agent_tools.py` `_dispatch` / scan_quality: `logger.info("scan_quality: scanning %s (%d records)", sanitize_for_log(file_path), df.height)`
+2. `mcp/agent_tools.py` `_dispatch` / fix_quality: sanitize `file_path` and `fix_mode`.
+3. `mcp/agent_tools.py` `_dispatch` / run_transforms: sanitize `file_path`.
+4. `core/match_one.py` `match_one`: the tainted value is `mk.threshold` (config-sourced float) — coerce instead of sanitize: `float(mk.threshold)` inline in the call. `float()` is a recognized sanitizer and honest about the type.
+5. `core/match_one.py` `_match_one_brute`: same `float(mk.threshold)` coercion.
+6. `core/rollback.py` `rollback_run`: sanitize `run_id`.
+7. `core/lineage.py` `save_lineage`: sanitize `path` (`sanitize_for_log(path)`).
+8. `core/domain_registry.py` `save_rulebook`: sanitize `rulebook.name` and `path`.
+
+Import as `from goldenmatch.core._logging import sanitize_for_log` (in `mcp/agent_tools.py` too — absolute imports match the package style).
+
+- [ ] **Step 7: Targeted regression check (imports still work, no syntax errors)**
+
+```bash
+python -m py_compile goldenmatch/mcp/agent_tools.py goldenmatch/core/match_one.py goldenmatch/core/rollback.py goldenmatch/core/lineage.py goldenmatch/core/domain_registry.py goldenmatch/core/_logging.py
+python -m pytest tests/unit/test_log_sanitize.py -v
+```
+
+Then run the existing test files that already cover the touched modules (find them: `grep -rln "match_one\|rollback\|lineage\|domain_registry" tests/unit | head`), individually — NOT the full suite.
+
+- [ ] **Step 8: Commit, push, PR (auth dance)**
+
+```bash
+git commit -m "feat(security): sanitize user-supplied values in log output
+
+Adds core/_logging.sanitize_for_log (strip CR/LF + ANSI/control chars,
+truncate) and applies it at the 9 CodeQL py/log-injection sites."
+```
+
+- [ ] **Step 9: After merge, verify alerts #396-#404 close on the next CodeQL scan**
+
+```bash
+for n in 396 397 398 399 400 401 402 403 404; do gh api repos/benseverndev-oss/goldenmatch/code-scanning/alerts/$n -q '[.number,.state] | @tsv'; done
+```
+
+If `float()`/`sanitize_for_log` isn't recognized by CodeQL for a residual site, dismiss it: `-f dismissed_reason="false positive" -f dismissed_comment="Value passes through sanitize_for_log (core/_logging.py) which strips CR/LF and control chars before logging."`
+
+---
+
+### Task 6: PR 6 — path-injection hardening (targets the 19 high alerts)
+
+**Files:**
+- Create: `packages/python/goldenmatch/goldenmatch/core/_paths.py`
+- Test: `packages/python/goldenmatch/tests/unit/test_safe_path.py`
+- Modify: `packages/python/goldenmatch/goldenmatch/mcp/server.py` (`_tool_pprl_link`, `_tool_export_results`, plus any other flagged `_tool_*` site found by grep)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/ingest.py` (`load_file`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/smart_ingest.py` (`detect_encoding`, `smart_load`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/rollback.py` (`rollback_run`, `_load_run_log`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/lineage.py` (`save_lineage`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/domain_registry.py` (`save_rulebook`)
+- Modify: `packages/python/goldenmatch/README.md` or the MCP docs section (document `GOLDENMATCH_ALLOWED_ROOT`)
+
+**Design (decided with Ben):** harden with a shared helper, opt-in sandbox root.
+
+```
+safe_path(value, *, base_dir=None) -> Path
+  1. fspath() the value; reject NUL bytes (ValueError)
+  2. Path(value).resolve()  — collapses ../, resolves symlinks
+  3. containment root = base_dir or env GOLDENMATCH_ALLOWED_ROOT (unset => no containment, local-first default)
+  4. if root set and not resolved.is_relative_to(root.resolve()): raise PathOutsideAllowedRootError
+```
+
+**Honesty note:** CodeQL's taint tracking may not recognize a *conditional* containment barrier — expect some of the 19 to stay open after the PR. The endgame for residuals is dismissal with the justification "path normalized + validated via core/_paths.safe_path; containment enforced when GOLDENMATCH_ALLOWED_ROOT is set; arbitrary local file access is the product for this local-first tool." The hardening is real either way: the MCP server deployed on Railway gets `GOLDENMATCH_ALLOWED_ROOT=/data` set as an env var (final step).
+
+- [ ] **Step 1: Create worktree + branch**
+
+```bash
+git worktree add .worktrees/sec-pr6 -b feat/sec-safe-path origin/main
+cd .worktrees/sec-pr6/packages/python/goldenmatch
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/unit/test_safe_path.py`:
+
+```python
+"""Tests for goldenmatch.core._paths.safe_path."""
+
+from pathlib import Path
+
+import pytest
+
+from goldenmatch.core._paths import PathOutsideAllowedRootError, safe_path
+
+
+def test_plain_path_resolves(tmp_path):
+    f = tmp_path / "data.csv"
+    f.write_text("a,b\n1,2")
+    assert safe_path(str(f)) == f.resolve()
+
+
+def test_rejects_null_byte():
+    with pytest.raises(ValueError):
+        safe_path("data\x00.csv")
+
+
+def test_traversal_collapsed(tmp_path):
+    p = safe_path(str(tmp_path / "sub" / ".." / "data.csv"))
+    assert ".." not in p.parts
+
+
+def test_containment_blocks_escape(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "secret.txt"
+    with pytest.raises(PathOutsideAllowedRootError):
+        safe_path(str(outside), base_dir=root)
+
+
+def test_containment_allows_inside(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    inside = root / "ok.csv"
+    assert safe_path(str(inside), base_dir=root) == inside.resolve()
+
+
+def test_env_root(tmp_path, monkeypatch):
+    root = tmp_path / "jail"
+    root.mkdir()
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(root))
+    with pytest.raises(PathOutsideAllowedRootError):
+        safe_path(str(tmp_path / "outside.csv"))
+    assert safe_path(str(root / "in.csv")) == (root / "in.csv").resolve()
+
+
+def test_no_root_no_containment(tmp_path, monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_ALLOWED_ROOT", raising=False)
+    assert safe_path(str(tmp_path / "anything")) == (tmp_path / "anything").resolve()
+```
+
+- [ ] **Step 3: Run, verify failure**
+
+```bash
+python -m pytest tests/unit/test_safe_path.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: goldenmatch.core._paths`.
+
+- [ ] **Step 4: Implement the helper**
+
+Create `goldenmatch/core/_paths.py`:
+
+```python
+"""Path validation (CodeQL py/path-injection mitigation).
+
+GoldenMatch is local-first: reading the user's own files by path is the
+product, so containment is OPT-IN. Setting GOLDENMATCH_ALLOWED_ROOT (or
+passing base_dir) jails all user-supplied paths under that root --
+deploy-time hardening for network-exposed surfaces (the Railway MCP
+server sets it to the /data volume).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ENV_ROOT = "GOLDENMATCH_ALLOWED_ROOT"
+
+
+class PathOutsideAllowedRootError(ValueError):
+    """Raised when a user-supplied path escapes the configured root."""
+
+
+def safe_path(value: str | os.PathLike, *, base_dir: str | os.PathLike | None = None) -> Path:
+    """Normalize *value* and (when a root is configured) enforce containment.
+
+    Raises ValueError on NUL bytes, PathOutsideAllowedRootError on escape.
+    """
+    raw = os.fspath(value)
+    if "\x00" in raw:
+        raise ValueError("path contains NUL byte")
+    resolved = Path(raw).resolve()
+    root = base_dir if base_dir is not None else os.environ.get(_ENV_ROOT)
+    if root:
+        root_resolved = Path(root).resolve()
+        if not resolved.is_relative_to(root_resolved):
+            raise PathOutsideAllowedRootError(
+                f"path {str(resolved)!r} is outside allowed root {str(root_resolved)!r}"
+            )
+    return resolved
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+```bash
+python -m pytest tests/unit/test_safe_path.py -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 6: Apply at entry points (one commit per file, run that file's existing tests after each)**
+
+Principle: validate at the **boundary where the user value enters**, then pass the returned `Path` downstream — don't sprinkle `safe_path` on derived paths.
+
+1. `core/ingest.py` `load_file`: `path = safe_path(path)` replacing `path = Path(path)` (before the `.exists()` check).
+2. `core/smart_ingest.py` `smart_load`: `path = safe_path(path)` replacing `path = Path(path)`. `detect_encoding` receives the already-validated path from `smart_load`; if it's also called with raw user input elsewhere (grep callers), add `path = safe_path(path)` at its top too.
+3. `core/rollback.py` `rollback_run`: `output_dir = safe_path(output_dir)` at function top; inside the delete loop, `p = safe_path(filepath, base_dir=None)` then the existing `is_absolute` join logic — but run the JOINED path through `safe_path(p)` again before `p.unlink()` (the run-log JSON is attacker-influenceable, this is the delete primitive — strictest site).
+4. `core/lineage.py` `save_lineage`: `output_dir = safe_path(output_dir)` before `mkdir`. Also sanitize `run_name` into the filename: `run_name = Path(run_name).name` (strips any directory components) before building `f"{run_name}_lineage.json"`.
+5. `core/domain_registry.py` `save_rulebook`: `path = safe_path(path)` replacing `path = Path(path)`.
+6. `mcp/server.py` `_tool_pprl_link`: `file_a = safe_path(args["file_a"])`, `file_b = safe_path(args["file_b"])` — wrap in try/except returning `{"error": str(exc)}` consistent with the function's existing error style.
+7. `mcp/server.py` `_tool_export_results`: `path = safe_path(output_path)` with the same try/except style.
+8. `mcp/server.py`: grep for the remaining flagged sites (`grep -n "Path(args\|Path(output_path\|Path(file_path" goldenmatch/mcp/server.py`) — alerts #377/#388-#392 span ~6 lines; apply the same pattern to each `_tool_*` that takes a path arg.
+
+After each file: `python -m py_compile <file>` + run that module's existing unit-test file(s) individually.
+
+- [ ] **Step 7: Add a containment integration test for the MCP boundary**
+
+Append to `tests/unit/test_safe_path.py`:
+
+```python
+def test_mcp_export_respects_root(tmp_path, monkeypatch):
+    root = tmp_path / "jail"
+    root.mkdir()
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(root))
+    from goldenmatch.mcp import server as mcp_server
+    result = mcp_server._tool_export_results(str(tmp_path / "escape.json"), "json")
+    assert "error" in result
+```
+
+(Adjust the call signature to match the actual function — verify with grep before writing. If `_tool_export_results` needs global state (`_result`), set the minimal stub the error path requires, or pick whichever flagged `_tool_*` is stateless as the integration probe.)
+
+- [ ] **Step 8: Document the env var**
+
+Add `GOLDENMATCH_ALLOWED_ROOT` to wherever the package documents env vars (grep `GOLDENMATCH_` in `packages/python/goldenmatch/README.md` and the docs tree; follow the existing format): "Opt-in path sandbox. When set, every user-supplied file path (MCP tools, ingest, rollback, lineage, domain registry) must resolve under this directory."
+
+- [ ] **Step 9: Commit, push, PR (auth dance)**
+
+```bash
+git commit -m "feat(security): safe_path validation for user-supplied file paths
+
+Adds core/_paths.safe_path (NUL rejection, resolve(), opt-in
+GOLDENMATCH_ALLOWED_ROOT containment) and applies it at every CodeQL
+py/path-injection site: ingest, smart_ingest, rollback (incl. the
+delete loop), lineage, domain_registry, and the MCP tool handlers."
+```
+
+- [ ] **Step 10: After merge — set the Railway sandbox root, then triage residual alerts**
+
+Set the env var on the deployed MCP service (Railway project `golden-suite-mcp`, service `goldenmatch-mcp`): `GOLDENMATCH_ALLOWED_ROOT=/data`. **Produce the command / do it via the Railway MCP tooling only with Ben's confirmation** (it changes prod service behavior — existing users passing paths outside `/data` would start erroring; confirm the service's actual data layout first).
+
+Then check the 19 alerts:
+
+```bash
+for n in 377 378 379 380 381 382 383 384 385 386 387 388 389 390 391 392 393 394 395; do gh api repos/benseverndev-oss/goldenmatch/code-scanning/alerts/$n -q '[.number,.state] | @tsv'; done
+```
+
+Dismiss residuals (expected — conditional barrier):
+
+```bash
+gh api -X PATCH repos/benseverndev-oss/goldenmatch/code-scanning/alerts/<n> \
+  -f state=dismissed -f dismissed_reason="won't fix" \
+  -f dismissed_comment="Path is normalized and validated via core/_paths.safe_path (NUL rejection, resolve(), opt-in GOLDENMATCH_ALLOWED_ROOT containment -- set on the deployed MCP service). Arbitrary local-file access by user-supplied path is the product for this local-first tool; containment is deploy-time policy."
+```
+
+---
+
+### Task 7: Final sweep
+
+- [ ] **Step 1: Verify both counters are zero**
+
+```bash
+export GH_TOKEN=$(gh auth token --user benzsevern)
+gh api repos/benseverndev-oss/goldenmatch/dependabot/alerts -q '[.[] | select(.state=="open")] | length'
+gh api repos/benseverndev-oss/goldenmatch/code-scanning/alerts --paginate -q '[.[] | select(.state=="open")] | length'
+```
+
+Expected: `0` and `0`. CodeQL/Scorecard close on their next default-branch run — if non-zero immediately after the last merge, identify which scan hasn't rerun yet before treating anything as a miss.
+
+- [ ] **Step 2: Clean up worktrees**
+
+```bash
+git worktree remove .worktrees/sec-pr1  # ... and pr3..pr6 (no pr2 worktree — Task 2 was no-code)
+git worktree prune
+```
+
+- [ ] **Step 3: Report**
+
+Summarize per-alert disposition (fixed vs dismissed + justification) back to Ben.

--- a/docs/superpowers/plans/2026-06-05-surface-gap-roadmap.md
+++ b/docs/superpowers/plans/2026-06-05-surface-gap-roadmap.md
@@ -1,0 +1,300 @@
+# GoldenMatch Surface-Gap Roadmap (CLI / TUI / Web / API)
+
+> **For agentic workers:** Each wave is independently shippable. Steps use checkbox (`- [ ]`) syntax. Use superpowers:executing-plans (or subagent-driven-development) per wave. `docs/superpowers/` is gitignored — do NOT `git add` this plan.
+
+**Goal:** Close every gap surfaced in the 2026-06-05 four-surface audit (CLI, TUI, Web/HTTP, programmatic API) for the `goldenmatch` product, including full Python↔TypeScript parity.
+
+**Source audit:** four-surface sweep, 2026-06-05. Version baseline: Python `goldenmatch` **1.25.0**, TS `goldenmatch` **0.13.0**.
+
+**Ordering principle: RISK-FIRST.** Wave 0 fixes the one publicly-exposed security hole and the confirmed user-facing bugs. Then HTTP hardening, then orphaned-UI wiring, then library→CLI exposure, then TS parity (cheap surface-existing first, heavy net-new ports last), then polish.
+
+**Scope decision (TS parity):** FULL parity in scope — every Python-only capability is treated as a TS gap. Exception: subsystems that are Python-only *by architecture* (native Rust kernel, Ray/Sail/DataFusion distributed backends, the React SPA) are NOT ported; Wave 6 records that decision explicitly rather than forcing an edge-hostile port.
+
+**Branch/auth SOP:** feature branch per wave, squash-merge via PR, clean history. Python/TS packages use the work account; `packages/rust/extensions/` + `benseverndev-oss` use **personal** `benzsevern` (`gh auth switch --user benzsevern` before push, switch back after).
+
+**Effort key:** S = <0.5 day · M = 0.5–2 days · L = 2–5 days · XL = >1 week.
+
+---
+
+# STATUS LEDGER (2026-06-05, end of execution session — supersedes the per-wave checkboxes below)
+
+All waves executed in one session. 2 PRs merged, 10 open, all open PRs pairwise
+merge-tree-verified conflict-free (any merge order works).
+
+## Shipped / merged
+| Item | PR | Notes |
+|------|----|-------|
+| Wave 0 — fail-closed MCP/A2A auth, `--preview` collision, `review` cmd, `unmerge` fix | #766 ✅ merged | **ACTION STILL OPEN: set `GOLDENMATCH_MCP_TOKEN` on the Railway `goldenmatch-mcp` service or the next deploy crash-loops** (fail-closed working as intended). CI lesson: never assert substrings of Rich-rendered `--help` (narrow CI terminal wraps tokens) — introspect click params. |
+| Wave 1 — web/REST auth + CORS allowlist, SPA fallback, real health, A2A streaming:false | #767 ✅ merged | New env tokens: `GOLDENMATCH_WEB_TOKEN`, `GOLDENMATCH_API_TOKEN`, `GOLDENMATCH_API_CORS_ORIGINS`. |
+| Wave 2.1 — wire 3 orphaned TUI widgets (progress overlay, threshold slider, autoconfig screen) | #769 ✅ merged | |
+| (user's parallel PR) safe_path validation | #768 ✅ merged | Not from this roadmap; verified non-conflicting. |
+
+## Open PRs (the queue)
+| Item | PR |
+|------|----|
+| Wave 3.1 — `explain` / `lineage` / `anomalies` CLI commands | #771 |
+| Wave 3.2 — `match` zero-config + `--backend` help | #773 |
+| Wave 2.4 — in-TUI guided triage loop (Ctrl+T → TriageScreen) | #774 |
+| Wave 3.3 — REST `/shatter` + `/unmerge` (cluster surgery) | #775 |
+| Wave 2.2 — goldenpipe TUI stub → real (4 tabs wired to PipeResult) | #776 |
+| Wave 2.3 — TS-TUI boost write-back + real export (`writeExports`) | #777 |
+| Wave 4 — TS `evaluate` CLI + hardcoded-version fix | #779 |
+| Wave 4 — TS `resolveClusters` port + identity `findConflicts`/`history` helpers | #780 |
+| Wave 4 — TS config optimizer (ConfigEdit vocabulary + grid/coordinate loop) | #781 |
+| Wave 4 — TS PPRL faithful port (CLK protocol + bitwise scoring) | #782 |
+
+## Audit corrections discovered during execution (don't re-flag these)
+- `analyze-blocking` NameError: **false positive** (module-level `console` resolves at call time).
+- Web shatter: **already covered** via `POST /runs/{name}/unmerge` `mode="cluster"`.
+- Web evaluation GT upload: **already covered** — GT derives from browser-writable steward labels, not a server path.
+- TS identity `findConflicts`/`history`: not "un-exported" — they were **not implemented** as module helpers (store methods existed).
+- Python `link_smc` is itself a **simulated** secret-sharing structure (real mp-spdz = future enhancement) — "port the MPC crypto" meant "match what Python actually does."
+
+## Deferred with rationale (not silently dropped)
+- **3.2 `schedule list/status/cancel`** — needs a job store + PID/signal layer (`ScheduledJob.start()` is a foreground blocking loop); a feature, not a consistency fix.
+- **3.2 port unification** — Typer already shows defaults; changing `serve`'s 8080 breaks scripts.
+- **3.3 REST sensitivity** — duplicates web `POST /api/v1/sensitivity`; low marginal value.
+- **TS optimizer `confidence` objective** — needs a zero-label ComplexityProfile port first (`optimizeConfig` throws with guidance; `groundTruth`/`scoreFn` work).
+- **TS `LLMProposer` / LLMRefitPolicy / llm_label_pairs / llm_extract_features** — env-gated LLM territory; custom `Proposer`/hooks accepted instead.
+- **TS resolveClusters extras** — postgres bulk path, `cluster_frames` path, legacy hash-migration candidate, controllerSnapshot, batch-fingerprint (documented in TS CLAUDE.md).
+- **`DOMAIN_EXTRACTED_COLS` 3→12** — requires the TS extractors to *produce* 9 more columns, not just list them.
+- **TS `sensitivity` / `compare-clusters` CLI** — need cluster-file loader / sweep plumbing.
+- **AgentSession + 13 agent MCP tools** — the last heavy port; deterministic and fixture-able but the widest surface. Own session.
+- **Wave 6 polish** — SCORERS/TRANSFORMS codegen sync, docs-vs-registered-CLI test: still open.
+
+## Declared Python-only by design (per TS CLAUDE.md — do not port)
+Distributed/Ray/GPU, REST API + React web UI, native Rust kernel, Polars-only `bucket` backend.
+
+## Methodology that worked (reuse for AgentSession + future ports)
+Every heavy TS port shipped with a **Python-emitted parity fixture** (`packages/python/goldenmatch/scripts/emit_*_fixture.py` → `tests/parity/fixtures/*.json`):
+- UUID outputs → compare **structure** (summary counts, record→entity groupings), not literal ids (resolveClusters).
+- Float-boundary decisions → the emitter **asserts margins** (every score ≥0.10 from every threshold for the optimizer; ≥1e-3 for PPRL f32-vs-f64) so scorer tolerance can't flip an outcome.
+- The fixtures caught two real divergences pre-merge: pydantic revalidation on blocking-key removal (config-edits) and a fragile borderline pair (optimizer emitter assertion).
+
+---
+
+## Wave 0 — Risk & confirmed bugs (ship first)
+
+The only items that are either actively exposed or break documented workflows.
+
+### 0.1 — Auth on the deployed MCP HTTP server `[M]` `[SECURITY]`
+The Railway-hosted MCP endpoint `goldenmatch-mcp-production.up.railway.app/mcp/` is publicly reachable with **no token check** — any caller can invoke all 43 tools incl. file-writing ones (`export_results`, `create_domain`, `pprl_link`).
+
+**Files:** `goldenmatch/mcp/server.py:1264` (`run_server_http`), `goldenmatch/mcp/server.py:1299` (`/mcp` route), `railway.json`.
+
+- [ ] Add a bearer-token Starlette middleware gated on `GOLDENMATCH_MCP_TOKEN`; reject `/mcp` without it (401). Keep `/.well-known/mcp/server-card.json` public for healthcheck.
+- [ ] Default-DENY when the env var is **unset in a server (HTTP) context** — fail closed, log a clear startup error. (stdio transport stays unauthenticated — local only.)
+- [ ] Set `GOLDENMATCH_MCP_TOKEN` on the Railway service; document in `packages/python/goldenmatch/CLAUDE.md` under the Railway section.
+- [ ] Mirror the same gate in TS `node/mcp` HTTP path if/when it serves over HTTP.
+- **Acceptance:** `curl .../mcp/` without a token → 401; with token → tool list. Railway redeploy verified live.
+
+### 0.2 — `dedupe --preview` option collision `[S]` `[BUG]`
+`dedupe.py:72` (`preview`) and `dedupe.py:93` (`merge_preview`) both register the option string `--preview`. One shadows the other; `merge_preview` is unreachable.
+
+**Files:** `goldenmatch/cli/dedupe.py:72,93`.
+
+- [ ] Rename the merge-preview flag to `--merge-preview` (keep `--preview` = sample-without-writing).
+- [ ] Add a regression test that both flags parse independently (`CliRunner`).
+- **Acceptance:** `goldenmatch dedupe --help` shows both flags; each toggles its own behavior.
+
+### 0.3 — Implement the phantom `review` command `[M]` `[BUG]`
+`goldenmatch review` is documented in README:446, 3 wiki docs, and `docs/learning-memory.md` as the Learning-Memory quickstart, but is **not registered** — users hit "No such command." Machinery exists in `core/review_queue.py` (`ReviewQueue`, `gate_pairs()`).
+
+**Files:** new `goldenmatch/cli/review.py`; register in `goldenmatch/cli/main.py` (~line 116, near `label`).
+
+- [ ] Build `review_cmd`: load config, run/restore a run, gate borderline pairs, walk them interactively (reuse the GoldenCheck `action_guided_review` pattern), write decisions to MemoryStore/labels.
+- [ ] Wire `app.command("review", ...)(review_cmd)`.
+- [ ] Reconcile docs ↔ implementation (flags must match README example `goldenmatch review --config goldenmatch.yml`).
+- **Acceptance:** the README Learning-Memory quickstart runs end-to-end.
+
+### 0.4 — Make `unmerge` actually unmerge `[S]` `[BUG]`
+`rollback.py:63` reads the CSV and logs what it *would* do but never calls `unmerge_record()`/`unmerge_cluster()`.
+
+**Files:** `goldenmatch/cli/rollback.py:63-113`.
+
+- [ ] Call `core.cluster.unmerge_record` / `unmerge_cluster` on the parsed input; honor `--shatter`.
+- [ ] Remove the "use the Python API directly" dead-end message.
+- **Acceptance:** `goldenmatch unmerge <record_id> --clusters out.csv` mutates the cluster file; round-trip test passes.
+
+### 0.5 — A2A auth posture decision `[S]` `[SECURITY]`
+`a2a/server.py:327` enforces bearer only if `GOLDENMATCH_AGENT_TOKEN` is set; unset = fully open.
+
+- [ ] Decide + implement: fail-closed in HTTP/server mode (match 0.1), or document the open-by-default as intentional for local discovery. Recommend fail-closed for parity with 0.1.
+- **Acceptance:** documented + enforced consistently with the MCP server.
+
+---
+
+## Wave 1 — HTTP hardening & observability
+
+Bring the remaining 4 servers up to the Wave-0 bar before any of them get deployed.
+
+### 1.1 — Auth on Web UI API + REST matching API `[M]` `[SECURITY]`
+40+ `/api/v1/` routes (incl. `POST /run`, `/identities/{id}/merge|split`, `/rules/save`) and the stdlib REST server are both fully open; REST also sets `Access-Control-Allow-Origin: *` on every response.
+
+**Files:** `goldenmatch/web/app.py`, `goldenmatch/api/server.py:458`.
+
+- [ ] Optional bearer middleware (env-gated) on both, off by default for the localhost dev-tool use, **required** when bind host != `127.0.0.1`. Refuse to start on `0.0.0.0` without a token.
+- [ ] Tighten REST CORS: reflect an allowlist env var instead of `*`.
+- **Acceptance:** binding to `0.0.0.0` without a token aborts with a clear message.
+
+### 1.2 — SPA catch-all fallback `[S]`
+`web/app.py:61` mounts StaticFiles at `/` for exact `/` only; hard-refresh/shared URL to `/workbench`, `/runs/foo` → 404.
+
+- [ ] Add a catch-all route returning `index.html` before the StaticFiles mount (CLAUDE.md already prescribes this).
+- **Acceptance:** hard refresh on every client route serves the SPA.
+
+### 1.3 — Real health checks `[S]`
+All `/health(z)` endpoints return `{"status":"ok"}` unconditionally.
+
+**Files:** `web/app.py:17`, `api/server.py:358`; add `/health` to A2A (`a2a/server.py` — currently none).
+
+- [ ] Probe data.csv presence, memory-store reachability, project-root usability; return 503 + reasons on failure.
+- [ ] Add a health endpoint to the A2A server.
+
+### 1.4 — A2A streaming: implement or stop advertising `[M]`
+Agent card claims `"streaming": true` (`a2a/server.py:182`) but `_handle_send_task` is synchronous — streaming clients hang on long skills.
+
+- [ ] Either implement SSE/chunked task streaming, or set the capability to `false`. Recommend `false` now, real streaming as a follow-up.
+
+---
+
+## Wave 2 — Orphaned & half-wired UI
+
+Fully-built components one wiring away from working.
+
+### 2.1 — Wire the 3 orphaned Textual widgets `[M]`
+- [ ] `tui/widgets/progress_overlay.py` — mount in `GoldenMatchApp`; drive from the `@work(thread=True)` match jobs (8-stage progress instead of a toast).
+- [ ] `tui/widgets/threshold_slider.py` — add to Matches/Config tab; bind to `engine.recluster_at_threshold()` (already tested) for live re-cluster.
+- [ ] `tui/screens/autoconfig_screen.py` — push from the dedupe auto-launch path, pre-populated with detected config.
+- **Acceptance:** each widget visibly functions in `goldenmatch tui`; add pilot tests to `tests/test_tui.py`.
+
+### 2.2 — goldenpipe TUI: stub → real `[M]`
+`goldenpipe/tui/app.py` is 4 `Static` placeholders. The orchestrator package has the most to show and the least TUI.
+
+- [ ] Wire Pipeline tab to `Pipeline.run()` stage timings; Config tab to `PipelineConfig`; Results tab to final golden records; Log tab to `PipeResult.reasoning`.
+- [ ] Add a `goldenpipe interactive` launch command.
+
+### 2.3 — TS TUI: persist boost labels + real export `[M]` `[PARITY]`
+- [ ] Boost tab (`node/tui/app.ts:430`) — call the TS memory `addCorrection()` (exists) instead of dropping labels in local state.
+- [ ] Export tab (`node/tui/app.ts:545`) — call the real file connector/CSV writer instead of the `setTimeout` simulation.
+
+### 2.4 — Review-queue triage loop in the goldenmatch TUI `[M]`
+No interactive borderline-pair triage (GoldenCheck has guided review; goldenmatch doesn't). Overlaps with 0.3 — share the walk-one-at-a-time component between CLI `review` and the TUI.
+
+---
+
+## Wave 3 — Library→CLI/HTTP exposure (Python)
+
+Capabilities that exist in the API with no front door.
+
+### 3.1 — New CLI commands for existing library features `[L]`
+- [ ] `goldenmatch explain` → `core/explain.py` (`explain_pair_nl`/`explain_cluster_nl`).
+- [ ] `goldenmatch lineage` → `core/lineage.py` (`build_lineage`/`save_lineage`).
+- [ ] `goldenmatch graph-er` → `core/graph_er.py` (multi-table ER).
+- [ ] `goldenmatch anomalies` standalone → `core/anomaly.py` (currently only a `dedupe --anomalies` flag).
+- [ ] `goldenmatch domain` CRUD (list/create/test/save) → `core/domain_registry.py` (exists as MCP tools, no CLI).
+- **Acceptance:** each command has `--help` + a smoke test.
+
+### 3.2 — Fill CLI inconsistencies `[M]`
+- [ ] `schedule` subcommands: `list` / `status` / `cancel` (`schedule.py` — currently start-only, no introspection).
+- [ ] Unify "serve" port defaults (today: `serve`=8080, `mcp-serve`=8200, TS=8000). Pick a documented scheme.
+- [ ] Let `match` run zero-config like `dedupe` (`match.py:22` currently requires `--config`).
+- [ ] `dedupe --backend` help text: list all valid values (`bucket`, `chunked`, `ray`, `duckdb`).
+
+### 3.3 — HTTP exposure gaps `[M]`
+- [ ] Expose `shatter_cluster` over the Web UI API + REST (MCP has it; HTTP doesn't).
+- [ ] Sensitivity endpoint on the REST matching server (only the Web UI API has it).
+- [ ] Ground-truth upload for `/api/v1/runs/{run}/evaluation` (today requires a server-local path — blocks browser-only eval).
+
+---
+
+## Wave 4 — TS parity: surface existing library (cheap)
+
+Close gaps where the TS library function **already ships** and just lacks a CLI/export.
+
+### 4.1 — TS CLI commands over existing functions `[M]` `[PARITY]`
+- [ ] `evaluate` → `core/evaluate.ts` (functions exist).
+- [ ] `sensitivity` → `core/sensitivity.ts`.
+- [ ] `compare-clusters` → `core/compare-clusters.ts`.
+- [ ] `memory add` (TS memory group has stats/learn/export/import/show but no `add`).
+
+### 4.2 — Python CLI parity with TS `[S]` `[PARITY]`
+- [ ] `goldenmatch score <a> <b>` (TS has it; Python has `score_strings()` lib but no CLI).
+- [ ] `goldenmatch info` (list scorers/strategies/transforms/blocking; TS has it, Python doesn't).
+
+### 4.3 — Identity graph: self-population + re-exports `[M]` `[PARITY]`
+- [ ] Wire `resolveClusters` in the TS pipeline so the TS identity graph self-populates (today read/query/manual-merge only; nothing fills it). Mirrors Python `identity/resolve.py:resolve_clusters`.
+- [ ] Re-export `findConflicts` + `history` from `core/identity/index.ts` (they exist in `query.ts` but aren't surfaced).
+- [ ] Add `identity resolve` to the TS CLI (deferred per `cli.ts:627`).
+
+### 4.4 — Cheap TS correctness fixes `[S]` `[PARITY]`
+- [ ] `cli.ts:221` — read version from `package.json` instead of the hardcoded `v0.1.0`.
+- [ ] `domain.ts` — expand `DOMAIN_EXTRACTED_COLS` from 3 → 12 to match Python (flagged in TS CLAUDE.md).
+- [ ] Document `recordFingerprint` sync(Py)/async(TS) divergence at both call sites, or add a sync TS path.
+
+---
+
+## Wave 5 — TS parity: net-new algorithm ports (heavy)
+
+Real porting work where no TS implementation exists. Each is independently shippable.
+
+### 5.1 — Config optimizer stack `[L]` `[PARITY]`
+Port `optimize_config`, `GridProposer`/`LLMProposer`/`CoordinateDescentProposer`, the 6 config-edit types (`ThresholdShift` etc.), `suggest_threshold` (Otsu).
+
+### 5.2 — PPRL real crypto `[L]` `[PARITY]`
+TS `linkTrustedThirdParty`/`linkSMC` (`pprl/protocol.ts:180,201`) are self-labeled "API-parity stubs" over a simplified bloom approximation. Port the real CLK bloom-filter + MPC path; add `auto_configure_pprl_llm`, `compute_bloom_filters`.
+
+### 5.3 — LLM subsystem parity `[M]` `[PARITY]`
+Port `llm_label_pairs`, `llm_extract_features`, `LLMRefitPolicy` to TS.
+
+### 5.4 — Data-ops parity `[M]` `[PARITY]`
+Port `detect_anomalies`, `auto_map_columns` (schema match), `generate_diff`, `rollback_run`, `boost_accuracy`, `run_stream`, `save_lineage_streaming`/`load_lineage`.
+
+### 5.5 — AgentSession + agent tools `[L]` `[PARITY]`
+Port `core/agent.py:AgentSession` and the 13 MCP agent tools (`mcp/agent_tools.py`) to the TS Node surface.
+
+### 5.6 — TS blocker + plugin completeness `[M]` `[PARITY]`
+- [ ] Implement `ann` / `ann_pairs` / `canopy` / `learned` blocking (today `blocker.ts:593` throws at runtime — `ANNBlocker`/`HNSWANNBlocker` exist to build on).
+- [ ] Open the `registerScorer`/`registerTransform`/`registerConnector` plugin slots (today only `golden_strategy` works).
+- [ ] Decide: real embedder vs the hash-placeholder fallback (`scorer.ts:46`). At minimum make embedding-scorer calls **error loudly** when no real embedder is registered instead of silently producing placeholder vectors.
+
+### 5.7 — TS memory/connector parity `[M]` `[PARITY]`
+- [ ] `MemoryLearner.fieldWeights` (`learner.ts:76`) — implement or document the permanent null.
+- [ ] TS Postgres memory backend (today in-memory + SQLite only).
+- [ ] Expand TS connectors (5 → match Python's 12) as demand dictates — track per-connector, don't block the wave.
+
+---
+
+## Wave 6 — Polish, sync, and architecture decisions
+
+### 6.1 — Frontend/config drift `[S]`
+- [ ] Codegen `SCORERS`/`TRANSFORMS` in `web/frontend/src/lib/types.ts` from `config/schemas.py::VALID_SCORERS/VALID_SIMPLE_TRANSFORMS` (today hand-synced — new scorers silently miss the dropdowns).
+
+### 6.2 — Doc reconciliation `[S]`
+- [ ] Sweep README/wiki for other commands-that-don't-exist (the `review` class of bug); add a CLI-inventory test that asserts every documented command is registered.
+
+### 6.3 — Record intentional Python-only boundaries (decision, not port) `[S]`
+These are Python-only **by architecture**; the roadmap's job is to document the decision, not force an edge-hostile port:
+- [ ] Native Rust/PyO3 kernel (`native.py`) — TS is edge-safe by design.
+- [ ] Ray / Sail / DataFusion distributed backends — server-side only.
+- [ ] React SPA (`web/`) — single-tenant local tool.
+- [ ] `snowflake/udfs.py` Phase-2 stored procs + `identity/store.py` SQLite bulk-write stubs — confirm these are still wanted; either schedule or delete.
+- **Acceptance:** a "TS parity: intentional exclusions" section in `packages/typescript/goldenmatch/CLAUDE.md` so future audits don't re-flag them.
+
+---
+
+## Suggested PR sequencing
+
+| PR | Wave items | Why first |
+|----|-----------|-----------|
+| 1 | 0.1, 0.5 | Live security exposure |
+| 2 | 0.2, 0.3, 0.4 | Confirmed bugs / broken docs |
+| 3 | 1.1–1.4 | HTTP hardening before any new deploy |
+| 4 | 2.1, 2.4 | High-value/low-cost orphaned UI |
+| 5 | 2.2, 2.3 | Remaining UI wiring |
+| 6 | 3.1, 3.2, 3.3 | Python feature exposure |
+| 7 | 4.1–4.4 | Cheap TS parity (lib exists) |
+| 8+ | 5.1–5.7 | Heavy TS ports, one PR each |
+| last | 6.1–6.3 | Polish + record decisions |
+
+**Cross-cutting gates:** every wave adds tests; CI parity gates (backend + cross-language) must stay green; per `feedback_verify_perf_not_just_ship`, any perf-touching change verifies wall-clock on the failing env, not just that it shipped.

--- a/docs/superpowers/plans/2026-06-08-fs-per-rule-em.md
+++ b/docs/superpowers/plans/2026-06-08-fs-per-rule-em.md
@@ -1,0 +1,431 @@
+# Fellegi-Sunter Per-Rule EM Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace GoldenMatch's single global EM (which corrupts non-blocking fields' `m`-estimates and collapses precision) with Splink's per-blocking-rule EM: estimate each field's `m` from the runs where it is free to vary, average across runs, keep `u` from random sampling.
+
+**Architecture:** `train_em` runs one EM pass per blocking rule (holding that rule's columns fixed, estimating the rest), then averages each field's per-run `m`. `u` stays from random sampling; the neutral-`u` override for blocking fields is dropped. `EMResult` is unchanged, so the already-shipped sigmoid normalization, TF adjustments, and fast path are untouched. Default-on with `GOLDENMATCH_FS_PER_RULE_EM=0` restoring the current single-run path.
+
+**Tech Stack:** Python 3.11+, NumPy, Polars, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-fs-per-rule-em-design.md`
+
+---
+
+## Conventions for the implementing engineer
+
+- Run tests (Windows): `$env:POLARS_SKIP_CPU_CHECK=1; $env:PYTHONIOENCODING="utf-8"; .venv\Scripts\python.exe -m pytest <path> -v`. Do NOT run the full suite (OOMs this box). Run only touched files.
+- Branch `feat/probabilistic-splink-parity` (continue on it). Commit code+tests only; NEVER `git add docs/`. ASCII-only commit messages. Do NOT push.
+- This builds on already-shipped work on this branch: sigmoid normalization (`_fs_sigmoid_enabled`), TF (`_tf_adjusted_weight`, `EMResult.tf_tables`), union-aware exclusion (`_em_excluded_fields`), multi-pass blocking. Do not regress them.
+
+## Background: current `train_em` shape (READ before starting)
+
+`core/probabilistic.py::train_em(df, mk, n_sample_pairs, max_iterations, convergence, seed, blocks=None, blocking_fields=None)`:
+1. Builds `row_lookup`; estimates `u_probs` from `_sample_pairs` random pairs (~line 313-326).
+2. **Overrides `u` to neutral for `blocking_fields`** (~line 328-334) — THIS OVERRIDE IS DROPPED under per-rule EM.
+3. Samples within-block pairs via `_sample_blocked_pairs(blocks, ...)` (~line 338-347).
+4. Builds `comp_matrix`; inits `m_probs` with an exponential prior (~line 349-361).
+5. **EM loop** (~line 363-399+): vectorized E-step (per-field log-prob tables), M-step that **skips `blocking_fields`** (`if f.field in blocking_fields: continue`, ~line 397).
+6. Computes `match_weights` = fixed `[-3..3]` for `blocking_fields`, else `log2(m/u)`; builds `tf_tables`; returns `EMResult`.
+
+The M-step already skips a field-set — per-rule EM is this loop run once per pass with `excluded = that pass's fields`.
+
+## File Structure
+
+- **Modify** `core/probabilistic.py`: extract the EM loop into `_estimate_m_one_pass(...)`; add `_fs_per_rule_em_enabled()`; add a `passes` param + per-rule branch to `train_em`; the per-rule branch drops the neutral-`u` override and does per-field averaging + fallback.
+- **Modify** `core/pipeline.py`: build per-pass blocks (`_build_blocks_per_pass`) and pass them to `train_em(passes=...)` at both call sites (dedupe ~1417, match ~2388). Keep the union `blocks` for scoring. The single-run kill-switch path keeps using `blocks` + `_em_excluded_fields`.
+- **New** `tests/test_probabilistic_per_rule_em.py`.
+
+---
+
+## Task 1: Kill-switch helper + extract the per-pass EM loop (pure refactor)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/probabilistic.py`
+- Test: `packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py`
+
+- [ ] **Step 1: Write the failing test** (kill-switch parsing + extracted helper reproduces current EM)
+
+```python
+import os
+import numpy as np
+import polars as pl
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.probabilistic import (
+    _fs_per_rule_em_enabled, _estimate_m_one_pass, _build_comparison_matrix,
+)
+
+def test_per_rule_default_on_and_killswitch():
+    assert _fs_per_rule_em_enabled() is True
+    for v in ("0", "false", "DISABLED", "no", "  0 "):
+        os.environ["GOLDENMATCH_FS_PER_RULE_EM"] = v
+        try:
+            assert _fs_per_rule_em_enabled() is False
+        finally:
+            os.environ.pop("GOLDENMATCH_FS_PER_RULE_EM", None)
+
+def test_estimate_m_one_pass_skips_excluded_and_estimates_rest():
+    # 6 rows: two clear dup clusters agreeing on name+city, distinct otherwise
+    df = pl.DataFrame({
+        "__row_id__": [0,1,2,3,4,5],
+        "name": ["ann","ann","bob","bob","cara","dee"],
+        "city": ["x","x","y","y","z","w"],
+    })
+    mk = MatchkeyConfig(name="p", type="probabilistic", fields=[
+        MatchkeyField(field="name", scorer="exact", levels=2, partial_threshold=0.9),
+        MatchkeyField(field="city", scorer="exact", levels=2, partial_threshold=0.9),
+    ])
+    cols = ["name","city"]
+    row_lookup = {r["__row_id__"]: r for r in df.select(["__row_id__"]+cols).to_dicts()}
+    pairs = [(0,1),(2,3),(0,2),(1,4)]
+    comp = _build_comparison_matrix(pairs, row_lookup, mk)
+    u_probs = {"name":[0.5,0.5], "city":[0.5,0.5]}
+    # exclude "name" (as if blocked on name): only "city" m should move off the prior
+    m, p_match, converged, iterations = _estimate_m_one_pass(
+        comp, mk, u_probs, excluded={"name"}, max_iterations=20, convergence=1e-3)
+    assert "city" in m and "name" in m
+    assert 0.0 < p_match <= 1.0 and isinstance(converged, bool) and iterations >= 1
+    # city was estimated (not the bare exponential prior [1/3, 2/3] for 2 levels)
+    assert m["city"] != [1/3, 2/3]
+    # name was EXCLUDED -> left at the exponential prior
+    assert m["name"] == [1/3, 2/3]
+```
+
+- [ ] **Step 2: Run, verify fail** (`ImportError: cannot import name '_estimate_m_one_pass'`).
+Run: `$env:POLARS_SKIP_CPU_CHECK=1; $env:PYTHONIOENCODING="utf-8"; .venv\Scripts\python.exe -m pytest packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py -v`
+
+- [ ] **Step 3: Implement.**
+Add the kill-switch helper near `_fs_sigmoid_enabled`:
+```python
+def _fs_per_rule_em_enabled() -> bool:
+    """Per-rule EM (estimate each field's m from runs where it is free) -- default ON.
+    GOLDENMATCH_FS_PER_RULE_EM=0/false/disabled/no restores the single-run EM."""
+    return os.environ.get("GOLDENMATCH_FS_PER_RULE_EM", "1").strip().lower() not in (
+        "0", "false", "disabled", "no")
+```
+Extract the EM loop (current ~line 353-401, the `m_probs` init + the `for iteration` loop + the M-step that skips a field-set) into a module-level helper. It takes a prebuilt `comp_matrix` + `u_probs` + the `excluded` field-set and returns the estimated `m_probs` dict:
+```python
+def _estimate_m_one_pass(comp_matrix, mk, u_probs, excluded, max_iterations, convergence):
+    """One EM run: estimate m for fields NOT in `excluded` (the run's blocking fields,
+    held constant in this block). Returns (m_probs, p_match, converged, iterations).
+    m_probs covers ALL fields (excluded ones keep the exponential prior; callers ignore
+    those). Vectorized E-step identical to the inline loop it replaces. The extra return
+    values (p_match/converged/iterations) preserve what train_em's EMResult needs so the
+    single-run refactor is behavior-preserving (existing tests assert converged/iterations)."""
+    n_pairs = comp_matrix.shape[0]
+    p_match = 0.02
+    m_probs = {}
+    for f in mk.fields:
+        raw = [2 ** k for k in range(f.levels)]
+        m_probs[f.field] = [r / sum(raw) for r in raw]
+    converged = False
+    iteration = 0
+    for iteration in range(max_iterations):
+        old_m = {k: list(v) for k, v in m_probs.items()}
+        log_m = np.zeros(n_pairs); log_u = np.zeros(n_pairs)
+        for j, f in enumerate(mk.fields):
+            levels_j = comp_matrix[:, j]
+            m_table = np.log(np.maximum(np.asarray(m_probs[f.field], dtype=np.float64), 1e-10))
+            u_table = np.log(np.maximum(np.asarray(u_probs[f.field], dtype=np.float64), 1e-10))
+            log_m += m_table[levels_j]; log_u += u_table[levels_j]
+        log_match = math.log(max(p_match, 1e-10)) + log_m
+        log_nonmatch = math.log(max(1 - p_match, 1e-10)) + log_u
+        max_log = np.maximum(log_match, log_nonmatch)
+        e_match = np.exp(log_match - max_log); e_nonmatch = np.exp(log_nonmatch - max_log)
+        posteriors = e_match / (e_match + e_nonmatch)
+        total_match = posteriors.sum()
+        p_match = max(total_match / n_pairs, 1e-6)
+        for j, f in enumerate(mk.fields):
+            if f.field in excluded:
+                continue
+            new_m = [0.0] * f.levels
+            for level in range(f.levels):
+                mask = comp_matrix[:, j] == level
+                new_m[level] = (posteriors[mask].sum() + 1e-6) / (total_match + f.levels * 1e-6)
+            m_probs[f.field] = new_m
+        max_delta = max((abs(m_probs[f.field][k] - old_m[f.field][k])
+                         for f in mk.fields if f.field not in excluded
+                         for k in range(f.levels)), default=0.0)
+        if max_delta < convergence:
+            converged = True
+            break
+    iterations = iteration + 1
+    return m_probs, p_match, converged, iterations
+```
+**Return contract is `(m_probs, p_match, converged, iterations)` everywhere** — the Task 1 test, the single-run refactor, and Task 2 all unpack the 4-tuple. This is required because existing `test_probabilistic.py` asserts `result.converged`/`result.iterations` on the single-run path (lines ~193, 427, 476, 538); the refactor must thread all four into `EMResult`, not just `m_probs`.
+
+Then **refactor the existing single-run `train_em` body to call**
+`_estimate_m_one_pass(comp_matrix, mk, u_probs, set(blocking_fields), max_iterations, convergence)`
+in place of its inline `m_probs` init + `for iteration` loop, unpacking
+`m_probs, p_match, converged, iterations = _estimate_m_one_pass(...)` and threading
+`converged`/`iterations`/`proportion_matched=p_match` into the returned `EMResult` exactly
+as the inline loop did. The single-run match-weights computation (fixed `-3..3` for
+`blocking_fields`, else `log2(m/u)`) and the TF-table build stay where they are (the TF
+build is factored out in Task 2). This keeps the kill-switch path byte-equivalent.
+
+- [ ] **Step 4: Run the new test + the existing probabilistic suite — all green.**
+`.venv\Scripts\python.exe -m pytest packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py packages/python/goldenmatch/tests/test_probabilistic.py packages/python/goldenmatch/tests/test_probabilistic_sigmoid.py packages/python/goldenmatch/tests/test_probabilistic_tf.py -q`
+Expected: PASS (the refactor is behavior-preserving for the single-run path).
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/probabilistic.py packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py
+git commit -m "refactor(probabilistic): extract _estimate_m_one_pass + add per-rule-EM kill-switch (behavior-preserving)"
+```
+
+---
+
+## Task 2: Per-rule EM path in `train_em` (average across passes, drop neutral-u override, fallback)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/probabilistic.py` (`train_em`)
+- Test: `packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py`
+
+- [ ] **Step 1: Write the failing tests** (the behavioral guards from the spec)
+
+```python
+from goldenmatch.core.probabilistic import train_em
+
+def _df_person():
+    # matches agree on name AND postcode; non-matches in a name block disagree on postcode
+    return pl.DataFrame({
+        "__row_id__": list(range(8)),
+        "name":     ["smith","smith","smith","smith","jones","jones","lee","ng"],
+        "postcode": ["AA1","AA1","BB2","CC3","DD4","DD4","EE5","FF6"],
+    })
+
+def _mk():
+    return MatchkeyConfig(name="p", type="probabilistic", fields=[
+        MatchkeyField(field="name", scorer="exact", levels=2, partial_threshold=0.9),
+        MatchkeyField(field="postcode", scorer="exact", levels=2, partial_threshold=0.9),
+    ])
+
+def _passes_blocks(df, fieldsets):
+    # build one BlockResult-like per pass via the real blocker
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+    from goldenmatch.core.blocker import build_blocks
+    out = []
+    for fs in fieldsets:
+        cfg = BlockingConfig(keys=[BlockingKeyConfig(fields=fs)])
+        out.append((fs, build_blocks(df.lazy(), cfg)))
+    return out
+
+def test_per_rule_postcode_disagree_penalty_is_strong():
+    df, mk = _df_person(), _mk()
+    # passes: block on name (postcode free) AND block on postcode (name free)
+    passes = _passes_blocks(df, [["name"], ["postcode"]])
+    em = train_em(df, mk, passes=passes)
+    # postcode estimated in the name-blocked run where it varies -> disagree weight clearly negative
+    assert em.match_weights["postcode"][0] <= -1.0
+    # name estimated in the postcode-blocked run
+    assert "name" in (em.tf_tables or {}) or em.match_weights["name"][1] > 0
+
+def test_per_rule_beats_single_run_on_disagree_penalty():
+    df, mk = _df_person(), _mk()
+    passes = _passes_blocks(df, [["name"], ["postcode"]])
+    em_perrule = train_em(df, mk, passes=passes)
+    # single-run kill-switch path: block on name only, postcode m corrupted
+    os.environ["GOLDENMATCH_FS_PER_RULE_EM"] = "0"
+    try:
+        blocks = passes[0][1]
+        em_single = train_em(df, mk, blocks=blocks, blocking_fields=["name"])
+    finally:
+        os.environ.pop("GOLDENMATCH_FS_PER_RULE_EM", None)
+    # per-rule gives a stronger (more negative) postcode-disagree weight than single-run
+    assert em_perrule.match_weights["postcode"][0] < em_single.match_weights["postcode"][0]
+
+def test_per_rule_u_not_overridden_for_sometimes_blocked_field():
+    df, mk = _df_person(), _mk()
+    passes = _passes_blocks(df, [["name"], ["postcode"]])
+    em = train_em(df, mk, passes=passes)
+    # name is a block key in pass 1 but u must be the random-pair estimate, NOT neutral 0.5
+    assert em.u_probs["name"] != [0.5, 0.5]
+
+def test_per_rule_fallback_for_always_blocked_field():
+    df, mk = _df_person(), _mk()
+    # both passes block on name -> name free in NO pass -> fixed prior fallback
+    passes = _passes_blocks(df, [["name"], ["name"]])
+    em = train_em(df, mk, passes=passes)
+    assert em.match_weights["name"] == [-3.0, 3.0]  # fixed 2-level prior
+```
+
+- [ ] **Step 2: Run, verify fail** (train_em has no `passes` param yet / weights wrong).
+
+- [ ] **Step 3: Implement the per-rule branch in `train_em`.**
+Add `passes: list | None = None` to the signature (list of `(field_set, blocks)` tuples). Near the top, branch:
+```python
+    if passes is not None and _fs_per_rule_em_enabled():
+        return _train_em_per_rule(df, mk, passes, n_sample_pairs, max_iterations,
+                                  convergence, seed)
+```
+Implement `_train_em_per_rule`:
+```python
+def _train_em_per_rule(df, mk, passes, n_sample_pairs, max_iterations, convergence, seed):
+    cols = [f.field for f in mk.fields if f.field != "__record__"]
+    row_lookup = {r["__row_id__"]: r for r in df.select(["__row_id__"]+cols).to_dicts()}
+    # u from random pairs -- shared, NO neutral override (spec: random u is unbiased for all)
+    random_pairs = _sample_pairs(df, min(n_sample_pairs, 5000), seed)
+    if len(random_pairs) < 10:
+        return _fallback_result(mk)
+    random_matrix = _build_comparison_matrix(random_pairs, row_lookup, mk)
+    u_probs = {}
+    for j, f in enumerate(mk.fields):
+        counts = [float((random_matrix[:, j] == lv).sum()) for lv in range(f.levels)]
+        total = sum(counts) + f.levels * 1e-6
+        u_probs[f.field] = [(c + 1e-6) / total for c in counts]
+    # per-pass EM, collect m estimates for fields free in that pass
+    m_runs = {f.field: [] for f in mk.fields}
+    p_matches = []
+    converged_any = False
+    iters_max = 0
+    for field_set, blocks in passes:
+        pair_list = _sample_blocked_pairs(blocks, n_sample_pairs, seed)
+        if len(pair_list) < 10:
+            logger.info("per-rule EM: pass %s skipped (only %d pairs)", field_set, len(pair_list))
+            continue
+        comp = _build_comparison_matrix(pair_list, row_lookup, mk)
+        excluded = set(field_set)
+        m_pass, p_match, conv, iters = _estimate_m_one_pass(
+            comp, mk, u_probs, excluded, max_iterations, convergence)
+        p_matches.append(p_match)
+        converged_any = converged_any or conv
+        iters_max = max(iters_max, iters)
+        for f in mk.fields:
+            if f.field not in excluded:
+                m_runs[f.field].append(m_pass[f.field])
+    if all(len(v) == 0 for v in m_runs.values()):
+        return _fallback_result(mk)  # every pass thin
+    # combine: average across runs where the field was free; fixed prior if free in none
+    m_probs, match_weights = {}, {}
+    for f in mk.fields:
+        runs = m_runs[f.field]
+        if runs:
+            m_probs[f.field] = [float(np.mean([r[lv] for r in runs])) for lv in range(f.levels)]
+            match_weights[f.field] = [
+                math.log2(max(m_probs[f.field][lv], 1e-10) / max(u_probs[f.field][lv], 1e-10))
+                for lv in range(f.levels)]
+        else:
+            # free in NO pass -> fixed neutral prior (same shape as the single-run blocking-field path)
+            n = f.levels
+            m_probs[f.field] = [r / sum(2**k for k in range(n)) for r in (2**k for k in range(n))]
+            match_weights[f.field] = [(-3.0 + 6.0*k/(n-1)) if n > 1 else 3.0 for k in range(n)]
+    # TF tables -- reuse the existing builder logic (factor it out if inline today)
+    tf_tables = _build_tf_tables(df, mk)   # see TF-factoring step below
+    return EMResult(m_probs=m_probs, u_probs=u_probs, match_weights=match_weights,
+                    converged=converged_any, iterations=iters_max,
+                    proportion_matched=(float(np.mean(p_matches)) if p_matches else 0.05),
+                    tf_tables=(tf_tables or None))
+```
+Notes:
+- `_estimate_m_one_pass` returns `(m_probs, p_match, converged, iterations)` (Task 1) — unpack all four; aggregate `converged` via OR and `iterations` via max across passes (shown above).
+- The fixed-weight fallback for free-in-no-pass fields must match the single-run path's blocking-field weights (linear `-3..3`) so single-static-key equivalence holds.
+
+**Step 3a (do FIRST, before writing `_train_em_per_rule`): factor out `_build_tf_tables`.**
+The TF-table construction currently lives INLINE in `train_em` (the loop that builds
+`tf_tables` from `tf_adjust` fields via `apply_transforms(str(value), f.transforms)` +
+per-value frequency — real source ~lines 444-467). Extract it verbatim into a module-level
+`def _build_tf_tables(df, mk) -> dict[str, dict[str, float]]:` and replace the inline block
+in the single-run `train_em` with a call to it. Run the existing TF tests
+(`test_probabilistic_tf.py`) to confirm the extraction is behavior-preserving BEFORE
+building the per-rule path (which also calls `_build_tf_tables`). This keeps one TF
+definition (DRY) and identical tables on both paths.
+
+- [ ] **Step 4: Run the Task-2 tests + the full probabilistic suite — all green.** Adjust ONLY if a test's expected number is wrong for a defensible reason (note it); never weaken a behavioral assertion (the disagree-penalty and u-not-overridden tests are load-bearing).
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/probabilistic.py packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py
+git commit -m "feat(probabilistic): per-rule EM -- estimate each field's m where it is free, average across passes, drop neutral-u override"
+```
+
+---
+
+## Task 3: Pipeline wiring (build per-pass blocks; call train_em(passes=...))
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/pipeline.py` (both probabilistic branches)
+- Test: `packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py`
+
+- [ ] **Step 1: Write the failing test** (end-to-end dedupe runs via per-rule EM, multi-pass config)
+
+```python
+def test_pipeline_per_rule_em_runs_end_to_end():
+    from goldenmatch import dedupe_df
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    df = pl.DataFrame({
+        "first_name": ["ann","ann","bob","bobby","cara","cara","dan","eve"],
+        "surname":    ["lee","lee","kim","kim","ng","ng","ono","poe"],
+        "dob":        ["1990","1990","1985","1985","1972","1972","1965","1959"],
+    })
+    cfg = auto_configure_probabilistic_df(df)
+    res = dedupe_df(df, config=cfg)
+    assert res is not None  # per-rule EM path executes, no crash
+```
+
+- [ ] **Step 2: Make the test assert the per-rule path is taken, and verify it FAILS pre-wiring.** Add a spy on `_train_em_per_rule` and assert it fired during `dedupe_df`. Patch it on the `probabilistic` MODULE (the pipeline imports `train_em` from there lazily; `_train_em_per_rule` is called *inside* `train_em`, so patching the module binding works):
+```python
+def test_pipeline_per_rule_em_runs_end_to_end(monkeypatch):
+    import goldenmatch.core.probabilistic as P
+    calls = {"n": 0}
+    orig = P._train_em_per_rule
+    def spy(*a, **k):
+        calls["n"] += 1
+        return orig(*a, **k)
+    monkeypatch.setattr(P, "_train_em_per_rule", spy)
+    # ... build df + cfg + dedupe_df(df, config=cfg) as above ...
+    assert res is not None
+    assert calls["n"] >= 1, "per-rule EM path was not taken (passes not wired into the pipeline)"
+```
+Before Step 3 wires `passes` into the `train_em` call, `calls["n"]` stays 0 → the assert FAILS. That's the red state.
+
+- [ ] **Step 3: Implement.** Add a helper (in `pipeline.py` or `blocker.py`) that returns per-pass blocks from a `BlockingConfig`:
+```python
+def _build_blocks_per_pass(lf, blocking):
+    """Return [(field_set, blocks), ...] -- one entry per blocking pass (or per key when
+    no passes). Reuses the static block builder per pass so pass identity is retained
+    (build_blocks unions+dedupes and loses it)."""
+    from goldenmatch.config.schemas import BlockingConfig
+    passes = blocking.passes if blocking.passes else (blocking.keys or [])
+    out = []
+    for p in passes:
+        cfg = BlockingConfig(keys=[p], max_block_size=blocking.max_block_size,
+                             skip_oversized=blocking.skip_oversized)
+        out.append((list(p.fields), build_blocks(lf, cfg)))
+    return out
+```
+At BOTH probabilistic branches in pipeline.py: keep the existing union `blocks = build_blocks(...)` (used for SCORING), and add `passes = _build_blocks_per_pass(combined_lf, config.blocking)`; call `train_em(collected_df, mk, ..., passes=passes)` (drop the `blocking_fields=` arg on the per-rule call; the single-run kill-switch path inside train_em still uses `blocks`+`blocking_fields` when `passes is None` OR per-rule disabled — so under the kill-switch, pass `blocks=blocks, blocking_fields=_em_excluded_fields(config.blocking)` and `passes=None`). Simplest wiring: always pass BOTH `blocks=blocks, blocking_fields=_em_excluded_fields(config.blocking), passes=passes`; `train_em` chooses per-rule when enabled+passes, else single-run.
+
+- [ ] **Step 4: Run the test + a broad probabilistic regression** (`test_probabilistic*.py`, `test_autoconfig_probabilistic*.py`) — all green.
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/pipeline.py packages/python/goldenmatch/goldenmatch/core/blocker.py packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py
+git commit -m "feat(probabilistic): wire per-rule EM into both pipeline branches (per-pass blocks)"
+```
+
+---
+
+## Task 4: Measure against the gate (no code; uses the surviving-dump PR-curve method)
+
+- [ ] **Step 1** Re-run the local PR-curve diagnostic (the `.profile_tmp/diag_pr_tf.py` shape, but training via the per-rule path — i.e. pass `passes=_build_blocks_per_pass(...)` into `train_em`, or just run through `auto_configure_probabilistic_df` + the pipeline pair-dump hook and compute pairwise P/R from the dump as in `.profile_tmp/compute_pairwise.py`).
+- [ ] **Step 2** Check the spec gate on `historical_50k`:
+  - **Mechanism:** postcode-disagree weight ≤ −1.5 (vs −0.06 before).
+  - **Headline:** an operating point with F1 materially > 0.655 (target P ≥ ~0.8 @ R ≥ ~0.7).
+- [ ] **Step 3** Non-regression: febrl3 + synthetic don't drop (run the panel GM-only on those two, which complete locally).
+- [ ] **Step 4: DECISION GATE.** If the mechanism metric improved but precision still collapses on the PR curve → the residual wall is blocking-candidate quality → STOP and open the selective-compound-blocking spec (lever #3) before further EM work. If the gate is met → per-rule EM is validated; record the numbers in the PR body.
+
+---
+
+## Final checks before PR
+
+- [ ] Run all touched test files individually (not the full suite).
+- [ ] `ruff check` the changed files.
+- [ ] Confirm `GOLDENMATCH_FS_PER_RULE_EM=0` restores the current single-run + `_em_excluded_fields` intersection behavior (the kill-switch equivalence test).
+- [ ] Confirm `EMResult` shape unchanged → sigmoid/TF/fast-path tests still green.
+- [ ] PR body: the before/after PR-curve numbers + the gate verdict. Do NOT `git add docs/`.
+
+## Follow-ups (NOT in this plan)
+
+- Selective compound blocking (lever #3) — only if the kill criterion fires, or as the next planned lever.
+- Sample-weighted m-combination; threshold auto-calibration; `train_em_continuous` parity; TS parity.
+- CI/Splink head-to-head panel + branch rebase onto origin/main + merge.

--- a/docs/superpowers/plans/2026-06-08-probabilistic-splink-parity.md
+++ b/docs/superpowers/plans/2026-06-08-probabilistic-splink-parity.md
@@ -1,0 +1,1001 @@
+# Probabilistic → Splink Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close GoldenMatch's recall-bound gap vs Splink on the probabilistic (Fellegi-Sunter) path by adding a diagnostic gate panel, multi-pass union blocking, and term-frequency weight adjustments — proven on a benchmark panel anchored on Splink's `historical_50k`.
+
+**Architecture:** C→A. Stage 0 builds a benchmark/attribution harness (the success gate + the microscope). Stage 1 lifts recall by emitting multi-pass union blocking for the probabilistic auto-config (reusing the existing `_build_multi_pass_blocks`) and fixing a latent EM `blocking_fields` bug. Stage 2 sharpens discrimination with per-value term-frequency adjustments on the exact-agree level (slow + fast scoring paths). All new behavior is behind the existing `type: probabilistic` matchkey; weighted/exact defaults are untouched.
+
+**Tech Stack:** Python 3.11+, Polars, NumPy, rapidfuzz, Pydantic v2; DuckDB + Splink as bench-only optional deps; pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-probabilistic-splink-parity-design.md`
+
+---
+
+## Conventions for the implementing engineer
+
+- **Run tests** (Windows, this repo): `.venv\Scripts\python.exe -m pytest <path> -v`. Do NOT run the full suite locally (xdist OOMs this box — see root CLAUDE.md). Run only the file(s) you touched.
+- Set `POLARS_SKIP_CPU_CHECK=1` and `PYTHONIOENCODING=utf-8` in the shell before any python invocation (local Polars-import WMI hang + non-ASCII console).
+- **Never `git add docs/superpowers/`** — it is gitignored. Commit only code + tests.
+- Branch/merge SOP: feature branch, squash-merge via PR. Auth dance for `benseverndev-oss` (switch to `benzsevern`, switch back) only when pushing.
+- Commit after every green step. Use ASCII-only commit messages (no em-dashes).
+- `historical_50k`, NCVR, Leipzig datasets live under the gitignored `tests/benchmarks/datasets/`. Every test reading them MUST `pytest.skip` when the file/dep is absent.
+
+## File Structure
+
+**New (Stage 0 — all under the existing `scripts/bench_er_headtohead/`):**
+- `datasets.py` — dataset loaders + adapters to the common `{record_id, …fields}` / truth `{record_id, cluster_id}` shape. Includes `historical_50k`.
+- `attribution.py` — recall decomposition (`blocking_recall` / `threshold_loss` / `final_recall`) from candidate-pair, emitted-pair, and GT-pair sets.
+- `run_panel.py` — orchestrator: run every dataset × {goldenmatch-probabilistic, splink}, call `evaluate.py` + `attribution.py`, emit markdown + JSON.
+
+**New (Stage 0 — CI):**
+- `.github/workflows/bench-probabilistic.yml` — `workflow_dispatch` only.
+
+**Modified:**
+- `packages/python/goldenmatch/pyproject.toml` — `[bench]` optional extra.
+- `scripts/bench_er_headtohead/run_splink.py`, `run_goldenmatch.py` — accept a `--dataset` arg + `historical_50k`.
+- `packages/python/goldenmatch/goldenmatch/core/pipeline.py` — Stage 1a: collect EM `blocking_fields` from `keys` AND `passes`.
+- `.../goldenmatch/core/autoconfig.py` — Stage 1b: `_build_probabilistic_blocking`; Stage 2c: `tf_adjust` enable in `build_probabilistic_matchkeys`.
+- `.../goldenmatch/core/probabilistic.py` — Stage 2: `EMResult.tf_tables`, TF table build in `train_em`, TF-aware `score_probabilistic` + `score_pair_probabilistic`, `TF_MIN_U`/`TF_MAX_U`.
+- `.../goldenmatch/core/probabilistic_fast.py` — Stage 2b: TF freq table in the resolved spec + TF-aware top-level scoring.
+- `.../goldenmatch/config/schemas.py` — Stage 2c: `MatchkeyField.tf_adjust: bool = False`.
+- `.../goldenmatch/core/blocker.py` — Stage 1c: only if `_build_static_blocks` does not already skip oversized blocks under `skip_oversized`.
+
+**New test modules:**
+- `tests/bench/test_attribution.py`, `tests/bench/test_datasets_loader.py`
+- `tests/test_probabilistic_union_blocking.py`
+- `tests/test_probabilistic_tf.py`
+- extend `tests/test_fast_path_probabilistic.py` (TF parity)
+
+---
+
+# STAGE 0 — Diagnostic gate panel (C)
+
+> Goal of the stage: a runnable panel that reports, per dataset, GoldenMatch-vs-Splink {P,R,F1,B³} **and** the recall attribution split. The Stage-0 exit deliverable is a *measured* baseline that sets the gate values and confirms recall is blocking-dominated (or redirects the plan — see Kill criteria in the spec).
+
+### Task 0.1: `[bench]` extra + `historical_50k` loader
+
+**Files:**
+- Modify: `packages/python/goldenmatch/pyproject.toml` (`[project.optional-dependencies]`, after line 58)
+- Create: `scripts/bench_er_headtohead/datasets.py`
+- Test: `tests/bench/test_datasets_loader.py`
+
+- [ ] **Step 1: Add the `[bench]` extra**
+
+In `pyproject.toml` under `[project.optional-dependencies]` add:
+```toml
+bench = [
+    "splink>=4.0",
+    "duckdb>=0.10",
+    "pyarrow>=15",
+]
+```
+(DuckDB is already used by `evaluate.py`; pin it here so the extra is self-contained.)
+
+- [ ] **Step 2: Write the failing loader test**
+
+```python
+# tests/bench/test_datasets_loader.py
+import importlib.util
+from pathlib import Path
+import pytest
+
+# test file is at packages/python/goldenmatch/tests/bench/test_*.py
+# parents: [bench, tests, goldenmatch, python, packages, <repo-root>] -> [5] = repo root
+REPO = Path(__file__).resolve().parents[5]
+SPEC = REPO / "scripts" / "bench_er_headtohead" / "datasets.py"
+
+def _load():
+    spec = importlib.util.spec_from_file_location("bench_datasets", SPEC)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+def test_load_historical_50k_shape_or_skip():
+    mod = _load()
+    try:
+        records, truth = mod.load_dataset("historical_50k")
+    except mod.DatasetUnavailable as e:
+        pytest.skip(f"historical_50k unavailable: {e}")
+    # records: polars DF with __row_id__-able id col; truth: {record_id, cluster_id}
+    assert "record_id" in records.columns
+    assert set(truth.columns) >= {"record_id", "cluster_id"}
+    assert records.height > 1000
+    # every truth.record_id exists in records
+    rec_ids = set(records["record_id"].to_list())
+    assert set(truth["record_id"].to_list()).issubset(rec_ids)
+```
+
+- [ ] **Step 3: Run it, verify it fails**
+
+Run: `.venv\Scripts\python.exe -m pytest tests/bench/test_datasets_loader.py -v`
+Expected: FAIL (`datasets.py` missing / `load_dataset` undefined).
+
+- [ ] **Step 4: Implement `datasets.py` with the `historical_50k` loader**
+
+```python
+#!/usr/bin/env python
+"""Dataset loaders for the probabilistic accuracy panel.
+
+Each loader returns (records, truth):
+  records: polars.DataFrame with a 'record_id' column + matchable fields
+  truth:   polars.DataFrame with columns {record_id, cluster_id}
+
+historical_50k is Splink's home-turf biographical dataset (Wikidata historical
+people, with a ground-truth cluster label). Loaded via splink_datasets when
+splink is installed, else from a vendored parquet under the gitignored
+tests/benchmarks/datasets/.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+REPO = Path(__file__).resolve().parents[2]
+DATASETS_DIR = REPO / "packages" / "python" / "goldenmatch" / "tests" / "benchmarks" / "datasets"
+
+
+class DatasetUnavailable(RuntimeError):
+    """Raised when a dataset's data or its loader dependency is missing."""
+
+
+def _historical_50k() -> tuple[pl.DataFrame, pl.DataFrame]:
+    # Preferred: splink ships the parquet via splink_datasets.
+    df = None
+    try:
+        from splink import splink_datasets  # type: ignore
+        pdf = splink_datasets.historical_50k
+        df = pl.from_pandas(pdf)
+    except Exception:
+        vendored = DATASETS_DIR / "historical_50k.parquet"
+        if not vendored.exists():
+            raise DatasetUnavailable(
+                "install `goldenmatch[bench]` (for splink_datasets) or vendor "
+                f"{vendored}"
+            )
+        df = pl.read_parquet(vendored)
+
+    # historical_50k columns: unique_id, cluster, first_name, surname, dob,
+    # birth_place, postcode_fake, occupation, ...
+    df = df.rename({"unique_id": "record_id", "cluster": "cluster_id"})
+    truth = df.select(["record_id", "cluster_id"])
+    records = df.drop("cluster_id")
+    return records, truth
+
+
+_LOADERS = {
+    "historical_50k": _historical_50k,
+    # DBLP-ACM / Febrl3 / NCVR / synthetic adapters added in Task 0.2.
+}
+
+
+def load_dataset(name: str) -> tuple[pl.DataFrame, pl.DataFrame]:
+    if name not in _LOADERS:
+        raise KeyError(f"unknown dataset {name!r}; have {sorted(_LOADERS)}")
+    return _LOADERS[name]()
+```
+
+- [ ] **Step 5: Run it, verify it passes (or skips cleanly)**
+
+Run: `.venv\Scripts\python.exe -m pytest tests/bench/test_datasets_loader.py -v`
+Expected: PASS or SKIP ("historical_50k unavailable") — both are green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/python/goldenmatch/pyproject.toml scripts/bench_er_headtohead/datasets.py packages/python/goldenmatch/tests/bench/test_datasets_loader.py
+git commit -m "bench: add [bench] extra + historical_50k loader for probabilistic panel"
+```
+
+---
+
+### Task 0.2: Adapters for DBLP-ACM / Febrl3 / NCVR / synthetic
+
+**Files:**
+- Modify: `scripts/bench_er_headtohead/datasets.py`
+- Test: `tests/bench/test_datasets_loader.py`
+
+- [ ] **Step 1: Write failing tests** — parametrized over the four names; each asserts the `(records, truth)` contract or `pytest.skip(DatasetUnavailable)`.
+
+```python
+import pytest
+
+@pytest.mark.parametrize("name", ["dblp_acm", "febrl3", "ncvr", "synthetic_person"])
+def test_adapter_contract_or_skip(name):
+    mod = _load()
+    try:
+        records, truth = mod.load_dataset(name)
+    except mod.DatasetUnavailable as e:
+        pytest.skip(f"{name} unavailable: {e}")
+    assert "record_id" in records.columns
+    assert set(truth.columns) >= {"record_id", "cluster_id"}
+    assert set(truth["record_id"].to_list()).issubset(set(records["record_id"].to_list()))
+```
+
+- [ ] **Step 2: Run, verify fail** (`KeyError: unknown dataset 'dblp_acm'`).
+
+- [ ] **Step 3: Implement the four adapters** in `datasets.py`. Reuse existing loaders where present:
+  - `dblp_acm`, `febrl3`: wrap `packages/python/goldenmatch/tests/benchmarks/run_leipzig.py` / `recordlinkage.datasets.load_febrl3(return_links=True)`. Convert their pairwise/labels into a `cluster_id` (connected components over the GT links via `goldenmatch.core.cluster.UnionFind`).
+  - `ncvr`: read the gitignored `tests/benchmarks/datasets/NCVR/ncvoter_sample_10k.txt` (tab-delimited; `pl.read_csv(separator="\t", encoding="utf8-lossy", ignore_errors=True)`); cluster_id = the voter id grouping per the existing NCVR convention.
+  - `synthetic_person`: import `scripts/bench_er_headtohead/generate_fixture.py` and adapt its output (it already emits person rows + a cluster label).
+  - Each raises `DatasetUnavailable` (not `FileNotFoundError`) when its file/dep is missing.
+
+- [ ] **Step 4: Run, verify pass/skip.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "bench: dataset adapters (dblp_acm, febrl3, ncvr, synthetic_person) to common shape"
+```
+
+---
+
+### Task 0.3: Recall attribution instrument
+
+**Files:**
+- Create: `scripts/bench_er_headtohead/attribution.py`
+- Test: `tests/bench/test_attribution.py`
+
+- [ ] **Step 1: Write the failing test (hand-built, known split)**
+
+```python
+# tests/bench/test_attribution.py
+import importlib.util
+from pathlib import Path
+
+# parents: [bench, tests, goldenmatch, python, packages, <repo-root>] -> [5] = repo root
+REPO = Path(__file__).resolve().parents[5]
+SPEC = REPO / "scripts" / "bench_er_headtohead" / "attribution.py"
+
+def _load():
+    spec = importlib.util.spec_from_file_location("bench_attribution", SPEC)
+    mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+    return mod
+
+def test_attribution_known_split():
+    mod = _load()
+    # 10 ground-truth matching pairs (ids 0..9 paired 0-1, 2-3, ... 18-19)
+    gt = {(2*i, 2*i+1) for i in range(10)}
+    # candidate generation surfaced 7 of them (3 never blocked together)
+    candidates = {(2*i, 2*i+1) for i in range(7)} | {(0, 4), (1, 5)}  # +2 non-GT cands
+    # scorer emitted 5 of the candidate GT pairs (2 scored but below threshold)
+    emitted = {(2*i, 2*i+1) for i in range(5)} | {(0, 4)}             # +1 non-GT emit
+    rep = mod.attribution(gt_pairs=gt, candidate_pairs=candidates, emitted_pairs=emitted)
+    assert rep["n_gt_pairs"] == 10
+    assert rep["blocking_recall"] == 0.7      # 7/10 GT pairs survived blocking
+    assert rep["final_recall"] == 0.5         # 5/10 emitted
+    assert round(rep["threshold_loss"], 4) == 0.2  # (7-5)/10 GT lost at scoring
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement `attribution.py`**
+
+```python
+#!/usr/bin/env python
+"""Recall attribution: localize where true pairs die (blocking vs threshold).
+
+All inputs are sets of canonical (min,max) record-id pairs:
+  gt_pairs        ground-truth matching pairs
+  candidate_pairs pairs that survived candidate generation (blocking)
+  emitted_pairs   pairs the scorer emitted above threshold
+
+  blocking_recall = |gt & candidates| / |gt|     (the ceiling)
+  final_recall    = |gt & emitted|    / |gt|
+  threshold_loss  = (|gt & candidates| - |gt & emitted|) / |gt|
+"""
+from __future__ import annotations
+
+
+def _canon(pairs):
+    return {(min(a, b), max(a, b)) for a, b in pairs}
+
+
+def attribution(gt_pairs, candidate_pairs, emitted_pairs) -> dict:
+    gt = _canon(gt_pairs)
+    cand = _canon(candidate_pairs)
+    emit = _canon(emitted_pairs)
+    n = len(gt)
+    if n == 0:
+        return {"n_gt_pairs": 0, "blocking_recall": 0.0,
+                "final_recall": 0.0, "threshold_loss": 0.0}
+    blocked = len(gt & cand)
+    emitted_gt = len(gt & emit)
+    return {
+        "n_gt_pairs": n,
+        "blocking_recall": round(blocked / n, 4),
+        "final_recall": round(emitted_gt / n, 4),
+        "threshold_loss": round((blocked - emitted_gt) / n, 4),
+    }
+
+
+def truth_to_pairs(truth) -> set:
+    """Expand a {record_id, cluster_id} frame into within-cluster GT pairs."""
+    from itertools import combinations
+    import polars as pl
+    pairs = set()
+    for _cid, grp in truth.group_by("cluster_id"):
+        ids = grp["record_id"].to_list()
+        if len(ids) > 1:
+            pairs.update((min(a, b), max(a, b)) for a, b in combinations(ids, 2))
+    return pairs
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "bench: recall attribution instrument (blocking vs threshold split)"
+```
+
+---
+
+### Task 0.4: Extend Splink + GoldenMatch runners for `--dataset`
+
+**Files:**
+- Modify: `scripts/bench_er_headtohead/run_splink.py`, `scripts/bench_er_headtohead/run_goldenmatch.py`
+
+- [ ] **Step 1:** Add a `--dataset NAME` arg to both runners. When set, load via `datasets.load_dataset(name)` instead of reading the synthetic fixture parquet. Keep the existing fixture path working (backward compatible) when `--dataset` is absent.
+
+- [ ] **Step 2:** `run_goldenmatch.py` — for the panel, build the config via `auto_configure_probabilistic_df(records)` (the probabilistic path) and run `dedupe_df(records, config=config)`. Emit predictions parquet `{record_id, pred_cluster_id}` in the shape `evaluate.py` consumes. Also emit `candidate_pairs.parquet` and `emitted_pairs.parquet` for attribution (see Task 0.5 for how these are captured — `run_dedupe` exposes clusters; emitted pairs come from cluster expansion, candidate pairs from the blocker). If candidate-pair capture needs a hook, add an opt-in `GOLDENMATCH_BENCH_DUMP_PAIRS=<dir>` env that the probabilistic pipeline branch honors (guard with `if os.environ.get(...)`, zero cost otherwise).
+
+- [ ] **Step 3:** `run_splink.py` — add a `historical_50k` code path using Splink's documented settings for that dataset (the runner already trains EM; parametrize the comparison columns by dataset). Emit predictions in the same `{record_id, pred_cluster_id}` shape.
+
+- [ ] **Step 4:** Manual smoke (not a unit test — these need datasets/splink):
+```bash
+.venv\Scripts\python.exe scripts/bench_er_headtohead/run_goldenmatch.py --dataset historical_50k --out .profile_tmp/gm_hist.parquet
+.venv\Scripts\python.exe scripts/bench_er_headtohead/run_splink.py --dataset historical_50k --out .profile_tmp/splink_hist.parquet
+```
+Expected: both write a predictions parquet (or skip with a clear "dataset unavailable").
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "bench: --dataset arg + historical_50k path for both runners"
+```
+
+---
+
+### Task 0.5: Panel orchestrator + CI workflow
+
+**Files:**
+- Create: `scripts/bench_er_headtohead/run_panel.py`
+- Create: `.github/workflows/bench-probabilistic.yml`
+
+- [ ] **Step 1:** Implement `run_panel.py`: for each dataset in `[historical_50k, dblp_acm, febrl3, ncvr, synthetic_person]` × engine in `[goldenmatch, splink]`, invoke the runner, then `evaluate.py::evaluate(pred, truth)` and (for GoldenMatch) `attribution.attribution(...)`. Collect into one JSON + a markdown table with columns: dataset, engine, P, R, F1, B³-F1, blocking_recall, threshold_loss. Datasets/engines that raise `DatasetUnavailable` are recorded as `skipped`, never fatal.
+
+- [ ] **Step 2:** Implement `.github/workflows/bench-probabilistic.yml` as `workflow_dispatch` only, `runs-on: large-new-64GB` (per `feedback_bench_default_runner`), installs `goldenmatch[bench]`, runs `run_panel.py`, uploads the markdown + JSON as artifacts. Do NOT gate any other workflow on it yet (no `needs:`).
+
+- [ ] **Step 3:** Commit
+
+```bash
+git add scripts/bench_er_headtohead/run_panel.py .github/workflows/bench-probabilistic.yml
+git commit -m "bench: probabilistic panel orchestrator + workflow_dispatch CI"
+```
+
+---
+
+### Task 0.6: Run the baseline + set the gate (STAGE-0 EXIT GATE)
+
+> This is the C deliverable. No code; it produces the numbers that drive Stages 1–2.
+
+- [ ] **Step 1:** Trigger `bench-probabilistic.yml` (`gh workflow run bench-probabilistic.yml --ref <branch>`), or run `run_panel.py` locally on whatever datasets are available.
+- [ ] **Step 2:** Read the attribution row for `historical_50k` and `dblp_acm`. Record `blocking_recall` vs `final_recall`.
+- [ ] **Step 3: DECISION GATE.**
+  - If `blocking_recall` is well below Splink's recall AND `threshold_loss` is small → **recall is blocking-dominated → proceed to Stage 1** as planned.
+  - If `threshold_loss` ≫ the blocking-ceiling gap → **re-sequence: do Stage 2 (TF) first.** Note this in the plan and swap the stage order. (Spec Kill criteria.)
+- [ ] **Step 4:** Write the concrete gate values into the plan/PR description: e.g. `historical_50k F1 >= <splink_f1> - 0.02`; `dblp_acm recall >= <X>` with `precision >= 0.95`; Febrl3/NCVR/synthetic non-regression floors = their measured baselines.
+- [ ] **Step 5:** Commit the baseline JSON/markdown into the PR (artifact or `.profile_tmp/`, which is gitignored — paste the table into the PR body instead of committing data).
+
+---
+
+# STAGE 1 — Multi-pass union blocking (A1, recall lever)
+
+> Reuses the existing `_build_multi_pass_blocks`. No new module, no new config field.
+
+### Task 1.1: Fix the latent EM `blocking_fields` bug (CORRECTNESS — do first)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/pipeline.py:1337-1340`
+- Test: `tests/test_probabilistic_union_blocking.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_probabilistic_union_blocking.py
+import polars as pl
+from goldenmatch.config.schemas import (
+    BlockingConfig, BlockingKeyConfig, GoldenMatchConfig,
+    MatchkeyConfig, MatchkeyField,
+)
+
+def _collect_blocking_fields(config):
+    # Mirror the production helper extracted in Step 3.
+    from goldenmatch.core.pipeline import _collect_blocking_fields
+    return _collect_blocking_fields(config.blocking)
+
+def test_blocking_fields_include_passes():
+    blocking = BlockingConfig(
+        strategy="multi_pass",
+        passes=[
+            BlockingKeyConfig(fields=["first_name", "birth_year"]),
+            BlockingKeyConfig(fields=["surname"]),
+        ],
+    )
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="p", type="probabilistic",
+                                  fields=[MatchkeyField(field="first_name", scorer="jaro_winkler")])],
+        blocking=blocking,
+    )
+    fields = _collect_blocking_fields(cfg)
+    assert set(fields) == {"first_name", "birth_year", "surname"}
+
+def test_blocking_fields_include_keys_only_still_works():
+    blocking = BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])])
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="p", type="probabilistic",
+                                  fields=[MatchkeyField(field="zip", scorer="exact")])],
+        blocking=blocking,
+    )
+    assert set(_collect_blocking_fields(cfg)) == {"zip"}
+```
+
+- [ ] **Step 2: Run, verify fail** (`ImportError: cannot import name '_collect_blocking_fields'`).
+
+- [ ] **Step 3: Implement.** Extract a helper near the probabilistic branch in `pipeline.py` and use it at the call site:
+
+```python
+def _collect_blocking_fields(blocking) -> list[str]:
+    """Fields that are agree-by-construction within their block, so EM must
+    treat them as blocking fields (neutral priors). Under strategy='multi_pass'
+    the fields live in `passes`, not `keys` -- collect the union of both so EM
+    does not try to learn m/u for always-agree fields (which collapses the
+    weights). This is a conservative over-approximation under union blocking
+    (a field anchoring one pass is not agree in pairs from another pass); see
+    the spec's Stage 1d. Conservative = never wrong merges.
+    """
+    if blocking is None:
+        return []
+    fields: list[str] = []
+    for kc in (blocking.keys or []):
+        fields.extend(kc.fields)
+    for pc in (blocking.passes or []):
+        fields.extend(pc.fields)
+    # de-dup, preserve order
+    seen: set[str] = set()
+    out: list[str] = []
+    for f in fields:
+        if f not in seen:
+            seen.add(f); out.append(f)
+    return out
+```
+
+Replace the inline collection at `pipeline.py:1337-1340`:
+```python
+            blocking_fields = _collect_blocking_fields(config.blocking)
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+Run: `.venv\Scripts\python.exe -m pytest tests/test_probabilistic_union_blocking.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(probabilistic): EM blocking_fields must include multi_pass `passes`, not just `keys`"
+```
+
+---
+
+### Task 1.2: Probabilistic auto-config emits a capped multi-pass config
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py` (`_build_probabilistic_blocking` + use in `auto_configure_probabilistic_df`)
+- Test: `tests/test_probabilistic_union_blocking.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_build_probabilistic_blocking_emits_capped_multipass():
+    from goldenmatch.core.autoconfig import _build_probabilistic_blocking, profile_columns
+    import polars as pl
+    df = pl.DataFrame({
+        "first_name": ["ann", "ann", "bob", "bob", "cara", "cara"] * 50,
+        "surname":    ["lee", "lee", "kim", "kim", "ng", "ng"] * 50,
+        "birth_year": ["1990", "1990", "1985", "1985", "1972", "1972"] * 50,
+        "postcode":   ["AA1", "AA1", "BB2", "BB2", "CC3", "CC3"] * 50,
+    })
+    profiles = profile_columns(df)
+    blocking = _build_probabilistic_blocking(profiles, df)
+    assert blocking.strategy == "multi_pass"
+    assert blocking.passes is not None
+    assert 1 <= len(blocking.passes) <= 4      # capped
+    assert blocking.skip_oversized is True
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement `_build_probabilistic_blocking`** in `autoconfig.py`:
+
+> **Reviewer-fix:** `ColumnProfile` has NO `identity_score` attribute (it has
+> `name, dtype, col_type, confidence, sample_values, null_rate, cardinality_ratio,
+> avg_len`). `identity_score` lives on `ColumnPrior`, produced by
+> `compute_column_priors(df) -> dict[str, ColumnPrior]` in `core/indicators.py`.
+> Rank using that map — do NOT `getattr(p, "identity_score", 0.0)` (silent no-op).
+
+```python
+def _build_probabilistic_blocking(
+    profiles: list[ColumnProfile],
+    df: pl.DataFrame,
+    max_passes: int = 4,
+) -> BlockingConfig:
+    """Derive a Splink-style multi-pass union blocking config for the
+    probabilistic path. Each pass is a conjunction of identity-ish fields;
+    union over passes lifts blocking recall (the F-S recall lever). Capped at
+    `max_passes` to bound the pair budget; oversized blocks are skipped.
+
+    Reuses core/blocker.py::_build_multi_pass_blocks via strategy='multi_pass'.
+    """
+    from goldenmatch.core.indicators import compute_column_priors
+
+    # identity_score per column (0..~0.95) -- the real ranking signal, from
+    # ColumnPrior. Columns absent from the map default to 0.0.
+    priors = compute_column_priors(df)
+    def _identity(name: str) -> float:
+        p = priors.get(name)
+        return p.identity_score if p is not None else 0.0
+
+    # Rank identity-ish columns by identity_score (desc), require moderate
+    # cardinality (not perfectly unique, not near-constant), drop high-null.
+    def _eligible(p: ColumnProfile) -> bool:
+        null_rate = df[p.name].null_count() / df.height if df.height else 1.0
+        return (
+            p.col_type not in ("numeric", "date", "description")
+            and 0.01 <= p.cardinality_ratio < 1.0
+            and null_rate <= 0.20
+        )
+
+    ranked = sorted(
+        (p for p in profiles if _eligible(p)),
+        key=lambda p: (_identity(p.name), p.cardinality_ratio),
+        reverse=True,
+    )
+    passes: list[BlockingKeyConfig] = []
+    # Single-key passes on the strongest identity columns.
+    for p in ranked[:2]:
+        passes.append(BlockingKeyConfig(fields=[p.name]))
+    # 2-field conjunctions of the next strongest pairs (orthogonal coverage).
+    for i in range(0, min(len(ranked) - 1, 4), 2):
+        if len(passes) >= max_passes:
+            break
+        passes.append(BlockingKeyConfig(fields=[ranked[i].name, ranked[i + 1].name]))
+    passes = passes[:max_passes]
+    if not passes:
+        # Fall back to the standard single-strategy blocker.
+        return build_blocking(profiles, df)
+
+    # Row-count-aware oversized cap (the #715 lesson: block size scales with N).
+    n = df.height
+    max_safe_block = max(1000, min(10_000, n // 200)) if n else 5000
+    return BlockingConfig(
+        strategy="multi_pass",
+        passes=passes,
+        max_block_size=max_safe_block,
+        skip_oversized=True,
+    )
+```
+
+- [ ] **Step 4:** Wire it into `auto_configure_probabilistic_df` (replace the `build_blocking(...)` call at autoconfig.py:2837):
+```python
+    blocking = _build_probabilistic_blocking(profiles, df)
+```
+Note: this deliberately drops the `llm_provider=llm_provider` arg the old `build_blocking` call passed. The probabilistic path needs no LLM blocking suggestions; the multi-pass derivation is purely profile-driven. Intentional, not a regression. (The `_build_probabilistic_blocking` internal fallback still calls `build_blocking(profiles, df)` without the provider, which is fine.)
+
+- [ ] **Step 5: Run, verify pass.**
+
+- [ ] **Step 6: End-to-end smoke test** (no Splink needed):
+
+```python
+def test_probabilistic_dedupe_with_multipass_runs():
+    import polars as pl
+    from goldenmatch import dedupe_df
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    df = pl.DataFrame({
+        "first_name": ["ann","an","bob","bobby","cara","cara"],
+        "surname":    ["lee","lee","kim","kim","ng","ng"],
+        "birth_year": ["1990","1990","1985","1985","1972","1972"],
+    })
+    cfg = auto_configure_probabilistic_df(df)
+    res = dedupe_df(df, config=cfg)
+    assert res is not None  # runs end-to-end, multi-pass + F-S, no collapse
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -am "feat(probabilistic): auto-config emits capped multi-pass union blocking (recall lever)"
+```
+
+---
+
+### Task 1.3: Per-pass oversized guard test
+
+**Files:**
+- Test: `tests/test_probabilistic_union_blocking.py`
+- Modify (only if needed): `packages/python/goldenmatch/goldenmatch/core/blocker.py`
+
+- [ ] **Step 1: Write the guard test** — a dataset where one pass key produces a giant block and another produces clean small blocks; assert the **invariant** (no surviving block exceeds `max_block_size`) and that the clean pass still contributes. Do NOT assert the mechanism: `_build_static_blocks` under `skip_oversized=True` may *auto-split* the giant block (on its highest-cardinality column) rather than skip it — both outcomes satisfy the invariant we care about (bounded block sizes, recall preserved).
+
+```python
+def test_multipass_bounds_oversized_block_keeps_clean_passes():
+    import polars as pl
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+    from goldenmatch.core.blocker import build_blocks
+    n = 400
+    df = pl.DataFrame({
+        "__row_id__": list(range(n)),
+        "country": ["X"] * n,                       # one giant block (skipped OR auto-split)
+        "pid": [f"p{i//2}" for i in range(n)],      # clean 2-record blocks
+    }).lazy()
+    cfg = BlockingConfig(strategy="multi_pass", skip_oversized=True,
+                         max_block_size=50,
+                         passes=[BlockingKeyConfig(fields=["country"]),
+                                 BlockingKeyConfig(fields=["pid"])])
+    blocks = build_blocks(df, cfg)
+    sizes = [b.df.collect().height if hasattr(b.df, "collect") else b.df.height for b in blocks]
+    assert not sizes or max(sizes) <= 50    # INVARIANT: no oversized block survives
+    assert len(blocks) >= 100               # the clean pid pass still contributes
+```
+
+- [ ] **Step 2: Run, verify behavior.** If a surviving block exceeds `max_block_size` (i.e. `_build_static_blocks` neither skips nor splits under `skip_oversized`), fix `_build_static_blocks` (`blocker.py:~135`, oversized handling ~261-269) to skip blocks above `max_block_size` when `skip_oversized` is True. If the invariant already holds (skip or auto-split), no `blocker.py` change is needed — this task is test-only.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "test(probabilistic): multi-pass skips oversized blocks, keeps clean passes"
+```
+
+---
+
+### Task 1.4: Measure Stage 1 on the panel (no code)
+
+- [ ] Re-run `run_panel.py` on `historical_50k` + `dblp_acm`. Confirm `blocking_recall` rose vs the Stage-0 baseline and `final_recall`/F1 followed. Paste the before/after table into the PR. If the ceiling rose but F1 did not, that's the Stage 2 signal (do not add more passes).
+
+---
+
+# STAGE 2 — Term-frequency adjustments (A2, discrimination lever)
+
+### Task 2.1: `MatchkeyField.tf_adjust` schema field
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/config/schemas.py:73-96`
+- Test: `tests/test_probabilistic_tf.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_probabilistic_tf.py
+from goldenmatch.config.schemas import MatchkeyField, MatchkeyConfig
+
+def test_tf_adjust_defaults_false_and_roundtrips():
+    f = MatchkeyField(field="surname", scorer="exact")
+    assert f.tf_adjust is False
+    f2 = MatchkeyField(field="surname", scorer="exact", tf_adjust=True)
+    assert f2.tf_adjust is True
+    # exclude_none must NOT drop a True flag; default False stays out of YAML when excluded
+    mk = MatchkeyConfig(name="p", type="probabilistic", fields=[f2])
+    assert mk.fields[0].tf_adjust is True
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** — add to `MatchkeyField` (after `partial_threshold`, line 83):
+```python
+    # Probabilistic-only (Splink term-frequency): when True, the exact-agree
+    # (top) level weight is adjusted per shared value -- rare shared values
+    # score higher. Default False = today's level-only behavior. See
+    # core/probabilistic.py TF section.
+    tf_adjust: bool = False
+```
+
+- [ ] **Step 4: Run, verify pass. Step 5: Commit**
+
+```bash
+git commit -am "feat(probabilistic): add MatchkeyField.tf_adjust schema flag"
+```
+
+---
+
+### Task 2.2: `EMResult.tf_tables` + TF table build in `train_em`
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/probabilistic.py` (`EMResult` dataclass lines 31-40; `train_em` lines 217-399; new module constants)
+- Test: `tests/test_probabilistic_tf.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import polars as pl
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.probabilistic import train_em
+
+def test_train_em_builds_tf_table_for_tf_fields_only():
+    df = pl.DataFrame({
+        "__row_id__": list(range(8)),
+        "surname": ["smith","smith","smith","smith","zato","zato","ng","lee"],
+        "city": ["x"]*8,
+    })
+    mk = MatchkeyConfig(name="p", type="probabilistic", fields=[
+        MatchkeyField(field="surname", scorer="exact", levels=2, tf_adjust=True),
+        MatchkeyField(field="city", scorer="exact", levels=2, tf_adjust=False),
+    ])
+    em = train_em(df, mk, n_sample_pairs=50)
+    assert em.tf_tables is not None
+    assert "surname" in em.tf_tables and "city" not in em.tf_tables
+    # relative frequencies sum ~1, smith most common
+    t = em.tf_tables["surname"]
+    assert abs(sum(t.values()) - 1.0) < 1e-6
+    assert t["smith"] > t["zato"]
+```
+
+- [ ] **Step 2: Run, verify fail** (`EMResult has no field 'tf_tables'`).
+
+- [ ] **Step 3: Implement.**
+  - Add module constants near the top of `probabilistic.py`:
+    ```python
+    import os
+    TF_MIN_U = float(os.environ.get("GOLDENMATCH_TF_MIN_U", "1e-6"))
+    TF_MAX_U = float(os.environ.get("GOLDENMATCH_TF_MAX_U", "0.5"))
+    ```
+  - Add `tf_tables: dict[str, dict[str, float]] | None = None` to `EMResult` (default None — backward compatible with all existing constructors, incl. `_fallback_result`).
+  - In `train_em`, after computing `u_probs` (after line ~284), build the TF tables from the **transformed** field values over the full `df` (use the same transforms the scorer sees):
+    ```python
+    from goldenmatch.utils.transforms import apply_transforms
+    tf_tables: dict[str, dict[str, float]] = {}
+    for f in mk.fields:
+        if not getattr(f, "tf_adjust", False):
+            continue
+        vals = df[f.field].to_list()
+        if f.transforms:
+            vals = [apply_transforms(str(v), f.transforms) if v is not None else None for v in vals]
+        counts: dict[str, int] = {}
+        total = 0
+        for v in vals:
+            if v is None:
+                continue
+            key = str(v)
+            counts[key] = counts.get(key, 0) + 1
+            total += 1
+        if total == 0:
+            continue
+        tf_tables[f.field] = {k: c / total for k, c in counts.items()}
+    ```
+  - Pass `tf_tables=(tf_tables or None)` into the `EMResult(...)` return (line ~392).
+
+> **Fast/slow parity requirement (read before Task 2.4):** the TF-table keys built
+> here MUST match the encoding the fast path reads from the precomputed
+> `__xform_<sig>__` column. The slow path keys on `apply_transforms(str(v), f.transforms)`;
+> the fast path will key on the xform-column value. If the native precompute and the
+> manual `apply_transforms` loop ever diverge on edge cases (None handling, numeric→str
+> coercion), the fast-vs-slow parity test in Task 2.4 will fail. Keep both keyed on the
+> exact same transformed-string form; the parity test is the guard.
+
+- [ ] **Step 4: Run, verify pass. Step 5: Commit**
+
+```bash
+git commit -am "feat(probabilistic): EMResult.tf_tables built in train_em for tf_adjust fields"
+```
+
+---
+
+### Task 2.3: TF-aware scoring (slow path)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/probabilistic.py` (`score_probabilistic` 669-728; `score_pair_probabilistic` 731-750; new helper `_tf_adjusted_weight`)
+- Test: `tests/test_probabilistic_tf.py`
+
+- [ ] **Step 1: Write failing tests (monotonicity, clamp, no-op)**
+
+```python
+import math
+from goldenmatch.core.probabilistic import _tf_adjusted_weight, TF_MIN_U, TF_MAX_U
+
+def test_tf_weight_monotonic_rarer_is_larger():
+    # base: m_exact=0.8, u_exact=0.1; field has 4 distinct values
+    common = _tf_adjusted_weight(m_exact=0.8, u_exact=0.1, freq_v=0.7, n_distinct=4)
+    rare   = _tf_adjusted_weight(m_exact=0.8, u_exact=0.1, freq_v=0.02, n_distinct=4)
+    base   = _tf_adjusted_weight(m_exact=0.8, u_exact=0.1, freq_v=0.25, n_distinct=4)  # avg freq
+    assert rare > base > common
+    assert abs(base - math.log2(0.8 / 0.1)) < 1e-9   # avg-freq value == base weight
+
+def test_tf_weight_clamped():
+    w = _tf_adjusted_weight(m_exact=0.9, u_exact=0.1, freq_v=1e-12, n_distinct=10**6)
+    # u_v floored at TF_MIN_U -> weight bounded
+    assert w <= math.log2(0.9 / TF_MIN_U) + 1e-9
+```
+
+Then an end-to-end no-op test: `tf_adjust=False` everywhere ⇒ `score_probabilistic` output is byte-identical to before (compare against a fixed expected list on a tiny block).
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement the helper + thread it through scoring.**
+
+```python
+def _tf_adjusted_weight(m_exact: float, u_exact: float, freq_v: float, n_distinct: int) -> float:
+    """Splink scale-the-base TF adjustment for the exact-agree level.
+
+      freq_avg = 1 / n_distinct
+      u_v      = u_exact * freq_v / freq_avg = u_exact * freq_v * n_distinct
+      u_v      = clamp(u_v, TF_MIN_U, TF_MAX_U)
+      weight   = log2(m_exact / u_v)
+
+    Rarer value -> smaller u_v -> larger weight. An average-frequency value
+    (freq_v == 1/n_distinct) returns exactly log2(m_exact/u_exact) (the base).
+    """
+    freq_avg = 1.0 / max(n_distinct, 1)
+    u_v = u_exact * (freq_v / freq_avg) if freq_avg > 0 else u_exact
+    u_v = min(max(u_v, TF_MIN_U), TF_MAX_U)
+    return math.log2(max(m_exact, 1e-10) / u_v)
+```
+
+In `score_probabilistic`, the per-field accumulation (lines 714-717) becomes TF-aware. The top (exact-agree) level index is `f.levels - 1`. When the field is `tf_adjust` and the pair hit the top level, recompute that field's contribution using the shared transformed value's frequency:
+
+```python
+            total_weight = 0.0
+            for k, f in enumerate(mk.fields):
+                level = vec[k]
+                top = f.levels - 1
+                if (em_result.tf_tables and getattr(f, "tf_adjust", False)
+                        and f.field in em_result.tf_tables and level == top):
+                    # shared value at exact-agree: use a's transformed value
+                    raw = row_a.get(f.field)
+                    val = str(raw) if raw is not None else None
+                    if val is not None and f.transforms:
+                        from goldenmatch.utils.transforms import apply_transforms
+                        val = apply_transforms(val, f.transforms)
+                    tft = em_result.tf_tables[f.field]
+                    freq_v = tft.get(val, 1.0 / max(len(tft), 1)) if val is not None else None
+                    if freq_v is not None:
+                        m_exact = max(em_result.m_probs[f.field][top], 1e-10)
+                        u_exact = max(em_result.u_probs[f.field][top], 1e-10)
+                        total_weight += _tf_adjusted_weight(m_exact, u_exact, freq_v, len(tft))
+                        continue
+                total_weight += em_result.match_weights[f.field][level]
+```
+
+**Normalization caveat:** `max_weight`/`min_weight` (lines 692-694) are computed from `match_weights`. A TF-boosted weight can exceed the field's stored `max`. To keep `normalized` in [0,1], clamp `normalized = min(1.0, max(0.0, normalized))` after the division (lines 720-723), and add the same clamp in `score_pair_probabilistic`. Document this: TF can push a field above its level-average max; clamping preserves the [0,1] contract without re-deriving the range per pair.
+
+Apply the identical TF block + clamp to `score_pair_probabilistic`.
+
+- [ ] **Step 4: Run, verify pass** (monotonic, clamp, byte-identical no-op).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(probabilistic): TF-adjusted exact-level scoring (slow path) + [0,1] clamp"
+```
+
+---
+
+### Task 2.4: TF on the fast path + parity
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py`
+- Test: extend `tests/test_fast_path_probabilistic.py`
+
+- [ ] **Step 1: Write failing parity test** — build a block with a `tf_adjust=True` field, train EM, score via both `score_probabilistic` (slow) and the fast path; assert identical emitted pairs + scores (within 1e-6).
+
+- [ ] **Step 2: Run, verify fail** (fast path ignores TF → scores diverge).
+
+- [ ] **Step 3: Implement.**
+  - Extend `ProbFieldSpec` to carry `(xform_col, fn, levels, partial_threshold, weights, tf_table_or_None, m_top, u_top)`.
+  - In `_resolve_probabilistic_fast_path`: for each field, if `f.tf_adjust` and `em_result.tf_tables` has it, attach the frequency dict + `m_probs[top]`/`u_probs[top]`; else `None`. (Keep the gate otherwise unchanged — TF does not disqualify the fast path.)
+  - In `score_probabilistic_fast`: when a field is TF-enabled and the pair maps to the top level, compute `freq_v` from the field's xform array value (already materialized) and use `_tf_adjusted_weight(...)` instead of `weights_list[k][top]`. Apply the same `normalized = min(1.0, max(0.0, normalized))` clamp.
+  - Import `_tf_adjusted_weight` from `probabilistic.py`.
+
+- [ ] **Step 4: Run, verify pass** (fast == slow with TF on; and the existing TF-off parity tests still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(probabilistic): TF adjustment on the fast scoring path (slow/fast parity preserved)"
+```
+
+---
+
+### Task 2.5: Auto-config enables `tf_adjust` for skewed identity fields
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py` (`build_probabilistic_matchkeys` lines 2786-2792)
+- Test: `tests/test_probabilistic_tf.py`
+
+- [ ] **Step 1: Write failing test** — a profile set with a high-skew name column and a low-skew code column; assert the built probabilistic matchkey has `tf_adjust=True` on the name field, `False` on the code field.
+
+```python
+def test_autoconfig_enables_tf_on_skewed_identity_field():
+    import polars as pl
+    from goldenmatch.core.autoconfig import build_probabilistic_matchkeys, profile_columns
+    df = pl.DataFrame({
+        "surname": (["smith"]*60 + ["zato","ng","lee","kim","ohara"]*8),  # Zipfian
+        "member_code": [f"C{i}" for i in range(100)],                      # near-unique, flat
+    })
+    profiles = profile_columns(df)
+    mks = build_probabilistic_matchkeys(profiles)
+    by_field = {f.field: f for f in mks[0].fields}
+    assert by_field["surname"].tf_adjust is True
+    # near-unique surrogate is excluded entirely (card>=1.0) OR tf_adjust False
+    assert "member_code" not in by_field or by_field["member_code"].tf_adjust is False
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** a skew check + enable. Add a helper and set the flag when building the field (autoconfig.py ~2786):
+
+```python
+def _is_skewed_identity(p: ColumnProfile, df: pl.DataFrame) -> bool:
+    """TF helps when exact-agreements vary a lot in informativeness, i.e. the
+    value frequency distribution is skewed (a few common values + a long tail).
+    Gate on name-like identity columns with Zipfian skew; skip flat/uniform
+    columns where TF is a no-op."""
+    if p.col_type not in ("name", "string"):
+        return False
+    s = df[p.name].drop_nulls()
+    if s.len() < 20:
+        return False
+    vc = s.value_counts()
+    counts = vc[vc.columns[-1]].to_list()
+    if not counts:
+        return False
+    top = max(counts) / sum(counts)
+    # skew: most-common value covers notably more than uniform share
+    return top >= 2.0 * (1.0 / len(counts))
+```
+
+Then in the field append:
+```python
+        fields.append(MatchkeyField(
+            field=p.name,
+            scorer=scorer,
+            transforms=transforms,
+            levels=levels,
+            partial_threshold=partial_threshold,
+            tf_adjust=_is_skewed_identity(p, _df),   # pass the df into the builder
+        ))
+```
+Note: `build_probabilistic_matchkeys(profiles)` currently has no `df` param. Add an optional `df: pl.DataFrame | None = None` parameter (default None ⇒ `tf_adjust=False`, fully backward compatible) and pass `df` from `auto_configure_probabilistic_df`.
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(probabilistic): auto-enable tf_adjust on skewed identity fields"
+```
+
+---
+
+### Task 2.6: Measure Stage 2 on the panel + final gate (no code)
+
+- [ ] Re-run `run_panel.py` across all available datasets. Verify:
+  - `historical_50k` F1 ≥ the gate value set in Task 0.6.
+  - `dblp_acm` recall up materially from 57.6% with precision ≥ ~0.95.
+  - Febrl3 / NCVR / synthetic ≥ their baseline floors (non-regression).
+- [ ] Paste the final panel table (vs Splink) into the PR. If a floor regressed, diagnose with `attribution.py` before merging.
+
+---
+
+## Final integration checks (before PR)
+
+- [ ] Run all touched test files individually (not the full suite):
+  `.venv\Scripts\python.exe -m pytest tests/bench/test_attribution.py tests/bench/test_datasets_loader.py tests/test_probabilistic_union_blocking.py tests/test_probabilistic_tf.py tests/test_fast_path_probabilistic.py -v`
+- [ ] `ruff check` on changed files (E9/F63/F7 are the CI-blocking set).
+- [ ] Confirm `tf_adjust=False` + single-key blocking path is byte-identical to pre-change behavior (the no-op parity tests in 2.3/2.4 are the guard).
+- [ ] PR body: the before/after panel table + the attribution decomposition + the gate values. Do NOT `git add` anything under `docs/superpowers/`.
+
+## Follow-ups (explicitly NOT in this plan)
+
+- TS parity for TF adjustments (`probabilistic.ts` + `EMResult` schema) — separate PR.
+- Probabilistic threshold-calibration loop / controller integration — only if Stage 0 attribution showed threshold-loss dominates.
+- Perf optimization + bio/product domain scorers — separate cycles (see spec Out of Scope).

--- a/docs/superpowers/plans/2026-06-08-rust-coverage-gaps.md
+++ b/docs/superpowers/plans/2026-06-08-rust-coverage-gaps.md
@@ -1,0 +1,588 @@
+# Rust Coverage Gaps (P1/P2) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three highest-value Rust test-coverage gaps found in the 2026-06-08 audit: (A) wire the standalone pure-Rust crates' (`graph-core`, `score-core`) tests into CI, (B) add Rust-level unit tests to the `native` kernel and run them in CI, (C) make the `postgres` pgrx `#[pg_test]` suite actually execute via `cargo pgrx test`.
+
+**Architecture:** Three independent tasks, each shippable as its own PR/branch. None share state. Task A is a pure CI-wiring change (the tests already exist). Task B adds in-crate `#[cfg(test)]` tests to pure-Rust kernel helpers plus a Cargo feature-gate so the pyo3 `extension-module` crate's test binary links. Task C wires `cargo pgrx test` into the existing `rust_pgrx` matrix lane and adds a few pyo3-free `#[pg_test]`s.
+
+**Tech Stack:** Rust 1.94 (`cargo test`, `cargo clippy`), pyo3 0.23/0.24 (`extension-module` / `abi3`), pgrx 0.12.9 (`cargo pgrx test`), GitHub Actions (`.github/workflows/ci.yml`, `dorny/paths-filter`), pytest (native parity lane).
+
+**Context for the executor — read before starting:**
+- Local Rust on Windows needs this bash preamble before any `cargo`/`maturin` command (from `packages/rust/extensions/CLAUDE.md`):
+  `export PATH="/c/Users/bsevern/.cargo/bin:$PATH" && export RUSTUP_HOME="C:/Users/bsevern/.rustup" && export CARGO_HOME="C:/Users/bsevern/.cargo"`
+- **Task A (`graph-core`, `score-core`)** crates are pyo3-free standalone workspaces — `cargo test` runs cleanly locally on Windows with the preamble.
+- **Task B (`native`)** is a pyo3 `extension-module` cdylib (no libpython linkage). Its test binary will NOT link by default — Step B1 fixes that. Local `cargo test` for it is best-effort; **CI's `native` lane is the authoritative verifier.**
+- **Task C (`postgres`)** builds + tests ONLY on Linux CI (needs `libclang` + PG dev headers). Do NOT expect to run `cargo pgrx test` locally on Windows — verify via a CI run on the branch.
+- Per `feedback_avoid_full_suite_oom`: never run the full pytest suite locally (xdist OOMs the box); run targeted files only, and lean on CI for the suite.
+- Per `feedback_verify_perf_not_just_ship` and the repo's parity discipline: a test that doesn't actually go red on a regression is worthless. Each parity test below includes a "prove it catches a regression" sanity step.
+
+---
+
+## File Structure
+
+| File | Task | Responsibility / change |
+|---|---|---|
+| `.github/workflows/ci.yml` | A, B, C | Add `cargo test` steps for sibling crates (`rust` job); add native unit-test step + seq-parity pytest (`native` lane); add `cargo pgrx test` step (`rust_pgrx` lane). |
+| `packages/rust/extensions/graph-core/src/lib.rs` | A | (no change — tests already present; verifying they pass.) |
+| `packages/rust/extensions/score-core/src/lib.rs` | A | Add a `#[cfg(test)] mod tests` with anchored scorer vectors. |
+| `packages/rust/extensions/native/Cargo.toml` | B | Gate `pyo3/extension-module` behind a `default` feature so `cargo test --no-default-features` links libpython. |
+| `packages/rust/extensions/native/src/featurize.rs` | B | Add `#[cfg(test)] mod tests` for `prepare`/`hash_gram`/`featurize_one`/`project_one` invariants. |
+| `packages/rust/extensions/native/src/score.rs` | B | Add `#[cfg(test)] mod tests` for `soundex`/`soundex_code`/`compute_pairwise` mirror. |
+| `packages/rust/extensions/native/src/pairs.rs` | B | Add `#[cfg(test)] mod tests` for `canonicalize_pairs`/`candidate_pair_count`/`block_histogram`. |
+| `packages/rust/extensions/native/src/hash.rs` | B | Add `#[cfg(test)] mod tests` for the `gm_record_fingerprint` C ABI. |
+| `packages/rust/extensions/postgres/src/kernels.rs` | C | Add a few pyo3-free `#[pg_test]`s (graph + fingerprint edge cases). |
+
+---
+
+## Task A: Wire `graph-core` + `score-core` tests into CI (P2)
+
+**Why:** `graph-core` has 9 unit tests and `score-core` has 0; neither crate is a member of the `extensions` cargo workspace (each is its own standalone `[workspace]`), so the `rust` job's `cargo test --workspace` (which only builds `bridge`) never touches them. The `rust` job already TRIGGERS on `packages/rust/**`, so the only missing piece is the test invocation itself.
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `rust:` job, currently ends at the two `cargo` steps ~line 734-735)
+- Create test module in: `packages/rust/extensions/score-core/src/lib.rs`
+- Verify-only: `packages/rust/extensions/graph-core/src/lib.rs`
+
+- [ ] **Step A1: Confirm graph-core's existing tests pass locally**
+
+Run (with the Windows cargo preamble):
+```bash
+cargo test --manifest-path packages/rust/extensions/graph-core/Cargo.toml
+```
+Expected: PASS, 7 tests run — 6 in `src/lib.rs` (`dedup_keeps_max_and_canonicalizes`, `cc_groups_transitive_and_includes_singletons`, `dedup_arrow_int64_canonicalizes_and_keeps_max`, `dedup_arrow_utf8_maps_back_to_strings`, `cc_arrow_int64_returns_sorted_list`, `cc_arrow_utf8_returns_sorted_list`) + 1 in `src/dict.rs` (`first_seen_order_is_deterministic`). This proves the tests are real and currently green — they just never run in CI. (Take the count `cargo test` actually prints as authoritative.)
+
+- [ ] **Step A2: Add score-core unit tests (write the failing tests)**
+
+Append to `packages/rust/extensions/score-core/src/lib.rs` (use the crate's actual public fn names — confirm via `grep -n "pub fn" packages/rust/extensions/score-core/src/lib.rs` first; the names below match the shims in `native/src/score.rs`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jaro_winkler_identity_and_disjoint() {
+        assert_eq!(jaro_winkler_similarity("abc", "abc"), 1.0);
+        assert_eq!(jaro_winkler_similarity("abc", "xyz"), 0.0);
+    }
+
+    #[test]
+    fn levenshtein_identity_and_disjoint() {
+        assert_eq!(levenshtein_similarity("abc", "abc"), 1.0);
+        // one substitution out of three chars -> 1 - 1/3
+        let s = levenshtein_similarity("abc", "abx");
+        assert!((s - (2.0 / 3.0)).abs() < 1e-9, "got {s}");
+    }
+
+    #[test]
+    fn token_sort_is_order_invariant_on_0_100_scale() {
+        // token_sort_ratio is the 0-100 scale (score_field divides by 100).
+        assert_eq!(token_sort_ratio("a b", "b a"), 100.0);
+    }
+
+    #[test]
+    fn score_one_dispatches_by_id() {
+        // ids: 0=jaro_winkler, 1=levenshtein, 2=token_sort (0-1 here per
+        // score.rs docs), 3=exact. Confirm the dispatch table is wired.
+        assert_eq!(score_one(3, "abc", "abc"), 1.0); // exact match
+        assert_eq!(score_one(3, "abc", "abd"), 0.0); // exact mismatch
+    }
+}
+```
+
+- [ ] **Step A3: Run score-core tests to verify they pass**
+
+Run:
+```bash
+cargo test --manifest-path packages/rust/extensions/score-core/Cargo.toml
+```
+Expected: PASS, 4 tests. If a name/scale assertion fails, FIX THE TEST to match the crate's real contract (do not change the crate) — these are characterization tests over known-correct code. Note the exact `score_one` token-sort scale: `score.rs:509-511` says ids 0-3 return `[0,1]` from `score_one`, while the `token_sort_ratio` *shim* returns 0-100. Keep the two assertions consistent with that.
+
+- [ ] **Step A4: Prove the tests catch a regression (sanity)**
+
+Temporarily change `assert_eq!(jaro_winkler_similarity("abc", "abc"), 1.0);` to `0.9`, run Step A3, confirm it FAILS, then revert. This proves the assertion is load-bearing.
+
+- [ ] **Step A5: Wire both crates into the `rust` job in CI**
+
+In `.github/workflows/ci.yml`, the `rust:` job has `working-directory: packages/rust/extensions` and currently ends with:
+```yaml
+      - run: cargo test --workspace
+      - run: cargo clippy --workspace -- -D warnings
+```
+Add four steps after them:
+```yaml
+      # The standalone pyo3-free sibling crates (graph-core, score-core) are
+      # each their own [workspace], so `cargo test --workspace` above (which
+      # only builds the `bridge` member) never touches them. Their logic IS
+      # exercised indirectly (native parity + the datafusion FFI tests), but
+      # their own unit tests + clippy were dead in CI. Run them explicitly.
+      - run: cargo test --manifest-path graph-core/Cargo.toml
+      - run: cargo clippy --manifest-path graph-core/Cargo.toml -- -D warnings
+      - run: cargo test --manifest-path score-core/Cargo.toml
+      - run: cargo clippy --manifest-path score-core/Cargo.toml -- -D warnings
+```
+
+- [ ] **Step A6: Validate the workflow edit**
+
+Run:
+```bash
+python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml parses')"
+```
+Expected: `ci.yml parses`. (Editing `ci.yml` also force-triggers every CI job per the `ci_workflow` filter, so the new steps run on the very first push.)
+
+- [ ] **Step A7: Commit**
+
+```bash
+git add .github/workflows/ci.yml packages/rust/extensions/score-core/src/lib.rs
+git commit -m "test(rust): run graph-core + score-core unit tests in CI
+
+The two crates are standalone [workspace]s, so the rust job's
+cargo test --workspace (bridge-only) never ran them. graph-core had
+9 dead-in-CI tests; score-core had none. Wire both + add score-core
+scorer-vector tests.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task B: Native kernel Rust unit tests (P1)
+
+**Why:** `native` is 1,859 lines of perf-critical kernels with ZERO Rust-level tests — covered only by Python parity, which only exercises the inputs the pytest suite happens to feed. This task adds in-crate `#[cfg(test)]` tests for the pure-Rust helpers (featurize/soundex/pairs-math/C-ABI), runs them in CI, AND wires the orphaned `test_native_block_seq_parity.py` (the rayon-vs-sequential `#688` branch) into the native lane.
+
+**The linking constraint (read first):** `native/Cargo.toml` declares `pyo3` with the `extension-module` feature, which tells pyo3 NOT to link libpython (the `.so` is loaded BY CPython). A `cargo test` binary is a standalone executable; with `extension-module` on, the `#[pyfunction]`/`#[pyclass]` symbols compiled into the crate reference undefined `Py*` symbols and the test binary fails to link. The documented pyo3 fix (https://pyo3.rs/main/faq, "I can't run cargo test") is to gate `extension-module` behind a default feature and run `cargo test --no-default-features` (which links libpython). Our pure-Rust test helpers never initialize Python, so no `auto-initialize` is needed — they just need the symbols to resolve at link time.
+
+**Files:**
+- Modify: `packages/rust/extensions/native/Cargo.toml`
+- Modify: `packages/rust/extensions/native/src/featurize.rs`, `src/score.rs`, `src/pairs.rs`, `src/hash.rs`
+- Modify: `.github/workflows/ci.yml` (the `native:` lane, ~line 744-792)
+
+- [ ] **Step B1: Feature-gate `extension-module` in native/Cargo.toml**
+
+In `packages/rust/extensions/native/Cargo.toml`, change the `pyo3` dependency line and add a `[features]` table. From:
+```toml
+pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+```
+to:
+```toml
+# extension-module is a DEFAULT feature (not always-on) so `cargo test
+# --no-default-features` can link the test binary against libpython. maturin
+# (native_wheel lane) and scripts/build_native.py both build with default
+# features, so the shipped wheel/.so still gets extension-module. See the
+# pyo3 FAQ "I can't run cargo test".
+pyo3 = { version = ">=0.23.3, <0.25", features = ["abi3-py311"] }
+```
+Add (place after the `[dependencies]` block, before `[profile.release]`):
+```toml
+[features]
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
+```
+
+- [ ] **Step B2: Verify the production build still gets extension-module**
+
+Run (Windows preamble first):
+```bash
+uv run python scripts/build_native.py
+```
+Expected: builds `goldenmatch/_native.*.so` (or `.pyd`) successfully — `build_native.py` runs `cargo build --release` with default features, so `extension-module` is still on. Then confirm the ext imports:
+```bash
+uv run python -c "from goldenmatch.core import _native_loader; m=_native_loader.native_module(); print('native ok', m and m.__name__)"
+```
+Expected: `native ok goldenmatch._native`. If this regresses, the feature wiring in B1 is wrong — fix before continuing.
+
+- [ ] **Step B3: Verify the test binary now LINKS (the make-or-break step)**
+
+This is the highest-risk step. Run (CI is the real target; locally needs libpython discoverable):
+```bash
+cargo test --manifest-path packages/rust/extensions/native/Cargo.toml --no-default-features
+```
+Expected: COMPILES AND LINKS (0 tests run yet, "running 0 tests ... test result: ok. 0 passed"). 
+
+If it FAILS TO LINK with undefined `Py*`/`PyInit` symbols, the runner's Python lib isn't being found. Remedies in order:
+1. Set `PYO3_PYTHON` to an interpreter whose shared libpython is present (CI: system `python3` after `apt-get install -y libpython3-dev`; local Windows: the dev Python that has `python3xx.dll`).
+2. If `--no-default-features` still won't link on CI's python-build-standalone interpreter, **fall back to the extract-to-core approach**: create a pyo3-free sibling crate `native-kernels-core` (mirroring `score-core`/`graph-core`), MOVE the pure helpers (`prepare`, `hash_gram`, `featurize_one`, `project_one`, `soundex`, `soundex_code`, `compute_pairwise[_precomputed]`, and the `pairs.rs` math) into it, have `native`'s `#[pyfunction]`s delegate to it (matches the existing "thin shim over score-core" pattern), and put the B4-B7 tests in the core crate (which `cargo test`s with zero linking risk). This is more churn but is the architecturally-consistent path the repo already uses. **Decision point:** prefer `--no-default-features` if B3 links on CI; only extract if it doesn't. Surface the choice in the PR description either way.
+
+- [ ] **Step B4: featurize.rs unit tests**
+
+Append to `packages/rust/extensions/native/src/featurize.rs`. These assert Rust-internal invariants (byte-exact cross-language parity stays covered by `tests/test_embeddings.py`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SEED: [u8; 8] = 42u64.to_le_bytes();
+
+    #[test]
+    fn prepare_lowercases_collapses_and_wraps() {
+        assert_eq!(prepare("  John   SMITH ", true, "#"), "#john smith#");
+        assert_eq!(prepare("John Smith", false, "#"), "#John Smith#");
+    }
+
+    #[test]
+    fn prepare_empty_stays_empty_no_boundary() {
+        assert_eq!(prepare("   ", true, "#"), "");
+        assert_eq!(prepare("", true, "#"), "");
+    }
+
+    #[test]
+    fn hash_gram_is_deterministic_and_in_range() {
+        let (i1, s1) = hash_gram(&SEED, "abc", 64);
+        let (i2, s2) = hash_gram(&SEED, "abc", 64);
+        assert_eq!((i1, s1), (i2, s2)); // deterministic
+        assert!(i1 < 64);
+        assert!(s1 == 1.0 || s1 == -1.0);
+    }
+
+    #[test]
+    fn featurize_one_is_l2_unit_norm_for_nonempty() {
+        let row = featurize_one("john smith", 256, 2, 3, true, "#", &SEED);
+        let norm: f32 = row.iter().map(|v| v * v).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-5, "expected unit norm, got {norm}");
+    }
+
+    #[test]
+    fn featurize_one_empty_text_is_zero_vector() {
+        let row = featurize_one("   ", 256, 2, 3, true, "#", &SEED);
+        assert!(row.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn project_one_is_l2_unit_norm_for_nonempty() {
+        // dim=4, n_features=8 row-major weights (all ones -> nonzero acc).
+        let dim = 4usize;
+        let nf = 8usize;
+        let w = vec![1.0f32; nf * dim];
+        let out = project_one("john", &w, nf, dim, 2, 3, true, "#", &SEED);
+        let norm: f32 = out.iter().map(|v| v * v).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-5 || norm == 0.0, "got {norm}");
+    }
+}
+```
+
+- [ ] **Step B5: score.rs unit tests (soundex parity + mirror)**
+
+Append to `packages/rust/extensions/native/src/score.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn soundex_characterizes_implementation_output() {
+        // These pin score.rs::soundex()'s ACTUAL output (it targets
+        // jellyfish.soundex parity, asserted at the Python level). Robert/
+        // Ashcraft match jellyfish exactly; Tymczak is T522 under THIS impl's
+        // H/W-collapse handling (some jellyfish builds return T520) — assert
+        // the impl's output, see the recovery note below.
+        assert_eq!(soundex("Robert"), "R163");
+        assert_eq!(soundex("Ashcraft"), "A261");
+        assert_eq!(soundex("Tymczak"), "T522");
+    }
+
+    #[test]
+    fn soundex_pads_short_codes_to_four() {
+        assert_eq!(soundex("Lee").len(), 4);
+        assert_eq!(soundex("A"), "A000");
+    }
+
+    #[test]
+    fn soundex_non_alpha_is_empty() {
+        assert_eq!(soundex("123"), "");
+        assert_eq!(soundex(""), "");
+    }
+
+    #[test]
+    fn soundex_code_table() {
+        assert_eq!(soundex_code('B'), b'1');
+        assert_eq!(soundex_code('R'), b'6');
+        assert_eq!(soundex_code('A'), b'0');
+    }
+
+    #[test]
+    fn compute_pairwise_symmetric_mirrors_upper_triangle() {
+        let a = vec!["x".to_string(), "y".to_string()];
+        let out = compute_pairwise(&a, &a, true, |p, q| if p == q { 1.0 } else { 0.3 });
+        // 2x2 row-major: [ (x,x) (x,y) ; (y,x) (y,y) ] = [1, .3, .3, 1]
+        assert_eq!(out, vec![1.0, 0.3, 0.3, 1.0]);
+    }
+}
+```
+Note: these are CHARACTERIZATION tests — they pin `soundex()`'s actual output. If a vector mismatches at runtime, update the TEST to the value the function actually prints (do NOT change `soundex()`). Do not "correct" a vector to a jellyfish value you computed by hand — the Python-level parity suite owns cross-language parity; this test owns the Rust impl's stability.
+
+- [ ] **Step B6: pairs.rs unit tests (exact-integer kernels)**
+
+Append to `packages/rust/extensions/native/src/pairs.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalize_pairs_orders_min_max_preserving_score() {
+        let got = canonicalize_pairs(vec![(2, 1, 0.5), (1, 3, 0.9)]);
+        assert_eq!(got, vec![(1, 2, 0.5), (1, 3, 0.9)]);
+    }
+
+    #[test]
+    fn candidate_pair_count_sums_n_choose_2() {
+        assert_eq!(candidate_pair_count(vec![3]), 3);
+        assert_eq!(candidate_pair_count(vec![4]), 6);
+        assert_eq!(candidate_pair_count(vec![3, 4]), 9);
+        assert_eq!(candidate_pair_count(vec![1, 0]), 0);
+    }
+
+    #[test]
+    fn candidate_pair_count_large_block_does_not_overflow_i64_via_i128() {
+        // 1e6 choose 2 = 499_999_500_000 (overflows i64 product before /2 only
+        // if accumulated in i64; the kernel uses i128 internally).
+        assert_eq!(candidate_pair_count(vec![1_000_000]), 499_999_500_000);
+    }
+
+    #[test]
+    fn block_histogram_nearest_rank_percentiles() {
+        // sorted [1,2,3,4]: count=4 total=10 max=4
+        // p50 idx=ceil(.5*4)-1=1 -> 2 ; p95 idx=ceil(3.8)-1=3 -> 4 ; p99 -> 4
+        assert_eq!(block_histogram(vec![4, 1, 3, 2]), (4, 10, 4, 2, 4, 4));
+        assert_eq!(block_histogram(vec![]), (0, 0, 0, 0, 0, 0));
+    }
+}
+```
+
+- [ ] **Step B7: hash.rs C-ABI unit test**
+
+Append to `packages/rust/extensions/native/src/hash.rs` (tests the pyo3-free C boundary + NUL handling; the fingerprint value is the pinned cross-surface vector):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn gm_record_fingerprint_c_abi_matches_pinned_vector() {
+        let json = CString::new(r#"{"a":"x"}"#).unwrap();
+        let mut out = [0i8; 65];
+        let rc = gm_record_fingerprint(json.as_ptr(), out.as_mut_ptr());
+        assert_eq!(rc, 0);
+        let bytes: Vec<u8> = out[..64].iter().map(|&c| c as u8).collect();
+        assert_eq!(
+            String::from_utf8(bytes).unwrap(),
+            "7381d5ba2dac5be0af49232a3209ab8d0dc2e4ed804a60ce533fdfe5254307e3"
+        );
+        assert_eq!(out[64], 0, "missing NUL terminator");
+    }
+
+    #[test]
+    fn gm_record_fingerprint_null_ptr_returns_error() {
+        let mut out = [0i8; 65];
+        assert_eq!(
+            gm_record_fingerprint(std::ptr::null(), out.as_mut_ptr()),
+            1
+        );
+    }
+}
+```
+Note: `out_hex` is `*mut c_char`; on platforms where `c_char` is `u8` the `[0i8; 65]` / `as u8` casts may need to become `[0u8;65]` + `as_mut_ptr() as *mut c_char`. Adjust to the crate's `c_char` (it's `std::os::raw::c_char`); use `as *mut c_char` casts to stay portable.
+
+- [ ] **Step B8: Run all native unit tests + prove one catches a regression**
+
+Run:
+```bash
+cargo test --manifest-path packages/rust/extensions/native/Cargo.toml --no-default-features
+```
+Expected: PASS, ~18 tests across featurize/score/pairs/hash. Then sanity: change the pinned fingerprint in B7 by one hex char, re-run, confirm FAIL, revert. (If running locally on Windows is blocked by the libpython link, defer the authoritative run to CI per Step B10 and note it in the PR.)
+
+- [ ] **Step B9: Wire native unit tests into the `native` CI lane**
+
+In `.github/workflows/ci.yml`, the `native:` lane currently has a "clippy + test (fingerprint-core crate)" step (~line 770-777) followed by "Build native extension into the package". Add a step right AFTER the fingerprint-core step and BEFORE the build step:
+```yaml
+      - name: Unit-test the native kernels (pure-Rust helpers)
+        # extension-module is gated behind a default feature so the test binary
+        # can link libpython (--no-default-features turns it off). Covers
+        # soundex/featurize/pairs-math/C-ABI logic that the Python parity suite
+        # only exercises indirectly. Build below still uses default features.
+        working-directory: packages/rust/extensions/native
+        env:
+          PYO3_PYTHON: /usr/bin/python3
+        run: |
+          sudo apt-get update && sudo apt-get install -y libpython3-dev
+          cargo test --no-default-features
+```
+(If Step B3's fallback extract-to-core path was taken instead, replace this with `cargo test --manifest-path native-kernels-core/Cargo.toml` and drop the libpython install — the core crate links without it.)
+
+- [ ] **Step B10: Wire the orphaned seq-parity test into the lane**
+
+`packages/python/goldenmatch/tests/test_native_block_seq_parity.py` exists but is referenced in NO workflow — it asserts the rayon path and the sequential path emit byte-identical pairs (the `#688` `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS` branch). The test already sweeps BOTH thresholds internally (it `monkeypatch.setenv`s `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS` to `"0"` and a huge value per case), so wiring it is a one-line list addition — do NOT add a separate forced-env step (it would be a no-op the monkeypatch overrides). In the `native:` lane's final "Parity + in-house suite" pytest step (~line 784-792), add the file to the list:
+```yaml
+      - name: Parity + in-house suite (ext present -> native path runs, not skips)
+        run: |
+          uv run pytest \
+            packages/python/goldenmatch/tests/test_native_parity.py \
+            packages/python/goldenmatch/tests/test_native_block_seq_parity.py \
+            packages/python/goldenmatch/tests/test_record_fingerprint.py \
+            packages/python/goldenmatch/tests/test_pairs.py \
+            packages/python/goldenmatch/tests/test_embeddings.py \
+            packages/python/goldenmatch/tests/test_inhouse_embedder.py \
+            -v
+```
+Before relying on the above, confirm the internal sweep is really there: `grep -n "RAYON_MIN_PAIRS\|monkeypatch\|setenv" packages/python/goldenmatch/tests/test_native_block_seq_parity.py`. If (and only if) it does NOT sweep internally, add a second invocation of just that file under `env: GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS: "0"` to force the rayon path.
+
+- [ ] **Step B11: Validate the workflow + commit**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml parses')"
+```
+Then:
+```bash
+git add packages/rust/extensions/native/Cargo.toml \
+  packages/rust/extensions/native/src/featurize.rs \
+  packages/rust/extensions/native/src/score.rs \
+  packages/rust/extensions/native/src/pairs.rs \
+  packages/rust/extensions/native/src/hash.rs \
+  .github/workflows/ci.yml
+git commit -m "test(native): unit-test the pure-Rust kernels + run the rayon parity guard
+
+native had 0 Rust tests across 1859 lines. Gate extension-module behind
+a default feature so cargo test --no-default-features links, then cover
+soundex/featurize/pairs-math/C-ABI. Also wires the orphaned
+test_native_block_seq_parity.py (the #688 rayon-vs-sequential branch)
+into the native lane.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step B12: Push the branch and confirm the `native` lane is green in CI**
+
+This is the authoritative verification (local Windows linking is best-effort). Push, then:
+```bash
+gh pr checks <N> --watch    # or poll: while gh pr checks <N> | grep -qE "pending|in_progress"; do sleep 30; done
+gh run view <run-id> --log | grep -E "test result:|passed|failed,"
+```
+Confirm the "Unit-test the native kernels" step ran (not skipped) and the pytest summary shows the seq-parity test passed under both threshold settings.
+
+---
+
+## Task C: Make the pgrx `#[pg_test]` suite execute (P1)
+
+**Why:** `cargo pgrx test` appears NOWHERE in `.github/`. The 5 `#[pg_test]`s in `postgres/src/kernels.rs` are written but never run; the `rust_pgrx` lane only does `cargo pgrx install` + a `psql` smoke. This wires `cargo pgrx test` into the lane so the pg_test suite actually runs, and adds a few more pyo3-free `#[pg_test]`s. **Bridge-backed pg_tests (quick.rs/pipeline.rs/correction.rs/core_apis.rs, which go through embedded CPython) are deferred to a follow-up** — they need `import goldenmatch` live in the pgrx-test backend and carry more flake surface; the psql smoke already covers several of them end-to-end.
+
+**This task is CI-only.** Do not attempt `cargo pgrx test` locally on Windows (no `libclang`/PG dev headers). Verify on the branch via CI.
+
+**Files:**
+- Modify: `packages/rust/extensions/postgres/src/kernels.rs` (extend the existing `#[cfg(any(test, feature = "pg_test"))] mod tests`)
+- Modify: `.github/workflows/ci.yml` (the `rust_pgrx:` matrix lane)
+
+- [ ] **Step C1: Add new pyo3-free `#[pg_test]`s to kernels.rs**
+
+In `packages/rust/extensions/postgres/src/kernels.rs`, inside the existing `mod tests` (after `connected_components_str_includes_singleton`, before the closing brace ~line 286), add edge-case tests that exercise the graph-core + fingerprint-core direct paths through the pgrx surface:
+
+```rust
+    /// Empty edge list: every id is its own singleton component.
+    #[pg_test]
+    fn connected_components_all_singletons_when_no_edges() {
+        let rows: Vec<(i64, i64)> = crate::kernels::goldenmatch_connected_components(
+            vec![],
+            vec![],
+            vec![],
+            vec![10, 20, 30],
+        )
+        .collect();
+        // 3 ids, no edges -> 3 distinct component labels.
+        let labels: std::collections::HashSet<i64> = rows.iter().map(|(c, _)| *c).collect();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(labels.len(), 3);
+    }
+
+    /// Fingerprint is stable across key order (canonicalization sorts fields).
+    #[pg_test]
+    fn record_fingerprint_is_key_order_independent() {
+        let a = crate::kernels::goldenmatch_record_fingerprint(r#"{"x":"1","y":"2"}"#.to_string());
+        let b = crate::kernels::goldenmatch_record_fingerprint(r#"{"y":"2","x":"1"}"#.to_string());
+        assert_eq!(a, b);
+    }
+
+    /// dedup keeps the max score across duplicate canonical pairs.
+    #[pg_test]
+    fn pair_dedup_keeps_max_across_duplicates() {
+        let rows: Vec<(i64, i64, f64)> = crate::kernels::goldenmatch_pair_dedup(
+            vec![1, 1, 2],
+            vec![2, 2, 1],
+            vec![0.3, 0.7, 0.5],
+        )
+        .collect();
+        // (1,2) seen thrice -> keep 0.7.
+        assert_eq!(rows, vec![(1, 2, 0.7)]);
+    }
+```
+First confirm the exact signatures of `goldenmatch_connected_components` / `goldenmatch_pair_dedup` (arg order, return iterator types) by reading `kernels.rs` — match the existing tests' call style exactly.
+
+- [ ] **Step C2: Add the `cargo pgrx test` step to the `rust_pgrx` lane**
+
+In `.github/workflows/ci.yml`, the `rust_pgrx:` lane builds the extension at "Build + install extension" (~line 1094-1106, `working-directory: packages/rust/extensions/postgres`). Add a step immediately after it, gated to the pg16 leg (the pg_tests are PG-version-independent pure logic; one leg bounds CI cost):
+```yaml
+      - name: cargo pgrx test (runs the #[pg_test] suite in a managed PG)
+        # The pgrx test harness builds a fresh extension into its own initdb'd
+        # instance (cargo pgrx init ran above) and runs every #[pg_test]. Without
+        # this, the kernels.rs pg_tests never execute. Pinned to the pg16 leg —
+        # the tests are pyo3-free pure logic (graph-core/fingerprint-core), so
+        # they're PG-major-independent and one leg is sufficient coverage.
+        if: matrix.pg == '16'
+        working-directory: packages/rust/extensions/postgres
+        run: cargo pgrx test --no-default-features --features "pg16 pg_test" pg16
+```
+Note: confirm the exact pgrx 0.12.9 invocation. The canonical form is `cargo pgrx test pg16`; pgrx auto-enables the `pg_test` feature for the run. If `cargo pgrx test pg16` alone errors on feature resolution, use the explicit `--no-default-features --features "pg16 pg_test"` form shown. Verify against `cargo pgrx test --help` in the lane if it fails.
+
+- [ ] **Step C3: Validate the workflow edit**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml parses')"
+```
+Expected: `ci.yml parses`.
+
+- [ ] **Step C4: Commit**
+
+```bash
+git add packages/rust/extensions/postgres/src/kernels.rs .github/workflows/ci.yml
+git commit -m "test(pg): execute the pgrx #[pg_test] suite via cargo pgrx test
+
+cargo pgrx test was nowhere in CI -> the 5 kernels.rs pg_tests never ran.
+Wire it into the rust_pgrx lane (pg16 leg) and add graph/fingerprint
+edge-case pg_tests. Bridge-backed (embedded-CPython) pg_tests for
+quick/pipeline/correction are a deferred follow-up.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step C5: Push and confirm the `rust_pgrx` lane runs the pg_test step green in CI**
+
+```bash
+while gh pr checks <N> | grep -qE "pending|in_progress"; do sleep 30; done
+gh run view <run-id> --log | grep -E "cargo pgrx test|pg_test|test result:|passed|failed,"
+```
+Confirm the "cargo pgrx test" step appears on the pg16 leg and reports all `#[pg_test]`s passing. If the managed backend fails to start because the embedded bridge can't `import goldenmatch`, confirm the goldenmatch pip-install step (lane line ~1083) ran before this step; if the bridge imports at `_PG_init` (load time) rather than lazily, move the goldenmatch install ahead of the pgrx test step.
+
+---
+
+## Deferred (documented, NOT in scope)
+
+- **Bridge-backed pgrx pg_tests** (`quick.rs`, `pipeline.rs`, `correction.rs`, `core_apis.rs`, `goldenflow.rs`, `spi.rs`): need `import goldenmatch` live in the pgrx-test backend (embedded CPython); higher flake surface. The psql smoke already exercises several end-to-end. Add incrementally once Task C's harness is proven green.
+- **`bridge/api.rs` wrapper tests** (P2 from the audit, 33 pub fns / 6 tests): separate plan — the JSON-marshalling shims for `autoconfig`/`match_tables`/`identity_*`/`evaluate`/`train_em`/etc. are untested at the Rust level. Out of scope here.
+- **`cargo-llvm-cov` measured coverage job**: the meta-gap (no quantified line coverage anywhere). A single coverage lane over the buildable crates would turn this structural audit into a tracked number. Separate plan.
+- **`datafusion-udf` graph `_str` variants + `goldenembed/main.rs` CLI**: low-priority tail; not in P1/P2.
+
+---
+
+## Done criteria
+
+- [ ] `rust` job runs `graph-core` (7) + `score-core` (4) tests green in CI.
+- [ ] `native` lane runs the new Rust unit tests (~18) green AND runs `test_native_block_seq_parity.py` under both rayon thresholds.
+- [ ] `rust_pgrx` lane (pg16) runs `cargo pgrx test` with all `#[pg_test]`s green.
+- [ ] `scripts/build_native.py` + the `native_wheel` lane still produce a working `extension-module` artifact (feature-gate is transparent to them).
+- [ ] No new `continue-on-error` masking; the new steps are hard gates.

--- a/docs/superpowers/plans/2026-06-08-selective-compound-blocking.md
+++ b/docs/superpowers/plans/2026-06-08-selective-compound-blocking.md
@@ -1,0 +1,738 @@
+# Selective Compound Blocking (Probabilistic Path) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the historical_50k candidate flood (8.84M pairs, 3.4% precision ceiling) by replacing `_build_probabilistic_blocking`'s broad single-key union with a candidate-budget-driven, coverage-greedy selection of selective compound passes -- so the now-correct per-rule F-S scoring can clear the gate (historical_50k F1 >> 0.655, P>=~0.8 @ R>=~0.7) without regressing febrl3/synthetic.
+
+**Architecture:** Add an optional per-field transform mechanism to `BlockingKeyConfig` (so a compound can soundex the name AND year-coarsen the date). Generate a POOL of candidate passes (transform-rich name passes + per-field-transformed compounds + self-selective orthogonals), estimate each pass's exact candidate count + (capped) record-pair coverage, then greedily select a union maximizing marginal coverage-per-candidate under a `K*N` budget, always keeping a name-bearing recall anchor. The emitted `BlockingConfig(strategy="multi_pass", ...)` is the exact shape the pipeline + per-rule EM already consume.
+
+**Tech Stack:** Python 3.11+, Polars, Pydantic, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-selective-compound-blocking-design.md`
+
+---
+
+## Conventions for the implementing engineer
+
+- Run tests (Windows PowerShell): `$env:POLARS_SKIP_CPU_CHECK=1; $env:PYTHONIOENCODING="utf-8"; .venv\Scripts\python.exe -m pytest <path> -v`. **Do NOT run the full suite** (OOMs this box). Run only the touched files. If python hangs > 2 min, kill zombies: `powershell.exe -Command "Get-Process python -ErrorAction SilentlyContinue | Stop-Process -Force"`, then retry.
+- Branch `feat/probabilistic-splink-parity` (continue on it; do NOT branch, do NOT push). Commit code+tests only; NEVER `git add docs/`. ASCII-only commit messages.
+- This builds on already-shipped work on this branch (sigmoid, TF, union-aware EM exclusion, multi-pass blocking, per-rule EM). Do not regress them.
+
+## Background: current shape (READ before starting)
+
+- `core/blocker.py::_build_block_key_expr(key_config)` (~line 99): loops over `key_config.fields`, applies the SAME `key_config.transforms` list to EVERY field via `_try_native_chain` (native) or `map_elements(apply_transforms(...))` (python e.g. soundex), then `pl.concat_str(..., separator="||")`. There is NO per-field transform support today -- Task 1 adds it.
+- `config/schemas.py::BlockingKeyConfig` (~line 343): `fields: list[str]`, `transforms: list[str] = Field(default_factory=list)`, with a `@model_validator(mode="after")` requiring non-empty `fields`.
+- `core/autoconfig.py::_build_probabilistic_blocking(profiles, df, max_extra_passes=5)` (~line 2804): AUGMENTS `build_blocking(profiles, df)`'s transform-rich name passes with orthogonal single-key passes (high-card) or `[orthogonal, anchor]` compounds (moderate-card), capped at `max_extra_passes`. Returns `BlockingConfig(strategy="multi_pass", passes=...)`. Its inline `_orthogonal(p)` test: `p.name not in covered_fields and col_type != "description" and col_type != "numeric" and null_rate <= 0.20 and 0.02 <= cardinality_ratio < 1.0`. This is the function Task 6 rewrites.
+- `ColumnProfile` has `.name`, `.col_type` (date columns are `"date"`), `.cardinality_ratio`. `compute_column_priors(df)` (from `core/indicators`) gives per-column `identity_score`.
+- The probabilistic pipeline branches consume the emitted config via `build_blocks(combined_lf, config.blocking)` (scoring) and `_build_blocks_per_pass(combined_lf, config.blocking)` (per-rule EM).
+
+## File Structure
+
+- **Modify** `config/schemas.py`: add `BlockingKeyConfig.field_transforms: list[list[str]] | None = None` + a length validator.
+- **Modify** `core/blocker.py`: `_build_block_key_expr` uses per-field transforms when `field_transforms` is set (default None => current behavior, byte-identical).
+- **Modify** `core/autoconfig.py`: add `_blocking_candidate_budget_k()`, `_candidate_blocking_passes(profiles, df)`, `_estimate_pass_stats(pass_cfg, df)`, `_select_passes_within_budget(pool, budget)`; rewrite `_build_probabilistic_blocking` to wire them together with a degenerate fallback to plain `build_blocking`.
+- **New** `tests/test_autoconfig_selective_blocking.py` (autoconfig helpers). Per-field-transform unit test lives there too (or `tests/test_blocker.py`).
+
+---
+
+## Task 1: Per-field transforms in BlockingKeyConfig (schema + blocker)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/config/schemas.py` (`BlockingKeyConfig`)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/blocker.py` (`_build_block_key_expr`)
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import BlockingKeyConfig
+from goldenmatch.core.blocker import _build_block_key_expr
+
+def _key(df, cfg):
+    return df.lazy().with_columns(_build_block_key_expr(cfg)).collect()["__block_key__"].to_list()
+
+def test_field_transforms_per_field():
+    df = pl.DataFrame({"surname": ["SMITH", "Jones"], "dob": ["1990-05-01", "1985-12-30"]})
+    cfg = BlockingKeyConfig(
+        fields=["surname", "dob"],
+        field_transforms=[["lowercase"], ["substring:0:4"]],
+    )
+    # surname lowercased, dob year-truncated, concatenated with ||
+    assert _key(df, cfg) == ["smith||1990", "jones||1985"]
+
+def test_field_transforms_none_matches_shared_transforms():
+    df = pl.DataFrame({"surname": ["SMITH", "Jones"], "dob": ["1990-05-01", "1985-12-30"]})
+    shared = BlockingKeyConfig(fields=["surname", "dob"], transforms=["lowercase"])
+    # field_transforms is None -> shared transforms apply to every field (today's behavior)
+    assert _key(df, shared) == ["smith||1990-05-01", "jones||1985-12-30"]
+
+def test_field_transforms_length_must_match_fields():
+    with pytest.raises(ValueError):
+        BlockingKeyConfig(fields=["surname", "dob"], field_transforms=[["lowercase"]])
+```
+
+- [ ] **Step 2: Run, verify fail** (`TypeError: unexpected keyword 'field_transforms'` / no validation).
+Run: `$env:POLARS_SKIP_CPU_CHECK=1; $env:PYTHONIOENCODING="utf-8"; .venv\Scripts\python.exe -m pytest packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py -v`
+
+- [ ] **Step 3: Implement.**
+In `schemas.py`, add the field + validator to `BlockingKeyConfig` (the model already imports `Field`, `model_validator`):
+```python
+class BlockingKeyConfig(BaseModel):
+    fields: list[str]
+    transforms: list[str] = Field(default_factory=list)
+    # Optional per-field transform chains, aligned 1:1 with `fields`. When set,
+    # field_transforms[i] applies to fields[i] (overriding `transforms`). Default
+    # None preserves the shared-`transforms` behavior. Lets a compound key soundex
+    # the name component AND year-coarsen the date component in one pass.
+    field_transforms: list[list[str]] | None = None
+
+    @model_validator(mode="after")
+    def _validate_fields_nonempty(self) -> BlockingKeyConfig:
+        if not self.fields:
+            raise ValueError("Blocking key must have at least one field.")
+        if self.field_transforms is not None and len(self.field_transforms) != len(self.fields):
+            raise ValueError(
+                "field_transforms must align 1:1 with fields "
+                f"({len(self.field_transforms)} != {len(self.fields)})."
+            )
+        return self
+```
+In `blocker.py::_build_block_key_expr`, select the per-field transform list inside the loop:
+```python
+    field_exprs: list[pl.Expr] = []
+    for i, field_name in enumerate(key_config.fields):
+        if key_config.field_transforms is not None:
+            transforms = key_config.field_transforms[i] or []
+        else:
+            transforms = key_config.transforms or []
+        native = _try_native_chain(field_name, transforms) if transforms else None
+        if native is not None:
+            field_exprs.append(native)
+        elif transforms:
+            field_exprs.append(
+                pl.col(field_name).map_elements(
+                    lambda val, transforms=transforms: apply_transforms(val, transforms),
+                    return_dtype=pl.Utf8,
+                )
+            )
+        else:
+            field_exprs.append(pl.col(field_name).cast(pl.Utf8))
+    ...
+```
+(The rest of the function -- single-field alias vs `concat_str` -- is unchanged.)
+
+- [ ] **Step 4: Run the new test + the blocker suite -- all green.**
+`$env:POLARS_SKIP_CPU_CHECK=1; $env:PYTHONIOENCODING="utf-8"; .venv\Scripts\python.exe -m pytest packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py packages/python/goldenmatch/tests/test_blocker.py packages/python/goldenmatch/tests/test_config.py -q`
+Expected: PASS (default-None path is byte-identical; existing blocker/config tests unaffected).
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/config/schemas.py packages/python/goldenmatch/goldenmatch/core/blocker.py packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py
+git commit -m "feat(blocker): optional per-field transforms in BlockingKeyConfig (default-None byte-identical)"
+```
+
+---
+
+## Task 1b: Honor `field_transforms` in the other two block-key builders
+
+**Why:** `_build_block_key_expr` is not the only place that turns a `BlockingKeyConfig`
+into a block key. Two other consumers read `key_config.transforms` directly and would
+SILENTLY ignore `field_transforms` (producing wrong block keys once Task 6 emits
+compounds under those paths). Fix both now so the mechanism is complete before any
+auto-config emits it. (Latent today: default-None is byte-identical, so nothing breaks
+until emission.)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/chunked.py` (`_block_key_column`, ~line 223)
+- Modify: `packages/python/goldenmatch/goldenmatch/db/blocking.py` (`build_blocking_query`, ~line 31-45)
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py`
+
+- [ ] **Step 1: Write the failing tests** (append)
+
+```python
+from goldenmatch.db.blocking import build_blocking_query
+
+def test_db_blocking_query_honors_field_transforms():
+    cfg = BlockingConfig(keys=[BlockingKeyConfig(
+        fields=["surname", "dob"],
+        field_transforms=[["soundex"], ["substring:0:4"]],
+    )])
+    sql = build_blocking_query("people", {"surname": "Smith", "dob": "1990-05-01"}, cfg)
+    # surname uses soundex(), dob uses substring(col,1,4); NOT lower() on dob
+    assert "soundex(" in sql.lower()
+    assert "substring(" in sql.lower()
+
+def test_chunked_block_key_honors_field_transforms():
+    # the chunked inline builder must match _build_block_key_expr for a field_transforms config
+    import polars as pl
+    from goldenmatch.config.schemas import BlockingKeyConfig
+    from goldenmatch.core.blocker import _build_block_key_expr
+    df = pl.DataFrame({"surname": ["SMITH", "Jones"], "dob": ["1990-05-01", "1985-12-30"]})
+    cfg = BlockingKeyConfig(fields=["surname", "dob"], field_transforms=[["lowercase"], ["substring:0:4"]])
+    expected = df.lazy().with_columns(_build_block_key_expr(cfg)).collect()["__block_key__"].to_list()
+    from goldenmatch.core.chunked import <ChunkedClass>   # implementer: find the class owning _block_key_column
+    inst = <construct minimally>
+    got = inst._block_key_column(df, cfg)["__block_key__"].to_list()
+    assert got == expected == ["smith||1990", "jones||1985"]
+```
+(Implementer: locate the class that owns `_block_key_column` (grep `def _block_key_column`), and construct a minimal instance; if construction is heavy, instead assert the delegation by calling the method on a minimally-built instance, or refactor `_block_key_column` to a thin wrapper that's trivially testable. The DB test needs NO database -- `build_blocking_query` is pure string generation.)
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.**
+(a) `chunked.py::_block_key_column` -- DELEGATE to the shared builder (DRY; also gains the native fast path it currently lacks, and field_transforms support for free):
+```python
+    def _block_key_column(self, df: pl.DataFrame, key_config: Any) -> pl.DataFrame:
+        """Add a ``__block_key__`` column to a DataFrame by delegating to
+        ``blocker._build_block_key_expr`` (single source of truth: native fast path,
+        shared AND per-field transforms)."""
+        from goldenmatch.core.blocker import _build_block_key_expr
+        return df.with_columns(_build_block_key_expr(key_config))
+```
+(Remove the inline `apply_transforms` duplication + the stale "Mirrors ... kept inline" docstring.)
+(b) `db/blocking.py::build_blocking_query` -- select transforms per field:
+```python
+        for i, field_name in enumerate(key_config.fields):
+            value = record.get(field_name)
+            if value is None:
+                continue
+            col_expr = _quote_ident(field_name)
+            val_expr = _escape_value(str(value))
+            if key_config.field_transforms is not None:
+                field_xf = key_config.field_transforms[i]
+            else:
+                field_xf = key_config.transforms
+            for transform in field_xf:
+                col_expr, val_expr = _apply_sql_transform(col_expr, val_expr, transform)
+            field_conditions.append(f"{col_expr} = {val_expr}")
+```
+
+- [ ] **Step 4: Run the tests + chunked/db regression -- all green.**
+`$env:POLARS_SKIP_CPU_CHECK=1; $env:PYTHONIOENCODING="utf-8"; .venv\Scripts\python.exe -m pytest packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py packages/python/goldenmatch/tests/test_chunked.py -q` (run `test_db.py` only if Postgres-free; `build_blocking_query` tests need no DB). ruff clean on the two changed files.
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/chunked.py packages/python/goldenmatch/goldenmatch/db/blocking.py packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py
+git commit -m "fix(blocker): honor field_transforms in chunked + db/blocking key builders (DRY chunked via _build_block_key_expr)"
+```
+
+---
+
+## Task 2: Candidate budget constant + env read
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py`
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+import os
+from goldenmatch.core.autoconfig import _blocking_candidate_budget_k
+
+def test_blocking_candidate_budget_k_default_and_override():
+    assert _blocking_candidate_budget_k() == 25
+    for raw, expected in [("10", 10), ("100", 100), ("0", 25), ("-5", 25), ("junk", 25)]:
+        os.environ["GOLDENMATCH_BLOCKING_CANDIDATE_BUDGET_K"] = raw
+        try:
+            assert _blocking_candidate_budget_k() == expected
+        finally:
+            os.environ.pop("GOLDENMATCH_BLOCKING_CANDIDATE_BUDGET_K", None)
+```
+
+- [ ] **Step 2: Run, verify fail** (ImportError). Same pytest command on the test file.
+
+- [ ] **Step 3: Implement.** Add near the other env helpers in `autoconfig.py` (`os` is already imported):
+```python
+_BLOCKING_CANDIDATE_BUDGET_K_DEFAULT = 25
+
+def _blocking_candidate_budget_k() -> int:
+    """Candidate-pair budget per record for selective probabilistic blocking
+    (budget = K * N deduped-union candidate pairs). Override via
+    GOLDENMATCH_BLOCKING_CANDIDATE_BUDGET_K (the dump PR-curve sweep calibrates it).
+    Invalid / non-positive values fall back to the default."""
+    raw = os.environ.get("GOLDENMATCH_BLOCKING_CANDIDATE_BUDGET_K")
+    if raw is None:
+        return _BLOCKING_CANDIDATE_BUDGET_K_DEFAULT
+    try:
+        v = int(raw.strip())
+    except (ValueError, AttributeError):
+        return _BLOCKING_CANDIDATE_BUDGET_K_DEFAULT
+    return v if v > 0 else _BLOCKING_CANDIDATE_BUDGET_K_DEFAULT
+```
+
+- [ ] **Step 4: Run the test -- green.**
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig.py packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py
+git commit -m "feat(autoconfig): selective-blocking candidate budget constant + env override"
+```
+
+---
+
+## Task 3: `_candidate_blocking_passes` (build the candidate pool)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py`
+
+- [ ] **Step 1: Write the failing test** (append). Uses real `profile_columns` + a person-shaped df so the pool reflects production profiling.
+
+```python
+import polars as pl
+from goldenmatch.core.autoconfig import _candidate_blocking_passes, profile_columns
+
+def _person_df():
+    return pl.DataFrame({
+        "first_name": ["ann", "ann", "bob", "bob", "cara", "dan", "eve", "fay"],
+        "surname":    ["lee", "lee", "kim", "kim", "ng", "ono", "poe", "qua"],
+        "dob":        ["1990-01-02", "1990-01-02", "1985-03-04", "1985-03-04",
+                       "1972-07-08", "1965-09-10", "1959-11-12", "1944-02-14"],
+        "postcode":   ["AA1", "AA1", "BB2", "BB2", "CC3", "DD4", "EE5", "FF6"],
+    })
+
+def test_candidate_pool_has_name_passes_and_compounds():
+    df = _person_df()
+    profiles = profile_columns(df)
+    pool = _candidate_blocking_passes(profiles, df)
+    field_sets = [tuple(p.fields) for p in pool]
+    # at least one single-field name pass present (the recall floor candidate)
+    assert any(len(fs) == 1 for fs in field_sets)
+    # at least one COMPOUND pass (name + orthogonal) present
+    compounds = [p for p in pool if len(p.fields) == 2]
+    assert compounds, "expected compound (name x orthogonal) passes in the pool"
+    # a compound that includes the date column carries per-field transforms with a
+    # year-coarsen (substring:0:4) on the date component, NOT on the name component
+    date_compounds = [p for p in compounds if "dob" in p.fields]
+    assert date_compounds
+    dc = date_compounds[0]
+    assert dc.field_transforms is not None and len(dc.field_transforms) == 2
+    dob_i = dc.fields.index("dob")
+    assert any("substring:0:4" in t for t in dc.field_transforms[dob_i])
+    # the non-date component's transforms are NOT the year-coarsen
+    other_i = 1 - dob_i
+    assert all("substring:0:4" not in t for t in dc.field_transforms[other_i])
+```
+
+- [ ] **Step 2: Run, verify fail** (ImportError).
+
+- [ ] **Step 3: Implement.** Add to `autoconfig.py`. Reuse `build_blocking`, `compute_column_priors`, and the existing orthogonal-eligibility shape:
+```python
+def _candidate_blocking_passes(profiles, df):
+    """Build the POOL of candidate blocking passes for selective probabilistic
+    blocking: build_blocking's transform-rich name passes (recall floor) + per-field
+    transformed compounds (name x orthogonal, date coarsened to year) + self-selective
+    orthogonal single-keys. Returns list[BlockingKeyConfig] (not yet budget-selected)."""
+    base = build_blocking(profiles, df)
+    base_passes = list(base.passes) if base.passes else list(base.keys or [])
+    name_fields = {f for p in base_passes for f in p.fields}
+
+    def _null_rate(name):
+        return df[name].null_count() / df.height if df.height else 1.0
+
+    by_name = {p.name: p for p in profiles}
+
+    def _orthogonal(p):
+        return (
+            p.name not in name_fields
+            and p.col_type not in ("description", "numeric")
+            and _null_rate(p.name) <= 0.20
+            and 0.02 <= p.cardinality_ratio < 1.0
+        )
+
+    orthogonals = [p for p in profiles if _orthogonal(p)]
+
+    pool: list[BlockingKeyConfig] = []
+    seen: set[tuple] = set()
+
+    def _add(fields, field_transforms):
+        # canonical key incl. transforms so distinct-transform variants are distinct
+        ft = tuple(tuple(t) for t in field_transforms) if field_transforms else None
+        key = (tuple(fields), ft)
+        if key in seen:
+            return
+        seen.add(key)
+        if field_transforms is None:
+            pool.append(BlockingKeyConfig(fields=list(fields)))
+        else:
+            pool.append(BlockingKeyConfig(fields=list(fields), field_transforms=field_transforms))
+
+    # 1. Name / recall-floor passes verbatim (keep their shared transforms).
+    for p in base_passes:
+        # express the base pass as per-field transforms so it composes uniformly
+        ft = [list(p.transforms or []) for _ in p.fields]
+        _add(list(p.fields), ft if any(ft) else None)
+
+    def _coarsen(o_profile):
+        # date orthogonals -> year via substring:0:4 (ISO leading-year; GoldenFlow
+        # date_iso8601 runs before autoconfig). Other orthogonals: no transform.
+        return ["substring:0:4"] if o_profile.col_type == "date" else []
+
+    # 2. Compounds: each base name pass's PRIMARY field x each orthogonal.
+    for p in base_passes:
+        if not p.fields:
+            continue
+        name_field = p.fields[0]
+        name_xf = list(p.transforms or [])
+        for o in orthogonals:
+            if o.name == name_field:
+                continue
+            _add([name_field, o.name], [name_xf, _coarsen(o)])
+
+    # 3. Self-selective orthogonal single-keys (high cardinality only).
+    for o in orthogonals:
+        if o.cardinality_ratio >= 0.30:
+            _add([o.name], [_coarsen(o)] if _coarsen(o) else None)
+
+    return pool
+```
+NOTE: `_add`'s `field_transforms=None` branch builds a bare key; the name-pass branch passes per-field transforms (so the single recall pass and its compound share the same name transform). The dedup `seen` keys on (fields, transforms) so a name pass and its bare orthogonal single-key don't collide.
+
+- [ ] **Step 4: Run the test -- green.** Also run `test_autoconfig_probabilistic_entry.py` to confirm `build_blocking`/`profile_columns` integration is intact.
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig.py packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py
+git commit -m "feat(autoconfig): _candidate_blocking_passes -- name + per-field-transformed compound + orthogonal pool"
+```
+
+---
+
+## Task 4: `_estimate_pass_stats` (exact candidate count + capped coverage)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py`
+
+- [ ] **Step 1: Write the failing test** (append). Hand-computable on a tiny df.
+
+```python
+from goldenmatch.config.schemas import BlockingKeyConfig
+from goldenmatch.core.autoconfig import _estimate_pass_stats
+
+def test_estimate_pass_stats_exact_count_and_coverage():
+    # surname blocks: {smith: rows 0,1,2} (3 -> C(3,2)=3 pairs), {jones: rows 3,4} (1 pair)
+    df = pl.DataFrame({
+        "surname": ["smith", "smith", "smith", "jones", "jones", "lee"],
+        "dob":     ["x", "x", "x", "y", "y", "z"],
+    })
+    cfg = BlockingKeyConfig(fields=["surname"])
+    count, coverage = _estimate_pass_stats(cfg, df)
+    assert count == 3 + 1  # 4 candidate pairs, lee is a singleton (0)
+    # coverage pair-ids canonical (min*N+max), N=6: smith pairs (0,1),(0,2),(1,2) + jones (3,4)
+    N = 6
+    expected = {0*N+1, 0*N+2, 1*N+2, 3*N+4}
+    assert coverage == expected
+```
+
+- [ ] **Step 2: Run, verify fail** (ImportError).
+
+- [ ] **Step 3: Implement.** Add to `autoconfig.py`:
+```python
+# Per-block row-id cap for the coverage signal: pathologically large blocks are
+# subsampled (deterministic, sorted-first-K) so coverage enumeration stays bounded.
+# candidate_count stays EXACT (computed from full block sizes), only the coverage
+# pair-set is capped. 150 -> at most C(150,2)=11175 pairs per oversized block.
+_COVERAGE_BLOCK_CAP = 150
+
+def _estimate_pass_stats(pass_cfg, df):
+    """Return (candidate_count, coverage) for a candidate pass.
+
+    candidate_count: EXACT sum over blocks of C(size, 2) (the budget is enforced on
+    this). coverage: set of canonical record-pair ids (min*N + max) the pass blocks
+    together, with per-block row-ids capped at _COVERAGE_BLOCK_CAP for boundedness.
+    Pair-ids are global (independent of the pass) so set ops across passes compose."""
+    from goldenmatch.core.blocker import _build_block_key_expr
+
+    n = df.height
+    if n < 2:
+        return 0, set()
+    key_expr = _build_block_key_expr(pass_cfg)
+    grouped = (
+        df.lazy()
+        .with_row_index("__rid__")
+        .with_columns(key_expr)
+        .filter(
+            pl.col("__block_key__").is_not_null()
+            & (pl.col("__block_key__").str.strip_chars() != "")
+        )
+        .group_by("__block_key__")
+        .agg(pl.col("__rid__"))
+        .collect()
+    )
+    candidate_count = 0
+    coverage: set[int] = set()
+    for rids in grouped["__rid__"].to_list():
+        size = len(rids)
+        if size < 2:
+            continue
+        candidate_count += size * (size - 1) // 2
+        sample = sorted(rids)[:_COVERAGE_BLOCK_CAP]
+        for i in range(len(sample)):
+            a = sample[i]
+            for j in range(i + 1, len(sample)):
+                b = sample[j]
+                lo, hi = (a, b) if a < b else (b, a)
+                coverage.add(lo * n + hi)
+    return candidate_count, coverage
+```
+
+- [ ] **Step 4: Run the test -- green.**
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig.py packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py
+git commit -m "feat(autoconfig): _estimate_pass_stats -- exact candidate count + capped pair coverage"
+```
+
+---
+
+## Task 5: `_select_passes_within_budget` (coverage-greedy set-cover)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py`
+
+- [ ] **Step 1: Write the failing tests** (append). Synthetic stats so the greedy/budget/anchor behavior is asserted without real data.
+
+```python
+from goldenmatch.core.autoconfig import _select_passes_within_budget
+
+def _mkpass(fields):
+    return BlockingKeyConfig(fields=list(fields))
+
+def test_select_respects_budget_and_is_coverage_greedy():
+    # pool entries: (pass, candidate_count, coverage_set)
+    name = _mkpass(["surname"])                 # broad, expensive, covers {1,2,3,4}
+    cA   = _mkpass(["surname", "dob"])           # tight, covers {1,2}
+    cB   = _mkpass(["surname", "postcode"])      # tight, covers {3,4}
+    cDup = _mkpass(["surname", "city"])          # tight but REDUNDANT, covers {1,2}
+    pool = [
+        (name, 100, {1, 2, 3, 4}),
+        (cA, 10, {1, 2}),
+        (cB, 10, {3, 4}),
+        (cDup, 10, {1, 2}),
+    ]
+    selected = _select_passes_within_budget(pool, budget=25)
+    fsets = {tuple(p.fields) for p in selected}
+    # within budget 25: the broad name (100) does NOT fit; cA + cB (20) cover everything,
+    # cDup adds zero NEW coverage so it is NOT chosen over the complementary cB.
+    assert ("surname", "dob") in fsets and ("surname", "postcode") in fsets
+    assert ("surname",) not in fsets          # too expensive for the budget
+    assert ("surname", "city") not in fsets   # redundant, no marginal coverage
+    assert sum({"surname": 100, ("surname","dob"): 10, ("surname","postcode"): 10,
+                ("surname","city"): 10}[tuple(p.fields) if len(p.fields)>1 else p.fields[0]]
+               for p in selected) <= 25
+
+def test_select_always_emits_a_name_bearing_pass():
+    # budget too tight for even the cheapest name-bearing pass -> anchor override
+    name = _mkpass(["surname"])
+    pool = [(name, 1000, {1, 2, 3})]
+    selected = _select_passes_within_budget(pool, budget=10)
+    assert selected, "must never return an empty config"
+    assert any("surname" in p.fields for p in selected)
+```
+
+- [ ] **Step 2: Run, verify fail** (ImportError).
+
+- [ ] **Step 3: Implement.** Add to `autoconfig.py`. A pass is "name-bearing" if any of its fields is in the name-field set; to keep this helper self-contained, treat a pass as name-bearing when the caller marks it -- simplest is: the caller passes the name-field set. Use this signature:
+```python
+def _select_passes_within_budget(pool, budget, name_fields=None):
+    """Greedy coverage-per-candidate set-cover under a candidate budget.
+
+    pool: list of (BlockingKeyConfig, candidate_count, coverage_set).
+    budget: max total candidate_count (K * N) of the selected union.
+    name_fields: set of field names considered recall-bearing; the result is
+    guaranteed to include >= 1 name-bearing pass (recall anchor), overriding the
+    budget if necessary (a name-less probabilistic config is never acceptable).
+
+    Returns list[BlockingKeyConfig]. Stops when no remaining pass fits the budget or
+    the best marginal coverage is zero (saturated)."""
+    name_fields = name_fields or set()
+    remaining = list(pool)
+    covered: set[int] = set()
+    spent = 0
+    selected: list[BlockingKeyConfig] = []
+
+    def _is_name(cfg):
+        return any(f in name_fields for f in cfg.fields)
+
+    while remaining:
+        best = None  # (ratio, idx)
+        for idx, (cfg, count, cov) in enumerate(remaining):
+            if count <= 0 or spent + count > budget:
+                continue
+            new = len(cov - covered)
+            if new <= 0:
+                continue
+            ratio = new / count
+            if best is None or ratio > best[0]:
+                best = (ratio, idx)
+        if best is None:
+            break
+        cfg, count, cov = remaining.pop(best[1])
+        selected.append(cfg)
+        covered |= cov
+        spent += count
+
+    # Recall anchor: guarantee >= 1 name-bearing pass, overriding the budget if no
+    # name-bearing pass fit. Pick the most-covering name-bearing pass from the pool.
+    if name_fields and not any(_is_name(c) for c in selected):
+        name_candidates = [(cfg, cov) for (cfg, count, cov) in pool if _is_name(cfg)]
+        if name_candidates:
+            anchor = max(name_candidates, key=lambda t: len(t[1]))[0]
+            selected.append(anchor)
+
+    return selected
+```
+NOTE the Task-5 tests call `_select_passes_within_budget(pool, budget=...)` WITHOUT `name_fields`; in those tests every pass contains `"surname"`, and the first test asserts the budget path while the second asserts the anchor. For the second test to exercise the anchor, call it with `name_fields={"surname"}`. **Update the second test to pass `name_fields={"surname"}`** (the real caller in Task 6 always supplies `name_fields`):
+```python
+    selected = _select_passes_within_budget(pool, budget=10, name_fields={"surname"})
+```
+(Adjust the test in Step 1 accordingly before implementing -- the first test does not need `name_fields` because it asserts budget/greedy behavior where passes already fit.)
+
+- [ ] **Step 4: Run the tests -- green.**
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig.py packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py
+git commit -m "feat(autoconfig): _select_passes_within_budget -- coverage-greedy set-cover w/ recall anchor"
+```
+
+---
+
+## Task 6: Rewrite `_build_probabilistic_blocking` to wire it together
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py` (`_build_probabilistic_blocking`)
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py`
+
+- [ ] **Step 1: Write the failing tests** (append).
+
+```python
+from goldenmatch.core.autoconfig import _build_probabilistic_blocking, profile_columns
+
+def test_build_probabilistic_blocking_within_budget_and_name_bearing():
+    df = _person_df()  # from Task 3
+    profiles = profile_columns(df)
+    cfg = _build_probabilistic_blocking(profiles, df)
+    assert cfg.strategy == "multi_pass"
+    assert cfg.passes, "must emit passes"
+    # at least one name-bearing pass (recall anchor)
+    name_fields = {"first_name", "surname"}
+    assert any(any(f in name_fields for f in p.fields) for p in cfg.passes)
+    # total candidate count of the selected union is within K*N (+ allow the anchor
+    # override, so assert it is not the full broad union: fewer candidates than a
+    # single broad [surname] pass would give if that pass is excluded)
+    # (smoke: it returns a usable multi_pass config consumed downstream)
+
+def test_build_probabilistic_blocking_degenerate_fallback():
+    # df with ONLY name columns -> no orthogonal fields -> fall back to build_blocking
+    from goldenmatch.core.autoconfig import build_blocking
+    df = pl.DataFrame({
+        "first_name": ["ann", "ann", "bob", "bob"],
+        "surname":    ["lee", "lee", "kim", "kim"],
+    })
+    profiles = profile_columns(df)
+    cfg = _build_probabilistic_blocking(profiles, df)
+    base = build_blocking(profiles, df)
+    # fallback returns build_blocking's output unchanged (deliberate change from the
+    # old augmented-superset degenerate path -- see spec)
+    assert (cfg.passes or cfg.keys) == (base.passes or base.keys)
+```
+
+- [ ] **Step 2: Run, verify fail** (the rewrite isn't in place; old function returns the augmented union).
+
+- [ ] **Step 3: Implement.** Replace the body of `_build_probabilistic_blocking` (keep the signature `(profiles, df, max_extra_passes=5)`; `max_extra_passes` is now unused but kept for call-site compatibility -- callers pass it positionally? verify and drop if safe):
+```python
+def _build_probabilistic_blocking(profiles, df, max_extra_passes=5):
+    """Selective compound blocking for the probabilistic path: pick a union of passes
+    under a K*N candidate budget via coverage-greedy set-cover (compounds preferred),
+    keeping a name-bearing recall anchor. Replaces the old broad-single-key augment
+    that flooded candidates (8.84M on historical_50k -> 3.4% precision ceiling).
+    Degenerate input (no orthogonal fields / profiling failure) -> build_blocking."""
+    base = build_blocking(profiles, df)
+    base_passes = list(base.passes) if base.passes else list(base.keys or [])
+    name_fields = {f for p in base_passes for f in p.fields}
+
+    try:
+        pool = _candidate_blocking_passes(profiles, df)
+    except Exception:
+        logger.warning("selective blocking pool build failed; falling back to build_blocking", exc_info=True)
+        return base
+
+    # Degenerate: pool is just single-field name passes (no compounds/orthogonals)
+    # -> fall back to build_blocking. NOTE: if build_blocking itself emitted a
+    # multi-field compound name pass (its geo/compound paths), len(fields)>1 makes
+    # this True and we proceed -- that base compound IS selective, so that is correct.
+    has_compound_or_orthogonal = any(
+        len(p.fields) > 1 or not (set(p.fields) & name_fields) for p in pool
+    )
+    if not has_compound_or_orthogonal:
+        return base
+
+    n = df.height
+    budget = _blocking_candidate_budget_k() * max(n, 1)
+    stats = []
+    for p in pool:
+        count, cov = _estimate_pass_stats(p, df)
+        if count > 0:
+            stats.append((p, count, cov))
+    if not stats:
+        return base
+
+    selected = _select_passes_within_budget(stats, budget, name_fields=name_fields)
+    if not selected:
+        return base
+
+    fallback_block = max(1000, min(10_000, n // 200)) if n else 5000
+    return BlockingConfig(
+        strategy="multi_pass",
+        passes=selected,
+        max_block_size=base.max_block_size or fallback_block,
+        skip_oversized=base.skip_oversized,
+    )
+```
+Verify call sites of `_build_probabilistic_blocking` (grep) still work; if `max_extra_passes` was only ever defaulted, leave the param (harmless) or drop it and update the one caller.
+
+- [ ] **Step 4: Run the new tests + the probabilistic autoconfig + blocker regression -- all green.**
+`$env:POLARS_SKIP_CPU_CHECK=1; $env:PYTHONIOENCODING="utf-8"; .venv\Scripts\python.exe -m pytest packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py packages/python/goldenmatch/tests/test_autoconfig_probabilistic_entry.py packages/python/goldenmatch/tests/test_autoconfig_probabilistic_721.py packages/python/goldenmatch/tests/test_blocker.py -q`
+Then a quick end-to-end smoke that the emitted config is consumed by the pipeline + per-rule EM:
+`...python.exe -m pytest packages/python/goldenmatch/tests/test_probabilistic_per_rule_em.py -q`
+All must pass.
+
+- [ ] **Step 5: Commit**
+```
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig.py packages/python/goldenmatch/tests/test_autoconfig_selective_blocking.py
+git commit -m "feat(autoconfig): selective compound blocking -- budget set-cover replaces broad single-key flood"
+```
+
+---
+
+## Task 7: K calibration + gate measurement (no code; dump PR-curve method)
+
+- [ ] **Step 1** Extend the measurement script `.profile_tmp/diag_pr_per_rule.py` (or a copy) so it loads the config via `auto_configure_probabilistic_df` (which now routes through the new `_build_probabilistic_blocking`) and reports, for historical_50k: total candidate count of the emitted union (confirm it dropped from ~8.84M into K*N), blocking_recall (via `.profile_tmp/diag_blocking_recall.py`), and the per-rule PR-curve BEST F1 (P/R at best).
+- [ ] **Step 2** **Sweep K** in {10, 25, 50, 100} via `GOLDENMATCH_BLOCKING_CANDIDATE_BUDGET_K` (no code edits). For each K record: emitted candidate count, blocking_recall, per-rule BEST F1 + P/R. Pick the K that maximizes historical_50k F1 subject to non-regression.
+- [ ] **Step 3** **Non-regression:** run the same on febrl3 + synthetic_person at the chosen K; confirm F1 does not drop below the floors (febrl3 ~0.982, synthetic ~0.987). These have low candidate ratios so the budget should not bind -- confirm.
+- [ ] **Step 4: DECISION GATE.**
+  - If a K exists where historical_50k F1 is materially > 0.655 (target P >= ~0.8 @ R >= ~0.7) AND febrl3/synthetic hold -> the lever is validated. Decide whether to update the shipped `_BLOCKING_CANDIDATE_BUDGET_K_DEFAULT` constant to the winning K (commit that one-line change) or keep 25 and document the winner. Record the before/after PR-curve numbers for the PR body.
+  - If NO K clears the gate (cutting candidates craters recall before precision rises, or within-budget candidates are still dominated by same-name non-matches) -> **kill criterion fires**: the wall is F-S same-name-different-person disambiguation, not blocking selectivity. STOP and re-brainstorm scoring-side disambiguation / a learned blocker; do NOT keep chasing K. Record the swept numbers as the evidence.
+
+---
+
+## Final checks before PR
+
+- [ ] Run all touched test files individually (not the full suite).
+- [ ] `ruff check` the changed files (`schemas.py`, `blocker.py`, `autoconfig.py`, the test file).
+- [ ] Confirm `field_transforms=None` keeps `_build_block_key_expr` byte-identical (Task 1 test) so the weighted/exact path is untouched.
+- [ ] Confirm the emitted `BlockingConfig` is consumed unchanged by the pipeline's probabilistic branches + `_build_blocks_per_pass` (per-rule EM smoke green).
+- [ ] PR body: the K sweep table + before/after candidate count, blocking_recall, and PR-curve F1 on historical_50k + the febrl3/synthetic non-regression + the gate verdict. Do NOT `git add docs/`.
+
+## Follow-ups (NOT in this plan)
+
+- Large-N (>> 50K) budget estimation (block size scales with N; the exact-groupby estimate is computed at the 50K gate scale -- sample-extrapolation is a separate effort).
+- Weighted/exact-path blocking selectivity; TS parity for `field_transforms`; CI Splink head-to-head panel + branch rebase.
+- If the kill criterion fires: scoring-side entity disambiguation / learned blocker.

--- a/docs/superpowers/plans/2026-06-09-splink-bakeoff.md
+++ b/docs/superpowers/plans/2026-06-09-splink-bakeoff.md
@@ -1,0 +1,233 @@
+# Splink (hand-rolled) vs GoldenMatch (autoconfig) Bake-off Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A reproducible accuracy + performance bake-off across the ER benchmark datasets pitting hand-rolled expert Splink against GoldenMatch's two zero-tuning autoconfig modes, emitting one unified table (P/R/F1 + B3 + wall + peak RSS + throughput per engine x dataset), run on a Linux CI runner.
+
+**Architecture:** Reuse the working `scripts/bench_er_headtohead/` flow. Add `--mode` to `run_goldenmatch.py` so GM runs in its own subprocess (isolated perf) under zero-config and probabilistic-autoconfig. New `run_bakeoff.py` orchestrates the 3 engines per dataset (mirroring `run_panel.py`'s proven Utf8-truth + string-record_id eval), collects accuracy + perf, emits `bakeoff.md`/`.json`. A non-gating CI lane runs it; results commit to `docs/benchmarks/`.
+
+**Tech Stack:** Python, polars, DuckDB (Splink + evaluate), splink, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-splink-bakeoff-design.md`
+
+---
+
+## Conventions
+
+- Run tests (Windows): `$env:POLARS_SKIP_CPU_CHECK=1; $env:PYTHONIOENCODING="utf-8"; .venv\Scripts\python.exe -m pytest <path> -v`. Do NOT run the full suite (OOMs the box). Hang >2min -> kill zombies `powershell.exe -Command "Get-Process python -ErrorAction SilentlyContinue | Stop-Process -Force"`.
+- Branch off latest `origin/main`. Commit code+tests only; NEVER `git add docs/`. ASCII commit messages.
+- `splink` is pip-installed in the venv. `resource` is Linux-only -> perf-capture code paths are exercised in CI, but the unit tests must NOT depend on `resource` returning a real RSS (they assert structure, not Linux RSS values).
+- **Read `scripts/bench_er_headtohead/run_panel.py` before Tasks 1-2** -- it is the working reference for the Utf8-truth write (`:358`), the string-record_id GM pred (`_gm_predictions_path`, esp. `:96`), and the Splink subprocess eval (`_run_splink`). The bake-off LIFTS these patterns; do not reinvent them.
+
+## Background (current state)
+
+- `run_goldenmatch.py`: takes `--input <parquet>` + `--rows` + `--pred-out` + `--threshold`; runs an EXPLICIT hand-built bucket+native+weighted config; `--pred-out` writes `record_id` as int64 `__row_id__` (valid only when record_id == row index, i.e. the synthetic fixture). Self-times wall + `_peak_rss_mb()` (Linux `resource`). `except BaseException ... raise` re-raises after writing the result JSON.
+- `run_splink.py`: `--dataset <name>` loads `(records, truth)` via `datasets.load_dataset`; per-dataset hand-rolled `_SETTINGS_BY_DATASET`; writes `--pred-out` as `record_id, cluster_id AS pred_cluster_id` (REAL record_id); self-captures perf; skips dblp_acm.
+- `run_panel.py`: accuracy-only; runs GM INLINE (`_gm_predictions_path`, string record_id) + Splink subprocess; writes truth Utf8 (`:358`); evals via `evaluate.evaluate(pred, truth) -> {pairwise, bcubed}`. **Stays UNTOUCHED.**
+- `evaluate.evaluate(pred, truth)`: DuckDB join `p.record_id = t.record_id`; returns `{"pairwise": {precision,recall,f1}, "bcubed": {f1,...}}`.
+
+## File Structure
+
+- **Modify** `scripts/bench_er_headtohead/run_goldenmatch.py`: add `--mode {hand_built,zeroconfig,probabilistic}` (default `hand_built`, byte-unchanged). Bake-off modes run the autoconfig path + write string-record_id preds + handle refuse + force rerank off.
+- **New** `scripts/bench_er_headtohead/run_bakeoff.py`: the unified orchestrator.
+- **New** tests: `scripts/bench_er_headtohead/test_bakeoff.py` (or `packages/python/goldenmatch/tests/test_bench_bakeoff.py`).
+- **Modify** `.github/workflows/bench-probabilistic.yml`: add the `bake-off` lane.
+- **(Task 4, post-merge)** `docs/benchmarks/2026-06-09-splink-bakeoff.md` (results) + doc links.
+
+---
+
+## Task 1: `--mode` on run_goldenmatch.py (zeroconfig + probabilistic autoconfig)
+
+**Files:**
+- Modify: `scripts/bench_er_headtohead/run_goldenmatch.py`
+- Test: `scripts/bench_er_headtohead/test_bakeoff.py`
+
+- [ ] **Step 1: Write failing tests.** Create the test file. Use a tiny person-shaped parquet with a STRING `record_id` column (so the bake-off remap is exercised). Invoke the runner as a subprocess.
+
+```python
+import json, subprocess, sys
+from pathlib import Path
+import polars as pl
+import pyarrow.parquet as pq
+
+HERE = Path(__file__).resolve().parent
+RUN_GM = HERE / "run_goldenmatch.py"
+
+def _tiny_parquet(tmp_path):
+    # string record_ids (like historical_50k/febrl3/dblp_acm), 2 obvious dup pairs
+    df = pl.DataFrame({
+        "record_id": ["r0", "r1", "r2", "r3", "r4", "r5"],
+        "first_name": ["ann", "ann", "bob", "bob", "cara", "dan"],
+        "surname":    ["lee", "lee", "kim", "kim", "ng", "ono"],
+        "dob":        ["1990-01-01", "1990-01-01", "1985-02-02", "1985-02-02", "1972-03-03", "1965-04-04"],
+        "postcode":   ["AA1", "AA1", "BB2", "BB2", "CC3", "DD4"],
+    })
+    p = tmp_path / "tiny.parquet"; df.write_parquet(p); return p, df
+
+def _run(p, mode, tmp_path):
+    out = tmp_path / "res.json"; pred = tmp_path / "pred.parquet"
+    proc = subprocess.run(
+        [sys.executable, str(RUN_GM), "--input", str(p), "--rows", "6",
+         "--mode", mode, "--out", str(out), "--pred-out", str(pred),
+         "--allow-pure-python", "--threshold", "0.85"],
+        capture_output=True, text=True, timeout=300,
+        env={**__import__("os").environ, "POLARS_SKIP_CPU_CHECK": "1", "PYTHONIOENCODING": "utf-8"},
+    )
+    return proc, out, pred
+
+def test_zeroconfig_emits_string_record_id_preds(tmp_path):
+    p, df = _tiny_parquet(tmp_path)
+    proc, out, pred = _run(p, "zeroconfig", tmp_path)
+    assert out.exists(), proc.stderr
+    res = json.loads(out.read_text())
+    assert res["mode"] == "zeroconfig"
+    assert res["status"] in ("ok", "refused")  # refuse is a valid recorded outcome
+    if res["status"] == "ok":
+        t = pq.read_table(pred)
+        assert t.column_names == ["record_id", "pred_cluster_id"]
+        rids = set(t.column("record_id").to_pylist())
+        assert rids <= set(df["record_id"].to_list())   # REAL string ids, not 0..N
+        assert all(isinstance(x, str) for x in rids)
+
+def test_probabilistic_mode_runs_and_string_preds(tmp_path):
+    p, df = _tiny_parquet(tmp_path)
+    proc, out, pred = _run(p, "probabilistic", tmp_path)
+    assert out.exists(), proc.stderr
+    res = json.loads(out.read_text())
+    assert res["mode"] == "probabilistic" and res["status"] == "ok", res.get("error")
+    t = pq.read_table(pred)
+    assert all(isinstance(x, str) for x in t.column("record_id").to_pylist())
+
+def test_hand_built_mode_unchanged_int_ids(tmp_path):
+    # hand_built keeps int64 __row_id__ preds (orchestrate.py back-compat)
+    p, df = _tiny_parquet(tmp_path)
+    proc, out, pred = _run(p, "hand_built", tmp_path)
+    res = json.loads(out.read_text())
+    assert res["mode"] == "hand_built"
+    if res["status"] == "ok":
+        t = pq.read_table(pred)
+        import pyarrow as pa
+        assert pa.types.is_integer(t.schema.field("record_id").type)
+```
+
+- [ ] **Step 2: Run, verify fail** (`--mode` unknown / `mode` not in result). `.venv\Scripts\python.exe -m pytest scripts/bench_er_headtohead/test_bakeoff.py -v`
+
+- [ ] **Step 3: Implement.** In `run_goldenmatch.py`:
+  - Add `ap.add_argument("--mode", choices=["hand_built","zeroconfig","probabilistic"], default="hand_built")`. Put `result["mode"] = args.mode` early.
+  - Branch the dedupe by mode:
+    - `hand_built`: the EXISTING explicit-config `dedupe_df(df, config=config)` path -- LEAVE IT EXACTLY AS-IS, and keep the EXISTING int64 `__row_id__` `--pred-out` write for this mode only.
+    - `zeroconfig`: `from goldenmatch.core.autoconfig_controller import ControllerNotConfidentError` (**IMPORTANT: it lives in `autoconfig_controller`, NOT `autoconfig` -- importing from the wrong module silently breaks the refuse path; do NOT wrap this import in a try/except that would bind a never-matching sentinel**). Wrap `ded = dedupe_df(df)` in `try/except ControllerNotConfidentError as e: result.update(status="refused", error=str(e)); _atomic_write(args.out, result); print(...); return` (exit 0, do NOT re-raise -- handle BEFORE the generic `except BaseException ... raise`). NOTE: refuse only fires at `df.height >= 100_000`, so none of the 4 panel datasets (max = historical_50k at 50K) will actually refuse -- this is a defensive guard, exercised only if the scale follow-up adds a >=100K dataset. (`auto_configure_probabilistic_df` IS correctly importable from `goldenmatch.core.autoconfig`.)
+    - `probabilistic`: `from goldenmatch.core.autoconfig import auto_configure_probabilistic_df`; `cfg = auto_configure_probabilistic_df(df)`; then HARD-force rerank off: `for mk in cfg.get_matchkeys(): if getattr(mk, "type", None) == "weighted": mk.rerank = False`; `ded = dedupe_df(df, config=cfg)`.
+  - **Pred-out remap (bake-off modes only):** factor the pred-out write into a helper. For `zeroconfig`/`probabilistic`, remap to the input df's real record_id as a STRING column (mirror `run_panel.py::_gm_predictions_path`):
+    ```python
+    rid = df["record_id"].to_list()  # the input parquet's real record_id column
+    rids, cids = [], []
+    for cid, c in clusters.items():
+        members = c["members"] if isinstance(c, dict) else c.members
+        for m in members:
+            rids.append(str(rid[m])); cids.append(cid)
+    pq.write_table(pa.table({"record_id": pa.array(rids, pa.string()),
+                             "pred_cluster_id": pa.array(np.asarray(cids, dtype=np.int64))}),
+                   args.pred_out, compression="zstd")
+    ```
+    For `hand_built`, keep the existing int64 write untouched.
+  - Native gate: the bake-off modes can run with `--allow-pure-python` (autoconfig may not pick the native bucket path); keep `--require-native` default-on for `hand_built` only, or relax the native-required RuntimeError to `hand_built` mode. (The bake-off CI run will pass `--require-native` off for the autoconfig modes since the controller chooses the backend.)
+
+- [ ] **Step 4: Run tests -- green.** `.venv\Scripts\python.exe -m pytest scripts/bench_er_headtohead/test_bakeoff.py -v` then `ruff check scripts/bench_er_headtohead/run_goldenmatch.py scripts/bench_er_headtohead/test_bakeoff.py`. NOTE: these tests run a real (tiny, 6-row) GM dedupe -- set the polars env vars. If `probabilistic` mode can't build a matchkey on the tiny fixture, enrich the fixture (more distinct names) rather than weaken the assert.
+
+- [ ] **Step 5: Commit.** `git add scripts/bench_er_headtohead/run_goldenmatch.py scripts/bench_er_headtohead/test_bakeoff.py && git commit -m "feat(bench): run_goldenmatch --mode {hand_built,zeroconfig,probabilistic} for the bake-off (string-record_id preds, refuse-handling, rerank guard)"`
+
+---
+
+## Task 2: `run_bakeoff.py` orchestrator (accuracy + perf, 3 engines x all datasets)
+
+**Files:**
+- Create: `scripts/bench_er_headtohead/run_bakeoff.py`
+- Test: `scripts/bench_er_headtohead/test_bakeoff.py` (append)
+
+- [ ] **Step 1: Write failing tests** for the pure table-assembly logic (no live engines). Factor the orchestrator so a `build_rows(per_engine_results)` / `render_md(rows)` are unit-testable with STUB inputs:
+
+```python
+def test_bakeoff_table_assembly_and_missing_engine():
+    from run_bakeoff import build_rows, render_md  # import the sibling module
+    # stub: dataset -> engine -> (result_dict, metrics_dict-or-None)
+    stub = {
+      "febrl3": {
+        "gm_zeroconfig": ({"status":"ok","dedupe_wall_seconds":3.1,"peak_rss_mb":900.0,"scored_pairs":12000},
+                          {"pairwise":{"precision":0.99,"recall":0.98,"f1":0.985},"bcubed":{"f1":0.97}}),
+        "gm_probabilistic": ({"status":"ok","dedupe_wall_seconds":4.0,"peak_rss_mb":950.0,"scored_pairs":15000},
+                          {"pairwise":{"precision":0.99,"recall":0.99,"f1":0.991},"bcubed":{"f1":0.98}}),
+        "splink": ({"status":"ok","dedupe_wall_seconds":8.0,"peak_rss_mb":1200.0,"scored_pairs":20000},
+                          {"pairwise":{"precision":0.97,"recall":0.96,"f1":0.965},"bcubed":{"f1":0.95}}),
+      },
+      "dblp_acm": {  # splink skips
+        "gm_zeroconfig": ({"status":"ok","dedupe_wall_seconds":2.0,"peak_rss_mb":800.0,"scored_pairs":9000},
+                          {"pairwise":{"precision":0.9,"recall":0.86,"f1":0.879},"bcubed":{"f1":0.86}}),
+        "gm_probabilistic": ({"status":"ok","dedupe_wall_seconds":2.2,"peak_rss_mb":810.0,"scored_pairs":9100},
+                          {"pairwise":{"precision":0.9,"recall":0.86,"f1":0.879},"bcubed":{"f1":0.86}}),
+        "splink": ({"status":"skipped","error":"bibliographic out of scope"}, None),
+      },
+    }
+    rows = build_rows(stub)
+    # one row per (dataset, engine); splink/dblp_acm is a 'skipped' row with no F1.
+    # NOTE: use "skipped" to match run_splink.py's actual status string (run_panel.py
+    # maps it to row["status"]="skipped"); keep build_rows/render_md + this stub in sync.
+    skips = [r for r in rows if r["dataset"]=="dblp_acm" and r["engine"]=="splink"]
+    assert skips and skips[0]["status"]=="skipped" and skips[0].get("f1") in (None,"")
+    md = render_md(rows)
+    assert "febrl3" in md and "throughput" in md.lower() and "peak" in md.lower()
+    # a delta line exists somewhere (GM vs Splink) for febrl3
+    assert "ratio" in md.lower() or "delta" in md.lower()
+```
+
+- [ ] **Step 2: Run, verify fail** (ImportError / build_rows missing).
+
+- [ ] **Step 3: Implement `run_bakeoff.py`.** Structure:
+  - `_import_sibling(name)` (copy from run_panel.py) for datasets/attribution/evaluate.
+  - `ENGINES = ["gm_zeroconfig", "gm_probabilistic", "splink"]`; `DATASETS = ["historical_50k","febrl3","synthetic_person","dblp_acm"]`.
+  - Per dataset: `records, truth = datasets.load_dataset(name)`; write `records` to `ds_dir/records.parquet` (preserve the real `record_id` column verbatim); write truth Utf8: `truth.with_columns(pl.col("record_id").cast(pl.Utf8)).write_parquet(ds_dir/"truth.parquet")` (copy run_panel.py:358).
+  - For `gm_zeroconfig` / `gm_probabilistic`: subprocess `run_goldenmatch.py --input records.parquet --rows <h> --mode <zeroconfig|probabilistic> --allow-pure-python --pred-out gm_<mode>_pred.parquet --out gm_<mode>_res.json --threshold 0.85`, with a per-engine timeout (reuse run_panel's `_TIMEOUT`). On `status=ok`, `metrics = evaluate.evaluate(pred, truth_path)`; on `refused`/`error`/timeout, metrics=None (record the status).
+  - For `splink`: subprocess `run_splink.py --dataset <name> --pred-out splink_pred.parquet --out splink_res.json --threshold 0.85` (copy run_panel.py::_run_splink). On ok, `evaluate.evaluate(splink_pred, truth_path)`; a dataset Splink doesn't support records `status=skips`.
+  - `build_rows(per_engine_results)`: flatten to one row per (dataset, engine) with `{dataset, engine, status, precision, recall, f1, bcubed_f1, dedupe_wall_seconds, peak_rss_mb, scored_pairs, throughput_pairs_per_s = round(scored_pairs/wall) if both, rows}`.
+  - `render_md(rows)`: a markdown table (engine columns grouped per dataset) + a per-dataset delta block (GM-zeroconfig & GM-probabilistic vs Splink: wall ratio GM/Splink, RSS ratio, F1 delta). Plus the honest-framing footer (pairwise under one evaluator; ~0.97 is cluster-level; Splink skips dblp_acm).
+  - `main()`: `--out-dir`, `--datasets` (default all), write `bakeoff.json` (the rows) + `bakeoff.md` (render_md). Print a one-line-per-cell progress log.
+
+- [ ] **Step 4: Run tests + ruff -- green.** (The assembly tests use stubs; no live engines.) `.venv\Scripts\python.exe -m pytest scripts/bench_er_headtohead/test_bakeoff.py -v`. Optionally do ONE tiny live smoke: `run_bakeoff.py --datasets febrl3 --out-dir .profile_tmp/bakeoff_smoke` IF febrl3 + splink run locally in reasonable time (skip if slow; CI is the real run).
+
+- [ ] **Step 5: Commit.** `git add scripts/bench_er_headtohead/run_bakeoff.py scripts/bench_er_headtohead/test_bakeoff.py && git commit -m "feat(bench): run_bakeoff.py -- unified accuracy+perf bake-off (GM zeroconfig+probabilistic vs hand-rolled Splink)"`
+
+---
+
+## Task 3: CI bake-off lane in bench-probabilistic.yml
+
+**Files:**
+- Modify: `.github/workflows/bench-probabilistic.yml`
+
+- [ ] **Step 1: Read** the existing `panel` / `panel-v1-v2` jobs in `bench-probabilistic.yml` to copy the setup (checkout, python, `pip install -e packages/python/goldenmatch[bench]`, native build via `scripts/build_native.py` if used, the Leipzig DBLP-ACM fetch step, `runs-on: large-new-64GB`).
+
+- [ ] **Step 2: Add a `bake-off` job** (workflow_dispatch-gated, mirror the panel job's `if`/inputs toggle, e.g. `run_bakeoff` input). Steps: setup (as panel) + build native runtime + fetch DBLP-ACM + `python scripts/bench_er_headtohead/run_bakeoff.py --out-dir bakeoff_out` + `actions/upload-artifact` of `bakeoff_out/bakeoff.md` + `bakeoff.json`. Non-gating (no required check). Add the `run_bakeoff` toggle to the workflow's `changes`/dispatch inputs consistently with the other bench lanes.
+
+- [ ] **Step 3:** Validate YAML locally if a linter is available (`python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/bench-probabilistic.yml'))"`). No unit test for the workflow itself.
+
+- [ ] **Step 4: Commit.** `git add .github/workflows/bench-probabilistic.yml && git commit -m "ci(bench): add workflow_dispatch bake-off lane (run_bakeoff.py on large-new-64GB)"`
+
+---
+
+## Final checks before PR
+
+- [ ] Run `test_bakeoff.py` individually (not the full suite). ruff clean on the 3 changed/new files.
+- [ ] Confirm `--mode hand_built` is byte-unchanged (orchestrate.py path): diff `run_goldenmatch.py` hand_built branch vs the original; the int64 pred-out write is untouched.
+- [ ] PR with the spec link. Squash-merge via `benzsevern` auth (benseverndev-oss), switch back to benzsevern-mjh.
+
+## Task 4: Run + record (post-merge; no code)
+
+- [ ] After the PR merges to main (workflow_dispatch lanes only register on the default branch), dispatch the `bake-off` lane: `gh workflow run bench-probabilistic.yml --repo benseverndev-oss/goldenmatch -f run_bakeoff=true` (benzsevern auth).
+- [ ] Watch it; download the `bakeoff.md`/`.json` artifacts.
+- [ ] Commit the results to `docs/benchmarks/2026-06-09-splink-bakeoff.md` (create the dir; include the runner + commit SHA for provenance) and add a link from `context-network/architecture/fellegi-sunter-splink-parity.md` + `docs-site/reference/vendor-comparison.mdx`. (This doc commit is the one place `docs/` content lands -- it is NOT under `docs/superpowers/`, so it commits normally.)
+- [ ] DECISION POINT: read the numbers honestly. If GM zero-config refuses or trails badly on a dataset, RECORD it as-is (the bake-off's value is honesty). Surface the headline (does zero-config / probabilistic-autoconfig beat hand-rolled Splink on accuracy, and how does perf compare) to the user.
+
+## Follow-ups (NOT in this plan)
+
+- Synthetic 10K/100K/1M throughput curve (the "at scale" story).
+- NCVR adapter (needs synthesized corrupted-duplicate ground truth).
+- Re-tuning the hand-rolled Splink configs (reuse as-is for now).

--- a/docs/superpowers/plans/2026-06-10-sail-tier-stage-s5-identity.md
+++ b/docs/superpowers/plans/2026-06-10-sail-tier-stage-s5-identity.md
@@ -1,0 +1,827 @@
+# Sail Tier — Stage S5: identity-on-Sail Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Sail-native distributed **create + edge-emit** identity stage that, on a fresh store, produces the durable identity graph (`nodes`, `source_records`, `same_as` edges) as Spark DataFrames, parity-proven against the one-box `resolve_clusters` create path.
+
+**Architecture:** A new `goldenmatch/sail/identity.py` re-expresses Layer 1 of identity resolution (create + edges — entity-independent + content-deterministic) as relational Spark ops + scalar pandas-UDFs, mirroring S3's `build_golden`. Pure-python helpers carry the parity-critical logic (record-id derivation, deterministic entity-id) reused identically by the reference and the UDFs (parity by construction). The stateful incremental layer (absorb/merge against an existing store) is deferred, honest-null — exactly as the Ray path left it.
+
+**Tech Stack:** Python, PySpark (Spark Connect client, pure gRPC — no JVM), pysail (in-process Sail server), pandas-UDFs, pytest. Spec: `docs/superpowers/specs/2026-06-10-sail-tier-stage-s5-identity-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `packages/python/goldenmatch/goldenmatch/sail/identity.py` | The S5 stage: pure helpers + Spark frame builders + `build_identity_graph` orchestrator | Create |
+| `packages/python/goldenmatch/goldenmatch/sail/pipeline.py` | Add opt-in `emit_identity` to `run_sail_pipeline` | Modify (`run_sail_pipeline`, lines 10-55) |
+| `packages/python/goldenmatch/tests/test_sail_identity_parity.py` | Unit tests (pure helpers) + the 3-part parity gate + determinism, against the in-process Sail server | Create |
+| `.github/workflows/ci.yml` | New blocking gate step in the `sail` lane (path filter already covers `tests/test_sail_*.py` + `sail/**`) | Modify (`sail` job, after the golden gate ~line 1314) |
+| `docs/superpowers/specs/2026-06-03-sail-tier-design.md` | Record the S5 honest-null (deferred incremental) | Modify (append S5 note) |
+
+**Conventions to follow (from S1–S4, non-negotiable):**
+- Lazy `pyspark` imports **inside** functions (never at module top) — keeps `sail/identity.py` importable without the extra (mirrors `sail/golden.py`).
+- Joins on **shared column names** only; rename before join. Never `df["col"]` cross-handle refs across self-similar joins (the S2 `AMBIGUOUS_REFERENCE` lesson).
+- Test files `pytest.importorskip("pysail")` / `("pyspark")` at top; module-scoped `spark` fixture spins up `SparkConnectServer` (copy from `test_sail_golden_parity.py:15-26`).
+- These tests run in the **`sail` CI lane** (`.venv/bin/python -m pytest ... --timeout=300`), not the default python lane. Local runs need `pip install -e 'packages/python/goldenmatch[sail]'`; the sail lane is the authoritative gate.
+
+---
+
+### Task 0: Branch setup
+
+- [ ] **Step 1: Create the feature branch**
+
+This plan was NOT created in a dedicated worktree. Per the project branch/merge SOP, work on a feature branch off `main` (not the release branch).
+
+```bash
+git fetch origin
+git switch -c feat/sail-s5-identity origin/main
+```
+
+Expected: on a fresh `feat/sail-s5-identity` branch.
+
+---
+
+### Task 1: Pure helpers — record-id + deterministic entity-id
+
+The parity-critical logic, with zero pyspark dependency. These are reused verbatim by both the parity reference and the Spark UDFs → parity by construction.
+
+**Files:**
+- Create: `packages/python/goldenmatch/goldenmatch/sail/identity.py`
+- Test: `packages/python/goldenmatch/tests/test_sail_identity_parity.py`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+In a NEW `tests/test_sail_identity_parity.py` (top of file: `import pytest`; the pure-helper tests do NOT need the server, but keep the file under `test_sail_*` so the path filter routes it to the sail lane):
+
+```python
+from goldenmatch.sail.identity import record_id_for_row, entity_id_for_members
+
+
+def test_record_id_pk_path():
+    # PK present -> "{source}:{pk}" (mirrors one-box _record_id_candidates).
+    rid = record_id_for_row({"id": 42, "name": "x"}, "people", "id")
+    assert rid == "people:42"
+
+
+def test_record_id_h1_path_matches_one_box():
+    # No PK -> "{source}:h1:{fingerprint[:12]}", byte-identical to the one-box
+    # primary id (parity by construction: same record_fingerprint call).
+    from goldenmatch.core._hashing import record_fingerprint
+    from goldenmatch.identity.fingerprint_batch import _canonical_payload
+
+    payload = {"first_name": "Jon", "email": "jon@x.com"}
+    expected = f"dataframe:h1:{record_fingerprint(_canonical_payload(payload))[:12]}"
+    assert record_id_for_row(payload, "dataframe", None) == expected
+
+
+def test_entity_id_order_independent():
+    # Shuffling members yields the SAME entity_id (sorted before hashing).
+    a = entity_id_for_members(["people:1", "people:2", "people:3"])
+    b = entity_id_for_members(["people:3", "people:1", "people:2"])
+    assert a == b
+    assert a.startswith("ent:h1:")
+
+
+def test_entity_id_distinct_for_distinct_members():
+    a = entity_id_for_members(["people:1", "people:2"])
+    b = entity_id_for_members(["people:1", "people:3"])
+    assert a != b
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_sail_identity_parity.py -k "record_id or entity_id" -v`
+Expected: FAIL — `cannot import name 'record_id_for_row'`.
+
+- [ ] **Step 3: Implement the pure helpers**
+
+Create `sail/identity.py` (lazy pyspark imports come in later tasks; module top stays pyspark-free):
+
+```python
+"""S5: identity-on-Sail — distributed create + edge-emit (Stage S5).
+
+Re-expresses Layer 1 of one-box ``identity.resolve.resolve_clusters`` (create +
+``same_as`` edges — entity-independent + content-deterministic) as relational
+Spark ops + scalar pandas-UDFs. The stateful incremental layer (absorb/merge
+against an existing store) is DEFERRED, honest-null: it stays driver-side, as
+the Ray path left it. Spec: docs/superpowers/specs/2026-06-10-sail-tier-stage
+-s5-identity-design.md.
+
+pyspark is imported lazily INSIDE the builder functions so this module imports
+without the [sail] extra (mirrors sail/golden.py)."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+_ENT_PREFIX = "ent:h1:"
+_ENT_HASH_LEN = 16  # 64 bits of hex; collision-safe for entity populations.
+
+
+def record_id_for_row(
+    payload: dict[str, Any], source: str, source_pk_col: str | None
+) -> str:
+    """Primary record_id for a row, mirroring one-box ``_record_id_candidates``
+    PRIMARY path. PK -> ``{source}:{pk}``. No PK -> canonical fingerprint
+    ``{source}:h1:{fingerprint[:12]}``; un-fingerprintable rows fall to the
+    legacy ``{source}:hash:{12}`` (same as the one-box ``except`` branch). The
+    legacy id is NOT emitted as a separate lookup candidate here — candidate
+    resolution is the deferred Layer-2 (overlap) concern."""
+    if source_pk_col and source_pk_col in payload and payload[source_pk_col] is not None:
+        return f"{source}:{payload[source_pk_col]}"
+    clean = {k: v for k, v in payload.items() if not str(k).startswith("__")}
+    from goldenmatch.core._hashing import record_fingerprint
+    from goldenmatch.identity.fingerprint_batch import _canonical_payload
+
+    try:
+        full_h1 = record_fingerprint(_canonical_payload(clean))
+    except (TypeError, ValueError):
+        blob = json.dumps(clean, sort_keys=True, default=str)
+        return f"{source}:hash:{hashlib.sha256(blob.encode('utf-8')).hexdigest()[:12]}"
+    return f"{source}:h1:{full_h1[:12]}"
+
+
+def entity_id_for_members(record_ids: list[str]) -> str:
+    """Deterministic content-derived entity_id: SHA-256 of the cluster's
+    canonical (sorted) member record_ids. Order-independent, reproducible, no
+    worker coordination. Sail-create-only scheme (``ent:h1:``)."""
+    canonical = "\n".join(sorted(record_ids))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"{_ENT_PREFIX}{digest[:_ENT_HASH_LEN]}"
+
+
+def _id_scheme() -> str:
+    """``h1`` (deterministic content hash, default) or ``uuid7`` (per-worker
+    UUIDv7, matches the one-box scheme but non-deterministic output)."""
+    return os.environ.get("GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME", "h1").strip().lower()
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_sail_identity_parity.py -k "record_id or entity_id" -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+.venv/Scripts/python.exe -m ruff check packages/python/goldenmatch/goldenmatch/sail/identity.py
+git add packages/python/goldenmatch/goldenmatch/sail/identity.py packages/python/goldenmatch/tests/test_sail_identity_parity.py
+git commit -m "feat(sail): S5 pure helpers — record_id + deterministic entity_id"
+```
+
+---
+
+### Task 2: Spark frame builders — record_ids + entity_ids
+
+**Files:**
+- Modify: `sail/identity.py`
+- Test: `tests/test_sail_identity_parity.py`
+
+- [ ] **Step 1: Add the module-scoped `spark` fixture + builder tests**
+
+Add to the test file (the fixture is copied verbatim from `test_sail_golden_parity.py:15-26`; add `pytest.importorskip` guards just above it so server-dependent tests skip without the extra but the pure-helper tests above still run):
+
+```python
+pysail = pytest.importorskip("pysail")
+pyspark = pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def test_derive_record_ids_pk(spark):
+    from goldenmatch.sail.identity import derive_record_ids
+
+    df = spark.createDataFrame(
+        [(0, "people", 10, "Jon"), (1, "people", 11, "Marg")],
+        ["__row_id__", "__source__", "pk", "first_name"],
+    )
+    out = {r["__row_id__"]: r["record_id"]
+           for r in derive_record_ids(df, source_pk_col="pk").collect()}
+    assert out == {0: "people:10", 1: "people:11"}
+
+
+def test_mint_entity_ids(spark):
+    from goldenmatch.sail.identity import entity_id_for_members, mint_entity_ids
+
+    # assignments with a record_id per member.
+    rows = [(0, "people:10"), (0, "people:11"), (5, "people:15")]
+    df = spark.createDataFrame(rows, ["cluster_id", "record_id"])
+    got = {r["cluster_id"]: r["entity_id"] for r in mint_entity_ids(df).collect()}
+    assert got[0] == entity_id_for_members(["people:10", "people:11"])
+    assert got[5] == entity_id_for_members(["people:15"])
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_sail_identity_parity.py -k "derive_record_ids or mint_entity_ids" -v`
+Expected: FAIL — `cannot import name 'derive_record_ids'`.
+
+- [ ] **Step 3: Implement the builders**
+
+Append to `sail/identity.py`:
+
+```python
+def derive_record_ids(
+    source_df: Any,
+    *,
+    source_col: str = "__source__",
+    source_pk_col: str | None = None,
+    id_col: str = "__row_id__",
+) -> Any:
+    """Add a ``record_id`` column to ``source_df``. PK path is a pure column
+    expression; the no-PK h1 path runs ``record_id_for_row`` in a struct
+    pandas_udf over the payload columns (parity with one-box by construction)."""
+    from pyspark.sql import functions as F
+    from pyspark.sql.types import StringType
+
+    has_source = source_col in source_df.columns
+    src_expr = F.col(source_col) if has_source else F.lit("dataframe")
+
+    if source_pk_col is not None:
+        return source_df.withColumn(
+            "record_id", F.concat(src_expr, F.lit(":"), F.col(source_pk_col).cast("string"))
+        )
+
+    payload_cols = [c for c in source_df.columns if not c.startswith("__")]
+    # Thread the row's REAL __source__ through to the helper (one-box uses the
+    # row's source, not a constant) -- pass it as an extra struct column so the
+    # no-PK h1 id matches one-box per-row. Falls back to "dataframe" per row when
+    # __source__ is absent (matches one-box row.get default).
+    udf_cols = payload_cols + ([source_col] if has_source else [])
+
+    @F.pandas_udf(StringType())
+    def _rid(*cols):
+        import pandas as pd
+
+        frame = pd.concat(cols, axis=1)
+        frame.columns = udf_cols
+        out = []
+        for _, row in frame.iterrows():
+            payload = {c: row[c] for c in payload_cols}
+            source = str(row[source_col]) if has_source else "dataframe"
+            out.append(record_id_for_row(payload, source, None))
+        return pd.Series(out)
+
+    return source_df.withColumn("record_id", _rid(*[F.col(c) for c in udf_cols]))
+
+
+def mint_entity_ids(assignments_with_recid: Any) -> Any:
+    """``(cluster_id, record_id)`` -> ``(cluster_id, entity_id)``: collect each
+    cluster's member record_ids and hash them deterministically. ``uuid7``
+    scheme mints a per-cluster UUIDv7 instead (non-deterministic; matches the
+    one-box scheme)."""
+    from pyspark.sql import functions as F
+    from pyspark.sql.types import StringType
+
+    grouped = assignments_with_recid.groupBy("cluster_id").agg(
+        F.collect_list("record_id").alias("__rids__")
+    )
+
+    if _id_scheme() == "uuid7":
+        from goldenmatch.identity.store import new_entity_id
+
+        @F.pandas_udf(StringType())
+        def _eid(col):
+            import pandas as pd
+
+            return pd.Series([new_entity_id() for _ in col])
+    else:
+        @F.pandas_udf(StringType())
+        def _eid(col):
+            import pandas as pd
+
+            return pd.Series([entity_id_for_members(list(v)) for v in col])
+
+    return grouped.withColumn("entity_id", _eid(F.col("__rids__"))).select(
+        "cluster_id", "entity_id"
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/test_sail_identity_parity.py -k "derive_record_ids or mint_entity_ids" -v`
+Expected: PASS (skips locally if `[sail]` absent — then verify via the sail lane after push).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+.venv/Scripts/python.exe -m ruff check packages/python/goldenmatch/goldenmatch/sail/identity.py
+git add -A && git commit -m "feat(sail): S5 derive_record_ids + mint_entity_ids Spark builders"
+```
+
+---
+
+### Task 3: `build_same_as_edges` — distributed edge emit
+
+**Files:** Modify `sail/identity.py`; Test `tests/test_sail_identity_parity.py`.
+
+- [ ] **Step 1: Write the failing test** (edge-set is entity-independent; assert the canonical pair set + within-cluster invariant):
+
+```python
+def test_same_as_edges_set(spark):
+    from goldenmatch.sail.identity import build_same_as_edges
+
+    # pairs (a,b,score) post-dedup; assignments map members to clusters;
+    # recid_map maps member_id -> record_id.
+    pairs = spark.createDataFrame([(0, 1, 0.97), (2, 3, 0.91)], ["a", "b", "score"])
+    assignments = spark.createDataFrame(
+        [(0, 0), (0, 1), (2, 2), (2, 3)], ["cluster_id", "member_id"]
+    )
+    recid = spark.createDataFrame(
+        [(0, "p:0"), (1, "p:1"), (2, "p:2"), (3, "p:3")], ["member_id", "record_id"]
+    )
+    entity_ids = spark.createDataFrame(
+        [(0, "ent:A"), (2, "ent:B")], ["cluster_id", "entity_id"]
+    )
+    run_meta = {"run_name": "r1", "dataset": None, "recorded_at": "2026-06-10T00:00:00",
+                "matchkey_name": "mk"}
+    edges = build_same_as_edges(pairs, assignments, recid, entity_ids, run_meta=run_meta)
+    got = {(r["record_a_id"], r["record_b_id"], r["entity_id"]) for r in edges.collect()}
+    assert got == {("p:0", "p:1", "ent:A"), ("p:2", "p:3", "ent:B")}
+    assert all(r["kind"] == "same_as" for r in edges.collect())
+```
+
+- [ ] **Step 2: Run → FAIL** (`cannot import name 'build_same_as_edges'`).
+
+- [ ] **Step 3: Implement**:
+
+```python
+def build_same_as_edges(
+    pairs: Any,
+    assignments: Any,
+    recid_map: Any,
+    entity_ids: Any,
+    *,
+    run_meta: dict[str, Any],
+) -> Any:
+    """``same_as`` evidence edges, one per scored within-cluster pair. Join each
+    pair's endpoints to their cluster (via assignments) and entity, map member
+    ids to record_ids. Entity-independent content; every post-dedup pair is
+    within-cluster by WCC construction."""
+    from pyspark.sql import functions as F
+
+    # member_id -> cluster_id (a's cluster == b's cluster by construction).
+    a_cl = assignments.select(
+        F.col("member_id").alias("a"), F.col("cluster_id")
+    )
+    ra = recid_map.select(F.col("member_id").alias("a"), F.col("record_id").alias("record_a_id"))
+    rb = recid_map.select(F.col("member_id").alias("b"), F.col("record_id").alias("record_b_id"))
+
+    e = (
+        pairs.join(a_cl, on="a", how="inner")
+        .join(entity_ids, on="cluster_id", how="inner")
+        .join(ra, on="a", how="inner")
+        .join(rb, on="b", how="inner")
+    )
+    return e.select(
+        "entity_id", "record_a_id", "record_b_id",
+        F.lit("same_as").alias("kind"),
+        F.col("score"),
+        F.lit(run_meta.get("matchkey_name")).alias("matchkey_name"),
+        F.lit(run_meta["run_name"]).alias("run_name"),
+        F.lit(run_meta.get("dataset")).alias("dataset"),
+        F.lit(run_meta["recorded_at"]).alias("recorded_at"),
+    )
+```
+
+- [ ] **Step 4: Run → PASS** (or verify in the sail lane).
+
+- [ ] **Step 5: Commit** `feat(sail): S5 build_same_as_edges`.
+
+---
+
+### Task 4: `build_identity_nodes` + `build_source_records` (incl. singletons)
+
+The reviewer-flagged gap: `build_golden` emits multi-member clusters only; nodes need one row per entity **including singletons**.
+
+**Files:** Modify `sail/identity.py`; Test `tests/test_sail_identity_parity.py`.
+
+- [ ] **Step 1: Write the failing test** (assert one node per cluster incl. the singleton, and the record→entity assignment):
+
+```python
+def test_nodes_include_singletons_and_records(spark):
+    from pyspark.sql import functions as F
+
+    from goldenmatch.sail.identity import build_identity_nodes, build_source_records
+
+    assignments = spark.createDataFrame(
+        [(0, 0), (0, 1), (5, 5)], ["cluster_id", "member_id"]
+    )
+    recid = spark.createDataFrame(
+        [(0, "p:0"), (1, "p:1"), (5, "p:5")], ["member_id", "record_id"]
+    )
+    entity_ids = spark.createDataFrame(
+        [(0, "ent:A"), (5, "ent:S")], ["cluster_id", "entity_id"]
+    )
+    # build_golden emits cluster 0 only (multi-member); cluster 5 is a singleton.
+    golden = spark.createDataFrame([(0, "Jonathan")], ["cluster_id", "first_name"])
+    source = spark.createDataFrame(
+        [(0, "Jon"), (1, "Jonathan"), (5, "Solo")], ["__row_id__", "first_name"]
+    )
+    run_meta = {"run_name": "r1", "dataset": None, "recorded_at": "2026-06-10T00:00:00"}
+
+    nodes = build_identity_nodes(entity_ids, golden, run_meta=run_meta)
+    node_ids = {r["entity_id"] for r in nodes.collect()}
+    assert node_ids == {"ent:A", "ent:S"}  # singleton node MUST exist
+
+    records = build_source_records(assignments, recid, entity_ids, run_meta=run_meta)
+    rec_to_ent = {r["record_id"]: r["entity_id"] for r in records.collect()}
+    assert rec_to_ent == {"p:0": "ent:A", "p:1": "ent:A", "p:5": "ent:S"}
+```
+
+- [ ] **Step 2: Run → FAIL**.
+
+- [ ] **Step 3: Implement**:
+
+```python
+def build_identity_nodes(
+    entity_ids: Any,
+    golden_df: Any,
+    *,
+    run_meta: dict[str, Any],
+) -> Any:
+    """One node per entity (incl. singletons). ``golden_record`` LEFT-joins
+    ``build_golden`` (multi-member only); SINGLETON ``golden_record`` is NULL by
+    design -- node *count* (one per cluster) is the gate invariant, content is
+    not. (One-box populates singleton golden from the single row; S5 leaves it
+    NULL, a documented gate-neutral simplification -- populating it is a deferred
+    polish, not needed for the create-path graph.)"""
+    from pyspark.sql import functions as F
+    from pyspark.sql.types import StringType
+
+    # entity -> golden JSON for multi-member clusters.
+    gcols = [c for c in golden_df.columns if c != "cluster_id"]
+
+    @F.pandas_udf(StringType())
+    def _as_json(*cols):
+        import pandas as pd
+
+        frame = pd.concat(cols, axis=1)
+        frame.columns = gcols
+        out = []
+        for _, row in frame.iterrows():
+            rec = {c: (None if pd.isna(row[c]) else row[c]) for c in gcols}
+            out.append(json.dumps(rec, default=str))
+        return pd.Series(out)
+
+    golden_json = (
+        golden_df.join(entity_ids, on="cluster_id", how="inner")
+        .withColumn("golden_record", _as_json(*[F.col(c) for c in gcols]))
+        .select("entity_id", "golden_record")
+    )
+
+    # LEFT join keeps EVERY entity (singletons get NULL golden_record).
+    nodes = entity_ids.select("cluster_id", "entity_id").join(
+        golden_json, on="entity_id", how="left"
+    )
+    return nodes.select(
+        "entity_id",
+        F.lit("active").alias("status"),
+        F.lit(None).cast("string").alias("merged_into"),
+        F.col("golden_record"),
+        F.lit(None).cast("double").alias("confidence"),
+        F.lit(run_meta.get("dataset")).alias("dataset"),
+        F.lit(run_meta["recorded_at"]).alias("created_at"),
+        F.lit(run_meta["recorded_at"]).alias("updated_at"),
+    )
+
+
+def build_source_records(
+    assignments: Any,
+    recid_map: Any,
+    entity_ids: Any,
+    *,
+    run_meta: dict[str, Any],
+) -> Any:
+    """record_id -> entity assignment (the record->entity partition)."""
+    from pyspark.sql import functions as F
+
+    return (
+        assignments.join(recid_map, on="member_id", how="inner")
+        .join(entity_ids, on="cluster_id", how="inner")
+        .select(
+            "record_id",
+            "entity_id",
+            F.lit(run_meta.get("dataset")).alias("dataset"),
+            F.lit(run_meta["recorded_at"]).alias("first_seen_at"),
+            F.lit(run_meta["recorded_at"]).alias("last_seen_at"),
+        )
+    )
+```
+
+> Note: drop the dead `emit_singletons=False` branch above when implementing — S5's default is `True`; keep the param for API symmetry but implement only the gated-on path. (Cleaned up in the simplify pass.)
+
+- [ ] **Step 4: Run → PASS**.
+
+- [ ] **Step 5: Commit** `feat(sail): S5 identity nodes (incl singletons) + source_records`.
+
+---
+
+### Task 5: `build_identity_graph` orchestrator + the 3-part parity gate
+
+This is the make-or-break gate.
+
+**Files:** Modify `sail/identity.py`; Test `tests/test_sail_identity_parity.py`.
+
+- [ ] **Step 1: Write the failing parity test**
+
+Reference = one-box `resolve_clusters` on a **fresh SQLite store**, on a chain + junction-multimerge + singleton fixture. Feed one-box the **same post-dedup pairs** S5 builds edges from (fixture constraint from the spec). Compare (1) `same_as` edge set, (2) record→entity partition equivalence, (3) counts.
+
+> Note: this fixture sets a `pk` column + `source_pk_col="pk"`, so both sides take the **PK record-id path** (`p:100` …). The end-to-end parity gate therefore exercises the PK path only; the no-PK `h1` path's parity rests on the shared-helper-by-construction argument + the Task 1 unit tests (`test_record_id_h1_path_matches_one_box`), not this gate. Deliberate — keeps the gate about graph structure, not fingerprint reproduction (already gated elsewhere).
+
+```python
+def _fixture():
+    # rows: (__row_id__, __source__, pk, name). Clusters by design:
+    #   chain 0-1-2 (a-b 0.96, b-c 0.95), junction-multimerge 5-6,6-7 (two pairs
+    #   share member 6), singleton 9.
+    rows = [
+        (0, "p", 100, "Ann"), (1, "p", 101, "Anne"), (2, "p", 102, "Annie"),
+        (5, "p", 105, "Bob"), (6, "p", 106, "Bobby"), (7, "p", 107, "Robert"),
+        (9, "p", 109, "Zed"),
+    ]
+    pairs = [(0, 1, 0.96), (1, 2, 0.95), (5, 6, 0.93), (6, 7, 0.92)]
+    # assignments via union-find over pairs (cluster_id = min member id).
+    assignments = [(0, 0), (0, 1), (0, 2), (5, 5), (5, 6), (5, 7), (9, 9)]
+    return rows, pairs, assignments
+
+
+def _one_box_graph(rows, pairs, assignments):
+    """Run the one-box resolver on a fresh SQLite store; return
+    (edge_set, record->entity partition signature)."""
+    import polars as pl
+
+    from goldenmatch.identity.resolve import resolve_clusters
+    from goldenmatch.identity.store import IdentityStore
+
+    df = pl.DataFrame(
+        {"__row_id__": [r[0] for r in rows], "__source__": [r[1] for r in rows],
+         "pk": [r[2] for r in rows], "name": [r[3] for r in rows]}
+    )
+    members = {}
+    for cid, mid in assignments:
+        members.setdefault(cid, []).append(mid)
+    pair_scores = {}
+    for a, b, s in pairs:
+        # bucket each pair under its cluster.
+        cid = next(c for c, ms in members.items() if a in ms)
+        pair_scores.setdefault(cid, {})[(min(a, b), max(a, b))] = s
+    clusters = {
+        cid: {"members": ms, "confidence": 1.0, "bottleneck_pair": None,
+              "pair_scores": pair_scores.get(cid, {})}
+        for cid, ms in members.items()
+    }
+    store = IdentityStore(backend="sqlite", path=":memory:")
+    resolve_clusters(clusters, df, [(a, b, s) for a, b, s in pairs], "mk", store,
+                     "r1", source_pk_col="pk")
+    edges, partition = set(), {}
+    for node in store.list_identities():
+        eid = node.entity_id
+        for rec in store.get_records_for_entity(eid):
+            partition[rec.record_id] = eid
+        for edge in store.edges_for_entity(eid):
+            if edge.kind == "same_as":
+                edges.add((edge.record_a_id, edge.record_b_id))
+    return edges, _partition_sig(partition)
+
+
+def _partition_sig(rec_to_ent):
+    # Entity-id-independent signature: frozenset of frozensets of record_ids.
+    from collections import defaultdict
+    groups = defaultdict(set)
+    for rid, eid in rec_to_ent.items():
+        groups[eid].add(rid)
+    return frozenset(frozenset(g) for g in groups.values())
+
+
+def test_identity_graph_parity(spark):
+    from goldenmatch.sail.identity import build_identity_graph
+
+    rows, pairs, assignments = _fixture()
+    edges_ref, part_ref = _one_box_graph(rows, pairs, assignments)
+
+    source = spark.createDataFrame(rows, ["__row_id__", "__source__", "pk", "name"])
+    pairs_df = spark.createDataFrame(pairs, ["a", "b", "score"])
+    assign_df = spark.createDataFrame(assignments, ["cluster_id", "member_id"])
+    golden_df = spark.createDataFrame(
+        [(0, "Annie"), (5, "Robert")], ["cluster_id", "name"]  # multi-member only
+    )
+    run_meta = {"run_name": "r1", "dataset": None, "recorded_at": "2026-06-10T00:00:00",
+                "matchkey_name": "mk"}
+
+    g = build_identity_graph(pairs_df, assign_df, source, golden_df,
+                             run_meta=run_meta, source_pk_col="pk")
+
+    edges_got = {(r["record_a_id"], r["record_b_id"]) for r in g.edges.collect()}
+    part_got = _partition_sig(
+        {r["record_id"]: r["entity_id"] for r in g.records.collect()}
+    )
+    node_count = g.nodes.count()
+
+    # canonicalize edge direction for comparison (one-box may store either order)
+    canon = lambda S: {tuple(sorted(p)) for p in S}
+    assert canon(edges_got) == canon(edges_ref)        # (1) edge-set parity
+    assert part_got == part_ref                         # (2) partition equivalence
+    assert node_count == len(assignments_to_clusters(assignments))  # (3) count
+
+
+def assignments_to_clusters(assignments):
+    return {cid for cid, _ in assignments}
+```
+
+- [ ] **Step 2: Run → FAIL** (`cannot import name 'build_identity_graph'`).
+
+- [ ] **Step 3: Implement the orchestrator**:
+
+```python
+@dataclass
+class IdentityGraphFrames:
+    nodes: Any
+    records: Any
+    edges: Any
+
+
+def build_identity_graph(
+    pairs: Any,
+    assignments: Any,
+    source_df: Any,
+    golden_df: Any,
+    *,
+    run_meta: dict[str, Any],
+    source_col: str = "__source__",
+    source_pk_col: str | None = None,
+    id_col: str = "__row_id__",
+) -> IdentityGraphFrames:
+    """Produce the create-path identity graph as distributed Spark frames.
+    Layer 1 only (create + same_as edges); incremental absorb/merge is the
+    deferred Layer 2 (honest-null)."""
+    from pyspark.sql import functions as F
+
+    src_rid = derive_record_ids(
+        source_df, source_col=source_col, source_pk_col=source_pk_col, id_col=id_col
+    )
+    # member_id -> record_id
+    recid_map = src_rid.select(
+        F.col(id_col).alias("member_id"), F.col("record_id")
+    )
+    assign_rid = assignments.join(recid_map, on="member_id", how="inner").select(
+        "cluster_id", "record_id"
+    )
+    entity_ids = mint_entity_ids(assign_rid)
+
+    edges = build_same_as_edges(pairs, assignments, recid_map, entity_ids, run_meta=run_meta)
+    nodes = build_identity_nodes(entity_ids, golden_df, run_meta=run_meta)
+    records = build_source_records(assignments, recid_map, entity_ids, run_meta=run_meta)
+    return IdentityGraphFrames(nodes=nodes, records=records, edges=edges)
+```
+
+- [ ] **Step 4: Run → PASS** (sail lane). If edge direction mismatches, the `canon` lambda already normalizes; if the partition differs, debug the WCC→assignment fixture, not the resolver.
+
+- [ ] **Step 5: Commit** `feat(sail): S5 build_identity_graph orchestrator + 3-part parity gate`.
+
+---
+
+### Task 6: Determinism test
+
+- [ ] **Step 1: Write the failing test** (re-run → byte-identical frames):
+
+```python
+def test_identity_graph_deterministic(spark):
+    from goldenmatch.sail.identity import build_identity_graph
+
+    rows, pairs, assignments = _fixture()
+    source = spark.createDataFrame(rows, ["__row_id__", "__source__", "pk", "name"])
+    pairs_df = spark.createDataFrame(pairs, ["a", "b", "score"])
+    assign_df = spark.createDataFrame(assignments, ["cluster_id", "member_id"])
+    golden_df = spark.createDataFrame([(0, "Annie"), (5, "Robert")], ["cluster_id", "name"])
+    run_meta = {"run_name": "r1", "dataset": None, "recorded_at": "2026-06-10T00:00:00",
+                "matchkey_name": "mk"}
+
+    def run():
+        g = build_identity_graph(pairs_df, assign_df, source, golden_df,
+                                 run_meta=run_meta, source_pk_col="pk")
+        return sorted((r["record_id"], r["entity_id"]) for r in g.records.collect())
+
+    assert run() == run()  # deterministic entity_ids across runs
+```
+
+- [ ] **Step 2: Run → PASS** (the content-hash scheme makes this hold; if it fails, a non-deterministic id leaked in).
+- [ ] **Step 3: Commit** `test(sail): S5 identity determinism gate`.
+
+---
+
+### Task 7: Pipeline wiring — `run_sail_pipeline(emit_identity=...)`
+
+**Files:** Modify `sail/pipeline.py` (`run_sail_pipeline`, lines 10-55); Test `tests/test_sail_pipeline.py` (add a case).
+
+- [ ] **Step 1: Write the failing test** in `test_sail_pipeline.py` (mirror its existing fixture; assert default path unchanged + opt-in returns identity frames):
+
+```python
+def test_run_sail_pipeline_emit_identity(spark):
+    from goldenmatch.sail.identity import IdentityGraphFrames
+    from goldenmatch.sail.pipeline import run_sail_pipeline
+
+    # ... build the existing pipeline fixture df with __row_id__/block/value/golden cols,
+    # plus __source__ + pk for identity ...
+    out = run_sail_pipeline(
+        source_df, id_col="__row_id__", block_col="blk", value_col="name",
+        golden_cols=["name"], emit_identity=True, source_pk_col="pk",
+        run_meta={"run_name": "r1", "dataset": None,
+                  "recorded_at": "2026-06-10T00:00:00", "matchkey_name": "jaro_winkler"},
+    )
+    assert isinstance(out.identity, IdentityGraphFrames)
+    assert out.golden is not None
+```
+
+- [ ] **Step 2: Run → FAIL**.
+
+- [ ] **Step 3: Implement** — add `emit_identity=False`, `source_col`, `source_pk_col`, `run_meta` params **after the existing `*` (keyword-only, all defaulted)** so the existing positional `run_sail_pipeline(source_df, ...)` callers in `test_sail_pipeline.py` and the S4 bench entrypoint don't break. When set, call `build_identity_graph` after `build_golden` and return a small result object `SailPipelineResult(golden, identity)`. Default (`emit_identity=False`) returns the golden frame exactly as today (back-compat — existing `test_sail_pipeline.py` asserts unchanged).
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class SailPipelineResult:
+    golden: Any
+    identity: Any  # IdentityGraphFrames | None
+
+# in run_sail_pipeline, after building `golden = build_golden(...)`:
+#   if not emit_identity:
+#       return golden            # unchanged back-compat path
+#   from goldenmatch.sail.identity import build_identity_graph
+#   identity = build_identity_graph(pairs, assignments, source_df, golden,
+#       run_meta=run_meta, source_col=source_col, source_pk_col=source_pk_col, id_col=id_col)
+#   return SailPipelineResult(golden=golden, identity=identity)
+```
+
+- [ ] **Step 4: Run → PASS**; also run the full `test_sail_pipeline.py` to confirm the default path is unchanged.
+- [ ] **Step 5: Commit** `feat(sail): S5 run_sail_pipeline emit_identity opt-in`.
+
+---
+
+### Task 8: CI lane — 7th blocking gate
+
+**Files:** Modify `.github/workflows/ci.yml` (`sail` job).
+
+- [ ] **Step 1: Add the gate step** after the golden gate (~line 1314), before the e2e pipeline gate:
+
+```yaml
+      # GATE (blocking): identity create + edge-emit parity vs the one-box
+      # resolve_clusters on a fresh store (S5) — edge-set + record->entity
+      # partition equivalence + count + determinism.
+      - name: Sail identity parity gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_identity_parity.py -v --timeout=300
+```
+
+- [ ] **Step 2: Confirm path filter** — `tests/test_sail_*.py` + `sail/**` already in the `sail:` filter (ci.yml lines 234-235), so the new file is covered. No filter edit needed.
+
+- [ ] **Step 3: Commit** `ci(sail): S5 identity parity gate (7th sail gate)`.
+
+- [ ] **Step 4: Push + watch the sail lane** (the authoritative verification — local Windows runs are best-effort):
+
+```bash
+git push -u origin feat/sail-s5-identity
+# open PR, then:
+gh run watch <run-id> --exit-status
+```
+Expected: the `sail` job green with 7 gates (connectivity, score, WCC, golden, **identity**, pipeline).
+
+---
+
+### Task 9: Record the honest-null + finish
+
+**Files:** Modify `docs/superpowers/specs/2026-06-03-sail-tier-design.md`; update memory.
+
+- [ ] **Step 1: Append an S5 note** to the sail design doc: S5 shipped distributed create + edge-emit, parity-gated; incremental absorb/merge remains deferred/driver-side (honest-null, like the Ray path). Ray NOT retired (still gates on the real 100M bench).
+
+- [ ] **Step 2: Update the `project_sail_tier` memory** — add the S5 line (7th gate, deferred incremental, kill-switch `GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME`).
+
+- [ ] **Step 3: Open the PR** (per the branch/merge SOP; `benzsevern` auth dance for the `benseverndev-oss` remote). PR body: scope, parity gate, the honest-null on incremental.
+
+- [ ] **Step 4: Simplify pass** — invoke `code-simplifier` on `sail/identity.py` (remove the dead `emit_singletons=False` branch noted in Task 4, tighten the UDFs) before merge.
+
+---
+
+## Done = all of:
+- `sail/identity.py` with 6 functions + 2 pure helpers; pyspark imported lazily.
+- 7th `sail` CI gate green: edge-set + partition + count + determinism parity vs one-box fresh-store create.
+- `run_sail_pipeline(emit_identity=...)` opt-in; default path byte-for-byte unchanged.
+- Deferred incremental recorded as an explicit honest-null in the sail design doc + memory.
+- Ray untouched (retirement still gates on the real 100M bench).

--- a/docs/superpowers/specs/2026-05-29-native-matrix-kernel-design.md
+++ b/docs/superpowers/specs/2026-05-29-native-matrix-kernel-design.md
@@ -1,0 +1,178 @@
+# Native matrix kernel for slow path — design
+
+**Status:** Draft, 2026-05-29
+**Tracks:** Opt #5 (post-v1.24.0 perf arc)
+**Author:** Ben + Claude
+
+## Problem
+
+We have two parallel scoring backends in the Python layer:
+
+1. **Bucket fast path** (`backends/score_buckets.py`)
+   Calls `goldenmatch._native.score_block_pairs_arrow` — a Rust kernel that
+   takes a flat row layout + `block_sizes`, scores all in-block pairs in
+   parallel via rayon, applies weighted-sum aggregation, and emits
+   `(row_a, row_b, score)` triples above threshold. Zero-copy Arrow handoff
+   from Polars. Already shipped, default-on.
+
+2. **Slow path** (`core/scorer.py::find_fuzzy_matches`)
+   Builds per-field `NxN` matrices via `rapidfuzz.process.cdist`, combines
+   them with weights, applies NE penalty math, match-mode filtering, and
+   probabilistic scoring. Pure Python orchestration over `rapidfuzz` C
+   primitives. Used when the bucket fast path declines (e.g. embedding
+   scorers, ensemble that breaks bucket assumptions, callers without
+   bucket layout).
+
+The bucket backend has a Rust scorer dispatch (`score.rs::score_one`) covering
+IDs 0–3: `jaro_winkler`, `levenshtein`, `token_sort`, `exact`. The slow path
+goes through `rapidfuzz.cdist` directly for the same four scorers plus
+`soundex_match`, `dice`, `jaccard`, `ensemble`, and embedding kernels.
+
+**Two scorer surfaces, two implementations, two test matrices.** Per the
+session strategic frame: "slowly port each feature in slow over to fast with
+native Rust." Continuing to invest in the slow-path matrix orchestration is
+debt; the goal is convergence on one kernel.
+
+## Why not just route the slow path through `score_block_pairs_arrow`?
+
+Incompatible aggregation API. `score_block_pairs_arrow` is a high-level
+"weighted aggregate + threshold filter" primitive that emits pairs. The
+slow path needs **per-field score matrices** held in Python land because:
+
+- **Probabilistic matchkey** consumes per-field match/non-match comparison
+  vectors, not a weighted aggregate.
+- **NE penalty math** subtracts per-NE-field disagreement penalties from a
+  composite that's already weighted on the in-matchkey fields — needs both
+  surfaces visible at the Python layer.
+- **Match-mode filtering** (the `_first_block_df` probabilistic fast path)
+  reads per-field scores to decide acceptance independent of threshold.
+- **Auto-config indicators** (`compute_column_priors`,
+  `estimate_sparse_match_signal`) instrument per-field score distributions.
+
+The two kernels are at different layers of abstraction, not duplicates.
+
+## Proposal: `score_field_matrix` Rust kernel
+
+Add a low-level cdist primitive to `goldenmatch_native`:
+
+```rust
+#[pyfunction]
+pub fn score_field_matrix(
+    py: Python<'_>,
+    values_a: PyArrowType<ArrayData>,  // Utf8 or LargeUtf8
+    values_b: PyArrowType<ArrayData>,  // Utf8 or LargeUtf8; may alias values_a
+    scorer_id: u8,                     // 0=jw, 1=lev, 2=ts, 3=exact, 4=soundex, 5=dice, 6=jaccard
+) -> PyResult<PyObject /* np.ndarray<f32> of shape (a.len, b.len) */>;
+```
+
+Behavior:
+
+- **Zero-copy Arrow in.** Accepts both `Utf8` (pyarrow default, i32 offsets) and
+  `LargeUtf8` (Polars default, i64 offsets) — pattern already in `StrCol` enum.
+- **Symmetric self-cdist** when `values_a == values_b` by identity — skip the
+  lower triangle in the parallel loop.
+- **Output ndarray.** Use `pyo3-numpy` to return a `PyArray2<f32>`, owning
+  buffer allocated in Rust, exposed zero-copy to NumPy.
+- **Null handling.** Mirror `rapidfuzz.cdist`'s "None → empty string" convention
+  already baked into the slow path callers (`_fuzzy_score_matrix:349`). Caller
+  remains responsible for null masks.
+- **Parallelism.** `py.allow_threads(|| {...})` + rayon `par_iter` on rows of
+  the output matrix. Same threading shape as `score_block_pairs_arrow`.
+
+Scorer dispatch shares the existing `score_one` function — extended with three
+new IDs:
+
+| id | scorer        | Rust impl                                                   |
+|----|---------------|-------------------------------------------------------------|
+| 0  | jaro_winkler  | `rapidfuzz::distance::jaro_winkler::normalized_similarity`  |
+| 1  | levenshtein   | `rapidfuzz::distance::levenshtein::normalized_similarity`   |
+| 2  | token_sort    | existing `token_sort_string` + ratio                        |
+| 3  | exact         | `a == b ? 1.0 : 0.0`                                        |
+| 4  | soundex_match | port `jellyfish.soundex` — pure-string, no external dep     |
+| 5  | dice          | bigram-set Dice; cache per-string bigrams via `OnceCell`    |
+| 6  | jaccard       | bigram-set Jaccard; share bigram cache with dice            |
+
+`ensemble` is composable in Python (max of three matrix calls) rather than a
+dedicated ID — keeps the kernel ID space minimal.
+
+## Python integration
+
+In `core/scorer.py`:
+
+```python
+def _fuzzy_score_matrix(values, scorer, weights=None):
+    if _NATIVE is not None and scorer in _NATIVE_FIELD_SCORERS:
+        return _NATIVE.score_field_matrix(_to_arrow(values), _to_arrow(values), _SCORER_ID[scorer])
+    # existing rapidfuzz.cdist fallback unchanged
+```
+
+The native call is **strictly additive** — when `[native]` is absent, the
+rapidfuzz path runs unmodified. No behavior change beyond perf.
+
+Soundex / dice / jaccard get the same dispatcher entry, replacing their
+hand-rolled Python matrices (`_soundex_score_matrix`, `_dice_score_matrix`,
+`_jaccard_score_matrix`).
+
+## Parity tests
+
+Mirror the pattern in `tests/test_native_parity.py`:
+
+- Per scorer: 200 string pairs spanning ASCII / Unicode / null / empty;
+  assert `score_field_matrix` output equals `rapidfuzz.cdist` output within
+  `1e-6` (rapidfuzz's own f64-to-f32 rounding band).
+- Self-cdist symmetry: `M[i,j] == M[j,i]`.
+- Diagonal: `M[i,i] == 1.0` for all scorers on non-null values.
+- Null propagation: empty-string mapping matches caller convention.
+
+## Bench targets
+
+10M-bucket-realistic isn't the right measurement target — bucket already uses
+the higher-level kernel and would not benefit. The slow-path benchmark surfaces
+where this kernel pays back:
+
+- **Bench A:** DBLP-ACM via `find_fuzzy_matches` (auto-config picks slow path).
+  Per-field rapidfuzz cdist vs native cdist. Expected: 2-4x per-field
+  speedup on jw/lev/ts (rapidfuzz is already C; we're amortizing FFI
+  overhead). 5-10x on soundex/dice/jaccard (replacing Python matrices).
+- **Bench B:** Probabilistic matchkey on a 100K synthetic. Today runs the
+  pure-Python `_soundex_score_matrix` for the soundex column. Expected: this
+  becomes the dominant lift.
+
+## Out of scope
+
+- **Embedding / record_embedding kernels.** Still model-backed; orthogonal
+  port.
+- **Bucket-backend changes.** `score_block_pairs_arrow` keeps its weighted-pair
+  surface. This spec only adds a sibling primitive.
+- **Slow-path retirement.** Not retiring the slow path — only narrowing the
+  gap between its scorer kernel and the bucket's.
+
+## Open questions
+
+1. **Bigram caching across calls.** Dice/Jaccard build bigram sets per string;
+   in a self-cdist over N values, each string's bigrams are computed once and
+   reused for N comparisons. Bigram cache lives inside the kernel call, not
+   across calls — keeps the API stateless. Cross-call cache (e.g. attached to
+   the prepared-record store) is a follow-up.
+2. **Numpy version.** `pyo3-numpy` pins to a numpy major. The native package
+   already depends on numpy via the existing `to_pyarray` paths — confirm
+   versions align before adding `score_field_matrix`.
+3. **GIL release granularity.** Inside `allow_threads`, rayon spawns OS
+   threads. Test under `pytest -n auto` to confirm no regression vs the
+   current scorer.
+
+## Build / ship
+
+- Land kernel in `packages/rust/extensions/native/src/score.rs` alongside
+  `score_block_pairs_arrow`.
+- Bump `goldenmatch-native` to `0.2.0`. (Goldenmatch python depends on
+  `goldenmatch-native>=0.1.0` — bump the floor to `0.2.0` in the `[native]`
+  extra once the kernel ships.)
+- Python loader stays unchanged — `_native_loader.py` discovers
+  `goldenmatch_native._native` and exposes whichever attributes are present.
+- One PR per scorer family is too granular; bundle all 7 IDs in one PR so
+  the parity test matrix lands together.
+
+## Decision needed
+
+Approve scope → implement. Otherwise return with scope edits.

--- a/docs/superpowers/specs/2026-05-30-bulk-record-fingerprint-kernel-spec.md
+++ b/docs/superpowers/specs/2026-05-30-bulk-record-fingerprint-kernel-spec.md
@@ -1,0 +1,178 @@
+# Bulk record_fingerprint kernel — design
+
+**Status:** Draft, 2026-05-30
+**Targets:** Identity Graph upsert path; gated on `config.identity.enabled`
+**Lesson carried forward:** cluster-orchestration kernel bench (PR #610/#611)
+showed the **dict-construction floor** kills Rust kernels that return Python
+dicts. This kernel returns `list[str]` — no dict floor.
+
+## Problem
+
+`identity/resolve.py:233` iterates rows in a hot loop:
+
+```python
+for row in rows:
+    ...
+    primary_id, candidates = _record_id_candidates(row, source, source_pk_col)
+    ...
+```
+
+`_record_id_candidates` (line 110-139) calls `record_fingerprint` (native
+single-record kernel) for rows without a natural PK. At N records that's:
+
+- N PyDict creations (the `_canonical_payload` step)
+- N FFI hops into Rust (`record_fingerprint(record: dict)`)
+- N internal pyo3 dict iterations
+- N SHA-256 computations
+- N hex-encodings
+- N Python `str` returns
+
+Per-record FFI overhead is ~100ns. At 10M records that's only ~1 s of pure
+overhead — small. But the per-record Python loop also pays for:
+
+- Python interpreter overhead between records (~10-20 us each at 10M records
+  → ~100-200 s)
+- Per-row `_canonical_payload` allocation
+- Per-row `_hash_payload` (legacy json hash, single-record only)
+- Sequential compute — no parallelism
+
+The bulk variant amortizes Python interpreter cost across the batch AND
+parallelizes the SHA-256 work across cores.
+
+## Goal
+
+Add `record_fingerprints_batch(records: list[dict]) -> list[str]` that:
+
+1. Iterates records in Rust (no Python interpreter between iterations).
+2. Parallelizes SHA-256 + hex via rayon (16-core boxes finish 10M records
+   in ~2-3 s instead of 10-15 s).
+3. Returns `Vec<String>` → `list[str]` — flat list output, **no dict
+   construction**, so the cluster-kernel bench's dict-floor result doesn't
+   apply.
+
+## API design
+
+```rust
+#[pyfunction]
+pub fn record_fingerprints_batch(
+    py: Python<'_>,
+    records: Vec<Bound<'_, PyDict>>,
+) -> PyResult<Vec<String>>;
+```
+
+Behavior:
+- Each input dict is processed identically to the existing single-record
+  `record_fingerprint` — same canonicalization, same SHA-256, same hex
+  output, same `__`-prefix-drop rule.
+- Returns one hex string per input record, in order.
+- Errors propagate from the FIRST failing record (matching Python
+  `try`/`except` ordering would change a "stop on first error" contract
+  to "continue and report all errors"; defer that to v2).
+- The interior is `py.allow_threads(|| rayon::par_iter(...))` so the GIL
+  is released for the bulk SHA-256 + hex work.
+
+## What stays in Python
+
+- `_canonical_payload` (Python-side temporal coercion). Could be ported
+  but adds complexity for a single-digit-percent win; defer.
+- `_hash_payload` (legacy JSON-based hash). Also called per-row but
+  separate concern.
+- The lookup-candidate construction (`legacy_id` + `h1_id` formatting,
+  primary/candidates ordering).
+
+The bulk kernel only covers the SHA-256 + hex pipeline. The wrapper
+function in `_hashing.py` becomes:
+
+```python
+def record_fingerprints_batch(records: list[dict]) -> list[str]:
+    if native_enabled("hashing"):
+        return native_module().record_fingerprints_batch(records)
+    return [record_fingerprint(r) for r in records]
+```
+
+And `identity/resolve.py` gets refactored to collect canonical payloads
+first, call the bulk fingerprint once, then zip the IDs back into the
+candidate-construction loop.
+
+## Decision gate
+
+Decision gate: **large-shape speedup ≥ 2×** at 1M records → ship the
+wire-up PR. Below that the win is too small to justify the refactor in
+`identity/resolve.py`.
+
+The bench script (`scripts/bench_native_bulk_fingerprint.py`) measures
+three shapes:
+
+| shape | records | predicted Python | predicted bulk | predicted speedup |
+|---|---|---|---|---|
+| smoke | 10K | 0.5 s | 0.2 s | 2.5× |
+| medium | 100K | 5 s | 1 s | 5× |
+| large | 1M | 50 s | 5 s | 10× |
+
+Predictions are based on rayon-parallel SHA-256 throughput (~1 GB/s
+per core) on 16-core hardware; real numbers will differ.
+
+## Parity testing
+
+`tests/test_native_bulk_fingerprint_parity.py`:
+- Single-record outputs match `record_fingerprint` for the same input.
+- Bulk-of-1 equals single-record.
+- Bulk-of-N preserves order.
+- Error-on-bad-record raises at the right index.
+- Cross-surface byte-equivalence: bulk output matches the existing
+  C-ABI `gm_record_fingerprint` (DuckDB/Postgres surfaces).
+
+## Wire-up scope (separate PR after decision gate passes)
+
+`identity/resolve.py` refactor:
+1. Collect all rows-without-PK and their canonical payloads in a pre-pass.
+2. Call `record_fingerprints_batch(payloads)` once.
+3. Zip the resulting hex strings back into `_record_id_candidates`'s
+   primary/candidates output.
+
+Backward compat: callers of `record_fingerprint(single_dict)` keep working
+(single-record entry stays in place); only the loop site changes.
+
+## Risk
+
+- **The per-row `_canonical_payload` Python pre-pass may dominate.** If
+  Python's dict-walking + value-coercion is the floor (not the SHA-256
+  compute), the bulk kernel can't help past that. Bench measures the
+  COMPLETE wrapped path, including the Python pre-pass, so the decision
+  gate captures this honestly.
+- **Per-record dict iteration inside Rust is still pyo3-bound.** Each
+  `Bound<'_, PyDict>` iteration acquires the GIL implicitly. We release
+  the GIL via `py.allow_threads()` only AFTER extracting field tuples;
+  the extraction phase is sequential. If extraction is most of the wall,
+  rayon parallelism doesn't help.
+
+These are the same dict-floor risks the cluster kernel hit, surfaced
+honestly in the bench shape so we don't waste a wire-up PR.
+
+## Implementation steps
+
+1. **Rust kernel** in `hash.rs`: add `record_fingerprints_batch`. Two
+   phases — sequential pyo3 field extraction, then `py.allow_threads`
+   over rayon for SHA-256 + hex.
+2. **Python wrapper** in `_hashing.py`: thin native dispatch + Python
+   fallback.
+3. **Bench script** `scripts/bench_native_bulk_fingerprint.py`: same
+   smoke/medium/large shape pattern as the cluster bench.
+4. **Bench workflow** `.github/workflows/bench-native-bulk-fingerprint.yml`:
+   workflow_dispatch only, posts the speedup table to step summary.
+5. **Parity tests** `tests/test_native_bulk_fingerprint_parity.py`:
+   lock down the contract before wiring.
+
+## Out of scope for this PR
+
+- `identity/resolve.py` refactor (separate PR after decision gate).
+- C ABI `gm_record_fingerprints_batch` for the DuckDB/pgrx surfaces
+  (separate; lower priority).
+- v1.1 canonical payload spec (temporals etc. inline in Rust).
+- Removing the legacy `_hash_payload` (json-based) call site — that
+  hash has different bytes and is a separate decision.
+
+## Decision needed
+
+Approve scope → ship the prototype kernel + bench + parity tests. The
+bench result picks the path: wire-up PR or document-and-pivot.

--- a/docs/superpowers/specs/2026-05-30-cluster-orchestration-kernel-spec.md
+++ b/docs/superpowers/specs/2026-05-30-cluster-orchestration-kernel-spec.md
@@ -1,0 +1,149 @@
+# Cluster post-UF orchestration kernel — design
+
+**Status:** Draft, 2026-05-30
+**Targets:** v34 attribution: 60% of cluster's 75s wall in Python orchestration
+
+## Problem
+
+v34 sub-stage attribution of `core/cluster.py::build_clusters`:
+
+| sub-stage | s | % | language |
+|---|---|---|---|
+| `cluster_connected_components` | 18.0 | 24% | Rust (native UF) |
+| `cluster_sort_clusters` | 1.6 | 2% | Python |
+| `cluster_member_to_cid` | 1.3 | 2% | Python (10M ops) |
+| `cluster_result_dict_init` | 21.7 | 29% | Python (2M dict allocs) |
+| `cluster_pair_scores_fill` | 23.3 | 31% | Python (20M tuple+dict ops) |
+| `cluster_compute_confidence` | 7.5 | 10% | 2M FFI hops |
+| `cluster_quality_assignment` | 2.0 | 3% | Python |
+
+The native UF is fast. Everything around it is Python orchestration over
+native data structures: dict allocations, tuple-key inserts, FFI ping-pong
+for per-cluster confidence. Combined hot loop: ~55s of the 75s.
+
+## Goal
+
+Push the post-UF orchestration into Rust. A single FFI hop returns the
+ready-to-use `dict[int, dict]` shape that downstream code expects.
+
+## API design
+
+```rust
+#[pyfunction]
+pub fn build_clusters_native(
+    py: Python<'_>,
+    pairs: Vec<(i64, i64, f64)>,   // pre-canonicalized? doesn't matter; we'll canonicalize internally
+    all_ids: Vec<i64>,
+    max_cluster_size: usize,
+    weak_cluster_threshold: f64,
+) -> PyResult<PyObject>;
+// returns dict[int, dict] with the existing shape:
+//   {cluster_id: {
+//      "members":  list[int],            # unsorted (per #598)
+//      "size":     int,
+//      "oversized": bool,
+//      "pair_scores": dict[tuple[int,int], float],
+//      "confidence": float,
+//      "bottleneck_pair": tuple[int,int] | None,
+//   }}
+```
+
+What it subsumes (vs current Python):
+- `connected_components` (already Rust, reuse internally)
+- `sorted(clusters, key=lambda s: min(s))`
+- `member_to_cid` build
+- `result` dict allocation per cluster
+- `pair_scores` dict-of-tuples fill
+- `compute_cluster_confidence` per cluster (already Rust, batched here)
+
+What stays in Python:
+- `auto_split` loop and `split_oversized_cluster` (calls graph.py; out of scope)
+- `cluster_quality_assignment` (small loop; 2s wall; depends on auto_split outcome)
+- The `_emit_cluster_profile(result)` instrumentation
+
+## pyo3 conversion strategy — the perf risk
+
+Returning `dict[int, dict[str, dict[tuple, float]]]` materializes 2M+ Python
+dicts and 20M+ Python tuples regardless of which language constructs them.
+The win has to come from doing fewer Python-bytecode-interpreted operations
+between the inserts — not from avoiding the inserts.
+
+Best-case estimate: pyo3's `IntoPyDict` is a C-level loop, ~3-5x faster
+than CPython bytecode for the same insert volume. Realistic save: 20s on
+pair_scores fill alone. Plus the ~7s of compute_confidence FFI overhead
+becomes one hop. **Total realistic save: 25-35s.**
+
+If the dict-construction cost in pyo3 is similar to Python's, the win
+shrinks. Worth measuring before celebrating.
+
+## Backward-compatibility contract
+
+Audit of `pair_scores` readers across the codebase:
+
+- `cli/compare.py`, `cli/label.py` — `.items()` iteration
+- `core/explain.py` — `.values()`, `.get((a,b))`
+- `core/graph.py` — `.get(key)` with tuple key
+- `core/_profile_helpers.py::transitivity_rate` — random access via tuple
+- `core/cluster.py::split_oversized_cluster` — `min(p, key=lambda)` over keys
+- `core/cluster.py::cluster_quality_assignment` — `.values()`
+
+All consumers depend on the **dict-with-tuple-key** shape. Cannot switch
+to a flat list without updating all readers; out of scope for this PR.
+
+The kernel must return the exact same shape Python builds today.
+
+## Parity testing
+
+`tests/test_native_cluster_orchestration_parity.py` (new):
+
+For three workload shapes (small / medium / oversized):
+
+1. Build clusters via the existing Python path (force-disable native via
+   `GOLDENMATCH_NATIVE=0`).
+2. Build clusters via the new native kernel.
+3. Assert deep-equal on the result dict, including:
+   - Same `cluster_id` for each member (order may differ; compare by
+     `frozenset(members) -> cluster_id`)
+   - Same `pair_scores` dict contents (canonicalized keys)
+   - Same `confidence` within `1e-6`
+   - Same `bottleneck_pair` (handle None / either tuple ordering)
+   - `oversized` agreement
+   - `quality` field assigned identically AFTER Python wrapper
+
+## Implementation steps
+
+1. **Spec → PR**: spec lives at this path (gitignored).
+2. **Rust kernel** (`cluster.rs`): build the orchestrator. Reuse the
+   internal `find`/`union` and `cluster_confidence` helpers.
+3. **Python wiring** (`core/cluster.py::build_clusters`): when
+   `native_enabled("clustering")`, route through the new kernel. The
+   auto_split + quality loops stay in Python on the returned dict.
+4. **Parity tests**: as above.
+5. **Bench**: v40 (10M bucket) baseline is 488s with cluster at 75s.
+   Target post-PR cluster wall: 30-40s. Total wall improvement: 5-7%.
+
+## Risks
+
+1. **pyo3 dict-construction cost may dominate.** First profile of the
+   kernel should split out FFI handoff time vs internal compute time.
+   If FFI dominates, the win is smaller than projected and we should
+   reconsider whether to ship.
+2. **Memory peak may rise.** Rust builds the full result structure
+   before returning. Bucket peak at 10M was 35-36 GB; this kernel may
+   transiently double-buffer cluster data. Bench with care.
+3. **Auto-split contract**: the Python auto-split loop reads
+   `cinfo["pair_scores"]` mid-loop and rebuilds clusters. The native
+   kernel returns the dict but auto-split mutates it. As long as the
+   returned dict is a normal Python dict (not a wrapper), this works.
+
+## Out of scope
+
+- Batched soundex / dice / jaccard cdist variants (separate Rust spec).
+- PPRL bloom-filter native kernel (separate spec).
+- Identity Graph bulk fingerprint kernel (separate spec — #2 on the
+  priority list).
+
+## Decision needed
+
+Approve scope → implement. PR-sized lift (Rust kernel + Python wiring
++ parity tests + bench).

--- a/docs/superpowers/specs/2026-05-30-datafusion-backend-spike-design.md
+++ b/docs/superpowers/specs/2026-05-30-datafusion-backend-spike-design.md
@@ -1,0 +1,251 @@
+# DataFusion backend spike — design
+
+**Date:** 2026-05-30
+**Status:** spike scoping (not committed)
+**Author:** assistant
+**Lane:** strategic — evaluate DataFusion as a third backend alongside
+`polars-direct` and `bucket`. Pivoting away from Ray-as-load-bearing
+(see prior session context on Distributed Plan v1 soft-revert + 25M
+bucket landing at 6.5min/57GB).
+
+## Goal
+
+Decide whether `backend="datafusion"` is worth building as a
+production backend. Output: one bench number per shape (10K, 100K, 1M)
+comparing DataFusion vs bucket on wall, peak RSS, and result-set
+parity, plus a written go/no-go recommendation.
+
+Explicitly NOT in scope for the spike:
+- Distributed DataFusion (Ballista / Sail). Single-node only.
+- Replacing the planner. New backend is opt-in via explicit
+  `config.backend="datafusion"`.
+- Wiring DataFusion into the controller's runtime profile signals.
+- Full scorer coverage. Spike covers ONE scorer (jaro_winkler) end to
+  end; if it wins, we extend.
+
+## Strategic context
+
+GoldenMatch's current scale story:
+- 25M on one box at 6.5min / 57GB peak (bucket + native, PR #526)
+- Ray path soft-reverted, currently slower than bucket below ~50M
+- Splink ships DuckDB as their popular backend; we don't have a
+  comparable engine-class backend (polars-direct + bucket are tightly
+  coupled to our pipeline shape, not a general query engine)
+
+DataFusion gives us:
+- Cost-based query planning (bucket has none)
+- Arrow-native, zero JVM, zero shuffle (vs Spark)
+- Native Rust UDF interface (vs Python scorer cost in
+  polars-direct/bucket)
+- Apache top-level project = credible institutional backing for the
+  "we go to scale" pitch
+
+The bet: at 1M+ scale, DataFusion's planner + Rust UDFs beat
+bucket because (a) the planner picks the right join strategy per
+block-size distribution, (b) Rust scorers eliminate the per-cdist
+Python boundary cost that bucket pays in its inner loop.
+
+The risk: DataFusion's UDF dispatch overhead plus the per-block
+DataFrame construction cost swamps the win at small N. We need to
+measure, not theorize.
+
+## Path A vs Path B
+
+**Path A** (rejected): DataFusion engine, Python UDF scorers via
+`datafusion-python`'s Python UDF interface. Easy to wire, but pays
+Python⇄Arrow boundary cost on every score call, defeating the entire
+performance premise. Spike result would be uninterpretable: if it
+loses, we can't tell whether DataFusion is bad or Python UDFs are
+bad.
+
+**Path B** (this spike): DataFusion engine, native scorers in the inner
+loop. Two implementation tiers:
+
+- **B1 — vectorized Python UDF wrapping existing pyo3 native scorer.**
+  DataFusion calls the UDF once per record batch (~8K rows), passing
+  Arrow arrays. The UDF converts Arrow→numpy zero-copy and calls
+  `goldenmatch._native.jaro_winkler_similarity` (already exists). Python
+  overhead is one-call-per-batch, amortized over thousands of rows. Get
+  this running first.
+- **B2 — true Rust UDF via datafusion-python's Rust FFI.** Only if B1
+  is competitive but the per-batch Python boundary is measurably
+  significant in cProfile. Pushes the spike toward the 5-day end.
+
+B1 is NOT Path A. Path A is per-row Python (UDF called billions of
+times, each call ~10µs of Python overhead). B1 is per-batch Python
+(UDF called thousands of times, each call processing thousands of rows
+in native code). The overhead delta is 1000-10000x.
+
+## Architecture
+
+```
++--------------------------------+
+| pipeline.py                    |
+|   _get_block_scorer(config)    |
+|     case "datafusion":         |
+|       return                   |
+|       score_blocks_datafusion  |
++--------------------------------+
+              |
+              v
++--------------------------------+
+| goldenmatch/backends/          |
+|   datafusion_backend.py        |
+|                                |
+|   score_blocks_datafusion(     |
+|     blocks: list[Block],       |
+|     matchkey: MatchkeyConfig,  |
+|     ...                        |
+|   ) -> list[Pair]:             |
+|     ctx = SessionContext()     |
+|     register_native_udfs(ctx)  |
+|     for block in blocks:       |
+|       df = ctx.from_arrow(...)  |
+|       result = df               |
+|         .join(df, "block_key") |
+|         .filter(id_a < id_b)    |
+|         .select(                |
+|           score_udf(a, b)       |
+|         )                       |
+|         .filter(score >= thr)   |
+|         .collect()              |
+|     return pairs                |
++--------------------------------+
+              |
+              v
++--------------------------------+
+| packages/rust/extensions/      |
+|   native/src/datafusion_udfs.rs|
+|                                |
+|   #[pyfunction]                |
+|   fn register_native_udfs(     |
+|     ctx: SessionContext        |
+|   ) -> PyResult<()> {          |
+|     ctx.register_udf(          |
+|       jaro_winkler_udf()       |
+|     );                         |
+|     ctx.register_udf(          |
+|       token_sort_udf()         |
+|     );                         |
+|   }                            |
++--------------------------------+
+```
+
+## Concrete deliverables
+
+1. **`packages/python/goldenmatch/pyproject.toml`** — add
+   `[project.optional-dependencies] datafusion = ["datafusion>=44"]`.
+
+2. **`packages/rust/extensions/native/src/datafusion_udfs.rs`** — new
+   module. Wraps existing jaro_winkler scorer as a DataFusion scalar
+   UDF (Utf8 a, Utf8 b -> Float64). Registered on a SessionContext
+   passed in from Python. Reuses the existing
+   `score_field_matrix` kernel internals where possible.
+
+3. **`packages/python/goldenmatch/goldenmatch/backends/datafusion_backend.py`**
+   — new module. Defines `score_blocks_datafusion(blocks, matchkey,
+   matched_pairs, ...)` matching the signature shape of
+   `score_blocks_parallel` and `score_blocks_ray` exactly.
+
+4. **`packages/python/goldenmatch/goldenmatch/core/pipeline.py`** —
+   extend `_get_block_scorer(config)` to dispatch
+   `config.backend == "datafusion"` to the new function. Lazy import
+   to keep the extra truly optional (see CLAUDE.md note on `[web]`
+   precedent).
+
+5. **`packages/python/goldenmatch/scripts/bench_datafusion_vs_bucket.py`**
+   — bench harness. Shapes: 10K, 100K, 1M. Same input frame, same
+   matchkey config (single jaro_winkler scorer to start, since that's
+   all we'll have wired). Outputs JSON with wall, RSS, output pair
+   count, result-set Jaccard vs bucket reference.
+
+6. **`packages/python/goldenmatch/tests/backends/test_datafusion_backend.py`**
+   — minimal parity test. Same input, both backends, assert the
+   produced pair set is identical (modulo ordering).
+
+## Bench design
+
+Inputs at each shape (10K, 100K, 1M):
+- Synthetic person fixture from existing `_person_df(n)` helper in
+  `tests/test_autoconfig_regressions.py`
+- Single matchkey: weighted with one field
+  `(name, scorer=jaro_winkler, threshold=0.85, weight=1.0)`
+- Blocking: name-based (existing default)
+
+Measurements per (shape, backend):
+- Wall: median of 3 runs
+- Peak RSS: psutil maxRSS over the run
+- Pairs emitted: count
+- Parity: Jaccard(pairs_datafusion, pairs_bucket) — must be 1.0 or we
+  have a correctness bug to fix before publishing numbers
+
+Output: markdown table at the end of the spike doc.
+
+## Go / no-go gate
+
+DataFusion advances to production-backend status if AT LEAST ONE of:
+
+- **Wall:** >= 1.3x faster than bucket at 1M
+- **RSS:** >= 20% lower peak RSS than bucket at 1M
+- **Architectural:** parity at 1M with materially simpler code path
+  that lets us drop bucket's per-block Python orchestration
+
+If none of these are met at 1M, write up the lesson and shelve
+DataFusion. No second spike unless something material changes
+(e.g., DataFusion ships a major perf rev, or a customer constraint
+forces an engine-backend rewrite).
+
+## Day-by-day plan (3-5 day estimate)
+
+- **Day 1:** wire the optional extra + Rust UDF skeleton + lazy
+  registration. Get one block scored end to end via DataFusion in a
+  REPL, no benchmarking yet.
+- **Day 2:** flesh out `score_blocks_datafusion`, parity test against
+  bucket on a 1K fixture. Iterate until Jaccard == 1.0.
+- **Day 3:** bench harness, 10K/100K runs, observe shape. If 100K is
+  >2x slower than bucket, stop and triage; if competitive, continue.
+- **Day 4:** 1M bench, debug if slow. Likely culprits: per-block
+  SessionContext recreation, Arrow conversion in inner loop, UDF
+  dispatch overhead.
+- **Day 5:** write up the result, update this doc with measurements,
+  produce the go/no-go recommendation.
+
+## Risks and open questions
+
+1. **`datafusion-python`'s Rust UDF FFI quality.** Documentation is
+   thin. May need to drop to `datafusion` crate directly and re-bind,
+   which would push the spike toward 5 days.
+
+2. **Per-block SessionContext cost.** DataFusion isn't designed for
+   thousands of micro-queries; it expects fewer, larger queries. If
+   we create one SessionContext per block (we have ~1.67M blocks at
+   5M scale per CLAUDE.md), that overhead will dominate. The right
+   shape may be to load all blocks at once and run a single query
+   with `groupby(block_key)`. That's a bigger architectural shift
+   than "per-block driver" but it's the shape DataFusion wants.
+
+3. **Backend invariants.** The existing scorer functions return
+   `list[tuple[int, int, float]]` (canonicalized). DataFusion's
+   output is an Arrow table; we'll convert, but the conversion is
+   non-trivial at 1M+ pairs and may eat the win.
+
+4. **Pair canonicalization.** Bucket emits `(min, max)` pairs (per
+   CLAUDE.md). The DataFusion query needs to enforce this with a
+   `WHERE id_a < id_b` filter. Drop-or-keep semantics on equality
+   need to match bucket exactly.
+
+## What this spike does NOT prove
+
+- That DataFusion-distributed (Ballista / Sail) is viable. Wholly
+  separate question.
+- That DataFusion beats bucket at 25M+. We're not testing past 1M.
+  If 1M shows promise we'd do a follow-up at 5M/25M before commit.
+- That the controller can pick DataFusion intelligently. Manual
+  opt-in only via `config.backend="datafusion"`.
+
+## Decision artifact
+
+At spike completion, update the "## Go / no-go gate" section above
+with the measured numbers and a one-paragraph recommendation. That
+becomes the input to deciding whether to invest the multi-week effort
+to make DataFusion a real production backend.

--- a/docs/superpowers/specs/2026-05-30-ray-file-based-bench-spec.md
+++ b/docs/superpowers/specs/2026-05-30-ray-file-based-bench-spec.md
@@ -1,0 +1,205 @@
+# Ray file-based bench harness — design
+
+**Status:** Draft, 2026-05-30
+**Replaces:** `2026-05-30-ray-phase5-routing-spec.md` (retracted)
+
+## Problem
+
+The Ray Phase 5 streaming pipeline is feature-complete from a code-path
+perspective (PRs #337-#367 over April-May 2026). But it has never been
+benchmarked on its **native shape**:
+
+- Input: partition-aware reads from on-disk Parquet (or remote storage)
+- Compute: distributed across N worker nodes
+- Output: streaming `write_parquet` (no driver collect)
+
+Every previous Ray bench in this repo has done one of:
+
+1. **`bench-phase5-simulated`** — 4 Ray workers inside ONE
+   `large-new-64GB` runner. Honest scoping per CLAUDE.md: *"single NIC
+   + single disk + shared OS page cache; this is a regression check,
+   NOT a Splink-Spark parity proof."*
+2. **`bench-phase5-end2end`** — designed for real multi-node, gated on
+   `RAY_ADDRESS` secret + `bench_100000000.parquet` on the bench
+   release. **Never run.** The secret was never provisioned.
+3. **The QIS bench** (`bench-quality-invariant-scale`) — single runner,
+   in-memory DataFrame input. NOT Ray's native shape.
+
+PRs #603-#606 from this session shipped a routing wrapper around
+`dedupe_df(df)` to test Ray on the QIS bench's in-memory workload.
+v43 result (5M-ray-realistic): 370s / 16 GB / F1 0.9925, vs bucket's
+240s / 18 GB / F1 0.9923. **Ray lost on wall by 1.54×, won on RSS by
+2 GB.** Both numbers are on the wrong workload for Ray.
+
+## Goal
+
+Design and stand up a bench harness that compares Ray and bucket on
+the **same Parquet input**, calls each via its NATIVE entry point
+(file-based `dedupe(files=...)` for Ray; current in-memory
+`dedupe_df(df)` is still bucket's shape), and validates Ray's scale-out
+at 100M+ rows where bucket physically cannot fit.
+
+## Out of scope
+
+- Provisioning a Ray cluster (infrastructure work; happens outside
+  this spec).
+- The Ray Phase 5 pipeline's correctness — already shipped and (modulo
+  PR #606's documented cheat-line) functional at 5M.
+- Optimizing Ray below 100M. Below that, bucket wins by construction.
+
+## Inventory of what exists
+
+### File-based input plumbing
+
+| component | status |
+|---|---|
+| `goldenmatch.distributed.dataset.read_parquet_partitioned` | shipped (PRs #337-#340), tested at 25M |
+| `apply_transforms_distributed(ds, transforms)` | shipped, used by Phase 5 |
+| `_load_input_frames(config)` env-gate | shipped (`backend="ray" + GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1`) |
+| `dedupe(files=...)` entry point | shipped, but **does it actually route Ray to the partitioned loader?** Need to audit. |
+
+### Streaming pipeline
+
+| component | status |
+|---|---|
+| `_run_phase5_pipeline` | shipped, validated at 5M via v43 (with #606 cheat-line) |
+| `score_blocks_distributed` | shipped |
+| `dedup_pairs_distributed` | shipped, but uses the #606 driver-collect cheat-line |
+| `build_clusters` polymorphic on Ray Dataset | shipped (Phase 3) |
+| `build_golden_records_batch` polymorphic on Ray Dataset | shipped (Phase 4) |
+| `materialize_cluster_dict` | shipped — explicit cheat-line at the Phase 3→4 boundary |
+
+### Multi-node infrastructure
+
+| component | status |
+|---|---|
+| Multi-node Ray cluster bootstrap | docs at `docs/distributed-ray-cluster-setup.md` (Splink-posture: docs not bootstrap) |
+| `bench-phase5-end2end` workflow | exists, requires `RAY_ADDRESS` secret + bench-release Parquet asset |
+| 100M Parquet on `bench-dataset-v1` release | not generated |
+| `RAY_ADDRESS` GitHub secret | not provisioned |
+
+## Proposed work, ordered by infrastructure dependency
+
+### Phase A: in-repo plumbing (no external infrastructure)
+
+#### PR A1: audit and document `dedupe(files=...)` Ray routing
+
+Trace what actually happens when a user calls
+`dedupe(files=["data.parquet"], config=cfg, backend="ray")`:
+
+- Does `_load_input_frames` engage the partitioned loader?
+- Does the controller's auto-config route through the distributed
+  path or fall back to a driver materialize?
+- Where does the pipeline's prep frame live (driver or workers)?
+- Does scoring engage `score_blocks_distributed` or fall back to the
+  legacy `score_blocks_ray` swap?
+
+Output: a clear mermaid diagram + audit table of where each stage
+runs. No code changes; this is the basis for PR A2+.
+
+#### PR A2: generate Parquet bench dataset
+
+Modify `scripts/generate_phase5_dataset.py` (or write a sibling) to
+produce QIS-shape Parquet files at multiple scales (1M, 5M, 25M,
+100M). Upload to `bench-dataset-v1` GitHub Release as assets.
+
+QIS-shape = realistic synthetic person data, 5 rows per cluster, the
+same shape we've benched bucket against all session.
+
+This is the **honest apples-to-apples input**. Both bucket and Ray
+read the same Parquet.
+
+#### PR A3: file-based bench workflow
+
+New `bench-ray-file-based.yml` workflow that:
+
+- Takes `rows`, `backend` (`bucket | ray`), `cluster_address` inputs.
+- Downloads the appropriate Parquet from the bench-dataset-v1 release.
+- Calls `dedupe(files=...)` with the right backend.
+- If `backend=ray` AND `cluster_address` is provided, sets
+  `RAY_ADDRESS` to point at the external cluster. Otherwise uses
+  local Ray (single-runner simulated).
+- Records the same stage timings + RSS + F1 as the QIS harness.
+
+The output JSON shape matches the existing QIS bench so the
+comparison reports stay consistent.
+
+### Phase B: validation rungs (no external infrastructure)
+
+#### PR B1: bucket-file-based baseline at 5M, 25M, 100M
+
+Run the new workflow with `backend=bucket` on each scale. This
+establishes the file-based bucket baseline — different from the
+in-memory `dedupe_df(df)` numbers we have because file reading has
+its own cost.
+
+100M-bucket WILL fail (out of memory on one box). That's the
+expected breakpoint; it's the rung that justifies Ray's existence.
+
+#### PR B2: ray-simulated bench at 5M, 25M
+
+Run the new workflow with `backend=ray` + no `cluster_address` (local
+Ray on one runner). This validates the file-based Ray path
+end-to-end. We expect it to lose to bucket at 5M-25M (Ray init +
+single-node bottleneck), but the gap should be smaller than v43's
+1.54× because we're not paying for `from_arrow` materialization.
+
+### Phase C: real-cluster kill criterion (requires infrastructure)
+
+#### Infrastructure dependency
+
+Someone provisions a Ray cluster:
+
+- 4 nodes minimum (so the architecture is exercised)
+- 16 cores / 64 GB each (matches the simulated baseline)
+- `RAY_ADDRESS` set as a GitHub secret on the goldenmatch-monorepo repo
+
+Possible providers: Railway (we already use it for the MCP service),
+GCE, EKS, locally-provisioned. The choice is outside this spec.
+
+#### PR C1: ray-cluster bench at 100M, 200M, 500M
+
+Run the new workflow with `backend=ray` + `cluster_address` pointing
+at the provisioned cluster. Generate Parquet at 100M (extending the
+generator from A2) and at 200M / 500M.
+
+**Whole-lane kill criterion:** Ray completes 100M end-to-end within
+30 minutes wall AND under 40 GB max per-node RSS. (Numbers from the
+spec at `docs/superpowers/plans/2026-05-19-phase-5-multi-node-parity.md`.)
+
+If Ray passes 100M: close the documented cheat-lines (#606,
+`materialize_cluster_dict`, etc.) one PR at a time, re-bench at each
+to verify. Lane is alive.
+
+If Ray fails 100M: real architectural problem; revisit Phase 5's
+design before further investment.
+
+## Risks
+
+- **Cluster provisioning is a real ops task.** GitHub Actions can't
+  do it. Someone has to commit to maintaining a Ray cluster for the
+  duration of this lane.
+- **The 100M Parquet generator may itself be slow.** CLAUDE.md notes
+  the generator at 50M ran in ~70s; 100M extrapolates to ~140s.
+  Should fit in a `large-new-64GB` runner, but worth verifying.
+- **Closing the cheat-lines is its own multi-PR initiative**, only
+  unlocked after Phase C1's pass.
+
+## Decision needed
+
+Two questions to answer before this lane proceeds:
+
+1. **Is anyone going to provision the Ray cluster?** Without this,
+   the lane stalls at Phase B. Phase A and B are useful (real
+   file-based bench harness) but don't validate Ray's value
+   proposition.
+2. **What's the target deployment shape?** If goldenmatch users
+   primarily run on one machine via `dedupe_df(df)`, Ray is a niche
+   feature. If users have S3-scale data and read from Parquet, Ray
+   is core. The answer determines how much to invest.
+
+If both answers are "yes" / "S3-scale matters", ship Phase A and B
+this session, queue Phase C for when the cluster arrives. If either
+answer is "no", acknowledge the lane is parked and document that
+the existing Ray code is correctness-tested but performance-
+unvalidated at scale.

--- a/docs/superpowers/specs/2026-05-30-ray-phase5-routing-spec.md
+++ b/docs/superpowers/specs/2026-05-30-ray-phase5-routing-spec.md
@@ -1,0 +1,49 @@
+# Ray Phase 5 routing — RETRACTED, see file-based-bench spec
+
+**Status:** Retracted 2026-05-30, same day as drafted
+**Replaces:** N/A (this was the original PR sequence; superseded by reframing)
+**Superseded by:** `2026-05-30-ray-file-based-bench-spec.md`
+
+## Why this was retracted
+
+The original spec proposed routing `dedupe_df(df)` (in-memory Polars
+DataFrame input) through `run_dedupe_pipeline_distributed`. PRs #603,
+#604, #605, #606 landed; v43 confirmed the routing path was functional
+at 5M (370s / 16 GB / F1 0.9925).
+
+But the comparison was on bucket's home turf:
+
+- `dedupe_df(df)` assumes the input is already materialized in driver
+  memory. Bucket is designed for exactly this; Ray's value is in
+  **avoiding** the driver materialization. Wrapping `dedupe_df(df)`
+  for Ray puts it on a workload where it can't win.
+- The QIS bench is single-node (16 cores / 64 GB on one runner). Ray
+  cannot out-scale bucket on one node by definition; the bench can
+  only validate correctness, not scale-out behavior.
+- The routing's `ray.data.from_arrow(df.to_arrow())` IS the driver
+  materialization the streaming pipeline is supposed to avoid. We
+  built a streaming pipeline and then prefixed it with a "collect
+  everything to driver first" entry point.
+
+The cheat-lines we were planning to close (driver-collect dedup,
+`materialize_cluster_dict`, etc.) are local minima at 5M. They become
+real bottlenecks at 100M+, and the only honest path to validating Ray's
+behavior at that scale is a file-based bench against a real multi-node
+cluster.
+
+## What lands anyway
+
+- **#604** (pandas dep on bench workflow) — keep. Even the file-based
+  path needs pandas because `ray.data` imports it at module load.
+- **#606** (driver-collect for `dedup_pairs_distributed`) — keep. It's
+  a documented cheat-line workaround for a real Ray bug
+  (single-partition HashAggregate). The proper fix (num_partitions
+  config or hash-shuffle repartition) is deferred until we have a
+  file-based bench against a real cluster to measure on.
+- **#603 + #605** — reverted. The routing wrapper put Ray on the wrong
+  shape; the workaround flag (`confidence_required=False`) was carried
+  through the routing function so it goes with it.
+
+## What this lane needs instead
+
+See `2026-05-30-ray-file-based-bench-spec.md`.

--- a/docs/superpowers/specs/2026-06-02-columnar-view-frame-backed-design.md
+++ b/docs/superpowers/specs/2026-06-02-columnar-view-frame-backed-design.md
@@ -1,0 +1,232 @@
+# Columnar Pair-Score View (opt #3b) Design
+
+**Status:** Approved scope (both stages, staged). Parity-gated.
+
+**Goal:** Make `ClusterPairScores.from_frames` (the columnar identity pair-score
+view) cheap and low-RSS at 100M pairs, so the Phase-2 frames-out cutover wins
+wall AND RSS at scale instead of losing 2x on `id_prep`.
+
+**Author context:** continues the SP-A/B/C frames-out cutover. SP-A/B/C shipped
+(PRs #684/#685/#686) + opt #1 (#691, native-frames-direct build). The binding
+100M complete-path bench (run `26858805412`) returned the verdict that motivates
+this work.
+
+---
+
+## Background: the 100M verdict
+
+Complete-path bench (`scripts/bench_pipeline_complete_path.py`), 100M pairs,
+`large-new-64GB`:
+
+| variant  | build s | golden s | id_prep s | peak RSS MB |
+|----------|---------|----------|-----------|-------------|
+| legacy   | 303.7   | 60.9     | 49.1      | 61,079.6    |
+| columnar | 316.1   | **3.9**  | **515.7** | 60,540.0    |
+
+- **No OOM** on either; RSS delta is **-0.9%** (540 MB) — negligible.
+- Columnar is **~2x slower wall** (836s vs 414s), entirely in `id_prep`:
+  golden is a real 15.6x win, but `id_prep` is **10.5x slower** and swamps it.
+
+`id_prep` on each variant (bench `_one_run`):
+- legacy: `ClusterPairScores.from_pairs(pairs_list, clusters)` → 49.1s
+- columnar: `ClusterPairScores.from_frames(frames.assignments, pairs_list)` → 515.7s
+
+Both call the SAME `_bucket_pairs(pairs, member_to_cid)` Python loop over the
+SAME 100M `pairs_list`. The 5M cProfile shows `_bucket_pairs` is ~91% of
+`from_frames` (6.35s of 6.99s); the `member_to_cid` rebuild (`.to_list()` x2 +
+`int()` casts) is small at 5M. So the 10x blowup at 100M is **not** linear CPU —
+it is the **100M-entry `dict[int, dict[tuple[int,int], float]]` being built at
+the 60 GB ceiling**, where GC + page pressure make it superlinear. Legacy's
+49.1s is roughly the same `_bucket_pairs` work but it does not pay the columnar
+allocation profile at the same memory phase.
+
+**Conclusion:** the dict-of-dicts view IS the scale cost. SP-A/B/C was necessary
+plumbing but net-negative alone at 100M. The fix is to stop materializing a
+100M-entry Python dict-of-dicts on the columnar path.
+
+---
+
+## The byte-identical invariant (the durability constraint)
+
+`_bucket_pairs` semantics that MUST be preserved exactly (the CI parity gate +
+`test_cluster_frames_out_parity` enforce this; two runtime bugs already survived
+static review on SP-A, so the gate — not review — is the verifier):
+
+```python
+by_cid = {}
+for a, b, s in pairs:              # INPUT order
+    ca = member_to_cid.get(a)
+    if ca is not None and ca == member_to_cid.get(b):   # both endpoints, same cid
+        by_cid.setdefault(ca, {})[(a, b)] = s            # key (a,b) AS GIVEN; LAST-WINS
+return by_cid
+```
+
+Four properties any replacement must reproduce per cid, byte-for-byte:
+1. **Membership:** a pair is kept iff both endpoints map to the same cid
+   (cross-cut edges of a split cluster are dropped — one endpoint outside).
+   Either endpoint absent from `assignments` (`.get` → `None`) drops the pair.
+2. **Key:** `(a, b)` exactly as given in the input pair — NOT canonicalized.
+   `(7,3)` and `(3,7)` are DISTINCT keys in the same cid's dict.
+3. **Insertion order** of keys within a cid: order of **first** occurrence
+   (Python dict preserves first-insert position; later updates keep position).
+4. **Value:** the score at the **last** occurrence of that `(a, b)` (LAST-WINS).
+
+**Two latent behaviors that MUST be preserved bug-for-bug (the parity gate
+asserts current behavior, not "correct" behavior):**
+- **`score_for` query-canonicalize vs stored-as-given MISS.** `score_for`
+  (cluster_pairscores.py:106) looks up `(min(a,b), max(a,b))` while keys are
+  stored as-given. So a pair stored `(7,3)` is MISSED by `score_for(cid,3,7)`
+  → returns `None` → resolve.py:712 emits `score=None`. The frame-backed version
+  MUST canonicalize ONLY the query argument and compare against as-given stored
+  keys — do NOT canonicalize the stored keys (that would "fix" the miss and
+  change identity output). Identity parity fixture MUST include a weak cluster
+  whose `bottleneck_pair` orientation is the REVERSE of the stored input pair.
+- **Self-pairs** `(a,a)` with `a` in a cid pass the membership test and are
+  kept; the join+filter (`cid_a==cid_b`) keeps them too. Parity holds; no action
+  beyond not special-casing them.
+
+**Structural invariant the join depends on:** `assignments` is UNIQUE on
+`member_id` (one row per member, singletons included). If a member appeared in
+two rows the endpoint join would fan out and corrupt `first_i`/`last_score`.
+The parity test MUST assert `assignments["member_id"].is_unique().all()`.
+
+Consumers (`for_cluster`, `score_for`, `iter_clusters`) and their callers in
+`identity/resolve.py` (489/656 `for_cluster`, 702 `score_for`) read per-pair
+scores to emit one evidence edge per pair, so the view is load-bearing — it
+cannot be skipped.
+
+---
+
+## Stage 1 — #3b-min: vectorized build, dict-of-dicts retained
+
+Replace the Python `_bucket_pairs` loop in `from_frames` with a Polars join,
+then materialize the SAME dict-of-dicts. Output structure unchanged → identity
+and accessors untouched → smallest parity surface.
+
+**Build:**
+1. `pairs_df = pl.DataFrame({"a","b","s"})` with a row index `__i__` (0..N-1,
+   input order). On the pipeline path, prefer the existing `_columnar_pairs_df`
+   (SP3, pipeline.py:1935) so the 100M-tuple list is never re-materialized; the
+   bench can build it from `pairs_list` once.
+2. Map endpoints to cids via join against `assignments` (member_id → cluster_id):
+   `cid_a` on `a`, `cid_b` on `b`.
+3. Filter `cid_a.is_not_null() & cid_b.is_not_null() & (cid_a == cid_b)`; set
+   `cid = cid_a`.
+4. LAST-WINS + first-insert order, vectorized. The `last_score` expression is
+   PINNED — use exactly `pl.col("s").sort_by("__i__").last()` (or
+   `pl.col("s").gather(pl.col("__i__").arg_max())`). **NEVER `pl.col("s").max()`**
+   — max is MAX-score, not LAST-score, the exact bug the docstring at
+   cluster_pairscores.py:59-62 warns against, and it also mishandles NaN.
+   Per `(cid, a, b)` group: `first_i = pl.col("__i__").min()`,
+   `last_score = pl.col("s").sort_by("__i__").last()`. Then `sort` by
+   `(cid, first_i)` (a total order — `first_i` is unique within a cid, so the
+   sort is deterministic; do NOT sort by `(a,b)`).
+5. Materialize `by_cid` from the sorted frame.
+
+**Honest risk (do NOT bench Stage 1 at 100M):** step 5 still builds a 100M-entry
+dict-of-dicts AND adds a join + group_by + sort, so by this spec's own root-cause
+analysis (the blowup is allocation-bound at the ceiling, NOT `_bucket_pairs`
+CPU) Stage 1 is LIKELY a no-op-to-regression on the 100M verdict axis. Its
+value is ONLY as the byte-identical join FOUNDATION that Stage 2 reuses (it
+produces the `view_df` Stage 2 keeps frame-backed). Therefore Stage 1's gate is
+the **cheap CI parity lane only** — "prove it green" = byte-identical parity,
+NOT a 100M bench run. The single 100M complete-path bench is spent ONCE, after
+Stage 2, where the frame-backing actually removes the dict-of-dicts.
+
+## Stage 2 — #3b-full: frame-backed view, no dict-of-dicts
+
+Back `ClusterPairScores` with a Polars frame instead of `dict[int, dict]`.
+
+**Backing:** add a `_partitions` slot alongside the existing `_by_cid`.
+`from_frames` produces `view_df(cid, a, b, s)` already deduped (LAST-WINS) and
+ordered (`cid`, first-insert) from the Stage-1 join WITHOUT materializing the
+global dict-of-dicts, then `_partitions = view_df.partition_by("cid",
+as_dict=True)` ONCE → `dict[cid → small frame]`. This is a dict of ~num_clusters
+Arrow frames (dense, columnar), NOT a 100M-entry Python dict-of-tuples — that is
+the peak-RSS win. `_by_cid` stays the backing for the legacy dict paths
+(`from_pairs`/`from_cluster_dict`); the accessors check which backing is set.
+
+**Accessors (byte-identical semantics; the resolver calls `for_cluster(cid)`
+once per cid, so per-call cost must be O(cid), never O(total)):**
+- `for_cluster(cid)` → when `_partitions` is set, build the per-cid `dict`
+  on demand from `_partitions[cid]` (a small frame), in first-occurrence order
+  → keys/order/values byte-identical to Stage 1. The dict is transient (the
+  resolver GCs it after emitting that cluster's edges), so peak RSS holds ONE
+  cid's dict at a time, not all 100M. O(cid pairs) per call; total across the
+  resolver loop is O(total pairs) — same as legacy `_bucket_pairs`, but never
+  resident all at once. No `partition_by` per call (done once at build).
+- `score_for(cid, a, b)` → canonicalize ONLY the `(min,max)` QUERY, look up
+  against the as-given stored keys of `_partitions[cid]` — preserving the
+  existing MISS-on-reversed-orientation behavior (see latent-behaviors above).
+- `iter_clusters()` → yields `(cid, [(a,b,s), ...])` from each partition in
+  first-occurrence order (ordering is parity-tested even though no resolve.py
+  call site uses it today).
+
+**Identity consumption (`identity/resolve.py`):** UNCHANGED. The resolver keeps
+calling `for pair_key, score in view.for_cluster(cid).items()` per cid (489/656)
+and `view.score_for(...)` (702). Because `for_cluster` is now O(cid) and
+transient, no resolver restructure is needed and the dict and frame paths share
+one consumer. (We do NOT claim an `iter_clusters` fast path — the resolver loop
+is cid-driven; `iter_clusters` exists for completeness/future use only.) The
+dict-backed legacy paths stay exactly as they are.
+
+**Win target:** columnar `id_prep` at/below legacy's 49s AND peak RSS below
+legacy's 61 GB (no resident 100M-entry dict-of-dicts) → columnar wins wall AND
+RSS. Verified by the single post-Stage-2 100M bench.
+
+---
+
+## Parity & testing (the real verifier)
+
+- `tests/test_cluster_frames_out_parity.py` extended: assert the view (Stage 1
+  `_by_cid`, and Stage 2 via `for_cluster`/`score_for`/`iter_clusters`) is
+  byte-identical to `from_pairs(...)` for every cid, on a fixture that INCLUDES:
+  - a **cascading auto-split** clique (the shape that caught the two SP-A
+    runtime bugs);
+  - a **duplicate `(a,b)` whose LATER occurrence has a LOWER score than the
+    earlier** — so MAX-score and LAST-score DIVERGE (pins F1: catches any
+    `max()` slip);
+  - cross-cut edges (both-endpoints-same-cid drop);
+  - a `(7,3)` / `(3,7)` reversed-orientation pair (distinct-keys property);
+  - an assertion that `assignments["member_id"].is_unique().all()` (the join's
+    fan-out invariant);
+  - `iter_clusters()` tuple-order equality per cid.
+- An identity-level parity test (extend `test_identity_from_frames_parity`):
+  resolving with the frame-backed view yields the same evidence-edge set
+  (entity partition + per-edge scores) as the dict path — INCLUDING a weak
+  cluster whose `bottleneck_pair` is stored in the REVERSE orientation of the
+  `score_for` query, asserting the conflict edge still emits `score=None`
+  (preserves the F3 miss bug).
+- CI-validated posture: subagents validate Python via `ruff` + `py_compile`
+  only (the box hangs on `import goldenmatch`/`polars`); the parity gate runs in
+  CI's `python (goldenmatch)` lane (native=1 included). No local pytest.
+- After Stage 2 ONLY (Stage 1 gates on the cheap parity lane — see Stage 1's
+  honest-risk note): re-dispatch the 100M complete-path bench
+  (`bench-pipeline-complete-path.yml`, `np=100000000`) to measure the real
+  `id_prep` + RSS delta. The bench is DATA, not a kill gate.
+
+## Files
+
+- Modify: `goldenmatch/core/cluster_pairscores.py` (`from_frames`, the
+  `ClusterPairScores` backing + accessors).
+- Modify: `goldenmatch/core/pipeline.py` (thread `_columnar_pairs_df` into the
+  `from_frames` call so the view build is frame-native end-to-end).
+- Modify: `goldenmatch/identity/resolve.py` (frame-friendly consumption fast
+  path; dict interface preserved).
+- Test: `tests/test_cluster_frames_out_parity.py`,
+  `tests/test_identity_from_frames_parity.py`.
+- Bench: `scripts/bench_pipeline_complete_path.py` (pass the columnar pairs
+  frame to `from_frames` on the columnar leg so the bench measures the new path).
+
+## Non-goals
+
+- No change to legacy (`from_pairs`/`from_cluster_dict`) behavior or the
+  non-frames-out pipeline path.
+- No change to `build_cluster_frames` / SP-A/B/C.
+- No new public API surface beyond the frame-backed accessors.
+
+## Auth / process
+
+- Branch off `main`; benzsevern auth for push
+  (`GH_TOKEN=$(gh auth token --user benzsevern)`); open PR; CI parity gate
+  verifies. NEVER benzsevern-mjh.

--- a/docs/superpowers/specs/2026-06-03-autoconfig-identifier-pincer-design.md
+++ b/docs/superpowers/specs/2026-06-03-autoconfig-identifier-pincer-design.md
@@ -1,0 +1,172 @@
+# Auto-config identifier pincer (#715) -- design
+
+Date: 2026-06-03
+Issue: benseverndev-oss/goldenmatch#715
+Status: design (approved in brainstorming, pending spec review)
+
+## Problem
+
+`dedupe_df(df, config=None)` on healthcare-provider-shape data (~1M rows;
+sparse high-cardinality identifier columns: `npi`, `email`, `phone_number`)
+commits a fuzzy-only, mega-block config that severely over-merges (582K raw
+clusters from 996K input rows) and runs for ~16 minutes before the prune step
+crashes. A hand-tuned config solves the same data in ~30s at 98.8% precision.
+
+### Confirmed mechanism (the "pincer")
+
+Reproduced on CI (workflow `repro-issue-715.yml`, run 26922192773) with synthetic
+healthcare-shape data. Every identity-bearing column is excluded from matchkeys
+by one of three gates, and the leftover blocking key is unusable:
+
+| column         | col_type     | card  | excluded from matchkeys by |
+|----------------|--------------|-------|----------------------------|
+| `npi`          | identifier   | 0.618 | `col_type=="identifier"` skip (`autoconfig.py:566`) |
+| `phone_number` | identifier   | 0.472 | same identifier skip |
+| `email`        | email        | 0.699 | Guard 1: `df.height > 10000` (`:647`) |
+| `zip5`         | zip          | 0.875 | "blocking signal, not identity" (`:612`) |
+| `matching_id`  | identifier   | 1.000 | identifier skip (correct -- surrogate key) |
+
+Result: `weighted t=0.8 fields=['source','first_name','last_name']` (identical
+field set to the #715 report) and a single blocking key `first_name`
+(`card=0.02` -> ~50K-row blocks at 1M rows -> the over-merge and the 973s wall).
+
+### Why the guards are wrong
+
+1. **Exact matchkeys are Polars hash self-joins** (`find_exact_matches`), not
+   nested loops, and they do NOT pass through fuzzy blocking. Their real cost is
+   the number of *emitted equal-pairs*, which is bounded by cardinality. A
+   high-cardinality column (few records per value) emits few pairs and is both
+   cheap and mega-cluster-safe. Guard 1's `O(N^2)` framing models a nested loop
+   that the kernel never runs.
+
+2. **The mega-cluster risk Guard 1 fears is the opposite shape** -- a value
+   shared by a large fraction of rows, i.e. a *low*-cardinality column. That is
+   already caught by the separate `cardinality_ratio >= 0.5` gate at `:631`.
+   Guard 1 is therefore redundant where it is safe and harmful where it is not:
+   it rejects exactly the high-cardinality columns that are the cheapest and
+   safest exact matchkeys.
+
+3. **`col_type="identifier"` conflates two different things.** Near-unique
+   numeric columns are classified `identifier` (`:213-216`) and skipped from
+   matchkeys entirely (`:566`). But that bucket mixes real shared identifiers
+   (NPI, SSN, MRN -- appear on multiple rows for one entity, so `card < 1.0`,
+   SHOULD anchor exact matchkeys) with per-record surrogate keys (`matching_id`
+   -- `card == 1.0`, never shared, useless as an identity claim).
+
+## Design
+
+One root cause (identifier cost model), four touch-points.
+
+### Component 1 -- matchkey side (`build_matchkeys`, core fix)
+
+- **Remove the blanket row-count Guard 1** (`:644-655`). It is redundant with the
+  `cardinality_ratio >= 0.5` mega-cluster gate.
+- **Admit exact matchkeys via a cardinality band: `cardinality_ratio >= 0.5 and
+  cardinality_ratio < 1.0`** (exact comparison, matching the `:631` style so the
+  `card == 1.0` boundary is unambiguous in the failing-test task).
+  - Lower bound = the existing mega-cluster guard (`:631`).
+  - Upper bound excludes perfectly-unique surrogate keys (`card == 1.0`), which
+    emit zero useful pairs. Strict `< 1.0` (a column at `card=0.9999` has a few
+    real dupes worth catching -- admit it).
+- **Stop skipping `col_type="identifier"` outright** (`:566`). Route `identifier`
+  (already mapped to the `exact` scorer in `_SCORER_MAP`) plus the existing
+  `email`/`phone` exact-eligible types through the exact path under the same
+  band. `numeric`, `date`, `year` remain skipped (not identity claims).
+- **Update the aggregate "all exact-eligible columns excluded" warning**
+  (`:669-697`) to include `identifier` in the eligible set and reflect the new
+  admission outcome.
+
+**Sample-cardinality behavior (not a new projection):** the controller profiles
+a ~1-5K sample. A real shared identifier with nulls (npi, ~60% non-null) lands
+~0.6 on the sample (admitted); a surrogate key lands 1.0 (excluded). A sample
+too small to surface dupes can push a real identifier to `card=1.0` and exclude
+it -- but that is a *conservative* false-negative (falls back to today's
+behavior, no mega-cluster), so no projection is added in the matchkey path.
+
+### Component 2 -- blocking side (VERIFICATION, not new code)
+
+**Finding (revised during planning):** `build_blocking` already has the full
+compose stack -- `_build_compound_blocking` (greedy compound-key search), the
+`safe_exact` oversized-block filter (`:1348`), the `_all_single_oversized` check,
+geo-compound, and soundex/substring multi-pass fallback. Traced at true 1M
+scale: `max_safe_block` scales to ~5000, so `first_name` (~50K-row block) IS
+rejected (the repro only kept it because at 20K its ~1000-row block equals the
+cap); and `zip5` (col_type `zip`, ~5K distinct at 1M -> ~200 rows/block, #410
+projection drops its sample-inflated ratio under the 0.5 gate) would be selected
+as a clean single key. So `build_blocking` is already capable.
+
+`#715`'s reported `blocking: (none)` is therefore a **controller-commit
+artifact**, not a `build_blocking` deficiency: with zero exact matchkeys the
+config is fuzzy-only -> RED -> the controller's iteration thrashes and commits a
+v0/degenerate entry that drops blocking. Component 1 (real exact matchkeys on
+`npi`/`email`) makes the committed config healthy, so blocking (`zip5`) is
+retained.
+
+- **No new blocking code.** Do not reimplement the compose machinery.
+- **Verification task:** after Component 1, assert (regression test + at-scale
+  workflow) that the healthcare shape commits a healthy config that RETAINS a
+  bounded blocking key (e.g. `zip5`, max block size <= cap). Only add code if
+  this assertion fails -- in which case the gap is in the controller-commit path,
+  tracked as a follow-up, not in `build_blocking`.
+
+### Component 3 -- raise-on-RED (#3)
+
+- **No new refuse logic.** The existing path already raises
+  `ControllerNotConfidentError` at `df.height >= REFUSE_AT_N` on a RED commit
+  when `confidence_required=True` (default). The #715 reporter passed
+  `confidence_required=False` (the documented opt-out). The matchkey + blocking
+  fixes flip this shape RED -> GREEN/YELLOW, so it works rather than refusing.
+- **Deliverable: a regression assertion.** Healthcare-shape df ->
+  `auto_configure_df` commits a non-RED config with >= 1 exact matchkey on an
+  identifier column AND blocking with bounded max block size. `confidence_required`
+  semantics are untouched.
+
+### Component 4 -- docs (#4)
+
+- New user-facing page under `packages/python/goldenmatch/docs/` (sibling to
+  `blocking.md`): "Auto-config cost model -- why exact matchkeys are
+  cardinality-gated, not row-count-gated." Covers: the hash-join cost model, the
+  `0.5 <= card < 1.0` band, the blocking block-size cap + compose behavior, and
+  the relevant override env vars (`GOLDENMATCH_BLOCKING_MAX_RATIO`, etc.).
+
+## Testing and validation
+
+- **Unit (`build_matchkeys`):** identifier@0.6 -> exact matchkey; identifier@1.0
+  -> excluded; email@0.7 at `df.height=1_000_000` -> exact matchkey (no Guard 1
+  skip); low-card@0.3 -> still skipped (mega-cluster gate intact).
+- **Verification (no new `build_blocking` code):** the regression test asserts
+  the committed config retains a bounded blocking key after Component 1. If it
+  does not, the gap is in the controller-commit path (follow-up), not
+  `build_blocking`.
+- **Regression:** promote the repro generator to a shared `_healthcare_df`
+  fixture in `tests/test_autoconfig_regressions.py` (sibling to `_person_df`/
+  `_gate_test_df`); assert Component 3's committed-config invariant. Fix the
+  repro script's too-strict verdict line (it required zero blocking too; the
+  matchkey pincer is the primary signal).
+- **Quality-gate guard (primary risk):** dropping Guard 1 changes behavior for
+  ANY large dataset with a high-card email/identifier column. Before merge, run
+  the in-house backend-parity quality gate (#528) and DQbench T1/T2/T3 to confirm
+  no precision regression (notably an adversarial same-email/same-id collision
+  shape, which is the closest thing to the mega-cluster risk). Hard pre-merge
+  gate.
+- **At-scale:** keep `repro-issue-715.yml` as the confirmation harness; add a
+  post-fix assertion (exact matchkey present, blocking max block size bounded).
+
+## Risks and mitigations
+
+- **Behavior change for existing large datasets** (the main risk): a high-card
+  email/identifier column now backs an exact matchkey it previously did not.
+  Mitigation: the `0.5 <= card < 1.0` band + the existing `:631` gate bound the
+  mega-cluster risk; the DQbench/quality-gate pre-merge run is the empirical
+  backstop.
+- **Composite blocking is the least-certain piece.** It reuses existing
+  projection + block-size machinery and falls back to adaptive promotion, so the
+  worst case is today's behavior, not worse.
+
+## Out of scope
+
+- Changing `confidence_required` / `ControllerNotConfidentError` semantics.
+- A new shared-identifier-vs-surrogate-key classifier (the cardinality band
+  achieves the same separation without one).
+- Distributed / Ray / Sail paths (this is a controller-side config decision,
+  upstream of backend selection).

--- a/docs/superpowers/specs/2026-06-03-datafusion-scale-substrate-design.md
+++ b/docs/superpowers/specs/2026-06-03-datafusion-scale-substrate-design.md
@@ -1,0 +1,185 @@
+# DataFusion scale-substrate — sub-project 1: the cluster-edge rollup
+
+**Date:** 2026-06-03
+**Status:** design (approved by Ben, pre-spec-review)
+**Parent decision:** scale mode (see `2026-06-01-arrow-native-finish-line-design.md`
+§ "Scale mode decision"). Ben's call: the real unlock is DataFusion (embedded,
+one box) + Sail (distributed, later). This is sub-project 1 of that arc.
+
+**Scope guard:** this spec is ONE bounded proof-point. It does NOT migrate the
+pipeline to DataFusion, does NOT touch the fuzzy scorer / Union-Find / golden,
+and does NOT introduce Sail. Those are later sub-projects, each gated on this
+one's measured result.
+
+---
+
+## Why this, and why now
+
+The 25M/100M complete-path verdict (run 26878555131, post-#691/#692, dict-backed
+view) recorded:
+
+| pairs | variant | build s | golden s | id_prep s | peak RSS MB |
+|---|---|---|---|---|---|
+| 25M | legacy | 65.2 | 13.4 | 11.8 | 16,169 |
+| 25M | columnar | 31.4 | 0.92 | 45.8 | 14,155 (−12.5%) |
+| 100M | legacy | 284.8 | 56.7 | 47.6 | 61,082 |
+| 100M | columnar | 136.8 | 3.87 | **566.0** | 56,333 (−7.8%) |
+
+Two facts from it drive this sub-project:
+1. The RSS win is real but **modest** (−12.5% / −7.8%, short of the −30% target),
+   and the **dict never OOM'd** at 100M (61 GB fit a 64 GB box). The trump card —
+   "the dict doesn't finish at scale" — is **unproven**.
+2. `id_prep` (566s at 100M, **super-linear** from 45.8s @25M) is the limiter on
+   BOTH wall and the residual RSS.
+
+**Precise target (verify-don't-trust; corrected after spec-review #1):**
+`confidence`/`quality`/`bottleneck` (the per-cluster ROLLUP) are ALREADY computed
+columnar inside `build_cluster_frames` (the 136s build stage) — so a DataFusion
+rollup wins nothing; the rollup is not the cost. The 566s `id_prep` is the
+**per-pair edge VIEW**: `ClusterPairScores.from_frames` → `_bucket_pairs` builds
+a `dict[int, dict[(a,b),score]]` that identity iterates to emit one evidence edge
+per pair (`resolve.py:493/660`). **THAT per-pair dict-of-dicts is the 566s, and
+it is what we replace.**
+
+The replacement is NOT an `array_agg` (its in-memory group state ≈ the whole
+input and spills poorly). It is a **cid-sorted edge stream**: attach `cid` to
+each edge, `ORDER BY cid` via DataFusion's external (spilling) sort, and hand
+identity a stream it consumes in same-cid runs — same data as the dict, packed
+Arrow (~24 B/row vs ~100+ B/entry boxed), and **spills to disk** instead of
+building a multi-GB Python dict. The per-cluster rollup rides along as a cheap
+SECOND `group_by(cid)` (it duplicates what build already has, used only for the
+parity check). DataFusion over Polars-lazy because **Sail is DataFusion** — the
+proof transfers to the distributed sub-project.
+
+## What this builds
+
+A single bounded unit, gated behind scale mode, with TWO outputs from one
+`SessionContext`:
+
+```
+cluster_edges_datafusion(
+    pairs: pa.Table | pl.DataFrame,        # (a:i64, b:i64, score:f64) all_pairs
+    assignments: pa.Table | pl.DataFrame,  # (member_id:i64, cluster_id:i64), one row/member (WCC out)
+    *, memory_limit: int | None,           # bytes; None = unlimited; set low to force spilling
+) -> (edges: pa.RecordBatchReader,         # PRIMARY: cid-sorted edge stream (replaces the dict)
+      rollup: pa.Table)                    # SECONDARY: per-cluster aggregates (parity check)
+```
+
+**Step 0 — dedup (scale-mode policy).** The raw pairs may contain duplicate
+canonical `(a,b)` with different scores. The legacy dict is INPUT-order LAST-WINS
+(`_bucket_pairs`); scale mode resolves this to **MAX** (signed-off; R1 ≈ 0 on the
+default single-weighted-matchkey path). So first reduce to one row per `(a,b)`
+via MAX score (a `max(score) GROUP BY a,b`, or skip if the caller guarantees
+deduped pairs — assert the invariant). This makes `edge_count`/`avg_edge`
+well-defined and matches the scale-mode contract.
+
+**Step 1 — attach cid + filter.** Register `pairs`/`assignments` zero-copy
+(confirm at impl). Join `pairs.a→member_id` (`cid_a`) and `pairs.b→member_id`
+(`cid_b`); keep `cid_a == cid_b` (cross-cut edges dropped — `_bucket_pairs` rule);
+`cid = cid_a`.
+
+**Step 2 — PRIMARY output: cid-sorted edge stream.** `SELECT cid, a, b, score …
+ORDER BY cid` via DataFusion's **external sort** (spills through `DiskManager`).
+Returned as a `RecordBatchReader`; identity consumes same-cid runs. This is the
+per-pair view replacement — the 566s killer.
+
+**Step 3 — SECONDARY output: per-cluster rollup (for the parity gate).** Two
+group-bys joined on `cid`:
+  - over the filtered edges: `min(score)→min_edge`, `avg(score)→avg_edge`,
+    `count(*)→edge_count`, `first_value(struct(a,b) ORDER BY score,a,b)→bottleneck`
+    (lexicographic, order-free, deterministic — the parent doc's §7 tie-break).
+  - over `assignments`: `count(*) GROUP BY cluster_id → size` (REQUIRED — `size`
+    is the member count, independent of `edge_count`; connectivity =
+    `edge_count / (size*(size-1)/2)`).
+  **Drive the rollup from `assignments` (LEFT join to the edge aggregate)** so
+  singleton/edgeless clusters survive: coalesce `edge_count→0`, `min/avg→0.0`,
+  matching `_columnar_presplit`. Confidence: `size<=1 → 1.0`; else
+  `0.4*min + 0.3*avg + 0.3*conn`; weak iff `avg-min > 0.3` (split handled
+  upstream). Output schema: `cluster_id, size, edge_count, min_edge, avg_edge,
+  bottleneck_a, bottleneck_b`.
+
+**Step 4 — spilling.** `RuntimeEnv::with_memory_limit(memory_limit, frac)` so the
+external sort (Step 2) AND `GroupByHashExec` (Step 3) spill instead of OOM.
+
+## The benchmark (the actual deliverable)
+
+`scripts/bench_df_cluster_edges.py` + a `workflow_dispatch` job on
+`large-new-64GB`. Three variants over the SAME `(pairs, assignments)`:
+- **legacy** — the current `ClusterPairScores.from_frames` dict-of-dicts view
+  build (the 566s) + its per-cid iteration.
+- **datafusion** — `cluster_edges_datafusion` (this spec): the sorted edge
+  stream consumed in cid-runs + the rollup.
+- **polars** — the same via Polars lazy `sort`/`group_by` (attribution control:
+  is the win DataFusion-specific, or just "not a Python dict"?).
+
+**Input shape (the spec-review #1 gap — the toy fixture hides everything).** The
+in-tree `_make_pairs_df` makes uniform fully-connected size-5 clusters, score
+0.95 — which (a) never exercises sparse connectivity, oversized clusters, or the
+`first_value ORDER BY` per-group sort cost, and (b) makes EVERY pair a bottleneck
+tie, so "tie-break ≈ inert" is untestable on it. So the bench MUST run on a
+realistic-shaped input via ONE of:
+  1. a **capture step** that dumps `(pairs, assignments)` from an actual
+     `bench-dataset-v1` run (real heavy-tailed cluster-size distribution), or
+  2. a generator with a **heavy-tailed cluster-size distribution incl. oversized
+     clusters + partial (sparse) connectivity + duplicate canonical pairs**.
+The legacy dict scales with PAIR count (keyed per-pair), so size-5 does stress
+RSS at 200M pairs — but the rollup's cost drivers and the tie-break rate need the
+realistic shape. Report the bottleneck-divergence rate vs legacy on this input.
+
+Scales: **25M, 100M, and a deliberate OOM-seeking point** — push pairs past where
+the dict fits (200M+) AND/OR cap `memory_limit` low, so the legacy dict **OOMs**
+and DataFusion **spills and survives**. This is the experiment that settles
+binding-vs-non-binding — the question every prior bench dodged.
+
+Record per variant: wall, peak RSS, survives/OOM, and bottleneck-divergence rate.
+Commit the table into the roadmap doc.
+
+## Correctness gates (not bit-identical — per scale-mode policy)
+
+- **Edge-set parity (PRIMARY):** the cid-grouped edge SET from the DataFusion
+  stream equals the legacy `for_cluster(cid)` edge set for every cid — as SETS
+  (membership relaxed; edges are unordered identity inputs). Tested on a fixture
+  with sparse clusters, a singleton, an oversized/split cluster, and duplicate
+  canonical pairs (post-MAX-dedup).
+- **Rollup parity (SECONDARY):** `size`, `edge_count`, `min_edge`, `avg_edge`
+  (ε), and derived `confidence`/`cluster_quality` match the legacy per-cluster
+  values for EVERY cluster INCLUDING singletons (`confidence=1.0`) and edgeless
+  clusters (coalesced `min/avg=0.0`). Rand-1.0 partition assumed (WCC unchanged).
+  `bottleneck` uses the NEW lexicographic rule — an output change on ties only;
+  REPORT the divergence rate vs legacy on the realistic input (do NOT assert
+  "inert" — the toy fixture's all-tie shape made that unmeasurable).
+- **Dedup invariant:** assert the DataFusion `edge_count`/`avg_edge` match legacy
+  only AFTER MAX-dedup of duplicate canonical pairs (legacy is last-wins; scale
+  mode is MAX — the signed-off R1 change). If the caller passes raw pairs with
+  diff-score dups, the rollup uses MAX, not last-wins; document the input
+  contract.
+- **Determinism:** run the DataFusion plan at **≥3 different `target_partitions`**
+  (incl. one > core count); assert identical `cluster_id`/`size`/`edge_count`/
+  `bottleneck` + edge sets, and `avg_edge` equal to a **tight ε (1e-12)**. If
+  `avg_edge` drifts, pin the reduction (sort-then-sum) — the parent doc's §7
+  determinism trap (`2026-06-01-arrow-native-finish-line-design.md` § "Scale mode
+  decision", determinism row).
+- **CI-validated posture:** subagents validate via `ruff` + `py_compile` only
+  (box hangs on import); real tests + the bench run in CI. `datafusion` is a new
+  optional dep — add under an extra (`goldenmatch[datafusion]`) so core installs
+  are unaffected; the bench workflow installs it.
+
+## Out of scope (explicit — later sub-projects, each gated on this result)
+
+- Fuzzy scorer as a DataFusion `ScalarUDF` (needs the Rust-DataFusion build, #629).
+- Union-Find / connected components on DataFusion.
+- Golden survivorship on DataFusion.
+- Identity per-pair edge streaming from DataFusion.
+- Sail (distributed). DataFusion-embedded one-box must prove out first.
+
+## Risks
+
+- **Zero-copy ingest** — confirm DataFusion ingests the pairs/assignments frames
+  without a full copy (else RSS measurement is contaminated). Validate first.
+- **`first_value … ORDER BY` cost** — ordered aggregation may force a per-group
+  sort; if it dominates, fall back to `min_by`-style or a two-pass (min then
+  filter). Measure.
+- **Win may still be non-binding** — if even DataFusion's spill doesn't matter
+  because the dict fits at all reachable scale, the honest output is "one-box
+  DataFusion is a modest win; the real value is the Sail distributed path" — and
+  that reshapes the arc. The OOM-seeking bench is what tells us.

--- a/docs/superpowers/specs/2026-06-03-datafusion-spine-design.md
+++ b/docs/superpowers/specs/2026-06-03-datafusion-spine-design.md
@@ -1,0 +1,143 @@
+# DataFusion spine (scale-substrate SP2) — full relational spine, B2 Rust ScalarUDF
+
+**Date:** 2026-06-03
+**Status:** design (approved scope: full spine + B2; pre-spec-review)
+**Parent:** `2026-06-01-arrow-native-finish-line-design.md` § "Gate reframe: engine
+portability". Step 1 (id_prep plannable) is PROVEN + merged (#696): id_prep 566→34s
+@100M, end-to-end 2.11×. This is step 2 — insert DataFusion as the planner/spill
+spine over the relational stages.
+
+**Goal:** Thread **score → dedup → [UF break] → id_prep → golden** on ONE Python
+`datafusion` `SessionContext` with **out-of-core spill**, the native scorers as a
+**Rust `ScalarUDF` via `datafusion-ffi`** (B2), and Union-Find routed to the
+existing distributed **label-propagation** path. Gated behind `mode="scale"`.
+
+**The win being proven (per the handoff):** out-of-core spill — the spine SURVIVES
+where the in-memory path OOMs — and engine portability (the same plan distributes
+on Sail later). NOT constant-factor op speed.
+
+---
+
+## Scope guard
+
+IN: the full one-box relational spine + the B2 Rust ScalarUDF + UF→label-prop
+routing + the scale-mode contract + the out-of-core spill bench.
+OUT (later): **Sail** (distributed) — one-box spine proves first. Golden custom
+field-rules / quality_scores stay in-memory fallback (distributed-path is the
+uniform-strategy case). LLM/rerank/boost/NE/exotic matchkeys — DROPPED (error).
+
+## Architecture
+
+```
+            ┌─────────────── one datafusion.SessionContext (memory_limit → spill) ───────────────┐
+ blocked    │  score (SQL w/ FFI scorer UDF)  →  dedup (max(score) GROUP BY a,b)  →  pairs_df     │
+ candidates │                                                                          │          │
+            └──────────────────────────────────────────────────────────────────────────┼─────────┘
+                                                                                         ▼  [UF break — not relational]
+                                                          label-prop (goldenmatch.distributed.clustering) → assignments_df
+                                                                                         │
+            ┌────────────────────────────────────────────────────────────────────────────┼─────────┐
+            │  id_prep (group_by edges over pairs ⋈ assignments)   +   golden (group_by → representative) │
+            └──────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+- **One `SessionContext`** with `RuntimeEnvBuilder().with_disk_manager_os().with_fair_spill_pool(memory_limit)` (v53 API, confirmed in SP1 #695) so every RELATIONAL stage (score/dedup/id_prep/golden) spills.
+- **Stages are SQL/DataFrame ops**; each stage's output registered as a view for the next.
+- **The score stage is a block-self-join** (`a.block_key=b.block_key AND a.id<b.id` with the scorer UDF), NOT a flat re-score of a pre-joined pair frame — mirror `score_blocks_datafusion`'s shape (the UDF-batch efficiency depends on it). The spine input is BLOCK-shaped candidates, not pairs.
+- **The UF break is an in-memory island OUTSIDE the spill domain.** Below the 50M-pair threshold (`distributed.clustering._LABEL_PROP_PAIR_THRESHOLD`) `build_clusters_distributed` routes to the **scipy.csgraph driver path** (`_build_clusters_scipy_fallback`), NOT distributed label-prop — that's the real one-box code path (name it precisely in tests). It collects the deduped pairs frame to the driver, so its scaling envelope is scipy-on-driver (~50M pairs / ~1.2 GB), separate from DataFusion's spill. Hand `all_ids` as an Arrow array / derive it from the pairs frame inside the spine — do NOT materialize a Python `list[int]` of every record id (the CLAUDE.md WCC-rehydration-OOM trap; the current `all_ids: list[int]` signature does not protect against it). Round-trip IN: consume the returned `{member_id, cluster_id}` frame directly (`.to_arrow()`); do NOT route through `materialize_cluster_dict` (it `take_all()`s into a dict-of-dicts — the rehydration we are eliminating).
+- **B2 scorer:** a Rust crate exports the native string scorers as an `FFI_ScalarUDF` (`datafusion-ffi`), surfaced as a PyCapsule via pyo3; Python registers it into the ctx. Replaces the existing Python-batch UDF (`datafusion_backend.py::_make_score_udf`, B1).
+
+## The B2 Rust ScalarUDF (the load-bearing risk — de-risk FIRST)
+
+`datafusion-ffi` (`FFI_ScalarUDF` ↔ `ForeignScalarUDF`; Python side
+`ScalarUDF.from_pycapsule()` + the `__datafusion_scalar_udf__()` PyCapsule
+protocol — confirmed viable on v53) is the cross-crate ABI. The Python `datafusion`
+53 package and our Rust `datafusion` crate are SEPARATE DataFusion instances; the
+FFI PyCapsule is the only sound bridge. **Version lockstep (confirmed):** the
+crates version with the Python major — `datafusion-ffi 53.x` → `datafusion 53.x`,
+matching `datafusion-python` 53. So: **pin the Rust crate `datafusion = "=53.x"` +
+`datafusion-ffi = "=53.x"`**, and **bump the Python extra `datafusion>=53,<54`**
+(today it's `>=44`, which would let pip resolve a 44–52 wheel that mismatches the
+Rust 53 crate → the exact ABI break Stage A guards, hit at install time). Add a CI
+assertion that the installed Python `datafusion` major == the Rust crate's
+`datafusion` major. **Stage A de-risks this with a trivial UDF first** — if the
+boundary doesn't hold, B2 is blocked → fall back to B1 (Python UDF) for the spine,
+escalate to the human. **Arrow-major divergence (the concrete reason the crate MUST
+be separate, not just "build weight"):** DataFusion 53 pins **arrow 58**; the
+existing `_native` crate uses `arrow = "55"`. Two separate cdylibs tolerate this;
+putting DataFusion into the `_native` crate would force one arrow major on both
+and break the build. The new crate uses `arrow = "58"` with `features=["ffi"]`.
+
+## Stages (the spec decomposes the "full spine" into staged, independently-testable units)
+
+- **Stage A — FFI ScalarUDF spike.** A minimal Rust `ScalarUDF` (e.g. `add_one`)
+  exported via `datafusion-ffi` as a PyCapsule; a Python test registers it into a
+  `SessionContext` and `SELECT add_one(x)` returns correct values. Proves the
+  cross-crate v53 boundary. GATE: if it can't be made to work, STOP and escalate.
+- **Stage B — scorer as FFI ScalarUDF.** Wrap the existing native scorers
+  (jaro_winkler/token_sort/etc.) as `FFI_ScalarUDF`(s). Parity: the UDF's scores
+  equal the in-process native scorer's for a fixture of string pairs (ε for f32).
+- **Stage C — spine orchestration.** `run_spine(blocked_candidates, config, *,
+  memory_limit) -> (golden_df, assignments_df)`: thread score → dedup →
+  UF(scipy/label-prop) → id_prep + golden on one ctx. **Written against the UDF
+  INTERFACE, not the FFI impl** — so B1 (Python UDF) ↔ B2 (FFI) is a one-line swap
+  and C is testable even if B2 slips. Semantic parity vs the in-memory pipeline:
+  Rand-1.0 partition, identical golden content, edge-set parity on id_prep.
+- **Stage D — scale-mode contract.** Determinism across `target_partitions`
+  {1,3,N}: assert the **emitted pair SET and the cluster PARTITION are identical**
+  (NOT raw f32 float equality — scores are f32-origin, so a 1e-12 gate is below f32
+  ULP and would flag false non-determinism; the real hazard is a pair within f32-
+  ULP of the `score>=threshold` cutoff flipping across partitions and changing the
+  edge set → the partition). Use a fixture with NO pair within ε(1e-6) of the
+  threshold so the gate measures determinism, not threshold flapping. MAX dedup;
+  feature-gating (LLM/rerank/boost/NE/exotic → explicit error, never silent). D
+  does not strictly block on C (feature-gating is pure routing).
+- **Stage E — out-of-core spill bench.** Full spine at an OOM-seeking scale →
+  DataFusion SPILLS and SURVIVES where the in-memory pipeline OOMs. **Scope: the
+  spill-survival claim is for the RELATIONAL stages (score/dedup/id_prep/golden)
+  ONLY.** The UF break collects pairs to the driver (scipy.csgraph), an in-memory
+  island the spill pool does NOT cover — bound the pair-frame size at that
+  collection and keep Stage E below the scipy envelope (~50M pairs), else the spine
+  OOMs at the UF boundary and falsely reads as "spine doesn't survive" when the
+  relational stages actually did their job. (At Sail scale — OUT of this spec — UF
+  routes to true distributed label-prop above 50M, removing the island.) 3-way
+  where meaningful (in-memory / DataFusion / bucket). Commit numbers to the roadmap.
+
+## Gates (engine-portability, per the reframe — NOT one-box RSS)
+
+- Stage A: the FFI UDF evaluates correctly (feasibility).
+- Stage C: semantic parity (Rand 1.0 + golden content + id_prep edge sets) vs
+  in-memory; deterministic across `target_partitions`.
+- Stage E: spill-survives-where-in-memory-OOMs at the OOM-seeking scale; wall
+  holds out-of-core (not a constant-factor target).
+
+## Build / dependency surface
+
+- **A SEPARATE maturin crate** under `packages/rust/extensions/` depending on
+  `datafusion = "=53.x"` + `datafusion-ffi = "=53.x"`, with its OWN
+  `pyproject.toml` + wheel/publish lane (mirror `goldenmatch-native`). The
+  existing `native` crate is a standalone `[workspace]` built by
+  `scripts/build_native.py` (hard-codes the `native` crate → `_native.abi3.so`);
+  the DataFusion crate needs its own build entrypoint — do NOT extend
+  `build_native.py` or the `native` crate (arrow-major clash + bloat, see B2
+  section). The Python `goldenmatch[datafusion]` extra exists but pins `>=44`
+  (the B1 spike) — **bump to `>=53,<54`** so the Python package matches the Rust
+  crate major.
+- CI: the spine tests need the python `datafusion` extra + the new Rust crate
+  built (cargo). Mirror the native-build lane.
+- Posture: subagents validate via `ruff`+`py_compile` (Python) and `cargo check`
+  (Rust, if it doesn't hang) — real tests in CI.
+
+## Risks
+
+- **FFI ABI mismatch (Stage A gate)** — the whole B2 premise. De-risked first.
+- **DataFusion-crate build weight** — isolate the crate; don't bloat `_native`.
+- **UF break round-trip** — collecting the deduped pairs frame out to label-prop
+  and back is a materialization point; at scale it must stay frame-native (Arrow),
+  not a Python list (the CLAUDE.md WCC-rehydration-OOM lesson). label-prop already
+  takes frames (`distributed.clustering`) — verify the interface at Stage C.
+- **Determinism across workers** — DataFusion parallel float reduction; pin
+  reductions (Stage D), the scale-mode hard requirement.
+- **Spill may still not bind** — if the in-memory path doesn't OOM at reachable
+  scale, the spine's value is the engine-portability/Sail story, not one-box
+  survival. Stage E's OOM-seeking design is what tells us (same honesty as SP1).

--- a/docs/superpowers/specs/2026-06-04-autoconfig-491-lever-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-04-autoconfig-491-lever-coverage-design.md
@@ -1,0 +1,152 @@
+# Auto-config lever coverage: probabilistic + qgram + ANN (#491) -- design
+
+Date: 2026-06-04
+Issue: benseverndev-oss/goldenmatch#491
+Status: design (approved in brainstorming, pending spec review)
+
+## Problem
+
+The iterative `auto_configure_df` controller reaches only a subset of the repo's
+levers. #491's genuine remaining gaps (after the audit: levenshtein/soundex_match
+already reachable via the optimizer + the `phonetic_identity` heuristic; dice/jaccard
+are PPRL-only and struck):
+
+1. **Probabilistic matchkey type** -- reachable today ONLY via the standalone
+   `auto_configure_probabilistic_df` entry point. The iterative controller
+   (`dedupe_df(df)` zero-config) and the deterministic ConfigOptimizer proposer
+   never *select* it. (The optimizer's `LLMProposer` already has a
+   `matchkey_type -> probabilistic` op at `config_optimizer.py:301`, but the
+   deterministic `CoordinateDescentProposer` does not, and the LLM path is opt-in.)
+2. **qgram scorer** -- not in `_SCORER_MAP`/`build_matchkeys` and not in the
+   optimizer's scorer family (`config_optimizer.py:334` lists token_sort, ensemble,
+   levenshtein, soundex_match -- no qgram). Unreachable.
+3. **ANN blocking** -- `ANNBlocker` is wired in `blocker.py` but `build_blocking`
+   never emits `strategy="ann"` (it emits multi_pass / canopy / learned / static /
+   adaptive). Unreachable.
+
+## Design
+
+Three independent levers. Scope = all three. Probabilistic gets BOTH homes
+(controller heuristic + optimizer candidate); qgram gets heuristic + optimizer;
+ANN is a heuristic gate in `build_blocking`.
+
+### Lever A -- probabilistic as a selectable type (both homes)
+
+**A1. Optimizer (deterministic):** wire the EXISTING `MatchkeyTypeSwap` edit
+(`config_edits.py:167`, `weighted <-> probabilistic`, apply-revalidate-ready, with
+`_PERTURBABLE_TYPES = ("weighted","probabilistic")`) into `CoordinateDescentProposer`
+(`config_optimizer.py:307`) as a new `mktype` family in `_FAMILIES`/`_edits`. It is
+currently deserialized by the LLM JSON path but NOT imported into the optimizer or
+emitted by the deterministic proposer. So A1 is "import + add a family that emits
+`MatchkeyTypeSwap` for each weighted matchkey," NOT a new edit class. The search
+scores weighted-vs-probabilistic by the existing zero-label confidence / F1
+objective and keeps the winner.
+
+**A2. Controller heuristic:** new `rule_select_probabilistic_matchkey` in
+`autoconfig_rules.py`, appended to `DEFAULT_RULES`. **Conservative trigger** (all
+must hold): the committed config has a weighted matchkey with `>= 3` graded fuzzy
+fields, the scoring sub-profile is recall-limited (unimodal score histogram / low
+`mass_above_threshold`), and there is no strong exact-anchor matchkey. This is the
+shape where Fellegi-Sunter per-field m/u weighting beats a flat weighted average.
+The rule proposes converting that weighted matchkey to `type="probabilistic"`.
+m/u are EM-trained at dedupe time (existing `core/probabilistic.py`); blocking is
+already required for probabilistic (`autoconfig.py:2341`), so no blocking change.
+
+**Ship-or-defer:** A2 is best-effort. If the pre-merge quality gate shows ANY
+regression on NCVR / Febrl3 / DQbench T1-T3, **drop A2** and ship probabilistic
+optimizer-only (A1) -- that still satisfies #491's "reachable from the auto
+surface" acceptance. A1 carries no default-path risk (opt-in search).
+
+### Lever B -- qgram scorer
+
+**CORRECTION (plan review):** `qgram` is NOT currently a scorer. `VALID_SCORERS`
+(`goldenmatch/config/schemas.py`) has no qgram; the only `qgram` is the `qgram:N`
+*transform* (`utils/transforms.py`), which is **lossy/blocking-only** (it truncates
+to the first 5 n-grams: `" ".join(grams[:5])`). And `dice`/`jaccard` operate on
+hex-encoded **bloom filters** (PPRL-only), so they can't be repurposed. Real
+q-gram *similarity* therefore needs a NEW scorer.
+
+**B0. Implement the qgram scorer (prerequisite):** add a genuine character-n-gram
+set-similarity scorer (q-gram Jaccard on raw strings: pad, generate the full set of
+n-grams for each string, similarity = |A∩B| / |A∪B|) to `VALID_SCORERS` and to BOTH
+dispatch paths in `core/scorer.py` (the single `_qgram_score_single(a, b)` ~line 89
+and the NxN `_qgram_score_matrix(values)` ~line 419). Default n configurable (e.g.
+`qgram` = trigram; allow `qgram:N` scorer-arg parsing if the scorer dispatch
+supports args, else fixed n=3). Pure-Python set similarity, no bloom semantics.
+
+**B1. Heuristic:** add a "short-code" column-shape classifier and route it to
+the new `qgram` scorer in `build_matchkeys`. Short-code shape: `avg_len` small (~3-12),
+cardinality_ratio moderate-to-high, alphanumeric, and NOT already classified
+name/email/phone/zip/date/identifier-surrogate. (SKUs, license plates, postal
+codes, short product codes.) qgram (character n-gram overlap) beats token_sort
+(token-order-based) and levenshtein on short codes with internal transpositions.
+Implement as a refinement in the scorer-selection path, not a blanket `_SCORER_MAP`
+entry (col_type stays the existing classification; the short-code refinement picks
+qgram for the matchkey field).
+
+**B2. Optimizer:** add `qgram` to the `CoordinateDescentProposer` scorer family
+(`config_optimizer.py:334`) so the empirical search can pick it on data-dependent
+shapes.
+
+### Lever C -- ANN blocking (heuristic gate)
+
+**`build_blocking`:** a new selection branch emitting `strategy="ann"` and setting
+the FLAT `BlockingConfig` fields (`schemas.py:362`) -- `ann_column`, `ann_model`,
+`ann_top_k` (there is NO `ANNConfig` class / nested block; `strategy="ann"` is
+already a valid `Literal`, and `autoconfig.py:2349` already lists `ann` as a no-op
+for the adaptive-promotion swap). Gated STRICTLY on BOTH:
+- (a) **embeddings present**: the resolved matchkeys contain an `embedding` /
+  `record_embedding` scorer field, OR an embedding-typed/description column that
+  would carry vectors. ANN needs vectors -- it must NEVER fire without them.
+- (b) **scale**: `n_rows_full >= ANN_MIN_ROWS` (the FAISS index build only pays
+  off at scale; below it, exact/multi_pass blocking is cheaper). Default threshold
+  TBD in the plan (start ~100K, env-overridable).
+
+Reuse the embedding-bootstrap path already used to wire embedding scorers. When the
+gate fails (no embeddings or below scale), behavior is unchanged.
+
+## Testing and validation
+
+- **Unit B (qgram):** short-code fixture -> `build_matchkeys` emits a qgram
+  matchkey field; a name/email/date column does NOT get qgram (precision).
+- **Unit A1 / B2 (optimizer):** `CoordinateDescentProposer.propose` yields a
+  probabilistic-type candidate for a weighted matchkey, and a qgram candidate in
+  the scorer family. (Assert the candidate set contains them; don't need the full
+  search.)
+- **Unit A2 (controller rule):** `rule_select_probabilistic_matchkey` fires on the
+  target shape (>=3 graded fuzzy fields + recall-limited + no exact anchor) and
+  does NOT fire on a DQbench-like shape (has an exact_email anchor) or a simple
+  2-field weighted shape.
+- **Unit C (ANN):** `build_blocking` emits `strategy="ann"` when embeddings present
+  AND `n_rows_full >= threshold`; emits the normal strategy when no embeddings
+  (most important: never `ann` without vectors) and when below scale.
+- **Reachability tests (the #491 acceptance):** assert each lever is reachable from
+  the auto surface (qgram via build_matchkeys; probabilistic via the controller
+  rule output AND the optimizer candidate set; ann via build_blocking).
+- **Quality gate (HARD pre-merge, the central risk):** A2 (and to a lesser extent
+  B1) change default-path selection. Run the #528 in-house quality gate +
+  DQbench T1/T2/T3 + NCVR + Febrl3. **Any regression on those drops A2** (ship
+  A1-only) and re-examines B1's short-code precision. ANN and the optimizer
+  additions don't touch the default zero-config path, so their regression risk is
+  bounded to their own opt-in/gated surfaces.
+
+## Risks
+
+- **A2 over-fires -> benchmark regression** (primary). Mitigation: conservative
+  multi-condition trigger + hard quality gate + ship-or-defer (A1 is the safety
+  net for the "reachable" acceptance).
+- **C fires without embeddings -> ANNBlocker crash on missing vectors.**
+  Mitigation: strict embeddings-present gate + a test asserting `ann` is never
+  emitted without an embedding scorer/column.
+- **B1 qgram on the wrong columns -> noise.** Mitigation: precise short-code shape
+  detector; the optimizer (B2) can always override empirically.
+
+## Out of scope
+
+- dice/jaccard scorers (PPRL/bloom-CLK path, intentionally separate -- struck per
+  the audit).
+- levenshtein/soundex_match (already reachable -- audit confirmed).
+- `build_probabilistic_matchkeys` column admission for identifiers (that is #721 --
+  WHICH columns probabilistic uses, distinct from whether the controller SELECTS
+  probabilistic). This spec may interact with #721 but does not subsume it.
+- Distributed/Ray paths.

--- a/docs/superpowers/specs/2026-06-04-autoconfig-blocking-cost-guard-refuse-red-design.md
+++ b/docs/superpowers/specs/2026-06-04-autoconfig-blocking-cost-guard-refuse-red-design.md
@@ -1,0 +1,192 @@
+# Auto-config blocking cost guard + refuse-on-RED (#715 reopened) -- design
+
+Date: 2026-06-04
+Issue: benseverndev-oss/goldenmatch#715 (reopened after PR #720)
+Status: design (investigation reproduced; pending spec review)
+
+## Context
+
+PR #720 fixed the matchkey half of #715 (high-cardinality identifiers now back
+exact matchkeys). The reporter verified that half works, then reopened: the
+config still commits `RED` and runs anyway, and a new failure mode replaced the
+old one -- auto-config picks an unbounded `soundex(name)` blocking pass that
+produces ~30K-row blocks at 1M rows -> 39.6M candidate edges -> 18-min run ->
+cancelled at the GH job timeout. Net: equivalent-or-worse than pre-fix.
+
+## Reproduced root cause (not reasoned -- measured)
+
+Ran `profile_columns` + `build_blocking` (unchanged by #720) on the synthetic
+healthcare shape at 50K (dense zip5) and 200K (sparse zip5, 45% null, matching
+the reporter's "30-70% non-null identifier" description):
+
+- **Dense zip5 (50K):** blocking picks the bounded compound `zip5+last_name`
+  (max_block 77). No problem. Confirms the bug is shape-specific.
+- **Sparse zip5 (200K):** `zip5` reclassifies `zip -> identifier` (near-unique on
+  the non-null sample) and is dropped from the compound candidate pool. Blocking
+  falls back to a `multi_pass` whose passes include a single-column
+  `soundex(last_name)` -- `last_name` alone has max_block 4,055 vs a
+  `max_safe_block` target of 1,000; soundex collapses surnames further. At 1M
+  (5x) this is the reporter's ~30K block / 39.6M edges.
+
+Three separable problems:
+
+- **B1 (primary):** `build_blocking` emits single-column `soundex(name)` /
+  substring passes (and can emit an oversized primary key) **without checking
+  each emitted key/pass's full-N max block size against `max_safe_block`.** v0 is
+  built on the FULL df (`autoconfig_controller.py:580-586`), so `_max_block_size`
+  is exact at build time -- the code simply never gates the recall passes on it.
+- **B2 (support):** a sparse numeric column (`zip5` at 45% null) reclassifies to
+  `identifier` and is excluded from `_build_compound_blocking`'s candidate pool
+  (`autoconfig.py:892` excludes `identifier`), starving the compound search of the
+  one column that would bound block size (`zip5+last_name` = max_block 1,864,
+  usable).
+- **A (backstop):** the controller commits the RED v0 and the downstream pipeline
+  runs anyway. The raise gate exists but is gated on
+  `confidence_required=True AND n_rows >= REFUSE_AT_N`; the reporter opts out via
+  `confidence_required=False` and gets the 18-min run.
+
+**On the iteration-budget angle (the user's hypothesis):** confirmed that
+`ControllerBudget.for_dataset` scales `max_seconds` (15->120s) and `sample_size`
+(2K->20K) with row count but leaves `max_iterations = 3` fixed for all sizes. It
+is a real limitation, but NOT the primary cause here: the controller iterates on
+a 2K-20K sample where `soundex(name)` blocks are small; the at-scale explosion is
+invisible at that altitude, so more sample-iterations would not catch it. We
+scale it anyway (cheap, correct-direction) but it is not load-bearing for #715.
+
+## Design
+
+### B1 -- bound every emitted blocking key/pass by full-N block size (core fix)
+
+`build_blocking` must not emit any blocking key or multi_pass pass whose max
+block size (on the full df; for the distributed/sample path, the #410 Chao1
+projection) exceeds `max_safe_block`.
+
+- Add a helper that, given candidate `fields`, returns its (projected) max block
+  size, reusing the existing `_max_block_size` + `n_rows_full` projection.
+- In the name-fallback multi_pass construction (`autoconfig.py:~1387-1499`),
+  build the pass list, then **filter out any pass whose projected max block size
+  > `max_safe_block`.** The primary `keys=` must itself be a bounded key.
+- If, after filtering, no bounded key/pass survives (and compound also failed),
+  `build_blocking` returns a config flagged degenerate (empty/oversized) -- the
+  blocking sub-profile then rolls up RED, which (with A) refuses.
+- Do NOT silently emit an oversized pass for "recall" -- an oversized soundex pass
+  does not improve recall, it produces a candidate-pair bomb that the cluster
+  budget then truncates anyway (the reporter's "422 oversized clusters" log).
+
+### B2 -- let the compound search use sparse/identifier-typed numeric columns
+
+`_build_compound_blocking` should judge candidates by whether they *bound block
+size*, not by col_type. Concretely:
+
+- Stop excluding `col_type == "identifier"` outright from the compound candidate
+  pool. Instead include a column when its single-column block size is NOT
+  near-singleton (i.e. it actually groups records) AND it is not perfectly unique
+  (`cardinality_ratio < 1.0`, excludes surrogate keys like `matching_id`).
+- High-null handling: a high-null column can still be a useful *multi_pass* key
+  (covers its non-null subset; other passes cover the rest), so it should be
+  admissible as a compound *component* even above the 20% null ceiling that gates
+  single-key blocking -- BUT only inside a multi_pass set where other passes cover
+  the null rows. Keep the existing single-key null ceiling; relax only for the
+  compound-component role.
+- Net: on the sparse-zip shape, `zip5+last_name` (max_block 1,864) becomes
+  reachable, bounding the fuzzy matchkey's candidate set.
+
+### Iteration-budget scaling (add-on, per user)
+
+In `ControllerBudget.for_dataset`, scale `max_iterations` with the size tier
+(e.g. 3 -> 4 -> 5 as n_rows crosses 100K / 1M). Low-risk, correct-direction; not
+load-bearing for #715 (documented above). Keep the default `max_iterations=3` for
+the base dataclass and small data.
+
+### A -- refuse-on-RED via `allow_red_config` (reporter's ask)
+
+- Add `allow_red_config: bool = False` to `auto_configure_df` / `dedupe_df` /
+  `match_df` and thread to `AutoConfigController.run`.
+- When the committed entry's health is RED with `stop_reason` set (genuine
+  give-up) AND `n_rows >= REFUSE_AT_N`, raise `ControllerNotConfidentError` by
+  DEFAULT. **CORRECTION (during implementation):** keep the `REFUSE_AT_N`
+  threshold -- small datasets (<100K) are cheap to run even when RED, and the
+  existing design deliberately scopes the raise to >=100K (memory
+  `feedback_controller_confidence_required`). The reporter's case is ~1M
+  (>> REFUSE_AT_N), so this fully covers it. (Original spec said "independent of
+  REFUSE_AT_N / small-N also raises" -- that over-reached and broke 19 small-N
+  warn-and-run tests; reverted to keep REFUSE_AT_N.)
+- The escape is `allow_red_config=True` (restores warn-and-run, the `:1071`
+  path). **`confidence_required=False` no longer bypasses the RED-refuse** -- that
+  was the reporter's actual bug (they used it to get a result and got garbage).
+  The RED gate is now `committed_RED AND n_rows >= REFUSE_AT_N AND not
+  allow_red_config`; `confidence_required` is dropped from the RED gate (still
+  gates the #417 NON-RED degenerate guard). Message names the failing sub-profile
+  and points at an explicit config or `allow_red_config=True`.
+
+### Reconciliation with the existing #408/#417 degenerate-blocking guard
+
+There is already a raise path at `autoconfig_controller.py:879-937`
+(`ControllerNotConfidentError`, `StopReason.BLOCKING_DEGENERATE`) that estimates
+avg block size scaled to full population (`estimate_avg_block_size` +
+`degenerate_guard_*` in `blocking_candidates.py`) and catches the no-keys /
+too-coarse-overall case -- but it is gated on the SAME
+`confidence_required AND n_rows >= REFUSE_AT_N AND profile RED` triple the
+reporter opts out of. The plan MUST reconcile the new work with it:
+
+- **A (allow_red_config)** is a NEW, orthogonal default-raise. Precedence: the new
+  `allow_red_config=False` RED-refuse fires regardless of `confidence_required`
+  and regardless of `REFUSE_AT_N`. The existing #417 guard stays as-is for the
+  `confidence_required` path. When both could fire, raise ONCE with the most
+  specific message (blocking-degenerate if that's the failing sub-profile, else
+  the generic RED-config message). Do not emit two different errors for one
+  condition.
+- **B1's per-pass guard** needs *max* block size per emitted key/pass; the
+  existing infra estimates *avg*. B1's block-size projection is **new code**
+  (Chao1-style on group sizes), NOT the existing #410 cardinality projection
+  (which corrects cardinality ratio, not block size) and NOT
+  `estimate_avg_block_size` (avg, not max). Add it alongside the existing helpers
+  in `blocking_candidates.py` for consistency; do not assume a projection helper
+  already exists.
+
+## Testing and validation
+
+- **Unit (`build_blocking`), B1:** sparse-zip healthcare profiles at a size where
+  a single `soundex(name)` pass exceeds `max_safe_block` -> assert NO emitted
+  key/pass has projected max block size > `max_safe_block`; assert a bounded
+  compound is chosen when available; assert degenerate-flag when nothing bounds.
+- **Unit, B2:** sparse `zip5` (identifier-typed, 45% null) -> assert it is
+  reachable as a compound component and `zip5+last_name` is selected.
+- **Unit, A:** monkeypatch a RED committed entry -> `auto_configure_df` raises by
+  default; `allow_red_config=True` returns the config; `confidence_required` left
+  at default does not change the new behavior. **Include a small-N (<100K) RED
+  case** asserting it now raises by default -- that is the broadest behavior
+  change (default-raise is independent of REFUSE_AT_N) and the easiest to miss.
+- **Unit, iteration budget:** `ControllerBudget.for_dataset(2_000_000).max_iterations`
+  > `for_dataset(10_000).max_iterations`.
+- **At-scale reproduction (the gap that let #715 reopen):** a CI
+  `workflow_dispatch` job that runs the FULL `auto_configure_df` (or
+  `build_blocking` on the full df) on the sparse-zip healthcare shape at >= 500K
+  rows and asserts the committed blocking's projected max block size <=
+  `max_safe_block` AND candidate-edge estimate under budget. A sample-sized unit
+  test CANNOT catch this (the whole reason #715 reopened) -- the at-scale check is
+  mandatory, not optional.
+- **Quality gate / DQbench:** B1/B2 change blocking-key selection for
+  sparse-identifier shapes; run the #528 quality gate + DQbench T1/T2/T3 before
+  merge to confirm no recall regression from dropping oversized recall passes.
+
+## Risks
+
+- **Dropping recall passes could lower recall** on shapes where the oversized pass
+  was actually finding true pairs. Mitigation: B2 makes a bounded compound
+  available so recall is preserved via a bounded key; the at-scale + DQbench gates
+  measure it. If a bounded key genuinely cannot be formed, refusing (A) is the
+  correct outcome (the user must supply an explicit config), not shipping a bomb.
+- **B2 admitting identifier-typed columns to blocking** risks singleton-block
+  keys. Mitigation: judge by block size (not type), exclude `card == 1.0`
+  surrogate keys, and only as a multi_pass component.
+- **`allow_red_config` default-raise is a behavior change** for callers currently
+  relying on `confidence_required=False` warn-and-run. Mitigation: document in
+  CHANGELOG; the escape hatch is one kwarg.
+
+## Out of scope
+
+- The matchkey admission fix (#720, done).
+- Distributed/Ray blocking (the reporter is single-node); the #410 projection
+  already covers the sample path's cardinality gate, and B1 reuses it.
+- `build_probabilistic_matchkey` identifier admission (#721 follow-up).

--- a/docs/superpowers/specs/2026-06-04-cluster-split-budget-661-726-design.md
+++ b/docs/superpowers/specs/2026-06-04-cluster-split-budget-661-726-design.md
@@ -1,0 +1,143 @@
+# Cluster split efficiency + edge-work budget (#661 + #726) -- design
+
+Date: 2026-06-04
+Issues: benseverndev-oss/goldenmatch#661 (root), #726 (symptom + DX)
+Status: design (approved in brainstorming, pending spec review)
+
+## Problem
+
+`split_oversized_cluster` (`core/cluster.py:157`) builds a max-weight MST (Kruskal
+over all O(E) edges) and removes the SINGLE weakest edge -> 2+ components, marking
+them all `oversized: False`. The CALLER (the split loop in `build_cluster_frames`
+~607-640 and the `_finalize` tail) re-checks each subcluster's size, re-enqueues
+the still-oversized ones, and **re-calls `split_oversized_cluster`, rebuilding the
+MST over O(E) edges each time**. Splitting a dense cluster into k pieces is
+**O(E*k)** (#661).
+
+That redundant work is charged against the hard-coded **5M `edge_work` budget**
+(`_split_edge_work_budget`, `:37`): each split call does `edge_work += len(ps)`
+(`:614`), and when `edge_work > 5_000_000` the loop stops and leaves clusters
+oversized, which are then **excluded from golden downstream** (`:32`) -- silently
+losing true-match clusters (#726). A probabilistic matchkey at ~1M rows emits a
+denser edge set -> bigger oversized clusters -> more split passes -> budget blown
+-> 849 clusters dropped (#726's report). #491 (just shipped) makes probabilistic
+selectable, so this now bites real datasets.
+
+**#661 is the root cause; #726 is the symptom + a silent-drop DX hole.**
+
+## Design
+
+### Component 1 -- efficient split: build the MST ONCE (#661 root fix)
+
+Replace the per-call re-MST with a single function that splits a cluster all the
+way down to `max_cluster_size` in ONE MST build:
+
+`split_oversized_cluster_to_size(members, pair_scores, max_size) -> list[dict]`:
+1. Build the MST once (`_build_mst`, or the native MST).
+2. Operate on the n-1 tree edges. Repeatedly: find a component still
+   `> max_size`, cut its **weakest tree edge** (same decision as today), update a
+   union-find over the tree edges. Repeat until no component exceeds `max_size`
+   OR a component has no remaining cuttable tree edge (leave it oversized).
+3. Return all final subclusters (member lists + partitioned pair_scores +
+   confidence), marking `oversized = size > max_size`.
+
+Cost: O(E) for the one MST build + O(tree cuts) -- not O(E*k).
+
+**INVARIANCE (the hard requirement):** this must preserve the EXACT same cut
+decisions as today (cut the weakest edge within each still-oversized component,
+recurse) -- just without rebuilding the MST. It is NOT the issue's looser "remove
+the k weakest tree edges globally" (which could cut inside already-small
+components and change co-clustering). The clustering quality-invariance gate must
+stay byte-identical.
+
+**Native path:** the existing `native_module().mst_split_components` does
+single-edge removal. Component 1 is implemented in PURE PYTHON (build MST once,
+cut tree edges); it does NOT require a Rust kernel change. Keep the native
+single-edge kernel available for any remaining single-split callers, but the
+oversized-split path routes through the new Python batch function. A native-parity
+test already exists (`test_native_parity`) -- ensure it still passes (the batch
+function's per-cut decision matches the kernel's weakest-edge choice).
+
+**Caller change:** the split loop (`build_cluster_frames` ~607-640 and the
+`_finalize` tail) calls `split_oversized_cluster_to_size(...)` ONCE per top-level
+oversized cluster instead of the re-enqueue loop. `edge_work` is charged
+`len(ps)` once per top-level oversized cluster (not per re-split), so the budget
+(#726) is no longer exhausted by redundant MST rebuilds.
+
+### Component 2 -- budget scaling + config (auto-scale AND config field) (#726)
+
+The edge-work budget becomes `max(5_000_000, n_rows * C)` (C default ~5, per the
+issue), with precedence: **explicit config field > `GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET`
+env > auto-scaled default**.
+
+**Threading reality (~5 edit sites, confirmed by review):** `build_clusters` /
+`build_cluster_frames` / `build_clusters_columnar` do NOT receive
+`GoldenRulesConfig` -- the pipeline unpacks loose scalars (`max_cluster_size`,
+`auto_split`, `weak_cluster_threshold`) at `pipeline.py:~1455-1461` and passes them
+to all three call sites (`:1497`, `:1504`, `:1519`). So Component 2 needs: (a) a new
+`split_edge_budget: int | None = None` field on `GoldenRulesConfig`
+(`config/schemas.py:439`, where `auto_split`/`max_cluster_size` live); (b) thread it
++ `n_rows` through the unpack block + the three build functions; (c) change
+`_split_edge_work_budget()` (`:37`) to `_split_edge_work_budget(n_rows, override=None)`
+applying precedence override > env > `max(5M, n_rows*C)`. `n_rows = len(all_ids)`
+is in scope inside `build_cluster_frames` (`:494`) and `_finalize_clusters`. With
+Component 1, exhaustion is rare; this makes the rare case scale-appropriate and
+tunable.
+
+### Component 3 -- loud, non-silent failure (#726 DX)
+
+When the (scaled) budget is GENUINELY exhausted:
+- Upgrade the existing log to a loud, actionable `WARNING`: the count of clusters
+  left oversized AND the knob to raise the budget (config field / env var).
+- **Keep the oversized clusters in the output, flagged** (`cluster_quality`/
+  `oversized` marker) -- do NOT silently drop them. The oversized-clusters-excluded-
+  from-golden behavior itself stays (a 30K-member cluster should not collapse to one
+  golden record), but the loss is now visible and actionable rather than silent.
+- (No exception by default -- partial-but-labeled output beats crashing the whole
+  run over a few dense clusters. Mirrors the "surface, don't silently degrade"
+  lesson from #715 without the hard raise, which the user chose for this case.)
+
+## Out of scope
+- The min-cut quality upgrade (#661 optional: Henzinger 1708.06127 / Karger) --
+  changes co-clustering, breaks the invariance gate, its own project. Deferred.
+- EM non-convergence (#726 hypothesis 3: em_iterations default / last-iter
+  weights) -- a separate probabilistic-scorer concern; Components 1+2 resolve the
+  exhaustion regardless. Parked as a follow-up note on #726.
+
+## Testing and validation
+- **Byte-identical parity backstop (HARD):** the REAL backstop is the
+  function/path parity test family, NOT the manual `scripts/quality_invariant_scale.py`
+  F1 harness (which is a separate doc-level scale check, not an automated
+  co-clustering gate). Component 1's equivalence test EXTENDS
+  `tests/test_columnar_drop_pairscores_parity.py::test_columnar_drop_pairscores_byte_identical`
+  -- it already exercises an oversized-that-splits cluster AND a dense-clique-that-
+  can't-split at `max_cluster_size=5`, asserting members/size/oversized/confidence/
+  bottleneck/cluster_quality byte-identical. Add a dense-multi-split fixture (needs
+  >=3 components) so the batch path's repeated cuts are exercised. This is the
+  mandatory backstop -- the one thing that catches a wrong batch implementation.
+- **Native parity:** `tests/test_native_parity.py::test_split_oversized_cluster_parity`
+  (5 MST-split fixtures incl. tie-scored + dense-clique) must still pass -- the
+  batch path's per-cut weakest-edge decision + first-minimum tie-break must match
+  the native kernel.
+- **Perf (#661):** on the known dense-cluster pathology fixture
+  (`project_build_clusters_dense_split_pathology`), assert the MST is built ONCE
+  per top-level oversized cluster (e.g. instrument `_build_mst` call count, or
+  assert wall/edge_work scales O(E) not O(E*k)). The hang is gone.
+- **Budget (#726):** auto-scale test (`n_rows` large -> budget > 5M); config-field
+  override; env precedence (config > env > default).
+- **Failure mode (#726):** force budget exhaustion (tiny budget + a dense cluster)
+  -> assert the WARNING fires with count + knob AND the oversized clusters are
+  present in the output (flagged), NOT dropped.
+- **Equivalence unit test:** for a dense cluster, `split_oversized_cluster_to_size`
+  returns the same final partition as the old iterative re-split loop (lock the
+  invariance at the function level, not just the gate).
+
+## Risks
+- **Component 1 silently changes co-clustering** (primary). Mitigation: preserve
+  exact per-component-weakest-edge decisions; the quality-invariance gate +
+  function-level equivalence test are the backstops.
+- **Native/Python divergence**: the batch path is Python; ensure decisions match
+  the native kernel's weakest-edge choice (parity test).
+- **Budget scaling makes a genuinely huge dense cluster expensive**: Component 1
+  bounds the split cost; the cap + the loud-warn-and-keep failure mode handle the
+  residual pathological case without a hang.

--- a/docs/superpowers/specs/2026-06-04-goldenembed-rs-finish-line-design.md
+++ b/docs/superpowers/specs/2026-06-04-goldenembed-rs-finish-line-design.md
@@ -1,0 +1,265 @@
+# goldenembed-rs finish-line (#508) — design
+
+**Date:** 2026-06-04
+**Issue:** #508 — *goldenembed-rs: standalone Rust embedding runtime (featurize + ONNX inference)*
+**Status:** approved (brainstorming), spec under review
+
+## Context
+
+The standalone Rust embedding crate already exists and is CI-tested:
+`packages/rust/extensions/goldenembed/` (lib + `goldenembed` CLI, ONNX via
+`ort` 2.0, dedicated CI lane), landed in PR #503. It loads a saved
+`GoldenEmbedModel` directory (`config.json` + `model.onnx`), featurizes text
+with a pure-Rust char-n-gram kernel byte-identical to the Python reference, and
+runs the learned projection head through onnxruntime — no Python, no torch.
+
+The issue's own audit comment (2026-06-04) narrowed the remaining acceptance
+criteria to three independent pieces:
+
+- **(a)** embedding cache — not implemented.
+- **(b)** batch/streaming throughput bench vs the pyo3/native path — absent.
+- **(c)** FFI wiring — nothing actually calls the crate yet; Python
+  `provider="inhouse"` and the SQL embed UDF still embed via CPython.
+
+This spec covers all three as **three independently-shippable stages** plus a
+small parity sub-stage. Each stage is a separate PR-sized unit so review stays
+tractable, matching the repo's staged-plan convention.
+
+### Relevant existing surfaces (verified)
+
+- **Python embed model** — `goldenmatch/embeddings/inhouse/model.py`.
+  `GoldenEmbedModel.model_id` = `f"inhouse:d{dim}:{hex}"` where `hex` is
+  `blake2b(self.weights.tobytes(), digest_size=8)`, with `bias.tobytes()`
+  appended via `h.update(...)` when a bias is present. `save()` writes
+  `weights.npz` (`np.savez`, uncompressed), `config.json`
+  (`dim`, `use_bias`, `featurizer`), and `model.onnx`.
+- **Python cache** — `goldenmatch/embeddings/cache.py`. `EmbeddingCache` is a
+  two-tier mem + optional SQLite cache keyed `(model_id, text_hash)`; values
+  are little-endian `float32` blobs (`<f4`) with `dim` stored alongside.
+- **Cache-key derivation** — `goldenmatch/embeddings/__init__.py`.
+  `normalize_text(text)` = `" ".join(str(text).split()).lower()` (collapse all
+  whitespace runs to single spaces, then lowercase; `None` → `""`).
+  `text_hash(text)` = `hashlib.sha256(text.encode("utf-8")).hexdigest()`. The
+  cache is keyed on the hash of the **normalized** text.
+- **Rust featurizer** — `goldenembed/src/featurizer.rs` already ports the
+  featurizer prepare/lowercase/collapse logic, but its `prepare()` adds
+  boundary chars and is gated on the featurizer `lowercase` config flag. The
+  cache key uses `normalize_text`, which is **independent** of featurizer config
+  — so the cache layer needs its own `normalize_text` port, not a reuse of
+  `prepare()`.
+- **Rust crate deps today** — `ort = "2.0.0-rc.10"`, `blake2`, `serde`,
+  `serde_json`, `anyhow`. Standalone `[workspace]` (isolated from the pyo3
+  crates).
+- **datafusion-udf crate** — `packages/rust/extensions/datafusion-udf/`. A
+  standalone-`[workspace]` cdylib (pyo3 `extension-module` + `abi3-py311`) that
+  registers DataFusion FFI ScalarUDFs and already takes a pure-Rust crate
+  (`goldenmatch-score-core`) by path dep. Adding `goldenembed` by path follows
+  the identical pattern. `datafusion-* = 53`, `arrow = 58`.
+- **goldenembed CI lane** — `.github/workflows/ci.yml` has a `goldenembed` job
+  gated on `packages/rust/extensions/goldenembed/**` path filter
+  (`cargo build` + `cargo test` in the crate dir), wired into the aggregate
+  gate.
+
+## Decisions (locked during brainstorming)
+
+1. **Cache backend = redb** (pure-Rust embedded KV). Cross-language cache
+   sharing with Python's SQLite is an explicit **non-goal** — this is an edge /
+   airgapped runtime; a Rust-only cache file is acceptable and avoids a C
+   sqlite dep.
+2. **model_id parity via npz parse in Rust** — zero Python change. The crate
+   reads `weights.npz`, reproduces the blake2b-8 digest, and formats the same
+   `model_id` string. This keeps cache-namespace semantics identical to Python
+   (a retrained model → fresh cache namespace) and lets the CLI/bench report a
+   model_id consistent with Python.
+3. **Piece (c) = datafusion-udf first**; `postgres gm_embed` is a follow-up
+   issue (pgrx is Linux/CI-only, harder to validate locally; de-risk one
+   surface first).
+4. **Two-tier cache** (in-memory HashMap front + redb disk tier) to mirror the
+   Python mem+disk shape.
+
+## Stage A — redb embedding cache
+
+**New module:** `goldenembed/src/cache.rs`.
+
+**Dependencies added:** `redb` (latest 2.x), `sha2`.
+
+**Parity helpers (exact ports):**
+
+- `normalize_text(text: &str) -> String` — split on Unicode whitespace, join
+  with single spaces, lowercase. Must match Python `normalize_text` on the
+  cache-relevant inputs. Python uses `str.split()` (splits on runs of any
+  whitespace, strips leading/trailing) then `.lower()`. Rust:
+  `text.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()`.
+  (`split_whitespace` uses the Unicode `White_Space` property; Python `split()`
+  uses `str.isspace`. These agree on all ASCII and the common Unicode
+  whitespace set. Known divergence: Python `str.isspace()` treats the C0
+  separators `\x1c`–`\x1f` and `\x85` as whitespace; Rust `split_whitespace`
+  does not. A parity test pins agreement on a representative corpus and
+  **documents which side wins** on those edge bytes rather than asserting
+  universal equality. This is not correctness-critical — a key mismatch only
+  forces a cache miss (re-embed), never a wrong vector — so the Rust behavior is
+  acceptable as-is and only needs to be recorded.)
+- `text_hash(normalized: &str) -> String` — `sha2::Sha256` hex digest of the
+  UTF-8 bytes. Matches Python `text_hash`.
+
+**`EmbedCache`:**
+
+```
+pub struct EmbedCache {
+    mem: HashMap<(String, String), Vec<f32>>,   // (model_id, text_hash) -> vec
+    db: Option<redb::Database>,                  // None => mem-only (ephemeral)
+}
+```
+
+- `EmbedCache::in_memory()` — mem tier only.
+- `EmbedCache::open(path)` — opens/creates a redb file with a single table
+  `embeddings: (&str, &str) -> &[u8]` keyed by a composite
+  `"{model_id}\u{0}{text_hash}"` string (redb supports tuple keys; a delimited
+  string keeps the key type trivial and collision-free since `\u{0}` cannot
+  appear in a hex hash or the model_id format). Value = `f32` slice as
+  little-endian bytes; dim inferred from `bytes.len() / 4` on read.
+- `get(model_id, text_hash) -> Option<Vec<f32>>` — mem first, then redb (and
+  promote into mem on a disk hit, mirroring Python).
+- `put(model_id, text_hash, vec)` — write-through to mem and redb.
+
+**Embed integration:** new method on `GoldenEmbed`:
+
+```
+pub fn embed_cached(
+    &mut self,
+    texts: &[&str],
+    cache: &mut EmbedCache,
+) -> Result<Vec<Vec<f32>>>
+```
+
+Per text: `normalize_text` → `text_hash` → `cache.get(self.model_id(), h)`.
+Collect the **unique misses keyed by `text_hash`** (not raw `&str`), run them
+through a single batched `embed()` call (reusing the existing ONNX path) on the
+normalized text, `put` each result, then re-stack the output in input order by
+hash — exactly the Python dedup shape (`embeddings/__init__.py:110-128`).
+Bounded
+memory: cap the miss batch at a configurable chunk size (default e.g. 4096) and
+loop, so a huge input never materializes one giant feature matrix.
+
+**Tests:** mem-only round-trip; redb persistence across reopen; repeated-text
+dedup; `normalize_text`/`text_hash` parity against committed Python-derived
+digests; `embed_cached` output equals uncached `embed` output.
+
+## Stage A′ — model_id parity (npz parse)
+
+**New module:** `goldenembed/src/model_id.rs`. **Dependency added:** `zip`.
+
+`np.savez` writes a ZIP archive with one **stored (uncompressed)** entry per
+array: `weights.npy` (and `bias.npy` if `use_bias`). The `.npy` format is a
+magic string + version + a header line (dict with `shape`, `descr`,
+`fortran_order`) padded to a 64-byte boundary, then the raw C-order array
+bytes. For a C-contiguous float32 array, those raw bytes are exactly
+`arr.tobytes()` — the same bytes Python blake2b-hashes.
+
+`compute_model_id(dir, dim) -> Result<String>`:
+
+1. Open `<dir>/weights.npz` with the `zip` crate.
+2. Read `weights.npy`, parse the header length, seek past the header to the
+   data section, read the remaining bytes.
+3. `blake2b` digest_size=8 over those bytes (reuse the existing `blake2` dep).
+4. If `bias.npy` exists, read its data section and `update` the same hasher.
+5. Return `format!("inhouse:d{dim}:{hex}")`.
+
+Wire into `GoldenEmbed::load` so `model_id()` is available; the CLI prints it in
+the no-input smoke path (`model loaded: dim=… model_id=…`). If `weights.npz` is
+absent (ONNX-only deployment), `model_id()` returns
+`Err`/`None` and `embed_cached` falls back to a **deterministic** placeholder
+namespace = `format!("onnx:d{dim}:{hex}")` where `hex` is `blake2b`-8 over the
+raw `model.onnx` bytes — so two ONNX-only deployments of the same model still
+share a cache namespace. Documented, since this namespace will **not** match the
+Python `inhouse:…` model_id (cache parity with Python isn't possible without the
+weights), which is fine: Python isn't sharing this redb file anyway.
+
+**Test:** commit a tiny fixture model dir (small dim, few features) generated by
+the Python `save()`, record its Python-computed `model_id`, assert the Rust
+`compute_model_id` matches exactly. Cover both the bias and no-bias cases.
+
+## Stage B — throughput bench
+
+**CLI subcommand:** extend `goldenembed/src/main.rs` to accept a `bench`
+verb: `goldenembed bench --model <dir> [--rows N] [--batch B[,B,...]]`.
+Generates `N` synthetic texts (or reads a file), times `embed()` throughput at
+each batch size, prints rows/sec and p50/p95 per-batch latency. Streams in
+chunks for bounded memory. Argument parsing stays hand-rolled (the crate has no
+clap dep today; keep it dependency-light).
+
+**Comparison harness:** `packages/python/goldenmatch/scripts/bench_goldenembed.py`
+— times the Python `GoldenEmbedModel.embed(..., backend="auto"|"onnx")` path on
+identical input, invokes the Rust `goldenembed bench` (or the CLI embed path)
+on the same texts, and prints a side-by-side table (rows/sec per side) plus a
+parity spot-check (cosine ≈ 1.0 on a sample of rows). Acceptance target from
+the issue: the Rust path beats the pyo3 path on large batches; the script
+reports the ratio rather than hard-asserting (env-dependent), and `log`s the
+runner.
+
+**CI:** a `workflow_dispatch`-only job (repo bench convention; default to
+`large-new-64GB` per `feedback_bench_default_runner`), not in the default lane.
+Builds the crate `--release`, runs `bench`, uploads the table as a job summary.
+
+## Stage C — datafusion-udf embed UDF
+
+**Dependency:** `datafusion-udf/Cargo.toml` gains
+`goldenembed = { path = "../goldenembed" }`.
+
+**New module:** `datafusion-udf/src/embed_udf.rs`.
+
+`goldenmatch_embed(text: Utf8) -> FixedSizeList<Float32, dim>`:
+
+- A `ScalarUDFImpl` struct holding the loaded model. Model directory from the
+  `GOLDENEMBED_MODEL_DIR` env var, loaded once at UDF construction; `dim` from
+  the model fixes the `FixedSizeList` field width in `return_type`.
+- `invoke_batch`: downcast the arg to `StringArray`, collect `&str`s
+  (null → empty string → zero vector, matching Python's None handling), call
+  `embed`, build a `FixedSizeListArray<Float32>` of width `dim`.
+- Registered alongside the existing scalar UDFs in `lib.rs`.
+
+**Spike-first risk (must resolve before building the UDF out):**
+
+1. `ort` 2.0-rc.10 `Session::run` receiver — `&self` vs `&mut self`. This
+   decides whether the model is `Arc<GoldenEmbed>` (shared, lock-free) or
+   `Arc<Mutex<GoldenEmbed>>` (serialized) under DataFusion's parallel batch
+   execution. Resolve by reading the `ort` 2.0-rc.10 API; if `&mut`, use a
+   `Mutex` (correctness over throughput for v1) and note the contention.
+2. onnxruntime binary discovery inside a cdylib loaded by CPython/DataFusion —
+   confirm the `ort` feature flags (e.g. `download-binaries`) the existing
+   `goldenembed` crate relies on still resolve the runtime when the symbol
+   lives in the `datafusion-udf` cdylib. The crate's existing CI lane proves
+   the binary build; the spike confirms the loaded-into-Python case.
+
+If either spike turns ugly, surface it to the user rather than forcing the UDF
+in; Stage C ships only when the spike is green.
+
+**Test:** a smoke test in the datafusion-udf lane — register the UDF against the
+fixture model, embed a 2–3 row table, assert shape `(n, dim)` and that two
+identical inputs produce identical vectors. Parity against the Python embed on
+the same fixture (cosine ≈ 1.0).
+
+## Non-goals
+
+- **Cross-language cache sharing** — redb is Rust-only by deliberate choice.
+- **Python pyo3 wrapper for `provider="inhouse"`** — `goldenmatch-native`
+  already runs the full featurize+project in Rust via `char_ngram_project`, so
+  a second Python↔Rust embed path is redundant.
+- **postgres `gm_embed`** — explicit follow-up issue once the datafusion
+  surface and the `ort` integration story are proven.
+
+## Sequencing
+
+A′ (model_id) is a prerequisite for A's cache key, so land **A′ → A → B → C**.
+A′+A can share one PR (cache is inert without a stable model_id). B and C are
+independent of each other and of A once A′ lands. C is gated on its spike.
+
+## Acceptance (maps to issue)
+
+- `goldenembed` produces vectors matching the Python path within float
+  tolerance — **already met** (PR #503), re-asserted by the Stage B parity
+  spot-check and the Stage C UDF parity test.
+- Embedding cache keyed by `model_id + normalized_text_hash` — **Stage A**.
+- Batch + streaming inference with bounded memory; throughput bench — **Stage B**.
+- Something other than CPython calls the crate (SQL embed via the Rust UDF) —
+  **Stage C**.

--- a/docs/superpowers/specs/2026-06-08-fs-per-rule-em-design.md
+++ b/docs/superpowers/specs/2026-06-08-fs-per-rule-em-design.md
@@ -1,0 +1,188 @@
+# Fellegi-Sunter per-rule EM (within-block-aware m-estimation) — design
+
+**Date:** 2026-06-08
+**Status:** Approved design, pre-plan
+**Scope:** GoldenMatch probabilistic (Fellegi-Sunter) `train_em` m-estimation only.
+**Parent effort:** Probabilistic → Splink parity. Builds on the already-shipped
+sigmoid normalization, TF adjustments, and multi-pass union blocking
+(branch `feat/probabilistic-splink-parity`). This is the deepest scoring lever,
+re-brainstormed after sigmoid+un-exclusion+TF recovered recall but not precision.
+
+## Problem
+
+On `historical_50k` (Splink's home-turf bio dataset), the probabilistic path —
+even with sigmoid match-probability + term-frequency adjustments + multi-pass union
+blocking — has **precision ~0.1** (PR-curve best F1 ~0.19). Measured root cause:
+GoldenMatch runs a **single global EM** over the union of all within-block pairs,
+holding the *union* of blocking fields constant. Splink's own docs name this exact
+failure: *"when we block on first name and surname, we can't get parameter estimates
+for these two columns because we've forced all comparisons to be equal."*
+
+The consequence is not just the (expected, Splink-shared) large weight on name
+agreement — it is **corrupted `m`-estimates for the OTHER fields**. Because the
+inflated name-agreement weight dominates the EM E-step posteriors, within-block
+non-matches look like matches, so EM over-estimates `m[disagree]` for the
+discriminating fields. Result: disagreement penalties are far too weak
+(`postcode_fake` disagree weight = **−0.06**, where a sound estimate is ≈ **−3**).
+With weak penalties, a same-name/different-person pair scores almost as high as a
+true match → precision collapse, and **no threshold separates them** (PR curve flat).
+
+## Approach (grounded in Splink's documented methodology)
+
+Splink estimates parameters with:
+1. `u` from **random sampling** (two random records are ~never a match) — GoldenMatch
+   already does this; keep it.
+2. `m` via **EM run once per blocking rule**. Each run blocks on rule `R`; the columns
+   in `R` are held constant (no `m` estimate for them in that run), and the OTHER
+   columns vary, so their `m` is estimated cleanly. Run across multiple rules so every
+   comparison is estimated in at least one run where it is free.
+3. Combine: a comparison's `m` is the **average** of its estimates across the runs that
+   estimated it (Splink: *"Under the hood, Splink will take an average."*).
+4. Term-frequency adjustment (per-value `u`) and the sigmoid match-probability layer on
+   top — both already shipped.
+
+This fixes the corrupted-posterior root: every field's `m` is learned from pairs where
+that field actually varies, restoring strong disagreement penalties.
+
+## Design
+
+### 1. Per-rule EM in `train_em` (`core/probabilistic.py`)
+New signature accepts the **list of blocking passes**, each carrying its field-set and
+its within-block pairs (or its blocks), instead of a single flat `blocks` list +
+single `blocking_fields` set.
+
+```
+estimate u[field][level]  from random pairs            # unchanged (_sample_pairs)
+m_runs: dict[field -> list[per-run m vectors]]
+for pass P with field-set F_P and within-P-block pairs S_P:
+    estimated_fields = [f for f in mk.fields if f.field not in F_P]
+    run the existing EM loop over S_P, updating m ONLY for estimated_fields
+    for f in estimated_fields: m_runs[f.field].append(this run's m[f])
+for each field f:
+    if m_runs[f]:  m[f] = elementwise mean over m_runs[f]      # Splink average
+    else:          m[f] = fallback prior (field constant in every pass)   # logged
+match_weight[field][level] = log2(m/u)     # then TF (per-value u), then sigmoid downstream
+```
+
+- The per-pass EM is the existing vectorized EM loop, parameterized by
+  `estimated_fields` (fields in `F_P` are skipped in the M-step — they're constant in
+  `S_P`, exactly as the single-run code already skips `blocking_fields`).
+- **u is shared** across runs (random-sampling, computed once). **Drop the current
+  neutral-`u` override for blocking fields** (`train_em` today forces
+  `u=[0.50,0.50]`/`[0.34,...]` for `blocking_fields`). That override existed only to
+  support the old wholesale fixed-weight treatment; under per-rule EM, random-sampling
+  `u` is the correct, unbiased non-match agreement rate for *every* field (including ones
+  that are a block key in some pass — random pairs reflect their true collision rate).
+  So estimated fields use `log2(m̄/u_random)` with `u` from random sampling; only the
+  always-blocked fallback fields keep fixed weights (where `u` is moot). This decision
+  affects every weight and must be pinned by a test (a sometimes-blocked field's `u`
+  equals its random-pair estimate, not `0.50`).
+- **Combine = simple elementwise mean** of the per-run `m` vectors for each field
+  (Splink's documented average). A sample-size-weighted mean is a possible refinement;
+  start with the simple mean (matches Splink), note the option.
+- **Min-sample guard (precise semantics):** a pass whose sampled within-block pairs fall
+  below the existing `len(pairs) < 10` floor is **skipped for estimation only** — it
+  contributes **no** `m_runs` entries and the loop continues to the next pass (logged).
+  This is distinct from today's `< 10` floor, which returns a full `_fallback_result`.
+  Only when **every** pass is below the floor (or the random-pair sample for `u` is
+  `< 10`) do we return `_fallback_result` (the existing whole-model fallback).
+- **Fallback for a field, not the model:** a field is held constant in `F_P` for *every*
+  pass → `m_runs[field]` is empty → it keeps the current fixed neutral prior
+  (`[-3,0,3]`-style), logged. **The `m_runs[field]` non-empty check is the mechanical
+  successor to the old `_em_excluded_fields` intersection** (which this design retires):
+  a field free in *any* pass MUST be estimated (from that pass), NOT given the fixed
+  prior — reintroducing the fixed prior for a sometimes-free field is exactly the
+  over-exclusion that previously halved recall, so the per-field check must gate on "was
+  it estimated in ≥1 run", never on "was it a blocking field in some pass." Under
+  multi-pass union, almost every field is free in some pass; under a single static key,
+  the one key is constant in the (only) pass → fixed prior (same as today).
+
+### 2. Pipeline wiring (`core/pipeline.py`, both branches)
+Both `train_em` call sites (dedupe ~1417, match ~2388) must supply per-pass structure.
+Build per-pass blocks by running the existing static-block builder once per pass (reuse
+`_build_multi_pass_blocks`'s per-pass loop, but retain pass identity → `(F_P, blocks_P)`
+tuples) and pass that list to `train_em`. Retire the `_em_excluded_fields` single-set
+call — per-rule exclusion supersedes it. For a single static-key config there is one
+pass → one EM run holding that key fixed → behavior equivalent to today.
+
+### 3. Default + kill-switch
+Per-rule EM is the new default. `GOLDENMATCH_FS_PER_RULE_EM=0` restores the **current
+branch default** — single-run `train_em` with the `_em_excluded_fields` *intersection*
+exclusion (NOT a hypothetical single-static config) — for A/B and rollback. Repo
+convention for behavior changes (mirrors `GOLDENMATCH_FS_SIGMOID`). The equivalence test
+must pin the kill-switch path against that exact current intersection behavior.
+
+### 4. `EMResult` unchanged
+The return shape (`m_probs`, `u_probs`, `match_weights`, `tf_tables`, `converged`,
+`iterations`, `proportion_matched`) is unchanged, so `score_probabilistic`,
+`score_probabilistic_fast`, `score_pair_probabilistic`, the TF tables, and the sigmoid
+layer are all untouched. This change is isolated to *how `m` is estimated*.
+
+## Measurement gate
+
+Measured locally via the **surviving-dump PR-curve method** (score a candidate sample
+with the trained EM; no clustering → no OOM), on `historical_50k` + febrl3 + synthetic:
+
+- **Primary (mechanism):** disagreement penalties strengthen — on a fixture where
+  matches agree on a discriminating field (e.g. postcode), that field's disagree weight
+  is meaningfully negative (≤ −1.5), vs the current −0.06.
+- **Headline:** `historical_50k` reaches a PR operating point with **F1 materially >
+  0.655 baseline** — target precision ≥ ~0.8 at recall ≥ ~0.7 (the Splink-class regime
+  the diagnostic showed is reachable if disagreements bite).
+- **Non-regression:** febrl3 (≈0.99) and synthetic do not drop.
+
+## Kill criterion
+
+If per-rule EM strengthens the disagreement penalties (primary metric improves) but
+`historical_50k` precision still collapses on the PR curve, the remaining wall is
+**blocking-candidate quality** (the 35:1 candidate ratio from broad orthogonal passes).
+Stop and re-sequence to **selective compound blocking** before any further EM work.
+
+## Testing
+
+- **Per-rule estimation:** a field held constant in pass A but free in pass B gets its
+  `m` from B (assert `m_runs` provenance / the resulting weight reflects B's data).
+- **Averaging:** a field free in two passes gets the elementwise mean of the two `m`
+  vectors.
+- **Disagreement-penalty behavioral test:** on a synthetic where matches reliably agree
+  on a discriminating field and non-matches don't, per-rule EM yields a clearly negative
+  disagree weight for that field (and the old single-run EM yields a near-zero one) —
+  the direct precision-mechanism guard.
+- **Fallback:** a field blocking-constant in every pass → fixed neutral prior, logged.
+- **Single-static-key equivalence:** one pass → one EM run → result equivalent to the
+  pre-change single-run EM on that key (within tolerance) — backward-compat guard.
+- **Kill-switch:** `GOLDENMATCH_FS_PER_RULE_EM=0` restores the single-run path
+  byte-for-byte.
+- **`EMResult` shape unchanged:** downstream scoring/TF/fast-path tests stay green.
+- Both `train_em` call sites updated; pipeline runs end-to-end on a small fixture.
+
+## Scope / out of scope
+
+- **In:** `train_em` per-rule restructure + averaging + fallback + min-sample guard; the
+  two pipeline call sites; the kill-switch.
+- **Out (separate, sequenced after the gate):** selective compound blocking (lever #3);
+  threshold auto-calibration beyond the sigmoid default; sample-weighted m-combination;
+  TS parity. CI/Splink head-to-head panel + the branch rebase/merge remain a follow-up.
+- **Explicitly NOT covered: `train_em_continuous`** (the Winkler/Gaussian variant). It
+  has the same single-global-EM structure and would benefit from the same per-rule
+  treatment, but it is opt-in, rarely used, and out of scope here — do not scope-creep
+  into it. The kill-switch + tests target the discrete `train_em` only.
+
+## Risks & mitigations
+
+- **Compute:** N passes × EM iterations. Mitigate by sampling per pass (existing
+  `n_sample_pairs` cap) and the min-sample guard; passes are independent (could
+  parallelize later, not now).
+- **Thin per-pass match signal → noisy `m`:** averaging across passes + the min-sample
+  guard; a pass below the floor contributes nothing rather than noise.
+- **Candidate-quality wall persists:** the kill criterion catches it and redirects to
+  selective blocking.
+
+## Affected files (anticipated)
+
+- Modified: `core/probabilistic.py` (`train_em` per-rule restructure + combine +
+  fallback + kill-switch helper), `core/pipeline.py` (both branches: per-pass block
+  construction + new `train_em` call; retire `_em_excluded_fields`).
+- New tests: `tests/test_probabilistic_per_rule_em.py`.
+- Reused: the local PR-curve diagnostic method (`.profile_tmp/diag_pr_tf.py` shape) for
+  the measurement gate.

--- a/docs/superpowers/specs/2026-06-08-probabilistic-splink-parity-design.md
+++ b/docs/superpowers/specs/2026-06-08-probabilistic-splink-parity-design.md
@@ -1,0 +1,342 @@
+# Probabilistic matching → Splink parity (design)
+
+**Date:** 2026-06-08
+**Status:** Approved design, pre-plan
+**Scope:** GoldenMatch probabilistic (Fellegi-Sunter) matching path only. Zero change to
+the weighted/exact default paths.
+**Workstream:** First of a planned pair — this cycle is *probabilistic accuracy*.
+Perf optimization and bio/product-domain scoring are deferred to later cycles.
+
+## Problem
+
+GoldenMatch's probabilistic engine already implements the Splink *core*: u-fixed-from-
+random-pairs EM, `log2(m/u)` match weights, 2/3/N comparison levels, and a Winkler
+continuous extension (`core/probabilistic.py`, `core/probabilistic_fast.py`). It is
+nonetheless "not Splink level" on accuracy.
+
+The decisive evidence (from `packages/python/goldenmatch/CLAUDE.md` Accuracy Strategy):
+
+> **Fellegi-Sunter: 98.8% precision, 57.6% recall, 72.8% F1 on DBLP-ACM.**
+
+That is a textbook **recall-bound** profile. Recall that low is almost always *candidate
+pairs never generated* (blocking), not *pairs scored and rejected* (threshold). The two
+levers GoldenMatch is missing versus Splink:
+
+1. **No multi-rule union blocking.** Splink generates candidates from a *union* of
+   blocking rules (~0.99 pair coverage); GoldenMatch's probabilistic path rides
+   single-key bucket blocking (~0.94). This is the recall lever.
+2. **No term-frequency adjustments.** Splink's signature accuracy feature: a match on a
+   rare value carries far more evidence than a match on a common one. GoldenMatch's
+   `comparison_vector()` is level-only — every exact-agree weighs identically. This is
+   the precision/discrimination lever.
+
+A third, lesser gap: the probabilistic path is non-iterative (no controller, no
+threshold-calibration loop). Out of scope for this cycle; revisit only if the harness
+says threshold loss dominates.
+
+## Success criterion
+
+A multi-benchmark **gate panel anchored on Splink's home-turf `historical_50k`** dataset
+(Wikidata-derived biographical historical-people set, with `cluster` ground-truth
+labels — the dataset Splink's own docs tune and demo on). The panel also covers DBLP-ACM,
+Febrl3, NCVR, and the existing synthetic head-to-head set, every row GoldenMatch-vs-Splink
+on identical data.
+
+Concrete gate values are **fixed after the first baseline run, not invented now**:
+- **Headline:** `historical_50k` F1 ≥ Splink − ε on the same data.
+- **Recall hole:** DBLP-ACM recall up materially from 57.6% with precision ≥ ~0.95.
+- **Non-regression:** Febrl3 + NCVR + head-to-head do not drop.
+
+## Approach: C → A
+
+Build the diagnostic harness first (C), use it to confirm the recall is
+blocking-dominated, then ship the two levers in attribution-justified order (A):
+
+```
+Stage 0 (C)  Diagnostic gate panel        — the success criterion + the microscope
+Stage 1 (A1) Multi-rule union blocking    — the recall lever
+Stage 2 (A2) Term-frequency adjustments   — the precision/discrimination lever
+```
+
+Each stage is independently shippable. Stages 1–2 are gated by the Stage 0 harness, and
+the harness can **overrule the plan ordering** (see Kill criteria).
+
+---
+
+## Stage 0 — Diagnostic gate panel
+
+The proof target *and* the instrument that localizes where recall dies.
+
+**DRY: extend the existing `scripts/bench_er_headtohead/` directory** rather than create a
+parallel `scripts/bench_probabilistic/`. That dir already has `evaluate.py` (pairwise
+P/R/F1 + B³ via a DuckDB contingency table), `run_splink.py`, `run_goldenmatch.py`, and
+`orchestrate.py`. New Stage-0 files are added there and reuse `evaluate.py` verbatim.
+
+### 0a. Dataset loaders — `scripts/bench_er_headtohead/datasets.py`
+- `historical_50k` — loaded via `splink_datasets.historical_50k` when `splink` is
+  installed, else from a vendored parquet in the gitignored
+  `tests/benchmarks/datasets/`. **Headline dataset.**
+- Adapters presenting DBLP-ACM, Febrl3, NCVR (existing loaders under `tests/benchmarks/`)
+  and the head-to-head synthetic person set in the common `{record_id, …fields}` +
+  truth `{record_id, cluster_id}` shape `evaluate.py` already consumes.
+
+### 0b. Recall attribution instrument — `scripts/bench_er_headtohead/attribution.py`
+The new diagnostic. For any labeled dataset, decompose recall into the three places a
+true pair can die:
+
+| Metric | Definition |
+|---|---|
+| `blocking_recall` | (GT pairs surviving candidate generation) / (all GT pairs) — the ceiling |
+| `threshold_loss` | (candidate∩GT − emitted∩GT) / (all GT pairs) — pairs scored but rejected |
+| `final_recall` | emitted∩GT / (all GT pairs) |
+
+A run reports e.g. "recall 57.6% = blocking ceiling 61% − 3.4% threshold loss" → blocking
+is the wall; or the opposite. This makes Stage 1-vs-2 prioritization evidence-based, and
+is what the kill criteria read.
+
+### 0c. Splink baseline runner
+Extend `scripts/bench_er_headtohead/run_splink.py` to cover `historical_50k` and emit the
+same `{P, R, F1, B³}` shape, so every panel row is apples-to-apples.
+
+### 0d. Gate runner + CI
+`scripts/bench_er_headtohead/run_panel.py` runs the full panel for both engines, writes a
+markdown comparison table + JSON. `.github/workflows/bench-probabilistic.yml` is
+`workflow_dispatch` only. `splink` stays an **optional, bench-only dep** (heavy, pulls
+DuckDB) — never in the shipped wheel; declared in a `[bench]` extra.
+
+---
+
+## Stage 1 — Multi-rule union blocking (recall lever)
+
+Give the probabilistic path Splink-style union-of-rules candidate generation.
+
+**DRY discovery (verified in source).** Multi-pass union blocking *already exists* and the
+probabilistic path *already routes through it*:
+- `BlockingConfig.passes: list[BlockingKeyConfig]` + `strategy="multi_pass"` →
+  `core/blocker.py::_build_multi_pass_blocks` runs each pass and unions blocks, deduped by
+  `block_key`.
+- The probabilistic pipeline branch calls `build_blocks(combined_lf, config.blocking)`
+  (`pipeline.py:1336`), so a `multi_pass` config flows straight in.
+- Pair-level dedup across passes is handled by the pipeline's `matched_pairs` exclude set
+  (`pipeline.py:1389-1390`).
+
+So Stage 1 builds **no new module and no new config field** (the spec's earlier
+`MatchkeyConfig.blocking_rules` / `core/probabilistic_blocking.py` idea is superseded by
+reuse). The actual work is three smaller pieces:
+
+### 1a. Fix the latent EM `blocking_fields` bug (correctness — do FIRST)
+At the train_em call site (`pipeline.py:1337-1340`) `blocking_fields` is collected from
+`config.blocking.keys` **only**. Under `strategy="multi_pass"` the fields live in
+`config.blocking.passes`, so `blocking_fields` comes back **empty** → EM tries to learn
+m/u for fields that are agree-by-construction within every pass's blocks → the exact
+m/u collapse the module docstring warns about. Fix: collect the **union of fields from
+both `keys` and `passes`**. This must land before 1b or the recall win is poisoned by a
+scoring regression.
+
+### 1b. Probabilistic auto-config emits a capped multi-pass config
+Add `_build_probabilistic_blocking(profiles, df)` and call it from
+`auto_configure_probabilistic_df` (replacing the single-strategy `build_blocking` call for
+this path). It derives a small pass set from column profiles: 2-field conjunctions of
+identity-ish fields (high `identity_score`, moderate cardinality) plus single
+high-cardinality keys, **capped at ~4 passes** (Splink's typical count) to bound the pair
+budget, and sets `strategy="multi_pass"`, `skip_oversized=True`, and a sane
+`max_block_size`. An explicit user `blocking` config always wins.
+
+### 1c. Per-pass block-size guard
+`_build_multi_pass_blocks` already forwards `max_block_size` + `skip_oversized` to
+`_build_static_blocks` per pass. Stage 1b sets `skip_oversized=True` so a pass that
+produces a mega-block (shared null, "info@") is dropped, not scored. A test asserts a
+mega-block pass is excluded while the other passes still contribute. (If
+`_build_static_blocks` truncates rather than skips on `skip_oversized`, add the skip there.)
+
+### 1d. EM neutral-prior approximation (record, don't fix)
+Treating the union of all pass fields as `blocking_fields` is a **conservative
+approximation, not an identity**: a field that anchors pass A is not agree-by-construction
+in pairs generated only by pass B, yet it gets neutral priors everywhere. Conservative
+(never produces wrong merges) but leaves some discrimination on the table. Splink's full
+per-comparison `u` handling is a deliberate non-goal this cycle — recorded so nobody chases
+a "why isn't this field exactly agree" discrepancy.
+
+### 1e. Stopping rule
+Stage 0's attribution reports the `blocking_recall` ceiling each added pass buys. Stop
+adding passes when the ceiling stops moving — not blindly.
+
+---
+
+## Stage 2 — F-S scoring core (REVISED 2026-06-08; supersedes the TF plan below)
+
+**Pivot driven by the Stage-1 attribution + a score-distribution diagnostic on
+`historical_50k`.** After Stage 1 raised the blocking ceiling to 0.83, F1 *fell*
+(0.655→0.585): the scorer rejected half the new candidates (threshold_loss 0.49). The
+diagnostic (`.profile_tmp/diag_score_dist.py`) found the cause is NOT the missing TF
+adjustments — it is two F-S scoring-core flaws:
+
+1. **Min-max normalization is pathological.** `score_probabilistic` /
+   `score_probabilistic_fast` / `score_pair_probabilistic` map the summed log2-Bayes
+   weight to [0,1] via `(W − min)/(max − min)`. One high-variance EM weight
+   (`postcode_fake` ≈ +31.63 on rare values) blows up the range so a pair agreeing on all
+   five name fields scores 0.45 < the 0.5 threshold → rejected. **Fix: Splink-style sigmoid
+   match-probability** `P = 1/(1 + 2^(−W))` (W is already the sum of log2 Bayes factors).
+   Measured: same weights, t=0.5 recall 0.329 (min-max) → **0.655 (sigmoid)**.
+2. **Wholesale blocking-field exclusion neuters the strongest fields.** `train_em`
+   excludes every blocking-pass field (fixed `[-3,0,3]` priors). Under *multi-pass union*
+   blocking a field varies across passes, so EM *can* train it. Stage 1's orthogonal passes
+   pulled name components into the blocking set → names neutered. **Fix: exclude only fields
+   agree-by-construction in EVERY pass (the intersection of pass field-sets), not the union**
+   — usually empty under union blocking. Measured: no-exclusion + sigmoid → recall **0.828
+   @t=0.5 and 0.788 @t=0.95** (≈ the full ceiling at a high-precision threshold ⇒ F1 0.585 →
+   ~0.85, the Splink trajectory).
+3. **Threshold calibration.** Sigmoid makes the threshold a real match-probability;
+   `compute_thresholds`/default link_threshold must be sigmoid-aware (a 0.5 min-max default
+   ≠ a sensible match-probability default).
+
+### Revised design
+- **2a. Sigmoid match-probability.** Replace the min-max final step in `score_probabilistic`,
+  `score_probabilistic_fast`, and `score_pair_probabilistic` with `1/(1+2^(-W))`. Default-on,
+  env kill-switch `GOLDENMATCH_FS_SIGMOID=0` restores min-max (repo convention for behavior
+  changes). The three paths must stay in parity (fast == slow under sigmoid).
+- **2b. Union-aware EM exclusion.** The EM-excluded set = intersection of pass field-sets
+  (fields in EVERY candidate-generation pass), treating `keys` as one pass when `passes` is
+  absent. Single static key → that key excluded (unchanged); multi-pass union → ~nothing
+  excluded (names train). Revises Task 1.1's union semantics (which over-excluded).
+- **2c. Sigmoid-aware thresholds.** `compute_thresholds` + the probabilistic default
+  link_threshold become match-probability values (e.g. ~0.9 link), refined by measurement on
+  the panel.
+
+### Success bar (unchanged target, now concrete)
+`historical_50k` F1 materially > the 0.655 Stage-0 baseline (target ≈ Splink-class), with
+precision held (confirm at a high match-probability threshold); febrl3/synthetic/dblp_acm
+non-regression. Verify precision-at-threshold during implementation (the diagnostic scored
+only GT pairs).
+
+### TF demoted
+Term-frequency adjustments are now an **optional follow-up**, not this cycle (the data
+already uses `name_freq_weighted_jw` similarity scorers; sigmoid + un-exclusion capture the
+dominant gap). The original TF design is retained below for the record, superseded by 2a–2c.
+
+---
+
+## (SUPERSEDED) Stage 2 — Term-frequency adjustments (discrimination lever)
+
+Make the top (exact-agree) level value-aware, the way Splink does.
+
+### 2a. The math
+For a TF-enabled field, replace the level's population-average `u` with the value-specific
+`u_v` at the exact-agree level. Use Splink's **scale-the-base** form, centered so a value
+of *average* frequency lands on the base weight:
+```
+freq(v)   = count(v) / N                 # relative frequency of the shared value
+freq_avg  = 1 / n_distinct               # mean relative frequency over distinct values
+u_v       = u_exact * ( freq(v) / freq_avg ) = u_exact * freq(v) * n_distinct
+u_v       = clamp(u_v, TF_MIN_U, TF_MAX_U)
+weight_exact(v) = log2( m_exact / u_v )
+```
+Sign check (this is the trap — get it right): rarer value ⇒ `freq(v) < freq_avg` ⇒
+`u_v < u_exact` ⇒ **larger** positive weight. Average-frequency value ⇒ `u_v == u_exact`
+⇒ base weight (TF is a no-op there). Common value ⇒ `u_v > u_exact` ⇒ weight collapses
+toward / below base. Partial/disagree levels are unchanged (TF only sharpens exact
+agreement).
+
+**This is the mandated formula** — "rarer ⇒ larger weight" is satisfiable by several
+non-equivalent expressions (raw-frequency replacement `u_v = freq(v)` vs this scale-the-base
+form); the scale-the-base form keeps the non-TF default as the centered case. The
+monotonicity test guards the sign; this formula fixes the exact relationship.
+`TF_MIN_U`/`TF_MAX_U` are module constants (env-overridable) that bound the hapax /
+huge-value extremes.
+
+### 2b. Implementation
+- Precompute per-field relative-frequency tables from the prepared data (Polars
+  `value_counts` → normalized dict), stored on a new
+  `EMResult.tf_tables: dict[str, dict[str, float]] | None` field.
+- **Clamp** like Splink: `u_v` floored/capped (`tf_min_u`, `tf_max_u`) so a hapax value or
+  a tiny sample cannot produce an unbounded weight.
+- Scoring carries the shared value for TF fields: extend the score path to look up `u_v`
+  for the exact-agree level and recompute that field's contribution; non-TF fields and
+  non-exact levels untouched.
+- **Fast path** (`probabilistic_fast.py`): extend the pre-resolved spec with the frequency
+  lookup table for TF fields (a dict lookup, fully vectorizable). Fall back to slow path
+  only if a TF field is model-backed.
+
+### 2c. Config + auto-config
+- `tf_adjust: bool` per `MatchkeyField` (default `False`). Auto-config enables it for
+  high-skew identity fields (name-like, where `value_counts` shows Zipfian skew) — exactly
+  the fields where Splink gets its lift.
+
+### 2d. Parity scope
+Python first. TS port (`probabilistic.ts`) and the `EMResult` schema sync are an explicit
+**follow-up**, not in this cycle (keeps the loop tight; matches how prior probabilistic
+work landed Python-first).
+
+---
+
+## Testing
+
+### Stage 0
+- Attribution math on a hand-built labeled fixture where the blocking-vs-threshold split
+  is known by construction (e.g. 10 GT pairs, 3 deliberately un-blockable →
+  `blocking_recall` must read 0.7).
+- Loader smoke tests `pytest.skip` cleanly when `splink`/datasets absent (the repo's
+  gitignored-dataset pattern).
+
+### Stage 1
+- Union dedup correctness: overlapping rules produce each canonical pair exactly once.
+- Block-size guard: a rule with a mega-block is dropped + warned, not truncated; other
+  rules still contribute.
+- Backward compat: `blocking_rules=None` reproduces today's candidate set byte-for-byte.
+- EM `blocking_fields` now covers the union of rule fields.
+
+### Stage 2
+- Weight monotonicity: same field+level, rarer shared value ⇒ strictly larger weight.
+- Clamp: a hapax value's weight is bounded by `tf_max_u`.
+- Fast-vs-slow parity *with TF on* (within rapidfuzz tolerance) — extends the existing
+  parity test.
+- `tf_adjust=False` is byte-identical to the pre-change scorer.
+
+## Kill criteria
+
+- **After Stage 0:** if attribution shows recall is *not* blocking-dominated
+  (`threshold_loss` ≫ the blocking-ceiling gap), re-sequence — TF/calibration before union
+  blocking. The harness overrules the plan.
+- **After Stage 1:** if union blocking lifts the `blocking_recall` ceiling but final F1
+  does not follow, the wall is scoring/threshold → Stage 2 carries the work; stop piling
+  on blocking rules.
+
+## Risks & mitigations
+
+- **Splink as bench dep** — heavy (DuckDB), version-sensitive. → optional `[bench]` extra,
+  `workflow_dispatch` only, never in the wheel.
+- **`historical_50k` provenance** — Wikidata-derived, ships with Splink (MIT). → vendor to
+  the gitignored datasets dir; loader prefers `splink_datasets`, falls back to URL fetch.
+- **Pair-budget blow-up** from union blocking — this is where accuracy work touches the
+  deferred *perf* workstream. → bounded by the per-rule block-size guard + the ≤4-rule cap.
+- **Fast-path divergence** — TF must stay on the vectorized path or it silently falls back
+  to slow scoring at scale. → the fast-vs-slow parity test (TF on) is a hard gate.
+
+## Out of scope (explicit)
+
+- Perf optimization (native clustering/golden, driver-side materialization) — next cycle.
+- Bio/product domain-aware scorers (unit/dosage comparators, identifier checksums) — next
+  cycle.
+- TS parity for TF adjustments — follow-up after Python lands.
+- Probabilistic threshold-calibration loop / controller integration — only if Stage 0
+  attribution says threshold loss dominates.
+
+## Affected files (anticipated)
+
+- New: `scripts/bench_er_headtohead/{datasets,attribution,run_panel}.py`,
+  `.github/workflows/bench-probabilistic.yml`, test modules under `tests/`.
+- Modified:
+  - `core/pipeline.py` — `blocking_fields` collected from `keys` **and** `passes` (Stage 1a).
+  - `core/autoconfig.py` — `_build_probabilistic_blocking` (multi-pass derivation, Stage 1b)
+    + `tf_adjust` enable in `build_probabilistic_matchkeys` (Stage 2c).
+  - `core/probabilistic.py` — `EMResult.tf_tables`, TF table computation in `train_em`,
+    TF-aware scoring in `score_probabilistic` / `score_pair_probabilistic` (Stage 2).
+  - `core/probabilistic_fast.py` — TF freq table in the resolved spec + TF-aware top-level
+    scoring (Stage 2b).
+  - `config/schemas.py` — `MatchkeyField.tf_adjust: bool = False` (Stage 2c).
+    **No `MatchkeyConfig.blocking_rules`** — Stage 1 reuses `BlockingConfig.passes`.
+  - `core/blocker.py` — only if `_build_static_blocks` needs a `skip_oversized` skip
+    (Stage 1c; likely already honored).
+  - `scripts/bench_er_headtohead/run_splink.py` + `run_goldenmatch.py` — `historical_50k`
+    + dataset arg (Stage 0).
+  - `pyproject.toml` — `[bench]` optional extra (`splink`, dataset deps).

--- a/docs/superpowers/specs/2026-06-08-selective-compound-blocking-design.md
+++ b/docs/superpowers/specs/2026-06-08-selective-compound-blocking-design.md
@@ -1,0 +1,253 @@
+# Selective compound blocking (probabilistic path) -- design
+
+**Date:** 2026-06-08
+**Status:** Approved design, pre-plan
+**Scope:** GoldenMatch probabilistic (Fellegi-Sunter) auto-config blocking only
+(`core/autoconfig.py::_build_probabilistic_blocking`).
+**Parent effort:** Probabilistic -> Splink parity. This is **lever #3**, the
+kill-criterion redirect from the per-rule EM work
+(`2026-06-08-fs-per-rule-em-design.md`). Builds on the already-shipped sigmoid
+normalization, TF adjustments, union-aware EM exclusion, multi-pass union
+blocking, and per-rule EM on branch `feat/probabilistic-splink-parity`.
+
+## Problem
+
+Per-rule EM (lever just landed) is a validated scoring lever -- it strengthens
+disagreement penalties (proven on febrl3 +0.6pp F1 and synthetic +1.5pp F1, no
+regression) and fixes the corrupted-m root cause. But it does NOT rescue
+`historical_50k`, and the measurement gate fired the **kill criterion**: the
+residual wall is **blocking-candidate quality**, not scoring.
+
+Measured (dump PR-curve method, single-run vs per-rule on the same candidate
+sample):
+- `historical_50k` candidate pool = **8,844,485 pairs** for **303,961** ground-truth
+  pairs. Emitting ALL candidates caps precision at `303961 / 8844485 = 3.4%`.
+- per-rule BEST F1 = 0.058 (P=0.031, R=0.461); single-run BEST F1 = 0.077.
+  Precision never exceeds ~4% at any threshold; no P>=0.8 @ R>=0.7 operating point
+  exists. The scorer is now correct; it simply cannot produce high precision from
+  a candidate set that is 96.6% noise.
+
+Root cause of the flood: `_build_probabilistic_blocking` augments
+`build_blocking`'s transform-rich name passes with **broad single-key** orthogonal
+passes (e.g. `[birth_place]`, `[full_name]`, `[surname]`). Each generates huge
+blocks because many people share a name or birthplace, and the within-block
+non-matches share the blocking field by construction. Splink instead uses more
+**selective compound rules** (conjunctions of 2+ fields) unioned across several
+complementary passes.
+
+## Approach (grounded in Splink's blocking methodology)
+
+Redesign `_build_probabilistic_blocking` to select a union of passes under an
+**explicit candidate budget**, using a **coverage-per-candidate set-cover**
+objective that favours selective compound conjunctions while protecting recall:
+
+1. **Generate a candidate POOL** of passes: the transform-rich name passes
+   (recall-bearing) + **compound variants** (name component with its transforms,
+   conjoined with an orthogonal selective field, optionally coarsened) +
+   self-selective orthogonal single-keys.
+2. **Estimate per-pass cost + coverage:** exact candidate count via a groupby
+   (`sum C(block_size, 2)`); a (sampled, cost-capped) set of canonical record-pair
+   ids for the coverage signal.
+3. **Select within budget** `K x N` deduped-union candidate pairs via greedy
+   set-cover on marginal `|new_pairs| / candidate_cost`, always emitting at least
+   one name-bearing pass (recall anchor).
+
+This cuts the redundant noise that floors precision while the coverage objective
+keeps the GT-bearing, complementary passes -- exactly the precision-ceiling lift
+the gate needs, with recall protected by the set-cover objective rather than by
+exempting passes.
+
+## Design
+
+### 0. Enabling change: per-field transforms in `BlockingKeyConfig`
+
+The current blocker (`blocker.py::_build_block_key_expr`) applies a key's single
+`transforms` list UNIFORMLY to every field in the key, then concatenates. That
+cannot express the central selective compound `[soundex(surname), birth_year]`
+(soundex on a date is meaningless; year-coarsening a surname is wrong). Without
+per-field transforms a compound is forced to be either bare/uniform (selective but
+recall-brittle to a name typo) or to lean on a broad standalone `[soundex(surname)]`
+pass that the candidate budget likely cannot afford -- collapsing recall. The
+transform-rich compound (selective AND typo-robust on the name) is what clears the
+gate, so it must be expressible.
+
+Add an OPTIONAL, backward-compatible per-field transform mechanism:
+- `BlockingKeyConfig.field_transforms: list[list[str]] | None = None` -- when set,
+  it is a list aligned 1:1 with `fields`, giving each field its own transform chain
+  (`field_transforms[i]` applies to `fields[i]`). Default `None` preserves today's
+  shared-`transforms` behavior exactly. A validator requires
+  `len(field_transforms) == len(fields)` when set.
+- `_build_block_key_expr` uses `field_transforms[i]` for field `i` when
+  `field_transforms` is set, else falls back to the shared `transforms` list (the
+  current code path, byte-identical when `field_transforms is None`).
+
+The weighted/exact path never sets `field_transforms`, so it is untouched. TS parity
+is out of scope.
+
+### 1. Candidate-pass generation -- `_candidate_blocking_passes(profiles, df)`
+
+Returns a POOL of candidate `BlockingKeyConfig`s (not yet selected):
+
+- **Name / recall-floor passes:** reuse `build_blocking`'s transform-rich passes
+  verbatim as candidates (e.g. `[surname]` + `['lowercase','substring:0:5']`,
+  `[first_name]` + `['lowercase','soundex']`). These carry the typo-robustness
+  that is the recall lever.
+- **Compound variants:** for each name pass `P_name` and each eligible orthogonal
+  field `o` (the same orthogonal-eligibility test the current code uses: not a
+  name field, not description/numeric, null-rate <= 0.20, `0.02 <= cardinality < 1.0`,
+  plus dob-like dates allowed), emit a compound pass that conjoins `P_name`'s
+  field+transforms with `o`. **Coarsening rule (concrete, so the implementer does
+  not invent a heuristic):** coarsen date / `dob`-typed orthogonals to year via
+  `substring` (the `historical_50k` recall case); leave non-date orthogonals
+  (postcode, birth_place, etc.) uncoarsened. The conjunction is a multi-field
+  `BlockingKeyConfig(fields=[name_field, o], field_transforms=[<name pass's
+  transforms>, <year-coarsen-or-empty for o>])` -- using the per-field
+  `field_transforms` from section 0 so the name component keeps its soundex/substring
+  recall transforms while the date component gets year-coarsening (and non-date
+  orthogonals get an empty transform list).
+- **Orthogonal single-keys:** an orthogonal field on its own ONLY when its
+  cardinality is high enough to be self-selective (reuse the existing `>= 0.30`
+  threshold as the single-key gate).
+
+Standalone name passes keep using the shared `transforms` field (no
+`field_transforms`); only compounds populate `field_transforms`.
+
+### 2. Per-pass cost + coverage -- `_estimate_pass_stats(pass, df)`
+
+- **Exact candidate count:** materialize the pass's blocks (via the existing
+  static block builder / a groupby on the transformed key columns) and compute
+  `candidate_count = sum over blocks of C(size, 2)`. Cheap; this is the quantity
+  the budget is enforced on.
+- **Coverage signal:** the set of canonical record-pair ids (`min*N + max`) the
+  pass generates. To bound autoconfig-time cost, per-pass pair enumeration is
+  **capped at a sample** (default ~500K pairs/pass; a pass above the cap
+  contributes a uniformly sampled subset). The set-cover ratio is therefore an
+  ESTIMATE; the budget itself stays exact (from the groupby).
+
+### 3. Budget set-cover selection -- `_select_passes_within_budget(stats, budget)`
+
+- `budget = K x N` deduped-union candidate pairs. **`K` default 25**, overridable
+  via `GOLDENMATCH_BLOCKING_CANDIDATE_BUDGET_K`; calibrated in the plan (sweep).
+- Greedy: `covered = empty set`, `selected = []`, `spent = 0`. Each round, among
+  passes whose `candidate_count` still fits (`spent + count <= budget`), pick the
+  one maximizing `|pass_pairs - covered| / candidate_count`; add it, union its
+  pairs into `covered`, add its count to `spent`. Stop when no pass fits or
+  marginal coverage saturates (best ratio ~ 0).
+- **Recall anchor (safety):** always include at least one name-bearing pass -- the
+  highest-coverage name/compound pass that fits the budget -- so the emitted config
+  is never degenerate or name-less. If the budget is so tight that no name-bearing
+  pass fits, include the single most-covering name-bearing pass anyway (documented
+  budget-override; a name-less probabilistic config is never acceptable).
+- **Degenerate fallback:** if the pool has no orthogonal fields to form compounds
+  from (or `compute_column_priors` fails), return `build_blocking`'s output
+  unchanged -- never regress. Note this is a deliberate change from today's
+  degenerate path: the current `_build_probabilistic_blocking` returns an AUGMENTED
+  superset (base passes + orthogonal extras); the new fallback returns plain
+  `build_blocking` (more conservative). The plan must assert this in a
+  non-regression test so a reviewer does not read it as an accidental regression.
+
+### 4. Emit
+
+`BlockingConfig(strategy="multi_pass", passes=selected, max_block_size=...,
+skip_oversized=...)` -- the exact shape the pipeline's probabilistic branches and
+`_build_blocks_per_pass` (per-rule EM) already consume. Nothing downstream changes.
+
+## Budget calibration (plan, not code)
+
+The design ships `K = 25` (candidates per record; current `historical_50k` is
+~175/record). The plan sweeps `K` in `{10, 25, 50, 100}` on the dump PR-curve gate
+and picks the `K` that maximizes `historical_50k` F1 subject to febrl3/synthetic
+non-regression. `K` is a module constant + env override so the sweep needs no code
+edits per point.
+
+## Measurement gate (reuses the lever-#1/#2 harness)
+
+- **Blocking-recall ceiling** per config via `.profile_tmp/diag_blocking_recall.py`
+  (coverage-only, no OOM): the selected config's `blocking_recall` on
+  `historical_50k` (current ceiling 0.83) is the recall side.
+- **PR-curve F1** via the per-rule dump method (`.profile_tmp/diag_pr_per_rule.py`
+  shape): per-rule scoring on the NEW (selective) candidate set.
+- **Primary (mechanism):** the scored candidate pool shrinks materially (8.84M ->
+  within `K x N`) and the precision ceiling rises well above 3.4%.
+- **Headline:** `historical_50k` reaches an operating point with **F1 materially >
+  0.655** -- target P >= ~0.8 at R >= ~0.7 (the regime per-rule scoring can reach
+  once the candidate set is clean).
+- **Non-regression:** febrl3 (>= ~0.982) and synthetic_person (>= ~0.987) F1 do not
+  drop (their candidate ratios are already low, so the budget should not bind; the
+  gate confirms it).
+
+## Kill criterion
+
+If a selective candidate budget that holds the febrl3/synthetic non-regression
+floors STILL cannot lift `historical_50k` precision into the gate (i.e. cutting
+candidates to `K x N` either craters recall before precision rises, or the
+remaining within-budget candidates are still dominated by same-name non-matches),
+then the wall is deeper than blocking-rule selectivity -- it is the F-S model's
+inability to separate same-name different-person pairs on this biographical data,
+and the redirect is to scoring-side entity disambiguation / a learned blocker,
+sequenced after this lever. Stop and re-brainstorm rather than chase K.
+
+## Testing
+
+- **Compound generation:** `_candidate_blocking_passes` emits compounds that
+  preserve the name component's transforms and conjoin an orthogonal field;
+  high-card orthogonals also appear as single-keys; name passes are present as
+  candidates.
+- **Budget selection:** `_select_passes_within_budget` never exceeds `K x N`, is
+  coverage-greedy (a strictly-dominated redundant pass is not chosen over a
+  complementary one), and always emits >= 1 name-bearing pass.
+- **Degenerate fallback:** no orthogonal fields -> returns `build_blocking` output
+  unchanged.
+- **Behavioral (synthetic fixture):** the selected config has materially fewer
+  candidate pairs than the old broad union AND retains the GT-bearing pairs
+  (blocking recall on the fixture is held).
+- **Non-regression:** existing autoconfig-probabilistic tests + blocker tests stay
+  green; the emitted `BlockingConfig` is consumed by the pipeline + per-rule EM
+  unchanged.
+
+## Scope / out of scope
+
+- **In:** the per-field `field_transforms` mechanism (`BlockingKeyConfig` schema
+  field + validator + `_build_block_key_expr` support, all backward-compatible);
+  `_build_probabilistic_blocking` redesign + `_candidate_blocking_passes`,
+  `_estimate_pass_stats`, `_select_passes_within_budget`; the `K` budget constant +
+  env override; tests. `K`-calibration is executed in the plan via the dump
+  PR-curve sweep.
+- **Out:** the weighted/exact-path blocking (`build_blocking` /
+  `_build_compound_blocking`) stays unchanged; TS parity; the CI Splink head-to-head
+  panel + branch rebase; any further EM/scoring work.
+- **Explicitly NOT covered: large-N (>> 50K) budget estimation.** Candidate counts
+  scale with N (block size proportional to N), so the exact-groupby budget estimate
+  is computed at the gate dataset's 50K scale; at larger N where auto-config samples,
+  the estimate needs extrapolation. The probabilistic path's gate is `historical_50k`
+  (50K); a sample-extrapolated budget for large-N selective blocking is a noted
+  follow-up, not in scope here.
+
+## Risks & mitigations
+
+- **Compounds drop recall:** a typo in either component kills the pair. Mitigated
+  by (a) keeping the name component's recall transforms (soundex/substring) inside
+  the compound, (b) the coverage-greedy set-cover preferring complementary passes
+  that catch different corruption modes, and (c) the recall anchor + the
+  blocking-recall ceiling measurement gating each K.
+- **Coverage estimation cost at autoconfig time:** the per-pass pair-enumeration
+  cap (~500K/pass) bounds it; the budget itself uses the cheap exact groupby count.
+- **K mis-calibration:** the plan sweeps K against the real gate (F1 +
+  non-regression) rather than guessing; K is env-overridable for A/B.
+- **The wall is deeper than blocking:** the kill criterion catches it and redirects
+  to scoring-side disambiguation / learned blocking.
+
+## Affected files (anticipated)
+
+- Modified: `config/schemas.py` (`BlockingKeyConfig.field_transforms` optional field
+  + length validator); `core/blocker.py` (`_build_block_key_expr` per-field transform
+  support, default-None byte-identical); `core/autoconfig.py`
+  (`_build_probabilistic_blocking` rewrite + `_candidate_blocking_passes` +
+  `_estimate_pass_stats` + `_select_passes_within_budget` + the `K` budget
+  constant/env read). May reuse helpers/patterns from the existing
+  `_build_compound_blocking`.
+- New tests: `tests/test_autoconfig_selective_blocking.py` (and a per-field-transform
+  unit test, in `tests/test_blocker.py` or the new file).
+- Reused (no change): the dump PR-curve + blocking-recall diagnostics
+  (`.profile_tmp/diag_pr_per_rule.py`, `.profile_tmp/diag_blocking_recall.py`) for
+  the measurement gate.

--- a/docs/superpowers/specs/2026-06-09-splink-bakeoff-design.md
+++ b/docs/superpowers/specs/2026-06-09-splink-bakeoff-design.md
@@ -1,0 +1,169 @@
+# Splink (hand-rolled) vs GoldenMatch (autoconfig) bake-off -- design
+
+**Date:** 2026-06-09
+**Status:** Approved design, pre-plan
+**Scope:** A reproducible accuracy + performance bake-off across the ER benchmark
+datasets, pitting expert hand-rolled Splink against GoldenMatch's zero-tuning
+auto-config (two GM modes). Extends `scripts/bench_er_headtohead/`.
+
+## Problem / goal
+
+We have a head-to-head accuracy panel (`run_panel.py`, used for the #823 numbers:
+GM probabilistic auto-config beats Splink). What we do NOT have in one place is a
+fair **autoconfig-vs-hand-rolled** comparison that records BOTH accuracy AND
+performance (wall, peak RSS, throughput) for every engine on every benchmark
+dataset. The existing perf runner (`run_goldenmatch.py`) deliberately uses an
+EXPLICIT hand-built GM config (bucket+native+weighted) -- it measures GM-hand-built
+vs Splink-hand-built raw engine speed, NOT GM autoconfig. This bake-off adds the
+autoconfig comparison and unifies accuracy + perf into one artifact.
+
+Goal: a committed bake-off table -- per benchmark dataset, for each of three engines,
+pairwise P/R/F1 + B3 F1 AND dedupe wall (s) + peak RSS (MB) + throughput -- run on
+one Linux CI runner for fairness, with honest framing.
+
+## Engines (three columns per dataset)
+
+1. **GM zero-config** -- `dedupe_df(df)` with NO config (the controller auto-picks
+   weighted/exact/probabilistic). The product headline: "zero-config vs hand-tuned."
+   Honestly surfaces the controller's overhead/RED-refuse behavior on off-distribution
+   data (a real autoconfig cost, not hidden).
+2. **GM probabilistic auto-config** -- `auto_configure_probabilistic_df(df)` ->
+   `dedupe_df(df, config=...)`. Like-for-like vs Splink (both Fellegi-Sunter),
+   zero-tuning. Directly validates the #823 win under the unified harness.
+3. **Splink hand-rolled** -- the existing per-dataset expert configs in
+   `run_splink.py::_SETTINGS_BY_DATASET` (compound blocking rules + JaroWinkler /
+   DamerauLevenshtein / ExactMatch comparisons + EM training rules). Reused as-is
+   (already genuinely hand-tuned, not a strawman). Splink honestly **skips dblp_acm**
+   (bibliographic isn't its tuned domain) -- recorded as "skips," never a zero.
+
+## Datasets
+
+All benchmark datasets via `datasets.py::load_dataset`: **historical_50k** (50K,
+Splink's home turf -- the scale anchor + headline), **febrl3**, **synthetic_person**,
+**dblp_acm**. No synthetic 1M scale curve in this pass (scoped to the real benchmark
+datasets; an optional throughput curve is a documented follow-up).
+
+## Metrics (per engine x dataset)
+
+- **Accuracy:** pairwise precision / recall / F1 + B3 (cluster) F1, via `evaluate.py`
+  against `attribution.truth_to_pairs(truth)` and the per-record predicted cluster
+  assignment. Identical evaluator for all three engines.
+- **Performance:** `dedupe_wall_seconds`, `peak_rss_mb` (Linux `resource` RU_MAXRSS),
+  throughput (`scored_pairs/sec` and `rows/sec`). Each engine self-times in its OWN
+  subprocess so peak RSS is that engine's true high-water mark.
+
+## Design
+
+### 1. GM runner modes -- `run_goldenmatch.py`
+Add `--mode {hand_built, zeroconfig, probabilistic}` (default `hand_built` so
+`orchestrate.py`'s existing perf bench is byte-unchanged):
+- `hand_built`: today's explicit bucket+native+weighted config (unchanged).
+- `zeroconfig`: `dedupe_df(df)` -- no config. Captures the controller path incl. its
+  overhead. **MUST catch `ControllerNotConfidentError` SPECIFICALLY** and write
+  `status=refused` + the reason to the result JSON, then **exit 0 (do NOT re-raise)** so
+  the orchestrator reads it as a clean data point, not a subprocess failure. (The runner
+  currently does `except BaseException ... raise`; the refuse case must be handled before
+  that re-raise.)
+- `probabilistic`: `cfg = auto_configure_probabilistic_df(df)`; **then walk `cfg`'s
+  matchkeys and force `rerank=False` on any weighted matchkey** (hard guard, not "if"),
+  so CI never attempts a HuggingFace cross-encoder download; `dedupe_df(df, config=cfg)`.
+
+**CORRECTNESS -- record_id remap (REQUIRED; the existing `--pred-out` is wrong for the
+real datasets):** today `run_goldenmatch.py`'s `--pred-out` writes `record_id` as the
+int `__row_id__` (cluster member positions), relying on "record_id == row index" -- which
+holds ONLY for `synthetic_person`. `historical_50k` / `dblp_acm` / `febrl3` carry STRING
+record_ids (Wikidata `Q...`, `dblp:123`/`acm:456`, `rec-123-org`) that are NOT row
+positions, so the unremapped pred never joins the truth table and accuracy reads ~0. Fix
+(copy `run_panel.py:83-108`): for the **bake-off modes only (`zeroconfig` /
+`probabilistic`)**, the runner reads the input df's real `record_id` column, remaps each
+cluster member `__row_id__` -> `df["record_id"][member]`, and writes `record_id` as a
+**string-typed** column; the `run_bakeoff.py` orchestrator casts its truth to Utf8 (§2)
+so that lane's preds + truth share one string key space.
+
+**`hand_built` mode is left BYTE-UNCHANGED** -- it keeps today's int64 `__row_id__`
+`--pred-out` write (`run_goldenmatch.py:138-158`). This is REQUIRED for back-compat:
+`orchestrate.py`'s synthetic fixture (`generate_fixture.py`) carries an int64 `record_id`
+column AND writes int64 truth with no Utf8 cast, so a string remap there would mismatch
+the join and zero out the synthetic F1. The remap is gated on MODE, NOT on record_id
+column presence (the synthetic fixture HAS the column). Net: bake-off lane = string key
+space (truth cast to Utf8); orchestrate lane = int64 key space (unchanged). Each lane is
+self-consistent: pred dtype matches truth dtype within the lane.
+
+### 2. Orchestrator -- new `run_bakeoff.py` (additive; does NOT disturb `run_panel.py`)
+The existing `run_panel.py` (accuracy-only, GM inline) stays for the CI panel lane.
+`run_bakeoff.py` is the unified accuracy+perf orchestrator:
+- For each dataset: `load_dataset` -> write `records` to a temp parquet **preserving the
+  dataset's REAL `record_id` column** (string for the non-synthetic datasets -- do NOT
+  overwrite it with a row index), and write `truth` to a temp parquet with `record_id`
+  **cast to Utf8** so it joins the string-keyed preds (mirror `run_panel.py:358`).
+- Run THREE subprocesses (each self-times, each `--pred-out`):
+  `run_goldenmatch.py --mode zeroconfig`, `run_goldenmatch.py --mode probabilistic`,
+  `run_splink.py` (its dataset settings). A per-engine timeout records `timeout`/`error`,
+  never hangs the bake-off. Splink's pred output is ALREADY real-record_id-keyed
+  (`run_splink.py:255-262` projects `record_id, cluster_id AS pred_cluster_id`), so the
+  orchestrator reuses `run_panel.py::_run_splink`'s eval flow verbatim -- no Splink-side
+  adaptation. GM preds are corrected by the §1 remap to the same string key space.
+- Compute accuracy from each `--pred-out` (joined to the Utf8 truth) via `evaluate.py`;
+  collect perf from each engine's result JSON. All three engines + truth share ONE
+  string `record_id` key space, so the join is apples-to-apples.
+- Emit `bakeoff.md` + `bakeoff.json`: one row per (dataset, engine) with accuracy +
+  perf columns, plus a per-dataset GM-vs-Splink delta (wall ratio, RSS ratio, F1 delta).
+- `--require-native` defaults on for the GM runs (a silent pure-Python fallback would
+  make the perf comparison a lie -- mirror `run_goldenmatch.py`'s existing guard);
+  CI installs/builds the native runtime.
+
+### 3. CI lane -- `bench-probabilistic.yml`
+Add a `bake-off` job (`workflow_dispatch`, `runs-on: large-new-64GB` per the bench
+default) that installs `goldenmatch[bench]` + builds the native runtime + fetches the
+Leipzig DBLP-ACM dataset (as the panel lane does), runs `run_bakeoff.py`, and uploads
+`bakeoff.md` / `bakeoff.json` as artifacts. Does NOT gate CI (it's a measurement, not
+a test).
+
+### 4. Recording
+Commit the produced `bakeoff.md` results to `docs/benchmarks/2026-06-09-splink-bakeoff.md`
+(create `docs/benchmarks/` if absent) and link it from
+`context-network/architecture/fellegi-sunter-splink-parity.md` and
+`docs-site/reference/vendor-comparison.mdx`. The committed doc carries the run's
+runner + commit SHA for provenance.
+
+## Fairness + honest framing (recorded with the numbers)
+
+- Same Linux runner, same datasets, same evaluator. Single run per cell (perf has
+  runner variance -- noted; accuracy is deterministic).
+- Pairwise F1 under one shared evaluator; the cited ~0.97 Splink historical_50k figure
+  is a cluster-level metric (preserve the caveat already in the docs).
+- Splink's config is genuinely hand-tuned per dataset; GM gets ZERO tuning (the point).
+- GM zero-config's controller overhead / RED-refuse is reported, not hidden -- if
+  zero-config refuses or is slower than hand-built/Splink, that is the honest result.
+- Splink skipping dblp_acm is recorded as "skips," not scored 0.
+
+## Scope / out of scope
+
+- **In:** `--mode` on `run_goldenmatch.py` (+ zeroconfig/probabilistic paths);
+  `run_bakeoff.py`; the `bake-off` CI lane; the committed results doc + doc links;
+  tests for the new runner modes + the orchestrator's table assembly (no live CI).
+- **Out:** synthetic 1M+ throughput curve (follow-up); re-tuning the Splink configs
+  (reuse as-is); NCVR adapter (ground-truth synthesis is separate); changing the
+  existing `run_panel.py` accuracy lane or `orchestrate.py`.
+
+## Testing
+
+- `run_goldenmatch.py --mode zeroconfig` / `--mode probabilistic` on a tiny fixture
+  produce a valid result JSON + a `--pred-out` parquet (no live CI; small df).
+- `run_bakeoff.py` table assembly: given stub per-engine result + pred files, it emits
+  a well-formed `bakeoff.json`/`.md` with the right columns + the delta rows; a missing
+  engine result becomes a `skips`/`error` cell, not a crash.
+- A `--mode probabilistic` smoke that the emitted config routes through the probabilistic
+  path (consumed end-to-end on a small df).
+- Existing `run_panel.py` / `orchestrate.py` / `run_splink.py` behavior unchanged
+  (default `--mode hand_built`).
+
+## Affected files (anticipated)
+
+- Modified: `scripts/bench_er_headtohead/run_goldenmatch.py` (`--mode`); maybe
+  `evaluate.py` (reuse, no change expected); `.github/workflows/bench-probabilistic.yml`
+  (bake-off lane); `context-network/architecture/fellegi-sunter-splink-parity.md` +
+  `docs-site/reference/vendor-comparison.mdx` (link the results).
+- New: `scripts/bench_er_headtohead/run_bakeoff.py`; tests under
+  `packages/python/goldenmatch/tests/` (or `scripts/bench_er_headtohead/`);
+  `docs/benchmarks/2026-06-09-splink-bakeoff.md` (results, committed after the CI run).

--- a/docs/superpowers/specs/2026-06-10-sail-tier-stage-s5-identity-design.md
+++ b/docs/superpowers/specs/2026-06-10-sail-tier-stage-s5-identity-design.md
@@ -1,0 +1,215 @@
+# Sail tier — Stage S5: identity-on-Sail (distributed create + edge-emit)
+
+**Date:** 2026-06-10
+**Status:** design (approved by Ben; pre-spec-review)
+**Parent:** `2026-06-03-sail-tier-design.md` (the Sail tier). S1–S4 shipped the buildable
+Sail pipeline (load → block → score → dedup → WCC → golden). The S3 scope decision split
+**identity** off to its own later stage ("stateful entity store + `resolve_clusters`
+overlap, resolved driver-side even in the Ray path — not a relational op"). This is that
+stage.
+
+**Goal:** Re-express the **create + edge-emit** layer of identity resolution against Sail
+(Spark Connect), distributed, so the identity graph for a **fresh-store run** is produced
+as Spark DataFrames written distributed — removing the driver-side identity island for the
+common case. The stateful **incremental** layer (absorb/merge against an existing store)
+is explicitly deferred as an honest-null, exactly as the one-box DataFusion spine recorded
+for one-box spill survival (Stage E) and as S3 did for order-dependent golden strategies.
+
+---
+
+## The finding that shapes the scope
+
+`goldenmatch.identity.resolve.resolve_clusters` splits into two layers:
+
+**Layer 1 — relational (distributable).**
+- Emitting `same_as` evidence edges between scored within-cluster pairs. Entity-independent:
+  depends only on cluster membership + pair scores.
+- The **brand-new-cluster create** path. In `resolve.py` this is already a special-cased
+  batch path (`use_bulk_fast_path`, postgres-only, no existing entities, no weak conflict →
+  bulk COPY of nodes/records/edges/events). On a **fresh store every cluster takes it.**
+
+**Layer 2 — stateful (NOT relational).**
+- The create/absorb/**merge** decision reads the existing identity store, is order-dependent
+  (merge winner = most members, tie-break oldest `created_at`; loser records reassigned
+  *before* the next iteration sees them), and writes to a transactional DB.
+
+**Decisive evidence:** the Ray path never distributed Layer 2 either.
+`distributed/identity.py::resolve_identities_distributed` does `materialize_cluster_dict`
+(driver-side collect) then runs the *same* `resolve_clusters` against a pooled Postgres
+connection. The "true per-partition resolve" was a documented Phase-5 follow-up that never
+landed — only the `identity_partition.py::partition_cluster_frames` building block exists,
+used in tests, never wired into a production per-worker resolve. So Layer 2 staying
+driver-side is **intrinsic to the algorithm**, not a Sail limitation.
+
+**Scope (Ben's call, 2026-06-10):** S5 covers **Layer 1 only** — distributed create +
+edge-emit on a fresh store. Layer 2 (incremental) is deferred, honest-null. This mirrors
+the S3 golden-only scoping exactly.
+
+## Scope guard
+
+**IN:** a new `sail/identity.py` — given the upstream Sail frames (`pairs`, `assignments`,
+`source_df`, `golden_df`) plus run metadata, produce the durable identity graph as
+**distributed Spark DataFrames** (`nodes`, `source_records`, `same_as` edges, + an optional
+`events` bookkeeping frame), written distributed (parquet), never collected to the driver.
+Pure-relational joins + scalar pandas-UDFs, reusing S1/S3's proven `pandas_udf` mechanism.
+
+**OUT (deferred, explicit honest-null):**
+- Incremental resolve — absorb/merge against an existing store. Inherently stateful +
+  order-dependent; stays driver-side exactly like the Ray path. Documented, not silent.
+- Weak-cluster `conflicts_with` edges and merge carry-forward (both touch Layer 2).
+- Loading the produced frames into the durable Postgres store (a thin downstream COPY step;
+  the one-box `bulk_upsert_*`/`bulk_add_edges` COPY methods already exist). S5 *produces*
+  the graph distributed; *landing* it is out of scope for the distributed stage.
+
+---
+
+## Determinism (a load-bearing property, not a nicety)
+
+The one-box create path mints **UUIDv7** entity_ids (`new_entity_id()` — time + random,
+non-reproducible even one-box). A distributed create cannot and should not reproduce that
+sequence. S5 instead mints a **deterministic content-derived entity_id**:
+
+> `entity_id = "ent:h1:" + sha256(canonical(sorted(member_record_ids)))[:N]`
+
+Sorted member record_ids → order-independent; SHA-256 (the existing record-id `h1`
+h-scheme) → reproducible; no worker coordination, no driver-side counter. Combined with
+**passed-in** run timestamps (`run_meta.recorded_at`, not per-row `datetime.now()`), the
+entire S5 output is **byte-identical on re-run** for the same input — matching the spine's
+determinism-gate posture and making the parity test exact rather than fuzzy.
+
+This introduces a second entity-id scheme (`ent:h1:`), **Sail-create-only**, gated by a
+kill-switch (`GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME`, default `h1`). On a fresh store there is
+no prior identity to be stable against, so the content hash *is* the natural stable seed;
+cross-run stability via overlap detection is a property of the deferred Layer 2, not of S5.
+
+---
+
+## Module layout (`sail/identity.py`)
+
+All functions take/return Spark DataFrames; joins are on **shared column names** (the S2
+`AMBIGUOUS_REFERENCE` lesson: never `df["col"]` cross-handle refs across self-similar joins).
+
+- `derive_record_ids(source_df, *, source_col="__source__", source_pk_col=None)`
+  → `source_df` + a `record_id` column. A scalar `pandas_udf` mirroring one-box
+  `_record_id_candidates` **primary** path: PK present → `{source}:{pk}`; no PK →
+  `{source}:h1:{record_fingerprint(_canonical_payload(payload))[:12]}` (the canonical
+  cross-surface fingerprint, reused inside the UDF → parity by construction). The legacy
+  `{source}:hash:` *lookup candidate* is a Layer-2 concern (overlap resolution) and is not
+  emitted by S5.
+
+- `mint_entity_ids(assignments_with_recid)` → `(cluster_id, entity_id)`.
+  `groupBy(cluster_id).agg(collect_list(record_id))` → a scalar `pandas_udf` that sorts the
+  member record_ids and hashes them to `ent:h1:{hash[:N]}`. Order-independent, reproducible.
+
+- `build_same_as_edges(pairs, assignments, recid_map, entity_ids, *, run_meta)` → the
+  `same_as` edge frame `(entity_id, record_a_id, record_b_id, kind, score, matchkey_name,
+  run_name, dataset, recorded_at)`. Join `pairs(a,b,score)` → `cluster_id` (via assignments)
+  → `entity_id`; map `a,b → record_id`. Every above-threshold dedup'd pair is within-cluster
+  by WCC construction, so the edge set equals one-box's per-cluster `pair_scores` items.
+
+- `build_identity_nodes(entity_ids, golden_df, *, run_meta)` → node frame
+  `(entity_id, status, merged_into, golden_record, confidence, dataset, created_at,
+  updated_at)`, **one node per entity including singletons**. `status=ACTIVE`,
+  `merged_into=NULL` (create-only); timestamps from `run_meta`. `golden_record`:
+  **LEFT-join** S3's `build_golden` output (which emits multi-member clusters only,
+  `count>1`) onto the full `entity_ids` set — the LEFT join is what keeps singleton
+  entities (their `golden_record` is **NULL**). The parity gate checks node *count* (one
+  per cluster), not `golden_record` *content*, so NULL singleton golden is gate-neutral;
+  populating it from the single source row (as one-box does) is a deferred polish, not
+  needed for the create-path graph. The load-bearing point: naive reuse of `build_golden`
+  (inner-join) would silently DROP singleton entities and fail count parity — the LEFT join
+  is the fix.
+
+- `build_source_records(assignments, recid_map, entity_ids, *, run_meta)` → record frame
+  `(record_id, source, source_pk, record_hash, entity_id, dataset, first_seen_at,
+  last_seen_at)` = the record→entity assignment (the join `assignments → record_id →
+  entity_id`).
+
+- `build_identity_graph(pairs, assignments, source_df, golden_df, *, run_meta, ...)` →
+  orchestrates the above; returns `IdentityGraphFrames(nodes, records, edges, events?)`.
+  The optional `events` frame is one `CREATED` row per entity (store-parity bookkeeping).
+
+## Data flow
+
+```
+source_df ─┬─► derive_record_ids ─────────► source_df + record_id
+           │
+assignments(cluster_id,member_id) ─► join record_id ─┬─► mint_entity_ids ─► (cluster_id, entity_id)
+                                                      │
+pairs(a,b,score) ──────────────────────────────────► build_same_as_edges ──► EDGES frame
+golden_df(cluster_id,*cols) ──LEFT-join─► build_identity_nodes ◄─ entity_ids ──► NODES frame (incl. singletons; singleton golden=NULL)
+                                          build_source_records  ◄─ entity_ids ──► RECORDS frame
+                                          (CREATED per entity)   ◄─ entity_ids ──► EVENTS frame (optional)
+```
+
+## Pipeline wiring
+
+`run_sail_pipeline` gains an opt-in `emit_identity: bool = False` (+ `source_col`,
+`source_pk_col`, `run_meta`). When set, after `build_golden` it also calls
+`build_identity_graph` and returns/writes the identity-graph frames alongside the golden
+frame (default path returns golden only — byte-identical to today). The `run_meta`
+(run_name, dataset, recorded_at) is passed in, not synthesized, for determinism.
+
+---
+
+## Parity gate (the make-or-break, CI)
+
+Against the **one-box** `resolve_clusters` on a **fresh SQLite store**, on a small chain +
+junction-multimerge + singleton fixture (the S2/S4 fixture family), via the in-process Sail
+server.
+
+**Two fixture-construction constraints the plan MUST honor:**
+- The parity reference is the **per-row "Brand-new identity" create branch** (`resolve.py`
+  line ~527), the path taken on a fresh SQLite store. The postgres-only `use_bulk_fast_path`
+  (foregrounded in "the finding" above) is semantically identical for create output but is
+  never exercised on SQLite — do NOT wire the fixture against postgres to reach it.
+- One-box `resolve_clusters` must be fed the **same post-dedup `pairs`** (MAX-aggregated) as
+  its `scored_pairs` argument, the identical set S5's edge frame is built from. Feeding raw
+  pre-dedup pairs would inflate the one-box edge count and break edge-count parity (gate
+  part 3) for a non-real reason.
+
+The comparison:
+
+1. **`same_as` edge-set parity** — the canonical `(record_a_id, record_b_id)` set is
+   identical; `score` matches within the established native-kernel/rapidfuzz tolerance.
+   Entity-independent → exact set comparison.
+2. **record→entity partition equivalence** — `{record_id → entity_id}` from S5 induces the
+   *same partition* of records as one-box (exact partition match / Rand index 1.0), even
+   though literal entity_id strings differ (one-box mints UUIDv7, S5 mints `ent:h1:`).
+3. **count parity** — one node per cluster; every member record assigned to exactly one
+   entity; edge count == one-box edge count.
+
+This is the 7th `sail` CI gate, path-filtered into the existing `sail` lane (install the
+`[sail]` extra, `.venv/bin/python -m pytest`, in-process Sail server), same posture as S1–S4.
+
+## Testing
+
+- Unit: `derive_record_ids` PK and no-PK paths vs one-box `_record_id_candidates`;
+  `mint_entity_ids` order-independence (shuffle members → same id) and determinism (re-run →
+  same id); `build_same_as_edges` within-cluster invariant.
+- Parity: the three-part gate above on the chain/multimerge/singleton fixture.
+- Determinism: run S5 twice on the same input → byte-identical `nodes`/`records`/`edges`.
+- Negative: `emit_identity=False` returns golden only, unchanged.
+
+---
+
+## What S5 is and is NOT (the honest framing)
+
+**Is:** the genuine removal of the driver-side identity island for the
+**first-resolution-of-a-fresh-dataset** case — the common case and the one that actually
+scales — produced distributed and parity-proven against the one-box create path.
+
+**Is NOT:** "identity fully solved on Sail." Incremental resolve (absorb/merge against an
+existing store) remains genuinely driver-side, because the algorithm is stateful and
+order-dependent (the Ray path confirms it never distributed). S5 makes the Sail tier's
+identity story honest and parity-proven for the create case; closing incremental at scale
+is a separate, harder problem deferred here by design — the same call S3 made for golden.
+
+## Sign-off checklist (to be finalized in the plan)
+
+- [ ] `sail/identity.py` with the six functions above; joins on shared names only.
+- [ ] Deterministic `ent:h1:` entity_id + kill-switch; passed-in run timestamps.
+- [ ] 7th `sail` CI gate: edge-set + partition + count parity vs one-box fresh-store resolve.
+- [ ] `run_sail_pipeline(emit_identity=...)` opt-in; default path unchanged.
+- [ ] Honest-null note for deferred incremental recorded in the sail design doc + memory.
+- [ ] Ray NOT retired (unchanged — that still gates on the real 100M bench).


### PR DESCRIPTION
## What

Backfills the **44 uncommitted spec/plan design docs** under `docs/superpowers/{plans,specs}` that had been sitting untracked in the working tree.

These are the design source-of-truth that the context network and root `CLAUDE.md` reference by path (e.g. decision `0005` cites `docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md`; `meta/updates.md` cites several). Leaving them untracked orphaned those links for anyone who clones; the repo convention (80 such docs already committed) is to commit them.

Covers: datafusion-spine (stages B–E), sail-tier (S1–S5), autoconfig levers, columnar-frames layer2, security-alerts remediation, FS/Splink parity, goldenembed-rs, cluster-split budget, and related specs.

## Notes

- **Additive only** — all 44 are new files; no tracked file is modified. (3 of the original 47 untracked-in-the-release-branch files turned out to already be on `main`, identical, so git correctly no-op'd them.)
- No code, no workflows — pure design docs.
