### PR TITLE
feat(wcc): wire recall-complete path into Phase-5 e2e, opt-in (#844 Spec 2)

### DIFF
--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -461,12 +461,19 @@ jobs:
             --pattern "bench_100000000.parquet" \
             --dir bench-dataset/
           ls -lh bench-dataset/
-      - name: Run Phase 5 100M bench
+      - name: Run Phase 5 100M bench (recall-complete)
+        # recall-complete leg: block-shuffle=1 routes clustering through the
+        # randomized-contraction WCC (cross-partition merge). Requires:
+        #   RAY_ADDRESS secret  -- pre-provisioned multi-node Ray cluster
+        #   GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH secret  -- must be gs://<bucket>/rc_scratch
+        #     (a node-local scratch path silently breaks cross-node parquet reads
+        #      in the WCC per-round checkpoint; GCS is load-bearing here)
         working-directory: packages/python/goldenmatch
         env:
           RAY_ADDRESS: ${{ secrets.RAY_ADDRESS }}
           GOLDENMATCH_ENABLE_DISTRIBUTED_RAY: "1"
           GOLDENMATCH_DISTRIBUTED_PIPELINE: "2"
+          GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH: ${{ secrets.GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH }}
         run: |
           set -o pipefail
           mkdir -p bench-out
@@ -475,6 +482,7 @@ jobs:
           python scripts/bench_phase5_end2end.py \
             --input "$INPUT" \
             --output bench-out/phase5_golden.parquet \
+            --block-shuffle 1 \
             2>&1 | tee bench-out/phase5_end2end.log
           echo '## bench-phase5-end2end results' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
@@ -691,7 +699,7 @@ jobs:
               --object-store-memory=8000000000
           done
           ray status
-      - name: Run Phase 5 streaming bench
+      - name: Run Phase 5 streaming bench (baseline, block-shuffle=0)
         working-directory: packages/python/goldenmatch
         env:
           GOLDENMATCH_DISTRIBUTED_PIPELINE: "2"
@@ -704,7 +712,50 @@ jobs:
             --parquet bench-dataset/bench_50000000.parquet \
             --rows 50000000 \
             --identity ${{ inputs.run_phase5_simulated_identity }} \
-            --out bench-out/phase5_simulated.json
+            --block-shuffle 0 \
+            --out bench-out/phase5_simulated_baseline.json
+      - name: Run Phase 5 streaming bench (recall-complete, block-shuffle=1)
+        working-directory: packages/python/goldenmatch
+        env:
+          GOLDENMATCH_DISTRIBUTED_PIPELINE: "2"
+          GOLDENMATCH_ENABLE_DISTRIBUTED_RAY: "1"
+          RAY_ADDRESS: "127.0.0.1:6379"
+          POSTGRES_URL: postgresql://postgres:bench@localhost:5432/postgres
+        run: |
+          mkdir -p bench-out
+          python scripts/bench_phase5_simulated.py \
+            --parquet bench-dataset/bench_50000000.parquet \
+            --rows 50000000 \
+            --identity ${{ inputs.run_phase5_simulated_identity }} \
+            --block-shuffle 1 \
+            --out bench-out/phase5_simulated_recall.json
+      - name: Compare baseline vs recall-complete
+        # Assert recall leg found strictly more multi-member clusters than
+        # baseline. Equal or lower means WCC is no better than per-partition
+        # Union-Find -- a clear signal something is wrong with the routing.
+        working-directory: packages/python/goldenmatch
+        run: |
+          python - <<'PYEOF'
+          import json, sys
+          baseline = json.loads(open("bench-out/phase5_simulated_baseline.json").read())
+          recall   = json.loads(open("bench-out/phase5_simulated_recall.json").read())
+          b = baseline.get("multi_member_cluster_count")
+          r = recall.get("multi_member_cluster_count")
+          print(f"baseline multi_member_cluster_count : {b}")
+          print(f"recall   multi_member_cluster_count : {r}")
+          if b is None or r is None:
+              print("WARN: one or both counts are None (golden write may have been skipped)")
+              sys.exit(0)
+          if r <= b:
+              print(
+                  f"FAIL: recall-complete ({r}) <= baseline ({b}). "
+                  "The randomized-contraction WCC should merge cross-partition "
+                  "clusters that per-partition Union-Find misses. "
+                  "Check GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE + WCC routing."
+              )
+              sys.exit(1)
+          print(f"PASS: recall-complete found {r - b} more multi-member clusters than baseline.")
+          PYEOF
       - name: Tear down Ray
         if: always()
         run: ray stop --force
@@ -714,8 +765,13 @@ jobs:
         run: |
           echo '## bench-phase5-simulated (4-worker Ray, one host @ 50M)' >> "$GITHUB_STEP_SUMMARY"
           echo '**Honest scoping: single NIC, single disk, shared OS page cache. Regression check, NOT a multi-node parity claim.**' >> "$GITHUB_STEP_SUMMARY"
+          echo '### Baseline (block-shuffle=0)' >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          cat bench-out/phase5_simulated.json 2>/dev/null || echo '{"error": "bench produced no output"}' >> "$GITHUB_STEP_SUMMARY"
+          cat bench-out/phase5_simulated_baseline.json 2>/dev/null || echo '{"error": "bench produced no output"}' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo '### Recall-complete (block-shuffle=1)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat bench-out/phase5_simulated_recall.json 2>/dev/null || echo '{"error": "bench produced no output"}' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
       - name: Upload bench artifacts
         if: always()

--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -744,8 +744,15 @@ jobs:
           print(f"baseline multi_member_cluster_count : {b}")
           print(f"recall   multi_member_cluster_count : {r}")
           if b is None or r is None:
-              print("WARN: one or both counts are None (golden write may have been skipped)")
-              sys.exit(0)
+              # On the sim leg golden is ALWAYS expected to be written, so a None
+              # count is a count-MECHANISM failure (golden dir missing / scan
+              # raised), not a legitimate "no signal" -- fail the gate rather than
+              # let a broken count pass silently.
+              print(
+                  f"FAIL: a count is None (baseline={b}, recall={r}); the golden "
+                  "write or parquet scan failed -- the recall gate can't run."
+              )
+              sys.exit(1)
           if r <= b:
               print(
                   f"FAIL: recall-complete ({r}) <= baseline ({b}). "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1276,7 +1276,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.distributed == 'true' || needs.changes.outputs.ci_workflow == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 30 (was 20): the #844 randomized-contraction WCC ray gate adds a ~3.5 min
+    # blocking step on top of the invariance gate (~5.5 min) + broad coverage
+    # (~9.5 min) + setup, which pushed the total past the old 20 min cap (the job
+    # was cancelled mid-run -> spurious "distributed" failure). 30 gives headroom.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
@@ -1301,7 +1305,7 @@ jobs:
       # each start a ray cluster and race on ports.
       # --timeout=300 (not 120): the label-prop partition-count invariance cases
       # iterate to fixpoint on chains (label-prop's worst case) and sit ~100s on
-      # a 2-core hosted runner; 120s clipped them. Job-level timeout-minutes: 20
+      # a 2-core hosted runner; 120s clipped them. Job-level timeout-minutes: 30
       # is the real backstop.
       #
       # GATE (blocking): the quality-invariance gate is this lane's reason for

--- a/docs/distributed-ray-cluster-setup.md
+++ b/docs/distributed-ray-cluster-setup.md
@@ -67,6 +67,117 @@ uploaded to the `bench-dataset-v1` release before the workflow can
 fire; the job exits fast with `::error::bench_50000000.parquet missing`
 otherwise.
 
+## Recall-complete Phase-5 run (100M)
+
+The default Phase-5 path uses per-partition scoring + per-partition Union-Find
+(`local_cc_assignments`). Pairs are isolated to their input partition; clusters
+never span partition boundaries. This is correct when the blocking plan doesn't
+shuffle records across partitions, but it under-merges when block-shuffle is
+active (pairs generated across partitions are discarded by the per-partition UF).
+
+The recall-complete leg routes clustering to the randomized-contraction WCC
+(`build_clusters_distributed(algorithm="randomized_contraction")`), which
+operates on the full cross-partition pair set. Enable it by setting:
+
+```bash
+export GOLDENMATCH_DISTRIBUTED_PIPELINE=2
+export GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1
+export GOLDENMATCH_DISTRIBUTED_WCC=randomized_contraction
+export GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH=gs://<your-bucket>/rc_scratch
+```
+
+Then run the bench driver as normal:
+
+```bash
+python packages/python/goldenmatch/scripts/bench_phase5_end2end.py \
+    --input bench-dataset-v1/bench_100000000.parquet \
+    --output gs://your-bucket/phase5_golden_rc.parquet \
+    --block-shuffle 1
+```
+
+> **GCS scratch is load-bearing.**
+> The randomized-contraction WCC checkpoints each round's contracted edges to
+> parquet so that Ray Data lineage is truncated (preventing the streaming-executor
+> deadlock the pointer-jumping variant hit). On a multi-node cluster, every worker
+> must be able to read every round's checkpoint -- a node-local directory is
+> invisible to other nodes and silently breaks the cross-node parquet reads,
+> causing the WCC to diverge or fail. `GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH` MUST
+> be a `gs://` (or other shared object-storage) path. The bench driver enforces
+> this: passing `--block-shuffle 1` without a `gs://` scratch path exits with a
+> clear error rather than proceeding silently.
+
+Peak scratch disk usage is roughly 4-5x the round-1 edge set (the edge set
+shrinks each contraction round, but all round files coexist until the run
+completes). Pruning per-round scratch is a tracked follow-up; size your GCS
+bucket accordingly and delete the scratch prefix after the run.
+
+### GCP cluster commands for the 100M recall-complete run
+
+These commands are produced for the operator to run manually. Do not
+auto-execute cloud commands.
+
+```bash
+# 1. Provision head node (e2-standard-16, us-central1-a).
+#    e2-standard-16 = 16 vCPU / 64 GB RAM.
+#    Use e2-standard-16 not n2-standard-16 -- n2 stockouts in us-central1
+#    are common and stall allocation indefinitely.
+gcloud compute instances create gm-phase5-head \
+    --zone=us-central1-a \
+    --machine-type=e2-standard-16 \
+    --image-family=debian-12 \
+    --image-project=debian-cloud \
+    --boot-disk-size=100GB
+
+# 2. Provision 4 worker nodes (same type).
+for i in 1 2 3 4; do
+  gcloud compute instances create gm-phase5-worker-$i \
+      --zone=us-central1-a \
+      --machine-type=e2-standard-16 \
+      --image-family=debian-12 \
+      --image-project=debian-cloud \
+      --boot-disk-size=100GB
+done
+
+# 3. SSH to head; install deps and start Ray head.
+#    (run on the head node)
+pip install "goldenmatch[ray]==<current-version>"
+pip install psutil pandas scipy
+ray start --head --port=6379 --num-cpus=16 \
+    --object-store-memory=20000000000
+
+# 4. SSH to each worker; join the cluster.
+#    (run on each worker node -- replace HEAD_IP)
+pip install "goldenmatch[ray]==<current-version>"
+pip install psutil pandas scipy
+ray start --address=HEAD_IP:6379 --num-cpus=16 \
+    --object-store-memory=20000000000
+
+# 5. Verify cluster (from head).
+ray status
+# Expect: 5 nodes, 80 CPU total.
+
+# 6. Run the bench (from your laptop / CI client with RAY_ADDRESS set).
+export RAY_ADDRESS=ray://HEAD_IP:10001
+export GOLDENMATCH_DISTRIBUTED_PIPELINE=2
+export GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1
+export GOLDENMATCH_DISTRIBUTED_WCC=randomized_contraction
+export GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH=gs://<your-bucket>/rc_scratch
+
+python packages/python/goldenmatch/scripts/bench_phase5_end2end.py \
+    --input bench-dataset-v1/bench_100000000.parquet \
+    --output gs://<your-bucket>/phase5_golden_rc.parquet \
+    --block-shuffle 1
+
+# 7. Tear down (billing continues while nodes are running).
+for i in 1 2 3 4; do
+  gcloud compute instances delete gm-phase5-worker-$i --zone=us-central1-a --quiet
+done
+gcloud compute instances delete gm-phase5-head --zone=us-central1-a --quiet
+```
+
+Rough cost: 5 x e2-standard-16 at ~$0.54/hr = ~$2.70/hr. A 30-min run
+costs ~$1.35 in cluster time. Tear down immediately after the bench.
+
 ## Recommended cluster shape
 
 Phase 5 kill criterion: **100M-row dedupe in under 30 min**. To hit that:

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Phase-5 e2e pipeline recall-complete leg (opt-in, #844 Spec 2).** When
+  `GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1`, the Phase-5 streaming pipeline now
+  routes clustering to the randomized-contraction WCC
+  (`build_clusters_distributed(algorithm="randomized_contraction")`) instead of
+  per-partition Union-Find. Per-partition Union-Find under-merges when the
+  blocking plan generates pairs across input-partition boundaries; the
+  distributed WCC correctly merges them. Default behavior is unchanged
+  (block-shuffle off, per-partition path). The binding 100M validation run is
+  operator-deferred (requires a multi-node cluster + GCS scratch); the simulated
+  4-worker CI bench runs both legs and asserts the recall-complete leg finds
+  strictly more multi-member clusters. See `docs/distributed-ray-cluster-setup.md`
+  for the operator recipe. (#844 Spec 2)
 - **Distributed randomized-contraction WCC (opt-in, #844 Spec 1).** New
   `randomized_contraction_wcc` in `goldenmatch.distributed.clustering` implements
   Bögeholz–Brand–Todor randomized contraction (arXiv:1802.09478) — a relational,

--- a/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
@@ -192,6 +192,7 @@ def build_clusters_distributed(
     weak_cluster_threshold: float = 0.3,
     convergence_max_iterations: int = 30,
     force_label_propagation: bool = False,
+    algorithm: str | None = None,
 ) -> Dataset:
     """Distributed clustering. Returns a Ray Dataset of cluster assignments.
 
@@ -206,6 +207,11 @@ def build_clusters_distributed(
         on non-convergence.
 
     Override threshold via env var GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD.
+
+    ``algorithm`` (keyword-only) overrides the GOLDENMATCH_DISTRIBUTED_WCC env
+    selector for this call (e.g. "randomized_contraction"); None = env default.
+    Only affects the at/above-threshold WCC path; below the threshold the route
+    is scipy regardless.
 
     ``all_ids`` is the full id universe (incl. isolated singletons). Pass
     ``None`` (default) for the golden scale path: only multi-member clusters
@@ -233,7 +239,11 @@ def build_clusters_distributed(
             already_sized=True,
         )
 
-    algorithm = _wcc_algorithm() if not force_label_propagation else "label_propagation"
+    # Caller-supplied algorithm wins (the pipeline passes "randomized_contraction"
+    # so the at-scale path can't route to two_phase, which head-wedges at 100M);
+    # otherwise the env selector / force_label_propagation default applies.
+    if algorithm is None:
+        algorithm = _wcc_algorithm() if not force_label_propagation else "label_propagation"
 
     if algorithm == "label_propagation":
         logger.info(

--- a/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
@@ -140,10 +140,14 @@ _RC_PRIME = 2**31 - 1
 def _wcc_algorithm() -> str:
     """Read GOLDENMATCH_DISTRIBUTED_WCC env var (default 'two_phase').
 
-    NOTE: the at-scale pipeline (``GOLDENMATCH_DISTRIBUTED_PIPELINE=2``) does NOT
-    route through this function -- it uses ``local_cc_assignments`` directly,
-    which has no driver collect and is what scales to 100M. This selector only
-    governs ``build_clusters_distributed``'s own callers, where 'two_phase'
+    NOTE: the at-scale pipeline (``GOLDENMATCH_DISTRIBUTED_PIPELINE=2``) uses
+    ``local_cc_assignments`` directly on the DEFAULT (per-partition) path, which
+    has no driver collect; only when the block-shuffle recall-complete path is
+    active (#844 Spec 2) does it route through ``build_clusters_distributed``, and
+    there it passes the ``algorithm`` kwarg explicitly -- so this env selector is
+    NOT consulted on the pipeline path either way. This selector only governs
+    ``build_clusters_distributed``'s OTHER callers (with no ``algorithm`` kwarg),
+    where 'two_phase'
     stays the default (Sem Sinchenko recommendation; partition-sensitive but
     correct). 'pointer_jump' (``distributed_wcc``) is OPT-IN only -- its
     iterative ``Dataset.join`` loop can deadlock Ray's streaming executor at

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -71,6 +71,38 @@ def _run_phase4_pipeline(ds: Dataset, **kwargs: Any):
     return dedupe_df(df, **kwargs)
 
 
+def _phase5_cluster(raw_pairs_ds: Dataset, cfg: Any) -> Dataset:
+    """Choose the Phase-5 clustering step.
+
+    When the block-shuffle recall-complete SCORING path is active (the same
+    detection ``score_blocks_distributed`` uses), pairs cross input-partition
+    boundaries, so per-partition Union-Find would under-merge -> route to the
+    distributed WCC (``build_clusters_distributed`` forced to
+    ``randomized_contraction``; ``two_phase`` head-wedges at 100M). Otherwise
+    scoring is per-partition and ``local_cc_assignments`` (cheap, no driver
+    collect, correct) is used -- the default.
+    """
+    from goldenmatch.distributed.clustering import (
+        build_clusters_distributed,
+        local_cc_assignments,
+    )
+    from goldenmatch.distributed.scoring import (
+        _block_shuffle_enabled,
+        _has_colocation_plan,
+    )
+
+    if _block_shuffle_enabled() and _has_colocation_plan(cfg):
+        logger.info(
+            "phase5 clustering: block-shuffle active -> build_clusters_distributed "
+            "(randomized_contraction; cross-partition pairs need real WCC)",
+        )
+        return build_clusters_distributed(
+            raw_pairs_ds, all_ids=None, algorithm="randomized_contraction",
+        )
+    logger.info("phase5 clustering: per-partition scoring -> local_cc_assignments")
+    return local_cc_assignments(raw_pairs_ds)
+
+
 def _run_phase5_pipeline(
     ds: Dataset,
     *,
@@ -98,7 +130,6 @@ def _run_phase5_pipeline(
     """
     from goldenmatch.config.schemas import GoldenRulesConfig
     from goldenmatch.core.autoconfig import auto_configure_df
-    from goldenmatch.distributed.clustering import local_cc_assignments
     from goldenmatch.distributed.golden import build_golden_records_distributed
     from goldenmatch.distributed.scoring import score_blocks_distributed
 
@@ -121,12 +152,14 @@ def _run_phase5_pipeline(
     #    component's edges are co-located in one block -- required by local_cc).
     raw_pairs_ds = score_blocks_distributed(ds, cfg)
 
-    # 3. Connected components via per-partition local Union-Find: a single
-    #    map_batches over the RAW pairs -> {member_id, cluster_id, cluster_size,
-    #    oversized}. No dedup (Union-Find is idempotent on duplicate edges), no
-    #    distributed-WCC iteration, no joins, no driver collect. Scoring is
-    #    per-partition so components never span partitions.
-    assignments_ds = local_cc_assignments(raw_pairs_ds)
+    # 3. Connected components: branch on whether block-shuffle is active.
+    #    block-shuffle OFF (default): scoring is per-partition, so components
+    #    never span partitions -- local_cc_assignments (single map_batches,
+    #    no driver collect, no distributed-WCC iteration) is correct and cheap.
+    #    block-shuffle ON + co-location plan: pairs cross input-partition
+    #    boundaries, so per-partition Union-Find would under-merge; route to
+    #    build_clusters_distributed(algorithm="randomized_contraction") instead.
+    assignments_ds = _phase5_cluster(raw_pairs_ds, cfg)
 
     # 4. Distributed hash join: annotate rows with __cluster_id__ (multi-member
     #    only). No broadcast member->cid dict.

--- a/packages/python/goldenmatch/scripts/bench_phase5_end2end.py
+++ b/packages/python/goldenmatch/scripts/bench_phase5_end2end.py
@@ -35,10 +35,40 @@ def main() -> int:
     ap.add_argument("--input", type=str, required=True)
     ap.add_argument("--output", type=str, required=True)
     ap.add_argument("--kill-wall-sec", type=float, default=KILL_WALL_SEC)
+    ap.add_argument(
+        "--block-shuffle",
+        choices=["0", "1"],
+        default="0",
+        help=(
+            "1 = recall-complete leg: enables GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE "
+            "and routes clustering to randomized_contraction WCC. "
+            "Requires GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH to be a gs:// path "
+            "(node-local scratch silently breaks cross-node parquet reads)."
+        ),
+    )
     args = ap.parse_args()
+
+    block_shuffle = bool(int(args.block_shuffle))
 
     os.environ.setdefault("GOLDENMATCH_ENABLE_DISTRIBUTED_RAY", "1")
     os.environ.setdefault("GOLDENMATCH_DISTRIBUTED_PIPELINE", "2")
+
+    if block_shuffle:
+        # HARD-set: these two flags define the recall-complete leg.
+        os.environ["GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE"] = "1"
+        os.environ["GOLDENMATCH_DISTRIBUTED_WCC"] = "randomized_contraction"
+        # GCS scratch is REQUIRED on multi-node: a node-local path silently
+        # breaks the cross-node parquet reads in the WCC per-round checkpoint.
+        scratch = os.environ.get("GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH", "")
+        if not scratch or not scratch.startswith("gs://"):
+            print(
+                "ERROR: --block-shuffle 1 requires "
+                "GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH=gs://<bucket>/rc_scratch. "
+                "A node-local scratch path silently breaks cross-node parquet reads "
+                "in the WCC per-round checkpoint.",
+                file=sys.stderr,
+            )
+            return 2
 
     from goldenmatch.distributed import read_partitioned
     from goldenmatch.distributed.pipeline import run_dedupe_pipeline_distributed
@@ -61,12 +91,38 @@ def main() -> int:
 
     peak_gb = proc.memory_info().rss / 1024**3
 
+    # Count multi-member clusters from the golden parquet written by the
+    # pipeline (one golden record per multi-member cluster). result.clusters
+    # is intentionally empty ({}) to avoid the driver-wedge at 100M.
+    multi_member_cluster_count: int | None = None
+    try:
+        import os as _os  # noqa: PLC0415
+
+        import polars as pl  # noqa: PLC0415
+
+        output_dir = args.output
+        golden_parts = [
+            f for f in _os.listdir(output_dir)
+            if f.endswith(".parquet")
+        ] if _os.path.isdir(output_dir) else []
+        if golden_parts:
+            multi_member_cluster_count = (
+                pl.scan_parquet(f"{output_dir}/**/*.parquet")
+                .select(pl.len())
+                .collect()
+                .item()
+            )
+    except Exception as exc:
+        print(f"WARNING: could not count multi-member clusters: {exc}", file=sys.stderr)
+
     print(f"load_wall_sec={load_wall:.1f}")
     print(f"pipeline_wall_sec={pipe_wall:.1f}")
     print(f"total_wall_sec={total:.1f}")
     print(f"client_peak_rss_gb={peak_gb:.2f}")
     print(f"client_baseline_rss_gb={baseline / 1024**3:.2f}")
     print(f"clusters={len(result.clusters) if result else 0}")
+    print(f"block_shuffle={block_shuffle}")
+    print(f"multi_member_cluster_count={multi_member_cluster_count}")
 
     if total >= args.kill_wall_sec:
         print(f"KILL: total wall {total:.1f}s >= {args.kill_wall_sec}s")

--- a/packages/python/goldenmatch/scripts/bench_phase5_end2end.py
+++ b/packages/python/goldenmatch/scripts/bench_phase5_end2end.py
@@ -57,6 +57,13 @@ def main() -> int:
         # HARD-set: these two flags define the recall-complete leg.
         os.environ["GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE"] = "1"
         os.environ["GOLDENMATCH_DISTRIBUTED_WCC"] = "randomized_contraction"
+        # Force the distributed WCC path: below the 50M-pair threshold
+        # build_clusters_distributed routes to the driver-collecting scipy
+        # fallback REGARDLESS of the algorithm, which is the head-wedge the
+        # recall-complete path exists to avoid. 100M block-shuffle pairs normally
+        # exceed 50M, but pin it so the run can't silently land on scipy.
+        # setdefault so an operator can still override.
+        os.environ.setdefault("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", "0")
         # GCS scratch is REQUIRED on multi-node: a node-local path silently
         # breaks the cross-node parquet reads in the WCC per-round checkpoint.
         scratch = os.environ.get("GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH", "")
@@ -96,22 +103,20 @@ def main() -> int:
     # is intentionally empty ({}) to avoid the driver-wedge at 100M.
     multi_member_cluster_count: int | None = None
     try:
-        import os as _os  # noqa: PLC0415
-
         import polars as pl  # noqa: PLC0415
 
-        output_dir = args.output
-        golden_parts = [
-            f for f in _os.listdir(output_dir)
-            if f.endswith(".parquet")
-        ] if _os.path.isdir(output_dir) else []
-        if golden_parts:
-            multi_member_cluster_count = (
-                pl.scan_parquet(f"{output_dir}/**/*.parquet")
-                .select(pl.len())
-                .collect()
-                .item()
-            )
+        # Scan the golden parquet directly -- args.output is the gs:// (or local)
+        # path the pipeline wrote to, and polars/pyarrow read gs:// natively. Do
+        # NOT pre-guard with os.path.isdir/listdir: those are local-FS calls that
+        # return False on a gs:// path, which would leave the count None on
+        # exactly the recall leg this instrumentation exists for. A missing/empty
+        # path raises -> caught below -> count stays None.
+        multi_member_cluster_count = (
+            pl.scan_parquet(f"{args.output.rstrip('/')}/**/*.parquet")
+            .select(pl.len())
+            .collect()
+            .item()
+        )
     except Exception as exc:
         print(f"WARNING: could not count multi-member clusters: {exc}", file=sys.stderr)
 

--- a/packages/python/goldenmatch/scripts/bench_phase5_simulated.py
+++ b/packages/python/goldenmatch/scripts/bench_phase5_simulated.py
@@ -157,7 +157,14 @@ def main() -> int:
     # The pipeline does not materialise clusters on the driver (intentionally);
     # a parquet scan is the only way to get a multi_member_cluster_count without
     # introducing a take_all that would wedge the driver.
-    golden_out = str(args.out.parent / "phase5_simulated_golden")
+    #
+    # PER-LEG dir derived from the --out stem: the baseline (--block-shuffle 0)
+    # and recall-complete (--block-shuffle 1) legs use DIFFERENT --out files, so
+    # this keeps their golden in separate dirs. Ray write_parquet appends
+    # UUID-named part files without clearing, so a SHARED dir would let the
+    # recall count include the baseline's golden and inflate the recall-vs-
+    # baseline comparison (the whole point of the two-leg gate).
+    golden_out = str(args.out.parent / f"{args.out.stem}_golden")
 
     # The pipeline auto-configures from the Ray Dataset itself; no
     # explicit config arg accepted. confidence_required=False keeps the

--- a/packages/python/goldenmatch/scripts/bench_phase5_simulated.py
+++ b/packages/python/goldenmatch/scripts/bench_phase5_simulated.py
@@ -68,6 +68,16 @@ def main() -> int:
         type=Path,
         default=Path("bench_phase5_simulated.json"),
     )
+    ap.add_argument(
+        "--block-shuffle",
+        choices=["0", "1"],
+        default="0",
+        help=(
+            "1 = recall-complete leg: enables GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE "
+            "and routes clustering to randomized_contraction WCC. Default 0 = "
+            "baseline (per-partition scoring + local_cc_assignments)."
+        ),
+    )
     args = ap.parse_args()
 
     identity_enabled = args.identity.lower() in ("true", "1", "yes")
@@ -129,14 +139,60 @@ def main() -> int:
     os.environ["GOLDENMATCH_DISTRIBUTED_PIPELINE"] = "2"
     os.environ["GOLDENMATCH_ENABLE_DISTRIBUTED_RAY"] = "1"
 
+    block_shuffle = bool(int(args.block_shuffle))
+    if block_shuffle:
+        # HARD-set: these two flags define the recall-complete leg.
+        os.environ["GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE"] = "1"
+        os.environ["GOLDENMATCH_DISTRIBUTED_WCC"] = "randomized_contraction"
+        # Force the WCC path on the few-M-row sim dataset (below the 50M-pair
+        # threshold the route is scipy, which would vacuously validate scipy not
+        # WCC). setdefault so an operator can override.
+        os.environ.setdefault("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", "0")
+        os.environ.setdefault(
+            "GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH",
+            str(args.out.parent / "rc_scratch"),
+        )
+
+    # Write golden to a temp output dir so we can count multi-member clusters.
+    # The pipeline does not materialise clusters on the driver (intentionally);
+    # a parquet scan is the only way to get a multi_member_cluster_count without
+    # introducing a take_all that would wedge the driver.
+    golden_out = str(args.out.parent / "phase5_simulated_golden")
+
     # The pipeline auto-configures from the Ray Dataset itself; no
     # explicit config arg accepted. confidence_required=False keeps the
     # bench from raising ControllerNotConfidentError on the synthetic
     # fixture (the controller's gates target real-shape data).
-    result = run_dedupe_pipeline_distributed(ds, confidence_required=False)
+    result = run_dedupe_pipeline_distributed(
+        ds, confidence_required=False, output_path=golden_out,
+    )
 
     wall_total = time.perf_counter() - t0
     rss_end_gb = _peak_rss_gb()
+
+    # Count multi-member clusters from the golden parquet written by the
+    # pipeline (one golden record per multi-member cluster). The pipeline
+    # intentionally does NOT materialise clusters on the driver
+    # (result.clusters == {}), so a parquet scan is the clean path.
+    multi_member_cluster_count: int | None = None
+    try:
+        import os as _os  # noqa: PLC0415
+
+        import polars as pl  # noqa: PLC0415
+
+        golden_parts = [
+            f for f in _os.listdir(golden_out)
+            if f.endswith(".parquet")
+        ] if _os.path.isdir(golden_out) else []
+        if golden_parts:
+            multi_member_cluster_count = (
+                pl.scan_parquet(f"{golden_out}/**/*.parquet")
+                .select(pl.len())
+                .collect()
+                .item()
+            )
+    except Exception as exc:
+        log.warning("could not count multi-member clusters: %s", exc)
 
     summary = {
         "ray_address": ray_address,
@@ -147,10 +203,12 @@ def main() -> int:
         "expected_rows": args.rows,
         "n_partitions": n_partitions,
         "identity_enabled": identity_enabled,
+        "block_shuffle": block_shuffle,
         "wall_total_s": round(wall_total, 2),
         "driver_rss_start_gb": round(rss_start_gb, 3),
         "driver_rss_end_gb": round(rss_end_gb, 3),
         "driver_rss_peak_gb": round(rss_end_gb, 3),  # ru_maxrss is high-water
+        "multi_member_cluster_count": multi_member_cluster_count,
         "identity_summary": (
             getattr(result, "identity_summary", None)
             if identity_enabled

--- a/packages/python/goldenmatch/tests/test_bench_phase5_simulated_script.py
+++ b/packages/python/goldenmatch/tests/test_bench_phase5_simulated_script.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 def test_bench_script_has_expected_cli_surface() -> None:
-    """--help must list --parquet, --identity, --out, --rows."""
+    """--help must list --parquet, --identity, --out, --rows, --block-shuffle."""
     package_root = Path(__file__).resolve().parent.parent
     script = package_root / "scripts" / "bench_phase5_simulated.py"
     result = subprocess.run(
@@ -22,3 +22,4 @@ def test_bench_script_has_expected_cli_surface() -> None:
     assert "--identity" in result.stdout
     assert "--out" in result.stdout
     assert "--rows" in result.stdout
+    assert "--block-shuffle" in result.stdout

--- a/packages/python/goldenmatch/tests/test_distributed_randomized_contraction_wcc.py
+++ b/packages/python/goldenmatch/tests/test_distributed_randomized_contraction_wcc.py
@@ -288,3 +288,26 @@ def test_randomized_contraction_wcc_default_scratch_consumable():
     labels = {r["id"]: r["label"] for r in out.take_all()}
     assert set(labels.values()) == {1}
     assert set(labels.keys()) == {1, 2, 3}
+
+
+def test_build_clusters_distributed_algorithm_kwarg_overrides_env(monkeypatch, caplog, tmp_path):
+    pytest.importorskip("ray")
+    import logging  # noqa: PLC0415
+
+    from goldenmatch.distributed.clustering import (  # noqa: PLC0415
+        build_clusters_distributed,
+        pairs_list_to_dataset,
+    )
+    # Env selector says two_phase; the kwarg must override to randomized_contraction.
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_WCC", "two_phase")
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", "0")  # force the WCC path
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH", str(tmp_path))
+    ds = pairs_list_to_dataset([(1, 2, 0.9), (2, 3, 0.85), (5, 6, 0.95)])
+    with caplog.at_level(logging.INFO):
+        out = build_clusters_distributed(
+            ds, all_ids=[1, 2, 3, 5, 6], algorithm="randomized_contraction",
+        )
+    msgs = [r.message.lower() for r in caplog.records]
+    assert any("randomized_contraction" in m for m in msgs), msgs
+    rows = {r["member_id"]: r["cluster_size"] for r in out.take_all()}
+    assert rows[1] == 3 and rows[5] == 2

--- a/packages/python/goldenmatch/tests/test_phase5_cluster_routing.py
+++ b/packages/python/goldenmatch/tests/test_phase5_cluster_routing.py
@@ -1,0 +1,60 @@
+"""Routing tests for _phase5_cluster (#844 Spec 2). No Ray runtime: the
+clustering functions are monkeypatched, so the branch is tested in isolation."""
+
+
+def test_phase5_cluster_uses_wcc_when_block_shuffle_on(monkeypatch):
+    import goldenmatch.distributed.clustering as C
+    import goldenmatch.distributed.pipeline as P
+    import goldenmatch.distributed.scoring as S
+
+    calls = {}
+    monkeypatch.setattr(C, "build_clusters_distributed",
+                        lambda ds, **kw: (calls.__setitem__("wcc", kw), "WCC")[1])
+    monkeypatch.setattr(C, "local_cc_assignments",
+                        lambda ds: (calls.__setitem__("local", True), "LOCAL")[1])
+    monkeypatch.setattr(S, "_block_shuffle_enabled", lambda: True)
+    monkeypatch.setattr(S, "_has_colocation_plan", lambda cfg: True)
+
+    out = P._phase5_cluster("PAIRS_DS", object())
+    assert out == "WCC"
+    assert calls["wcc"]["algorithm"] == "randomized_contraction"
+    assert calls["wcc"]["all_ids"] is None
+    assert "local" not in calls
+
+
+def test_phase5_cluster_uses_local_cc_when_block_shuffle_off(monkeypatch):
+    import goldenmatch.distributed.clustering as C
+    import goldenmatch.distributed.pipeline as P
+    import goldenmatch.distributed.scoring as S
+
+    calls = {}
+    monkeypatch.setattr(C, "build_clusters_distributed",
+                        lambda ds, **kw: (calls.__setitem__("wcc", kw), "WCC")[1])
+    monkeypatch.setattr(C, "local_cc_assignments",
+                        lambda ds: (calls.__setitem__("local", True), "LOCAL")[1])
+    monkeypatch.setattr(S, "_block_shuffle_enabled", lambda: False)
+    monkeypatch.setattr(S, "_has_colocation_plan", lambda cfg: True)
+
+    out = P._phase5_cluster("PAIRS_DS", object())
+    assert out == "LOCAL"
+    assert "wcc" not in calls
+
+
+def test_phase5_cluster_local_cc_when_no_colocation_plan(monkeypatch):
+    """Block-shuffle flag set but the config has no co-location plan -> the
+    shuffle scorer didn't fire, so clustering stays per-partition local_cc."""
+    import goldenmatch.distributed.clustering as C
+    import goldenmatch.distributed.pipeline as P
+    import goldenmatch.distributed.scoring as S
+
+    calls = {}
+    monkeypatch.setattr(C, "build_clusters_distributed",
+                        lambda ds, **kw: (calls.__setitem__("wcc", kw), "WCC")[1])
+    monkeypatch.setattr(C, "local_cc_assignments",
+                        lambda ds: (calls.__setitem__("local", True), "LOCAL")[1])
+    monkeypatch.setattr(S, "_block_shuffle_enabled", lambda: True)
+    monkeypatch.setattr(S, "_has_colocation_plan", lambda cfg: False)
+
+    out = P._phase5_cluster("PAIRS_DS", object())
+    assert out == "LOCAL"
+    assert "wcc" not in calls


### PR DESCRIPTION
Spec 2 of 2 for #844. Spec 1 (PR #851, merged) built the randomized-contraction WCC as a drop-in for `build_clusters_distributed`. This wires the **recall-complete path** (the #845 block-shuffle scoring + that WCC) into the Phase-5 e2e pipeline. **Opt-in, default unchanged.**

## What

- **`algorithm` kwarg on `build_clusters_distributed`** — overrides the env WCC selector for a call; `None` (default) is byte-identical to before. Lets the pipeline force `randomized_contraction` so the at-scale path can't route to `two_phase` (which head-wedges at 100M).
- **`_run_phase5_pipeline` step 3 branch** (`_phase5_cluster`): when the block-shuffle recall-complete scoring path is active (`_block_shuffle_enabled() and _has_colocation_plan(cfg)` — the *same* predicate `score_blocks_distributed` uses, so scoring + clustering stay a unit), clustering routes to `build_clusters_distributed(..., all_ids=None, algorithm="randomized_contraction")`; otherwise `local_cc_assignments` (default). Steps 2/4/5/6 untouched — both clustering routes emit the same `{member_id, cluster_id, cluster_size, oversized}` contract the join + golden consume.
- **Bench handoff:** a `--block-shuffle` recall-complete leg on `bench_phase5_simulated.py` + `bench_phase5_end2end.py`; the sim workflow runs baseline+recall and **fails if recall multi-member count ≤ baseline**; end2end requires a `gs://` scratch (node-local breaks cross-node parquet reads) and forces the WCC path. GCP cluster recipe + CHANGELOG.

## Why opt-in / what's deferred

Default stays `GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=0`. The binding **real 100M run** (operator provisions a multi-node Ray cluster + fires `run_phase5_bench`), the **default-flip**, and the scratch-dir parquet **pruning** are deferred to the operator's cluster / a follow-up — none are autonomously runnable from here.

## Test plan

- [x] 3 no-Ray routing tests for `_phase5_cluster` (full truth table incl. flag-on-but-no-plan → local) — **pass locally**.
- [x] Bench-script CLI-surface test updated + passing.
- [ ] **Ray lane (CI):** the `algorithm`-kwarg override test (`importorskip("ray")`) in the `distributed` lane.
- Handoff (NOT PR-CI-gated, operator-fired): the sim recall-vs-baseline bench leg + the real 100M `run_phase5_bench`.

## How it was built

Brainstorm → reviewer-approved spec → reviewer-approved plan → 2 TDD dispatches (core wiring; bench/docs), each spec+quality reviewed → final whole-impl review. Reviews caught: a sim-bench golden-dir collision that inflated the recall count, an end2end leg that could silently route to the driver-collecting scipy fallback, and a dead `gs://` count — all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)