### PR TITLE
feat(cluster): retirement runway for the Arrow frames-out cutover (deprecate CLUSTER_FRAMES_OUT=0)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -24,6 +24,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   (runs in the normal lane, no Spark). Unblocks downstream consumers that depend
   on a released identity-graph contract.
 
+### Deprecated
+- **The `GOLDENMATCH_CLUSTER_FRAMES_OUT=0` escape hatch + the legacy `dict[int,dict]`
+  cluster pipeline path.** The Arrow frames-out path is the default and only supported
+  clustering path; setting the variable to `0` now emits a once-per-process
+  `DeprecationWarning`. The escape hatch and the legacy pipeline branch are removed in
+  2.0 (public `build_clusters` is preserved as a frames-backed adapter).
+
 ### Performance
 - **Fellegi-Sunter block scoring ~3.5x faster on tiny-block / multi-pass shapes
   (PR #869).** The probabilistic (`type: probabilistic`) numpy scoring path was

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -6,6 +6,7 @@ import logging
 import operator
 import os
 import uuid
+import warnings
 from collections import defaultdict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -516,6 +517,31 @@ def build_clusters(
     )
 
 
+# v2.0 removal: delete `_cluster_frames_out_enabled` + `_warn_legacy_cluster_path_once`
+# + `_LEGACY_CLUSTER_PATH_WARNED`, and the pipeline's legacy `else` branch at
+# pipeline.py:~1710 (the `build_clusters(...)` dict path). The frames-out path
+# becomes unconditional. Public `build_clusters` is PRESERVED (it stays a
+# frames-backed adapter; its dict[int,dict] return contract is unchanged).
+_LEGACY_CLUSTER_PATH_WARNED = False
+
+
+def _warn_legacy_cluster_path_once() -> None:
+    """Emit a once-per-process deprecation warning when the legacy dict cluster
+    path is selected via ``GOLDENMATCH_CLUSTER_FRAMES_OUT=0`` (removed in 2.0)."""
+    global _LEGACY_CLUSTER_PATH_WARNED
+    if _LEGACY_CLUSTER_PATH_WARNED:
+        return
+    _LEGACY_CLUSTER_PATH_WARNED = True
+    msg = (
+        "GOLDENMATCH_CLUSTER_FRAMES_OUT=0 selects the legacy dict[int,dict] cluster "
+        "path, which is removed in GoldenMatch 2.0 (the Arrow frames-out path is the "
+        "default and only supported path going forward). Unset the variable to use "
+        "the default."
+    )
+    _clog.warning(msg)
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+
 def _cluster_frames_out_enabled() -> bool:  # pyright: ignore[reportUnusedFunction]  # used cross-module: pipeline.py imports + calls this; pyright's private-symbol unused check misses the call site
     """Frames-out path gate. When enabled, ``build_cluster_frames`` returns the
     two-frame ``ClusterFrames`` columnar representation directly, WITHOUT
@@ -525,7 +551,10 @@ def _cluster_frames_out_enabled() -> bool:  # pyright: ignore[reportUnusedFuncti
     path. Independent of ``build_clusters`` and all its consumers, which are
     untouched. The pipeline wires this gate to choose ``build_cluster_frames``
     vs ``build_clusters``."""
-    return os.environ.get("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1").strip() != "0"
+    enabled = os.environ.get("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1").strip() != "0"
+    if not enabled:
+        _warn_legacy_cluster_path_once()
+    return enabled
 
 
 def build_cluster_frames(

--- a/packages/python/goldenmatch/tests/test_cluster_frames_out_deprecation.py
+++ b/packages/python/goldenmatch/tests/test_cluster_frames_out_deprecation.py
@@ -1,0 +1,45 @@
+"""Retirement-runway guards for the cluster frames-out cutover.
+
+Locks the GOLDENMATCH_CLUSTER_FRAMES_OUT gate default to ON and asserts the
+legacy-opt-out deprecation warning. The SEMANTIC frames-vs-dict parity guard
+lives in tests/test_cluster_frames_out_parity.py + test_pipeline_frames_out_parity.py
+(already in CI) and is not duplicated here.
+"""
+import logging
+import warnings
+
+import goldenmatch.core.cluster as C
+import pytest
+from goldenmatch.core.cluster import _cluster_frames_out_enabled
+
+
+def test_default_on(monkeypatch):
+    # Locks the cutover: if anyone reverts the gate default to "0", this fails.
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    monkeypatch.setattr(C, "_LEGACY_CLUSTER_PATH_WARNED", False)
+    assert _cluster_frames_out_enabled() is True
+
+
+def test_silent_on_default(monkeypatch, recwarn, caplog):
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    monkeypatch.setattr(C, "_LEGACY_CLUSTER_PATH_WARNED", False)
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.cluster"):
+        assert _cluster_frames_out_enabled() is True
+    assert not any("CLUSTER_FRAMES_OUT" in r.message for r in caplog.records)
+    assert not any(issubclass(w.category, DeprecationWarning) for w in recwarn.list)
+
+
+def test_warns_once_on_legacy_optout(monkeypatch, caplog):
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "0")
+    monkeypatch.setattr(C, "_LEGACY_CLUSTER_PATH_WARNED", False)
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.cluster"):
+        # First call: warns on the DeprecationWarning channel.
+        with pytest.warns(DeprecationWarning, match="GOLDENMATCH_CLUSTER_FRAMES_OUT=0"):
+            assert _cluster_frames_out_enabled() is False
+        # Second call: once-per-process -> no NEW warning (promote to error to prove it).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert _cluster_frames_out_enabled() is False
+    # Logging channel fired exactly once.
+    log_warns = [r for r in caplog.records if "CLUSTER_FRAMES_OUT" in r.message]
+    assert len(log_warns) == 1

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -181,6 +181,7 @@ def _golden_as_setrows(results):
 
 
 @pytest.mark.parametrize("native", ["1", "0"])
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_frames_out_pipeline_parity(monkeypatch, native):
     """Golden + dupes + stats byte-identical, gate ON vs OFF (fast golden)."""
     monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
@@ -202,6 +203,7 @@ def test_frames_out_pipeline_parity(monkeypatch, native):
 
 
 @pytest.mark.parametrize("native", ["1", "0"])
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_frames_out_pipeline_parity_provenance_slow(monkeypatch, native):
     """Same parity with provenance=True so the golden SLOW path is covered."""
     monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
@@ -327,6 +329,7 @@ def _record_partition(db_path: str, source: str, ids: list[str]):
 
 
 @pytest.mark.parametrize("native", ["1", "0"])
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_frames_out_identity_parity(monkeypatch, tmp_path, native):
     """Identity partition + ResolveSummary key counts identical, gate ON vs OFF.
 
@@ -395,6 +398,7 @@ def test_frames_out_identity_parity(monkeypatch, tmp_path, native):
 
 
 @pytest.mark.parametrize("native", ["1", "0"])
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_frames_out_identity_consumes_cluster_frames_directly(
     monkeypatch, tmp_path, native
 ):
@@ -512,6 +516,7 @@ def _clusters_partition(results):
 
 
 @pytest.mark.parametrize("native", ["1", "0"])
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_frames_out_output_on_deferred_dict_parity(monkeypatch, tmp_path, native):
     """Deferred output_clusters + lineage consumers: gate-ON dict == gate-OFF.
 


### PR DESCRIPTION
## Summary

Non-breaking 1.x prep so the v2.0 deletion of the legacy `dict[int,dict]` cluster path is a clean, signposted removal. The cutover itself is already done — `GOLDENMATCH_CLUSTER_FRAMES_OUT` flipped default-ON in PR #841 and the at-scale verdict passed (25M 2.24×, 100M 2.06× wall). This adds the Release-N runway from the Arrow finish-line SOP:

- **Deprecation warning** — `core/cluster.py` warns once per process (both `_clog.warning` + `DeprecationWarning`) when `GOLDENMATCH_CLUSTER_FRAMES_OUT=0` selects the legacy path. Fired from inside `_cluster_frames_out_enabled()`; default path is byte-unchanged and silent (verified under `-W error::DeprecationWarning`).
- **CI regression guard** — `tests/test_cluster_frames_out_deprecation.py`: `test_default_on` locks the gate default to ON (a revert to `0` fails CI), plus warns-once (both channels) + silent-on-default. The existing frames-vs-dict parity tests remain the semantic guard.
- **2.0-deletion docs** — CHANGELOG `### Deprecated` + a co-located `# v2.0 removal:` note at the gate spelling out what 2.0 deletes (the gate + the pipeline legacy `else` at ~1710), with public `build_clusters` preserved as a frames-backed adapter.
- **Hygiene** — `@pytest.mark.filterwarnings` on the 5 existing parity tests that intentionally run `=0`, so the now-expected warning doesn't clutter the CI summary.

Explicitly out of scope: public `build_clusters`/its callers (frozen till 2.0), a blanket annotation lint, and the scorer-layer `COLUMNAR_PIPELINE` cutover (the next sub-project).

Brainstorm→spec→plan were reviewer-approved; executed via subagent-driven TDD (3 commits).

## Test Plan
- [x] 3 new guard tests (default-on lock, warns-once both channels, silent-on-default)
- [x] `tests/test_cluster.py` + guards: **30 passed**, ruff clean, default path silent under `-W error`
- [x] No production behavior change on the default (frames-out) path
- [ ] CI: full suite incl. the native `=1` parity arms (the stale local native wheel skips those locally; fresh on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)