### PR TITLE
fix(autoconfig): zero-config multi-source over-merge guard (#858)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Changed
+- **Zero-config `dedupe_df` no longer over-merges multi-source CRM (#858).** When
+  auto-config detects a source partition at config time (the internal
+  `__source__`, or a user `source`/`lead_source`/`*_source`/`origin`/`src`-named
+  column that genuinely partitions records into disjoint-valued groups), it now
+  (1) excludes the source-indicator column and every column whose values are
+  fully disjoint across sources (per-source surrogate ids) from match features,
+  and (2) demotes `phone` from a standalone exact matchkey to a blocking-only
+  candidate. This removes the source-correlated precision crater (realistic
+  multi-source CRM F1 ~0.35 → ~0.84). **Provable no-op** on single-source data
+  and in match mode (`match_df` / `run_match`; cross-source linking is the goal
+  there, suppressed by an explicit dedupe-mode gate). Default ON; disable with
+  `GOLDENMATCH_MULTISOURCE_AUTOCONFIG=0`; a caller `force_include` (or
+  `exclude_columns`) re-admits any auto-excluded column.
 - **Phase-5 distributed recall-complete path is now the DEFAULT (#844 finish
   line).** The blocking-key-aware shuffle scoring + randomized-contraction WCC,
   previously opt-in via `GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE=1`, is now ON by

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -591,12 +591,16 @@ def match_df(
                 # Pass reference= so auto-config sees both column sets and emits
                 # matchkeys/blocking that apply uniformly across the join.
                 # Access via module attribute so tests can patch goldenmatch._api.auto_configure_df.
-                config = _self_api.auto_configure_df(
-                    target, reference=reference, _skip_finalize=True,
-                    confidence_required=confidence_required,
-                    allow_red_config=allow_red_config,
-                    planning_effort=planning_effort,
-                )
+                from goldenmatch.core.autoconfig import _match_mode_autoconfig
+                # #858: match mode -- suppress the multi-source dedupe guard even
+                # if `target` itself carries a user source-pattern column.
+                with _match_mode_autoconfig():
+                    config = _self_api.auto_configure_df(
+                        target, reference=reference, _skip_finalize=True,
+                        confidence_required=confidence_required,
+                        allow_red_config=allow_red_config,
+                        planning_effort=planning_effort,
+                    )
                 _used_controller = True
 
         assert config is not None, "match_df: config resolution above must bind config"

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -687,6 +687,7 @@ def _adaptive_threshold(fields: list[MatchkeyField]) -> float:
 
 def build_matchkeys(
     profiles: list[ColumnProfile], df: pl.DataFrame | None = None,
+    *, multi_source: bool = False,
 ) -> list[MatchkeyConfig]:
     """Generate matchkeys from column profiles."""
     # Separate exact and fuzzy columns
@@ -760,6 +761,18 @@ def build_matchkeys(
         # guard already rewrote it; this no-ops on non-token_sort). See
         # _noise_aware_scorer.
         scorer = _noise_aware_scorer(p.col_type, scorer)
+
+        # #858: when multi-source, phone is a blocking signal, not an identity
+        # claim -- an exact match on phone collapses distinct people who share a
+        # work / household phone. Demote to blocking-only (this continue skips
+        # both exact_fields and fuzzy_fields; phone remains a build_blocking
+        # candidate, which is unchanged).
+        if multi_source and scorer == "exact" and p.col_type == "phone":
+            skipped_exact.append((
+                p.name,
+                "multi-source: phone is a blocking signal, not an identity claim",
+            ))
+            continue
 
         # Geo and zip are blocking signals, NOT identity claims. An exact
         # matchkey on a city column asserts "two records sharing a city are

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import polars as pl
 
@@ -1413,8 +1413,8 @@ def _source_disjoint(df: pl.DataFrame, col: str, partition_col: str) -> bool:
     per_value = sub.group_by(col).agg(
         pl.col(partition_col).n_unique().alias("_np")
     )
-    max_parts = per_value["_np"].max()
-    return (max_parts or 0) <= 1
+    max_parts = cast("int | None", per_value["_np"].max())
+    return max_parts is None or max_parts <= 1
 
 
 # Bounded source-indicator name patterns (case-insensitive). NOT a general

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import re
@@ -2261,6 +2262,31 @@ _LAST_AUTOCONFIG_EXCLUSIONS: ContextVar = ContextVar(
 _RUNTIME_EXCLUDE_COLUMNS: ContextVar = ContextVar(
     "_RUNTIME_EXCLUDE_COLUMNS", default=None,
 )
+
+# #858: set by the match pipeline (`_run_match_pipeline`) and `match_df` around
+# their `auto_configure_df` call so the multi-source guard is suppressed in
+# match mode (cross-source linking is the goal there). Dedupe paths never set it.
+_AUTOCONFIG_MATCH_MODE: ContextVar = ContextVar(
+    "_AUTOCONFIG_MATCH_MODE", default=False,
+)
+
+
+@contextlib.contextmanager
+def _match_mode_autoconfig():
+    """Suppress the #858 multi-source guard for the duration (match mode)."""
+    token = _AUTOCONFIG_MATCH_MODE.set(True)
+    try:
+        yield
+    finally:
+        _AUTOCONFIG_MATCH_MODE.reset(token)
+
+
+def _multisource_autoconfig_enabled() -> bool:
+    """#858 multi-source zero-config guard. Default ON; disable with
+    ``GOLDENMATCH_MULTISOURCE_AUTOCONFIG=0`` (or false/disabled/off/no)."""
+    return os.environ.get(
+        "GOLDENMATCH_MULTISOURCE_AUTOCONFIG", "1"
+    ).strip().lower() not in {"0", "false", "disabled", "off", "no"}
 
 
 def _env_force_exclude() -> list[str]:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1429,6 +1429,32 @@ def _detect_source_partition(
     return None
 
 
+def _source_correlated_exclusions(
+    df: pl.DataFrame,
+    profiles: list[ColumnProfile],
+    partition: str | None,
+) -> set[str]:
+    """Columns to exclude from ALL match features when multi-source (spec §3).
+
+    = {the user source-indicator column} U {columns 0-overlap across sources}.
+    Computed on the FULL frame so ``== 0.0`` is exact. Empty when no partition.
+    ``__source__`` is never added (``profile_columns`` already skips dunder
+    columns, so it never reaches the matchkeys).
+    """
+    if partition is None:
+        return set()
+    exclude: set[str] = set()
+    if not partition.startswith("__"):
+        exclude.add(partition)
+    for p in profiles:
+        col = p.name
+        if col.startswith("__") or col == partition:
+            continue
+        if _check_source_overlap(df, col, partition_col=partition) == 0.0:
+            exclude.add(col)
+    return exclude
+
+
 # ── Blocking generation ────────────────────────────────────────────────────
 
 def _make_quality_column_profile(

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1395,6 +1395,28 @@ def _check_source_overlap(
 
 # ── #858: multi-source over-merge guard ──────────────────────────────────────
 
+def _source_disjoint(df: pl.DataFrame, col: str, partition_col: str) -> bool:
+    """True iff no value of ``col`` appears under 2+ distinct partitions.
+
+    The "fully source-specific" signal #858 uses to identify provenance /
+    per-source surrogate columns (the source label, per-source ids). Unlike
+    ``_check_source_overlap`` (all-partition intersection, which is 0 even for a
+    real identifier shared between only SOME of >2 sources), this is a
+    max-pairwise test: a genuine shared identifier (the same person appearing in
+    two sources with the same value) is NOT disjoint, so it is kept.
+    """
+    if partition_col not in df.columns:
+        return False
+    sub = df.select([col, partition_col]).drop_nulls()
+    if sub.height == 0:
+        return False
+    per_value = sub.group_by(col).agg(
+        pl.col(partition_col).n_unique().alias("_np")
+    )
+    max_parts = per_value["_np"].max()
+    return (max_parts or 0) <= 1
+
+
 # Bounded source-indicator name patterns (case-insensitive). NOT a general
 # provenance regex (name-regex was rejected as the primary mechanism, spec §1);
 # this only LOCATES a user source partition when there is no ``__source__``.
@@ -1433,8 +1455,7 @@ def _detect_source_partition(
         if n_unique < 2 or n_unique > card_cap:
             continue
         has_cosig = any(
-            other != p.name
-            and _check_source_overlap(df, other, partition_col=p.name) == 0.0
+            other != p.name and _source_disjoint(df, other, p.name)
             for other in other_cols
         )
         if has_cosig:
@@ -1463,7 +1484,7 @@ def _source_correlated_exclusions(
         col = p.name
         if col.startswith("__") or col == partition:
             continue
-        if _check_source_overlap(df, col, partition_col=partition) == 0.0:
+        if _source_disjoint(df, col, partition):
             exclude.add(col)
     return exclude
 
@@ -2545,6 +2566,7 @@ def auto_configure_df(
     # Skipped when df is a Ray Dataset (distributed path) -- those have
     # their own column-selection story; exclusions land at the per-
     # partition kernel layer separately.
+    _ms_partition: str | None = None  # #858 source partition (None => feature off)
     if not _is_ray_dataset(df) and isinstance(df, pl.DataFrame):
         from goldenmatch.core.quality_exclusions import (
             detect_autoconfig_exclusions,
@@ -2559,6 +2581,17 @@ def auto_configure_df(
         force_exclude_list, force_include_list = (
             _resolve_effective_exclusion_overrides(config=None)
         )
+        # #858: multi-source source-correlated over-merge guard (spec §0-§4).
+        # Detect the source partition on the FULL frame, then exclude the
+        # source-indicator column + every 0-cross-source-overlap column from
+        # match features by folding them into force_exclude (dropped below).
+        _ms_profiles = profile_columns(df)
+        _ms_partition = _detect_source_partition(df, _ms_profiles)
+        _ms_exclude = _source_correlated_exclusions(df, _ms_profiles, _ms_partition)
+        if _ms_exclude:
+            force_exclude_list = list(force_exclude_list) + [
+                c for c in _ms_exclude if c not in force_exclude_list
+            ]
         # Internal bookkeeping columns are invisible to detectors.
         skip = {"__row_id__", "__source__"}
         for col in df.columns:
@@ -2615,6 +2648,9 @@ def auto_configure_df(
         "llm_auto": llm_auto,
         "strict": strict,
         "allow_remote_assets": allow_remote_assets,
+        # #858: full-frame source-partition detection result, threaded to
+        # build_matchkeys via _legacy_auto_configure_v0 for phone demotion.
+        "multi_source": _ms_partition is not None,
     }
     config, profile, history = controller.run(
         df,
@@ -2654,6 +2690,7 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
     strict: bool = False,
     allow_remote_assets: bool = False,
     n_rows_full: int | None = None,
+    multi_source: bool = False,
 ) -> GoldenMatchConfig:
     """Legacy column-profiling + rule-based auto-config heuristic (the v0
     starting point for the controller). Implementation unchanged from the
@@ -2737,7 +2774,7 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
             )
 
     # Build matchkeys
-    matchkeys = build_matchkeys(profiles, df=df)
+    matchkeys = build_matchkeys(profiles, df=df, multi_source=multi_source)
 
     # ── Add domain-extracted fields to matchkeys ──
     if extracted_columns:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1380,6 +1380,55 @@ def _check_source_overlap(
     return len(intersection) / len(union)
 
 
+# ── #858: multi-source over-merge guard ──────────────────────────────────────
+
+# Bounded source-indicator name patterns (case-insensitive). NOT a general
+# provenance regex (name-regex was rejected as the primary mechanism, spec §1);
+# this only LOCATES a user source partition when there is no ``__source__``.
+_SOURCE_NAME_RE = re.compile(
+    r"(?i)^(source|origin|channel|system|data_source|record_source"
+    r"|lead_source|src|crm)$|_source$"
+)
+
+
+def _detect_source_partition(
+    df: pl.DataFrame, profiles: list[ColumnProfile]
+) -> str | None:
+    """Return the column that partitions records by origin, or ``None``.
+
+    ``None`` => single-source / match mode / killed => the whole #858 feature is
+    a no-op (the regression firewall). See the design spec §0-§1.
+    """
+    if not _multisource_autoconfig_enabled():
+        return None
+    if _AUTOCONFIG_MATCH_MODE.get():
+        return None
+    # 1) internal __source__ with >= 2 distinct values (multi-file dedupe).
+    if "__source__" in df.columns and df["__source__"].n_unique() >= 2:
+        return "__source__"
+    # 2) a name-pattern user column: low cardinality + >= 2 distinct + a
+    #    disjoint-id co-signature (>= 1 other column 0-overlap vs it). The
+    #    co-signature is the real discriminator; the cardinality cap (absolute
+    #    floor of 20, else 10% of rows) excludes free-text "source"-ish fields
+    #    while staying robust on small frames.
+    other_cols = [p.name for p in profiles if not p.name.startswith("__")]
+    card_cap = max(20, int(0.1 * df.height))
+    for p in profiles:
+        if p.name.startswith("__") or not _SOURCE_NAME_RE.search(p.name):
+            continue
+        n_unique = df[p.name].n_unique()
+        if n_unique < 2 or n_unique > card_cap:
+            continue
+        has_cosig = any(
+            other != p.name
+            and _check_source_overlap(df, other, partition_col=p.name) == 0.0
+            for other in other_cols
+        )
+        if has_cosig:
+            return p.name
+    return None
+
+
 # ── Blocking generation ────────────────────────────────────────────────────
 
 def _make_quality_column_profile(

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -2383,7 +2383,7 @@ _AUTOCONFIG_MATCH_MODE: ContextVar = ContextVar(
 
 
 @contextlib.contextmanager
-def _match_mode_autoconfig():
+def _match_mode_autoconfig():  # pyright: ignore[reportUnusedFunction]  # used cross-module (pipeline / _api) via local imports
     """Suppress the #858 multi-source guard for the duration (match mode)."""
     token = _AUTOCONFIG_MATCH_MODE.set(True)
     try:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1339,23 +1339,28 @@ def _llm_suggest_blocking_keys(
 # ── Cross-source overlap ──────────────────────────────────────────────────
 
 
-def _check_source_overlap(df: pl.DataFrame, col: str) -> float:
-    """Compute value overlap ratio for a column across sources.
+def _check_source_overlap(
+    df: pl.DataFrame, col: str, partition_col: str = "__source__"
+) -> float:
+    """Compute value overlap ratio for a column across source partitions.
 
-    Returns |intersection| / |union| of unique values per source.
-    Returns 1.0 if no __source__ column or only one source (no check needed).
+    Returns |intersection| / |union| of unique values per partition.
+    Returns 1.0 if ``partition_col`` is absent or has only one partition
+    (no check needed). ``partition_col`` defaults to the internal
+    ``__source__`` so existing callers are unchanged; #858 passes a detected
+    user source column when there is no ``__source__``.
     """
-    if "__source__" not in df.columns:
+    if partition_col not in df.columns:
         return 1.0
 
-    sources = df["__source__"].unique().to_list()
+    sources = df[partition_col].unique().to_list()
     if len(sources) < 2:
         return 1.0
 
     value_sets = []
     for src in sources:
         vals = set(
-            df.filter(pl.col("__source__") == src)[col]
+            df.filter(pl.col(partition_col) == src)[col]
             .drop_nulls()
             .cast(pl.Utf8)
             .to_list()

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1420,9 +1420,11 @@ def _source_disjoint(df: pl.DataFrame, col: str, partition_col: str) -> bool:
 # Bounded source-indicator name patterns (case-insensitive). NOT a general
 # provenance regex (name-regex was rejected as the primary mechanism, spec §1);
 # this only LOCATES a user source partition when there is no ``__source__``.
+# Deliberately excludes business-attribute-ish names (channel / system / crm)
+# that are plausibly real low-card match signal, not data origin -- they were a
+# false-positive vector flagged in spec review.
 _SOURCE_NAME_RE = re.compile(
-    r"(?i)^(source|origin|channel|system|data_source|record_source"
-    r"|lead_source|src|crm)$|_source$"
+    r"(?i)^(source|origin|src|data_source|record_source|lead_source)$|_source$"
 )
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2382,13 +2382,20 @@ def _run_match_pipeline(
 
     # ── Step 2.5a': AUTO-CONFIG ON CLEANED DATA (if zero-config) ──
     if auto_config:
-        from goldenmatch.core.autoconfig import auto_configure_df
-        combined_df_tmp = combined_lf.collect()
-        auto_cfg = auto_configure_df(
-            combined_df_tmp,
-            llm_provider=auto_config_llm_provider,
-            llm_auto=config.llm_auto,
+        from goldenmatch.core.autoconfig import (
+            _match_mode_autoconfig,
+            auto_configure_df,
         )
+        combined_df_tmp = combined_lf.collect()
+        # #858: this is match mode -- the 2-value __source__ here is the
+        # target/reference split, and cross-source linking is the goal, not
+        # over-merge. Suppress the multi-source dedupe guard.
+        with _match_mode_autoconfig():
+            auto_cfg = auto_configure_df(
+                combined_df_tmp,
+                llm_provider=auto_config_llm_provider,
+                llm_auto=config.llm_auto,
+            )
         config.matchkeys = auto_cfg.matchkeys
         config.match_settings = auto_cfg.match_settings
         config.blocking = auto_cfg.blocking

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -60,9 +60,11 @@ def test_detect_user_source_column_with_cosignature():
 
 
 def test_detect_none_user_source_without_cosignature():
+    # name matches the pattern, but no other column is disjoint per its value
+    # (email fully shared across both values) -> no co-signature -> not a source.
     df = pl.DataFrame({
-        "channel": ["web", "web", "phone", "phone"],
-        "email": ["x@y", "x@y", "x@y", "x@y"],  # fully shared -> no co-signature
+        "lead_source": ["a", "a", "b", "b"],
+        "email": ["x@y", "x@y", "x@y", "x@y"],  # fully shared -> not disjoint
     })
     assert _detect_source_partition(df, _profiles(df)) is None
 
@@ -230,6 +232,37 @@ def test_match_pipeline_suppresses_858_feature(monkeypatch):
     except Exception:
         pass  # downstream pipeline errors are irrelevant; assert the wrap fired
     assert seen.get("mm") is True
+
+
+# ── Task 9: firewalls / parity (lock the no-ops) ─────────────────────────────
+
+def test_single_source_is_byte_identical_to_killswitch(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")  # isolate cross-run
+    df = pl.DataFrame({
+        "first": [f"f{i}" for i in range(20)],
+        "last": [f"l{i}" for i in range(20)],
+        "email": [f"u{i}@ex.com" for i in range(20)],
+        "phone": [f"555{i:07d}" for i in range(20)],
+    })
+    monkeypatch.setenv("GOLDENMATCH_MULTISOURCE_AUTOCONFIG", "1")
+    on = auto_configure_df(df)
+    monkeypatch.setenv("GOLDENMATCH_MULTISOURCE_AUTOCONFIG", "0")
+    off = auto_configure_df(df)
+    assert _mk_names(on) == _mk_names(off)
+    assert _all_match_fields(on) == _all_match_fields(off)
+
+
+def test_business_categorical_not_excluded_single_source():
+    # `channel` is a real low-card business attribute on single-source data:
+    # no source partition -> never excluded.
+    df = pl.DataFrame({
+        "channel": (["web", "phone"] * 10),
+        "first": [f"f{i}" for i in range(20)],
+        "email": [f"u{i}@ex.com" for i in range(20)],
+    })
+    part = _detect_source_partition(df, _profiles(df))
+    assert part is None
+    assert _source_correlated_exclusions(df, _profiles(df), part) == set()
 
 
 # ── Task 1: generalized _check_source_overlap ────────────────────────────────

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -31,6 +31,54 @@ def test_match_mode_contextvar_default_and_scoped():
     assert ac._AUTOCONFIG_MATCH_MODE.get() is False
 
 
+# ── Task 4: _detect_source_partition ─────────────────────────────────────────
+
+from goldenmatch.core.autoconfig import _detect_source_partition, profile_columns
+
+
+def _profiles(df):
+    return profile_columns(df)   # returns list[ColumnProfile] directly
+
+
+def test_detect_dunder_source():
+    df = pl.DataFrame({"__source__": ["a", "a", "b"], "rid": ["1", "2", "3"]})
+    assert _detect_source_partition(df, _profiles(df)) == "__source__"
+
+
+def test_detect_none_single_source():
+    df = pl.DataFrame({"__source__": ["a", "a"], "rid": ["1", "2"]})  # 1 distinct
+    assert _detect_source_partition(df, _profiles(df)) is None
+
+
+def test_detect_user_source_column_with_cosignature():
+    df = pl.DataFrame({
+        "source": ["hubspot", "hubspot", "salesforce", "salesforce"],
+        "crm_id": ["h1", "h2", "s1", "s2"],   # disjoint per source -> co-signature
+        "name": ["a", "b", "c", "d"],
+    })
+    assert _detect_source_partition(df, _profiles(df)) == "source"
+
+
+def test_detect_none_user_source_without_cosignature():
+    df = pl.DataFrame({
+        "channel": ["web", "web", "phone", "phone"],
+        "email": ["x@y", "x@y", "x@y", "x@y"],  # fully shared -> no co-signature
+    })
+    assert _detect_source_partition(df, _profiles(df)) is None
+
+
+def test_detect_suppressed_in_match_mode():
+    df = pl.DataFrame({"__source__": ["a", "b"], "rid": ["1", "2"]})
+    with ac._match_mode_autoconfig():
+        assert _detect_source_partition(df, _profiles(df)) is None
+
+
+def test_detect_suppressed_by_killswitch(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_MULTISOURCE_AUTOCONFIG", "0")
+    df = pl.DataFrame({"__source__": ["a", "b"], "rid": ["1", "2"]})
+    assert _detect_source_partition(df, _profiles(df)) is None
+
+
 # ── Task 1: generalized _check_source_overlap ────────────────────────────────
 
 def test_overlap_against_user_partition_column():

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -6,10 +6,15 @@ demotion, and the dedupe-only / single-source / match-mode firewalls.
 from __future__ import annotations
 
 import polars as pl
-
 from goldenmatch.core import autoconfig as ac
-from goldenmatch.core.autoconfig import _check_source_overlap
-
+from goldenmatch.core.autoconfig import (
+    _check_source_overlap,
+    _detect_source_partition,
+    _source_correlated_exclusions,
+    auto_configure_df,
+    build_matchkeys,
+    profile_columns,
+)
 
 # ── Task 2: kill-switch ──────────────────────────────────────────────────────
 
@@ -32,9 +37,6 @@ def test_match_mode_contextvar_default_and_scoped():
 
 
 # ── Task 4: _detect_source_partition ─────────────────────────────────────────
-
-from goldenmatch.core.autoconfig import _detect_source_partition, profile_columns
-
 
 def _profiles(df):
     return profile_columns(df)   # returns list[ColumnProfile] directly
@@ -83,9 +85,6 @@ def test_detect_suppressed_by_killswitch(monkeypatch):
 
 # ── Task 5: _source_correlated_exclusions ────────────────────────────────────
 
-from goldenmatch.core.autoconfig import _source_correlated_exclusions
-
-
 def test_exclusions_dunder_source():
     df = pl.DataFrame({
         "__source__": ["a", "a", "b", "b"],
@@ -123,9 +122,6 @@ def test_exclusions_empty_when_no_partition():
 
 # ── Task 6: phone demotion in build_matchkeys ────────────────────────────────
 
-from goldenmatch.core.autoconfig import build_matchkeys
-
-
 def _phone_df():
     # 10 distinct 10-digit phones, each repeated -> cardinality 0.5 (a real
     # exact candidate: not < 0.5, not perfectly-unique >= 1.0).
@@ -152,9 +148,6 @@ def test_phone_demoted_when_multi_source():
 
 
 # ── Task 7: wired into auto_configure_df ─────────────────────────────────────
-
-from goldenmatch.core.autoconfig import auto_configure_df
-
 
 def _crm_df():
     rows = []

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -79,6 +79,46 @@ def test_detect_suppressed_by_killswitch(monkeypatch):
     assert _detect_source_partition(df, _profiles(df)) is None
 
 
+# ── Task 5: _source_correlated_exclusions ────────────────────────────────────
+
+from goldenmatch.core.autoconfig import _source_correlated_exclusions
+
+
+def test_exclusions_dunder_source():
+    df = pl.DataFrame({
+        "__source__": ["a", "a", "b", "b"],
+        "surrogate": ["s1", "s2", "s3", "s4"],   # 0-overlap -> excluded
+        "email": ["x@y", "p@q", "x@y", "z@w"],   # shared -> kept
+        "name": ["A", "B", "A", "C"],
+    })
+    profiles = _profiles(df)
+    part = _detect_source_partition(df, profiles)
+    excl = _source_correlated_exclusions(df, profiles, part)
+    assert "surrogate" in excl
+    assert "email" not in excl
+    assert "name" not in excl
+    assert "__source__" not in excl   # handled by the dunder skip, not added here
+
+
+def test_exclusions_user_source_includes_the_source_column():
+    df = pl.DataFrame({
+        "source": ["hubspot", "hubspot", "salesforce", "salesforce"],
+        "crm_id": ["h1", "h2", "s1", "s2"],
+        "email": ["x@y", "p@q", "x@y", "z@w"],
+    })
+    profiles = _profiles(df)
+    part = _detect_source_partition(df, profiles)   # == "source"
+    excl = _source_correlated_exclusions(df, profiles, part)
+    assert "source" in excl       # the partition label itself
+    assert "crm_id" in excl       # 0-overlap surrogate
+    assert "email" not in excl
+
+
+def test_exclusions_empty_when_no_partition():
+    df = pl.DataFrame({"email": ["x@y"], "name": ["A"]})
+    assert _source_correlated_exclusions(df, _profiles(df), None) == set()
+
+
 # ── Task 1: generalized _check_source_overlap ────────────────────────────────
 
 def test_overlap_against_user_partition_column():

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -119,6 +119,36 @@ def test_exclusions_empty_when_no_partition():
     assert _source_correlated_exclusions(df, _profiles(df), None) == set()
 
 
+# ── Task 6: phone demotion in build_matchkeys ────────────────────────────────
+
+from goldenmatch.core.autoconfig import build_matchkeys
+
+
+def _phone_df():
+    # 10 distinct 10-digit phones, each repeated -> cardinality 0.5 (a real
+    # exact candidate: not < 0.5, not perfectly-unique >= 1.0).
+    phones = [f"5551{i:06d}" for i in range(10)]
+    return pl.DataFrame({
+        "phone": phones + phones,
+        "name": [f"person {i}" for i in range(20)],
+    })
+
+
+def test_phone_is_exact_matchkey_single_source():
+    df = _phone_df()
+    mks = build_matchkeys(_profiles(df), df=df, multi_source=False)
+    assert any(m.name == "exact_phone" for m in mks)
+
+
+def test_phone_demoted_when_multi_source():
+    df = _phone_df()
+    mks = build_matchkeys(_profiles(df), df=df, multi_source=True)
+    assert not any(m.name == "exact_phone" for m in mks)
+    # phone is not silently turned into a weighted field either
+    for m in mks:
+        assert all(f.field != "phone" for f in (m.fields or []))
+
+
 # ── Task 1: generalized _check_source_overlap ────────────────────────────────
 
 def test_overlap_against_user_partition_column():

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -149,6 +149,57 @@ def test_phone_demoted_when_multi_source():
         assert all(f.field != "phone" for f in (m.fields or []))
 
 
+# ── Task 7: wired into auto_configure_df ─────────────────────────────────────
+
+from goldenmatch.core.autoconfig import auto_configure_df
+
+
+def _crm_df():
+    rows = []
+    srcs = ["hubspot", "salesforce", "cvent"]
+    for i in range(30):
+        s = srcs[i % 3]
+        rows.append({
+            "source": s,
+            "rec_id": f"{s}-{i}",                  # disjoint per source
+            "first": f"first{i // 2}",
+            "last": f"last{i // 2}",
+            "email": f"user{i // 2}@ex.com",       # shared across sources
+            "phone": "5551112222" if i < 6 else f"555{i:07d}",
+        })
+    return pl.DataFrame(rows)
+
+
+def _mk_names(cfg):
+    return {m.name for m in cfg.get_matchkeys()}
+
+
+def _all_match_fields(cfg):
+    return {
+        f.field
+        for m in cfg.get_matchkeys()
+        for f in (m.fields or [])
+        if f.field
+    }
+
+
+def test_zeroconfig_excludes_source_and_demotes_phone():
+    cfg = auto_configure_df(_crm_df())
+    fields = _all_match_fields(cfg)
+    assert "source" not in fields          # source label excluded
+    assert "rec_id" not in fields          # 0-overlap surrogate excluded
+    assert "exact_phone" not in _mk_names(cfg)   # phone demoted
+    assert "email" in fields               # genuine shared identifier kept
+
+
+def test_killswitch_restores_legacy(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_MULTISOURCE_AUTOCONFIG", "0")
+    cfg = auto_configure_df(_crm_df())
+    fields = _all_match_fields(cfg)
+    # legacy behaviour: source admitted OR phone exact present
+    assert "source" in fields or "exact_phone" in _mk_names(cfg)
+
+
 # ── Task 1: generalized _check_source_overlap ────────────────────────────────
 
 def test_overlap_against_user_partition_column():

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -200,6 +200,38 @@ def test_killswitch_restores_legacy(monkeypatch):
     assert "source" in fields or "exact_phone" in _mk_names(cfg)
 
 
+# ── Task 8: match-mode firewall (the in-pipeline path) ───────────────────────
+
+def test_match_pipeline_suppresses_858_feature(monkeypatch):
+    """run_match_df(auto_config=True) injects a 2-value __source__ BEFORE
+    auto-config; the #858 dedupe guard must stay suppressed there (cross-source
+    linking is the goal). Asserts the match-mode ContextVar is set during the
+    in-pipeline auto-config call."""
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.core.pipeline import run_match_df
+
+    seen = {}
+    real = ac.auto_configure_df
+
+    def spy(df, *a, **k):
+        seen["mm"] = ac._AUTOCONFIG_MATCH_MODE.get()
+        return real(df, *a, **k)
+
+    monkeypatch.setattr(ac, "auto_configure_df", spy)
+    target = pl.DataFrame({
+        "source": ["hubspot"] * 6,
+        "rec_id": [f"h{i}" for i in range(6)],
+        "phone": ["5551112222"] * 3 + [f"5550000{i}" for i in range(3)],
+        "email": [f"u{i}@ex.com" for i in range(6)],
+    })
+    reference = target.clone()
+    try:
+        run_match_df(target, reference, GoldenMatchConfig(), auto_config=True)
+    except Exception:
+        pass  # downstream pipeline errors are irrelevant; assert the wrap fired
+    assert seen.get("mm") is True
+
+
 # ── Task 1: generalized _check_source_overlap ────────────────────────────────
 
 def test_overlap_against_user_partition_column():

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -7,7 +7,28 @@ from __future__ import annotations
 
 import polars as pl
 
+from goldenmatch.core import autoconfig as ac
 from goldenmatch.core.autoconfig import _check_source_overlap
+
+
+# ── Task 2: kill-switch ──────────────────────────────────────────────────────
+
+def test_killswitch_default_on_and_off(monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_MULTISOURCE_AUTOCONFIG", raising=False)
+    assert ac._multisource_autoconfig_enabled() is True
+    monkeypatch.setenv("GOLDENMATCH_MULTISOURCE_AUTOCONFIG", "0")
+    assert ac._multisource_autoconfig_enabled() is False
+    monkeypatch.setenv("GOLDENMATCH_MULTISOURCE_AUTOCONFIG", "false")
+    assert ac._multisource_autoconfig_enabled() is False
+
+
+# ── Task 3: match-mode ContextVar ────────────────────────────────────────────
+
+def test_match_mode_contextvar_default_and_scoped():
+    assert ac._AUTOCONFIG_MATCH_MODE.get() is False
+    with ac._match_mode_autoconfig():
+        assert ac._AUTOCONFIG_MATCH_MODE.get() is True
+    assert ac._AUTOCONFIG_MATCH_MODE.get() is False
 
 
 # ── Task 1: generalized _check_source_overlap ────────────────────────────────

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -1,0 +1,29 @@
+"""#858: zero-config multi-source over-merge guard.
+
+Tests the source-partition detection, source-correlated exclusion, phone
+demotion, and the dedupe-only / single-source / match-mode firewalls.
+"""
+from __future__ import annotations
+
+import polars as pl
+
+from goldenmatch.core.autoconfig import _check_source_overlap
+
+
+# ── Task 1: generalized _check_source_overlap ────────────────────────────────
+
+def test_overlap_against_user_partition_column():
+    df = pl.DataFrame({
+        "src": ["a", "a", "b", "b"],
+        "rid": ["1", "2", "3", "4"],            # disjoint across src -> 0.0
+        "email": ["x@y.com", "p@q.com", "x@y.com", "z@w.com"],  # shares x@y.com
+    })
+    assert _check_source_overlap(df, "rid", partition_col="src") == 0.0
+    assert _check_source_overlap(df, "email", partition_col="src") > 0.0
+
+
+def test_overlap_default_partition_is_dunder_source():
+    df = pl.DataFrame({"__source__": ["a", "b"], "rid": ["1", "2"]})
+    assert _check_source_overlap(df, "rid") == 0.0          # disjoint
+    # absent partition -> 1.0 (fail-open)
+    assert _check_source_overlap(pl.DataFrame({"rid": ["1"]}), "rid") == 1.0


### PR DESCRIPTION
## Why

Bare zero-config `goldenmatch.dedupe_df(df)` over-merges multi-source CRM data: on a realistic fixture (HubSpot / Salesforce / Cvent / Mailchimp / csv_import mix) F1 craters **~0.74 → ~0.35**. Two drivers, both in the auto-config output: the ingestion `source` column lands in the weighted matchkey (same-source pairs get spurious agreement weight → source-correlated precision crater), and `phone` becomes a standalone exact matchkey (collapses distinct people sharing a work/household phone). The bensevern.dev showcase therefore never calls bare `dedupe_df`; this makes the zero-config promise hold on its own.

## Approach (data-driven, dedupe-only)

The real signal is **cross-source value disjointness**, not a name regex. When a source partition is detected at config time (the internal `__source__`, or a `source`/`lead_source`/`*_source`/`origin`/`src`-named user column that genuinely partitions records — confirmed by a disjoint-id co-signature), auto-config:

1. **Excludes the source-indicator column + every fully-disjoint column** (per-source surrogate ids) from match features, via the existing `detect_autoconfig_exclusions → df.drop` path, computed on the full frame.
2. **Demotes `phone`** from an exact matchkey to a blocking-only candidate.

A genuine shared identifier (`email`/`ssn`/`npi`) appears under 2+ sources, so it is **not** disjoint and is kept. The signal is **pairwise** disjointness (a value appearing under 2+ sources), not the all-source intersection — the latter wrongly drops an identifier shared between only some of >2 sources (caught during implementation).

**Firewalls (provable no-ops):** single-source data (no partition → feature off); match mode (`run_match` / `match_df` inject a 2-value `__source__` *before* auto-config, so this is gated off by an explicit `_AUTOCONFIG_MATCH_MODE` ContextVar, **not** injection ordering — that was a real blocker the spec review caught). Kill-switch `GOLDENMATCH_MULTISOURCE_AUTOCONFIG=0`; `force_include`/`exclude_columns` overrides.

## Process

Full brainstorm → spec → plan → TDD. The spec review loop (3 iterations) caught two design blockers before any code: the phone-demotion "stays a weighted field" claim was false (it's blocking-only), and the match-mode no-op couldn't rest on injection ordering. 11 commits, each a TDD red→green step.

## Verification

- **20 new tests** in `tests/test_autoconfig_multisource.py` — green locally: detection, exclusion, phone demotion, the dedupe/single-source/match-mode/business-categorical firewalls, kill-switch parity. `ruff` clean.
- Oracle (the 467-row `crm_multisource_realistic`) lives in golden-showcase and is the F1 number; the in-repo tests assert the mechanism + firewalls.
- **Note:** two *pre-existing* tests in `test_autoconfig_regressions.py` fail on my local Windows `.venv` (a controller `ValueError: not enough values to unpack` from an editable-install version skew). They fail identically with this feature kill-switched off, use no source columns, and pass on main's CI — so they're local-env, not this change. CI's clean env is authoritative; I'm watching those two in this PR's run.

Closes #858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
