### PR TITLE
fix(scorer): zero-pad mismatched-length bloom hex in dice/jaccard single-pair scorers (#784)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -10,6 +10,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 - Removed the dominated `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` opt-in (SP1);
   superseded by `GOLDENMATCH_CLUSTER_FRAMES_OUT`.
 
+### Fixed
+- **`dice`/`jaccard` single-pair scorers no longer crash on different-length
+  bloom hex inputs (#784).** `score_field(a, b, "dice")` / `"jaccard"` decoded
+  the two hex strings to byte arrays and called `np.bitwise_and` with no length
+  validation, so mismatched lengths (e.g. `"0000"` vs `"000000"`) raised an
+  opaque numpy broadcast `ValueError` — while the matrix variants
+  (`_dice_score_matrix` / `_jaccard_score_matrix`) zero-pad to `max_len` and
+  scored the same inputs fine. The single-pair helpers now zero-pad the shorter
+  filter to `max_len` too, restoring single-vs-matrix parity (and matching the
+  TypeScript twins `diceCoefficient` / `jaccardSimilarity`, which already
+  zero-padded). Found by the hypothesis property suite (#778) on its first run.
+  In-pipeline PPRL pairs are fixed-length per config and were never affected;
+  the gap was reachable only via the public `score_field` API on cross-config or
+  hand-fed inputs.
+
 ## [1.30.0] - 2026-06-09
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -566,10 +566,32 @@ def _hex_to_bits(hex_str: str) -> np.ndarray:
     return np.frombuffer(bytes.fromhex(hex_str), dtype=np.uint8)
 
 
+def _pad_to_equal_length(
+    bits_a: np.ndarray, bits_b: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Zero-pad the shorter of two uint8 byte arrays up to the longer length.
+
+    Mirrors the ``max_len`` zero-padding in ``_dice_score_matrix`` /
+    ``_jaccard_score_matrix`` so the single-pair helpers agree with the batch
+    path on the same inputs. Without it, ``np.bitwise_and`` on different-length
+    arrays raises an opaque broadcast ``ValueError`` (issue #784). Padding with
+    zero bytes is bit-identical to bit-level padding (popcount is unchanged by
+    trailing zeros), and AND/OR against an implicit-zero tail is well defined.
+    """
+    len_a, len_b = len(bits_a), len(bits_b)
+    if len_a == len_b:
+        return bits_a, bits_b
+    max_len = max(len_a, len_b)
+    if len_a < max_len:
+        bits_a = np.concatenate([bits_a, np.zeros(max_len - len_a, dtype=np.uint8)])
+    else:
+        bits_b = np.concatenate([bits_b, np.zeros(max_len - len_b, dtype=np.uint8)])
+    return bits_a, bits_b
+
+
 def _dice_score_single(val_a: str, val_b: str) -> float:
     """Dice coefficient on two hex-encoded bloom filters."""
-    bits_a = _hex_to_bits(val_a)
-    bits_b = _hex_to_bits(val_b)
+    bits_a, bits_b = _pad_to_equal_length(_hex_to_bits(val_a), _hex_to_bits(val_b))
     intersection = np.unpackbits(np.bitwise_and(bits_a, bits_b)).sum()
     total = np.unpackbits(bits_a).sum() + np.unpackbits(bits_b).sum()
     return float(2.0 * intersection / total) if total > 0 else 0.0
@@ -577,8 +599,7 @@ def _dice_score_single(val_a: str, val_b: str) -> float:
 
 def _jaccard_score_single(val_a: str, val_b: str) -> float:
     """Jaccard similarity on two hex-encoded bloom filters."""
-    bits_a = _hex_to_bits(val_a)
-    bits_b = _hex_to_bits(val_b)
+    bits_a, bits_b = _pad_to_equal_length(_hex_to_bits(val_a), _hex_to_bits(val_b))
     intersection = np.unpackbits(np.bitwise_and(bits_a, bits_b)).sum()
     union = np.unpackbits(np.bitwise_or(bits_a, bits_b)).sum()
     return float(intersection / union) if union > 0 else 0.0

--- a/packages/python/goldenmatch/tests/test_property_invariants.py
+++ b/packages/python/goldenmatch/tests/test_property_invariants.py
@@ -13,17 +13,19 @@ Coverage:
     - sanitize_for_log output safety (no newlines, no control chars, length cap)
 
 Exclusions (documented empirically):
-    - dice/jaccard scorers expect same-length hex-encoded bloom filter strings.
-      KNOWN BUG: _dice_score_single / _jaccard_score_single raise ValueError
-      (numpy broadcast error) when the two inputs have DIFFERENT byte lengths
-      (e.g. '0000' vs '000000'). The matrix variants pad to max_len and handle
-      this correctly; the single-pair functions do not. Hypothesis found this:
+    - dice/jaccard scorers expect same-length hex-encoded bloom filter strings
+      (the well-formed PPRL shape -- bloom encodings are fixed-length per config).
+      Hypothesis (#778) originally found that _dice_score_single /
+      _jaccard_score_single raised a numpy broadcast ValueError on DIFFERENT-length
+      inputs (e.g. '0000' vs '000000'):
           Falsifying example: a='0000', b='000000'
           ValueError: operands could not be broadcast together with shapes (2,) (3,)
-      The bounds/symmetry tests use a same-length strategy to verify the invariant
-      on well-formed inputs. test_dice_mismatched_length_bug and
-      test_jaccard_mismatched_length_bug each assert the bug is present and act as
-      regression detectors for when it is fixed.
+      FIXED in #784: the single-pair helpers now zero-pad the shorter filter to
+      max_len, mirroring the matrix variants, so single-vs-matrix parity holds on
+      the same inputs. The bounds/symmetry tests still use a same-length strategy
+      to verify the invariant on the well-formed shape;
+      test_dice_mismatched_length_bug / test_jaccard_mismatched_length_bug are the
+      regression tests pinning the no-crash behaviour.
     - soundex_match is excluded from bounds-with-arbitrary-text because
       jellyfish.soundex is undefined for some surrogate-pair / very unusual
       codepoint sequences in older builds; we use a restricted printable-ASCII
@@ -79,11 +81,11 @@ _nonempty_text = st.text(
 )
 
 # Valid hex strings for bloom-filter scorers (dice/jaccard) -- same length.
-# KNOWN BUG: _dice_score_single / _jaccard_score_single crash with a numpy
-# broadcast error on different-length inputs (see module docstring). The
-# strategy generates SAME-length hex strings so bounds/symmetry/identity tests
-# verify the invariant on well-formed inputs; mismatched-length behaviour is
-# covered by test_dice_jaccard_mismatched_length_bug below.
+# Same-length is the well-formed PPRL shape (bloom encodings are fixed-length
+# per config), so bounds/symmetry/identity tests use it to verify the invariant.
+# Mismatched-length inputs no longer crash (fixed in #784, single helpers
+# zero-pad to max_len); that behaviour is pinned by
+# test_dice_mismatched_length_bug / test_jaccard_mismatched_length_bug below.
 _hex_byte_text = st.binary(min_size=1, max_size=32).map(lambda b: b.hex())
 # Same-length bloom filter pairs
 _hex_pair = st.integers(min_value=1, max_value=32).flatmap(
@@ -233,34 +235,55 @@ def test_jaccard_bounds(pair: tuple) -> None:
     assert 0.0 <= result <= 1.0, f"jaccard a={a!r} b={b!r} -> {result}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=ValueError,
-    reason="known bug: _dice_score_single numpy broadcast crash on "
-    "different-length bloom hex inputs (matrix variant pads to max_len "
-    "and is unaffected); XPASS means the bug was fixed -- remove marker",
-)
 def test_dice_mismatched_length_bug() -> None:
-    """Different-length hex inputs should score, not crash (found by hypothesis)."""
+    """Different-length hex inputs should score, not crash (found by hypothesis).
+
+    Regression for #784: the single-pair helper now zero-pads the shorter
+    bloom filter to the longer length, matching ``_dice_score_matrix``.
+    """
     from goldenmatch.core.scorer import score_field
 
     result = score_field("0000", "000000", "dice")
     assert result is not None and 0.0 <= result <= 1.0
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=ValueError,
-    reason="known bug: _jaccard_score_single numpy broadcast crash on "
-    "different-length bloom hex inputs (matrix variant pads to max_len "
-    "and is unaffected); XPASS means the bug was fixed -- remove marker",
-)
 def test_jaccard_mismatched_length_bug() -> None:
-    """Different-length hex inputs should score, not crash (found by hypothesis)."""
+    """Different-length hex inputs should score, not crash (found by hypothesis).
+
+    Regression for #784: the single-pair helper now zero-pads the shorter
+    bloom filter to the longer length, matching ``_jaccard_score_matrix``.
+    """
     from goldenmatch.core.scorer import score_field
 
     result = score_field("0000", "000000", "jaccard")
     assert result is not None and 0.0 <= result <= 1.0
+
+
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        ("ff", "ff00"),       # 1 byte vs 2 bytes, set bits in the short one
+        ("ff00", "ff"),       # reversed order (the shorter is the second arg)
+        ("a1b2", "a1b200"),   # partial overlap, mismatched length
+        ("0000", "000000"),   # all-zero, mismatched length (the #778 shrink)
+    ],
+)
+def test_dice_jaccard_single_matches_matrix_on_mismatched_length(a: str, b: str) -> None:
+    """#784: single-pair dice/jaccard agree with the matrix variant on
+    different-length bloom filters (both zero-pad the shorter to max_len)."""
+    from goldenmatch.core.scorer import (
+        _dice_score_matrix,
+        _jaccard_score_matrix,
+        score_field,
+    )
+
+    dice_single = score_field(a, b, "dice")
+    jaccard_single = score_field(a, b, "jaccard")
+    dice_matrix = float(_dice_score_matrix([a, b])[0, 1])
+    jaccard_matrix = float(_jaccard_score_matrix([a, b])[0, 1])
+
+    assert dice_single == pytest.approx(dice_matrix, abs=1e-9)
+    assert jaccard_single == pytest.approx(jaccard_matrix, abs=1e-9)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
@@ -142,6 +142,32 @@ describe("dice / jaccard (bloom filter hex)", () => {
     expect(diceCoefficient(zero, zero)).toBe(0.0);
     expect(jaccardSimilarity(zero, zero)).toBe(0.0);
   });
+
+  // #784: different-length hex inputs must not crash and must zero-pad the
+  // shorter filter to the longer length (parity with the Python single-pair
+  // helpers, which were fixed to match their matrix variants). The fast-check
+  // property suite only exercises same-length pairs, so these pin the
+  // mismatched-length contract explicitly.
+  it("mismatched lengths zero-pad rather than crash", () => {
+    // "ff" (1 byte, 8 set bits) vs "ff00" (2 bytes, 8 set bits): the implicit
+    // zero tail means |A|=|B|=8 and |A&B|=8 -> dice 1.0, jaccard 1.0.
+    expect(diceCoefficient("ff", "ff00")).toBeCloseTo(1.0, 9);
+    expect(jaccardSimilarity("ff", "ff00")).toBeCloseTo(1.0, 9);
+    // Symmetric regardless of which argument is shorter.
+    expect(diceCoefficient("ff00", "ff")).toBeCloseTo(1.0, 9);
+    expect(jaccardSimilarity("ff00", "ff")).toBeCloseTo(1.0, 9);
+  });
+
+  it("mismatched lengths with partial overlap score in [0, 1]", () => {
+    // "ff" = bits 0-7; "ff0f" = bits 0-7 and 12-15. Intersection 8, union 12.
+    expect(diceCoefficient("ff", "ff0f")).toBeCloseTo((2 * 8) / (8 + 12), 9);
+    expect(jaccardSimilarity("ff", "ff0f")).toBeCloseTo(8 / 12, 9);
+  });
+
+  it("mismatched all-zero lengths -> 0 (no crash)", () => {
+    expect(diceCoefficient("0000", "000000")).toBe(0.0);
+    expect(jaccardSimilarity("0000", "000000")).toBe(0.0);
+  });
 });
 
 describe("scoreField", () => {


### PR DESCRIPTION
Closes #784.

## Bug

`score_field(a, b, "dice")` / `"jaccard"` decoded the two hex strings to byte arrays and called `np.bitwise_and(bits_a, bits_b)` with **no length validation**, so different-length inputs (the shrunk counterexample `"0000"` vs `"000000"`) raised an opaque numpy error:

```
ValueError: operands could not be broadcast together with shapes (2,) (3,)
```

The matrix variants (`_dice_score_matrix` / `_jaccard_score_matrix`) already pad to `max_len`, so the single-pair and batch paths disagreed on the same inputs. Found by the hypothesis property suite (#778) on its first run.

## Fix

Zero-pad the shorter byte array to `max_len` in the single-pair helpers (new `_pad_to_equal_length`), mirroring the matrix variants. This was chosen over raising a typed error because it makes **all four paths agree**:

- Python single ↔ Python matrix (single-vs-matrix parity restored)
- Python ↔ TypeScript — the TS twins `diceCoefficient` / `jaccardSimilarity` **already** zero-pad (`popcountAnd` uses `Math.min`, `popcountOr` uses `Math.max` with `?? 0`), they were just untested on mismatched lengths.

Byte-level padding is bit-identical to the matrix's bit-level padding (`max_len` is always a multiple of 8, popcount is unchanged by trailing zeros).

## Tests

- **Python:** dropped the `@pytest.mark.xfail(strict=True)` markers on `test_dice_mismatched_length_bug` / `test_jaccard_mismatched_length_bug` (now real assertions); added `test_dice_jaccard_single_matches_matrix_on_mismatched_length` asserting single == matrix on 4 mismatched-length cases. Refreshed the "KNOWN BUG" docstring/comments to "fixed in #784".
- **TypeScript:** added 3 mismatched-length regression tests (the fast-check suite only exercised same-length pairs). No TS source change needed.
- **CHANGELOG:** `Fixed` entry under `[Unreleased]`.

## Verification

- `test_property_invariants.py`: **29 passed** against this branch's code (the two ex-xfail tests green, no strict-XPASS failure).
- `scorer.test.ts`: **46 passed** (TS `scorer.ts` source is byte-identical between this base and where the run was executed).
- `ruff check` on both Python files: clean.

## Reachability

Low risk: in-pipeline PPRL filters are fixed-length per config and were never affected. The gap was only reachable via the public `score_field` API on cross-config or hand-fed inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)