### PR TITLE
Spike: Lance vs Parquet for candidate retrieval (spec + bench)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-lance-vs-parquet-candidate-retrieval-design.md
+++ b/docs/superpowers/specs/2026-06-13-lance-vs-parquet-candidate-retrieval-design.md
@@ -1,0 +1,108 @@
+# Lance vs Parquet for Candidate Retrieval — Evaluation Design
+
+**Date:** 2026-06-13 · **Issue:** TBD · **Branch:** claude/iceoryx2-goldenmatch-bsmd9l · **Status:** spike (pre-decision)
+
+## Origin
+
+This came out of a "can iceoryx2 help GoldenMatch?" review. Conclusion there:
+iceoryx2 (zero-copy *local IPC*) is a weak fit — GoldenMatch is compute-bound, not
+IPC-copy-bound, and its distributed path is Ray-over-network, which iceoryx2
+cannot touch. The one trending Rust project that could move an *architecture*
+decision rather than tooling is **Lance** (`lance-format/lance`): an open columnar
+format with **fast random access** and zero-copy reads, already name-checked in
+`docs/er-vendor-comparison.md`. This spec scopes a measured bake-off before any
+adoption — per the performance-audit lesson, *measure 5-run median wall on real
+shapes before designing*.
+
+## Hypothesis
+
+Lance beats Parquet on the **scattered random-access** retrieval pattern, and is
+roughly at parity on full-scan throughput. If true, the win lands specifically on
+the ANN sub-blocking path and any "gather these candidate row-ids" step; it does
+*not* help the streaming full-scan stages (load, transform), which are already
+Parquet-friendly.
+
+## The two retrieval patterns that matter
+
+GoldenMatch reads its working set back off disk in two shapes:
+
+1. **Block-key predicate retrieval.** `core/blocker.py:283` groups by
+   `__block_key__`; downstream, scoring materializes the rows of a block. On disk
+   this is `WHERE __block_key__ = X`. Parquet serves it via row-group min/max
+   stats + (optionally) a sorted/partitioned layout; it is already reasonable when
+   the file is sorted on the block key. Lance serves it via its scanner with a
+   pushdown filter. **Expectation: near parity** when Parquet is sorted on the key;
+   Lance may win on unsorted data because its secondary structures localize better.
+
+2. **Scattered index `take`.** The ANN / sub-blocking path
+   (`core/blocker.py:486`, `..._ann_{min(member_list)}`) produces candidate row
+   *indices* that are non-contiguous across the file. Today the realistic status
+   quo is "read the needed column(s) for the whole partition, then gather"
+   (`pl.read_parquet(...)[indices]`) — Parquet has no true random row access; you
+   pay a full column scan to fetch a 0.1% sample. Lance's `dataset.take(indices)`
+   reads only the pages covering those rows. **Expectation: Lance wins large** as
+   the candidate fraction shrinks (e.g. 0.01–1% of N), because Parquet's cost is
+   ~O(N) regardless of how few rows you want while Lance's is ~O(rows_wanted).
+
+## Experiment
+
+`packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py` — standalone (no
+`goldenmatch` import), graceful when `lance` is absent (runs Parquet-only and
+prints install hint). It:
+
+1. Generates `--rows N` synthetic records with a realistic shape: surrogate `id`,
+   a bounded-cardinality `block_key` (zip-like), two text fields (name/address),
+   and a couple of numerics — i.e. the columns scoring actually touches.
+2. Writes both `dataset.parquet` (sorted on `block_key`, the fair Parquet layout)
+   and `dataset.lance`.
+3. Times three patterns at **5-run median wall**, each in a forked child so peak
+   RSS (`ru_maxrss`) is isolated from setup and from the other engine:
+   - `full_scan` — read the scoring columns end-to-end (baseline / sanity).
+   - `block_filter` — predicate-retrieve one randomly chosen block.
+   - `scatter_take` — gather `--candidates K` non-contiguous row indices (the ANN
+     pattern); swept across K = 0.01%, 0.1%, 1% of N.
+4. Prints a table: pattern x engine -> median wall, x-factor, peak RSS.
+
+Run shapes (the bench box, not CI): `N ∈ {1M, 10M, 50M}`,
+`K/N ∈ {1e-4, 1e-3, 1e-2}`.
+
+```
+python packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py \
+    --rows 10_000_000 --candidates-frac 0.001 --runs 5
+```
+
+## Decision criteria
+
+Adopt Lance for candidate retrieval **only if** `scatter_take` shows a
+**>= 5x median-wall win at K/N <= 1e-3** on >= 10M rows *and* `full_scan` /
+`block_filter` are within ~1.2x of Parquet (no regression on the streaming
+stages). Below 5x it is not worth a new on-disk format, a second writer in the
+loader, and the Ray-side read-path changes.
+
+If adopted, the integration is **narrow and opt-in**: a Lance writer alongside the
+existing Parquet writer in `core/ingest.py` / the distributed loader, gated by a
+config/env flag, feeding only the ANN-gather step. We do **not** replace Parquet
+as the interchange format (Ray, object-storage connectors, and the bench release
+assets all stay Parquet).
+
+## Risks / unknowns
+
+- **Format lock-in & ops.** Lance is younger than Parquet; the bench-dataset
+  release assets and `connectors/object_storage.py` (`scan_parquet`) assume
+  Parquet. Keep Parquet as the portable interchange; Lance stays an internal
+  acceleration cache.
+- **Ray integration.** `distributed/` reads via `ray.data.read_parquet`. Lance has
+  a Ray reader but it is a separate code path to validate; out of scope for the
+  first spike (single-node only).
+- **Sorted-Parquet is a strong baseline.** If we sort Parquet on `block_key` and
+  the real access is predicate-only (pattern 1), Lance's edge may be marginal —
+  which is exactly why pattern 2 (scatter `take`) is the load-bearing measurement.
+- **Apples-to-apples writes.** Lance write time and on-disk size must be reported
+  too; a read win that costs 3x write time / 2x disk may not pay off for one-shot
+  pipelines.
+
+## Non-goals
+
+- No production adoption in this spike — numbers first.
+- No change to the Parquet-based distributed path or release assets.
+- Not a general "Parquet is slow" claim — this targets one access pattern.

