### PR TITLE
ci: A/B proving harness for the quality-bridge default gates

### DIFF
--- a/.github/workflows/bench-quality-bridges.yml
+++ b/.github/workflows/bench-quality-bridges.yml
@@ -1,0 +1,74 @@
+name: bench-quality-bridges
+
+# A/B proving sweep for the GoldenCheck->GoldenMatch quality bridges
+# (FD-driven negative evidence + quality-aware blocking), both env-gated
+# default-OFF. Runs the real-dataset benchmark with each gate OFF (baseline)
+# then ON in isolation and posts a per-gate delta table + advisory verdict to
+# the step summary, so the maintainer can decide the default flip from evidence.
+# Manual only -- the datasets are large / license-restricted, same posture as
+# benchmarks.yml.
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  ab-sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Check prereqs
+        id: prereqs
+        shell: bash
+        run: |
+          # Same gating as benchmarks.yml: forks without dataset access exit 0
+          # with a notice rather than failing.
+          if [ "${{ vars.RUN_BENCHMARKS }}" != "true" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Benchmarks not configured::Set repo var RUN_BENCHMARKS=true and provide dataset access to enable. See docs/ci-lanes.md"
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install
+        if: steps.prereqs.outputs.configured == 'true'
+        run: |
+          uv sync --all-packages
+          # recordlinkage powers Febrl3; dqbench's ER adapter is the git version
+          # (PyPI 1.0.0 is detection-only) -- same as benchmarks.yml.
+          uv pip install recordlinkage || true
+          uv pip install "git+https://github.com/benseverndev-oss/dqbench" || true
+
+      - name: Run A/B quality-bridge sweep
+        if: steps.prereqs.outputs.configured == 'true'
+        shell: bash
+        env:
+          GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+          # DBLP-ACM auto-pulls from Leipzig (override if it 404s); NCVR points
+          # at a hosted 10k sample if available, else the runner skips it.
+          GOLDENMATCH_DBLP_ACM_URL: ${{ vars.DBLP_ACM_URL }}
+          GOLDENMATCH_NCVR_SAMPLE_URL: ${{ vars.NCVR_SAMPLE_URL }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/bench_quality_bridges.py \
+            --summary-md "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload A/B artifacts
+        if: always() && steps.prereqs.outputs.configured == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: quality-bridges-ab-${{ github.run_id }}
+          path: .ab_quality_bridges/*.json
+          retention-days: 90
+          if-no-files-found: warn

--- a/scripts/bench_quality_bridges.py
+++ b/scripts/bench_quality_bridges.py
@@ -1,0 +1,153 @@
+"""A/B proving sweep for the GoldenCheck->GoldenMatch quality bridges.
+
+Two bridges are env-gated default-OFF until a benchmark sweep proves them
+(``core/autoconfig.py::_quality_aware_blocking_enabled`` and
+``core/autoconfig_negative_evidence.py::_fd_negative_evidence_enabled``). This
+runs the real-dataset benchmark (``run_benchmarks.py``) three times -- a baseline
+with both gates off, then each gate on in isolation -- and emits a per-gate,
+per-dataset delta table plus an advisory verdict against each gate's stated
+criterion. The verdict is advisory; the maintainer flips the default from the
+table.
+
+The third bridge (quality-gated review) is deliberately NOT swept: it downgrades
+borderline auto-merges to a HUMAN review queue, so in a fully-automated benchmark
+it is recall-negative by construction. It stays opt-in for review workflows.
+
+Datasets: Febrl3 (synthetic PII corruption) + NCVR (voter corruption) are the
+proving ground -- these bridges target person-data typos/variants. DQbench is the
+non-regression guard (composite must hold >= ~91.04). DBLP-ACM is bibliographic
+(non-regression only -- the bridges should not move it).
+
+Benchmarks OOM the dev box; run this in CI (``bench-quality-bridges.yml``). Each
+run honours ``run_benchmarks.py``'s dataset auto-pull / graceful-skip.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNNER = REPO_ROOT / "scripts" / "run_benchmarks.py"
+
+# gate label -> env var
+GATES = {
+    "quality_aware_blocking": "GOLDENMATCH_QUALITY_AWARE_BLOCKING",
+    "fd_negative_evidence": "GOLDENMATCH_FD_NEGATIVE_EVIDENCE",
+}
+# datasets the gate's stated criterion is judged on (person-data corruption).
+TARGET_DATASETS = {"Febrl3", "NCVR"}
+DQBENCH_FLOOR = 91.04  # v1.12 committed composite; the non-regression guard.
+
+
+def _run(gate_env: dict[str, str], out_path: Path, datasets_dir: Path | None) -> dict:
+    """Run the full benchmark suite once with ``gate_env`` applied; return the
+    parsed ``{name: result}`` map. Missing datasets are silently absent."""
+    env = dict(os.environ)
+    env["GOLDENMATCH_AUTOCONFIG_MEMORY"] = "0"  # clean numbers, no cross-run cache
+    # Reset both gates off, then apply the requested overrides, so each run is
+    # isolated regardless of the ambient environment.
+    for var in GATES.values():
+        env[var] = "0"
+    env.update(gate_env)
+    cmd = [sys.executable, str(RUNNER), "--datasets", "all", "--output", str(out_path)]
+    if datasets_dir is not None:
+        cmd += ["--datasets-dir", str(datasets_dir)]
+    print(f"[ab] running: {' '.join(f'{k}={v}' for k, v in gate_env.items()) or 'baseline'}", flush=True)
+    subprocess.run(cmd, check=True, env=env, cwd=str(REPO_ROOT))
+    data = json.loads(out_path.read_text())
+    return {r["name"]: r for r in data.get("results", [])}
+
+
+def _fmt(x) -> str:
+    return f"{x:+.4f}" if isinstance(x, (int, float)) else "-"
+
+
+def _delta(on: dict, base: dict, key: str):
+    if key in on and key in base:
+        return round(on[key] - base[key], 4)
+    return None
+
+
+def _gate_report(label: str, base: dict, on: dict) -> tuple[str, bool | None]:
+    lines = [f"### `{label}` (env `{GATES[label]}`)", ""]
+    lines.append("| dataset | metric | OFF | ON | Δ |")
+    lines.append("|---|---|---:|---:|---:|")
+    target_recall_up = False
+    target_f1_up = False
+    target_precision_drop = False
+    target_recall_drop = False
+    dqbench_ok = True
+    for name in sorted(set(base) | set(on)):
+        b, o = base.get(name, {}), on.get(name, {})
+        if "composite" in b or "composite" in o:
+            d = _delta(o, b, "composite")
+            lines.append(f"| {name} | composite | {b.get('composite','-')} | {o.get('composite','-')} | {_fmt(d)} |")
+            if o.get("composite") is not None and o["composite"] < DQBENCH_FLOOR - 1.0:
+                dqbench_ok = False
+            continue
+        for m in ("f1", "precision", "recall"):
+            d = _delta(o, b, m)
+            lines.append(f"| {name} | {m} | {b.get(m,'-')} | {o.get(m,'-')} | {_fmt(d)} |")
+            if name in TARGET_DATASETS and d is not None:
+                if m == "recall" and d >= 0.005:
+                    target_recall_up = True
+                if m == "recall" and d <= -0.005:
+                    target_recall_drop = True
+                if m == "f1" and d >= 0.002:
+                    target_f1_up = True
+                if m == "precision" and d <= -0.005:
+                    target_precision_drop = True
+    # Advisory verdict against each gate's STATED criterion.
+    if label == "quality_aware_blocking":
+        # recall-up / no precision regression / DQbench non-regression
+        passed = target_recall_up and not target_precision_drop and dqbench_ok
+        crit = "recall up on a corruption set, precision flat, DQbench non-regression"
+    else:  # fd_negative_evidence
+        # F1/precision up / no recall loss / DQbench non-regression
+        passed = target_f1_up and not target_recall_drop and dqbench_ok
+        crit = "F1 up on a corruption set, no recall loss, DQbench non-regression"
+    verdict = "✅ CLEARS" if passed else "❌ does not clear"
+    lines += ["", f"**Advisory verdict: {verdict}** — criterion: {crit}.", ""]
+    return "\n".join(lines), passed
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--workdir", type=Path, default=REPO_ROOT / ".ab_quality_bridges")
+    ap.add_argument("--datasets-dir", type=Path, default=None)
+    ap.add_argument("--summary-md", type=Path, default=None,
+                    help="Write the markdown report here (e.g. $GITHUB_STEP_SUMMARY)")
+    args = ap.parse_args(argv)
+    args.workdir.mkdir(parents=True, exist_ok=True)
+
+    base = _run({}, args.workdir / "baseline.json", args.datasets_dir)
+    report = [
+        "# Quality-bridge A/B proving sweep",
+        "",
+        "Baseline = both gates OFF (current default). Each gate is then enabled in "
+        "isolation. Advisory verdicts apply each gate's stated proving criterion; "
+        "the maintainer makes the flip call from the deltas.",
+        "",
+    ]
+    any_clears = False
+    for label, var in GATES.items():
+        on = _run({var: "1"}, args.workdir / f"{label}.json", args.datasets_dir)
+        section, passed = _gate_report(label, base, on)
+        report.append(section)
+        any_clears = any_clears or bool(passed)
+
+    text = "\n".join(report)
+    print(text)
+    if args.summary_md:
+        with args.summary_md.open("a", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+    # Exit 0 always — this is a measurement, not a gate. The verdicts are advisory.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

First step of the "advance the v2.0 blockers" plan: build the evidence harness to decide flipping two env-gated **default-OFF** GoldenCheck→GoldenMatch bridges to default-ON.

**The two flip candidates:**
- **quality-aware blocking** (`GOLDENMATCH_QUALITY_AWARE_BLOCKING`) — recall lever; adds a fuzzy-tolerant blocking pass on columns with ≥2% variant rows.
- **FD-driven negative evidence** (`GOLDENMATCH_FD_NEGATIVE_EVIDENCE`) — precision lever; admits FD-anchor columns as negative evidence.

Both are gated "default OFF until the Febrl/DBLP-ACM/NCVR sweep proves it." This PR is that sweep.

**Deliberately not swept: quality-gated review.** It downgrades borderline auto-merges to a *human* review queue, so in a fully-automated benchmark it's recall-negative by construction. It's a correct *opt-in* safety feature for review workflows, not an automated-F1 default-flip candidate.

**What's here (no package behavior change):**
- `scripts/bench_quality_bridges.py` — runs `run_benchmarks.py` 3× (baseline both-off, then each gate on in isolation), emits a per-gate per-dataset delta table + an advisory verdict (quality-aware blocking: recall↑ / precision flat / DQbench non-regression; FD-NE: F1↑ / no recall loss / DQbench ≥ 91.04). Advisory only — exits 0; the maintainer flips from the deltas.
- `bench-quality-bridges.yml` — `workflow_dispatch`, gated on `vars.RUN_BENCHMARKS` (same posture as `benchmarks.yml`), posts the table to the step summary. Benchmarks OOM the dev box, so this runs in CI.

## Test Plan
- [x] `ruff` + `py_compile` clean; workflow YAML parses.
- [x] Verdict logic unit-checked against 4 mock cases (recall-up clears QAB; recall-flat doesn't; F1-up clears FD-NE; DQbench-regression doesn't).
- After merge: trigger the workflow on `main` → read the A/B table → **a follow-up PR flips the gates that clear** (default-on with the env var kept as a `=0` kill-switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)