### PR TITLE
docs: context-network + mintlify for #857 refdata name scorers + blocking parity

### DIFF
--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -31,7 +31,7 @@ links rather than reading everything.
 
 ## Planning (where it's going)
 - [planning/roadmap.md](planning/roadmap.md) — the Arrow-native arc and what's next.
-- [planning/surface-hardening.md](planning/surface-hardening.md) — the 2026-06-05 four-surface audit arc: fail-closed HTTP auth, CLI/TUI fixes, Python->TS parity ports (+ the parity-fixture methodology), and the open PR queue.
+- [planning/surface-hardening.md](planning/surface-hardening.md) — the 2026-06-05 four-surface audit arc: fail-closed HTTP auth, CLI/TUI fixes, Python->TS parity ports, and the parity-fixture methodology — now including the #856/#857 "fixtures rot silently" lesson and the merged #857 refdata-name-scorer + autoconfig-blocking TS port (generate-and-drift-guard bundled data; pin parity to Python ground truth).
 - [planning/security-hardening.md](planning/security-hardening.md) — the 2026-06-05 security-hardening arc: 42-alert remediation (Dependabot + code scanning), Scorecard 6.1->7.3 (Token-Permissions/Signed-Releases/Fuzzing), the CodeQL Autofix incident, property-test bug ledger, and open actions.
 
 ## Meta (keeping the network alive)
@@ -39,4 +39,4 @@ links rather than reading everything.
 - [meta/maintenance.md](meta/maintenance.md) — how to keep nodes accurate and small.
 
 ---
-**Classification:** navigation • **Last updated:** 2026-06-07
+**Classification:** navigation • **Last updated:** 2026-06-11

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,38 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-11 — TS parity: refdata name scorers + autoconfig blocking (#857, from the #856 audit)
+- Extended the parity workstream node
+  [../planning/surface-hardening.md](../planning/surface-hardening.md):
+  a new "Fixtures rot silently — the #856/#857 lesson" subsection under the
+  parity-fixture methodology, plus the #857 entry.
+- **The #856 audit found real cross-language drift sitting in `main`:** the
+  TS `typescript` CI lane runs only on TS path changes, so a pure-Python
+  autoconfig change leaves the committed parity vectors stale and the TS
+  test green against a fixture that no longer reflects Python. The
+  controller-stoppoint fixture had drifted (`ensemble` where Python now
+  emits the refdata name scorers + evolved multi-pass blocking).
+- **#857 (merged) closed it by porting, not pinning.** The edge-safe TS core
+  gained `given_name_aliased_jw` (alias-aware JW) and `name_freq_weighted_jw`
+  (Census surname-IDF-weighted JW), the first/last-name auto-config refine
+  (`refineNameScorer`, last-before-first; `multi_name` unrefined), and a
+  faithful port of `build_blocking`'s selection (exact gate at
+  `cardinality_ratio ≤ 0.5` on the exact pool only; secondary-name passes).
+  Scope grew twice (regen forced the 186KB surname table; the residual red
+  was a separate blocking-evolution gap). Both refdata tables are generated
+  TS modules synced from the Python source (`scripts/sync_ts_refdata.mjs`)
+  and drift-guarded; numeric parity is pinned by Python-computed values in
+  `tests/parity/scorer-ground-truth.test.ts` (4dp).
+- **Two durable methodology guards recorded:** generate-and-drift-guard
+  bundled data (never hand-copy), and pin scorer parity to Python ground
+  truth rather than a TS self-mirror (a self-mirror passes even if both
+  sides diverge from Python).
+- Deferred: refdata transform packs + geo/date blocking branches. Follow-up
+  **#860**: TS `buildWeightedMatchkey` still drops `nullRate>0.5` name
+  columns while the blocking path now keeps them (why `sparse_people` stays
+  loose-shape). Docs-site: `goldenmatch/typescript.mdx` (scorer list/table +
+  Python-comparison row) and `goldenmatch/reference-data.mdx` (TS-parity note).
+
 ## 2026-06-09 — FS auto-config v2: GoldenMatch now BEATS Splink on accuracy (#823)
 - Updated the architecture node + decision:
   [../architecture/fellegi-sunter-splink-parity.md](../architecture/fellegi-sunter-splink-parity.md)
