### PR TITLE
Lance bake-off, run for real: fair block_filter, isolated RSS, real gather sparsity

### DIFF
--- a/docs/superpowers/specs/2026-06-13-lance-vs-parquet-candidate-retrieval-design.md
+++ b/docs/superpowers/specs/2026-06-13-lance-vs-parquet-candidate-retrieval-design.md
@@ -85,6 +85,70 @@ config/env flag, feeding only the ANN-gather step. We do **not** replace Parquet
 as the interchange format (Ray, object-storage connectors, and the bench release
 assets all stay Parquet).
 
+## Results (measured 2026-06-13)
+
+Run on a fresh sandbox: polars 1.41, pyarrow 24, lance 7.0, numpy 2.4. Two
+methodology fixes landed before trusting numbers: **(a)** a BTREE scalar index on
+`block_key` for the Lance `block_filter` (the first pass handicapped Lance with no
+index against sorted-Parquet); **(b)** peak RSS via `/proc/self/status` `VmHWM`
+instead of `resource.ru_maxrss` — a spawned child inherits the parent's
+`ru_maxrss` high-water mark, so the first pass reported an identical (bogus)
+3560 MB for every pattern. Both are in `scripts/bench_lance_vs_parquet.py`.
+
+**Bench, N = 10M, 5-run median wall (x = Lance vs Parquet, RSS = VmHWM peak):**
+
+| Pattern | Parquet | Lance | x-factor | Parquet RSS | Lance RSS |
+|---|---:|---:|---|---:|---:|
+| `full_scan` | 267 ms | 674 ms | 0.4x (slower) | 1379 MB | 1497 MB |
+| `block_filter` (no index) | 4.3 ms | 159 ms | 0.03x | 78 MB | 379 MB |
+| `block_filter` (BTREE idx) | 4.3 ms | **8.2 ms** | 0.5x | 78 MB | 190 MB |
+| `scatter_take` K/N=1e-5 (K=100) | 248 ms | **9.1 ms** | **27.3x** | 1381 MB | **178 MB** |
+| `scatter_take` K/N=1e-4 (K=1k) | 239 ms | **41 ms** | **5.8x** | 1362 MB | 192 MB |
+| `scatter_take` K/N=1e-3 (K=10k) | 246 ms | 186 ms | 1.3x | 1375 MB | 321 MB |
+| `scatter_take` K/N=1e-2 (K=100k) | 265 ms | 482 ms | 0.5x | 1374 MB | 686 MB |
+
+Write/disk: Parquet 1.2 s / 183 MB; Lance 1.2 s / 412 MB (**2.3x larger**); BTREE
+index build 1.7 s.
+
+Two findings the fixes surfaced: the scalar index turns `block_filter` from ~37x
+slower into a single-digit-ms near-tie (the earlier "disaster" was the missing
+index); and on sparse gathers Lance uses **~8x less memory** (178 MB vs 1381 MB at
+K/N=1e-5) because Parquet must scan the whole column to gather a handful of rows
+while Lance reads only the covering pages. Lance's `scatter_take` advantage grows
+without bound as the gather gets sparser (1.3x → 5.8x → 27x as K/N → 1e-5).
+
+**Real gather sparsity (`scripts/measure_ann_gather_sparsity.py`, auto-configured
+blocker on `realistic_person_df`):** member-weighted median K/N = **3e-5 at 100K
+rows, 3e-6 at 1M** — both deep in Lance's win zone. At 100K (a coarse `first_name`
+pass creates a tail: p99=70, max=419) the gathered-row split is win 50% /
+marginal 43% / loss 7%; at 1M the synthetic 3-record identities give uniform
+3-row blocks (100% win). Caveat: synthetic identities understate the real
+heavy-tail — production surname/zip skew would push more gathered rows toward the
+loss zone.
+
+### Verdict — the gate splits by access pattern
+
+The original gate (`scatter_take >= 5x at K/N <= 1e-3` **and** `full_scan` /
+`block_filter` within 1.2x) is **not met for the batch dedup pipeline**:
+`full_scan` is 0.4x and Lance writes 2.3x more disk. Crucially, batch dedup
+*eventually gathers every row* (every block is scored), so cumulatively it is a
+full scan — Lance's per-row-address `take` cannot help, and its bigger files +
+slower scan make it a net loss. **Do not put Lance on the batch pipeline.**
+
+But the same numbers make Lance a **strong fit for the sparse one-shot retrieval
+path** — `core/match_one.py`, `core/streaming.py`, the `incremental` CLI, and the
+Postgres ANN-index path — where you hold a large base on disk and fetch only the
+ANN candidate rows per query (K/N ≈ 1e-5..1e-4 in the measured blocking): **6–27x
+faster and ~8x less memory**, with `full_scan` simply never on the critical path
+there. That is a different, smaller, opt-in integration than the spec first
+scoped (a Lance-backed base store for incremental matching, not a Lance writer in
+the batch loader).
+
+**Recommendation:** reject Lance for batch dedup; open a focused follow-up spike
+for a Lance-backed base store behind `match_one`/`streaming`/`incremental`,
+measured on a real skewed dataset (not synthetic 3-record identities) before any
+adoption.
+
 ## Risks / unknowns
 
 - **Format lock-in & ops.** Lance is younger than Parquet; the bench-dataset

