### PR TITLE
test(ts): #855 parity goldens + hardened parity test (follow-up to #873)

### DIFF
--- a/.github/workflows/regen-855-parity-goldens.yml
+++ b/.github/workflows/regen-855-parity-goldens.yml
@@ -1,0 +1,47 @@
+name: regen-855-parity-goldens
+
+# Regenerates the goldencheck TS parity goldens on a clean Linux runner (the
+# local dev box can't run Polars without OOMing). Fires when the #855 fixture
+# generator changes; uploads parity_cases.json + the goldens as an ARTIFACT
+# (does NOT commit back — the author downloads + commits so the push triggers
+# the normal `typescript` parity lane). See the #855 plan for the flow.
+
+on:
+  push:
+    branches: [feat/855-parity-goldens]
+    paths:
+      - "packages/python/goldencheck/scripts/gen_855_parity_fixtures.py"
+      - ".github/workflows/regen-855-parity-goldens.yml"
+  workflow_dispatch:
+
+jobs:
+  regen:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Generate #855 parity fixtures + goldens
+        working-directory: packages/typescript/goldencheck
+        run: |
+          PY=../../../.venv/bin/python
+          "$PY" ../../python/goldencheck/scripts/gen_855_parity_fixtures.py
+          "$PY" ../../python/goldencheck/scripts/gen_parity_goldens_js.py
+          echo "=== cases ==="
+          "$PY" -c "import json;print([c['name'] for c in json.load(open('tests/fixtures/parity_cases.json'))['cases']])"
+          echo "=== goldens ==="
+          ls -la tests/fixtures/_goldens_js/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: parity-855-goldens
+          path: |
+            packages/typescript/goldencheck/tests/fixtures/parity_cases.json
+            packages/typescript/goldencheck/tests/fixtures/_goldens_js/
+          if-no-files-found: error

--- a/packages/python/goldencheck/scripts/gen_855_parity_fixtures.py
+++ b/packages/python/goldencheck/scripts/gen_855_parity_fixtures.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Append the #855 parity cases to the TS port's parity_cases.json.
+
+Adds one case per newly-ported module (fuzzy-values, approx-duplicate,
+approx-fd, functional-dependency, composite-key). Record shapes mirror the
+TS unit tests so the Python-generated goldens line up with TS scan output.
+
+Run from the TS package dir (`packages/typescript/goldencheck`) so the relative
+`tests/fixtures/...` path resolves to the goldens the TS parity test reads, then
+run `gen_parity_goldens_js.py` from the same CWD to (re)generate the goldens.
+
+Idempotent: re-running will not duplicate a case already present by name.
+Ground rules (see docs/superpowers/plans/2026-06-11-855-goldencheck-ts-port.md):
+string/int columns only, no nulls, no floats — so Python's CSV round-trip and
+TS's TabularData agree on dtype and tuple distinctness.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+MANIFEST = Path("tests/fixtures/parity_cases.json")
+
+
+def _case(name: str, description: str, records: list[dict]) -> dict:
+    return {
+        "name": name,
+        "description": description,
+        "input": {"kind": "records", "records": records},
+        "options": {"sampleSize": 100000, "domain": None},
+    }
+
+
+def fuzzy_values_case() -> dict:
+    variants = ["California", "Californa", "CALIFORNIA", "Texas", "New York"]
+    clean = ["apple", "banana", "cherry"]
+    records = [
+        {"state": variants[i % len(variants)], "region": clean[i % len(clean)]}
+        for i in range(120)
+    ]
+    return _case("fuzzy_values", "near-duplicate state encodings (California spellings)", records)
+
+
+def approx_duplicate_case() -> dict:
+    # 12 rows; rows 0 and 5 are byte-identical (Acme / NYC) -> one duplicate pair.
+    rows = [
+        ("Acme", "NYC"), ("Beta", "LA"), ("Gamma", "SF"), ("Delta", "CHI"),
+        ("Epsilon", "BOS"), ("Acme", "NYC"), ("Zeta", "SEA"), ("Eta", "DEN"),
+        ("Theta", "MIA"), ("Iota", "ATL"), ("Kappa", "PHX"), ("Lambda", "DAL"),
+    ]
+    records = [{"company": n, "city": c} for (n, c) in rows]
+    return _case("approx_duplicate", "one exact duplicate row pair (Acme/NYC)", records)
+
+
+def approx_fd_case() -> dict:
+    records = [
+        {"zip": i % 10, "city": f"city_{i % 10}", "amt": (i * 13) % 97}
+        for i in range(300)
+    ]
+    for bad in (7, 50, 123):
+        records[bad]["city"] = "WRONGCITY"
+    return _case("approx_fd", "near-strict zip->city FD with 3 injected typos", records)
+
+
+def functional_dependency_case() -> dict:
+    zip_to_city = {0: 0, 1: 0, 2: 1, 3: 2, 4: 3, 5: 4}
+    records = [
+        {"zip": i % 6, "city": zip_to_city[i % 6], "amt": (i * 7) % 50}
+        for i in range(120)
+    ]
+    return _case("functional_dependency", "strict zip->city functional dependency", records)
+
+
+def composite_key_case() -> dict:
+    rows = [
+        (1, 1, "a", 2), (1, 2, "b", 1), (1, 3, "c", 5),
+        (2, 1, "a", 1), (2, 2, "d", 1), (3, 1, "e", 9),
+    ]
+    records = [
+        {"order_id": o, "line_no": l, "sku": s, "qty": q} for (o, l, s, q) in rows
+    ]
+    return _case("composite_key", "(order_id, line_no) composite key; no single-col key", records)
+
+
+NEW_CASES = [
+    fuzzy_values_case(),
+    approx_duplicate_case(),
+    approx_fd_case(),
+    functional_dependency_case(),
+    composite_key_case(),
+]
+
+
+def main() -> None:
+    manifest = json.loads(MANIFEST.read_text()) if MANIFEST.exists() else {"cases": []}
+    existing = {c["name"] for c in manifest["cases"]}
+    added = [c["name"] for c in NEW_CASES if c["name"] not in existing]
+    manifest["cases"].extend(c for c in NEW_CASES if c["name"] not in existing)
+    MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"parity_cases.json: added {added or '(none — all present)'}; "
+          f"total {len(manifest['cases'])} cases")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/typescript/goldencheck/src/core/relations/temporal.ts
+++ b/packages/typescript/goldencheck/src/core/relations/temporal.ts
@@ -66,9 +66,17 @@ function findDatePairs(columns: readonly string[]): Array<[string, string]> {
   });
 }
 
