### PR TITLE
docs(site): non-technical + academic getting-started on-ramps

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -18,7 +18,9 @@
             "group": "Get started",
             "pages": [
               "index",
-              "quickstart"
+              "quickstart",
+              "web-ui",
+              "for-researchers"
             ]
           },
           {

--- a/docs-site/for-researchers.mdx
+++ b/docs-site/for-researchers.mdx
@@ -1,0 +1,112 @@
+---
+title: "For researchers"
+description: "Reproduce the benchmarks, read the evaluation methodology and honest framing, cite the project, and find the comparison against other entity-resolution tools."
+keywords: ["research", "benchmark", "reproducibility", "citation", "entity resolution", "record linkage", "methodology", "splink", "evaluation"]
+---
+
+A start-here for academic and benchmarking use: how to reproduce every published
+number, the evaluation methodology behind the headline claims (including the honest
+caveats), how to cite the project, and where the academic comparisons live.
+
+## Cite it
+
+The repository carries a [`CITATION.cff`](https://github.com/benseverndev-oss/goldenmatch/blob/main/CITATION.cff),
+so GitHub shows a **"Cite this repository"** button (sidebar → *Cite this
+repository*) that exports BibTeX / APA. Cite the headline package as **GoldenMatch
+(Golden Suite)**, author Ben Severn, MIT-licensed, at
+`github.com/benseverndev-oss/goldenmatch`.
+
+## Reproduce the benchmarks
+
+Every published headline number maps back to a committed runner
+(`scripts/run_benchmarks.py`) with a pinned environment and a stated tolerance. The
+canonical guide is
+[`docs/reproducing-benchmarks.md`](https://github.com/benseverndev-oss/goldenmatch/blob/main/docs/reproducing-benchmarks.md)
+— it gives the dataset source, drop location, and expected output per number.
+
+```bash
+pip install -e packages/python/goldenmatch
+pip install recordlinkage dqbench        # dataset deps (Febrl3, DQbench)
+
+export GOLDENMATCH_AUTOCONFIG_MEMORY=0   # disable the cross-run config cache
+unset OPENAI_API_KEY                      # no-LLM = deterministic
+
+python scripts/run_benchmarks.py --datasets all --output results.json
+```
+
+| Number | Value | Dataset | Notes |
+|---|---|---|---|
+| DQbench composite | **91.04** | DQbench ER T1+T2+T3 (no-LLM) | ±1.5 pp run-to-run |
+| DBLP-ACM F1 | **0.9641** | Leipzig DBLP-ACM (cross-source `match_df`) | deterministic; P 0.969 / R 0.959 |
+| Febrl3 F1 | **0.9443** | `recordlinkage.load_febrl3` (synthetic) | deterministic; P 0.987 / R 0.906 |
+| NCVR F1 | **0.9719** | NC voter 10k sample (seeded corruption GT) | deterministic given `seed=42` |
+
+<Note>
+  No-LLM numbers are deterministic given fixed seeds and a fixed dataset (allow
+  sub-0.1 pp drift from `rapidfuzz` reduction order). `--with-llm` runs are **not**
+  re-runnable targets — treat them as single observations.
+</Note>
+
+## The Splink head-to-head (and its honest framing)
+
+GoldenMatch's zero-tuning probabilistic (Fellegi-Sunter) auto-config is benchmarked
+against an expert hand-rolled Splink config on **one shared evaluator** across every
+dataset Splink scores. Full writeup, including per-dataset P/R and performance:
+[`docs/benchmarks/2026-06-09-splink-bakeoff.md`](https://github.com/benseverndev-oss/goldenmatch/blob/main/docs/benchmarks/2026-06-09-splink-bakeoff.md).
+
+| Dataset | GM-prob F1 | Splink F1 | ΔF1 |
+|---|---|---|---|
+| historical_50k | **0.778** | 0.757 | +0.021 (cluster B³: 0.844 vs 0.789) |
+| febrl3 | **0.991** | 0.965 | +0.026 |
+| synthetic_person | **0.998** | 0.996 | +0.001 |
+
+Read the caveats before quoting these:
+
+- **These are *pairwise* F1 under one shared evaluator** (`evaluate.evaluate`), so all
+  engines are judged by identical code. The often-cited ~0.97 Splink number on
+  `historical_50k` is a *cluster/entity* metric, not exhaustive within-cluster
+  pairwise F1 — under this harness Splink scores ~0.757 *pairwise* (recall-bound; no
+  single field exceeds 0.60 recall → ~0.93 pairwise ceiling for any engine). The
+  honest claim is "matches/beats Splink on the same evaluator," not "0.97 pairwise."
+- **Reproducible as of the determinism fix (#829).** The earlier figures rested on a
+  non-deterministic EM training-pair sample (one CI run gave 0.805 / 0.779 / 0.643
+  for the identical path); sorting blocks by a stable key before the seeded shuffle
+  made it reproduce within 0.002.
+- **Splink is faster** (3–19× on these datasets) and retains distributed F-S at 1B+
+  rows on Spark plus the mature m/u comparison-viewer UI. GoldenMatch's edge is zero
+  tuning and accuracy parity.
+- **Bibliographic data:** the probabilistic path is weak on `dblp_acm` (F1 0.377,
+  recall-bound); use the **weighted** path there (0.964), not probabilistic.
+
+## Evaluation methodology
+
+The same primitives are available to you for your own measurements — pairwise
+precision / recall / F1 against a ground-truth pair set, cluster-level B³, and
+ground-truth-free run comparison (CCMS / Talburt-Wang Index). See the
+[Evaluation guide](/goldenmatch/evaluation) for the `evaluate`, `evaluate_clusters`,
+`compare_clusters`, and `goldenmatch evaluate --threshold-sweep` APIs.
+
+## Research arcs (documented negative results)
+
+Two exploratory ER designs are written up honestly, including where they *didn't*
+pan out — useful as prior art:
+
+<CardGroup cols={2}>
+  <Card title="Amortized Bayesian ER" icon="brain" href="/research/amortized-bayesian-er">
+    A calibrated neural posterior over the partition with EIG-driven active labelling. Mechanisms validated, not accuracy-competitive.
+  </Card>
+  <Card title="Landscape-sculpting ER" icon="mountain" href="/research/landscape-sculpting-er">
+    ER reframed as sculpting an attractor landscape. Novel framing, but cosmetic — same partition as a calibrated discrete split/merge loop.
+  </Card>
+</CardGroup>
+
+## Compare against other tools
+
+<CardGroup cols={2}>
+  <Card title="Vendor & tool comparison" icon="table-columns" href="/reference/vendor-comparison">
+    GoldenMatch vs Splink, Dedupe, Senzing, and others — feature and accuracy axes.
+  </Card>
+  <Card title="Entity resolution concepts" icon="diagram-project" href="/concepts/entity-resolution">
+    Blocking, scoring, clustering, survivorship — the model the benchmarks exercise.
+  </Card>
+</CardGroup>

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -6,6 +6,20 @@ keywords: ["entity resolution", "deduplication", "data quality", "record linkage
 
 The Golden Suite is a polyglot data-quality and entity-resolution toolkit. Each tool stands alone, but together they form a single pipeline: profile your data, standardize it, deduplicate it, and emit golden records. Every package ships zero-config defaults, a CLI, a Python and (mostly) a TypeScript library, and an AI-native surface (MCP server, REST API, agent skills).
 
+## Start where you fit
+
+<CardGroup cols={3}>
+  <Card title="Developers" icon="code" href="/quickstart">
+    Install and dedupe a CSV in 30 seconds from Python, TypeScript, or the CLI.
+  </Card>
+  <Card title="No code" icon="window-maximize" href="/web-ui">
+    Point-and-click in the browser workbench — edit rules, review matches, label pairs.
+  </Card>
+  <Card title="Researchers" icon="flask" href="/for-researchers">
+    Reproduce the benchmarks, read the methodology + honest framing, and cite the work.
+  </Card>
+</CardGroup>
+
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">
     Deduplicate a CSV in 30 seconds.
@@ -74,7 +88,7 @@ flowchart LR
 
 - **Zero-config that beats hand-tuned.** GoldenMatch's introspective auto-config controller reaches F1 0.964 on DBLP-ACM out of the box, above the hand-tuned ceiling of 0.918.
 - **Polyglot.** Python is the headline runtime; TypeScript runs the same scorers on edge runtimes (Vercel Edge, Cloudflare Workers, Deno); Rust powers the Postgres and DuckDB extensions.
-- **AI-native.** Every package ships an MCP server (35+ tools across the suite), a REST API, and agent skills.
+- **AI-native.** Every package ships an MCP server (50+ tools across the suite), a REST API, and agent skills.
 - **MIT-licensed.** Every package in the suite.
 
 <Note>

--- a/docs-site/web-ui.mdx
+++ b/docs-site/web-ui.mdx
@@ -1,0 +1,78 @@
+---
+title: "Web workbench (no code)"
+description: "The point-and-click way to use GoldenMatch: edit rules, preview matches, label pairs, and compare runs in a browser — no code after the first install."
+keywords: ["web ui", "workbench", "no-code", "browser", "non-technical", "serve-ui", "review"]
+---
+
+If you would rather not write code, GoldenMatch ships a browser workbench. You (or
+a teammate) run one command to start it; after that, everything happens
+point-and-click in your browser. It is the right starting point for analysts,
+data stewards, and anyone reviewing matches rather than building a pipeline.
+
+## Start it
+
+<Steps>
+  <Step title="Install the web extra">
+    ```bash
+    pip install 'goldenmatch[web]'
+    ```
+    One-time, and the only command line you need. If someone technical set this up
+    for you, skip to the browser.
+  </Step>
+  <Step title="Open the workbench">
+    ```bash
+    goldenmatch serve-ui my-project
+    ```
+    This opens **http://localhost:5050** in your browser. Point it at a folder of
+    CSVs or an existing project; it picks a free port automatically if 5050 is taken.
+  </Step>
+  <Step title="No data yet? Try the demo">
+    ```bash
+    goldenmatch demo
+    ```
+    Generates a small sample dataset and runs it, so you can click around before
+    bringing your own file.
+  </Step>
+</Steps>
+
+<Tip>
+  Drop a CSV in and run it with zero configuration — GoldenMatch detects the column
+  types, picks the scorers and blocking, and shows you the matches. You only touch
+  the rules if you want to.
+</Tip>
+
+## What you can do in the browser
+
+No code required for any of this:
+
+- **See your duplicates.** Browse clusters of records GoldenMatch thinks are the
+  same entity, with a field-by-field diff and a plain-English reason for each pair.
+- **Tune without YAML.** Edit match rules and thresholds with live validation and
+  preview the effect against a sampled slice before committing to a full run.
+- **Label pairs.** Mark borderline pairs as match / not-a-match. Your decisions are
+  saved to Learning Memory automatically and re-applied on the next run, so the
+  system stops asking you the same question twice.
+- **Compare two runs.** See what merged, split, or stayed the same between runs
+  (the CCMS view), so you can tell whether a change helped.
+- **Sweep a setting.** Move the threshold and watch the cluster count update live.
+- **Browse corrections.** Review and manage every label you have stored.
+
+## When you outgrow it
+
+The workbench writes the same config and corrections the code paths use, so nothing
+is locked in. When you are ready for automation or scale:
+
+<CardGroup cols={2}>
+  <Card title="Command line" icon="terminal" href="/goldenmatch/cli">
+    Run the same matching from a script or a scheduled job.
+  </Card>
+  <Card title="Quickstart (developers)" icon="rocket" href="/quickstart">
+    The Python / TypeScript / CLI path, install to deduped file in minutes.
+  </Card>
+</CardGroup>
+
+<Note>
+  The workbench is a single-process localhost app — your data never leaves your
+  machine. More screenshots and a full tour are on the
+  [Web UI wiki page](https://github.com/benseverndev-oss/goldenmatch/wiki/Web-UI).
+</Note>


### PR DESCRIPTION
## Summary

The docs site had a single getting-started path and it was technical (pip/npm + code). This adds the two missing audience on-ramps and routes the landing page by audience.

- **`docs-site/web-ui.mdx` (non-technical)** — the no-code browser workbench: one install, then point-and-click. Steps (install `[web]` → `serve-ui` on localhost:5050 → `demo`), what you can do without code (browse duplicates, tune rules with live preview, label pairs into Learning Memory, compare runs, sweep threshold), and where to go when you outgrow it.
- **`docs-site/for-researchers.mdx` (academic)** — cite via `CITATION.cff`, reproduce every headline number (`run_benchmarks.py` + the four verified numbers with tolerances), the **Splink head-to-head with its honest framing** (pairwise vs cluster B³, the ~0.97-is-cluster-level caveat, the #829 determinism note), the evaluation methodology (pairwise / B³ / CCMS-TWI), the two honest research arcs, and the vendor comparison.
- Wired both into the **Get started** nav group; added a **"Start where you fit"** Developers / No-code / Researchers card row on the landing page; fixed a stale `35+ → 50+` MCP-tool count on `index.mdx`.

## Test Plan
- [x] `docs.json` valid JSON; both new pages in nav
- [x] every internal href resolves to an existing page
- [x] numbers verified against source: `docs/reproducing-benchmarks.md`, `docs/benchmarks/2026-06-09-splink-bakeoff.md`, `serve-ui` default port (5050), vendor-comparison tool coverage
- Doc-only PR — CI runs the `changes` gate only

🤖 Generated with [Claude Code](https://claude.com/claude-code)