--- a/packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py
+++ b/packages/python/goldenmatch/scripts/bench_lance_vs_parquet.py
@@ -83,10 +83,17 @@ def write_formats(df, root: Path) -> dict[str, Path]:
 
     if _have("lance"):
         import lance
+        import pyarrow as pa
 
         lpath = root / "dataset.lance"
+        # Polars exports Utf8 as Arrow `large_string`, which Lance's BTREE scalar
+        # index rejects. Cast block_key (the indexed column) to plain `string`.
+        tbl = df.to_arrow()
+        if pa.types.is_large_string(tbl.schema.field("block_key").type):
+            ci = tbl.schema.get_field_index("block_key")
+            tbl = tbl.set_column(ci, "block_key", tbl.column("block_key").cast(pa.string()))
         t0 = time.perf_counter()
-        lance.write_dataset(df.to_arrow(), str(lpath))
+        lance.write_dataset(tbl, str(lpath))
         size = sum(f.stat().st_size for f in lpath.rglob("*") if f.is_file())
         print(f"  lance   write: {time.perf_counter() - t0:6.2f}s  size={size / 1e6:8.1f} MB")
         paths["lance"] = lpath
@@ -141,14 +148,49 @@ def _lance_take(path: Path, idx):
     return ds.take(list(idx), columns=SCORE_COLS).num_rows
 
 
+# Same scan as _lance_block; the scanner transparently uses a BTREE scalar
+# index on block_key if one was built (the indexed variant).
+_lance_block_idx = _lance_block
+
+
+def build_lance_scalar_index(path: Path, column: str = "block_key") -> float:
+    """Build a BTREE scalar index on `column`; return wall seconds."""
+    import lance
+
+    ds = lance.dataset(str(path))
+    t0 = time.perf_counter()
+    ds.create_scalar_index(column, "BTREE")
+    return time.perf_counter() - t0
+
+
 WORKLOADS = {
     ("parquet", "full_scan"): _parquet_full,
     ("parquet", "block_filter"): _parquet_block,
     ("parquet", "scatter_take"): _parquet_take,
     ("lance", "full_scan"): _lance_full,
     ("lance", "block_filter"): _lance_block,
+    ("lance", "block_filter_idx"): _lance_block_idx,
     ("lance", "scatter_take"): _lance_take,
 }