+// Python's temporal profiler only treats a value as a date when it is a real
+// Date/Datetime column OR a string that casts via str.to_date(format="%Y-%m-%d")
+// — so bare integers (zip=7, qty=2) are NOT dates. Mirror that by requiring the
+// ISO `YYYY-MM-DD` shape before parsing; `new Date("7")` would otherwise yield a
+// valid Date and make the fallback fire on numeric columns (TS<->Python gap).
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 function tryParseDate(v: unknown): Date | null {
   if (isNullish(v)) return null;
   const s = String(v);
+  if (!ISO_DATE_RE.test(s)) return null;
   const d = new Date(s);
   if (isNaN(d.getTime())) return null;
   return d;

--- a/packages/typescript/goldencheck/tests/fixtures/_goldens_js/approx_duplicate.json
+++ b/packages/typescript/goldencheck/tests/fixtures/_goldens_js/approx_duplicate.json
@@ -1,0 +1,62 @@
+{
+  "findings": [
+    {
+      "severity": "WARNING",
+      "column": "__dataset__",
+      "check": "identity_safe_pk",
+      "confidence": 0.9,
+      "affected_rows": 12
+    },
+    {
+      "severity": "WARNING",
+      "column": "__dataset__",
+      "check": "duplicate_rows",
+      "confidence": 0.8,
+      "affected_rows": 2
+    },
+    {
+      "severity": "INFO",
+      "column": "company",
+      "check": "nullability",
+      "confidence": 0.5,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "company",
+      "check": "pattern_consistency",
+      "confidence": 0.5,
+      "affected_rows": 1
+    },
+    {
+      "severity": "INFO",
+      "column": "company",
+      "check": "pattern_consistency",
+      "confidence": 0.5,
+      "affected_rows": 1
+    },
+    {
+      "severity": "INFO",
+      "column": "company",
+      "check": "pattern_consistency",
+      "confidence": 0.5,
+      "affected_rows": 1
+    },
+    {
+      "severity": "INFO",
+      "column": "city",
+      "check": "nullability",
+      "confidence": 0.5,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "city",
+      "check": "pattern_consistency",
+      "confidence": 0.5,
+      "affected_rows": 2
+    }
+  ],
+  "health_grade": "A",
+  "health_score": 94
+}

--- a/packages/typescript/goldencheck/tests/fixtures/_goldens_js/approx_fd.json
+++ b/packages/typescript/goldencheck/tests/fixtures/_goldens_js/approx_fd.json
@@ -1,0 +1,111 @@
+{
+  "findings": [
+    {
+      "severity": "WARNING",
+      "column": "zip",
+      "check": "type_inference",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "WARNING",
+      "column": "city",
+      "check": "fuzzy_duplicate_values",
+      "confidence": 0.7,
+      "affected_rows": 297
+    },
+    {
+      "severity": "WARNING",
+      "column": "__dataset__",
+      "check": "identity_safe_pk",
+      "confidence": 0.8,
+      "affected_rows": 300
+    },
+    {
+      "severity": "WARNING",
+      "column": "zip",
+      "check": "fd_violation",
+      "confidence": 0.8,
+      "affected_rows": 2
+    },
+    {
+      "severity": "WARNING",
+      "column": "city",
+      "check": "fd_violation",
+      "confidence": 0.8,
+      "affected_rows": 3
+    },
+    {
+      "severity": "INFO",
+      "column": "zip",
+      "check": "nullability",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "zip",
+      "check": "range_distribution",
+      "confidence": 1.0,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "zip",
+      "check": "cardinality",
+      "confidence": 0.7,
+      "affected_rows": 300
+    },
+    {
+      "severity": "INFO",
+      "column": "city",
+      "check": "nullability",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "city",
+      "check": "cardinality",
+      "confidence": 0.7,
+      "affected_rows": 300
+    },
+    {
+      "severity": "INFO",
+      "column": "city",
+      "check": "pattern_consistency",
+      "confidence": 0.8,
+      "affected_rows": 3
+    },
+    {
+      "severity": "INFO",
+      "column": "amt",
+      "check": "nullability",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "amt",
+      "check": "range_distribution",
+      "confidence": 1.0,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "amt",
+      "check": "composite_key",
+      "confidence": 0.6,
+      "affected_rows": 300
+    },
+    {
+      "severity": "INFO",
+      "column": "amt",
+      "check": "composite_key",
+      "confidence": 0.6,
+      "affected_rows": 300
+    }
+  ],
+  "health_grade": "B",
+  "health_score": 85
+}

--- a/packages/typescript/goldencheck/tests/fixtures/_goldens_js/composite_key.json
+++ b/packages/typescript/goldencheck/tests/fixtures/_goldens_js/composite_key.json
@@ -1,0 +1,62 @@
+{
+  "findings": [
+    {
+      "severity": "WARNING",
+      "column": "order_id",
+      "check": "type_inference",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "WARNING",
+      "column": "order_id",
+      "check": "identity_safe_pk",
+      "confidence": 1.0,
+      "affected_rows": 6
+    },
+    {
+      "severity": "INFO",
+      "column": "order_id",
+      "check": "range_distribution",
+      "confidence": 1.0,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "line_no",
+      "check": "range_distribution",
+      "confidence": 1.0,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "qty",
+      "check": "range_distribution",
+      "confidence": 1.0,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "order_id",
+      "check": "composite_key",
+      "confidence": 0.6,
+      "affected_rows": 6
+    },
+    {
+      "severity": "INFO",
+      "column": "sku",
+      "check": "composite_key",
+      "confidence": 0.6,
+      "affected_rows": 6
+    },
+    {
+      "severity": "INFO",
+      "column": "sku",
+      "check": "composite_key",
+      "confidence": 0.6,
+      "affected_rows": 6
+    }
+  ],
+  "health_grade": "A",
+  "health_score": 94
+}

--- a/packages/typescript/goldencheck/tests/fixtures/_goldens_js/functional_dependency.json
+++ b/packages/typescript/goldencheck/tests/fixtures/_goldens_js/functional_dependency.json
@@ -1,0 +1,97 @@
+{
+  "findings": [
+    {
+      "severity": "WARNING",
+      "column": "zip",
+      "check": "type_inference",
+      "confidence": 0.6,
+      "affected_rows": 0
+    },
+    {
+      "severity": "WARNING",
+      "column": "__dataset__",
+      "check": "identity_safe_pk",
+      "confidence": 0.8,
+      "affected_rows": 120
+    },
+    {
+      "severity": "INFO",
+      "column": "zip",
+      "check": "nullability",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "zip",
+      "check": "range_distribution",
+      "confidence": 1.0,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "zip",
+      "check": "cardinality",
+      "confidence": 0.7,
+      "affected_rows": 120
+    },
+    {
+      "severity": "INFO",
+      "column": "city",
+      "check": "nullability",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "city",
+      "check": "range_distribution",
+      "confidence": 1.0,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "city",
+      "check": "cardinality",
+      "confidence": 0.7,
+      "affected_rows": 120
+    },
+    {
+      "severity": "INFO",
+      "column": "amt",
+      "check": "nullability",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "amt",
+      "check": "range_distribution",
+      "confidence": 1.0,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "amt",
+      "check": "composite_key",
+      "confidence": 0.6,
+      "affected_rows": 120
+    },
+    {
+      "severity": "INFO",
+      "column": "amt",
+      "check": "composite_key",
+      "confidence": 0.6,
+      "affected_rows": 120
+    },
+    {
+      "severity": "INFO",
+      "column": "zip",
+      "check": "functional_dependency",
+      "confidence": 0.55,
+      "affected_rows": 120
+    }
+  ],
+  "health_grade": "A",
+  "health_score": 94
+}

--- a/packages/typescript/goldencheck/tests/fixtures/_goldens_js/fuzzy_values.json
+++ b/packages/typescript/goldencheck/tests/fixtures/_goldens_js/fuzzy_values.json
@@ -1,0 +1,76 @@
+{
+  "findings": [
+    {
+      "severity": "WARNING",
+      "column": "state",
+      "check": "fuzzy_duplicate_values",
+      "confidence": 0.6,
+      "affected_rows": 72
+    },
+    {
+      "severity": "WARNING",
+      "column": "__dataset__",
+      "check": "identity_safe_pk",
+      "confidence": 0.9,
+      "affected_rows": 120
+    },
+    {
+      "severity": "WARNING",
+      "column": "__dataset__",
+      "check": "duplicate_rows",
+      "confidence": 0.8,
+      "affected_rows": 120
+    },
+    {
+      "severity": "INFO",
+      "column": "state",
+      "check": "nullability",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "state",
+      "check": "cardinality",
+      "confidence": 0.7,
+      "affected_rows": 120
+    },
+    {
+      "severity": "INFO",
+      "column": "state",
+      "check": "pattern_consistency",
+      "confidence": 0.5,
+      "affected_rows": 24
+    },
+    {
+      "severity": "INFO",
+      "column": "state",
+      "check": "pattern_consistency",
+      "confidence": 0.5,
+      "affected_rows": 24
+    },
+    {
+      "severity": "INFO",
+      "column": "state",
+      "check": "pattern_consistency",
+      "confidence": 0.5,
+      "affected_rows": 24
+    },
+    {
+      "severity": "INFO",
+      "column": "region",
+      "check": "nullability",
+      "confidence": 0.7,
+      "affected_rows": 0
+    },
+    {
+      "severity": "INFO",
+      "column": "region",
+      "check": "cardinality",
+      "confidence": 0.7,
+      "affected_rows": 120
+    }
+  ],
+  "health_grade": "A",
+  "health_score": 91
+}

--- a/packages/typescript/goldencheck/tests/fixtures/_goldens_js/simple_mixed.json
+++ b/packages/typescript/goldencheck/tests/fixtures/_goldens_js/simple_mixed.json
@@ -4,97 +4,113 @@
       "severity": "WARNING",
       "column": "id",
       "check": "type_inference",
-      "confidence": 0.6
+      "confidence": 0.6,
+      "affected_rows": 0
     },
     {
       "severity": "WARNING",
       "column": "email",
       "check": "format_detection",
-      "confidence": 0.6
+      "confidence": 0.6,
+      "affected_rows": 2
     },
     {
       "severity": "WARNING",
       "column": "age",
       "check": "range_distribution",
-      "confidence": 0.8
+      "confidence": 0.8,
+      "affected_rows": 1
     },
     {
       "severity": "WARNING",
       "column": "age",
       "check": "sequence_detection",
-      "confidence": 0.8
+      "confidence": 0.8,
+      "affected_rows": 24
     },
     {
       "severity": "INFO",
       "column": "id",
       "check": "nullability",
-      "confidence": 0.5
+      "confidence": 0.5,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "id",
       "check": "uniqueness",
-      "confidence": 0.7
+      "confidence": 0.7,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "id",
       "check": "range_distribution",
-      "confidence": 1.0
+      "confidence": 1.0,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "name",
       "check": "nullability",
-      "confidence": 0.5
+      "confidence": 0.5,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "name",
       "check": "uniqueness",
-      "confidence": 0.7
+      "confidence": 0.7,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "email",
       "check": "nullability",
-      "confidence": 0.5
+      "confidence": 0.5,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "email",
       "check": "format_detection",
-      "confidence": 0.6
+      "confidence": 0.6,
+      "affected_rows": 18
     },
     {
       "severity": "INFO",
       "column": "email",
       "check": "pattern_consistency",
-      "confidence": 0.5
+      "confidence": 0.5,
+      "affected_rows": 2
     },
     {
       "severity": "INFO",
       "column": "age",
       "check": "nullability",
-      "confidence": 0.5
+      "confidence": 0.5,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "age",
       "check": "uniqueness",
-      "confidence": 0.7
+      "confidence": 0.7,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "age",
       "check": "range_distribution",
-      "confidence": 1.0
+      "confidence": 1.0,
+      "affected_rows": 0
     },
     {
       "severity": "INFO",
       "column": "status",
       "check": "nullability",
-      "confidence": 0.5
+      "confidence": 0.5,
+      "affected_rows": 0
     }
   ],
   "health_grade": "B",

