### PR TITLE
Spike: Lance-backed base store for match_one / incremental retrieval

### DIFF
--- a/docs/superpowers/plans/2026-06-13-lance-match-one-base-store.md
+++ b/docs/superpowers/plans/2026-06-13-lance-match-one-base-store.md
@@ -1,0 +1,148 @@
+# Plan — LanceBaseStore behind match_one / incremental / streaming
+
+**Spec:** `docs/superpowers/specs/2026-06-13-lance-match-one-base-store-design.md`
+**Branch:** `claude/lance-match-one-spike` (or a fresh `feat/lance-base-store`)
+**Status:** ready to execute · TDD, phase-by-phase, commit each task
+
+## Goal & invariants
+
+Let `match_one` (and its `streaming`/`incremental` callers) retrieve candidate
+rows from a pluggable **candidate store** instead of always holding the base as a
+polars frame and calling `df.to_dicts()` **every probe** (today's
+`core/match_one.py:81` — O(N) per call, RAM-bound). Add an opt-in
+`LanceCandidateStore` that serves per-probe gathers from disk (measured 3.6 ms/probe
+at 182 MB vs 1233 MB in-RAM, see spec).
+
+**Hard invariants:**
+- Default path is **byte-identical** to today. `store=None` ⇒ wrap `df` in the
+  in-memory store; existing callers and results unchanged (parity-gated).
+- Lance is **opt-in** (config/env + base-size threshold) and an **optional dep**
+  (`pip install goldenmatch[lance]`); plain installs never import lance.
+- Parquet stays the interchange format; Lance is an internal base-acceleration
+  store only.
+
+## Affected files (exact)
+
+- `core/match_one.py` — `match_one()` + `_match_one_ann()` (the `to_dicts()` site).
+- `core/streaming.py:130`, `core/incremental.py:97`, `mcp/server.py:1031`,
+  `tui/engine.py:470` — the four `match_one(...)` call sites.
+- `core/ann_blocker.py` — `query_one` returns `(faiss_idx, score)`; faiss_idx is
+  the base row position the store must resolve.
+- `config/schemas.py` — new opt-in flag.
+- `pyproject.toml` — new `[project.optional-dependencies] lance` extra (mirror the
+  `ray`/`native` blocks ~line 125/156).
+- New: `core/candidate_store.py`, `tests/test_candidate_store.py`.
+
+---
+
+## Phase 0 — optional dependency plumbing
+
+**Task 0.1** Add the extra. `pyproject.toml`: `lance = ["pylance>=0.20"]` under
+`[project.optional-dependencies]`; add `{ path = ... }` workspace note only if
+needed (it's PyPI, so no). Update root `pyproject.toml`/`uv` only if CI resolves
+the extra graph (see packages/python/CLAUDE.md friction note).
+- **Test:** `tests/test_candidate_store.py::test_lance_extra_optional` — importing
+  `goldenmatch.core.candidate_store` succeeds without lance installed (lazy import).
+- **Commit:** `Add optional lance extra + lazy import guard`.
+
+---
+
+## Phase 1 — CandidateStore protocol + in-memory impl (pure refactor)
+
+**Task 1.1 (failing test first)** `tests/test_candidate_store.py`:
+- `test_frame_store_take_positions` — `FrameCandidateStore(df).take([2,5,9])`
+  returns those rows (as dicts) + their `__row_id__`, in order.
+- `test_frame_store_gather_block` — `.gather_block(key)` returns rows where
+  `block_key == key`.
+
+**Task 1.2 (impl)** `core/candidate_store.py`:
+```python
+class CandidateStore(Protocol):
+    def take(self, positions: Sequence[int]) -> tuple[list[dict], list[int]]: ...
+    def gather_block(self, key: str) -> tuple[list[dict], list[int]]: ...
+    def __len__(self) -> int: ...
+
+class FrameCandidateStore:        # wraps today's df; gathers ONLY needed rows
+    def take(self, positions): 
+        sub = self._df[list(positions)]          # not df.to_dicts() over all N
+        return sub.to_dicts(), sub["__row_id__"].to_list()
+```
+- **Commit:** `CandidateStore protocol + FrameCandidateStore`.
+
+**Task 1.3 (refactor _match_one_ann, parity-gated)** Rewrite `_match_one_ann` to
+build a `FrameCandidateStore(df)` (when no store passed) and replace the
+`rows = df.to_dicts(); rows[faiss_idx]` loop with one `store.take(positions)`.
+- **Test:** `tests/test_match_one.py::test_ann_results_unchanged_after_refactor`
+  — same `(row_id, score)` list as before on a fixed fixture (golden parity).
+- **Test:** `test_match_one_ann_no_full_to_dicts` — monkeypatch `pl.DataFrame.to_dicts`
+  to assert it is NOT called on the full frame per probe (regression lock for the
+  O(N)-per-call bug).
+- **Run:** `pytest tests/test_match_one.py tests/test_candidate_store.py -q`
+- **Commit:** `Route _match_one_ann through CandidateStore (byte-identical)`.
+
+---
+
+## Phase 2 — LanceCandidateStore
+
+**Task 2.1 (failing parity test)** `tests/test_candidate_store.py::test_lance_matches_frame`
+(skip if no lance): build both stores over the same base; assert
+`lance.take(P) == frame.take(P)` (rows + row_ids) and `gather_block(k)` parity for
+several P and k. Marked `@pytest.mark.skipif(not _HAS_LANCE)`.
+
+**Task 2.2 (impl)** `LanceCandidateStore`:
+- `from_frame(df, path)` — write Lance dataset, cast `block_key` large_string→string
+  (lance BTREE requirement, learned in the bench), `create_scalar_index("block_key","BTREE")`.
+- `take(positions)` → `ds.take(list(positions), columns=...)` → dicts + row_ids.
+- `gather_block(key)` → indexed `ds.scanner(filter=f"block_key = '{key}'")`.
+- `open(path)` classmethod for reusing an existing base store.
+- **Run:** `pytest tests/test_candidate_store.py -q` (with lance installed).
+- **Commit:** `LanceCandidateStore (take + BTREE block gather)`.
+
+---
+
+## Phase 3 — opt-in wiring
+
+**Task 3.1** `match_one(..., store: CandidateStore | None = None)`: when provided,
+use it; else `FrameCandidateStore(df)`. `df` stays for back-compat (callers that
+pass only `df` are unchanged). **Test:** existing `tests/test_match_one.py` all green;
+add `test_match_one_with_lance_store` (skipif) asserting identical results to the df path.
+
+**Task 3.2** `config/schemas.py`: add `IncrementalConfig.base_store: Literal["memory","lance"] = "memory"`
++ `base_store_threshold_rows: int` (default e.g. 2_000_000). Resolver
+`resolve_base_store(n_rows, config, env=GOLDENMATCH_BASE_STORE)` → picks lance only
+when explicitly set OR base exceeds threshold AND lance importable; else memory.
+**Test:** `tests/test_candidate_store.py::test_resolve_base_store_*` (env/threshold/missing-dep fallback).
+
+**Task 3.3** Wire `StreamProcessor` (`core/streaming.py:86` `__init__`) to build the
+store once from its base and pass it to `match_one` at line 130 (not per-record).
+**Test:** `tests/test_streaming.py::test_stream_with_lance_store` (skipif) — same
+matches as the memory path on a small base.
+
+**Task 3.4** Wire `core/incremental.py:97` `run_incremental` to build the store from
+`base_file` once. `mcp/server.py:1031` and `tui/engine.py:470` keep passing `df`
+(memory) — no behavior change; document that the large-base path is incremental/streaming.
+**Commit each task.**
+
+---
+
+## Phase 4 — docs + close-out
+
+- `packages/python/goldenmatch/CLAUDE.md` Code Patterns: add a `CandidateStore` /
+  `LanceCandidateStore` entry (opt-in, out-of-core base, memory default).
+- `docs-site/goldenmatch/` incremental/streaming page: note the `[lance]` extra +
+  `base_store` config for out-of-core bases.
+- Mark spec **Status: implemented**; link the PR.
+
+## Validation gate (before flipping any default)
+
+Run `scripts/bench_match_one_lance.py` *plus* a real-data check on an NCVR-scale
+base (`tests/benchmarks/datasets/NCVR`, gitignored — skip if absent): confirm the
+spec's ~7x memory win + low-ms latency hold on real skew, and that the memory
+path stays byte-identical. **Defaults stay `memory`**; lance is opt-in until a
+real-data run justifies the threshold value.
+
+## Out of scope (future)
+
+- Distributed / Ray base store; incremental base UPDATES keeping FAISS + Lance
+  row-id-consistent (note in spec risks); replacing the FAISS index itself with
+  Lance's native vector index (separate spike).

--- a/docs/superpowers/specs/2026-06-13-lance-match-one-base-store-design.md
+++ b/docs/superpowers/specs/2026-06-13-lance-match-one-base-store-design.md
@@ -1,0 +1,98 @@
+# Lance-backed base store for incremental / match_one — Spike Design + Results
+
+**Date:** 2026-06-13 · **Branch:** claude/lance-match-one-spike · **Status:** spike (results in; pre-plan)
+
+## Origin
+
+Follow-up to `2026-06-13-lance-vs-parquet-candidate-retrieval-design.md`. That
+batch bake-off split by access pattern: **reject Lance for batch dedup** (it
+eventually full-scans every row, and writes 2.3x more disk), but Lance won big on
+**sparse one-shot gathers** (5.8x at K/N=1e-4, 27x at 1e-5, ~8x less memory). The
+only GoldenMatch path that is *purely* sparse one-shot gathers is
+incremental / streaming / `match_one`: `core/match_one.py` queries an ANN index
+for top-K candidates per probe and scores them — and today it holds the **whole
+base in memory** (`_match_one_ann` does `rows[faiss_idx]`), so it is RAM-bound.
+
+Question: can a Lance-backed base store serve per-probe candidate retrieval from
+**disk** fast enough to remove the in-RAM-base constraint?
+
+## Experiment
+
+`packages/python/goldenmatch/scripts/bench_match_one_lance.py` — standalone,
+graceful without `lance`. Models the per-probe candidate gather against a large
+**skewed** base (Zipfian block sizes — the realism the prior synthetic 3-record
+data lacked) across three base stores: `memory` (status quo — full base in a
+polars frame), `parquet` (on disk), `lance` (on disk, BTREE scalar index on
+`block_key`). Two candidate sources (`ann` = top-K scattered row-ids per probe;
+`block` = all rows sharing a key) × two regimes (`stream` = one probe at a time,
+the real match_one latency; `microbatch`). Per-probe median latency + peak RSS
+(VmHWM, isolated per store in a spawned child).
+
+## Results (measured 2026-06-13, 10M-row base, polars 1.41 / lance 7.0)
+
+Base skew: block size p50=1, p99=235, **max=3.83M**, 64,162 blocks. On disk:
+Parquet 165 MB, Lance 390 MB (2.3x) + BTREE index 1.7 s.
+
+| shape / regime | memory | parquet | lance |
+|---|---|---|---|
+| **ann stream** (match_one latency) | 0.1 ms/p · **1233 MB** | 240 ms/p · 1367 MB | **3.6 ms/p · 182 MB** |
+| block stream | 14.1 ms/p · 1234 MB | 3.4 ms/p · 94 MB | **2.3 ms/p · 190 MB** |
+| ann microbatch | 1.6 ms/p · 1231 MB | 316 ms/p · 1235 MB | 101 ms/p · 205 MB |
+
+**Read:**
+
+1. **ANN streaming — the load-bearing case — Lance wins decisively as a base
+   store.** It serves a per-probe top-50 gather in **3.6 ms holding 182 MB**,
+   versus the in-memory store's 0.1 ms but **1233 MB** (the whole base). Both
+   latencies are fine for streaming/interactive; the difference is **6.8x less
+   memory**. Parquet-on-disk is a non-starter for streaming (240 ms/probe — no
+   random access, it re-reads the whole column every probe).
+2. **Exact-block retrieval — Lance's BTREE index beats BOTH** (2.3 ms) the
+   in-memory polars `filter` (14.1 ms — an unindexed full-column scan) and sorted
+   Parquet (3.4 ms). (Caveat: a real in-memory impl would keep a hash index,
+   which would beat 14 ms — so this flatters Lance vs a *naive* memory filter. The
+   ANN comparison is the clean one.)
+3. Lance disk is 2.3x larger; the ANN candidate model is random scatter (FAISS
+   neighbors scatter similarly, so representative).
+
+## Verdict
+
+**The spike confirms the hypothesis.** Lance is a genuine fit for a base store
+behind `match_one` / `streaming` / `incremental`, with the win concentrated in the
+**out-of-core regime**: when the base exceeds worker RAM (or you run many
+concurrent matchers and want a small per-worker footprint), Lance delivers
+low-single-digit-ms per-probe candidate retrieval at ~7x less memory than holding
+the base in a frame — which `match_one` cannot do today at all.
+
+**When NOT to use it:** if the base comfortably fits in RAM and there is a single
+matcher, the in-memory store's 0.1 ms ANN gather is unbeatable — keep it the
+default. Lance is the *opt-in, large-base* path, not a replacement.
+
+## Proposed integration (for the plan, not this spike)
+
+- A `LanceBaseStore` behind a small retrieval interface (`gather_candidates(ids)`,
+  `gather_block(key)`), opt-in via config/env, consumed by `_match_one_ann` and
+  the `incremental` CLI / `StreamProcessor`. `match_one` takes the store instead
+  of an in-RAM `rows`/`row_ids` list.
+- Build the Lance dataset + BTREE `block_key` index once at base-ingest; reuse the
+  ANN index (FAISS) alongside it. Keep Parquet as the interchange format; Lance is
+  an internal acceleration store for the base only.
+- Gate behind a base-size threshold so fits-in-RAM stays on the in-memory path.
+
+## Risks / unknowns
+
+- **Skew tail.** max block = 3.8M rows here; a `block` gather on the giant key
+  returns millions of rows regardless of store — blocking-key choice still matters
+  (the existing scale-invariant-blocking work governs that).
+- **FAISS + base coupling.** The ANN index and the Lance base must stay
+  row-id-consistent across base updates; incremental inserts touch both.
+- **Real dataset.** Numbers are on synthetic skew; validate on a real
+  large base (NCVR-scale) before committing the integration.
+- **Disk + write cost** (2.3x size, index build) is paid once per base; amortized
+  over many incremental matches, but real for churny bases.
+
+## Non-goals
+
+- No production integration in this spike — numbers first (now in).
+- No change to the batch pipeline or the Parquet interchange/release assets.
+- Not a replacement for the in-memory path when the base fits in RAM.

--- a/packages/python/goldenmatch/scripts/bench_match_one_lance.py
+++ b/packages/python/goldenmatch/scripts/bench_match_one_lance.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Spike: can a Lance-backed base store serve incremental/match_one candidate
+retrieval from DISK, removing the in-RAM-base constraint, fast enough to matter?
+
+Follow-up to the batch bake-off (bench_lance_vs_parquet.py), whose verdict was:
+Lance loses on batch dedup (eventually full-scans) but wins big on SPARSE
+one-shot gathers (6-27x, ~8x less memory). The one path that is purely sparse
+one-shot gathers is incremental / streaming / match_one: `core/match_one.py`
+queries an ANN index for top-K candidates per probe, then scores them. Today
+that path holds the WHOLE base in memory (`rows[faiss_idx]`), so it is RAM-bound.
+
+This bench models the per-probe candidate gather against a large SKEWED base
+(realistic Zipfian block sizes, NOT the uniform 3-record synthetic that flatters
+sparsity) across three base stores:
+
+  * memory  -- the status quo: load the full base into a polars frame, gather
+               candidates in-RAM. Fast per probe, but RSS ~ the whole base.
+  * parquet -- base on disk. ANN gather has no random access -> read+gather per
+               probe (O(N) each). block gather via sorted predicate pushdown.
+  * lance   -- base on disk. ANN gather via `take(ids)` (reads only covering
+               pages); block gather via a BTREE scalar index scan.
+
+Two access shapes, the two `match_one` candidate sources:
+  * ann   -- top_k scattered row-ids per probe (the FAISS path).
+  * block -- all rows sharing the probe's block_key (the exact-blocking path).
+
+Two regimes:
+  * stream     -- one probe at a time (true match_one latency; per-call overhead).
+  * microbatch -- B probes' candidates gathered in one call (the streaming
+                  micro-batch path).
+
+Reports per-probe median latency + peak RSS (VmHWM, isolated per store in a
+spawned child -- ru_maxrss inherits the parent high-water mark and cannot
+isolate). The headline question: is lance per-probe latency close to `memory`
+while keeping RSS near zero?
+
+Usage:
+    python scripts/bench_match_one_lance.py --rows 5_000_000 --probes 50 --top-k 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing as mp
+import resource
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+SCORE_COLS = ["id", "block_key", "name", "address", "age", "score_hint"]
+
+
+def _have(mod: str) -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec(mod) is not None
+
+
+def _peak_rss_mb() -> float:
+    """Per-process peak RSS in MB via VmHWM (ru_maxrss inherits parent peak)."""
+    try:
+        with open("/proc/self/status") as fh:
+            for line in fh:
+                if line.startswith("VmHWM:"):
+                    return int(line.split()[1]) / 1024.0
+    except OSError:
+        pass
+    raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return raw / 1024.0 / 1024.0 if sys.platform == "darwin" else raw / 1024.0
+
+
+def generate_skewed(rows: int, seed: int = 7):
+    """Base with a Zipfian block-size distribution (heavy tail, like real
+    surname/zip skew) -- the realism the prior synthetic 3-record data lacked."""
+    import numpy as np
+    import polars as pl
+
+    rng = np.random.default_rng(seed)
+    # Zipf draw, clipped, then mod into a key space ~ rows/avg_block_size.
+    n_keys = max(1, rows // 20)
+    raw = rng.zipf(1.5, size=rows) % n_keys
+    block_key = raw.astype(np.int64)
+    first = rng.integers(0, 5000, size=rows)
+    df = pl.DataFrame(
+        {
+            "id": np.arange(rows, dtype=np.int64),
+            "block_key": [f"{z:08d}" for z in block_key],
+            "name": [f"person_{a}_{b}" for a, b in zip(first, rng.integers(0, 5000, size=rows))],
+            "address": [f"{s} main st apt {a}" for s, a in zip(rng.integers(0, 9999, size=rows), rng.integers(0, 999, size=rows))],
+            "age": rng.integers(18, 95, size=rows).astype("int32"),
+            "score_hint": rng.random(size=rows).astype("float32"),
+        }
+    )
+    return df.sort("block_key")
+
+
+def write_stores(df, root: Path) -> dict[str, Path]:
+    import pyarrow as pa  # noqa: F401
+
+    paths: dict[str, Path] = {}
+    pq = root / "base.parquet"
+    df.write_parquet(pq, row_group_size=128 * 1024, statistics=True)
+    paths["parquet"] = pq
+    print(f"  parquet: {pq.stat().st_size / 1e6:8.1f} MB")
+
+    if _have("lance"):
+        import lance
+        import pyarrow as pa
+
+        lpath = root / "base.lance"
+        tbl = df.to_arrow()
+        if pa.types.is_large_string(tbl.schema.field("block_key").type):
+            ci = tbl.schema.get_field_index("block_key")
+            tbl = tbl.set_column(ci, "block_key", tbl.column("block_key").cast(pa.string()))
+        lance.write_dataset(tbl, str(lpath))
+        ds = lance.dataset(str(lpath))
+        t0 = time.perf_counter()
+        ds.create_scalar_index("block_key", "BTREE")
+        size = sum(f.stat().st_size for f in lpath.rglob("*") if f.is_file())
+        print(f"  lance  : {size / 1e6:8.1f} MB  (+BTREE idx {time.perf_counter() - t0:.1f}s)")
+        paths["lance"] = lpath
+    return paths
+
+
+def _child(q, store, path_str, shape, regime, probe_ids, probe_keys, top_k, n):
+    """One store x shape x regime, in an isolated process. Reports per-probe
+    median latency, total wall, and peak RSS."""
+    import numpy as np
+
+    path = Path(path_str)
+    rng = np.random.default_rng(123)
+
+    # ---- per-store retrieval primitives ----
+    if store == "memory":
+        import polars as pl
+
+        base = pl.read_parquet(path, columns=SCORE_COLS)  # held in RAM
+        key_col = base["block_key"]
+
+        def gather_ann(ids):
+            return base[ids].height
+
+        def gather_block(key):
+            return base.filter(key_col == key).height
+
+    elif store == "parquet":
+        import polars as pl
+
+        def gather_ann(ids):
+            # no random access: read scoring cols then gather
+            return pl.read_parquet(path, columns=SCORE_COLS)[ids].height
+
+        def gather_block(key):
+            return pl.scan_parquet(path).filter(pl.col("block_key") == key).select(SCORE_COLS).collect().height
+
+    else:  # lance
+        import lance
+
+        ds = lance.dataset(str(path))
+
+        def gather_ann(ids):
+            return ds.take(list(ids), columns=SCORE_COLS).num_rows
+
+        def gather_block(key):
+            return ds.scanner(columns=SCORE_COLS, filter=f"block_key = '{key}'").to_table().num_rows
+
+    gather = gather_ann if shape == "ann" else gather_block
+    # Build the per-probe arguments.
+    if shape == "ann":
+        args = [np.sort(rng.choice(n, size=top_k, replace=False)) for _ in range(len(probe_ids))]
+    else:
+        args = list(probe_keys)
+
+    walls = []
+    t_all = time.perf_counter()
+    if regime == "stream":
+        for a in args:
+            t0 = time.perf_counter()
+            gather(a)
+            walls.append(time.perf_counter() - t0)
+    else:  # microbatch: one gather of all candidates
+        if shape == "ann":
+            allids = np.unique(np.concatenate(args))
+            t0 = time.perf_counter()
+            gather(allids)
+            walls.append(time.perf_counter() - t0)
+        else:
+            for a in args:  # block microbatch == union of predicates; approximate per-key
+                t0 = time.perf_counter()
+                gather(a)
+                walls.append(time.perf_counter() - t0)
+    total = time.perf_counter() - t_all
+    q.put((statistics.median(walls), total, _peak_rss_mb()))
+
+
+def measure(store, path, shape, regime, probe_ids, probe_keys, top_k, n):
+    ctx = mp.get_context("spawn")
+    qq = ctx.Queue()
+    p = ctx.Process(target=_child, args=(qq, store, str(path), shape, regime, probe_ids, probe_keys, top_k, n))
+    p.start()
+    p.join()
+    return qq.get() if not qq.empty() else (float("nan"), float("nan"), float("nan"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rows", type=int, default=5_000_000)
+    ap.add_argument("--probes", type=int, default=50)
+    ap.add_argument("--top-k", type=int, default=50)
+    ap.add_argument("--keep", action="store_true")
+    args = ap.parse_args()
+
+    if not (_have("polars") and _have("pyarrow") and _have("numpy")):
+        print("Need polars + pyarrow + numpy", file=sys.stderr)
+        return 2
+    import numpy as np
+
+    stores = ["memory", "parquet"] + (["lance"] if _have("lance") else [])
+    if "lance" not in stores:
+        print("NOTE: pylance not installed -> memory+parquet only\n")
+
+    tmp = Path(tempfile.mkdtemp(prefix="gm_match1_"))
+    print(f"rows={args.rows:,} probes={args.probes} top_k={args.top_k} stores={stores}\n  writing base ...")
+    df = generate_skewed(args.rows)
+    n = df.height
+    # Block-size skew report + probe keys drawn proportional to block mass.
+    vc = df.group_by("block_key").len().sort("len", descending=True)
+    sizes = vc["len"].to_list()
+    print(f"  block-size skew: p50={sizes[len(sizes)//2]} p99={sizes[max(0,len(sizes)//100)]} max={sizes[0]} n_blocks={len(sizes):,}")
+    rng = np.random.default_rng(99)
+    probe_keys = list(rng.choice(vc["block_key"].to_list(), size=args.probes))
+    probe_ids = list(range(args.probes))
+    paths = write_stores(df, tmp)
+    paths["memory"] = paths["parquet"]  # memory store loads from the parquet file
+    del df
+
+    print("\n" + "=" * 84)
+    print(f"  {'shape/regime':<20} " + " | ".join(f"{s:^18}" for s in stores))
+    print("  " + "-" * 82)
+
+    def run(shape, regime):
+        cells = []
+        for s in stores:
+            med, total, rss = measure(s, paths[s], shape, regime, probe_ids, probe_keys, args.top_k, n)
+            cells.append(f"{med*1000:6.1f}ms/p {rss:6.0f}MB")
+        print(f"  {shape+' '+regime:<20} " + " | ".join(cells))
+
+    run("ann", "stream")
+    run("block", "stream")
+    run("ann", "microbatch")
+    print("=" * 84)
+    print("cells: per-probe median latency  peak-RSS(VmHWM).  memory store holds the full base;")
+    print("parquet/lance serve from disk. Win = lance latency near memory with RSS near zero.")
+
+    if not args.keep:
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The follow-up the #900 verdict pointed to. The batch bake-off concluded Lance only pays off on **sparse one-shot gathers** — and the one GoldenMatch path that is purely that is `match_one` / `streaming` / `incremental`, which today holds the **whole base in RAM** (`core/match_one.py::_match_one_ann` does `rows[faiss_idx]`). This spike measures serving per-probe candidate retrieval from a **Lance base store on disk** instead.

`scripts/bench_match_one_lance.py` — standalone; realistic **Zipfian-skewed** base (not the prior synthetic 3-record identities); three stores (`memory` / `parquet` / `lance`); ANN + exact-block candidate sources; streaming + microbatch; VmHWM-isolated RSS.

## Results — 10M-row base (skew: p50=1, p99=235, max=3.83M)

| shape / regime | memory | parquet | lance |
|---|---|---|---|
| **ann stream** (match_one latency) | 0.1 ms/p · **1233 MB** | 240 ms/p · 1367 MB | **3.6 ms/p · 182 MB** |
| block stream | 14.1 ms/p · 1234 MB | 3.4 ms/p · 94 MB | **2.3 ms/p · 190 MB** |
| ann microbatch | 1.6 ms/p | 316 ms/p | 101 ms/p |

**Confirmed.** Lance serves a per-probe top-50 ANN gather in **3.6 ms holding 182 MB**, vs the in-memory store's 0.1 ms but **1233 MB** (the whole base) — **6.8× less memory** at streaming-fine latency. Parquet-on-disk is a non-starter (240 ms/probe — no random access). For exact-block retrieval, Lance's BTREE index (2.3 ms) even beats a naive in-memory `filter` (14 ms) and sorted Parquet (3.4 ms).

## Verdict
Lance is a real fit for an **opt-in, large-base store** behind `match_one`/`streaming`/`incremental` in the **out-of-core regime** (base exceeds worker RAM, or many concurrent matchers wanting a small footprint) — a capability `match_one` doesn't have today. Keep the in-memory path as the default when the base fits in RAM (its 0.1 ms ANN gather is unbeatable there). Spec sketches a `LanceBaseStore` integration for a follow-up plan.

Caveats: Lance disk 2.3× larger; synthetic skew (validate on NCVR-scale before integrating); the block-path "memory 14 ms" uses a naive filter (a real hash index would beat it — the ANN comparison is the clean one).

This is numbers-only; no production integration. If the verdict looks right, the next step is a plan for the `LanceBaseStore` behind `match_one`.

https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr)_