### PR TITLE
feat(native): per-run dispatch telemetry + GOLDENMATCH_NATIVE docs (#884)

### DIFF
--- a/docs-site/goldenmatch/backends-and-scale.mdx
+++ b/docs-site/goldenmatch/backends-and-scale.mdx
@@ -86,6 +86,34 @@ The recall-complete path is opt-in; the default per-partition path is unchanged.
   Debug the prep-versus-kernel split for the bucket backend with `GOLDENMATCH_BUCKET_DEBUG=1`. It prints a per-bucket prep / kernel / post-filter timing breakdown. It is off by default, costs nothing, and does not change output.
 </Note>
 
+## Native acceleration
+
+`pip install goldenmatch` ships the optional Rust kernel (`goldenmatch-native`) on common platforms, and the pure-Python paths run unchanged when it is absent. The `GOLDENMATCH_NATIVE` environment variable has **three** modes:
+
+| `GOLDENMATCH_NATIVE` | Behaviour |
+|---|---|
+| unset / `auto` (default) | Use the kernel **only** for the signed-off components: `clustering`, `block_scoring`, `pairs`, `featurize`, `hashing`. Everything else runs pure-Python. |
+| `1` | Use the kernel for **every** component that has one; raise if the wheel is not importable. |
+| `0` | Force the pure-Python path everywhere. |
+
+<Warning>
+  **For at-scale and benchmark runs, set `GOLDENMATCH_NATIVE=1`.** Under the default `auto`, only the allowlisted components dispatch to the kernel; a heavy stage that is not yet on the allowlist silently runs pure-Python. `1` turns the kernel on everywhere it exists.
+</Warning>
+
+**"Available" does not mean "your hot loop ran native."** The wheel being importable makes the native telemetry report `available: true` regardless of whether the stage that dominates *your* wall actually dispatched to the kernel — for example, the `bucket` backend's vectorized **numpy** fast-path handles many blocks instead of the native scoring kernel. Result telemetry therefore reports the per-run dispatch reality, not just availability:
+
+```json
+"native": {
+  "available": true,
+  "env_gate": "1",
+  "ran_native": ["block_scoring", "clustering", "hashing"],
+  "ran_fallback": [],
+  "hot_path_native": true
+}
+```
+
+`ran_native` / `ran_fallback` list the components that actually dispatched to the kernel vs fell back on this run; `hot_path_native` is true when the scoring or clustering stage went native. When the kernel is importable but `GOLDENMATCH_NATIVE` is unset, a one-line `INFO` log notes that `auto` is in effect and that `=1` enables full acceleration.
+
 <Card title="Scale envelope" icon="gauge-high" href="/concepts/scale-envelope">
   The block-size failure modes that matter more than the backend choice.
 </Card>

--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -17,8 +17,11 @@ Spec: ``docs/design/2026-05-25-rust-acceleration-spec.md`` §0.3.
 """
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # The kernel is reachable two ways, tried in order:
 #   1. ``goldenmatch._native`` — the in-tree build dropped by
@@ -77,6 +80,40 @@ _GATED_ON: frozenset[str] = frozenset(
 )
 
 
+# Per-process record of which components actually dispatched to the native
+# kernel vs fell back to Python, so telemetry can report THIS run's reality
+# (#884) instead of just "the wheel is importable + the static allowlist".
+# ``native_available()`` being true does NOT mean your workload's hot loop ran
+# native -- the component may be off the ``_GATED_ON`` allowlist under ``auto``,
+# or (for backend=bucket) the numpy fast-path may have handled the block instead
+# of the kernel. This counter answers "did stage X go native on THIS run?".
+_DISPATCH_LOG: dict[str, dict[str, int]] = {}
+_AUTO_HINT_LOGGED = False
+
+
+def _record_dispatch(component: str, native: bool) -> None:
+    slot = _DISPATCH_LOG.setdefault(component, {"native": 0, "fallback": 0})
+    slot["native" if native else "fallback"] += 1
+
+
+def native_dispatch_report() -> dict[str, dict[str, int]]:
+    """Per-component ``{native, fallback}`` dispatch counts for this process.
+
+    Empty until the first ``native_enabled()`` query. Telemetry reads this to
+    report which stages ACTUALLY ran native on this run rather than the static
+    ``available`` + allowlist (#884). A component with ``native > 0`` dispatched
+    to the kernel at least once; ``fallback > 0`` means it ran the Python path
+    at least once (off the allowlist, ``GOLDENMATCH_NATIVE=0``, or the wheel
+    isn't importable).
+    """
+    return {k: dict(v) for k, v in _DISPATCH_LOG.items()}
+
+
+def reset_native_dispatch_log() -> None:
+    """Clear the per-process dispatch counters (test isolation / per-run capture)."""
+    _DISPATCH_LOG.clear()
+
+
 def native_module() -> Any:
     """The imported ``goldenmatch._native`` module (typed ``Any`` — its kernels
     are dynamically loaded), or ``None`` if unavailable. Call sites must guard
@@ -89,14 +126,34 @@ def native_available() -> bool:
 
 
 def native_enabled(component: str) -> bool:
-    """Whether to use the native kernel for ``component`` on this call."""
+    """Whether to use the native kernel for ``component`` on this call.
+
+    Records the decision (see :func:`native_dispatch_report`) and, the first
+    time it runs under ``auto`` with the kernel importable, logs a one-line hint
+    that the gated-only allowlist is in effect (set ``GOLDENMATCH_NATIVE=1`` for
+    full native acceleration on large / benchmark runs).
+    """
+    global _AUTO_HINT_LOGGED
     mode = os.environ.get("GOLDENMATCH_NATIVE", "auto").lower()
     if mode == "0":
+        _record_dispatch(component, False)
         return False
     if mode == "1":
         if _native is None:
             raise RuntimeError(
                 "GOLDENMATCH_NATIVE=1 but goldenmatch._native is not built/importable"
             )
+        _record_dispatch(component, True)
         return True
-    return _native is not None and component in _GATED_ON
+    # auto / unset: native iff importable AND signed off (in _GATED_ON).
+    if _native is not None and not _AUTO_HINT_LOGGED:
+        _AUTO_HINT_LOGGED = True
+        logger.info(
+            "goldenmatch native kernel available; running under GOLDENMATCH_NATIVE=auto "
+            "(gated set only: %s). Set GOLDENMATCH_NATIVE=1 for full native "
+            "acceleration on large / benchmark runs.",
+            sorted(_GATED_ON),
+        )
+    result = _native is not None and component in _GATED_ON
+    _record_dispatch(component, result)
+    return result

--- a/packages/python/goldenmatch/tests/test_native_surface.py
+++ b/packages/python/goldenmatch/tests/test_native_surface.py
@@ -66,3 +66,38 @@ def test_string_similarity_fallback_matches_native(monkeypatch):
     monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
     forced_python = native.string_similarity("Margaret Chen", "Maggie Chen", "jaro_winkler")
     assert forced_python == pytest.approx(default, abs=1e-9)
+
+
+class TestNativeDispatchReport:
+    """#884: per-run dispatch telemetry — which components ACTUALLY ran native
+    vs fell back, so `available: true` no longer misleads.
+    """
+
+    def test_records_fallback_and_resets(self, monkeypatch):
+        from goldenmatch.core import _native_loader as nl
+
+        nl.reset_native_dispatch_log()
+        assert nl.native_dispatch_report() == {}
+
+        # Force pure-Python so the decision is deterministic regardless of
+        # whether the kernel is built in this environment.
+        monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+        assert nl.native_enabled("block_scoring") is False
+        report = nl.native_dispatch_report()
+        assert report["block_scoring"] == {"native": 0, "fallback": 1}
+
+        nl.reset_native_dispatch_log()
+        assert nl.native_dispatch_report() == {}
+
+    def test_force_native_records_native_when_available(self, monkeypatch):
+        from goldenmatch.core import _native_loader as nl
+
+        nl.reset_native_dispatch_log()
+        monkeypatch.setenv("GOLDENMATCH_NATIVE", "1")
+        if not nl.native_available():
+            # =1 requires the wheel; absent it, raise (and record nothing).
+            with pytest.raises(RuntimeError):
+                nl.native_enabled("block_scoring")
+            return
+        assert nl.native_enabled("block_scoring") is True
+        assert nl.native_dispatch_report()["block_scoring"]["native"] >= 1

--- a/scripts/quality_invariant_scale.py
+++ b/scripts/quality_invariant_scale.py
@@ -815,11 +815,26 @@ def run_rung(n_rows: int, seed: int = 0, shape: str = "realistic",
     # native-on/off witness. Prior runs silently fell back to pure-Python; this
     # ends that ambiguity.
     try:
-        from goldenmatch.core._native_loader import _GATED_ON, native_available
+        from goldenmatch.core._native_loader import (
+            _GATED_ON,
+            native_available,
+            native_dispatch_report,
+        )
+        # #884: report which stages ACTUALLY ran native on this run, not just
+        # that the wheel is importable. `available: true` does not mean your
+        # hot loop dispatched to the kernel (off-allowlist under `auto`, or the
+        # bucket numpy fast-path handled the block instead).
+        dispatched = native_dispatch_report()
+        ran_native = sorted(c for c, d in dispatched.items() if d.get("native", 0) > 0)
+        ran_fallback = sorted(c for c, d in dispatched.items() if d.get("fallback", 0) > 0)
         native_info = {
             "available": bool(native_available()),
             "env_gate": os.environ.get("GOLDENMATCH_NATIVE", "auto"),
             "gated_on_components": sorted(_GATED_ON),
+            "dispatched": dispatched,
+            "ran_native": ran_native,
+            "ran_fallback": ran_fallback,
+            "hot_path_native": ("block_scoring" in ran_native) or ("clustering" in ran_native),
         }
     except Exception as e:
         native_info = {"_capture_error": repr(e)[:120]}


### PR DESCRIPTION
## Summary

Closes #884. Native acceleration was easy to leave half-off, and the telemetry actively misled: `"native": {"available": true}` reads as "native is on," but the wheel being importable doesn't mean your workload's hot loop dispatched to the kernel (it's off the `_GATED_ON` allowlist under `auto`, or the `bucket` numpy fast-path handled the block instead). A power user ran a long, paid, multi-rung scale audit on the slow path because of it.

- **`_native_loader.py`** — record every `native_enabled()` decision per component (`native_dispatch_report()` / `reset_native_dispatch_log()`), so telemetry can report which stages **actually** dispatched native on **this run**. Plus a one-time `INFO` hint when the kernel is importable but `GOLDENMATCH_NATIVE` is unset (running under `auto`; set `=1` for full native).
- **`quality_invariant_scale.py`** — the result `native` block now carries `ran_native` / `ran_fallback` / `hot_path_native` from the per-run dispatch report, alongside the existing `available` / `env_gate` / `gated_on_components`.
- **docs** — a "Native acceleration" section in `backends-and-scale.mdx` documents the three `GOLDENMATCH_NATIVE` modes + the allowlist, says explicitly to set `GOLDENMATCH_NATIVE=1` for at-scale / benchmark runs, and explains why "available" ≠ "your hot loop ran native".

## Test Plan
- [x] `TestNativeDispatchReport`: records fallback + resets; force-native records native when the wheel is available, else raises. Full `tests/test_native_surface.py` green (13 passed).
- [x] `ruff` (CI lint set E9/F63/F7/F82) + `py_compile` clean on changed files. (Two pre-existing F841 in `quality_invariant_scale.py` are unrelated and not in the CI lint set.)
- Recorder overhead is one dict increment per dispatch decision (per-block/per-stage, not per-pair) — negligible vs the scoring work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)