--- a/packages/typescript/goldencheck/tests/fixtures/parity_cases.json
+++ b/packages/typescript/goldencheck/tests/fixtures/parity_cases.json
@@ -152,6 +152,2735 @@
         "sampleSize": 100000,
         "domain": null
       }
+    },
+    {
+      "name": "fuzzy_values",
+      "description": "near-duplicate state encodings (California spellings)",
+      "input": {
+        "kind": "records",
+        "records": [
+          {
+            "state": "California",
+            "region": "apple"
+          },
+          {
+            "state": "Californa",
+            "region": "banana"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "cherry"
+          },
+          {
+            "state": "Texas",
+            "region": "apple"
+          },
+          {
+            "state": "New York",
+            "region": "banana"
+          },
+          {
+            "state": "California",
+            "region": "cherry"
+          },
+          {
+            "state": "Californa",
+            "region": "apple"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "banana"
+          },
+          {
+            "state": "Texas",
+            "region": "cherry"
+          },
+          {
+            "state": "New York",
+            "region": "apple"
+          },
+          {
+            "state": "California",
+            "region": "banana"
+          },
+          {
+            "state": "Californa",
+            "region": "cherry"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "apple"
+          },
+          {
+            "state": "Texas",
+            "region": "banana"
+          },
+          {
+            "state": "New York",
+            "region": "cherry"
+          },
+          {
+            "state": "California",
+            "region": "apple"
+          },
+          {
+            "state": "Californa",
+            "region": "banana"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "cherry"
+          },
+          {
+            "state": "Texas",
+            "region": "apple"
+          },
+          {
+            "state": "New York",
+            "region": "banana"
+          },
+          {
+            "state": "California",
+            "region": "cherry"
+          },
+          {
+            "state": "Californa",
+            "region": "apple"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "banana"
+          },
+          {
+            "state": "Texas",
+            "region": "cherry"
+          },
+          {
+            "state": "New York",
+            "region": "apple"
+          },
+          {
+            "state": "California",
+            "region": "banana"
+          },
+          {
+            "state": "Californa",
+            "region": "cherry"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "apple"
+          },
+          {
+            "state": "Texas",
+            "region": "banana"
+          },
+          {
+            "state": "New York",
+            "region": "cherry"
+          },
+          {
+            "state": "California",
+            "region": "apple"
+          },
+          {
+            "state": "Californa",
+            "region": "banana"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "cherry"
+          },
+          {
+            "state": "Texas",
+            "region": "apple"
+          },
+          {
+            "state": "New York",
+            "region": "banana"
+          },
+          {
+            "state": "California",
+            "region": "cherry"
+          },
+          {
+            "state": "Californa",
+            "region": "apple"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "banana"
+          },
+          {
+            "state": "Texas",
+            "region": "cherry"
+          },
+          {
+            "state": "New York",
+            "region": "apple"
+          },
+          {
+            "state": "California",
+            "region": "banana"
+          },
+          {
+            "state": "Californa",
+            "region": "cherry"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "apple"
+          },
+          {
+            "state": "Texas",
+            "region": "banana"
+          },
+          {
+            "state": "New York",
+            "region": "cherry"
+          },
+          {
+            "state": "California",
+            "region": "apple"
+          },
+          {
+            "state": "Californa",
+            "region": "banana"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "cherry"
+          },
+          {
+            "state": "Texas",
+            "region": "apple"
+          },
+          {
+            "state": "New York",
+            "region": "banana"
+          },
+          {
+            "state": "California",
+            "region": "cherry"
+          },
+          {
+            "state": "Californa",
+            "region": "apple"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "banana"
+          },
+          {
+            "state": "Texas",
+            "region": "cherry"
+          },
+          {
+            "state": "New York",
+            "region": "apple"
+          },
+          {
+            "state": "California",
+            "region": "banana"
+          },
+          {
+            "state": "Californa",
+            "region": "cherry"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "apple"
+          },
+          {
+            "state": "Texas",
+            "region": "banana"
+          },
+          {
+            "state": "New York",
+            "region": "cherry"
+          },
+          {
+            "state": "California",
+            "region": "apple"
+          },
+          {
+            "state": "Californa",
+            "region": "banana"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "cherry"
+          },
+          {
+            "state": "Texas",
+            "region": "apple"
+          },
+          {
+            "state": "New York",
+            "region": "banana"
+          },
+          {
+            "state": "California",
+            "region": "cherry"
+          },
+          {
+            "state": "Californa",
+            "region": "apple"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "banana"
+          },
+          {
+            "state": "Texas",
+            "region": "cherry"
+          },
+          {
+            "state": "New York",
+            "region": "apple"
+          },
+          {
+            "state": "California",
+            "region": "banana"
+          },
+          {
+            "state": "Californa",
+            "region": "cherry"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "apple"
+          },
+          {
+            "state": "Texas",
+            "region": "banana"
+          },
+          {
+            "state": "New York",
+            "region": "cherry"
+          },
+          {
+            "state": "California",
+            "region": "apple"
+          },
+          {
+            "state": "Californa",
+            "region": "banana"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "cherry"
+          },
+          {
+            "state": "Texas",
+            "region": "apple"
+          },
+          {
+            "state": "New York",
+            "region": "banana"
+          },
+          {
+            "state": "California",
+            "region": "cherry"
+          },
+          {
+            "state": "Californa",
+            "region": "apple"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "banana"
+          },
+          {
+            "state": "Texas",
+            "region": "cherry"
+          },
+          {
+            "state": "New York",
+            "region": "apple"
+          },
+          {
+            "state": "California",
+            "region": "banana"
+          },
+          {
+            "state": "Californa",
+            "region": "cherry"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "apple"
+          },
+          {
+            "state": "Texas",
+            "region": "banana"
+          },
+          {
+            "state": "New York",
+            "region": "cherry"
+          },
+          {
+            "state": "California",
+            "region": "apple"
+          },
+          {
+            "state": "Californa",
+            "region": "banana"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "cherry"
+          },
+          {
+            "state": "Texas",
+            "region": "apple"
+          },
+          {
+            "state": "New York",
+            "region": "banana"
+          },
+          {
+            "state": "California",
+            "region": "cherry"
+          },
+          {
+            "state": "Californa",
+            "region": "apple"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "banana"
+          },
+          {
+            "state": "Texas",
+            "region": "cherry"
+          },
+          {
+            "state": "New York",
+            "region": "apple"
+          },
+          {
+            "state": "California",
+            "region": "banana"
+          },
+          {
+            "state": "Californa",
+            "region": "cherry"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "apple"
+          },
+          {
+            "state": "Texas",
+            "region": "banana"
+          },
+          {
+            "state": "New York",
+            "region": "cherry"
+          },
+          {
+            "state": "California",
+            "region": "apple"
+          },
+          {
+            "state": "Californa",
+            "region": "banana"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "cherry"
+          },
+          {
+            "state": "Texas",
+            "region": "apple"
+          },
+          {
+            "state": "New York",
+            "region": "banana"
+          },
+          {
+            "state": "California",
+            "region": "cherry"
+          },
+          {
+            "state": "Californa",
+            "region": "apple"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "banana"
+          },
+          {
+            "state": "Texas",
+            "region": "cherry"
+          },
+          {
+            "state": "New York",
+            "region": "apple"
+          },
+          {
+            "state": "California",
+            "region": "banana"
+          },
+          {
+            "state": "Californa",
+            "region": "cherry"
+          },
+          {
+            "state": "CALIFORNIA",
+            "region": "apple"
+          },
+          {
+            "state": "Texas",
+            "region": "banana"
+          },
+          {
+            "state": "New York",
+            "region": "cherry"
+          }
+        ]
+      },
+      "options": {
+        "sampleSize": 100000,
+        "domain": null
+      }
+    },
+    {
+      "name": "approx_duplicate",
+      "description": "one exact duplicate row pair (Acme/NYC)",
+      "input": {
+        "kind": "records",
+        "records": [
+          {
+            "company": "Acme",
+            "city": "NYC"
+          },
+          {
+            "company": "Beta",
+            "city": "LA"
+          },
+          {
+            "company": "Gamma",
+            "city": "SF"
+          },
+          {
+            "company": "Delta",
+            "city": "CHI"
+          },
+          {
+            "company": "Epsilon",
+            "city": "BOS"
+          },
+          {
+            "company": "Acme",
+            "city": "NYC"
+          },
+          {
+            "company": "Zeta",
+            "city": "SEA"
+          },
+          {
+            "company": "Eta",
+            "city": "DEN"
+          },
+          {
+            "company": "Theta",
+            "city": "MIA"
+          },
+          {
+            "company": "Iota",
+            "city": "ATL"
+          },
+          {
+            "company": "Kappa",
+            "city": "PHX"
+          },
+          {
+            "company": "Lambda",
+            "city": "DAL"
+          }
+        ]
+      },
+      "options": {
+        "sampleSize": 100000,
+        "domain": null
+      }
+    },
+    {
+      "name": "approx_fd",
+      "description": "near-strict zip->city FD with 3 injected typos",
+      "input": {
+        "kind": "records",
+        "records": [
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 0
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 13
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 26
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 39
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 52
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 65
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 78
+          },
+          {
+            "zip": 7,
+            "city": "WRONGCITY",
+            "amt": 91
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 7
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 20
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 33
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 46
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 59
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 72
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 85
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 1
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 14
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 27
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 40
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 53
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 66
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 79
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 92
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 8
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 21
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 34
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 47
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 60
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 73
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 86
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 2
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 15
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 28
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 41
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 54
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 67
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 80
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 93
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 9
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 22
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 35
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 48
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 61
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 74
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 87
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 3
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 16
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 29
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 42
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 55
+          },
+          {
+            "zip": 0,
+            "city": "WRONGCITY",
+            "amt": 68
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 81
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 94
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 10
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 23
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 36
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 49
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 62
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 75
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 88
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 4
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 17
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 30
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 43
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 56
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 69
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 82
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 95
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 11
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 24
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 37
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 50
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 63
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 76
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 89
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 5
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 18
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 31
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 44
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 57
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 70
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 83
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 96
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 12
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 25
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 38
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 51
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 64
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 77
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 90
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 6
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 19
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 32
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 45
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 58
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 71
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 84
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 0
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 13
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 26
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 39
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 52
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 65
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 78
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 91
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 7
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 20
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 33
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 46
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 59
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 72
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 85
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 1
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 14
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 27
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 40
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 53
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 66
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 79
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 92
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 8
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 21
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 34
+          },
+          {
+            "zip": 3,
+            "city": "WRONGCITY",
+            "amt": 47
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 60
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 73
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 86
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 2
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 15
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 28
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 41
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 54
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 67
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 80
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 93
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 9
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 22
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 35
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 48
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 61
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 74
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 87
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 3
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 16
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 29
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 42
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 55
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 68
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 81
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 94
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 10
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 23
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 36
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 49
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 62
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 75
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 88
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 4
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 17
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 30
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 43
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 56
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 69
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 82
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 95
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 11
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 24
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 37
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 50
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 63
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 76
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 89
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 5
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 18
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 31
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 44
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 57
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 70
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 83
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 96
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 12
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 25
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 38
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 51
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 64
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 77
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 90
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 6
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 19
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 32
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 45
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 58
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 71
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 84
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 0
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 13
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 26
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 39
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 52
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 65
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 78
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 91
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 7
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 20
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 33
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 46
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 59
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 72
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 85
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 1
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 14
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 27
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 40
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 53
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 66
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 79
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 92
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 8
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 21
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 34
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 47
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 60
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 73
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 86
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 2
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 15
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 28
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 41
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 54
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 67
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 80
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 93
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 9
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 22
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 35
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 48
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 61
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 74
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 87
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 3
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 16
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 29
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 42
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 55
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 68
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 81
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 94
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 10
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 23
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 36
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 49
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 62
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 75
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 88
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 4
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 17
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 30
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 43
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 56
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 69
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 82
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 95
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 11
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 24
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 37
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 50
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 63
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 76
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 89
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 5
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 18
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 31
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 44
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 57
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 70
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 83
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 96
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 12
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 25
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 38
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 51
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 64
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 77
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 90
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 6
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 19
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 32
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 45
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 58
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 71
+          },
+          {
+            "zip": 0,
+            "city": "city_0",
+            "amt": 84
+          },
+          {
+            "zip": 1,
+            "city": "city_1",
+            "amt": 0
+          },
+          {
+            "zip": 2,
+            "city": "city_2",
+            "amt": 13
+          },
+          {
+            "zip": 3,
+            "city": "city_3",
+            "amt": 26
+          },
+          {
+            "zip": 4,
+            "city": "city_4",
+            "amt": 39
+          },
+          {
+            "zip": 5,
+            "city": "city_5",
+            "amt": 52
+          },
+          {
+            "zip": 6,
+            "city": "city_6",
+            "amt": 65
+          },
+          {
+            "zip": 7,
+            "city": "city_7",
+            "amt": 78
+          },
+          {
+            "zip": 8,
+            "city": "city_8",
+            "amt": 91
+          },
+          {
+            "zip": 9,
+            "city": "city_9",
+            "amt": 7
+          }
+        ]
+      },
+      "options": {
+        "sampleSize": 100000,
+        "domain": null
+      }
+    },
+    {
+      "name": "functional_dependency",
+      "description": "strict zip->city functional dependency",
+      "input": {
+        "kind": "records",
+        "records": [
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 0
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 7
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 14
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 21
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 28
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 35
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 42
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 49
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 6
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 13
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 20
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 27
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 34
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 41
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 48
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 5
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 12
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 19
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 26
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 33
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 40
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 47
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 4
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 11
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 18
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 25
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 32
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 39
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 46
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 3
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 10
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 17
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 24
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 31
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 38
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 45
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 2
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 9
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 16
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 23
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 30
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 37
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 44
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 1
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 8
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 15
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 22
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 29
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 36
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 43
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 0
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 7
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 14
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 21
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 28
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 35
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 42
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 49
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 6
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 13
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 20
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 27
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 34
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 41
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 48
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 5
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 12
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 19
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 26
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 33
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 40
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 47
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 4
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 11
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 18
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 25
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 32
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 39
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 46
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 3
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 10
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 17
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 24
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 31
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 38
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 45
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 2
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 9
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 16
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 23
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 30
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 37
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 44
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 1
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 8
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 15
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 22
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 29
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 36
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 43
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 0
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 7
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 14
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 21
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 28
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 35
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 42
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 49
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 6
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 13
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 20
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 27
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 34
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 41
+          },
+          {
+            "zip": 0,
+            "city": 0,
+            "amt": 48
+          },
+          {
+            "zip": 1,
+            "city": 0,
+            "amt": 5
+          },
+          {
+            "zip": 2,
+            "city": 1,
+            "amt": 12
+          },
+          {
+            "zip": 3,
+            "city": 2,
+            "amt": 19
+          },
+          {
+            "zip": 4,
+            "city": 3,
+            "amt": 26
+          },
+          {
+            "zip": 5,
+            "city": 4,
+            "amt": 33
+          }
+        ]
+      },
+      "options": {
+        "sampleSize": 100000,
+        "domain": null
+      }
+    },
+    {
+      "name": "composite_key",
+      "description": "(order_id, line_no) composite key; no single-col key",
+      "input": {
+        "kind": "records",
+        "records": [
+          {
+            "order_id": 1,
+            "line_no": 1,
+            "sku": "a",
+            "qty": 2
+          },
+          {
+            "order_id": 1,
+            "line_no": 2,
+            "sku": "b",
+            "qty": 1
+          },
+          {
+            "order_id": 1,
+            "line_no": 3,
+            "sku": "c",
+            "qty": 5
+          },
+          {
+            "order_id": 2,
+            "line_no": 1,
+            "sku": "a",
+            "qty": 1
+          },
+          {
+            "order_id": 2,
+            "line_no": 2,
+            "sku": "d",
+            "qty": 1
+          },
+          {
+            "order_id": 3,
+            "line_no": 1,
+            "sku": "e",
+            "qty": 9
+          }
+        ]
+      },
+      "options": {
+        "sampleSize": 100000,
+        "domain": null
+      }
     }
   ]
 }

