### PR TITLE
chore(ci): TS parity-fixture staleness gate (#856)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       distributed: ${{ steps.filter.outputs.distributed }}
       sail: ${{ steps.filter.outputs.sail }}
       readme_callouts: ${{ steps.filter.outputs.readme_callouts }}
+      ts_parity: ${{ steps.filter.outputs.ts_parity }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
@@ -99,6 +100,18 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'turbo.json'
+            ts_parity:
+              # TS parity-fixture staleness gate (#856): a Python behaviour
+              # change that is not mirrored into the committed TS fixtures must
+              # turn the ts_parity_freshness lane red. Trigger on the fixture
+              # producers (goldenmatch + goldenpipe Python), the committed
+              # fixtures, and the gate tooling itself.
+              - 'packages/python/goldenmatch/**'
+              - 'packages/python/goldenpipe/**'
+              - 'packages/typescript/goldenmatch/tests/parity/**'
+              - 'packages/typescript/goldenpipe/tests/fixtures/**'
+              - 'scripts/regen_ts_parity_fixtures.sh'
+              - 'scripts/check_ts_parity_freshness.py'
             web:
               - 'packages/python/goldenmatch/web/**'
               - 'packages/python/goldenmatch/goldenmatch/web/**'
@@ -1717,6 +1730,32 @@ jobs:
       - name: Verify READMEs are in sync with CHANGELOG callouts
         run: python scripts/sync_readme_callouts.py --check
 
+  ts_parity_freshness:
+    needs: changes
+    if: needs.changes.outputs.ts_parity == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      # Regenerate every committed TS parity fixture from the Python emitters,
+      # then assert the working tree still matches HEAD within a 4-decimal float
+      # tolerance. Closes the silent-drift hole (#856): a pure-Python behaviour
+      # change that is not mirrored into the committed TS fixtures turns this lane
+      # red, instead of the TS parity test staying green against a stale fixture.
+      # Two controller-execution fixtures are allowlisted in the checker
+      # (optional-dependency-sensitive; see scripts/check_ts_parity_freshness.py).
+      - name: Regenerate TS parity fixtures
+        run: PYTHON=.venv/bin/python bash scripts/regen_ts_parity_fixtures.sh
+      - name: Assert TS parity fixtures are fresh (float-tolerant)
+        run: .venv/bin/python scripts/check_ts_parity_freshness.py
+
   # Single required-status-check for branch protection. Branch ruleset
   # references `ci-required` (stable name) instead of the matrix-instance
   # check names (`python (goldenmatch)`, `rust_pgrx (15)`, ...) which
@@ -1754,6 +1793,7 @@ jobs:
       - sail
       - pyright
       - readme_callouts
+      - ts_parity_freshness
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/packages/python/goldenmatch/scripts/emit_v2_parity_fixtures.py
+++ b/packages/python/goldenmatch/scripts/emit_v2_parity_fixtures.py
@@ -354,7 +354,14 @@ def _planner_case(
             "user_backend": user_backend,
         },
         "expected_plan": {
-            "backend": plan.backend,
+            # TS parity: the edge-safe TS port has no `bucket` backend -- it is
+            # the Polars-only native single-node path (Python v1.16), the same
+            # "deliberately not ported" class as `ray` (see the TS package
+            # CLAUDE.md). Emit its TS-reachable single-node equivalent,
+            # `polars-direct`, so this fixture stays byte-equal with what the TS
+            # planner actually produces. Recorded as a known divergence in
+            # scripts/check_ts_parity_freshness.py.
+            "backend": "polars-direct" if plan.backend == "bucket" else plan.backend,
             "chunk_size": plan.chunk_size,
             "max_workers": plan.max_workers,
             "pair_spill_threshold": plan.pair_spill_threshold,

--- a/packages/python/goldenmatch/tests/parity/export_ts_fixtures.py
+++ b/packages/python/goldenmatch/tests/parity/export_ts_fixtures.py
@@ -88,10 +88,17 @@ def serialize_fixture(name: str, df: pl.DataFrame) -> dict:
 
 
 def main() -> None:
+    # Repo root = parents[5] of
+    # packages/python/goldenmatch/tests/parity/export_ts_fixtures.py.
+    # (Pre-fold this pointed at packages/goldenmatch-js/; the monorepo fold
+    # moved the TS package to packages/typescript/goldenmatch/ and left this
+    # exporter writing to a bogus nested path -- fixed here so the fixture is
+    # regen-able by the parity-freshness gate.)
     out = (
-        Path(__file__).parent.parent.parent
+        Path(__file__).resolve().parents[5]
         / "packages"
-        / "goldenmatch-js"
+        / "typescript"
+        / "goldenmatch"
         / "tests"
         / "parity"
         / "autoconfig-verify-fixtures.json"

--- a/scripts/check_ts_parity_freshness.py
+++ b/scripts/check_ts_parity_freshness.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""TS cross-language parity-fixture staleness gate (#856).
+
+The cross-language parity harness validates the TypeScript port against
+*committed JSON fixtures*, never against *current Python*, and nothing kept the
+fixtures fresh -- so a pure-Python behaviour change left the committed vectors
+stale while the TS parity test stayed green against them ("TS matches the
+fixture", never "TS matches Python today").
+
+This gate closes that hole. Run AFTER ``scripts/regen_ts_parity_fixtures.sh``
+(which regenerates every committed fixture in place from the Python emitters):
+it compares the working tree against ``git HEAD`` with a FLOAT-TOLERANT JSON
+diff and fails if any non-allowlisted fixture drifted beyond tolerance.
+
+Tolerance: numeric leaves compare within ``FLOAT_TOL`` (the 4-decimal scorer
+parity contract); everything else must match exactly. This absorbs last-bit
+float noise (``0.19999999999999998`` vs ``0.20000000000000004``) -- which would
+make a naive byte-exact ``git diff`` gate flaky -- while still catching
+structural or real value drift.
+
+Known divergences (allowlisted, NOT compared): see ``ALLOWLIST`` below.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# 4-decimal scorer-parity contract (tests/parity/scorer-ground-truth.test.ts
+# asserts ``toBeCloseTo(expected, 4)``); match it here so the gate's notion of
+# "equal" is the same as the TS parity tests'.
+FLOAT_TOL = 1e-4
+
+# Metadata-stamp keys excluded from the comparison anywhere they appear. These
+# record HOW a fixture was generated, not the cross-language behaviour being
+# asserted -- comparing them would fail the gate on every release with zero
+# behavioural drift (e.g. goldenpipe's `pipe_parity.json` stamps the producing
+# `python_version`, which the TS test declares but does not assert against TS
+# output).
+IGNORE_KEYS = frozenset({"python_version"})
+
+# Directories holding committed TS cross-language parity fixtures.
+FIXTURE_DIRS = [
+    "packages/typescript/goldenmatch/tests/parity",
+    "packages/typescript/goldenpipe/tests/fixtures",
+]
+
+# Known divergences: committed fixtures the gate does NOT compare, each with a
+# reason. These are produced by EXECUTING the auto-config controller, whose
+# output depends on which optional deps are importable at runtime (the
+# polars/sklearn import paths documented in
+# controller-stoppoint.parity.test.ts) and is therefore not deterministically
+# reproducible across environments. They keep their existing TS-vs-committed
+# parity test instead. Pinning a canonical generation environment so these can
+# be gated too is a tracked #856 follow-up.
+ALLOWLIST = {
+    "controller-stoppoint-fixtures.json": (
+        "auto-config controller execution is optional-dependency-sensitive; "
+        "not deterministically reproducible across environments (#856)"
+    ),
+    "autoconfig-verify-fixtures.json": (
+        "auto_configure_df execution is optional-dependency-sensitive; "
+        "not deterministically reproducible across environments (#856)"
+    ),
+}
+
+
+def _git_head_text(relpath: str) -> str | None:
+    """Committed contents of ``relpath`` at HEAD, or None if untracked there."""
+    res = subprocess.run(
+        ["git", "show", f"HEAD:{relpath}"], capture_output=True, text=True
+    )
+    return res.stdout if res.returncode == 0 else None
+
+
+def _tracked_fixtures() -> list[str]:
+    res = subprocess.run(
+        ["git", "ls-files", "--", *FIXTURE_DIRS],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [
+        line.strip()
+        for line in res.stdout.splitlines()
+        if line.strip().endswith(".json")
+    ]
+
+
+def _num_close(a: float, b: float) -> bool:
+    return abs(a - b) <= FLOAT_TOL + FLOAT_TOL * max(abs(a), abs(b))
+
+
+def _diff(committed, current, path: str = "$"):
+    """Yield human-readable drift descriptions (empty => fresh within tol)."""
+    # bool is a subclass of int -- compare it before the numeric branch.
+    if isinstance(committed, bool) or isinstance(current, bool):
+        if committed != current:
+            yield f"{path}: {committed!r} != {current!r}"
+        return
+    if isinstance(committed, (int, float)) and isinstance(current, (int, float)):
+        if not _num_close(float(committed), float(current)):
+            yield f"{path}: {committed!r} != {current!r}"
+        return
+    if type(committed) is not type(current):
+        yield (
+            f"{path}: type {type(committed).__name__} != "
+            f"{type(current).__name__}"
+        )
+        return
+    if isinstance(committed, dict):
+        for key in sorted(set(committed) | set(current)):
+            if key in IGNORE_KEYS:
+                continue
+            if key not in committed:
+                yield f"{path}.{key}: new key not in committed fixture"
+            elif key not in current:
+                yield f"{path}.{key}: dropped by regeneration"
+            else:
+                yield from _diff(committed[key], current[key], f"{path}.{key}")
+        return
+    if isinstance(committed, list):
+        if len(committed) != len(current):
+            yield f"{path}: list length {len(committed)} != {len(current)}"
+            return
+        for i, (c, d) in enumerate(zip(committed, current)):
+            yield from _diff(c, d, f"{path}[{i}]")
+        return
+    if committed != current:
+        yield f"{path}: {committed!r} != {current!r}"
+
+
+def main() -> int:
+    fixtures = _tracked_fixtures()
+    drifted: dict[str, list[str]] = {}
+    missing: list[str] = []
+    allowlisted: list[str] = []
+
+    for rel in fixtures:
+        name = Path(rel).name
+        if name in ALLOWLIST:
+            allowlisted.append(rel)
+            continue
+        head = _git_head_text(rel)
+        if head is None:
+            # Brand-new fixture not yet in HEAD -- nothing to compare against.
+            continue
+        wt_path = Path(rel)
+        if not wt_path.exists():
+            missing.append(rel)
+            continue
+        try:
+            committed = json.loads(head)
+            current = json.loads(wt_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            drifted[rel] = [f"JSON parse error: {exc}"]
+            continue
+        deltas = list(_diff(committed, current))
+        if deltas:
+            drifted[rel] = deltas
+
+    print(
+        f"checked {len(fixtures) - len(allowlisted)} fixture(s) "
+        f"({len(allowlisted)} allowlisted, float tol={FLOAT_TOL})"
+    )
+    for rel in allowlisted:
+        print(f"  ~ allowlisted {rel}\n      reason: {ALLOWLIST[Path(rel).name]}")
+
+    if not drifted and not missing:
+        print("OK: all gated TS parity fixtures are fresh (within tolerance).")
+        return 0
+
+    print()
+    print(
+        "::error::TS parity fixtures are STALE. Run "
+        "`scripts/regen_ts_parity_fixtures.sh` and commit the result "
+        "(or add an intentional divergence to ALLOWLIST in this script):"
+    )
+    for rel, deltas in drifted.items():
+        print(f"  DRIFT  {rel}")
+        for line in deltas[:8]:
+            print(f"      {line}")
+        if len(deltas) > 8:
+            print(f"      ... and {len(deltas) - 8} more")
+    for rel in missing:
+        print(f"  MISSING after regeneration: {rel}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regen_ts_parity_fixtures.sh
+++ b/scripts/regen_ts_parity_fixtures.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Canonical regeneration entrypoint for the TypeScript cross-language parity
+# fixtures (#856). Runs EVERY Python emitter that produces a committed TS parity
+# fixture, in place. After running, `git diff` shows any drift and
+# `scripts/check_ts_parity_freshness.py` is the gate that fails CI on
+# non-allowlisted drift (with a float tolerance).
+#
+# Before this, regenerating the fixtures was tribal knowledge spread across a
+# dozen emitter scripts with different argument conventions; this is the single
+# source of truth.
+#
+# Usage (from anywhere in the repo):
+#     scripts/regen_ts_parity_fixtures.sh
+#
+# Requires `goldenmatch` and `goldenpipe` importable. Set PYTHON to choose the
+# interpreter (defaults to `python`); CI uses the uv venv:
+#     PYTHON=.venv/bin/python scripts/regen_ts_parity_fixtures.sh
+#
+# Two fixtures are produced here but ALLOWLISTED by the gate (their content is
+# optional-dependency-sensitive controller-execution output): the emitters still
+# run for completeness, but the checker does not compare them. See
+# scripts/check_ts_parity_freshness.py ALLOWLIST.
+set -euo pipefail
+
+export POLARS_SKIP_CPU_CHECK=1
+export PYTHONIOENCODING=utf-8
+
+PY="${PYTHON:-python}"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+GM="packages/python/goldenmatch"
+GP="packages/python/goldenpipe"
+PARITY="packages/typescript/goldenmatch/tests/parity"
+
+# $PY may be a multi-word launcher ("uv run python"); intentional word-split.
+# shellcheck disable=SC2086
+
+echo "== goldenmatch: controller-stoppoint (allowlisted) + indicators + negative-evidence =="
+$PY "$GM/scripts/emit_ts_parity_fixtures.py" \
+    --out "$PARITY/controller-stoppoint-fixtures.json" \
+    --indicators-out "$PARITY/indicators-fixtures.json" \
+    --ne-out "$PARITY/negative-evidence-fixtures.json"
+
+echo "== goldenmatch: v2 (planner / EM / domain / tuners / blocker / clustering / golden) =="
+$PY "$GM/scripts/emit_v2_parity_fixtures.py" --out "$PARITY/v2-fixtures.json"
+
+echo "== goldenmatch: numeric / golden-strategy / transform fixtures =="
+$PY "$GM/scripts/generate_parity_fixtures.py" --out "$PARITY/fixtures"
+
+echo "== goldenmatch: config-edits / config-optimizer / pprl / resolve =="
+$PY "$GM/scripts/emit_config_edits_fixture.py"
+$PY "$GM/scripts/emit_config_optimizer_fixture.py"
+$PY "$GM/scripts/emit_pprl_fixture.py"
+$PY "$GM/scripts/emit_resolve_fixture.py"
+
+echo "== goldenmatch: autoconfig-verify (allowlisted; regenerated for completeness) =="
+$PY "$GM/tests/parity/export_ts_fixtures.py"
+
+echo "== goldenpipe: pipe parity =="
+$PY "$GP/scripts/emit_ts_parity_fixtures.py"
+
+echo
+echo "Done. Verify freshness with:  $PY scripts/check_ts_parity_freshness.py"


### PR DESCRIPTION
Closes #856. **Please eyeball the `ci.yml` job + the allowlist before merge** (per our agreement) — flagged inline below.

## Why

The cross-language parity harness validates the TS port against **committed JSON fixtures**, never against **current Python**, and nothing kept the fixtures fresh. So a pure-Python behavior change leaves the committed vectors stale while the TS parity test stays green against them ("TS matches the fixture," never "TS matches Python today"). The 2026-06-11 audit found real drift already present.

## What

- **`scripts/regen_ts_parity_fixtures.sh`** — one command regenerates every committed TS parity fixture (was tribal knowledge across ~10 emitters with different arg conventions).
- **`scripts/check_ts_parity_freshness.py`** — float-tolerant (4-decimal, matching the scorer parity contract) JSON diff of the working tree vs `HEAD`. Absorbs last-bit float noise (`0.19999…` vs `0.20000…`) that would make a byte-exact gate flaky, while catching structural / value drift.
- **`ci.yml`** — `ts_parity_freshness` job (regen → assert fresh), a `ts_parity` path filter (fixture producers + committed fixtures + the tooling), and `ci-required` wiring.
- **`emit_v2_parity_fixtures.py`** — normalize the planner's `bucket` backend to its TS-reachable equivalent `polars-direct`.
- **`export_ts_fixtures.py`** — fix a pre-fold output path bug.

## Three decisions baked in (your call to confirm)

1. **`bucket` → `polars-direct` (architectural).** Python's planner now emits `backend: "bucket"` for 4 v2 planner cases; the committed fixture says `polars-direct` (the audit's drift). `bucket` is the Polars-only native single-node path, deliberately not ported to the edge-safe TS core (same class as `ray`; see the TS package CLAUDE.md). The emitter now maps it to `polars-direct` — the value the TS planner actually emits — so the fixture is byte-equal both ways. Net effect on the committed fixture: **none** (it was already `polars-direct`); the change makes *future* regen + the gate produce the TS-reachable value instead of red-failing.

2. **Allowlist 2 controller-execution fixtures** (`controller-stoppoint-fixtures.json`, `autoconfig-verify-fixtures.json`). These run the auto-config controller, whose output depends on which optional deps are importable at runtime (the `polars/sklearn` sensitivity the parity test header already documents) — not deterministically reproducible across environments. They keep their existing TS-vs-committed parity test. Pinning a canonical generation env so these can be gated too is a tracked follow-up.

3. **Exclude metadata-stamp keys** (`python_version`). goldenpipe's `pipe_parity.json` stamps the producing Python version (currently stale at 1.2.0 vs 1.2.1); the TS test declares but does not assert it. Comparing it would fail the gate on every release for zero behavioral drift.

## Validation (local)

- Green path: full regen → comparator → **exit 0** (30 gated fixtures fresh, 2 allowlisted).
- Red path: injected `backend → ray` drift → caught (`exit 1`, precise JSONPath).
- Float tolerance: a `1e-6` value bump passes; a structural change fails.
- `ci.yml` parses; no committed fixture changed (everything regenerates fresh).

## Follow-up (not this PR)

Pin a canonical Python env in CI so the 2 controller-execution fixtures regen deterministically and can come off the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