--- a/packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py
+++ b/packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import argparse
 import multiprocessing as mp
-import os
 import resource
 import statistics
 import sys
@@ -209,8 +208,6 @@ def main() -> int:
     print("generating + writing ...")
     df = generate(args.rows)
     # Pick a real block key (most populous) and candidate index sets up front.
-    import polars as pl
-
     top_key = (
         df.group_by("block_key").len().sort("len", descending=True).select("block_key").head(1).item()
     )
@@ -240,7 +237,7 @@ def main() -> int:
     row("full_scan", res)
     # block_filter
     res = {e: measure(e, "block_filter", paths[e], top_key, args.runs) for e in engines}
-    row(f"block_filter", res)
+    row("block_filter", res)
     # scatter_take across fractions
     for frac, idx in cand_sets.items():
         res = {e: measure(e, "scatter_take", paths[e], idx, args.runs) for e in engines}

--- a/packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py
+++ b/packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Lance vs Parquet bake-off for GoldenMatch's candidate-retrieval patterns.
+
+Standalone (does NOT import ``goldenmatch``) so it runs anywhere the bench env
+has polars + pyarrow (+ optionally lance) installed. If ``lance`` is missing the
+script runs Parquet-only and prints an install hint rather than failing.
+
+Motivation: see docs/superpowers/specs/2026-06-13-lance-vs-parquet-candidate-
+retrieval-design.md. We measure three on-disk read shapes that mirror how the
+pipeline reads its working set back:
+
+  * full_scan    -- read the scoring columns end-to-end (baseline).
+  * block_filter -- predicate-retrieve one block (blocker.py:283 group-by, on
+                    disk a ``WHERE __block_key__ = X``).
+  * scatter_take -- gather K non-contiguous row indices (the ANN sub-blocking
+                    path, blocker.py:486 ``_ann_``). This is the pattern Lance's
+                    random-access ``take`` should win; Parquet must scan the
+                    column(s) and gather.
+
+Per the performance-audit lesson we report **5-run median wall on real shapes**,
+and isolate peak RSS per measurement by running each in a forked child process.
+
+Usage:
+    python scripts/bench_lance_vs_parquet.py --rows 10_000_000 \
+        --candidates-frac 0.001 --runs 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing as mp
+import os
+import resource
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Columns the scorer actually touches -- name/address text + a couple numerics.
+SCORE_COLS = ["id", "block_key", "name", "address", "age", "score_hint"]
+
+
+def _have(mod: str) -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec(mod) is not None
+
+
+def generate(rows: int, seed: int = 7):
+    """Synthetic records: bounded-cardinality block key + text/numeric fields."""
+    import numpy as np
+    import polars as pl
+
+    rng = np.random.default_rng(seed)
+    # zip-like bounded cardinality (~40K real US zips) -> blocks grow with N.
+    n_zips = min(40_000, max(1, rows // 25))
+    block_key = rng.integers(0, n_zips, size=rows)
+    first = rng.integers(0, 5000, size=rows)
+    street = rng.integers(0, 9999, size=rows)
+    df = pl.DataFrame(
+        {
+            "id": np.arange(rows, dtype=np.int64),
+            "block_key": [f"{z:05d}" for z in block_key],
+            "name": [f"person_{a}_{b}" for a, b in zip(first, rng.integers(0, 5000, size=rows))],
+            "address": [f"{s} main st apt {a}" for s, a in zip(street, rng.integers(0, 999, size=rows))],
+            "age": rng.integers(18, 95, size=rows).astype("int32"),
+            "score_hint": rng.random(size=rows).astype("float32"),
+        }
+    )
+    # Sort on block_key: the FAIR Parquet layout (row-group stats localize blocks).
+    return df.sort("block_key")
+
+
+def write_formats(df, root: Path) -> dict[str, Path]:
+    import polars as pl  # noqa: F401
+
+    paths: dict[str, Path] = {}
+    pq = root / "dataset.parquet"
+    t0 = time.perf_counter()
+    df.write_parquet(pq, row_group_size=128 * 1024, statistics=True)
+    print(f"  parquet write: {time.perf_counter() - t0:6.2f}s  size={pq.stat().st_size / 1e6:8.1f} MB")
+    paths["parquet"] = pq
+
+    if _have("lance"):
+        import lance
+
+        lpath = root / "dataset.lance"
+        t0 = time.perf_counter()
+        lance.write_dataset(df.to_arrow(), str(lpath))
+        size = sum(f.stat().st_size for f in lpath.rglob("*") if f.is_file())
+        print(f"  lance   write: {time.perf_counter() - t0:6.2f}s  size={size / 1e6:8.1f} MB")
+        paths["lance"] = lpath
+    return paths
+
+
+# ---- read workloads (one per engine x pattern) --------------------------------
+
+def _parquet_full(path: Path):
+    import polars as pl
+
+    return pl.read_parquet(path, columns=SCORE_COLS).height
+
+
+def _parquet_block(path: Path, key: str):
+    import polars as pl
+
+    return (
+        pl.scan_parquet(path)
+        .filter(pl.col("block_key") == key)
+        .select(SCORE_COLS)
+        .collect()
+        .height
+    )
+
+
+def _parquet_take(path: Path, idx):
+    import polars as pl
+
+    # Status quo: Parquet has no random row access -> read column(s), then gather.
+    df = pl.read_parquet(path, columns=SCORE_COLS)
+    return df[idx].height
+
+
+def _lance_full(path: Path):
+    import lance
+
+    return lance.dataset(str(path)).to_table(columns=SCORE_COLS).num_rows
+
+
+def _lance_block(path: Path, key: str):
+    import lance
+
+    ds = lance.dataset(str(path))
+    return ds.scanner(columns=SCORE_COLS, filter=f"block_key = '{key}'").to_table().num_rows
+
+
+def _lance_take(path: Path, idx):
+    import lance
+
+    ds = lance.dataset(str(path))
+    return ds.take(list(idx), columns=SCORE_COLS).num_rows
+
+
+WORKLOADS = {
+    ("parquet", "full_scan"): _parquet_full,
+    ("parquet", "block_filter"): _parquet_block,
+    ("parquet", "scatter_take"): _parquet_take,
+    ("lance", "full_scan"): _lance_full,
+    ("lance", "block_filter"): _lance_block,
+    ("lance", "scatter_take"): _lance_take,
+}
+
+
+def _child(q, fn_key, path_str, arg, runs):
+    """Run one workload `runs` times in an isolated process; report wall+RSS."""
+    fn = WORKLOADS[fn_key]
+    path = Path(path_str)
+    walls = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        if arg is None:
+            fn(path)
+        else:
+            fn(path, arg)
+        walls.append(time.perf_counter() - t0)
+    rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    rss_mb = rss_kb / 1024.0 if sys.platform != "darwin" else rss_kb / 1024.0 / 1024.0
+    q.put((statistics.median(walls), min(walls), rss_mb))
+
+
+def measure(engine, pattern, path: Path, arg, runs: int):
+    ctx = mp.get_context("spawn")
+    q = ctx.Queue()
+    p = ctx.Process(target=_child, args=(q, (engine, pattern), str(path), arg, runs))
+    p.start()
+    p.join()
+    if not q.empty():
+        return q.get()
+    return (float("nan"), float("nan"), float("nan"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rows", type=int, default=1_000_000)
+    ap.add_argument(
+        "--candidates-frac",
+        type=float,
+        nargs="+",
+        default=[1e-4, 1e-3, 1e-2],
+        help="scatter_take candidate fraction(s) of N (the ANN gather size)",
+    )
+    ap.add_argument("--runs", type=int, default=5)
+    ap.add_argument("--keep", action="store_true", help="keep the generated datasets")
+    args = ap.parse_args()
+
+    if not _have("polars") or not _have("pyarrow") or not _have("numpy"):
+        print("Need polars + pyarrow + numpy. Install: pip install polars pyarrow numpy", file=sys.stderr)
+        return 2
+    has_lance = _have("lance")
+    engines = ["parquet"] + (["lance"] if has_lance else [])
+    if not has_lance:
+        print("NOTE: `lance` not installed -> Parquet-only run. Install: pip install pylance\n")
+
+    import numpy as np
+
+    tmp = Path(tempfile.mkdtemp(prefix="gm_lance_bench_"))
+    print(f"rows={args.rows:,}  runs={args.runs}  engines={engines}  dir={tmp}")
+    print("generating + writing ...")
+    df = generate(args.rows)
+    # Pick a real block key (most populous) and candidate index sets up front.
+    import polars as pl
+
+    top_key = (
+        df.group_by("block_key").len().sort("len", descending=True).select("block_key").head(1).item()
+    )
+    paths = write_formats(df, tmp)
+    n = df.height
+    del df  # free before forking read children so RSS reflects the read only
+
+    rng = np.random.default_rng(11)
+    cand_sets = {frac: np.sort(rng.choice(n, size=max(1, int(n * frac)), replace=False)) for frac in args.candidates_frac}
+
+    def row(label, results):
+        base = results.get("parquet", (float("nan"),))[0]
+        cells = []
+        for eng in engines:
+            med, mn, rss = results[eng]
+            x = f"{base / med:5.1f}x" if (eng == "lance" and med and not _isnan(med)) else "  -  "
+            cells.append(f"{med * 1000:9.1f}ms {x} {rss:7.0f}MB")
+        print(f"  {label:<22} " + " | ".join(cells))
+
+    print("\n" + "=" * 78)
+    hdr = "  {:<22} ".format("pattern") + " | ".join(f"{e:^28}" for e in engines)
+    print(hdr)
+    print("  " + "-" * (len(hdr)))
+
+    # full_scan
+    res = {e: measure(e, "full_scan", paths[e], None, args.runs) for e in engines}
+    row("full_scan", res)
+    # block_filter
+    res = {e: measure(e, "block_filter", paths[e], top_key, args.runs) for e in engines}
+    row(f"block_filter", res)
+    # scatter_take across fractions
+    for frac, idx in cand_sets.items():
+        res = {e: measure(e, "scatter_take", paths[e], idx, args.runs) for e in engines}
+        row(f"scatter_take {frac:g} (K={len(idx)})", res)
+
+    print("=" * 78)
+    print("cells: median-wall  (lance x-factor vs parquet)  peak-RSS")
+    print("decision gate (see spec): adopt only if scatter_take >= 5x at frac<=1e-3 on >=10M rows,")
+    print("and full_scan/block_filter within ~1.2x of parquet.")
+
+    if not args.keep:
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+    else:
+        print(f"\nkept datasets in {tmp}")
+    return 0
+
+
+def _isnan(x) -> bool:
+    return x != x
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Came out of a "can iceoryx2 help GoldenMatch?" review. iceoryx2 (zero-copy *local IPC*) is a weak fit — GoldenMatch is compute-bound, not IPC-copy-bound, and its distributed path is Ray-over-network which iceoryx2 can't touch. Scanning trending Rust repos, the one that could move an *architecture* decision rather than just tooling is **`lance-format/lance`** (open columnar format with fast random access), already name-checked in `docs/er-vendor-comparison.md`.

This PR adds **numbers-first** scaffolding — no adoption yet.

## What's here

- **Design spec** — `docs/superpowers/specs/2026-06-13-lance-vs-parquet-candidate-retrieval-design.md`: hypothesis, experiment, decision gate, risks, narrow opt-in integration plan if it pays off.
- **Prototype bench** — `packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py`: standalone (no `goldenmatch` import), graceful when `pylance` is absent (Parquet-only), **5-run median wall** + isolated peak RSS per measurement via forked children.

## The two read shapes measured

1. `block_filter` — block-key predicate retrieval (`core/blocker.py:283` group-by → `WHERE block_key = X`). Parquet is sorted on the key for a fair baseline; **expect near parity**.
2. `scatter_take` — gather K non-contiguous candidate row indices, the ANN sub-blocking path (`core/blocker.py:486` `_ann_`). Parquet has no random row access so it scans the column then gathers (~O(N)); Lance `take(indices)` reads only the covering pages (~O(K)). **This is where Lance should win**, swept across K/N ∈ {1e-4, 1e-3, 1e-2}.

## Decision gate

Adopt only if `scatter_take` ≥ **5x** median-wall at K/N ≤ 1e-3 on ≥10M rows, *and* `full_scan`/`block_filter` stay within ~1.2x of Parquet. If adopted, integration is narrow + opt-in (a Lance writer feeding only the ANN gather); Parquet stays the interchange format for Ray, object storage, and release assets.

## Status / not done

Data-science deps (polars/pyarrow/lance) aren't installed in the dev sandbox, so the bench is **syntax-checked but not yet executed** — it needs to run on the bench box. Run:

```
python packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py --rows 10_000_000 --candidates-frac 0.001 --runs 5
```

Draft until the numbers come back and we decide.

https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr)_