--- a/packages/typescript/goldencheck/tests/parity/parity.test.ts
+++ b/packages/typescript/goldencheck/tests/parity/parity.test.ts
@@ -1,6 +1,19 @@
 /**
  * Parity tests — validates TypeScript scan results match Python golden outputs.
- * Run `python scripts/gen_parity_goldens_js.py` to generate/update goldens.
+ * Run `python scripts/gen_parity_goldens_js.py` (from this package dir, with the
+ * goldencheck Python package importable) to (re)generate goldens. The #855
+ * fixtures + goldens are regenerated on CI via `regen-855-parity-goldens.yml`.
+ *
+ * Asserts per-finding identity (column, check, severity) PLUS confidence (to 4
+ * decimals) and affected-row counts, and FAILS (not skips) when the manifest or
+ * a golden is missing — so a newly-ported profiler can't silently regress.
+ *
+ * NOTE: the `freshness` profiler is intentionally NOT covered here. This harness
+ * round-trips each case through a temp CSV, and `pl.read_csv` defaults to
+ * `try_parse_dates=False`, so date columns arrive as Utf8 and Python's
+ * date-dtype-gated FreshnessProfiler never fires — while TS `dtype()` reports
+ * "date" for ISO strings. Freshness parity is covered by
+ * `tests/unit/profilers/freshness.test.ts` instead.
  */
 
 import { describe, it, expect } from "vitest";
