### PR TITLE
fix(bench): fast Febrl3+NCVR quality-bridge A/B sweep (+ inert verdict)

### DIFF
--- a/.github/workflows/bench-quality-bridges.yml
+++ b/.github/workflows/bench-quality-bridges.yml
@@ -16,7 +16,9 @@ permissions:
 jobs:
   ab-sweep:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Febrl3 + NCVR-synthetic only (DQbench's ~41 min/run is dropped from the
+    # iterative A/B); 3 configs x 2 fast datasets + install fits comfortably.
+    timeout-minutes: 45
     permissions:
       contents: read
     steps:
@@ -55,9 +57,9 @@ jobs:
         shell: bash
         env:
           GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
-          # DBLP-ACM auto-pulls from Leipzig (override if it 404s); NCVR points
-          # at a hosted 10k sample if available, else the runner skips it.
-          GOLDENMATCH_DBLP_ACM_URL: ${{ vars.DBLP_ACM_URL }}
+          # NCVR points at a hosted 10k sample if the repo var is set; otherwise
+          # run_benchmarks.py falls back to the committed synthetic NCVR-shaped
+          # fixture (labelled "NCVR-synthetic"). DBLP-ACM is no longer swept.
           GOLDENMATCH_NCVR_SAMPLE_URL: ${{ vars.NCVR_SAMPLE_URL }}
         run: |
           set -euo pipefail

--- a/scripts/bench_quality_bridges.py
+++ b/scripts/bench_quality_bridges.py
@@ -13,10 +13,13 @@ The third bridge (quality-gated review) is deliberately NOT swept: it downgrades
 borderline auto-merges to a HUMAN review queue, so in a fully-automated benchmark
 it is recall-negative by construction. It stays opt-in for review workflows.
 
-Datasets: Febrl3 (synthetic PII corruption) + NCVR (voter corruption) are the
-proving ground -- these bridges target person-data typos/variants. DQbench is the
-non-regression guard (composite must hold >= ~91.04). DBLP-ACM is bibliographic
-(non-regression only -- the bridges should not move it).
+Datasets: Febrl3 (synthetic PII corruption) + NCVR (voter corruption; the
+committed synthetic NCVR-shaped fixture in CI) are the proving ground -- these
+bridges target person-data typos/variants. DQbench (~41 min/run) and DBLP-ACM
+(bibliographic; the bridges should not move it) are deliberately dropped from
+the iterative A/B: a 3-config sweep over them blew the CI 90-min cap for zero
+signal on these gates. If a DQbench ``composite`` result is ever present in the
+run, the verdict still guards it as a non-regression floor (see ``_gate_report``).
 
 Benchmarks OOM the dev box; run this in CI (``bench-quality-bridges.yml``). Each
 run honours ``run_benchmarks.py``'s dataset auto-pull / graceful-skip.
@@ -39,13 +42,20 @@ GATES = {
     "fd_negative_evidence": "GOLDENMATCH_FD_NEGATIVE_EVIDENCE",
 }
 # datasets the gate's stated criterion is judged on (person-data corruption).
-TARGET_DATASETS = {"Febrl3", "NCVR"}
-DQBENCH_FLOOR = 91.04  # v1.12 committed composite; the non-regression guard.
+# "NCVR-synthetic" is the CI fallback label when the real (gitignored) NCVR
+# sample is absent -- run_benchmarks.py labels it distinctly, so include both.
+TARGET_DATASETS = {"Febrl3", "NCVR", "NCVR-synthetic"}
+# Datasets swept per config. DQbench (~41 min) and DBLP-ACM are dropped -- see
+# the module docstring. NCVR still imports dqbench_adapters, so the workflow's
+# dqbench install stays even though "dqbench" is no longer a swept dataset.
+SWEEP_DATASETS = ("febrl3", "ncvr")
+DQBENCH_FLOOR = 91.04  # v1.12 committed composite; guarded only if present.
 
 
 def _run(gate_env: dict[str, str], out_path: Path, datasets_dir: Path | None) -> dict:
-    """Run the full benchmark suite once with ``gate_env`` applied; return the
-    parsed ``{name: result}`` map. Missing datasets are silently absent."""
+    """Run each ``SWEEP_DATASETS`` benchmark once with ``gate_env`` applied and
+    return the merged ``{name: result}`` map. One JSON artifact is written per
+    dataset (``<stem>-<dataset>.json``). Missing datasets are silently absent."""
     env = dict(os.environ)
     env["GOLDENMATCH_AUTOCONFIG_MEMORY"] = "0"  # clean numbers, no cross-run cache
     # Reset both gates off, then apply the requested overrides, so each run is
@@ -53,13 +63,18 @@ def _run(gate_env: dict[str, str], out_path: Path, datasets_dir: Path | None) ->
     for var in GATES.values():
         env[var] = "0"
     env.update(gate_env)
-    cmd = [sys.executable, str(RUNNER), "--datasets", "all", "--output", str(out_path)]
-    if datasets_dir is not None:
-        cmd += ["--datasets-dir", str(datasets_dir)]
-    print(f"[ab] running: {' '.join(f'{k}={v}' for k, v in gate_env.items()) or 'baseline'}", flush=True)
-    subprocess.run(cmd, check=True, env=env, cwd=str(REPO_ROOT))
-    data = json.loads(out_path.read_text())
-    return {r["name"]: r for r in data.get("results", [])}
+    label = " ".join(f"{k}={v}" for k, v in gate_env.items()) or "baseline"
+    merged: dict = {}
+    for ds in SWEEP_DATASETS:
+        ds_path = out_path.with_name(f"{out_path.stem}-{ds}.json")
+        cmd = [sys.executable, str(RUNNER), "--datasets", ds, "--output", str(ds_path)]
+        if datasets_dir is not None:
+            cmd += ["--datasets-dir", str(datasets_dir)]
+        print(f"[ab] running {ds}: {label}", flush=True)
+        subprocess.run(cmd, check=True, env=env, cwd=str(REPO_ROOT))
+        data = json.loads(ds_path.read_text())
+        merged.update({r["name"]: r for r in data.get("results", [])})
+    return merged
 
 
 def _fmt(x) -> str:
@@ -101,15 +116,18 @@ def _gate_report(label: str, base: dict, on: dict) -> tuple[str, bool | None]:
                     target_f1_up = True
                 if m == "precision" and d <= -0.005:
                     target_precision_drop = True
-    # Advisory verdict against each gate's STATED criterion.
+    # Advisory verdict against each gate's STATED criterion. dqbench_ok is True
+    # by default and only tightens if a DQbench composite happens to be present
+    # (it isn't in the default Febrl3+NCVR sweep), so the guard is a no-op floor.
+    guard = "" if dqbench_ok else ", DQbench REGRESSED"
     if label == "quality_aware_blocking":
-        # recall-up / no precision regression / DQbench non-regression
+        # recall-up / no precision regression / (DQbench non-regression if swept)
         passed = target_recall_up and not target_precision_drop and dqbench_ok
-        crit = "recall up on a corruption set, precision flat, DQbench non-regression"
+        crit = "recall up on a corruption set, precision flat" + guard
     else:  # fd_negative_evidence
-        # F1/precision up / no recall loss / DQbench non-regression
+        # F1/precision up / no recall loss / (DQbench non-regression if swept)
         passed = target_f1_up and not target_recall_drop and dqbench_ok
-        crit = "F1 up on a corruption set, no recall loss, DQbench non-regression"
+        crit = "F1 up on a corruption set, no recall loss" + guard
     verdict = "✅ CLEARS" if passed else "❌ does not clear"
     lines += ["", f"**Advisory verdict: {verdict}** — criterion: {crit}.", ""]
     return "\n".join(lines), passed


### PR DESCRIPTION
## Summary

The quality-bridge A/B proving sweep (`bench_quality_bridges.py`) ran `--datasets all`, which pulled **DQbench (~41 min/run)**. At 3 configs that blew the 90-min CI cap and the run was cancelled with no table.

This drops DQbench and DBLP-ACM from the iterative A/B and sweeps only the person-data corruption sets the bridges actually target — **Febrl3** and the synthetic **NCVR-shaped** fixture (`NCVR-synthetic`). `_run` now calls `run_benchmarks.py` once per dataset and merges; `TARGET_DATASETS` gains `NCVR-synthetic`; the DQbench composite non-regression guard stays but is a no-op floor unless a composite is present; workflow timeout 90 → 45. NCVR still imports `dqbench_adapters`, so the dqbench install step stays.

## Result (the point of the sweep)

Sweep now runs clean in **~9 min** (run `27472821512`, green). Verdict: **both gates are byte-identical no-ops** — every delta is `+0.0000` on Febrl3 and NCVR-synthetic, neither clears.

| gate | Febrl3 Δ | NCVR-synthetic Δ | verdict |
|---|---|---|---|
| `quality_aware_blocking` | +0.0000 | +0.0000 | ❌ does not clear |
| `fd_negative_evidence` | +0.0000 | +0.0000 | ❌ does not clear |

This is **not a wiring bug** — `test_already_tolerant_key_not_doubled` and `test_fd_anchor_admitted_when_enabled` prove each gate changes config on a triggering input. The gates fire correctly but have nothing to add here: auto-config already emits a fuzzy-tolerant `multi_pass` blocking scheme on these person datasets (quality-aware blocking skips already-covered keys), and there's no surrogate FD-anchor column that isn't already admitted via the name-identity path (FD-NE admits nothing new).

**Recommendation: keep both bridges default-OFF.** A default flip requires a measured benefit; there is none on the corruption datasets they target, and flipping quality-aware-blocking ON globally could add fuzzy passes on weaker-auto-config shapes with no benchmark coverage proving it's net-positive. This sweep is the recorded evidence.

## Test Plan
- [x] ruff clean, `py_compile` OK, workflow YAML parses
- [x] verdict logic re-validated on 6 mock cases (recall-up clears QAB; precision-drop fails; f1-up clears FD-NE; recall-drop fails; no-move fails; DQbench-regressed composite kills an otherwise-clear gate)
- [x] green CI sweep run `27472821512` (~9 min, well under the new 45-min cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)