### PR TITLE
fix(ts): weighted-matchkey null-gate parity (#860)

### DIFF
--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -29,6 +29,17 @@ Closes the controller-stoppoint parity drift (#857, from the #856 audit). Numeri
 scorer parity is locked by Python-computed ground truth in
 `tests/parity/scorer-ground-truth.test.ts`.
 
+### Fixed — weighted-matchkey null-gate parity (#860)
+
+- `buildWeightedMatchkey` no longer drops `nullRate > 0.5` columns. Python's
+  `build_matchkeys` applies no null gate to fuzzy fields — high-null name columns
+  are kept and demoted via the downstream avg-null threshold adjustment, not
+  dropped. Surfaced by the #857 whole-branch review: TS emitted an empty weighted
+  matchkey on heavily-null person data (`sparse_people`, ~75% null `first`/`last`)
+  where Python emits a `given_name_aliased_jw` + `name_freq_weighted_jw` weighted
+  matchkey at threshold 0.75. `sparse_people` is now byte-equal in the
+  controller-stoppoint parity suite.
+
 ## [2.0.0] - 2026-05-22
 
 Major version: v1.18.2 plugin parity for the TS port (#208).

--- a/packages/typescript/goldenmatch/src/core/autoconfig.ts
+++ b/packages/typescript/goldenmatch/src/core/autoconfig.ts
@@ -317,7 +317,13 @@ function buildWeightedMatchkey(
 
   for (const p of profiles) {
     const kind = classifyColumn(p);
-    if (p.nullRate > 0.5) continue;
+    // Python parity (#860): `build_matchkeys` applies NO null gate to fuzzy
+    // fields. High-null columns are kept here and demoted downstream via the
+    // avg-null threshold adjustment (in `autoConfigureRows`), not dropped. A
+    // `nullRate > 0.5` gate here diverged from Python and silently emptied the
+    // weighted matchkey on sparse name data (sparse_people: ~75% null
+    // first/last produced an empty MK instead of the given_name_aliased_jw +
+    // name_freq_weighted_jw weighted matchkey at threshold 0.75).
     const colType = colTypeFor(kind);
 
     if (kind === "multi_name") {

--- a/packages/typescript/goldenmatch/tests/parity/controller-stoppoint.parity.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/controller-stoppoint.parity.test.ts
@@ -58,15 +58,17 @@ const VALID_STOP_REASONS: ReadonlySet<string> = new Set(Object.values(StopReason
  *
  * ``clean_people`` promoted to byte-equal in #857 (blocking parity restored:
  * 0.5 exact gate + secondary-name passes).
- * ``sparse_people`` still diverges on matchkeys (TS emits empty matchkeys;
- * Python emits given_name_aliased_jw + name_freq_weighted_jw weighted MK) —
- * scorer/matchkey divergence outside the scope of this blocking-parity task;
- * stays loose shape.
+ * ``sparse_people`` promoted to byte-equal in #860 (matchkey null-gate parity:
+ * ``buildWeightedMatchkey`` no longer drops ``nullRate > 0.5`` name columns,
+ * matching Python ``build_matchkeys`` which applies no null gate to fuzzy
+ * fields — the downstream avg-null threshold adjustment already handles
+ * high-null fuzzy fields, lowering the threshold to 0.75 here).
  */
 const BYTE_EQUAL_DATASETS: ReadonlySet<string> = new Set<string>([
   "dirty_people",
   "mixed_blocking",
   "clean_people",
+  "sparse_people",
 ]);
 
 function sortObject(obj: unknown): unknown {


### PR DESCRIPTION
## What

`buildWeightedMatchkey` (`src/core/autoconfig.ts`) dropped any column with `nullRate > 0.5`, which silently emptied the weighted matchkey on heavily-null person data. Python's `build_matchkeys` applies **no** null gate to fuzzy fields — high-null columns are kept and demoted via the downstream avg-null threshold adjustment (`autoConfigureRows`), not dropped. This removes the divergent gate.

Surfaced by the #857 whole-branch review (filed as #860): on `sparse_people` (~75% null `first`/`last`) TS emitted an empty matchkey where Python emits a `given_name_aliased_jw` + `name_freq_weighted_jw` weighted matchkey at threshold 0.75. The downstream `avgNull > 0.15 → −0.05` adjustment already produces the 0.75 once the name columns flow through, confirming the gate was the bug.

## Parity

- `sparse_people` promoted to `BYTE_EQUAL_DATASETS` in `controller-stoppoint.parity.test.ts` (now matches Python byte-for-byte).
- The blocking half of this seam was already brought to parity in #857 (name pool ungated in `buildBlocking`); this aligns the matchkey half, so both name paths now carry one consistent null policy.

## Verification (local)

- `tsc --noEmit`: clean.
- `vitest run`: **1451 passed**, 1 expected-fail (pre-existing infermap) — identical to baseline, so removing the gate regresses nothing.
- Parity suite: 6/6.

## Out of scope (noted)

TS still lacks Python's `max_fuzzy_fields = 5` utility-ranked truncation (`cardinality·(1−null_rate)·len`). No current fixture exercises >5 fuzzy columns, so it's a latent divergence on very wide data, not this issue. Tracked separately.

Closes #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
