### PR TITLE
fix(golden): deterministic survivorship tie-break by __row_id__ (#870)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -373,6 +373,57 @@ def _dispatch_custom_strategy(
     return _most_complete(non_null, quality_weights)
 
 
+def _stable_value_expr(
+    col: str, len_alias: str | None, strategy: str, has_row_id: bool
+) -> pl.Expr:
+    """Survivor-value expr for ``col`` with a deterministic tie-break (#870).
+
+    Survivorship resolved value ties by input row order (``sort_by(len).first()``
+    / ``drop_nulls().first()``), but the ``multi_df`` row order is not itself
+    stable run-to-run, so equally-valid tied survivors (e.g. same-length
+    ``name`` vs ``n@me``) were picked arbitrarily and the golden frame came out
+    byte-different across reruns of an identical input + config. Break ties by
+    the lowest ``__row_id__`` (the stable per-input-row id) so the pick is
+    reproducible regardless of upstream ordering. Falls back to the legacy
+    order-dependent pick when the frame carries no ``__row_id__``.
+    """
+    nn = pl.col(col).filter(pl.col(col).is_not_null())
+    if strategy == "most_complete":
+        by: list[pl.Expr] = [pl.col(len_alias).filter(pl.col(col).is_not_null())]
+        desc = [True]
+        if has_row_id:
+            by.append(pl.col("__row_id__").filter(pl.col(col).is_not_null()))
+            desc.append(False)
+        return nn.sort_by(by, descending=desc).first()
+    # first_non_null: "first" becomes the lowest-__row_id__ non-null value.
+    if has_row_id:
+        return nn.sort_by(pl.col("__row_id__").filter(pl.col(col).is_not_null())).first()
+    return pl.col(col).drop_nulls().first()
+
+
+def _stable_rid_expr(
+    col: str, len_alias: str | None, strategy: str, has_row_id: bool
+) -> pl.Expr:
+    """``__row_id__`` of the survivor chosen by :func:`_stable_value_expr`.
+
+    Uses the IDENTICAL filter + sort key as the value expr so the same physical
+    row wins both and ``source_row_id`` provenance stays aligned. Only invoked
+    on the ``provenance=True`` branch, where ``__row_id__`` is guaranteed.
+    """
+    rid = pl.col("__row_id__").filter(pl.col(col).is_not_null())
+    if strategy == "most_complete":
+        by: list[pl.Expr] = [pl.col(len_alias).filter(pl.col(col).is_not_null())]
+        desc = [True]
+        if has_row_id:
+            by.append(rid)
+            desc.append(False)
+        return rid.sort_by(by, descending=desc).first()
+    # first_non_null
+    if has_row_id:
+        return rid.sort_by(rid).first()
+    return rid.first()
+
+
 def _build_golden_records_polars_native(
     multi_df: pl.DataFrame,
     rules: GoldenRulesConfig,
@@ -400,10 +451,13 @@ def _build_golden_records_polars_native(
       - all values null: skipped (matches merge_field)
     """
     strategy = rules.default_strategy
+    # #870: break survivorship value ties by the stable __row_id__ so the
+    # golden frame is reproducible regardless of upstream multi_df row order.
+    has_row_id = "__row_id__" in multi_df.columns
     if strategy == "most_complete":
         # For each user col compute (winner_value, all_same_flag) per cluster.
         # winner is the non-null value with the longest string length;
-        # ties broken by row order (Polars stable sort).
+        # ties broken by lowest __row_id__ (was: by row order).
         len_col_aliases = {col: f"__len_{col}__" for col in user_cols}
         prepped = multi_df.with_columns([
             pl.col(col).cast(pl.Utf8).str.len_chars().alias(alias)
@@ -411,35 +465,19 @@ def _build_golden_records_polars_native(
         ])
         agg_exprs: list = []
         for col in user_cols:
-            # sort_by(descending=True).first() picks the longest non-null
-            # value, matching the prior top_k_by(by=..., k=1, reverse=False)
-            # intent. top_k_by mis-binds args on newer Polars where
-            # 'reverse' is no longer a kwarg; sort_by is stable across
-            # Polars 0.20+. See #362.
             agg_exprs.append(
-                pl.col(col).filter(pl.col(col).is_not_null())
-                .sort_by(
-                    pl.col(len_col_aliases[col]).filter(pl.col(col).is_not_null()),
-                    descending=True,
-                )
-                .first().alias(f"__val_{col}__")
+                _stable_value_expr(col, len_col_aliases[col], "most_complete", has_row_id)
+                .alias(f"__val_{col}__")
             )
             agg_exprs.append(
                 pl.col(col).drop_nulls().n_unique().alias(f"__nuniq_{col}__")
             )
             if provenance:
-                # Pick __row_id__ with the IDENTICAL filter + sort key as the
-                # value above, so the same physical row wins both (Polars
-                # stable sort guarantees alignment). All three exprs filter on
-                # the same ``col.is_not_null()`` predicate, so they stay
-                # row-aligned. All-null column -> empty filter -> first() None.
+                # __row_id__ of the winning value -- IDENTICAL sort key, so the
+                # same physical row wins both (row-aligned provenance).
                 agg_exprs.append(
-                    pl.col("__row_id__").filter(pl.col(col).is_not_null())
-                    .sort_by(
-                        pl.col(len_col_aliases[col]).filter(pl.col(col).is_not_null()),
-                        descending=True,
-                    )
-                    .first().alias(f"__rid_{col}__")
+                    _stable_rid_expr(col, len_col_aliases[col], "most_complete", has_row_id)
+                    .alias(f"__rid_{col}__")
                 )
         agg = (
             prepped.group_by("__cluster_id__", maintain_order=True)
@@ -449,16 +487,17 @@ def _build_golden_records_polars_native(
         agg_exprs = []
         for col in user_cols:
             agg_exprs.append(
-                pl.col(col).drop_nulls().first().alias(f"__val_{col}__")
+                _stable_value_expr(col, None, "first_non_null", has_row_id)
+                .alias(f"__val_{col}__")
             )
             agg_exprs.append(
                 pl.col(col).drop_nulls().n_unique().alias(f"__nuniq_{col}__")
             )
             if provenance:
-                # row_id of the first non-null value (same filter + first()).
+                # __row_id__ of the chosen (lowest-__row_id__) non-null value.
                 agg_exprs.append(
-                    pl.col("__row_id__").filter(pl.col(col).is_not_null())
-                    .first().alias(f"__rid_{col}__")
+                    _stable_rid_expr(col, None, "first_non_null", has_row_id)
+                    .alias(f"__rid_{col}__")
                 )
         agg = (
             multi_df.group_by("__cluster_id__", maintain_order=True)
@@ -551,6 +590,8 @@ def build_golden_records_df(
             "call build_golden_records_batch for slow-path strategies."
         )
     user_cols = [c for c in multi_df.columns if not c.startswith("__")]
+    # #870: deterministic tie-break by stable __row_id__ (see _stable_value_expr).
+    has_row_id = "__row_id__" in multi_df.columns
 
     same_strategy_conf = 1.0
     diff_strategy_conf = 0.7 if strategy == "most_complete" else 0.6
@@ -564,9 +605,12 @@ def build_golden_records_df(
 
     # Aggregation. Two strategies, matching the existing
     # _build_golden_records_polars_native semantics exactly:
-    #   - most_complete: pick the LONGEST non-null value (sort_by len DESC).
-    #     "Caroline" wins over "Carol" because it's more complete.
-    #   - first_non_null: pick the FIRST non-null value (drop_nulls().first()).
+    #   - most_complete: pick the LONGEST non-null value, ties broken by lowest
+    #     __row_id__ (#870). "Caroline" wins over "Carol" because it's more
+    #     complete; "name" vs "n@me" (same length) deterministically picks the
+    #     lower-__row_id__ row instead of input order.
+    #   - first_non_null: pick the lowest-__row_id__ non-null value (was: first
+    #     in input row order, which is not stable run-to-run).
     # Both record n_unique so the confidence assignment can branch on whether
     # the cluster agreed.
     agg_exprs: list[pl.Expr] = []
@@ -580,12 +624,8 @@ def build_golden_records_df(
         ])
         for col in user_cols:
             agg_exprs.append(
-                pl.col(col).filter(pl.col(col).is_not_null())
-                .sort_by(
-                    pl.col(len_col_aliases[col]).filter(pl.col(col).is_not_null()),
-                    descending=True,
-                )
-                .first().alias(col)
+                _stable_value_expr(col, len_col_aliases[col], "most_complete", has_row_id)
+                .alias(col)
             )
             agg_exprs.append(
                 pl.col(col).drop_nulls().n_unique().alias(f"__nuniq_{col}__")
@@ -593,7 +633,9 @@ def build_golden_records_df(
     else:  # first_non_null
         agg_input = multi_df
         for col in user_cols:
-            agg_exprs.append(pl.col(col).drop_nulls().first().alias(col))
+            agg_exprs.append(
+                _stable_value_expr(col, None, "first_non_null", has_row_id).alias(col)
+            )
             agg_exprs.append(
                 pl.col(col).drop_nulls().n_unique().alias(f"__nuniq_{col}__")
             )

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -387,17 +387,23 @@ def _stable_value_expr(
     reproducible regardless of upstream ordering. Falls back to the legacy
     order-dependent pick when the frame carries no ``__row_id__``.
     """
-    nn = pl.col(col).filter(pl.col(col).is_not_null())
+    mask = pl.col(col).is_not_null()
+    nn = pl.col(col).filter(mask)
     if strategy == "most_complete":
-        by: list[pl.Expr] = [pl.col(len_alias).filter(pl.col(col).is_not_null())]
-        desc = [True]
-        if has_row_id:
-            by.append(pl.col("__row_id__").filter(pl.col(col).is_not_null()))
-            desc.append(False)
-        return nn.sort_by(by, descending=desc).first()
+        # ONE composite sort key, not two separately-filtered keys: a list of
+        # filtered keys trips Polars' "expressions in 'sort_by' must have matching
+        # group lengths" inside group_by().agg() on some shapes. The struct
+        # ``(len, -__row_id__)`` sorted descending == (len desc, __row_id__ asc),
+        # and is a single filtered expression aligned with ``nn``.
+        key = (
+            pl.struct([pl.col(len_alias), -pl.col("__row_id__")]).filter(mask)
+            if has_row_id
+            else pl.col(len_alias).filter(mask)
+        )
+        return nn.sort_by(key, descending=True).first()
     # first_non_null: "first" becomes the lowest-__row_id__ non-null value.
     if has_row_id:
-        return nn.sort_by(pl.col("__row_id__").filter(pl.col(col).is_not_null())).first()
+        return nn.sort_by(pl.col("__row_id__").filter(mask)).first()
     return pl.col(col).drop_nulls().first()
 
 
@@ -410,14 +416,18 @@ def _stable_rid_expr(
     row wins both and ``source_row_id`` provenance stays aligned. Only invoked
     on the ``provenance=True`` branch, where ``__row_id__`` is guaranteed.
     """
-    rid = pl.col("__row_id__").filter(pl.col(col).is_not_null())
+    mask = pl.col(col).is_not_null()
+    rid = pl.col("__row_id__").filter(mask)
     if strategy == "most_complete":
-        by: list[pl.Expr] = [pl.col(len_alias).filter(pl.col(col).is_not_null())]
-        desc = [True]
-        if has_row_id:
-            by.append(rid)
-            desc.append(False)
-        return rid.sort_by(by, descending=desc).first()
+        # IDENTICAL single composite key as _stable_value_expr, so the same row
+        # wins both (row-aligned provenance). See that helper for why one struct
+        # key, not a list of filtered keys.
+        key = (
+            pl.struct([pl.col(len_alias), -pl.col("__row_id__")]).filter(mask)
+            if has_row_id
+            else pl.col(len_alias).filter(mask)
+        )
+        return rid.sort_by(key, descending=True).first()
     # first_non_null
     if has_row_id:
         return rid.sort_by(rid).first()

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -396,7 +396,7 @@ def _stable_value_expr(
         # ``(len, -__row_id__)`` sorted descending == (len desc, __row_id__ asc),
         # and is a single filtered expression aligned with ``nn``.
         key = (
-            pl.struct([pl.col(len_alias), -pl.col("__row_id__")]).filter(mask)
+            pl.struct([pl.col(len_alias), -pl.col("__row_id__").cast(pl.Int64)]).filter(mask)
             if has_row_id
             else pl.col(len_alias).filter(mask)
         )
@@ -423,7 +423,7 @@ def _stable_rid_expr(
         # wins both (row-aligned provenance). See that helper for why one struct
         # key, not a list of filtered keys.
         key = (
-            pl.struct([pl.col(len_alias), -pl.col("__row_id__")]).filter(mask)
+            pl.struct([pl.col(len_alias), -pl.col("__row_id__").cast(pl.Int64)]).filter(mask)
             if has_row_id
             else pl.col(len_alias).filter(mask)
         )

--- a/packages/python/goldenmatch/tests/test_golden.py
+++ b/packages/python/goldenmatch/tests/test_golden.py
@@ -229,3 +229,55 @@ def test_backward_compat_no_quality_scores():
     result_none = build_golden_record(df, rules, quality_scores=None)
     assert result_default["name"]["value"] == result_none["name"]["value"]
     assert abs(result_default["name"]["confidence"] - result_none["name"]["confidence"]) < 0.0001
+
+
+class TestGoldenTieBreakDeterminism:
+    """#870: survivorship value ties resolve by the stable __row_id__, so the
+    golden frame is byte-reproducible regardless of upstream multi_df row order.
+    """
+
+    @staticmethod
+    def _tied_multi_df(order: list[int]) -> pl.DataFrame:
+        # One multi-member cluster with a same-length tie ("abcd" vs "wxyz")
+        # carried on distinct __row_id__s. Lowest __row_id__ (2) must win.
+        rows = [
+            {"__row_id__": 5, "__cluster_id__": 0, "name": "wxyz"},
+            {"__row_id__": 2, "__cluster_id__": 0, "name": "abcd"},
+        ]
+        return pl.DataFrame([rows[i] for i in order])
+
+    def test_most_complete_tie_breaks_by_lowest_row_id_columnar(self):
+        from goldenmatch.core.golden import build_golden_records_df
+
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+        out_a = build_golden_records_df(self._tied_multi_df([0, 1]), rules)
+        out_b = build_golden_records_df(self._tied_multi_df([1, 0]), rules)
+        # Deterministic across input row order.
+        assert out_a.sort("__cluster_id__").to_dicts() == out_b.sort("__cluster_id__").to_dicts()
+        # Tie resolves to the lowest-__row_id__ value.
+        assert out_a.filter(pl.col("__cluster_id__") == 0)["name"].item() == "abcd"
+
+    def test_first_non_null_picks_lowest_row_id_columnar(self):
+        from goldenmatch.core.golden import build_golden_records_df
+
+        rules = GoldenRulesConfig(default_strategy="first_non_null")
+        out_a = build_golden_records_df(self._tied_multi_df([0, 1]), rules)
+        out_b = build_golden_records_df(self._tied_multi_df([1, 0]), rules)
+        assert out_a.sort("__cluster_id__").to_dicts() == out_b.sort("__cluster_id__").to_dicts()
+        assert out_a.filter(pl.col("__cluster_id__") == 0)["name"].item() == "abcd"
+
+    def test_polars_native_path_deterministic_with_provenance(self):
+        from goldenmatch.core.golden import _build_golden_records_polars_native
+
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+        recs_a = _build_golden_records_polars_native(
+            self._tied_multi_df([0, 1]), rules, ["name"], provenance=True
+        )
+        recs_b = _build_golden_records_polars_native(
+            self._tied_multi_df([1, 0]), rules, ["name"], provenance=True
+        )
+        assert recs_a == recs_b
+        rec0 = next(r for r in recs_a if r["__cluster_id__"] == 0)
+        # Value AND source_row_id both come from the lowest-__row_id__ tied row.
+        assert rec0["name"]["value"] == "abcd"
+        assert rec0["name"]["source_row_id"] == 2

--- a/packages/python/goldenmatch/tests/test_quality_weighting.py
+++ b/packages/python/goldenmatch/tests/test_quality_weighting.py
@@ -54,12 +54,24 @@ def test_missing_row_id_col_returns_none() -> None:
 
 def test_quality_weighting_flips_survivorship() -> None:
     """The computed scores, fed to the real golden builder, make the canonical
-    spelling win a cluster where the typo would otherwise survive."""
-    scores = compute_quality_scores(_df_with_typo())
-    # A 2-member dup cluster: the typo row (56) is FIRST, so first_non_null would
-    # otherwise keep 'Californa'.
+    spelling win a cluster where the typo would otherwise survive.
+
+    Survivorship now breaks ties deterministically by lowest ``__row_id__`` (#870),
+    so the typo is placed at the LOW row_id: without quality weighting the
+    deterministic pick keeps the typo, and quality weighting flips it to canonical.
+    """
+    # Typo 'Californa' at the LOWEST row_id (0) so the unweighted first_non_null
+    # pick (lowest __row_id__) would keep it; canonical 'California' is frequent
+    # and clean, so quality weighting penalizes only the typo cell.
+    typo_df = pl.DataFrame({
+        "__row_id__": list(range(60)),
+        "name": [f"p{i}" for i in range(60)],
+        "state": ["Californa"] + ["California"] * 28 + ["Texas"] * 28 + ["Florida"] * 3,
+    })
+    scores = compute_quality_scores(typo_df)
+    assert scores is not None and (0, "state") in scores  # the typo cell is penalized
     cluster = pl.DataFrame({
-        "__row_id__": [56, 0],
+        "__row_id__": [0, 1],
         "__cluster_id__": [1, 1],
         "name": ["dup", "dup"],
         "state": ["Californa", "California"],
@@ -69,7 +81,7 @@ def test_quality_weighting_flips_survivorship() -> None:
     without = build_golden_records_batch(cluster, rules, quality_scores=None)
     with_weights = build_golden_records_batch(cluster, rules, quality_scores=scores)
 
-    assert without[0]["state"]["value"] == "Californa"        # typo survives
+    assert without[0]["state"]["value"] == "Californa"        # lowest-row_id typo survives
     assert with_weights[0]["state"]["value"] == "California"  # quality flips it
 
 

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -118,7 +118,16 @@ def test_most_complete_strategy_uses_sort_by_not_top_k_by():
 
     from goldenmatch.core import golden
 
-    src = inspect.getsource(golden._build_golden_records_polars_native)
+    # The sort_by-based survivor pick lives in the shared _stable_value_expr /
+    # _stable_rid_expr helpers (#870), which the native builder delegates to.
+    src = "\n".join(
+        inspect.getsource(fn)
+        for fn in (
+            golden._build_golden_records_polars_native,
+            golden._stable_value_expr,
+            golden._stable_rid_expr,
+        )
+    )
     # Strip comment lines so the historical-context comment can stay.
     code_lines = [
         ln for ln in src.splitlines()


### PR DESCRIPTION
## Summary

Closes #870. Golden survivorship was order-nondeterministic: an identical input + fixed config produced byte-different golden frames (tied text fields + `__golden_confidence__`), even though the cluster **partition** is fully deterministic.

**Root cause:** value ties were resolved by input row order (`most_complete`'s `sort_by(len).first()`, `first_non_null`'s `drop_nulls().first()`), but `multi_df`'s row order is not itself stable run-to-run, so equally-valid tied survivors got picked arbitrarily.

**Fix:** both Polars batch paths now break ties by the lowest `__row_id__` (the stable per-input-row id), via a shared `_stable_value_expr` / `_stable_rid_expr` helper:
- `build_golden_records_df` (fast columnar path)
- `_build_golden_records_polars_native` (list[dict] path), **including the `provenance` `source_row_id` agg** — value and rid use the IDENTICAL sort key so provenance stays row-aligned.
- Guarded on `__row_id__` presence (carried through `_multi_df_from_frames` on the frames-out path; falls back to the legacy pick when absent — no regression for callers without it).
- `__golden_confidence__` is `nuniq`-derived, so it follows automatically.

This is the byte-identical-golden determinism that #510's QIS harness dropped with a documented note pointing here.

## Test Plan
- [x] New `TestGoldenTieBreakDeterminism`: identical golden output across two input row orders + lowest-`__row_id__` survivor, for the columnar path and the list[dict]+provenance path
- [x] Full `tests/test_golden.py` green (23 passed); `tests/test_golden_partition_perf.py` green on the pure path (the 4 local failures are a stale `goldenmatch-native 0.1.0` arrow-kernel signature skew in `cluster.py`, unrelated — CI builds fresh)
- [x] `ruff` (CI lint set + full) + `py_compile` clean

**Fixture note:** the fix changes which *tied* value is picked (now deterministic = lowest row_id). If CI surfaces an existing golden assertion that pinned a tied survivor, it just needs regen to the deterministic value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)