+
+
+def _peak_rss_mb() -> float:
+    """Peak resident set of THIS process, in MB.
+
+    Use /proc/self/status VmHWM on Linux: a spawned child's
+    ``resource.ru_maxrss`` inherits the PARENT's high-water mark (verified —
+    every child floored at the parent's peak), so it cannot isolate per-read
+    footprint. VmHWM is per-process correct. Fall back to ru_maxrss elsewhere.
+    """
+    try:
+        with open("/proc/self/status") as fh:
+            for line in fh:
+                if line.startswith("VmHWM:"):
+                    return int(line.split()[1]) / 1024.0  # kB -> MB
+    except OSError:
+        pass
+    raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return raw / 1024.0 / 1024.0 if sys.platform == "darwin" else raw / 1024.0
 
 
 def _child(q, fn_key, path_str, arg, runs):
@@ -163,9 +205,7 @@ def _child(q, fn_key, path_str, arg, runs):
         else:
             fn(path, arg)
         walls.append(time.perf_counter() - t0)
-    rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-    rss_mb = rss_kb / 1024.0 if sys.platform != "darwin" else rss_kb / 1024.0 / 1024.0
-    q.put((statistics.median(walls), min(walls), rss_mb))
+    q.put((statistics.median(walls), min(walls), _peak_rss_mb()))
 
 
 def measure(engine, pattern, path: Path, arg, runs: int):
@@ -235,16 +275,25 @@ def main() -> int:
     # full_scan
     res = {e: measure(e, "full_scan", paths[e], None, args.runs) for e in engines}
     row("full_scan", res)
-    # block_filter
+    # block_filter — parquet (sorted) vs lance UN-indexed first (apples-to-apples
+    # on raw scan), then lance WITH a BTREE scalar index built on block_key.
     res = {e: measure(e, "block_filter", paths[e], top_key, args.runs) for e in engines}
     row("block_filter", res)
+    if has_lance:
+        try:
+            idx_build_s = build_lance_scalar_index(paths["lance"])
+            print(f"  (built lance BTREE scalar index on block_key in {idx_build_s:.2f}s)")
+            lance_idx = measure("lance", "block_filter_idx", paths["lance"], top_key, args.runs)
+            row("block_filter (idx)", {"parquet": res["parquet"], "lance": lance_idx})
+        except Exception as e:  # noqa: BLE001 - index API drift shouldn't abort the run
+            print(f"  (lance scalar index step skipped: {type(e).__name__}: {e})")
     # scatter_take across fractions
     for frac, idx in cand_sets.items():
         res = {e: measure(e, "scatter_take", paths[e], idx, args.runs) for e in engines}
         row(f"scatter_take {frac:g} (K={len(idx)})", res)
 
     print("=" * 78)
-    print("cells: median-wall  (lance x-factor vs parquet)  peak-RSS")
+    print("cells: median-wall  (lance x-factor vs parquet)  peak-RSS (VmHWM)")
     print("decision gate (see spec): adopt only if scatter_take >= 5x at frac<=1e-3 on >=10M rows,")
     print("and full_scan/block_filter within ~1.2x of parquet.")
 

