### PR TITLE
fix(goldenpipe): derive API version from __version__ + add root CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to the Golden Suite
+
+This is a polyglot monorepo — Python, Rust, TypeScript, dbt, and GitHub Actions
+live side by side under `packages/`. This guide covers the shared workflow; each
+package also has its own `CLAUDE.md` with package-specific notes worth reading
+before changing internals.
+
+## Repository layout
+
+```
+packages/
+  python/      uv workspace: goldenmatch, goldencheck, goldenflow, goldenpipe,
+               infermap, goldenanalysis, goldensuite-mcp, goldencheck-types
+  rust/        cargo crates under extensions/ (native accelerators, FFI UDFs,
+               score/graph/fingerprint cores, wasm, pgrx, embed)
+  typescript/  pnpm workspace mirrors of the Python packages (+ wasm runtime)
+  dbt/         dbt package
+  actions/     composite GitHub Actions
+```
+
+## Local setup
+
+**Python** (uv workspace rooted at the repo `pyproject.toml`):
+
+```bash
+uv sync --all-packages
+uv run pytest packages/python/<pkg>        # run one package's tests
+uv run ruff check packages/python/<pkg>    # lint (required in CI)
+```
+
+**TypeScript** (pnpm + Turborepo; `pnpm@9.15.0` is pinned — Corepack rejects
+range specifiers):
+
+```bash
+corepack enable          # or: npm i -g pnpm@9.15.0
+pnpm install
+pnpm turbo run build test typecheck
+```
+
+**Rust**:
+
+```bash
+cargo test --workspace --manifest-path packages/rust/extensions/Cargo.toml
+# native (maturin/abi3) extensions build via their scripts, e.g.
+python scripts/build_native.py
+```
+
+## Branches, commits, and PRs
+
+- Branch off `main`; open a **pull request** back into `main` (draft until ready).
+- Commit messages use a type prefix: `feat:`, `fix:`, `ci:`, `docs:`, `test:`,
+  `chore:` (optionally scoped, e.g. `fix(goldenpipe): ...`). Keep them ASCII.
+- CI is path-filtered: only the areas you touched run. The single required check
+  is **`ci-required`** — it must be green to merge. A change to
+  `.github/workflows/ci.yml` re-runs every job so the filter logic stays tested.
+
+## Versioning — bump in lockstep
+
+A package's version is declared in **several** files and they **must** agree;
+nothing else will keep them honest (goldenflow once shipped 1.1.x with
+`pyproject.toml` = 1.1.2 while `__init__.py` said 1.1.1). When you bump a
+version, update **every** spot for that package:
+
+- **Python dist:** `pyproject.toml` `[project].version`, the package
+  `__init__.py` `__version__`, and `server.json` (if present).
+- **Native (maturin) crate:** `Cargo.toml` `[package].version`,
+  `pyproject.toml` `[project].version`, and any native `__init__.py` fallback.
+- Don't hardcode the version elsewhere — derive it (e.g.
+  `from <pkg> import __version__`) so it can't drift.
+
+CI enforces this with `scripts/check_version_consistency.py`; run it before
+pushing:
+
+```bash
+python scripts/check_version_consistency.py
+```
+
+## Releasing
+
+Releases are tag-driven; the matching workflow publishes:
+
+- Python → PyPI: tag `v<x.y.z>` (per-package `publish-*.yml`).
+- TypeScript → npm: tag `<pkg>-js-v<x.y.z>`.
+- Native wheels: tag `<pkg>-native-v<x.y.z>`.
+
+Cut the version bump (lockstep, above) in a PR first, merge, then tag.
+
+## Tests and quality bar
+
+- New behavior needs tests. Keep each test self-contained — CI runs `pytest -n
+  auto`, and tests cannot share global/registry state across xdist workers.
+- Anchor fixture paths to `__file__`, not the CWD (CWD differs between local and
+  CI runs).
+- `ruff` (Python) and `tsc --noEmit` (TypeScript) must pass.
+
+Thanks for contributing!

--- a/packages/python/goldenpipe/goldenpipe/api/server.py
+++ b/packages/python/goldenpipe/goldenpipe/api/server.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
+from goldenpipe import __version__
 from goldenpipe.engine.registry import StageRegistry
 from goldenpipe.engine.resolver import Resolver, WiringError
 from goldenpipe.models.config import PipelineConfig
@@ -22,11 +23,11 @@ class RunRequest(BaseModel):
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="GoldenPipe", version="1.0.0")
+    app = FastAPI(title="GoldenPipe", version=__version__)
 
     @app.get("/health")
     def health():
-        return {"status": "ok", "version": "1.0.0"}
+        return {"status": "ok", "version": __version__}
 
     @app.get("/stages")
     def list_stages():


### PR DESCRIPTION
## Summary

Fixes the two "unjustified drift" findings.

### 1. `goldenpipe` hardcoded API version (`1.0.0` → derives from `__version__`)
`goldenpipe/api/server.py` hardcoded `version="1.0.0"` in **two** spots while the package is **1.2.1**:
- `:25` — `FastAPI(title="GoldenPipe", version="1.0.0")`
- `:29` — the `/health` endpoint returned `"version": "1.0.0"` to clients

Rather than a one-time bump (which would just drift again next release), both now derive from `goldenpipe.__version__`. Circular-import-safe — `__init__.py` defines `__version__` and doesn't import `api`. **Verified:** `create_app().version == "1.2.1"`, ruff clean.

> Note: this is a class my new version-lockstep gate (#901) intentionally doesn't catch — it checks *declared-version files*, not a `version=` string literal in source. Deriving from `__version__` is the durable fix.

### 2. Root `CONTRIBUTING.md`
Added — consolidates the contributor workflow that was scattered across per-package `CLAUDE.md` files: monorepo layout, per-language setup (uv / pnpm+turbo / cargo), branch + PR + `ci-required` conventions, the **version-lockstep rule** (+ the `check_version_consistency.py` gate), tag-driven releases, and the test bar.

## Test Plan
- [x] `grep` confirms no `1.0.0` left in `server.py`; ruff clean.
- [x] Functional: installed goldenpipe + fastapi, `create_app().version == "1.2.1"` (asserts the derive works with no circular import).
- [x] `CONTRIBUTING.md` is descriptive only.

Independent of the other open PRs (#898, #901). The `CONTRIBUTING.md` references `scripts/check_version_consistency.py`, which lands with #901 — describing the rule either way, so order doesn't matter.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_