### PR TITLE
docs(sail): "past one box" roadmap + R2 multi-node determinism gate

### DIFF
--- a/docs/superpowers/specs/2026-06-13-sail-tier-past-one-box-roadmap.md
+++ b/docs/superpowers/specs/2026-06-13-sail-tier-past-one-box-roadmap.md
@@ -1,0 +1,121 @@
+# Sail tier — "past one box" roadmap (from scaffolded → proven multi-node)
+
+**Date:** 2026-06-13
+**Status:** roadmap (planning artifact — sequences remaining work; not a build spec)
+**Parent:** `2026-06-03-sail-tier-design.md` (the S1→S4 stage plan) +
+`2026-06-03-datafusion-spine-design.md` (the one-box spine Stage E hands off here)
+**Lane:** strategic — the distributed substrate that completes where the one-box
+spine OOMs. This roadmap takes the Sail tier from *scaffolded + one-box-parity-gated*
+to *proven multi-node, Ray-retired, default-eligible*.
+
+---
+
+## Why this exists
+
+The one-box DataFusion spine proved out-of-core spill for the RELATIONAL stages,
+but its Union-Find break collects pairs to the driver (scipy.csgraph) — an in-memory
+island that caps it at ~50M pairs. "Past one box" means removing that island:
+distribute the WCC across nodes. The chosen substrate is **Sail** (LakeSail, driven
+via the Spark Connect protocol), NOT a second engine. The thread that prompted this
+roadmap (Apache Ballista) is the *fallback*, not the path — see the last section.
+
+## Current state (real, on `main`)
+
+`goldenmatch/sail/` is built and gated against the one-box spine on tiny fixtures —
+but **nothing has executed on more than one box.** That single fact is the gap.
+
+| Stage | Scope | File(s) | Status |
+|---|---|---|---|
+| **S1** | harness + score/dedup | `session.py`, `scoring.py`, `scorers.py` | built — scorer is the **pure-Python rapidfuzz `pandas_udf` FLOOR**, not the native Arrow UDF target |
+| **S2** | WCC on Sail (the holdout) | `clustering.py` (`connected_components`, `connected_components_scale` pointer-jumping) | built, partition-parity-gated vs reference UF |
+| **S3** | golden + identity | `golden.py`, `identity.py` | built (survivorship + identity-graph builders) |
+| **S5** | identity API freeze → 1.31 | `IdentityGraphFrames` | in flight (#859 / PR #889) |
+| **S4** | multi-node bench + Ray retirement | `pipeline.py::run_sail_pipeline` | **NOT run — THE gate** |
+
+The tier's own kill criterion (from the parent design) stands: *no Ray retirement,
+no default-flip, until S4 is green.* Everything below is what makes an S4 green both
+*reachable* and *trustworthy*.
+
+## The roadmap
+
+The critical path is one item — **S4** — plus the prerequisites that make it a fair,
+trustworthy test. Sequenced:
+
+### R0 — Land S5 (in flight). Release 1.31 with the frozen `IdentityGraphFrames` API
+(#859 / #889). Off the critical scale path, but it stabilizes the S3 output contract
+S4 benches against and unblocks the showcase. No new work here — just land it.
+
+### R1 — Native scorer Arrow UDF (the PERF prerequisite).
+`sail/scorers.py` ships the *floor*: pure-Python rapidfuzz in a `pandas_udf`. The
+parent design's Decision 2 *target* is the existing `score-core` rapidfuzz kernel
+(already compiled into `_native` / `goldenmatch_native`) rebound as a **vectorized
+Spark Arrow UDF** (Sail runs Arrow UDFs zero-copy), with the pure-Python UDF kept as
+the always-available fallback + parity reference (`rust==python rapidfuzz @ 1e-9`).
+- **Why it gates S4:** benching the floor measures Python-UDF overhead, not the
+  engine — you would retire Ray on a number that does not represent the ceiling.
+- **Crosses the executor boundary as an Arrow UDF (the Spark protocol)** — more
+  proven than Ballista's FFI-ScalarUDF-across-scheduler path, which is exactly why
+  Sail (not Ballista) is the substrate.
+- **Gate:** UDF scores equal the in-process native scorer for a string-pair fixture
+  (ε for f32); throughput beats the pure-Python floor on a single-process bench.
+
+### R2 — Multi-node determinism gate (the TRUSTWORTHY prerequisite). ✅ landed in this change
+The spine has Stage D (determinism across `target_partitions` {1,3,N}); the Sail tier
+needs the same across *executors*: assert the emitted pair **SET** and the cluster
+**PARTITION** are invariant to the number of shuffle partitions Sail fans the plan
+across (`spark.sql.shuffle.partitions`). A green S4 on a partition-count-sensitive
+pipeline measures luck, not the engine.
+- **Fixture discipline (carried from Stage D):** every within-block pair scores 1.0
+  (0.15 margin over the 0.85 threshold) so NO pair sits within f32-ULP of the cutoff
+  — the gate measures determinism, not threshold flapping.
+- **Delivered as** `tests/test_sail_determinism.py` (skips without the `sail` extra,
+  same convention as the S1/S2 parity tests). Covers WCC alone (both algorithms) and
+  the full score→dedup→WCC path.
+
+### R3 — Coverage / feature-gate honesty.
+`run_sail_pipeline` is single `block_col` + single `value_col` + `most_complete`/
+`first`. Before any default-eligible claim: either widen to multi-field weighted
+matchkeys, or **explicitly error** on unsupported scorers (LLM/rerank/boost/NE/exotic)
+the way scale-mode does — never silently degrade. Pure routing; does not block R4.
+
+### R4 — S4: the binding multi-node bench (THE gate).
+`workflow_dispatch`, BYO multi-node Sail cluster via a `SAIL_REMOTE` secret, the
+phase5 50M/100M parquet from the bench generator.
+- **Kill criterion:** completes where one-box OOMs/can't, per-node RSS bounded, **wall
+  improves with node count.** Commit the numbers back to this roadmap.
+- **The structural win over the spine:** distributed WCC (S2) removes the ~50M
+  scipy-UF island that capped the spine's Stage E. NOTE the S2 in-code TODO — at 100M,
+  `connected_components_scale` must cache/checkpoint `labels` each round (Spark Connect
+  lineage growth) and the long-chain convergence wants large-star/small-star; verify
+  before the bind, not after a hang.
+- **Dependency:** a live multi-node cluster — a BYO/ops dependency, not code.
+
+### R5 — Ray retirement + wiring (ONLY after R4 is green).
+Add `backend="sail"` to the planner/public surface, flip Ray to legacy, document the
+BYO-cluster deploy recipe. Forbidden before R4 binds (the parent design's rule).
+
+## Dependency order
+
+```
+R0 (1.31 release) ───────────────┐
+R1 (native Arrow UDF) ──┐        │
+R2 (determinism gate) ──┼──► R4 (multi-node bench) ──► R5 (Ray retire + wire)
+R3 (coverage gate) ─────┘        │
+                                 └─ R0 stabilizes the S3 contract R4 benches
+```
+
+R1, R2, R3 are independent and parallelizable; all three precede R4. R2 and R3 are
+buildable + CI-testable WITHOUT a cluster (local single-process `sail spark server`);
+R1 is buildable but its throughput claim wants a real bench; R4 needs the cluster.
+
+## Ballista (the thread origin): fallback, not path
+
+Ballista is the *other* distributed-DataFusion option. The roadmap's stance: it
+re-opens the exact UDF-across-cluster risk that Sail's Arrow-UDF route (R1) already
+de-risks, and the team is 3-of-4 stages into Sail. Ballista re-enters ONLY if S2 (WCC)
+or S4 (the bind) fails the gate — the parent design's "Sail is not yet the substrate"
+branch. Neither has been run to fail. The minimal Ballista re-probe, if it ever comes,
+is one existing native scorer registered as an `FFI_ScalarUDF` on a 2-executor cluster
+running a block self-join — purely to answer whether our FFI UDFs survive the
+scheduler/executor boundary at the pinned DataFusion major. That is the only question
+Ballista can answer that Sail cannot.

--- a/packages/python/goldenmatch/tests/test_sail_determinism.py
+++ b/packages/python/goldenmatch/tests/test_sail_determinism.py
@@ -1,0 +1,158 @@
+"""Multi-node determinism gate -- the Stage-D analog for the Sail tier (R2 of
+``2026-06-13-sail-tier-past-one-box-roadmap.md``).
+
+The emitted pair SET and the cluster PARTITION must be invariant to the number
+of shuffle partitions Sail fans the plan across. This is the prerequisite that
+makes an S4 multi-node bench TRUSTWORTHY: a green bench on a
+partition-count-sensitive pipeline would be measuring luck, not the engine.
+
+Mirrors the one-box spine's Stage D (determinism across ``target_partitions``
+{1, 3, N}); here the knob is ``spark.sql.shuffle.partitions``. Self-contained;
+skips where the ``sail`` extra is absent; runs in the ``sail`` CI lane.
+
+Fixture discipline (carried from the spine's Stage D + the S1 score fixture):
+every within-block pair scores 1.0 -- a 0.15 margin over the 0.85 threshold --
+so NO pair sits within f32-ULP of the cutoff. The gate then measures
+determinism, NOT threshold flapping.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+pytest.importorskip("rapidfuzz")
+
+
+# Sweep the shuffle-partition count: 1 (single partition) up to more partitions
+# than rows, so the plan is forced to fan out and re-coalesce.
+_SHUFFLE_PARTITIONS = (1, 3, 8)
+_THRESHOLD = 0.85
+
+# block on zip, score last_name; identical within-block strings -> every pair
+# scores 1.0 (0.15 over threshold). 3-member / 2-member / singleton.
+_ROWS = [
+    (0, "Aaaa", "10001"),
+    (1, "Aaaa", "10001"),
+    (2, "Aaaa", "10001"),
+    (3, "Brown", "20002"),
+    (4, "Brown", "20002"),
+    (5, "Carter", "30003"),
+]
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def _reference_partition(ids, edges):
+    """Canonical connected components via plain Union-Find -> set of
+    frozensets of member ids (singletons included). The correctness oracle:
+    independent of shuffle count, scorer, and WCC algorithm."""
+    parent = {i: i for i in ids}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in edges:
+        parent[find(a)] = find(b)
+    comp: dict[int, set[int]] = {}
+    for i in ids:
+        comp.setdefault(find(i), set()).add(i)
+    return {frozenset(v) for v in comp.values()}
+
+
+def _partition_of(assignments_df):
+    """assignments DataFrame -> set of frozensets of member ids per cluster_id."""
+    from collections import defaultdict
+
+    by_cid: dict[int, set[int]] = defaultdict(set)
+    for r in assignments_df.collect():
+        by_cid[r["cluster_id"]].add(int(r["member_id"]))
+    return {frozenset(v) for v in by_cid.values()}
+
+
+def _pair_set(pairs_df):
+    """(a, b, score) DataFrame -> set of canonical (a, b) int pairs."""
+    return {(int(r["a"]), int(r["b"])) for r in pairs_df.collect()}
+
+
+@pytest.mark.parametrize(
+    "wcc_fn_name", ["connected_components", "connected_components_scale"]
+)
+def test_wcc_partition_invariant_to_shuffle_partitions(spark, wcc_fn_name):
+    """WCC alone: the cluster partition is identical across shuffle-partition
+    counts AND equals the reference Union-Find. Min-label propagation is
+    order-independent by construction; this proves Sail's distribution doesn't
+    break that for either the S2 (label-prop) or the scale (pointer-jumping)
+    algorithm."""
+    from goldenmatch.sail import clustering
+
+    fn = getattr(clustering, wcc_fn_name)
+    ids = list(range(12))
+    # two chains + a star + singletons {4}, {8}, {11}
+    edges = [(0, 1), (1, 2), (2, 3), (5, 6), (6, 7), (9, 10)]
+    ref = _reference_partition(ids, edges)
+
+    parts = []
+    for n in _SHUFFLE_PARTITIONS:
+        spark.conf.set("spark.sql.shuffle.partitions", str(n))
+        ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+        pairs_df = spark.createDataFrame(edges, ["a", "b"])
+        parts.append(_partition_of(fn(pairs_df, ids_df, id_col="__row_id__")))
+
+    # determinism: identical across every shuffle-partition count
+    assert all(p == parts[0] for p in parts)
+    # correctness: that invariant value is the right one
+    assert parts[0] == ref
+
+
+def test_pipeline_pair_set_and_partition_invariant_to_shuffle_partitions(spark):
+    """Full S1->S2 path (score -> dedup -> WCC): both the emitted pair SET and
+    the cluster PARTITION are invariant to shuffle-partition count. Covers the
+    float-reduction determinism the WCC-only test cannot -- the dedup
+    ``max(score)`` GROUP BY runs across partitions, the place a non-deterministic
+    parallel reduction would surface."""
+    from goldenmatch.sail.clustering import connected_components_scale
+    from goldenmatch.sail.scoring import score_and_dedup
+
+    pair_sets = []
+    partitions = []
+    for n in _SHUFFLE_PARTITIONS:
+        spark.conf.set("spark.sql.shuffle.partitions", str(n))
+        df = spark.createDataFrame(_ROWS, ["__row_id__", "last", "zip"])
+        pairs = score_and_dedup(
+            df,
+            block_col="zip",
+            value_col="last",
+            id_col="__row_id__",
+            scorer_name="jaro_winkler",
+            threshold=_THRESHOLD,
+        )
+        pair_sets.append(_pair_set(pairs))
+        ids_df = df.select("__row_id__")
+        assignments = connected_components_scale(
+            pairs, ids_df, id_col="__row_id__"
+        )
+        partitions.append(_partition_of(assignments))
+
+    # determinism: identical across every shuffle-partition count
+    assert all(ps == pair_sets[0] for ps in pair_sets)
+    assert all(pt == partitions[0] for pt in partitions)
+    # correctness: the WCC partition matches a reference UF over the EMITTED
+    # pairs (no dependence on exact scores -- robust to rapidfuzz versions)
+    ids = [r[0] for r in _ROWS]
+    assert partitions[0] == _reference_partition(ids, pair_sets[0])


### PR DESCRIPTION
## Summary

Started from the question "could [Apache Ballista] help?" → the real target is **"push the spine past one box,"** which is the **Sail tier**, not Ballista. This PR sequences that work and lands the first cluster-free prerequisite.

**1. Roadmap** (`docs/superpowers/specs/2026-06-13-sail-tier-past-one-box-roadmap.md`) — takes `goldenmatch/sail/` from *scaffolded + one-box-parity-gated* to *proven multi-node, Ray-retired, default-eligible*. Current state on `main`: S1–S3 built (scorer is the pure-Python `pandas_udf` floor), S5 (identity API → 1.31) in flight, **S4 the gate — never run on >1 box.** The roadmap:
- **R1** native scorer Arrow UDF (perf prerequisite — bench the engine, not Python-UDF overhead)
- **R2** multi-node determinism gate ← *landed here*
- **R3** coverage / feature-gate honesty
- **R4 = S4** binding multi-node bench (the gate; needs a BYO cluster)
- **R5** Ray retirement + `backend="sail"` wiring (only after R4 green)
- Records that **Ballista is the fallback, not the path** — it re-opens the UDF-across-cluster risk Sail's Arrow-UDF route de-risks; it only re-enters if S2/S4 fail their gates.

**2. R2 — multi-node determinism gate** (`tests/test_sail_determinism.py`) — the Stage-D analog for the Sail tier. Asserts the emitted **pair SET** and the cluster **PARTITION** are invariant to `spark.sql.shuffle.partitions` ∈ {1, 3, 8}. This is what makes an eventual S4 bench *trustworthy* rather than luck on one partitioning. Covers WCC alone (both `connected_components` and the `_scale` pointer-jumping path) and the full `score → dedup → WCC` path. Near-threshold-free fixture (every within-block pair scores 1.0, 0.15 over the 0.85 cutoff) so it measures determinism, not threshold flapping.

## Test Plan
- [x] `ruff check` (CI lint set `E9,F63,F7,F82` + full) clean on the new test.
- [x] `py_compile` clean.
- [x] `pytest` collects + **skips cleanly without the `sail` extra** (no pysail/pyspark here) — same `importorskip` convention as `test_sail_clustering_parity.py` / `test_sail_score_parity.py`. Runs for real in the `sail` CI lane against the in-process `sail spark server`.
- [x] The pure-Python Union-Find oracle + both fixtures verified standalone (WCC → `{0,1,2,3},{5,6,7},{9,10}` + singletons; pipeline → pairs `{(0,1),(0,2),(1,2),(3,4)}`, partition `{0,1,2},{3,4},{5}`).

Doc + test only; no runtime code changed.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_