### PR TITLE
ci: automate the CLAUDE.md gotchas — version-lockstep gate, Dependabot coverage, JS publish dedup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,12 @@ updates:
       python-dev:
         dependency-type: "development"
 
-  # TypeScript — goldenmatch-js package
+  # TypeScript — the pnpm workspace (one root pnpm-lock.yaml covers every
+  # member under packages/typescript/*). The old "/packages/goldenmatch-js"
+  # path did not exist, so Dependabot covered NO TS package; "/" (the lockfile
+  # root) covers the whole workspace.
   - package-ecosystem: "npm"
-    directory: "/packages/goldenmatch-js"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -41,6 +44,27 @@ updates:
           - "patch"
       ts-dev:
         dependency-type: "development"
+
+  # Rust — every crate under packages/rust/extensions/* (15+ crates: native
+  # accelerators, FFI UDFs, score/graph/fingerprint cores, wasm, pgrx, embed).
+  # Previously UNCOVERED, so crate CVE bumps (e.g. pyo3) were hand-planned.
+  - package-ecosystem: "cargo"
+    directories:
+      - "/packages/rust/extensions/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      rust-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/_publish-js.yml
+++ b/.github/workflows/_publish-js.yml
@@ -1,0 +1,100 @@
+# Reusable npm-publish template for the TypeScript packages. Each
+# packages/typescript/<pkg> has a thin `publish-<pkg>-js.yml` caller that fires
+# on its `<pkg>-js-v*` tag and delegates here — so this single body replaces the
+# ~70 near-identical lines that used to be copy-pasted across 7 workflows.
+#
+# Every TS package's dir name == its package.json `name` == its tag prefix base,
+# so one `package` input parameterizes the working dir, the turbo filter, and the
+# tag check. `build_deps` reproduces the per-package "Build workspace deps" step
+# exactly (only the packages that had it pass true).
+name: _publish-js (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: "TS package dir under packages/typescript/ (== package.json name == tag prefix base)"
+        required: true
+        type: string
+      build_deps:
+        description: "Pre-build this package's workspace dependencies (turbo --filter=<pkg>^...) before typecheck/build"
+        required: false
+        type: boolean
+        default: false
+      ref:
+        description: "Tag or commit to build (default: the triggering ref)"
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Pack and validate without publishing"
+        required: false
+        type: string
+        default: "false"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/typescript/${{ inputs.package }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
+
+      # Composing packages must build their workspace deps first so typecheck/
+      # test/build can resolve the deps' dist entrypoints.
+      - name: Build workspace deps
+        if: inputs.build_deps
+        working-directory: ${{ github.workspace }}
+        run: pnpm turbo run build --filter=${{ inputs.package }}^...
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify version matches tag
+        if: startsWith(github.ref, format('refs/tags/{0}-js-v', inputs.package))
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/${{ inputs.package }}-js-v}"
+          PKG_VERSION=$(jq -r .version package.json)
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - name: Pack (dry-run validation)
+        if: inputs.dry_run == 'true'
+        run: pnpm pack
+
+      - name: Publish to npm
+        if: inputs.dry_run != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --provenance --no-git-checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1892,6 +1892,23 @@ jobs:
       - run: uv sync --all-packages
       - run: uv run pyright
 
+  # Enforce per-package version lockstep across every file that declares it
+  # (pyproject / __init__ / server.json / Cargo.toml). The CLAUDE.md gotchas
+  # documented this rule but nothing enforced it -- goldenflow shipped 1.1.x
+  # drifted. No `if:` gate: a drift can be introduced by any change and the
+  # check is stdlib-only (~1s), so it always runs.
+  version_consistency:
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+      - name: Enforce per-package version lockstep
+        run: python scripts/check_version_consistency.py
+
   readme_callouts:
     needs: changes
     if: needs.changes.outputs.readme_callouts == 'true'
@@ -1967,6 +1984,7 @@ jobs:
       - distributed
       - sail
       - pyright
+      - version_consistency
       - readme_callouts
       - ts_parity_freshness
     if: always()

--- a/.github/workflows/publish-goldenanalysis-js.yml
+++ b/.github/workflows/publish-goldenanalysis-js.yml
@@ -1,5 +1,6 @@
 name: Publish goldenanalysis to npm
 
+# Thin caller -> .github/workflows/_publish-js.yml (the shared template).
 on:
   push:
     tags:
@@ -10,7 +11,7 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
-      dry-run:
+      dry_run:
         description: "Pack and validate without publishing"
         required: false
         default: "false"
@@ -21,55 +22,10 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/typescript/goldenanalysis
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-
-      - name: Install dependencies
-        working-directory: ${{ github.workspace }}
-        run: pnpm install --frozen-lockfile
-
-      # goldenanalysis-js is standalone (only `commander`; no workspace deps), so
-      # there is nothing to pre-build — go straight to typecheck/test/build.
-      - name: Typecheck
-        run: pnpm exec tsc --noEmit
-
-      - name: Test
-        run: pnpm exec vitest run
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Verify version matches tag
-        if: startsWith(github.ref, 'refs/tags/goldenanalysis-js-v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/goldenanalysis-js-v}"
-          PKG_VERSION=$(jq -r .version package.json)
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "Version OK: $PKG_VERSION"
-
-      - name: Pack (dry-run validation)
-        if: github.event.inputs.dry-run == 'true'
-        run: pnpm pack
-
-      - name: Publish to npm
-        if: github.event.inputs.dry-run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --provenance --no-git-checks
+    uses: ./.github/workflows/_publish-js.yml
+    with:
+      package: goldenanalysis
+      build_deps: false
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldencheck-js.yml
+++ b/.github/workflows/publish-goldencheck-js.yml
@@ -1,5 +1,6 @@
 name: Publish goldencheck to npm
 
+# Thin caller -> .github/workflows/_publish-js.yml (the shared template).
 on:
   push:
     tags:
@@ -10,7 +11,7 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
-      dry-run:
+      dry_run:
         description: "Pack and validate without publishing"
         required: false
         default: "false"
@@ -21,62 +22,10 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/typescript/goldencheck
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-
-      - name: Install dependencies
-        working-directory: ${{ github.workspace }}
-        run: pnpm install --frozen-lockfile
-
-      # goldencheck depends on goldencheck-types (workspace:^); it must be built
-      # before goldencheck's typecheck/test/build resolve its dist entrypoint.
-      - name: Build workspace deps
-        working-directory: ${{ github.workspace }}
-        run: pnpm turbo run build --filter=goldencheck^...
-
-      - name: Typecheck
-        run: pnpm exec tsc --noEmit
-
-      - name: Test
-        run: pnpm exec vitest run
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Verify version matches tag
-        if: startsWith(github.ref, 'refs/tags/goldencheck-js-v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/goldencheck-js-v}"
-          PKG_VERSION=$(jq -r .version package.json)
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "Version OK: $PKG_VERSION"
-
-      - name: Pack (dry-run validation)
-        if: github.event.inputs.dry-run == 'true'
-        # pnpm pack always writes a .tgz; running it in dry-run validates the
-        # package can be packed cleanly (file list, entry points, version)
-        # without publishing. The artifact is discarded on job teardown.
-        run: pnpm pack
-
-      - name: Publish to npm
-        if: github.event.inputs.dry-run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --provenance --no-git-checks
+    uses: ./.github/workflows/_publish-js.yml
+    with:
+      package: goldencheck
+      build_deps: true
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldencheck-types-js.yml
+++ b/.github/workflows/publish-goldencheck-types-js.yml
@@ -1,5 +1,6 @@
 name: Publish goldencheck-types to npm
 
+# Thin caller -> .github/workflows/_publish-js.yml (the shared template).
 on:
   push:
     tags:
@@ -10,7 +11,7 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
-      dry-run:
+      dry_run:
         description: "Pack and validate without publishing"
         required: false
         default: "false"
@@ -21,53 +22,10 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/typescript/goldencheck-types
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-
-      - name: Install dependencies
-        working-directory: ${{ github.workspace }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Typecheck
-        run: pnpm exec tsc --noEmit
-
-      - name: Test
-        run: pnpm exec vitest run
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Verify version matches tag
-        if: startsWith(github.ref, 'refs/tags/goldencheck-types-js-v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/goldencheck-types-js-v}"
-          PKG_VERSION=$(jq -r .version package.json)
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "Version OK: $PKG_VERSION"
-
-      - name: Pack (dry-run validation)
-        if: github.event.inputs.dry-run == 'true'
-        run: pnpm pack
-
-      - name: Publish to npm
-        if: github.event.inputs.dry-run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --provenance --no-git-checks
+    uses: ./.github/workflows/_publish-js.yml
+    with:
+      package: goldencheck-types
+      build_deps: false
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenflow-js.yml
+++ b/.github/workflows/publish-goldenflow-js.yml
@@ -1,5 +1,6 @@
 name: Publish goldenflow to npm
 
+# Thin caller -> .github/workflows/_publish-js.yml (the shared template).
 on:
   push:
     tags:
@@ -10,7 +11,7 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
-      dry-run:
+      dry_run:
         description: "Pack and validate without publishing"
         required: false
         default: "false"
@@ -21,56 +22,10 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/typescript/goldenflow
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-
-      - name: Install dependencies
-        working-directory: ${{ github.workspace }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Typecheck
-        run: pnpm exec tsc --noEmit
-
-      - name: Test
-        run: pnpm exec vitest run
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Verify version matches tag
-        if: startsWith(github.ref, 'refs/tags/goldenflow-js-v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/goldenflow-js-v}"
-          PKG_VERSION=$(jq -r .version package.json)
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "Version OK: $PKG_VERSION"
-
-      - name: Pack (dry-run validation)
-        if: github.event.inputs.dry-run == 'true'
-        # pnpm pack always writes a .tgz; running it in dry-run validates the
-        # package can be packed cleanly (file list, entry points, version)
-        # without publishing. The artifact is discarded on job teardown.
-        run: pnpm pack
-
-      - name: Publish to npm
-        if: github.event.inputs.dry-run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --provenance --no-git-checks
+    uses: ./.github/workflows/_publish-js.yml
+    with:
+      package: goldenflow
+      build_deps: false
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenmatch-js.yml
+++ b/.github/workflows/publish-goldenmatch-js.yml
@@ -1,5 +1,6 @@
-name: Publish goldenmatch-js to npm
+name: Publish goldenmatch to npm
 
+# Thin caller -> .github/workflows/_publish-js.yml (the shared template).
 on:
   push:
     tags:
@@ -10,7 +11,7 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
-      dry-run:
+      dry_run:
         description: "Pack and validate without publishing"
         required: false
         default: "false"
@@ -21,57 +22,10 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/typescript/goldenmatch
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-
-      - name: Install dependencies
-        working-directory: ${{ github.workspace }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Typecheck
-        run: pnpm exec tsc --noEmit
-
-      - name: Test
-        run: pnpm exec vitest run
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Verify version matches tag
-        if: startsWith(github.ref, 'refs/tags/goldenmatch-js-v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/goldenmatch-js-v}"
-          PKG_VERSION=$(jq -r .version package.json)
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "Version OK: $PKG_VERSION"
-
-      - name: Pack (dry-run validation)
-        if: github.event.inputs.dry-run == 'true'
-        # pnpm pack has no --dry-run flag; it always writes a .tgz. Running it
-        # here with dry-run=true validates the package can be packed cleanly
-        # (file list, entry points, version, etc.) without publishing. The
-        # artifact stays on the runner and is discarded on job teardown.
-        run: pnpm pack
-
-      - name: Publish to npm
-        if: github.event.inputs.dry-run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --provenance --no-git-checks
+    uses: ./.github/workflows/_publish-js.yml
+    with:
+      package: goldenmatch
+      build_deps: false
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenpipe-js.yml
+++ b/.github/workflows/publish-goldenpipe-js.yml
@@ -1,5 +1,6 @@
 name: Publish goldenpipe to npm
 
+# Thin caller -> .github/workflows/_publish-js.yml (the shared template).
 on:
   push:
     tags:
@@ -10,7 +11,7 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
-      dry-run:
+      dry_run:
         description: "Pack and validate without publishing"
         required: false
         default: "false"
@@ -21,60 +22,10 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/typescript/goldenpipe
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-
-      - name: Install dependencies
-        working-directory: ${{ github.workspace }}
-        run: pnpm install --frozen-lockfile
-
-      # goldenpipe composes goldencheck/goldenflow/goldenmatch (workspace:^);
-      # they must be built before goldenpipe's typecheck/test/build resolve
-      # their dist entrypoints.
-      - name: Build workspace deps
-        working-directory: ${{ github.workspace }}
-        run: pnpm turbo run build --filter=goldenpipe^...
-
-      - name: Typecheck
-        run: pnpm exec tsc --noEmit
-
-      - name: Test
-        run: pnpm exec vitest run
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Verify version matches tag
-        if: startsWith(github.ref, 'refs/tags/goldenpipe-js-v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/goldenpipe-js-v}"
-          PKG_VERSION=$(jq -r .version package.json)
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "Version OK: $PKG_VERSION"
-
-      - name: Pack (dry-run validation)
-        if: github.event.inputs.dry-run == 'true'
-        run: pnpm pack
-
-      - name: Publish to npm
-        if: github.event.inputs.dry-run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --provenance --no-git-checks
+    uses: ./.github/workflows/_publish-js.yml
+    with:
+      package: goldenpipe
+      build_deps: true
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-infermap-js.yml
+++ b/.github/workflows/publish-infermap-js.yml
@@ -1,5 +1,6 @@
 name: Publish infermap to npm
 
+# Thin caller -> .github/workflows/_publish-js.yml (the shared template).
 on:
   push:
     tags:
@@ -10,7 +11,7 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
-      dry-run:
+      dry_run:
         description: "Pack and validate without publishing"
         required: false
         default: "false"
@@ -21,63 +22,10 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/typescript/infermap
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-
-      - name: Install dependencies
-        working-directory: ${{ github.workspace }}
-        run: pnpm install --frozen-lockfile
-
-      # infermap imports goldencheck-types at runtime and goldenmatch in tests;
-      # both are workspace deps (workspace:^ / workspace:*) that must be built
-      # before infermap's typecheck/test/build resolve their dist entrypoints.
-      - name: Build workspace deps
-        working-directory: ${{ github.workspace }}
-        run: pnpm turbo run build --filter=infermap^...
-
-      - name: Typecheck
-        run: pnpm exec tsc --noEmit
-
-      - name: Test
-        run: pnpm exec vitest run
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Verify version matches tag
-        if: startsWith(github.ref, 'refs/tags/infermap-js-v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/infermap-js-v}"
-          PKG_VERSION=$(jq -r .version package.json)
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "Version OK: $PKG_VERSION"
-
-      - name: Pack (dry-run validation)
-        if: github.event.inputs.dry-run == 'true'
-        # pnpm pack always writes a .tgz; running it in dry-run validates the
-        # package can be packed cleanly (file list, entry points, version)
-        # without publishing. The artifact is discarded on job teardown.
-        run: pnpm pack
-
-      - name: Publish to npm
-        if: github.event.inputs.dry-run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --provenance --no-git-checks
+    uses: ./.github/workflows/_publish-js.yml
+    with:
+      package: infermap
+      build_deps: true
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "1.13.0",
+  "version": "1.30.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "1.13.0",
+      "version": "1.30.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
@@ -12,5 +12,5 @@ are logged at startup so deployers know which tool was shadowed.
 """
 from goldensuite_mcp.server import create_server
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["create_server", "__version__"]

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -20,4 +20,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.3"
+    __version__ = "0.1.5"

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Enforce per-package version lockstep across every file that declares it.
+
+The CLAUDE.md gotchas document this rule repeatedly ("bump in lockstep",
+"version lives in THREE spots") but nothing enforced it -- and it drifted in
+production: goldenflow shipped 1.1.x with ``pyproject.toml`` = 1.1.2 while
+``goldenflow/__init__.py`` said 1.1.1 (fixed in 1.1.5). This is the gate.
+
+For every package it discovers the version-bearing files and asserts they all
+agree:
+  - Python dist packages (``packages/python/<pkg>/``):
+      pyproject.toml ``[project].version`` == ``<importdir>/__init__.py``
+      ``__version__`` == ``server.json`` ``.version`` (+ nested ``packages[].version``)
+  - Native maturin crates (``packages/rust/extensions/<crate>/`` with BOTH a
+      Cargo.toml and a pyproject.toml):
+      Cargo.toml ``[package].version`` == pyproject.toml ``[project].version``
+      == any ``__init__.py`` ``__version__`` fallback under the crate.
+
+Exit 1 (listing every drift) if any package is inconsistent; 0 otherwise.
+Run: ``python scripts/check_version_consistency.py``
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_VERSION_RE = re.compile(r"""__version__\s*=\s*["']([^"']+)["']""")
+
+
+def _pyproject_version(path: Path) -> str | None:
+    return tomllib.loads(path.read_text(encoding="utf-8")).get("project", {}).get("version")
+
+
+def _cargo_version(path: Path) -> str | None:
+    return tomllib.loads(path.read_text(encoding="utf-8")).get("package", {}).get("version")
+
+
+def _init_version(path: Path) -> str | None:
+    m = _VERSION_RE.search(path.read_text(encoding="utf-8"))
+    return m.group(1) if m else None
+
+
+def _check(name: str, sources: list[tuple[str, str | None]], errors: list[str]) -> None:
+    present = [(label, v) for label, v in sources if v is not None]
+    distinct = {v for _, v in present}
+    if len(distinct) > 1:
+        detail = ", ".join(f"{label}={v}" for label, v in present)
+        errors.append(f"{name}: version drift -> {detail}")
+
+
+def main() -> int:
+    errors: list[str] = []
+    checked = 0
+
+    # --- Python dist packages ---
+    for pyproject in sorted((ROOT / "packages" / "python").glob("*/pyproject.toml")):
+        pkg_dir = pyproject.parent
+        sources: list[tuple[str, str | None]] = [("pyproject.toml", _pyproject_version(pyproject))]
+        # Top-level import package __init__ (only the canonical one carries __version__).
+        for init in sorted(pkg_dir.glob("*/__init__.py")):
+            v = _init_version(init)
+            if v is not None:
+                sources.append((str(init.relative_to(pkg_dir)), v))
+        server = pkg_dir / "server.json"
+        if server.exists():
+            data = json.loads(server.read_text(encoding="utf-8"))
+            if "version" in data:
+                sources.append(("server.json:.version", data["version"]))
+            for i, entry in enumerate(data.get("packages", [])):
+                if "version" in entry:
+                    sources.append((f"server.json:packages[{i}].version", entry["version"]))
+        _check(f"python/{pkg_dir.name}", sources, errors)
+        checked += 1
+
+    # --- Native maturin crates (Cargo.toml + pyproject.toml) ---
+    for cargo in sorted((ROOT / "packages" / "rust" / "extensions").glob("*/Cargo.toml")):
+        crate_dir = cargo.parent
+        pyproject = crate_dir / "pyproject.toml"
+        if not pyproject.exists():
+            continue  # pure crate -- no Python version to keep in lockstep
+        cargo_v = _cargo_version(cargo)
+        if cargo_v is None:
+            continue  # virtual/workspace manifest with no [package]
+        sources = [("Cargo.toml", cargo_v), ("pyproject.toml", _pyproject_version(pyproject))]
+        for init in sorted(crate_dir.glob("**/__init__.py")):
+            v = _init_version(init)
+            if v is not None:
+                sources.append((str(init.relative_to(crate_dir)), v))
+        _check(f"native/{crate_dir.name}", sources, errors)
+        checked += 1
+
+    if errors:
+        print(f"Version consistency check FAILED ({len(errors)} of {checked} packages drifted):")
+        for e in errors:
+            print(f"  - {e}")
+        print("\nBump every version-bearing file for the package in lockstep (see the")
+        print("package's CLAUDE.md). This is the gate goldenflow 1.1.x lacked.")
+        return 1
+
+    print(f"Version consistency OK: {checked} packages, all files in lockstep.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Automates the three "documented but unenforced" gotchas from the dogfood audit. The headline: **the version-consistency gate immediately caught 3 real drifts on `main`.**

### (a) Version-lockstep gate — `scripts/check_version_consistency.py` + CI job
CLAUDE.md says "bump in lockstep" / "version lives in THREE spots" all over, but nothing enforced it (goldenflow shipped 1.1.x with `pyproject`=1.1.2 / `__init__`=1.1.1). New stdlib-only checker asserts every version-bearing file per package agrees (pyproject / `__init__` / `server.json` for Python dists; Cargo.toml / pyproject / native `__init__` for maturin crates), wired as an always-on `version_consistency` job in the `ci-required` gate.

**It caught 3 live drifts, fixed in this PR:**
| package | drift | fix |
|---|---|---|
| `goldenmatch` | `server.json` = 1.13.0 vs package 1.30.0 (17 minors stale) | → 1.30.0 |
| `goldensuite-mcp` | `__init__` 0.1.0 vs pyproject 0.2.0 | → 0.2.0 |
| `goldenmatch-native` | `__init__` fallback 0.1.3 vs Cargo/pyproject 0.1.5 | → 0.1.5 |

### (b) Dependabot — cover Cargo + the real TS workspace (`dependabot.yml`)
- **No `cargo` ecosystem at all** → added `directories: ["/packages/rust/extensions/*"]` (15+ crates; pyo3 CVE bumps were hand-planned).
- **npm pointed at `/packages/goldenmatch-js` — a path that doesn't exist**, so Dependabot covered *zero* TS packages → repointed at `/` (the pnpm-lock root), covering every `packages/typescript/*` member.

### (c) Collapse 7 near-identical JS publish workflows → one reusable template
Extracted the ~73-line copy-pasted body into `_publish-js.yml` (`workflow_call`); each `publish-<pkg>-js.yml` is now a ~31-line thin caller (keeps its own `<pkg>-js-v*` tag trigger + dispatch). One `package` input drives dir/turbo-filter/tag (verified `dir == package.json name == tag base` for all 7); `build_deps` preserves the per-package "build workspace deps" step exactly — **no functional change**. The shared runner also moves to **Node 22** (Node 20 EOL).

## Test Plan
- [x] `check_version_consistency.py` runs green (14 packages) after the 3 fixes; ruff clean.
- [x] All touched YAML parses; `dependabot.yml` ecosystems = `pip, npm, cargo, github-actions, docker`; reusable `workflow_call` inputs + all 7 caller wirings verified programmatically; `server.json` valid JSON.
- [x] The `version_consistency` job is in `ci-required`.

## Caveats / coordination
- **Overlaps with #898:** that PR bumps Node 20→22 in the 7 JS publish files; (c) rewrites those same files. Whichever merges second needs a trivial rebase (keep the thin callers / drop the now-moot per-file edits). #898's `ci.yml` + `package.json` + infermap changes are independent and unaffected.
- **(c) is tag-triggered**, so the reusable is first exercised at the next JS release, not by this PR's CI. The extraction is faithful (byte-equivalent steps).

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_