### PR TITLE
docs: context-network + mintlify for the opt-in WASM acceleration arc

### DIFF
--- a/context-network/architecture/wasm-acceleration.md
+++ b/context-network/architecture/wasm-acceleration.md
@@ -1,0 +1,122 @@
+# Opt-in WASM acceleration (pyo3-free cores → TypeScript)
+
+The TypeScript packages reach the same Rust `*-core` kernels the Python native
+wheels and the SQL UDFs use — via **WebAssembly**, **opt-in**, without giving up
+the zero-dependency pure-TS default or the edge-safety guarantee. WASM is the TS
+sibling of the `*-native` abi3 wheels: same crate, byte-identical by construction.
+Pure-TS stays the default and the fallback forever; default users download and
+parse **zero** wasm bytes.
+
+**Status:** SHIPPED across four PRs — `score-core` → goldenmatch (#878), the
+pure-TS rapidfuzz alignment that unblocks parity (#879), `analysis-core` →
+goldenanalysis + the shared runtime (#880), token_sort coverage + dist-path
+validation (#881). **Spec:**
+`docs/superpowers/specs/2026-06-12-opt-in-wasm-rust-acceleration-design.md` (+
+`2026-06-12-analysis-wasm-acceleration-design.md`,
+`2026-06-12-scorer-rapidfuzz-parity-design.md`). **Decision:**
+[../decisions/0014-opt-in-wasm-acceleration.md](../decisions/0014-opt-in-wasm-acceleration.md).
+**Code-level notes:** `packages/typescript/CLAUDE.md` (shared runtime),
+`packages/typescript/goldenmatch/CLAUDE.md` (scorer slice).
+
+## The shared runtime: `goldenmatch-wasm-runtime`
+A tiny zero-dependency workspace package holding the genuinely-shared, fiddly
+plumbing — extracted once and reused, not duplicated per core:
+- `resolveWasmBytes(opts, fallbackUrl)` — the edge-safe byte loader + env
+  detection (fs on Node, `fetch` on browser/Workers; the documented
+  `await import("node:fs/promises" as string)` idiom keeps bundlers from
+  statically resolving node built-ins).
+- `enableWasmBackend<B>(opts, instantiate, register, fallbackUrl)` — the generic
+  async opt-in skeleton (browsers ban sync instantiation >4 KB): load → glue →
+  register, or fall back to pure-TS (`{ require: true }` to hard-fail instead).
+- `createBackendRegistry<B>()` — the module-singleton swap point (mirrors
+  `setSyncEmbedder(null)`).
+
+**Each consumer owns its artifact URL, its wasm-bindgen glue import, and its
+backend interface.** The `new URL('./artifacts/X_bg.wasm', import.meta.url)` and
+the dynamic `import('./artifacts/X.js')` MUST live in the consumer's own module
+so `import.meta.url` resolves to *that* package's `dist` — passing the URL into
+the shared package would resolve to the wrong location. That constraint is the
+whole reason the runtime takes `fallbackUrl` as a parameter.
+
+## Per-core slices (batch-first, never per-call)
+
+| Core → consumer | Covered ops | Win profile |
+|---|---|---|
+| `score-core` → goldenmatch `scoreMatrix` | `jaro_winkler` / `levenshtein` / `token_sort` / `exact` | jaro_winkler is the dominant scorer; the swap is at the NxN block boundary (one JS↔WASM crossing per block) |
+| `analysis-core` → goldenanalysis `histogram` / `quantile` | `histogram` / `quantile` | numeric arrays cross as **zero-copy `Float64Array`** + real Rust compute (quantile sorts); the Python native path measured 5.8–9.9x |
+
+The boundary is **batch-first**: a single crossing per NxN block / per array,
+never per-pair — per the perf-audit lesson that boundary cost dwarfs a single
+scorer. The swap is per-scorer: only covered ops route to WASM; everything else
+stays pure-TS even when enabled.
+
+## The two gates
+- **Parity:** a skip-guarded test (`tests/parity/wasm-*.test.ts`) asserts
+  WASM ≈ pure-TS ≈ Python goldens to 4 decimals, including non-BMP / accented
+  inputs. Skips without the built artifact; the CI lane builds it and runs
+  un-skipped.
+- **Bench (measure-first graduation):** a core ships acceleration only if the
+  wall-clock measurably beats pure-TS on a realistic block / large-array
+  workload. The bench is also the **dist-path validator** (see below).
+
+## The rapidfuzz-alignment prerequisite (#879)
+WASM parity (WASM ≈ pure-TS) is unachievable while the hand-rolled pure-TS
+scorers diverge from rapidfuzz (which `score-core` IS). #879 aligned them as one
+change — three latent divergences: **codepoint iteration** (`Array.from`, not
+UTF-16 code units), the **Winkler boost gated on `jaro > 0.7`**, and **floored
+transposition `t // 2`** (the divergence was integer-vs-float halving, NOT
+bit-parallel match-assignment — empirically settled, 0/50000 vs rapidfuzz incl.
+non-BMP). Existing canonical anchors (MARTHA, DIXON, …) and #857's refdata
+scorers do not shift.
+
+## token_sort coverage + the pinned asymmetry (#881)
+`score-core::token_sort_normalized_ratio` is a **new** fn doing the TS-parity
+lowercase + strip-non-alnum + token-sort normalize → `fuzz::ratio`. It is
+deliberately distinct from `score_one(2)`, which stays **un-normalized** (the
+pinned asymmetry the FFI / native path depends on — do not merge). score-wasm
+branches `id == 2` to the normalized fn; the rest of the FFI/native surface is
+untouched.
+
+## The dist artifact path (#881)
+The loader's `new URL('./artifacts/X_bg.wasm', import.meta.url)` resolves
+relative to wherever tsup bundles the loader in `dist` — unpredictable. Rather
+than guess, `copy_wasm_artifact.mjs` copies the artifact to **every plausible**
+`./artifacts/` parent (`dist/core/wasm/artifacts/`, `dist/core/artifacts/`,
+`dist/artifacts/`). The wasm benches were then flipped OFF `continue-on-error`:
+they build `dist` + run `enableWasm()` / `enableAnalysisWasm()`, so a broken
+bundled path reddens the (non-required) lane. That gate paid for itself on the
+first run — it caught `aggregate.ts` histogram's `Math.min(...vals)`
+stack-overflowing at 1M elements (exactly the large-array case WASM exists for),
+now a loop.
+
+## Parked cores (measure-first verdict, not built)
+- **`graph-core` → `cluster.ts` — PARK.** Its only accelerable op is the
+  UnionFind construction (`cluster.ts:317-323`), one O(N) step among several
+  O(N) steps in `buildClusters` (sort, pair-score assignment, confidence,
+  MST-split); marshaling N pairs across the boundary is itself O(N) →
+  boundary-bound. Python's native graph win comes from doing the *whole*
+  clustering in Rust, which the TS slice can't replicate without porting all of
+  `buildClusters`. Building a `graph-wasm` crate just to bench it would cost the
+  thing we'd park.
+- **`fingerprint-core` / `goldencheck-core` — PARK** (design): Web Crypto
+  SHA-256 is already native **and async**; the goldencheck TS path mirrors the
+  sampled, already-vectorized scan. Revisit either only with a bench showing a win.
+
+## Verification (CI)
+- The required `typescript` lane builds the shared runtime first (turbo `^build`)
+  and runs the artifact-free unit tests (`wasm-backend`, `wasm-fallback`).
+- The non-blocking `wasm_score` / `analysis_wasm` lanes build the `wasm32`
+  artifact, run the parity test un-skipped, and run the bench (now a dist-path
+  gate). Each lane builds `goldenmatch-wasm-runtime` before its parity vitest
+  (the parity test imports it; turbo isn't in that path).
+- Rust host `cargo test` on the `*-wasm` crates (logic lives in `score-core` /
+  `analysis-core`; the shims are trivial).
+
+## Adding a new accelerated core
+New `*-wasm` crate (mirror `score-wasm`), a consumer `src/core/wasm/` (backend +
+loader + index over the shared runtime), wire the batch boundary, a skip-guarded
+parity test + bench, a CI lane (build runtime before the parity test; bench as a
+dist gate). Only build it if a cheap profile says it will win.
+
+---
+**Classification:** architecture/shipped • **Last updated:** 2026-06-13

--- a/context-network/decisions/0014-opt-in-wasm-acceleration.md
+++ b/context-network/decisions/0014-opt-in-wasm-acceleration.md
@@ -1,0 +1,54 @@
+# 0014 — Opt-in WASM acceleration: pure-TS stays the default, measure before shipping each core
+
+**Status:** accepted (2026-06-12, Ben) • **Shipped:** PRs #878 (score-core) / #879 (rapidfuzz alignment) / #880 (analysis-core + shared runtime) / #881 (token_sort + dist-path) • **Architecture:** [../architecture/wasm-acceleration.md](../architecture/wasm-acceleration.md)
+
+## Context
+The Golden Suite TypeScript packages are **pure TypeScript** — `src/core/**` is
+edge-safe (no `node:*`), zero-dependency, and runs in browsers, Workers, and edge
+runtimes. That edge-safety is the value proposition. The Rust acceleration was
+Python-only: the pyo3-free `*-core` crates back the `*-native` wheels and the SQL
+UDFs, while the TS port reimplements the same algorithms by hand against a
+4-decimal parity contract. The question: can the TS side **optionally** reach the
+same Rust kernels via WebAssembly without losing the pure-TS default or the
+edge-safety guarantee?
+
+## Decision
+1. **Opt-in, never the default.** Pure-TS is the default and the fallback
+   forever; the `.wasm` is built in CI, never committed, and default users load
+   zero wasm bytes. `enableWasm()` is async and returns `false` (pure-TS stays)
+   on any load failure; `{ require: true }` hard-fails for callers who must have it.
+2. **One shared runtime, extracted — not duplicated.** The fiddly plumbing
+   (byte loader, env detection, the enable skeleton, the registry) lives in a
+   tiny zero-dep `goldenmatch-wasm-runtime` workspace package both consumers ride.
+   Each consumer keeps its artifact URL + glue import + backend interface in its
+   OWN module (so `import.meta.url` resolves to its dist).
+3. **Batch-first boundary, per-scorer swap.** Cross the JS↔WASM boundary once per
+   NxN block / per array, never per pair (boundary cost dwarfs a single op). Only
+   covered ops route to WASM; everything else stays pure-TS even when enabled.
+4. **Two gates per core: parity AND bench. Ship only on a measured win.** A core
+   graduates to shipped acceleration only when WASM ≈ pure-TS ≈ Python (4dp,
+   incl. non-BMP) *and* the wall-clock measurably beats pure-TS on a realistic
+   workload. "It's Rust/WASM" is never enough — the boundary + marshaling can
+   erase the win.
+5. **Align the reference, don't fork it.** WASM parity requires the pure-TS
+   scorers to match rapidfuzz first; #879 aligned them (codepoint iteration,
+   `>0.7` boost, floored transposition) as a single change rather than letting
+   WASM and pure-TS diverge.
+
+## Consequence
+- Two cores shipped: `score-core` → goldenmatch (jaro_winkler/levenshtein/
+  token_sort/exact) and `analysis-core` → goldenanalysis (histogram/quantile,
+  the 5.8–9.9x-in-Python numeric-reduction shape). The shared runtime is the
+  reusable substrate for any future core.
+- The measure-first gate **parked `graph-core`** without building it: its only
+  accelerable op (UnionFind construction) is one O(N) step among several in
+  `buildClusters`, and marshaling N pairs is itself O(N) → boundary-bound. The
+  TS slice can't replicate Python's whole-clustering-in-Rust win. `fingerprint-core`
+  / `goldencheck-core` stay parked by design. The verdict cost a paragraph, not a crate.
+- The bench-as-dist-validation gate paid for itself on the first real run: it
+  caught `aggregate.ts` histogram's `Math.min(...vals)` stack-overflowing at 1M
+  elements (the exact large-array case WASM is for) — a latent bug that the
+  small-corpus parity test could never have surfaced.
+- The `score_one(2)` token_sort asymmetry is preserved: token_sort WASM coverage
+  added a NEW normalized `score-core` fn rather than touching the un-normalized
+  dispatch the FFI/native path depends on. Don't reconcile them.

--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -17,6 +17,7 @@ links rather than reading everything.
 - [architecture/goldencheck-goldenmatch-integration.md](architecture/goldencheck-goldenmatch-integration.md) — data quality feeds entity resolution: four fail-open, default-OFF doors (survivorship, blocking, FD negative-evidence, quality-gated review); #794/#795/#798 shipped, #797 open.
 - [architecture/fellegi-sunter-splink-parity.md](architecture/fellegi-sunter-splink-parity.md) — the `type: probabilistic` matchkey from scorer to Splink-class engine: model lifecycle, supervised m, match-weight waterfall, calibration, accuracy analysis, bucket/native scale-out. FS auto-config v2 (#823, v1.29.0) now beats hand-rolled Splink on every dataset Splink scores (pairwise F1, shared evaluator), made reproducible by the #829 EM-sampling determinism fix; the deterministic three-engine bake-off is at [`docs/benchmarks/2026-06-09-splink-bakeoff.md`](../docs/benchmarks/2026-06-09-splink-bakeoff.md).
 - [architecture/rust-test-coverage.md](architecture/rust-test-coverage.md) — how the `packages/rust/extensions/` crates are tested in CI: per-crate map, the bridge CPython-in-CI dance, the `cargo pgrx test` structural dead-end, and the measured per-crate baseline; SHIPPED (#827/#830/#832, 2026-06-09).
+- [architecture/wasm-acceleration.md](architecture/wasm-acceleration.md) — opt-in WASM acceleration for the pyo3-free `*-core` crates → TypeScript: the shared `goldenmatch-wasm-runtime`, `score-core`→goldenmatch (jaro_winkler/levenshtein/token_sort/exact) + `analysis-core`→goldenanalysis (histogram/quantile), parity+bench gates, the rapidfuzz-alignment prerequisite; SHIPPED #878/#879/#880/#881; graph/fingerprint/goldencheck parked.
 
 ## Decisions (records with no other home)
 - [decisions/0001-gate-reframe-engine-portability.md](decisions/0001-gate-reframe-engine-portability.md) — retire one-box RSS as the gate; engine portability is the destination.
@@ -32,6 +33,7 @@ links rather than reading everything.
 - [decisions/0011-distributed-wcc-randomized-contraction.md](decisions/0011-distributed-wcc-randomized-contraction.md) — distributed WCC: randomized contraction (relational, chain-robust) over driver-collect / min-propagation; per-round parquet checkpoint dodges the Ray streaming-executor deadlock; VALIDATED at 100M (9.2 min) + default-flipped (#867); the e2e wall was per-group scoring (vectorized in #864), not the WCC.
 - [decisions/0012-fs-block-scoring-perf.md](decisions/0012-fs-block-scoring-perf.md) — FS block-scoring perf: "Splink 3-19x faster" was a numpy-path red herring (the bake-off never set `GOLDENMATCH_FS_NATIVE`); the wall is per-block fan-out, not scoring math, so the Rust kernel can't move it; three output-identical numpy optimizations took historical_50k −72% local.
 - [decisions/0013-goldencheck-ts-parity-hardening.md](decisions/0013-goldencheck-ts-parity-hardening.md) — goldencheck TS port: finish module parity (2 profilers / 4 relations / `validate`, mirroring the Python fallback) + harden the golden harness (assert confidence + affected_rows, fail-on-missing, regenerate on a CI runner since the box OOMs on Polars); it caught a pre-existing `temporal_order` over-fire on integer columns (#855 closed).
+- [decisions/0014-opt-in-wasm-acceleration.md](decisions/0014-opt-in-wasm-acceleration.md) — opt-in WASM for the TS packages: pure-TS stays the default + fallback, one shared runtime (extracted not duplicated), batch-first per-scorer swap, ship a core only on a measured parity+bench win (parked graph-core on the verdict, not a crate); the bench-as-dist-validation gate caught a real 1M-element histogram overflow.
 
 ## Processes (how work is done here)
 - [processes/development-workflow.md](processes/development-workflow.md) — spec → plan → execute → review → CI → merge, plus the hard environment constraints.
@@ -46,4 +48,4 @@ links rather than reading everything.
 - [meta/maintenance.md](meta/maintenance.md) — how to keep nodes accurate and small.
 
 ---
-**Classification:** navigation • **Last updated:** 2026-06-11
+**Classification:** navigation • **Last updated:** 2026-06-13

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,32 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-13 — Opt-in WASM acceleration arc (TypeScript) — #878/#879/#880/#881
+- New [../architecture/wasm-acceleration.md](../architecture/wasm-acceleration.md)
+  and [../decisions/0014-opt-in-wasm-acceleration.md](../decisions/0014-opt-in-wasm-acceleration.md);
+  linked both from [../discovery.md](../discovery.md).
+- The TS packages now optionally reach the same pyo3-free `*-core` Rust kernels
+  via WebAssembly — opt-in, pure-TS stays the default + fallback, edge-safe,
+  `.wasm` built in CI (never committed). Two cores shipped:
+  - **#878** `score-core` → goldenmatch `scoreMatrix` (`enableWasm()`; jaro_winkler/
+    levenshtein/exact at first).
+  - **#880** `analysis-core` → goldenanalysis `histogram`/`quantile`
+    (`enableAnalysisWasm()`) **+** extracted the shared `goldenmatch-wasm-runtime`
+    workspace package (byte loader + generic enable skeleton + registry) that both
+    consumers ride.
+  - **#879** aligned the hand-rolled pure-TS scorers with rapidfuzz (the parity
+    prerequisite): codepoint iteration, Winkler `>0.7` boost, floored transposition
+    `t//2` — empirically settled as integer-vs-float halving, not bit-parallel
+    matching (0/50000 vs rapidfuzz incl. non-BMP).
+  - **#881** added `token_sort` WASM coverage (new `score-core::token_sort_normalized_ratio`,
+    distinct from the pinned un-normalized `score_one(2)`) + validated the bundled
+    dist artifact path (defensive multi-location copy; flipped the benches to a
+    dist-path gate, which caught a real 1M-element `histogram` `Math.min(...vals)`
+    stack overflow).
+- **Measure-first parked `graph-core`** without building it (UnionFind is one O(N)
+  step among several in `buildClusters`, marshaling N pairs is O(N) →
+  boundary-bound); `fingerprint-core` / `goldencheck-core` stay parked by design.
+
 ## 2026-06-12 — #855 goldencheck TS port: module parity + hardened golden harness (#873/#874)
 - New [../decisions/0013-goldencheck-ts-parity-hardening.md](../decisions/0013-goldencheck-ts-parity-hardening.md);
   added the `#855` subsection to [../planning/surface-hardening.md](../planning/surface-hardening.md).
@@ -381,4 +407,4 @@ Newest first. One entry per meaningful change to the network.
 - Committed to git on branch `chore/context-network`.
 
 ---
-**Classification:** meta/log • **Last updated:** 2026-06-12
+**Classification:** meta/log • **Last updated:** 2026-06-13

--- a/docs-site/goldenanalysis/native.mdx
+++ b/docs-site/goldenanalysis/native.mdx
@@ -36,3 +36,20 @@ In-tree dev build (no maturin needed):
 ```bash
 uv run python scripts/build_analysis_native.py
 ```
+
+## TypeScript: opt-in WASM (browser / edge / Node)
+
+The TypeScript port (`goldenanalysis` on npm) reaches the **same `analysis-core` crate** via WebAssembly — the TS analogue of the Python native wheel. Same posture: pure-TS is the default and the byte-identical fallback; WASM is an explicit upgrade for large columns.
+
+```ts
+import { aggregate, enableAnalysisWasm, disableAnalysisWasm } from "goldenanalysis";
+
+await enableAnalysisWasm();                  // async: loads the .wasm once
+const h = aggregate.histogram(values, 256);  // now runs in WASM (Float64 array crosses zero-copy)
+const q = aggregate.quantile(values, 0.9);   // the sort runs in Rust
+disableAnalysisWasm();                        // back to pure-TS
+```
+
+- **Covered ops:** `histogram` / `quantile` — the numeric reductions where the win lives (a `Float64Array` crosses the boundary zero-copy and the quantile sort runs in Rust). Everything else in `aggregate` stays pure-TS.
+- **Opt-in, edge-safe, parity-gated** exactly like the scorer WASM backend in `goldenmatch`: pure-TS is the default + fallback, the `.wasm` is built in CI (never committed), and a CI lane asserts WASM ≈ pure-TS to 4 decimals. The plumbing is shared with `goldenmatch` via the `goldenmatch-wasm-runtime` package.
+- **Build locally:** `bash packages/rust/extensions/analysis-wasm/build_wasm.sh` (needs the rustup `wasm32-unknown-unknown` target + `wasm-bindgen-cli`).

--- a/docs-site/goldenmatch/typescript.mdx
+++ b/docs-site/goldenmatch/typescript.mdx
@@ -118,6 +118,25 @@ All scorers implement the same interface as Python `goldenmatch.core.scorer`:
 
 The two `*_jw` scorers are refdata-aware and edge-safe: their bundled lookup tables (a given-name alias corpus and the US Census 2010 top-10k surname table) ship inside the npm package, generated from the Python source of truth and drift-guarded in CI. Auto-config swaps them in automatically for first-name and last-name columns. See [Reference Data](/goldenmatch/reference-data) for the algorithms.
 
+## Optional WASM acceleration
+
+The pure-TS scorers run everywhere (browser, Workers, edge, Node) with zero dependencies — that's the default. For workloads that score large blocks you can **optionally** swap in a WebAssembly backend that wraps the same Rust `score-core` kernel the Python package and the SQL UDFs use:
+
+```ts
+import { dedupe, enableWasm, disableWasm } from "goldenmatch";
+
+await enableWasm();        // async: loads + instantiates the .wasm once
+const result = await dedupe(rows, { /* ... */ }); // covered scorers now run in WASM
+disableWasm();             // back to pure-TS (e.g. for test isolation)
+```
+
+- **Opt-in; pure-TS stays the default and the fallback.** Default users download and parse **zero** wasm bytes (the loader/glue/bytes load only on `enableWasm()`). It returns `false` (pure-TS stays active) on any load failure; pass `{ require: true }` to throw instead.
+- **Covered scorers:** `jaro_winkler` / `levenshtein` / `token_sort` / `exact` — the ops `score-core` implements. Every other scorer always stays pure-TS, even when WASM is enabled. The swap is at the NxN block boundary (one JS↔WASM crossing per block, never per pair).
+- **Edge-safe + portable:** Node, browsers, and Workers. The `.wasm` ships inside the npm package; the loader resolves it at runtime.
+- **Parity-guaranteed:** the WASM kernel *is* rapidfuzz, and the pure-TS scorers are aligned with rapidfuzz to 4 decimals — so enabling WASM does not change results, it just runs them faster.
+
+`goldenanalysis` exposes the same opt-in pattern for its aggregation primitives via `enableAnalysisWasm()` — see [GoldenAnalysis › Native accelerator](/goldenanalysis/native).
+
 ## Blocking Strategies
 
 - `static` — single blocking key with transforms


### PR DESCRIPTION
Documents the opt-in WASM acceleration arc shipped across #878/#879/#880/#881.

**Context network**
- New `architecture/wasm-acceleration.md` — the shared `goldenmatch-wasm-runtime`, the two shipped cores (score-core→goldenmatch, analysis-core→goldenanalysis), the parity+bench gates, the rapidfuzz-alignment prerequisite (#879), token_sort coverage + the pinned `score_one(2)` asymmetry, the dist-path validation, and the measure-first park verdicts (graph/fingerprint/goldencheck).
- New `decisions/0014-opt-in-wasm-acceleration.md` — pure-TS stays the default+fallback; one shared runtime (extracted not duplicated); batch-first per-scorer swap; ship a core only on a measured parity+bench win.
- Linked both from `discovery.md`; added a dated entry to `meta/updates.md`.

**Mintlify (docs-site)**
- `goldenmatch/typescript.mdx` — new "Optional WASM acceleration" section (`enableWasm`/`disableWasm`, covered scorers, edge-safe, parity-guaranteed).
- `goldenanalysis/native.mdx` — new "TypeScript: opt-in WASM" section (`enableAnalysisWasm` over the same `analysis-core` crate).

Docs-only; internal links resolve (`/goldenanalysis/native`, `/goldenmatch/reference-data` both exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)