### PR TITLE
chore(mcp): codebase-memory graph server for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SessionStart hook -- provision the codebase-memory MCP server for Claude Code
+# on the web. It installs the static binary on a cold container (the container
+# image is cached after the hook completes, so the ~266MB download is a
+# one-time cold-start cost, not per-session) and (re)indexes this repo so the
+# graph tools registered in .mcp.json are queryable from the first turn.
+#
+# Web-only: locally, the .mcp.json server entry uses whatever
+# `codebase-memory-mcp` a dev has on PATH -- we never mutate a local machine.
+# Every step is non-fatal: a failed install/index degrades gracefully (the
+# session works without the graph) rather than blocking startup.
+set -euo pipefail
+
+# Remote (Claude Code on the web) only.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+REPO="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# 1. Install the binary if it isn't already on PATH (idempotent).
+if ! command -v codebase-memory-mcp >/dev/null 2>&1; then
+  if ! npm install -g codebase-memory-mcp >/dev/null 2>&1; then
+    echo "[session-start] codebase-memory-mcp install failed; graph tools unavailable this session" >&2
+    exit 0
+  fi
+fi
+
+# 2. (Re)index the current checkout so the graph reflects HEAD. Cheap (~15s for
+#    this repo); honors the .gitignore hierarchy + .cbmignore automatically.
+if ! codebase-memory-mcp cli index_repository "{\"repo_path\":\"${REPO}\"}" >/dev/null 2>&1; then
+  echo "[session-start] codebase-memory index failed; run index_repository manually" >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ packages/python/goldenflow/goldenflow/_native*.so
 # Same, for goldenanalysis (built from packages/rust/extensions/analysis-native
 # via scripts/build_analysis_native.py).
 packages/python/goldenanalysis/goldenanalysis/_native*.so
+
+# codebase-memory-mcp local index/snapshot (rebuilt by the SessionStart hook)
+.codebase-memory/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "codebase-memory": {
+      "command": "codebase-memory-mcp",
+      "args": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Rolls out [`DeusData/codebase-memory-mcp`](https://github.com/DeusData/codebase-memory-mcp) for the team so **Claude Code on the web** sessions get a persistent code-knowledge graph (tree-sitter AST across 158 languages + lightweight LSP, queryable via `search_graph` / `trace_path` / openCypher `query_graph` / `get_architecture`). It replaces grep/Explore fan-out for structural questions across this polyglot monorepo with sub-millisecond graph queries.

Validated in a scoped trial first: indexed `goldenmatch` (39k nodes / 166k edges / 14k functions) in ~15s, and the call graph it returns matches what we reconstruct by hand-reading source (e.g. `run_sail_pipeline → {score_and_dedup, build_golden, build_identity_graph, …}`).

## What's in the PR
- **`.mcp.json`** — registers the `codebase-memory` MCP server (stdio).
- **`.claude/hooks/session-start.sh`** — **web-only** (`CLAUDE_CODE_REMOTE`) SessionStart hook that installs the static binary on a cold container (the image is cached after the hook completes, so the ~266MB download is a one-time cost, not per-session) and (re)indexes the checkout (~15s; honors `.gitignore`/`.cbmignore`). Every step is **non-fatal** — a failed install/index degrades gracefully (the session works without the graph) instead of blocking startup. Local (non-remote) sessions no-op, so a dev's own PATH binary backs `.mcp.json` untouched.
- **`.claude/settings.json`** — registers the SessionStart hook.
- **`.gitignore`** — ignores the rebuilt local index dir. **Deliberately no committed snapshot**: a `.codebase-memory/graph.db.zst` would be a 100MB-class binary blob with per-index churn, and the ~15s reindex makes it unnecessary.

I did **not** run the tool's auto-installer (which would add pre-tool hooks across 11 agents) — this is a minimal, reviewed, MCP-server-only entry.

## Validation
1. ✅ **SessionStart hook (web path):** `CLAUDE_CODE_REMOTE=true` → reindex in ~6s, exit 0, `index_status` = `ready` (39,075 nodes).
2. ✅ **SessionStart hook (local path):** non-remote → no-op in <0.1s, exit 0.
3. ✅ **Graph tools queryable post-hook:** `search_graph`, `query_graph` (Cypher CALLS), `get_architecture` all return correct results against the live index.

> Linter/test validation steps from the hook-skill are N/A here — this hook provisions an MCP tool, it doesn't set up the project's test env (the repo keeps its own setup).

## Hook execution mode: **synchronous**
- **Pro:** guarantees the graph is indexed before turn 1 — no race where the agent queries an empty index.
- **Con:** a cold container's first session waits on the install + index before starting (warm/cached containers are fast).
- Easy to flip to async (`{"async": true, "asyncTimeout": 300000}`) if faster startup is preferred over the guarantee.

Once merged to the default branch, all future web sessions pick this up automatically. Independent of the Sail roadmap PR (#890) — separate branch off `main`.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_