### PR TITLE
feat(sail): stable, contract-testable Python IdentityGraph API (#859)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added
+- **Stable Python IdentityGraph API for the Sail tier (#859).** The S5
+  identity-on-Sail create path now ships a frozen, documented, contract-testable
+  public surface: `from goldenmatch.sail import IdentityGraphFrames,
+  build_identity_graph` (imports without the `[sail]` extra — pyspark is lazy
+  inside the builders, so a consumer can pin the signature with `inspect` and no
+  Spark runtime). `IdentityGraphFrames` gains the optional `events` frame
+  (`IdentityGraphFrames(nodes, records, edges, events?)`, completing the S5
+  shape); `build_identity_graph(..., with_events=True)` emits one `CREATED` row
+  per entity. The frozen per-frame wire schema is exported as `NODE_COLUMNS` /
+  `RECORD_COLUMNS` / `EDGE_COLUMNS` / `EVENT_COLUMNS` — the edge frame carries
+  full provenance (`record_a_id`, `record_b_id`, `score`, `matchkey_name`,
+  `run_name`). **Incremental resolution (absorb/merge against an existing store)
+  remains the deferred Layer 2, honest-null:** on a fresh store every cluster is
+  a create, which is the common case. Pinned by `tests/test_sail_identity_contract.py`
+  (runs in the normal lane, no Spark). Unblocks downstream consumers that depend
+  on a released identity-graph contract.
+
 ### Performance
 - **Fellegi-Sunter block scoring ~3.5x faster on tiny-block / multi-pass shapes
   (PR #869).** The probabilistic (`type: probabilistic`) numpy scoring path was

--- a/packages/python/goldenmatch/goldenmatch/sail/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/__init__.py
@@ -8,3 +8,26 @@ not a port. Opt-in via ``pip install goldenmatch[sail]``.
 
 Spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md
 """
+from __future__ import annotations
+
+# Stable public IdentityGraph API (#859). These import without the [sail] extra
+# (pyspark is imported lazily inside the builders), so a downstream consumer can
+# pin the contract via `from goldenmatch.sail import IdentityGraphFrames,
+# build_identity_graph` and a `inspect.signature` test, without a Spark runtime.
+from goldenmatch.sail.identity import (
+    EDGE_COLUMNS,
+    EVENT_COLUMNS,
+    NODE_COLUMNS,
+    RECORD_COLUMNS,
+    IdentityGraphFrames,
+    build_identity_graph,
+)
+
+__all__ = [
+    "IdentityGraphFrames",
+    "build_identity_graph",
+    "NODE_COLUMNS",
+    "RECORD_COLUMNS",
+    "EDGE_COLUMNS",
+    "EVENT_COLUMNS",
+]

--- a/packages/python/goldenmatch/goldenmatch/sail/identity.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/identity.py
@@ -21,6 +21,23 @@ from typing import Any
 _ENT_PREFIX = "ent:h1:"
 _ENT_HASH_LEN = 16  # 64 bits of hex; collision-safe for entity populations.
 
+# --- frozen wire schema (the public contract, #859) ----------------------------
+# The column order/names of each produced frame. A downstream store persists these
+# verbatim, so they are the stable contract; the contract test pins them, and a
+# consumer (e.g. the golden-showcase IdentityGraph seam) maps onto them. The edge
+# frame carries full provenance: endpoints (record_a_id, record_b_id), the pair
+# ``score``, the ``matchkey_name`` that fired, and the ``run_name`` (run id).
+NODE_COLUMNS = (
+    "entity_id", "status", "merged_into", "golden_record",
+    "confidence", "dataset", "created_at", "updated_at",
+)
+RECORD_COLUMNS = ("record_id", "entity_id", "dataset", "first_seen_at", "last_seen_at")
+EDGE_COLUMNS = (
+    "entity_id", "record_a_id", "record_b_id", "kind",
+    "score", "matchkey_name", "run_name", "dataset", "recorded_at",
+)
+EVENT_COLUMNS = ("entity_id", "kind", "run_name", "dataset", "recorded_at")
+
 
 # --- pure helpers (no pyspark; locally testable, parity-by-construction) ---
 
@@ -270,11 +287,44 @@ def build_source_records(
     )
 
 
+def build_identity_events(
+    entity_ids: Any,
+    *,
+    run_meta: dict[str, Any],
+) -> Any:
+    """One ``CREATED`` event per entity (store-parity bookkeeping).
+
+    The optional ``events`` frame mirrors the one-box append-only event log's
+    create rows, so a downstream store can replay them. Columns: ``EVENT_COLUMNS``.
+    """
+    from pyspark.sql import functions as F
+
+    return entity_ids.select(
+        "entity_id",
+        F.lit("CREATED").alias("kind"),
+        F.lit(run_meta["run_name"]).alias("run_name"),
+        F.lit(run_meta.get("dataset")).alias("dataset"),
+        F.lit(run_meta["recorded_at"]).alias("recorded_at"),
+    )
+
+
 @dataclass
 class IdentityGraphFrames:
+    """The distributed identity graph as four Spark frames (S5 create path).
+
+    The stable public contract (#859): ``nodes`` (one per entity, ``NODE_COLUMNS``),
+    ``records`` (record->entity assignment, ``RECORD_COLUMNS``), ``edges``
+    (``same_as`` evidence with full provenance, ``EDGE_COLUMNS``), and an optional
+    ``events`` frame (one ``CREATED`` row per entity, ``EVENT_COLUMNS``). Each frame
+    is a distributed Spark DataFrame, written as parquet, never collected to the
+    driver. Incremental absorb/merge is the deferred Layer 2 (honest-null): on a
+    fresh store every cluster is a create, which is the common case.
+    """
+
     nodes: Any
     records: Any
     edges: Any
+    events: Any = None
 
 
 def build_identity_graph(
@@ -287,10 +337,15 @@ def build_identity_graph(
     source_col: str = "__source__",
     source_pk_col: str | None = None,
     id_col: str = "__row_id__",
+    with_events: bool = True,
 ) -> IdentityGraphFrames:
     """Produce the create-path identity graph as distributed Spark frames.
-    Layer 1 only (create + same_as edges); incremental absorb/merge is the
-    deferred Layer 2 (honest-null).
+
+    Layer 1 only (create + ``same_as`` edges + ``CREATED`` events); incremental
+    absorb/merge against an existing store is the deferred Layer 2 (honest-null,
+    driver-side as the Ray path left it). ``run_meta`` carries ``run_name`` (the
+    run id stamped onto edges/events), ``recorded_at``, and optional ``dataset`` /
+    ``matchkey_name``. Set ``with_events=False`` to skip the bookkeeping frame.
     """
     from pyspark.sql import functions as F
 
@@ -313,4 +368,5 @@ def build_identity_graph(
     records = build_source_records(
         assignments, recid_map, entity_ids, run_meta=run_meta
     )
-    return IdentityGraphFrames(nodes=nodes, records=records, edges=edges)
+    events = build_identity_events(entity_ids, run_meta=run_meta) if with_events else None
+    return IdentityGraphFrames(nodes=nodes, records=records, edges=edges, events=events)

--- a/packages/python/goldenmatch/tests/test_sail_identity_contract.py
+++ b/packages/python/goldenmatch/tests/test_sail_identity_contract.py
@@ -1,0 +1,81 @@
+"""Stable public IdentityGraph API contract (#859).
+
+These tests pin the public surface a downstream store (e.g. the golden-showcase
+``IdentityGraph`` seam) depends on, and they run in the NORMAL python lane: the
+public API imports without the ``[sail]`` extra because ``pyspark`` is imported
+lazily inside the builder bodies. If this file needs ``importorskip``, the
+contract has regressed (the import surface started pulling pyspark eagerly).
+
+Freezing this signature is the point: a change here is a breaking change for any
+consumer pinning the contract, and should bump the API accordingly.
+"""
+from __future__ import annotations
+
+import dataclasses
+import inspect
+
+
+def test_public_import_path_no_sail_extra():
+    # The stable path. Must import without pyspark / the [sail] extra installed.
+    from goldenmatch.sail import (  # noqa: F401
+        EDGE_COLUMNS,
+        EVENT_COLUMNS,
+        NODE_COLUMNS,
+        RECORD_COLUMNS,
+        IdentityGraphFrames,
+        build_identity_graph,
+    )
+
+
+def test_identity_graph_frames_shape():
+    from goldenmatch.sail import IdentityGraphFrames
+
+    assert dataclasses.is_dataclass(IdentityGraphFrames)
+    fields = {f.name: f for f in dataclasses.fields(IdentityGraphFrames)}
+    # The frozen field set: nodes / records / edges + an OPTIONAL events frame.
+    assert list(fields) == ["nodes", "records", "edges", "events"]
+    # events is optional (defaults to None) so existing 3-arg construction holds.
+    assert fields["events"].default is None
+    frames = IdentityGraphFrames(nodes="n", records="r", edges="e")
+    assert frames.events is None
+
+
+def test_build_identity_graph_signature():
+    from goldenmatch.sail import build_identity_graph
+
+    sig = inspect.signature(build_identity_graph)
+    params = sig.parameters
+    # Positional inputs the consumer always passes.
+    for name in ("pairs", "assignments", "source_df", "golden_df"):
+        assert name in params
+    # Keyword-only contract knobs + their stable defaults.
+    assert params["run_meta"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert params["source_col"].default == "__source__"
+    assert params["source_pk_col"].default is None
+    assert params["id_col"].default == "__row_id__"
+    assert params["with_events"].default is True
+
+
+def test_frozen_wire_schema():
+    from goldenmatch.sail import (
+        EDGE_COLUMNS,
+        EVENT_COLUMNS,
+        NODE_COLUMNS,
+        RECORD_COLUMNS,
+    )
+
+    assert NODE_COLUMNS == (
+        "entity_id", "status", "merged_into", "golden_record",
+        "confidence", "dataset", "created_at", "updated_at",
+    )
+    assert RECORD_COLUMNS == (
+        "record_id", "entity_id", "dataset", "first_seen_at", "last_seen_at",
+    )
+    # Edge provenance: endpoints + score + the matchkey that fired + the run id.
+    assert EDGE_COLUMNS == (
+        "entity_id", "record_a_id", "record_b_id", "kind",
+        "score", "matchkey_name", "run_name", "dataset", "recorded_at",
+    )
+    for col in ("record_a_id", "record_b_id", "score", "matchkey_name", "run_name"):
+        assert col in EDGE_COLUMNS
+    assert EVENT_COLUMNS == ("entity_id", "kind", "run_name", "dataset", "recorded_at")


### PR DESCRIPTION
## Summary

Part of #859 (the Phase-2 / 1.31 deliverable). The bensevern.dev showcase SaaS is blocked: it needs a **released, frozen** Python IdentityGraph API to depend on, but `goldenmatch.sail.identity.IdentityGraphFrames` sits under `[Unreleased]`. This stabilizes that surface (the S5 create path); the design is the already-approved S5 spec.

- **Stable public path:** `from goldenmatch.sail import IdentityGraphFrames, build_identity_graph` (+ the wire-schema constants). Imports **without** the `[sail]` extra — pyspark is lazy inside the builders — so the showcase's contract test can pin the signature with `inspect` and no Spark runtime.
- **Completed the S5 shape:** `IdentityGraphFrames` gains the optional `events` frame (`nodes, records, edges, events?`); `build_identity_graph(..., with_events=True)` emits one `CREATED` row per entity.
- **Frozen wire schema** exported as `NODE_COLUMNS` / `RECORD_COLUMNS` / `EDGE_COLUMNS` / `EVENT_COLUMNS`. The edge frame carries full provenance: `record_a_id`, `record_b_id`, `score`, `matchkey_name`, `run_name` (the issue's `(src, dst, score, matchkey, run_id)`).
- **Incremental semantics documented:** absorb/merge against an existing store stays the deferred Layer 2 (honest-null) — on a fresh store every cluster is a create, the common case. Documented on the dataclass, `build_identity_graph`, and the CHANGELOG.

## Test Plan
- [x] `tests/test_sail_identity_contract.py` (4 tests) pins the import path, the dataclass shape (incl. `events` default `None`, 3-arg construction still works), the `build_identity_graph` signature + defaults, and the wire schema — **runs in the normal python lane, no Spark**.
- [x] Existing `tests/test_sail_identity_parity.py` pure-helper tier green; the Spark-server tier correctly skips without `pysail` (8 passed, 6 skipped).
- [x] `ruff` (CI lint set + full, incl. import sort) + `py_compile` clean.

## Remaining for #859
The **1.31 release cut** (version bump in the 3 spots + finalize CHANGELOG `[Unreleased]` → `1.31.0` + tag `v1.31.0`) is the mechanical follow-up, done once this + the other 1.31-targeted changes (#870 golden determinism, #884 native telemetry) all land — so 1.31.0 bundles them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)