@@ -24,21 +37,37 @@ interface ParityCase {
   options?: { sampleSize?: number; domain?: string | null };
 }
 
+interface GoldenFinding {
+  severity: string;
+  column: string;
+  check: string;
+  confidence: number;
+  affected_rows: number;
+}
+
 interface GoldenOutput {
-  findings: Array<{
-    severity: string;
-    column: string;
-    check: string;
-    confidence: number;
-  }>;
+  findings: GoldenFinding[];
   health_grade: string;
   health_score: number;
 }
 
+const round4 = (x: number): number => Math.round(x * 1e4) / 1e4;
+
+interface CmpFinding {
+  column: string;
+  check: string;
+  severity: string;
+  confidence: number;
+  affectedRows: number;
+}
+
+const sortKey = (f: CmpFinding): string => `${f.column}|${f.check}|${f.affectedRows}`;
+
 describe("parity", () => {
-  // Skip if manifest doesn't exist (goldens not yet generated)
   if (!existsSync(MANIFEST_PATH)) {
-    it.skip("parity_cases.json not found — run scripts/gen_parity_goldens_js.py first", () => {});
+    it("parity_cases.json must exist (run scripts/gen_parity_goldens_js.py)", () => {
+      throw new Error(`Missing parity manifest at ${MANIFEST_PATH}`);
+    });
     return;
   }
 
@@ -48,8 +77,9 @@ describe("parity", () => {
     it(`matches Python output for: ${testCase.name}`, () => {
       const goldenPath = join(GOLDENS_DIR, `${testCase.name}.json`);
       if (!existsSync(goldenPath)) {
-        // Skip if golden not generated yet
-        return;
+        throw new Error(
+          `Missing golden for "${testCase.name}" — run scripts/gen_parity_goldens_js.py`,
+        );
       }
 
       const golden: GoldenOutput = JSON.parse(readFileSync(goldenPath, "utf-8"));
@@ -60,20 +90,23 @@ describe("parity", () => {
       });
       const findings = applyConfidenceDowngrade(result.findings, false);
 
-      // Compare finding identity: (column, check) pairs
-      const tsFindings = findings.map((f) => ({
+      const tsFindings: CmpFinding[] = findings.map((f) => ({
         column: f.column,
         check: f.check,
         severity: f.severity === 3 ? "ERROR" : f.severity === 2 ? "WARNING" : "INFO",
+        confidence: round4(f.confidence),
+        affectedRows: f.affectedRows,
       }));
-      const pyFindings = golden.findings.map((f) => ({
+      const pyFindings: CmpFinding[] = golden.findings.map((f) => ({
         column: f.column,
         check: f.check,
         severity: f.severity,
+        confidence: round4(f.confidence),
+        affectedRows: f.affected_rows,
       }));
 
-      // Sort both for comparison
-      const sortKey = (f: { column: string; check: string }) => `${f.column}|${f.check}`;
+      // Sort by a key spanning column+check+rows so multi-finding-per-column
+      // cases (fuzzy, approx-duplicate) compare order-independently.
       tsFindings.sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
       pyFindings.sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
 

--- a/packages/typescript/goldencheck/tests/unit/relations/all-relations.test.ts
+++ b/packages/typescript/goldencheck/tests/unit/relations/all-relations.test.ts
@@ -39,6 +39,16 @@ describe("TemporalOrderProfiler", () => {
     const findings = profiler.profile(data);
     expect(findings.some((f) => f.column.includes("open_date"))).toBe(true);
   });
+
+  it("does NOT fire on integer columns (parity with Python's %Y-%m-%d gate)", () => {
+    // `new Date("7")` is a valid Date in JS; Python only casts strings via
+    // str.to_date(format="%Y-%m-%d"), so integer pairs must NOT be treated as
+    // date columns. Regression guard for the TS<->Python temporal gap.
+    const data = new TabularData(
+      Array.from({ length: 20 }, (_, i) => ({ zip: i % 10, amt: (i * 13) % 7 })),
+    );
+    expect(profiler.profile(data)).toEqual([]);
+  });
 });
 
 describe("NullCorrelationProfiler", () => {


### PR DESCRIPTION
Follow-up to #873 (the goldencheck TS ports). Completes the parity-test hardening that #873 deferred because it needs a Polars run the local dev box can't do without OOMing.

## What this adds
- **5 parity cases** (`parity_cases.json`) for the new modules: fuzzy-values, approx-duplicate, approx-fd, functional-dependency, composite-key.
- **Python-generated goldens** for those 5 + a regenerated `simple_mixed` (now carrying `affected_rows`). Generated on a clean `ubuntu-latest` runner via the new `regen-855-parity-goldens.yml` workflow (`uv sync` + the generators, uploaded as an artifact), so they are genuine Python source-of-truth output.
- **`gen_855_parity_fixtures.py`** -- reproducible fixture construction (string/int only, no nulls, per the parity ground rules).
- **Hardened `parity.test.ts`** -- now asserts per-finding `confidence` (to 4 dp) and `affected_rows`, and FAILS (not skips) when the manifest or any golden is missing.

## Why it matters
The TS parity lane now compares full TS scan output against real Python output, including the corroboration-boosted confidences and affected-row counts. This is the cross-language check that locks the new profilers/relations against silent regression -- and the goldens exercise collateral profilers too (e.g. the approx-fd fixture's sequential `city_N` values fuzzy-cluster), so it is a broad check, not just the target modules.

`freshness` stays unit-test-only: the harness round-trips through a temp CSV and `pl.read_csv` defaults to `try_parse_dates=False`, so date columns arrive as Utf8 and Python's date-gated FreshnessProfiler never fires (TS would). Documented in the test header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)