### PR TITLE
fix: SQL-injection hardening in infermap DBProvider + Node 20→22 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,7 +836,7 @@ jobs:
         # That field MUST be exact semver (pnpm@9.15.0) — ranges error.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
         # cache: pnpm requires (a) pnpm on PATH (handled above) and
         # (b) pnpm-lock.yaml committed at repo root.
@@ -876,7 +876,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build WASM artifact (installs the matching wasm-bindgen-cli)
@@ -915,7 +915,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build WASM artifact (installs the matching wasm-bindgen-cli)
@@ -949,7 +949,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:

--- a/.github/workflows/publish-goldenanalysis-js.yml
+++ b/.github/workflows/publish-goldenanalysis-js.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 

--- a/.github/workflows/publish-goldencheck-js.yml
+++ b/.github/workflows/publish-goldencheck-js.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 

--- a/.github/workflows/publish-goldencheck-types-js.yml
+++ b/.github/workflows/publish-goldencheck-types-js.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 

--- a/.github/workflows/publish-goldenflow-js.yml
+++ b/.github/workflows/publish-goldenflow-js.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 

--- a/.github/workflows/publish-goldenmatch-js.yml
+++ b/.github/workflows/publish-goldenmatch-js.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 

--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:

--- a/.github/workflows/publish-goldenpipe-js.yml
+++ b/.github/workflows/publish-goldenpipe-js.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 

--- a/.github/workflows/publish-infermap-js.yml
+++ b/.github/workflows/publish-infermap-js.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "goldenmatch-monorepo",
   "private": true,
   "packageManager": "pnpm@9.15.0",
-  "engines": { "node": ">=20" },
+  "engines": { "node": ">=22" },
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test",

