### PR TITLE
docs: record the distributed WCC arc (#844) in the context network + Mintlify

### DIFF
--- a/context-network/architecture/distributed-wcc.md
+++ b/context-network/architecture/distributed-wcc.md
@@ -1,0 +1,85 @@
+# Distributed WCC (Ray) — randomized contraction + the recall-complete Phase-5 path
+
+How the Ray Phase-5 pipeline gets correct clustering at 100M+: a relational
+randomized-contraction connected-components pass that replaces the per-partition
+Union-Find once scoring crosses partition boundaries. The Ray-side answer to the
+same WCC-at-scale problem the [Sail tier](sail-tier.md) solves on its own track.
+
+**Status:** BOTH specs SHIPPED (2026-06-10). Spec 1 = the WCC algorithm (PR #851,
+`0aa1051f`); Spec 2 = wiring it into the Phase-5 e2e pipeline (PR #852, `d551f537`).
+Opt-in (`GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1`), default unchanged. Only the
+operator-side binding 100M run + the default-flip remain (need a BYO multi-node Ray
+cluster). **Specs/plans:** `docs/superpowers/specs|plans/2026-06-10-distributed-wcc-*`.
+**Decision:** [../decisions/0011-distributed-wcc-randomized-contraction.md](../decisions/0011-distributed-wcc-randomized-contraction.md).
+
+## The problem (#844)
+The Phase-5 distributed pipeline under-merged at scale. PR #845 added an opt-in
+blocking-aware shuffle to scoring (so true duplicates co-locate), but once pairs
+cross input-partition boundaries the per-partition `local_cc_assignments`
+Union-Find under-merges. A real distributed WCC was needed — and the two existing
+ones both died at 100M: `two_phase_wcc` collected members + boundary edges to the
+driver and ran a cpython-loop UnionFind there (head-wedge, proven on a real GCP
+run); `distributed_wcc` (min-label + pointer-jump) deadlocked Ray's streaming
+executor on its iterative `Dataset.join` loop. Two independent failure axes — a
+chain-fragile algorithm AND an iterative-join deadlock — had to be fixed at once.
+
+## The algorithm
+`randomized_contraction_wcc` (`distributed/clustering.py`) implements
+Bögeholz–Brand–Todor (2018, arXiv:1802.09478, "In-database connected component
+analysis") — the algorithm GraphFrames maintainer Sem Sinchenko recommended for
+chain-heavy identity graphs (min-propagation's worst case). Each round: a random
+affine hash `h(x)=(A·x+B) mod p` (p = 2^31-1, i64-safe); each vertex's
+representative is the min-hash vertex in its closed neighbourhood; edges contract
+to reps and self-loops drop. The edge set shrinks geometrically (O(log|V|) rounds
+w.h.p.), with no driver union-find and no O(N) driver dict. A pure-Polars
+reference (`_rc_wcc_polars`) is the correctness gate (validated vs
+`scipy.csgraph` on 425 random graphs + chain/star/cycle fixtures); the Ray path
+mirrors it.
+
+## The two Ray-execution gotchas (cost CI rounds; now load-bearing)
+Ray Data's hash-shuffle `Dataset.join` (pyarrow Acero under the hood) is finicky:
+1. **Distinct-named keys only.** Same-name keys on both sides (`edges.v == rep.v`)
+   raise `ArrowInvalid: ... multiple matches for key field reference`. The rep
+   table is keyed on `node`, so every join is distinct-keyed (v/node, w/node,
+   cur/node) — the working `distributed_wcc` joins are distinct-keyed for the same
+   reason.
+2. **ReadParquet inputs only.** A `map_batches`-derived dataset as a join input
+   fails the same way; checkpoint the intermediate to parquet so the join's inputs
+   are clean `ReadParquet` datasets. Diagnose from the CI log's "Execution plan of
+   Dataset" lines (working joins show `ReadParquet -> Join`; the failing one showed
+   `InputDataBuffer -> Join`).
+
+The per-round parquet checkpoint (the deadlock fix) doubles as the clean scratch
+those joins need.
+
+## The recall-complete Phase-5 path (Spec 2)
+`_run_phase5_pipeline` (`distributed/pipeline.py`) step 3 branches via
+`_phase5_cluster(raw_pairs_ds, cfg)`: when `_block_shuffle_enabled() and
+_has_colocation_plan(cfg)` (the SAME predicate `score_blocks_distributed` uses, so
+scoring and clustering stay a unit) it routes to
+`build_clusters_distributed(raw_pairs_ds, all_ids=None,
+algorithm="randomized_contraction")`; otherwise the default `local_cc_assignments`.
+The new `algorithm` kwarg overrides the env selector so the at-scale path can't
+route to `two_phase` (which head-wedges). The join + golden tail is unchanged —
+both clustering routes emit the same `{member_id, cluster_id, cluster_size,
+oversized}` contract that `_join_assignments_distributed` + distributed golden
+consume. Below the 50M-pair threshold `build_clusters_distributed` still uses
+driver-side scipy (correct, bounded); the distributed WCC fires at scale.
+
+## Operator run (deferred — needs a BYO cluster)
+`GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1` +
+`GOLDENMATCH_DISTRIBUTED_WCC=randomized_contraction` +
+`GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH=gs://<bucket>/...` (shared storage is
+load-bearing — node-local breaks the cross-node parquet reads). Bench via the
+`run_phase5_bench` leg of `bench-distributed-stack.yml` (RAY_ADDRESS +
+`bench_100000000.parquet`); the sim leg (`run_phase5_simulated`, 4 workers in one
+runner) asserts recall improves vs the per-partition baseline and fails on no
+signal. GCP cluster recipe in `docs/distributed-ray-cluster-setup.md`.
+
+## Relationship to the Sail tier
+This is the **Ray** answer to WCC-at-scale; the [Sail tier](sail-tier.md) (decision
+0004) is the **Spark-Connect** answer that ultimately retires Ray. Parallel tracks
+on the same problem; whichever binds its real 100M run first is the go-forward.
+
+---
+**Classification:** architecture/active • **Last updated:** 2026-06-10

--- a/context-network/decisions/0011-distributed-wcc-randomized-contraction.md
+++ b/context-network/decisions/0011-distributed-wcc-randomized-contraction.md
@@ -1,0 +1,70 @@
+# 0011 — Distributed WCC: randomized contraction over driver-collect / min-propagation
+
+**Status:** accepted (2026-06-10, PRs #851 Spec 1 + #852 Spec 2)
+**Evidence:** pure-Polars reference green vs `scipy.csgraph` on 425 random graphs + chain/star/cycle fixtures (a 1024-node chain converges in 9 rounds, not 1024); the Ray orchestration green on the `distributed` CI lane (the ray path produces the same components as the scipy-verified pure driver). The binding multi-node 100M run is operator-deferred.
+
+## Context
+#844: the Phase-5 distributed pipeline (`GOLDENMATCH_DISTRIBUTED_PIPELINE=2`)
+under-merged at scale. PR #845's opt-in blocking-aware shuffle co-locates
+duplicates, but making components cross input-partition boundaries breaks the
+per-partition `local_cc_assignments` Union-Find. A real distributed WCC was
+needed, and both existing implementations died at 100M: `two_phase_wcc`
+driver-collects members + boundary edges and runs a cpython-loop UnionFind on the
+head (wedges — proven on a real GCP run while workers sat idle); `distributed_wcc`
+(min-label + pointer-jump) deadlocks Ray's streaming executor on its iterative
+`Dataset.join` loop. GraphFrames maintainer Sem Sinchenko's advice was decisive:
+identity graphs are chain-heavy (min-propagation's worst case), so use Two-Phase
+(Kiveris 2014) or Randomized-Contraction (2018), implemented relationally — no
+cpython UF, no O(N) driver dict.
+
+## Decision
+1. **Algorithm: randomized contraction** (Bögeholz–Brand–Todor 2018,
+   arXiv:1802.09478) — relational, chain-robust, O(log|V|) rounds, no driver
+   union-find. A pure-Polars reference is the correctness gate (vs `scipy`); the
+   Ray path mirrors it.
+2. **Ray-execution fix: per-round parquet checkpoint** of the shrinking edge set,
+   truncating the lazy lineage that deadlocks the streaming executor (what
+   `.materialize()` alone did not). It also gives the joins clean `ReadParquet`
+   inputs — Ray Data's hash-shuffle join rejects both same-name keys AND
+   `map_batches`-derived inputs.
+3. **Opt-in, wired but not default.** `GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1`
+   turns on the whole recall-complete path (shuffle scoring + WCC clustering, kept
+   a unit by sharing the detection predicate). A new `algorithm` kwarg on
+   `build_clusters_distributed` lets the pipeline force `randomized_contraction`
+   so the at-scale path can't route to `two_phase`. Default stays
+   `local_cc_assignments`.
+4. **Decompose into two specs.** Spec 1 = the algorithm as a validated drop-in;
+   Spec 2 = the e2e wiring + ready-to-run bench. The binding 100M run + the
+   default-flip wait on a BYO cluster.
+
+### Rejected alternatives
+- **Fix `two_phase_wcc`'s driver collect.** The boundary super-graph is itself
+  large at 100M (tens of millions of distinct local roots); a driver-side Python
+  UF over it is the wedge. Sem named this exact antipattern.
+- **Fix `distributed_wcc`'s deadlock with `.materialize()`.** Already tried;
+  materialize doesn't truncate the iterative lineage enough — and min-propagation
+  is chain-fragile regardless.
+- **Two-Phase / large-star-small-star (Kiveris 2014).** Sem's other recommendation;
+  randomized contraction is "slightly better," and a literal large-star was found
+  buggy on the Sail tier (caught only by a plan-review hand-trace).
+- **Flip the default now.** The binding proof is a multi-node 100M run we cannot
+  run autonomously; flipping before it would be unproven. Opt-in until the
+  operator's run.
+
+## Consequences
+- Two un-locally-testable Ray Data join rules are now load-bearing knowledge
+  (distinct-keyed joins + `ReadParquet` inputs); recorded in
+  [../architecture/distributed-wcc.md](../architecture/distributed-wcc.md).
+- The `distributed` CI job gained a blocking ray gate for the new tests; its
+  `timeout-minutes` went 20 → 30 to fit it (the added ~3.5 min step had cancelled
+  the job).
+- The Ray broad-coverage `test_phase5_pipeline_*` failures (`KeyError '__row_id__'`
+  in a Ray `hash_partition`) are PRE-EXISTING and `continue-on-error`; verify
+  against a recent `main` run before treating a broad-coverage failure as new.
+- Parallel to the [Sail tier](../architecture/sail-tier.md)
+  ([decision 0004](0004-sail-tier-scope.md)) — the Spark-Connect track that
+  retires Ray. Whichever binds its 100M run first is the go-forward; this keeps the
+  Ray path viable in the meantime.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-06-10

--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -10,6 +10,7 @@ links rather than reading everything.
 ## Architecture (active technical knowledge)
 - [architecture/datafusion-spine.md](architecture/datafusion-spine.md) — the embedded-DataFusion "scale mode" spine (Stages A-E); current status + entry points.
 - [architecture/sail-tier.md](architecture/sail-tier.md) — the distributed Sail-native tier (Spark Connect) that replaces Ray; specced, build not started.
+- [architecture/distributed-wcc.md](architecture/distributed-wcc.md) — the Ray distributed-WCC solve for #844: randomized-contraction connected components + the recall-complete Phase-5 path (block-shuffle scoring + distributed clustering); both specs SHIPPED (#851/#852), opt-in, the 100M run operator-deferred.
 - [architecture/sql-native-extensions.md](architecture/sql-native-extensions.md) — graph + embedding UDFs on DuckDB/Postgres/DataFusion, native-direct (shared `graph-core` + `goldenembed-rs`); SHIPPED (#509).
 - [architecture/goldenflow-native-kernel.md](architecture/goldenflow-native-kernel.md) — GoldenFlow date/phone vectorized fast paths + the optional `goldenflow-native` phone kernel (NANP-only gated); SHIPPED (2026-06-07).
 - [architecture/goldencheck-native-kernel.md](architecture/goldencheck-native-kernel.md) — GoldenCheck's Arrow-native runtime (`goldencheck-native`) + deep-profiling expansion (Benford / composite-key / FD / fuzzy / approx-FD kernels, `--deep`, `refs`, freshness) + the `cell_quality` / `functional_dependencies` bridge APIs; SHIPPED (#793, 2026-06-07).
@@ -28,6 +29,7 @@ links rather than reading everything.
 - [decisions/0008-fellegi-sunter-splink-parity.md](decisions/0008-fellegi-sunter-splink-parity.md) — Fellegi-Sunter: close the Splink engine gap in dependency order, reuse the scale substrate, keep defaults reproducible (new power opt-in), measure the scale gate on a real runner.
 - [decisions/0009-rust-test-coverage.md](decisions/0009-rust-test-coverage.md) — Rust coverage: make the tests real (de-skip the bridge, run the standalone crates), route around the `cargo pgrx test` dead-end (psql smoke), then measure — informational baseline, not a hard gate.
 - [decisions/0010-publish-containers-ghcr-mirror.md](decisions/0010-publish-containers-ghcr-mirror.md) — publish-containers flakes were anonymous-Docker-Hub buildkit-pull timeouts; mirror buildkit/binfmt into ghcr (off the hot path) + native retry-once, no new secrets/actions.
+- [decisions/0011-distributed-wcc-randomized-contraction.md](decisions/0011-distributed-wcc-randomized-contraction.md) — distributed WCC: randomized contraction (relational, chain-robust) over driver-collect / min-propagation; per-round parquet checkpoint dodges the Ray streaming-executor deadlock; opt-in, 2-spec split, 100M operator-deferred.
 
 ## Processes (how work is done here)
 - [processes/development-workflow.md](processes/development-workflow.md) — spec → plan → execute → review → CI → merge, plus the hard environment constraints.

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,33 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-10 — Distributed WCC for #844: randomized contraction + recall-complete Phase 5 (#851/#852)
+- New nodes: [../architecture/distributed-wcc.md](../architecture/distributed-wcc.md)
+  + [../decisions/0011-distributed-wcc-randomized-contraction.md](../decisions/0011-distributed-wcc-randomized-contraction.md).
+- **Problem (#844):** the Phase-5 distributed pipeline under-merged at scale. PR
+  #845's opt-in block-shuffle co-locates duplicates but makes components cross
+  partitions, which the per-partition `local_cc_assignments` Union-Find
+  under-merges. The two existing distributed WCCs both die at 100M:
+  `two_phase_wcc` driver-collects + runs a cpython-loop UnionFind (head-wedge);
+  `distributed_wcc` deadlocks Ray's streaming executor on iterative joins.
+- **Fix (both specs SHIPPED):** Spec 1 (PR #851) = `randomized_contraction_wcc`
+  (Bögeholz–Brand–Todor 2018, arXiv:1802.09478) — relational, chain-robust,
+  O(log|V|) rounds, no driver UF, per-round parquet checkpoint to dodge the
+  deadlock; pure-Polars reference gated vs `scipy.csgraph`. Spec 2 (PR #852) =
+  wires it into `_run_phase5_pipeline` (block-shuffle on -> distributed WCC, off ->
+  `local_cc`; same predicate the scorer uses) via a new `algorithm` kwarg on
+  `build_clusters_distributed`; join + golden tail unchanged (shared contract).
+  Opt-in (`GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1`), **default unchanged**.
+- **Two un-locally-testable Ray Data join rules now recorded** (distinct-named keys
+  + `ReadParquet` inputs — both surfaced as `ArrowInvalid` on the CI ray lane).
+  The `distributed` job `timeout-minutes` went 20 -> 30 to fit the new blocking gate.
+- **Deferred (operator):** the binding multi-node 100M run + the default-flip (need
+  a BYO Ray cluster; `GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH` must be a `gs://` prefix).
+  Parallel to the [Sail tier](../architecture/sail-tier.md) (the Spark-Connect track
+  that retires Ray); whichever binds 100M first is go-forward. Mintlify scale page
+  (`docs-site/goldenmatch/backends-and-scale.mdx`) updated with the recall-complete
+  path.
+
 ## 2026-06-10 — publish-containers flake hardening (ghcr buildkit mirror, #846)
 - New decision: [../decisions/0010-publish-containers-ghcr-mirror.md](../decisions/0010-publish-containers-ghcr-mirror.md).
 - **Audit:** `publish-containers` went red ~1 run in 18 over 30 days (11 fails,

--- a/docs-site/goldenmatch/backends-and-scale.mdx
+++ b/docs-site/goldenmatch/backends-and-scale.mdx
@@ -60,6 +60,28 @@ goldenmatch dedupe big.csv --backend ray
 
 The Ray path short-circuits back to local parallel scoring below four large blocks, since the distribution overhead does not pay off for small workloads.
 
+## Distributed Phase 5 (100M+)
+
+At hundreds of millions of rows the pipeline runs fully distributed on a multi-node Ray cluster, keeping every stage as a Ray Dataset so the driver never holds the full graph. Enable it with `GOLDENMATCH_DISTRIBUTED_PIPELINE=2` and `GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1`, pointing `RAY_ADDRESS` at your cluster.
+
+By default, scoring runs per partition: two records are compared only if they land in the same arbitrary partition, so recall drops as the partition count rises. The **recall-complete path** fixes this. Setting `GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1` shuffles records by blocking key before scoring, so every record sharing a key is co-located. Clustering then switches automatically from per-partition Union-Find to a distributed connected-components pass that handles components spanning partitions.
+
+```bash
+export GOLDENMATCH_DISTRIBUTED_PIPELINE=2
+export GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1
+export GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1          # opt-in: recall-complete
+export GOLDENMATCH_DISTRIBUTED_WCC=randomized_contraction
+export GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH=gs://your-bucket/rc_scratch
+```
+
+The distributed connected-components algorithm is a randomized contraction (Bögeholz, Brand and Todor, 2018): relational, chain-robust, with no driver-side union-find and no per-vertex Python dictionary. Each round checkpoints its shrinking edge set to parquet, which keeps the Ray streaming executor from deadlocking on long iterative joins. Below 50M candidate pairs it uses driver-side `scipy` instead, which is correct and bounded at that scale.
+
+<Warning>
+  On a multi-node cluster, `GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH` must be shared storage (a `gs://` prefix). A node-local path is not readable by workers on other nodes, so the per-round parquet checkpoints would fail.
+</Warning>
+
+The recall-complete path is opt-in; the default per-partition path is unchanged. Cluster setup, the full env reference, and the benchmark live in the [distributed Ray cluster guide](https://github.com/benseverndev-oss/goldenmatch/blob/main/docs/distributed-ray-cluster-setup.md).
+
 <Note>
   Debug the prep-versus-kernel split for the bucket backend with `GOLDENMATCH_BUCKET_DEBUG=1`. It prints a per-bucket prep / kernel / post-filter timing breakdown. It is off by default, costs nothing, and does not change output.
 </Note>


### PR DESCRIPTION
Documents the now-merged #844 distributed WCC work (Spec 1 #851 + Spec 2 #852). No code change.

## Context network
- **New** `architecture/distributed-wcc.md`: the Ray randomized-contraction WCC + the recall-complete Phase-5 path (the problem, the algorithm, the two un-locally-testable Ray Data join rules, the `_phase5_cluster` wiring, the operator run, and the relationship to the Sail tier).
- **New** `decisions/0011-distributed-wcc-randomized-contraction.md`: randomized contraction over driver-collect / min-propagation; per-round parquet checkpoint as the deadlock fix; opt-in, 2-spec split; rejected alternatives.
- Discovery hub + updates log wired up.

## Mintlify (docs-site)
- `goldenmatch/backends-and-scale.mdx` gains a "Distributed Phase 5 (100M+)" section: `GOLDENMATCH_DISTRIBUTED_PIPELINE=2`, the opt-in `GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1` recall-complete path, the randomized-contraction WCC, and the load-bearing `gs://` scratch requirement.

Default behavior is unchanged; the binding 100M run stays operator-deferred. Docs only, so the only meaningful CI is the Mintlify deploy check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)