--- a/packages/python/goldenmatch/scripts/measure_ann_gather_sparsity.py
+++ b/packages/python/goldenmatch/scripts/measure_ann_gather_sparsity.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Measure GoldenMatch's real candidate-gather sparsity (block size / N).
+
+The Lance-vs-Parquet bake-off (scripts/bench_lance_vs_parquet.py) found Lance's
+random `take` beats Parquet only when the gather is very sparse: ~6x at
+K/N=1e-4, parity by 1e-3, a loss by 1e-2. So whether a Lance-backed on-disk
+candidate-retrieval path would pay off reduces to ONE empirical question:
+
+    how sparse is a real block relative to the dataset?  (K/N, where K = block
+    size, N = total rows)
+
+This script answers it by running the ACTUAL blocker (auto-configured) on a
+representative person dataset and reporting the K/N distribution, both
+block-count-weighted and MEMBER-weighted (member-weighted is what matters —
+scoring cost and rows-gathered concentrate in the big blocks, not the many
+tiny ones).
+
+Maps each block onto the bake-off crossover:
+    K/N <= 1e-4  -> Lance big win (~6x)
+    1e-4..1e-3   -> marginal / parity
+    > 1e-3       -> Lance loss
+
+Usage:
+    python scripts/measure_ann_gather_sparsity.py --rows 100000 1000000
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+from pathlib import Path
+
+# Keep auto-config hermetic/offline for a measurement run.
+os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+
+# Make the in-repo fixture generator importable.
+_PKG = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_PKG / "tests" / "fixtures"))
+
+# Crossover thresholds read straight off the bake-off curve.
+WIN = 1e-4   # <= this: Lance ~6x
+PAR = 1e-3   # <= this: marginal; above: Lance loses
+
+
+def _bucket(kn: float) -> str:
+    if kn <= WIN:
+        return "win (<=1e-4)"
+    if kn <= PAR:
+        return "marginal (<=1e-3)"
+    return "loss (>1e-3)"
+
+
+def measure(rows: int) -> None:
+    import polars as pl  # noqa: F401
+    from goldenmatch import auto_configure_df
+    from goldenmatch.core.blocker import build_blocks
+    from realistic_person import realistic_person_df
+
+    df = realistic_person_df(rows)
+    n = df.height
+    config = auto_configure_df(df)
+    # The pipeline injects __row_id__ before blocking; some strategies
+    # (learned/ann) read it. Add it for a standalone build_blocks call.
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__")
+    blocking = getattr(config, "blocking", None)
+    if blocking is None:
+        print(f"rows={rows:,}: auto-config produced no blocking; skipping")
+        return
+
+    if blocking.passes:
+        keys = [list(k.fields) for k in blocking.passes]
+    elif blocking.keys:
+        keys = [list(k.fields) for k in blocking.keys]
+    else:
+        keys = []
+
+    blocks = build_blocks(df.lazy(), blocking)
+    sizes = []
+    for b in blocks:
+        try:
+            sizes.append(b.df.select(pl.len()).collect().item())
+        except Exception:
+            pass
+    # Only multi-record blocks generate candidate pairs / gathers worth a take.
+    sizes = [s for s in sizes if s >= 2]
+    if not sizes:
+        print(f"rows={rows:,}: no multi-record blocks")
+        return
+
+    sizes.sort()
+    total_members = sum(sizes)
+
+    def pct(p: float) -> int:
+        i = min(len(sizes) - 1, int(p * len(sizes)))
+        return sizes[i]
+
+    p50, p95, p99, mx = pct(0.50), pct(0.95), pct(0.99), sizes[-1]
+
+    # Block-count-weighted and member-weighted bucket shares.
+    by_count = {"win (<=1e-4)": 0, "marginal (<=1e-3)": 0, "loss (>1e-3)": 0}
+    by_member = {"win (<=1e-4)": 0, "marginal (<=1e-3)": 0, "loss (>1e-3)": 0}
+    for s in sizes:
+        b = _bucket(s / n)
+        by_count[b] += 1
+        by_member[b] += s
+
+    # Member-weighted median K/N: the K/N a randomly chosen GATHERED row sees.
+    member_kn = []
+    for s in sizes:
+        member_kn.extend([s / n] * min(s, 1000))  # cap expansion for huge blocks
+    member_median_kn = statistics.median(member_kn)
+
+    print("=" * 70)
+    print(f"rows N = {n:,}   keys = {keys}")
+    print(f"multi-record blocks = {len(sizes):,}   total gathered members = {total_members:,}")
+    print(f"block size:  p50={p50}  p95={p95}  p99={p99}  max={mx}")
+    print(f"K/N      :  p50={p50/n:.2e}  p95={p95/n:.2e}  p99={p99/n:.2e}  max={mx/n:.2e}")
+    print(f"member-weighted median K/N = {member_median_kn:.2e}  -> {_bucket(member_median_kn)}")
+    print("-" * 70)
+    print(f"{'bucket':<20} {'% of blocks':>14} {'% of gathered rows':>20}")
+    for b in ("win (<=1e-4)", "marginal (<=1e-3)", "loss (>1e-3)"):
+        print(
+            f"{b:<20} {100*by_count[b]/len(sizes):>13.1f}% "
+            f"{100*by_member[b]/total_members:>19.1f}%"
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rows", type=int, nargs="+", default=[100_000, 1_000_000])
+    args = ap.parse_args()
+    print("Gather-sparsity vs Lance crossover (win<=1e-4, marginal<=1e-3, loss>1e-3)\n")
+    for r in args.rows:
+        measure(r)
+    print("=" * 70)
+    print("Read with the bake-off: a high MEMBER-weighted share in 'loss' means the")
+    print("rows that actually get gathered live in dense blocks where Parquet wins;")
+    print("a high share in 'win' means a Lance take-path would pay off on real work.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Follow-up to #891. The spike is now **executed with real numbers** (polars 1.41 / pyarrow 24 / lance 7.0), the two known unfairnesses are fixed, and the verdict is recorded in the spec.

## Part 1 — made the bench fair
- **Lance `block_filter` was handicapped** (raw scan vs sorted-Parquet's row-group skip). Added a BTREE scalar index on `block_key`; the bench now reports before/after.
- **Peak-RSS was bogus** — a spawned child inherits the parent's `resource.ru_maxrss` high-water mark, so every pattern reported an identical 3560 MB. Now measured via `/proc/self/status` `VmHWM` (verified: noop=13MB, import=147MB, readfull=137MB per child).

## Part 2 — measured the real gather sparsity
`scripts/measure_ann_gather_sparsity.py` runs the auto-configured blocker on `realistic_person_df` and maps the block-size K/N distribution onto the bake-off crossover. Member-weighted median K/N = **3e-5 (100K) → 3e-6 (1M)** — deep in Lance's win zone (caveat: synthetic 3-record identities understate real heavy-tail skew).

## Numbers (10M rows, 5-run median wall)

| Pattern | Parquet | Lance | x |
|---|---:|---:|---|
| full_scan | 267 ms | 674 ms | 0.4x |
| block_filter (no idx) | 4.3 ms | 159 ms | 0.03x |
| **block_filter (BTREE idx)** | 4.3 ms | **8.2 ms** | 0.5x (near-tie) |
| **scatter_take K/N=1e-5** | 248 ms | **9.1 ms** | **27.3x** + ~8x less RAM |
| scatter_take K/N=1e-4 | 239 ms | 41 ms | 5.8x |
| scatter_take K/N=1e-3 | 246 ms | 186 ms | 1.3x |
| scatter_take K/N=1e-2 | 265 ms | 482 ms | 0.5x |

Disk: Lance 412 MB vs Parquet 183 MB (2.3x larger).

## Verdict (recorded in the spec)
The decision gate **splits by access pattern**:
- ❌ **Batch dedup** — eventually gathers *every* row (every block scored) → cumulatively a full scan, where Lance is 0.4x and writes 2.3x more disk. **Reject.**
- ✅ **Sparse one-shot retrieval** (`match_one` / `streaming` / `incremental` / Postgres-ANN) — fetch only ANN candidate rows per query at K/N ≈ 1e-5..1e-4 → **6–27x faster + ~8x less memory**, `full_scan` never on the critical path. **Pursue as a focused follow-up**, measured on a real skewed dataset.

The index fix overturned the earlier "block_filter is a disaster" read, and the RSS fix surfaced Lance's large memory advantage on sparse gathers — neither was visible in #891's first pass.

Draft pending your call on whether to open the `match_one`-on-Lance follow-up spike.

https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr)_