--- a/packages/python/infermap/infermap/providers/db.py
+++ b/packages/python/infermap/infermap/providers/db.py
@@ -97,10 +97,27 @@ def _parse_connection(uri: str) -> dict:
     raise InferMapError(f"Unsupported database scheme: {scheme!r}")
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier (table/column) by wrapping it in double quotes and
+    doubling any embedded quote -- the standard escaping for SQLite / Postgres /
+    DuckDB. Bound parameters (``?`` / ``%s``) can only bind VALUES, never
+    identifiers, so an interpolated identifier MUST be escaped this way to stay
+    injection-safe."""
+    return '"' + name.replace('"', '""') + '"'
+
+
 class DBProvider:
     """Extracts SchemaInfo from a database table."""
 
     def extract(self, source: Any, *, table: str, sample_size: int = _DEFAULT_SAMPLE_SIZE, **kwargs) -> SchemaInfo:
+        # Injection hardening for untrusted args: the table name is interpolated
+        # as a quoted identifier at each use (params can't bind identifiers), so
+        # it must be a string and is escaped via _quote_ident; sample_size is
+        # bound/interpolated as an int, so coerce it here -- a non-numeric string
+        # raises ValueError instead of reaching a query.
+        if not isinstance(table, str):
+            raise InferMapError(f"table must be a string, got {type(table).__name__}")
+        sample_size = int(sample_size)
         conn_info = _parse_connection(str(source))
         driver = conn_info["driver"]
 
@@ -153,16 +170,20 @@ class DBProvider:
             if cur.fetchone() is None:
                 raise InferMapError(f"Table {table!r} not found in SQLite database: {db_path}")
 
-            # Get column info via PRAGMA
-            pragma = conn.execute(f"PRAGMA table_info({table})").fetchall()
-            # PRAGMA columns: (cid, name, type, notnull, dflt_value, pk)
+            # Get column info via the parameterized pragma table-valued function
+            # (PRAGMA table_info(<ident>) can't bind a param; pragma_table_info(?)
+            # can, removing the only unquoted-identifier interpolation).
+            pragma = conn.execute(
+                "SELECT * FROM pragma_table_info(?)", (table,)
+            ).fetchall()
+            # pragma_table_info columns: (cid, name, type, notnull, dflt_value, pk)
 
             # Total row count
-            total = conn.execute(f"SELECT COUNT(*) FROM \"{table}\"").fetchone()[0]
+            total = conn.execute(f"SELECT COUNT(*) FROM {_quote_ident(table)}").fetchone()[0]
 
-            # Fetch sample rows
+            # Fetch sample rows (sample_size bound as a parameter)
             sample_rows = conn.execute(
-                f"SELECT * FROM \"{table}\" LIMIT {sample_size}"
+                f"SELECT * FROM {_quote_ident(table)} LIMIT ?", (sample_size,)
             ).fetchall()
             col_names = [row[1] for row in pragma]
             col_types = [row[2] for row in pragma]
@@ -171,7 +192,7 @@ class DBProvider:
             for col_idx, (col_name, col_type) in enumerate(zip(col_names, col_types)):
                 # Null count for this column
                 null_count = conn.execute(
-                    f"SELECT COUNT(*) FROM \"{table}\" WHERE \"{col_name}\" IS NULL"
+                    f"SELECT COUNT(*) FROM {_quote_ident(table)} WHERE {_quote_ident(col_name)} IS NULL"
                 ).fetchone()[0]
 
                 null_rate = null_count / total if total > 0 else 0.0
@@ -231,11 +252,11 @@ class DBProvider:
                 raise InferMapError(f"Table '{table}' not found or has no columns")
 
             # Total row count
-            cur.execute(f'SELECT COUNT(*) FROM "{table}"')
+            cur.execute(f'SELECT COUNT(*) FROM {_quote_ident(table)}')
             total = cur.fetchone()[0]
 
             # Sample rows
-            cur.execute(f'SELECT * FROM "{table}" LIMIT %s', (sample_size,))
+            cur.execute(f'SELECT * FROM {_quote_ident(table)} LIMIT %s', (sample_size,))
             sample_rows = cur.fetchall()
 
             fields = []
@@ -288,10 +309,13 @@ class DBProvider:
                 raise InferMapError(f"Table '{table}' not found in DuckDB: {db_path}")
 
             # Total count
-            total = conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+            total = conn.execute(f'SELECT COUNT(*) FROM {_quote_ident(table)}').fetchone()[0]
 
-            # Sample
-            sample_rows = conn.execute(f'SELECT * FROM "{table}" USING SAMPLE {sample_size}').fetchall()
+            # Sample (sample_size is int-coerced in extract(), so safe to inline --
+            # DuckDB's USING SAMPLE clause does not accept a bound parameter)
+            sample_rows = conn.execute(
+                f'SELECT * FROM {_quote_ident(table)} USING SAMPLE {sample_size}'
+            ).fetchall()
 
             fields = []
             for col_idx, (col_name, data_type) in enumerate(result):

--- a/packages/python/infermap/tests/test_providers/test_db_injection.py
+++ b/packages/python/infermap/tests/test_providers/test_db_injection.py
@@ -1,0 +1,91 @@
+"""SQL-injection hardening regression tests for DBProvider.
+
+SQLite-only (stdlib) and deliberately in their OWN file: test_db.py gates the
+whole module behind a top-level ``importorskip("psycopg2")``, so its sqlite
+cases don't run in the infermap CI lane (which installs only ``.[dev]``). These
+must run unconditionally — they guard the parameterization/identifier-quoting in
+providers/db.py.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from infermap.errors import InferMapError
+from infermap.providers.db import DBProvider, _quote_ident
+
+
+@pytest.fixture
+def sqlite_db(tmp_path):
+    db_path = tmp_path / "inj.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE contacts (id INTEGER PRIMARY KEY, name TEXT)")
+    conn.executemany(
+        "INSERT INTO contacts (id, name) VALUES (?, ?)",
+        [(1, "Alice"), (2, "Bob"), (3, "Carol")],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _uri(db_path: Path) -> str:
+    return f"sqlite:///{db_path}"
+
+
+def _table_exists(db_path: Path, table: str) -> bool:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def test_quote_ident_doubles_embedded_quotes():
+    assert _quote_ident("plain") == '"plain"'
+    assert _quote_ident('we"ird') == '"we""ird"'
+    # The classic break-out attempt is neutralised: the payload becomes a single
+    # (absurd) quoted identifier, not closeable SQL.
+    assert _quote_ident('x" ; DROP TABLE t; --') == '"x"" ; DROP TABLE t; --"'
+
+
+def test_malicious_sample_size_is_rejected_not_executed(sqlite_db):
+    """A non-numeric sample_size must raise (int coercion in extract) rather than
+    reach a query — and the table must be untouched."""
+    with pytest.raises((ValueError, InferMapError)):
+        DBProvider().extract(
+            _uri(sqlite_db), table="contacts", sample_size="100; DROP TABLE contacts"
+        )
+    assert _table_exists(sqlite_db, "contacts")
+
+
+def test_non_string_table_is_rejected(sqlite_db):
+    with pytest.raises(InferMapError):
+        DBProvider().extract(_uri(sqlite_db), table=12345)  # type: ignore[arg-type]
+
+
+def test_injection_table_name_does_not_execute(sqlite_db):
+    """An injection-style table name doesn't match a real table, so the
+    parameterized existence check raises — no DROP runs."""
+    with pytest.raises(InferMapError):
+        DBProvider().extract(
+            _uri(sqlite_db), table='contacts"; DROP TABLE contacts; --'
+        )
+    assert _table_exists(sqlite_db, "contacts")
+
+
+def test_table_name_with_embedded_quote_round_trips(sqlite_db):
+    """A real table whose name contains a double quote extracts correctly —
+    proving the identifier escaping (not just rejection) is sound."""
+    conn = sqlite3.connect(str(sqlite_db))
+    conn.execute('CREATE TABLE "we""ird" (a INTEGER, b TEXT)')
+    conn.execute('INSERT INTO "we""ird" VALUES (1, \'x\'), (2, \'y\')')
+    conn.commit()
+    conn.close()
+
+    schema = DBProvider().extract(_uri(sqlite_db), table='we"ird')
+    assert {f.name for f in schema.fields} == {"a", "b"}


### PR DESCRIPTION
## Summary

Fixes the two **genuine** findings from the audit (the turbo-cache one was already fixed in #894; the Fellegi-Sunter "only integration-tested" claim was overstated — the discrete weight math has direct unit assertions like `match_weights["zip"] == [-3.0, 3.0]`, so a flipped operator would fail, not ship green).

### Commit 1 — SQL-injection hardening in `infermap/providers/db.py`
The provider interpolated identifiers and values straight into SQL. Worst spots: the **SQLite** path ran `PRAGMA table_info({table})` with *no quoting* and `LIMIT {sample_size}` raw; **DuckDB** inlined `USING SAMPLE {sample_size}` — while the **Postgres** sibling already bound its `LIMIT`, the exact asymmetry the audit flagged. Closed consistently across all three drivers:
- `extract()` now rejects a non-string `table` and coerces `sample_size` to `int` (a non-numeric string raises before any query runs).
- New `_quote_ident()` (double-quote + double embedded quotes) used for **every** interpolated table/column identifier — bound params can't bind identifiers.
- SQLite: `PRAGMA` → parameterized `SELECT * FROM pragma_table_info(?)`; `LIMIT ?` bound.
- Postgres/DuckDB: identifiers via `_quote_ident`; values stay bound/int-coerced.

**Also fixes a test-trust gap:** `test_db.py` gates the whole module behind a top-level `importorskip("psycopg2")`, so its sqlite cases never run in the infermap CI lane (which installs only `.[dev]`). Added `tests/test_providers/test_db_injection.py` — **sqlite-only**, so the hardening is actually CI-covered. (Left the existing module-gating alone to keep this PR focused; worth a follow-up.)

### Commit 2 — Node 20 → 22 (Node 20 EOL'd 2026-04-30)
Node 20 "Iron" reached end-of-life on **2026-04-30** (no more security updates). Bumped every CI/publish runner + the workspace engines floor to Node 22 "Jod" (Active LTS, EOL 2027-04-30): `ci.yml` (×4), the 8 `publish-*` workflows, and root `package.json` `engines.node`.

> Did **not** touch Debian "bookworm" (the audit's other EOL item): it appears only as the official `postgres:16-bookworm` image base, and Debian 12 has LTS security support through ~2028 — it is **not** past EOL.

## Test Plan
- [x] `infermap` db tests green locally: existing `test_db.py` **20 passed** (sqlite/pg-mocked/duckdb), new `test_db_injection.py` **5 passed** (quote escaping, malicious `sample_size` rejected, non-string table rejected, injection table name raises without executing, embedded-quote table round-trips).
- [x] `ruff` + `py_compile` clean on `db.py` and the new test.
- [x] All 9 touched workflows parse; `package.json` valid JSON.
- [x] Verified locally that `pragma_table_info(?)` binds correctly (even for a quote-laden table name) and `int("100; DROP…")` raises.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_