@@ -216,4 +248,4 @@ Newest first. One entry per meaningful change to the network.
 - Committed to git on branch `chore/context-network`.
 
 ---
-**Classification:** meta/log • **Last updated:** 2026-06-09
+**Classification:** meta/log • **Last updated:** 2026-06-11

--- a/context-network/planning/surface-hardening.md
+++ b/context-network/planning/surface-hardening.md
@@ -49,6 +49,43 @@ Every heavy TS port ships with a Python-emitted fixture
 - Track record: caught two real divergences pre-merge (pydantic
   revalidation on blocking-key removal; a fragile borderline pair).
 
+### Fixtures rot silently — the #856/#857 lesson
+The fixtures are the only invariant the TS lane checks, and **nothing kept
+them fresh**: the `typescript` CI job runs only on TS path changes, so a
+pure-Python behaviour change leaves the committed vectors stale and the TS
+parity test green against a fixture that no longer reflects Python (#856).
+The 2026-06-11 audit found real drift sitting in `main` this way. Two
+durable guards came out of fixing it (#857):
+- **Bundle data via a generator + drift-guard test, never hand-copied.**
+  When a TS port needs Python-side reference data (the refdata tables),
+  generate the TS module from the Python source of truth
+  (`scripts/sync_ts_refdata.mjs`) and add a test that deep-equals the
+  generated const against that source. A Python-side data change then fails
+  CI until re-synced — the table can't drift silently.
+- **Pin numeric parity to Python-computed ground truth, not a self-mirror.**
+  `tests/parity/scorer-ground-truth.test.ts` carries hardcoded
+  Python-`score_pair` values at 4-decimal tolerance. A unit test that only
+  checks "TS scorer == a TS re-implementation of its own rule" passes even
+  if both diverge from Python; the ground-truth file is what actually binds
+  the cross-language number.
+
+### #857 — refdata name scorers + autoconfig blocking parity (TS, merged)
+Closed the controller-stoppoint drift the #856 audit surfaced. Ported the
+two refdata name scorers to the edge-safe TS core — `given_name_aliased_jw`
+(alias-aware JW) and `name_freq_weighted_jw` (Census surname-IDF-weighted
+JW) — plus the first/last-name auto-config refine (`refineNameScorer`,
+last-before-first like Python; `multi_name` left unrefined) and a faithful
+port of `build_blocking`'s selection (exact-eligibility gated at
+`cardinality_ratio ≤ 0.5`, gates on the exact pool only, secondary-name
+multi-pass passes). Scope grew twice from the original one-scorer ask: the
+regen forced porting the surname scorer (its 186KB table) too, then the
+remaining red turned out to be a separate blocking-evolution gap that also
+got ported. Deferred (out of scope): the refdata transform packs
+(`legal_form_strip`/`address_normalize`/`naics_normalize`) and the geo/date
+blocking branches. Follow-up #860: TS `buildWeightedMatchkey` still drops
+`nullRate>0.5` name columns while the blocking path now keeps them — a
+matchkey-null-gate divergence (the reason `sparse_people` stays loose-shape).
+
 ## What remains
 - **AgentSession + 13 agent MCP tools** — the last heavy TS port; own session.
 - Small: `DOMAIN_EXTRACTED_COLS` 3→12, TS sensitivity/compare-clusters CLI,
@@ -56,4 +93,4 @@ Every heavy TS port ships with a Python-emitted fixture
 - TS `0.14.0` release cut (changelog + wave-history row) once the queue merges.
 
 ---
-**Classification:** planning/workstream • **Last updated:** 2026-06-05
+**Classification:** planning/workstream • **Last updated:** 2026-06-11

--- a/docs-site/goldenmatch/reference-data.mdx
+++ b/docs-site/goldenmatch/reference-data.mdx
@@ -76,6 +76,10 @@ else:
 
 The scorer never *lowers* a JW score — it only promotes known aliases. Degrades cleanly to plain JW when the bundled alias table is missing.
 
+<Note>
+Both name scorers — `given_name_aliased_jw` and `name_freq_weighted_jw` — are also in the [TypeScript port](/goldenmatch/typescript). The given-name alias corpus and the Census surname table ship inside the npm package as generated modules, synced from these Python source files and drift-guarded in CI, so the edge-safe TS core produces the same scores to four decimals. The transform packs (`legal_form_strip`, `address_normalize`, `naics_normalize`) remain Python-only for now.
+</Note>
+
 ## Transforms
 
 ### `legal_form_strip`

--- a/docs-site/goldenmatch/typescript.mdx
+++ b/docs-site/goldenmatch/typescript.mdx
@@ -79,7 +79,7 @@ Match target records against a reference dataset. Returns matched pairs with con
 ### scoreStrings(a, b, scorer?)
 
 Score similarity between two strings. Available scorers:
-`exact`, `jaro_winkler`, `levenshtein`, `token_sort`, `soundex_match`, `dice`, `jaccard`, `ensemble`.
+`exact`, `jaro_winkler`, `levenshtein`, `token_sort`, `soundex_match`, `dice`, `jaccard`, `ensemble`, `given_name_aliased_jw`, `name_freq_weighted_jw`.
 
 ```typescript
 import { scoreStrings } from "goldenmatch";
@@ -113,6 +113,10 @@ All scorers implement the same interface as Python `goldenmatch.core.scorer`:
 | **dice**, **jaccard** | Set-based similarity for hex-encoded bloom filters (PPRL) |
 | **embedding** | Cosine similarity of embeddings |
 | **record_embedding** | Cosine similarity across whole records |
+| **given_name_aliased_jw** | First names — alias-aware JW (William/Bill -> 1.0), bundled given-name table |
+| **name_freq_weighted_jw** | Surnames — JW reweighted by US Census surname IDF in the borderline zone |
+
+The two `*_jw` scorers are refdata-aware and edge-safe: their bundled lookup tables (a given-name alias corpus and the US Census 2010 top-10k surname table) ship inside the npm package, generated from the Python source of truth and drift-guarded in CI. Auto-config swaps them in automatically for first-name and last-name columns. See [Reference Data](/goldenmatch/reference-data) for the algorithms.
 
 ## Blocking Strategies
 
@@ -237,6 +241,7 @@ See [`packages/goldenmatch-js/examples/`](https://github.com/benseverndev-oss/go
 | Feature | Python | TypeScript |
 |---|---|---|
 | Core matching | Polars + rapidfuzz | Pure TS |
+| Refdata name scorers | `given_name_aliased_jw` + `name_freq_weighted_jw` | Both (bundled tables, 4-decimal parity) |
 | Fellegi-Sunter | Yes | Yes |
 | PPRL | SHA-256 | SHA-256 (interop verified byte-for-byte) |
 | Graph ER | Yes | Yes |


### PR DESCRIPTION
Docs for the #857 refdata-aware name scorers + autoconfig blocking parity (merged in #861). Context-network + Mintlify only — no code.

## Mintlify (`docs-site/`)

- `goldenmatch/typescript.mdx` — adds `given_name_aliased_jw` + `name_freq_weighted_jw` to the `scoreStrings` scorer list and the scorer table (with an edge-safe / bundled-table / drift-guard note), plus a refdata-scorers row in the Python-vs-TypeScript comparison table.
- `goldenmatch/reference-data.mdx` — a note that both name scorers now have 4-decimal-parity TS implementations (tables generated from the Python source + drift-guarded), and that the transform packs stay Python-only.

`mint broken-links` passes (the new typescript <-> reference-data cross-links resolve).

## Context network (`context-network/`)

- `planning/surface-hardening.md` — a "Fixtures rot silently" subsection capturing the durable #856/#857 lesson (generate-and-drift-guard bundled data; pin numeric parity to Python-computed ground truth, not a TS self-mirror) plus the #857 entry.
- `meta/updates.md` — dated log entry (2026-06-11).
- `discovery.md` — refreshed the surface-hardening hub line + stamp.

## Note

Targets the release branch for consistency with #861 (the code it documents lives there, not yet on `main`). Happy to retarget to `main` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
