### PR TITLE
deps(goldenembed): bump zip 2 → 8 (plan item #2)

### DIFF
--- a/packages/rust/extensions/goldenembed/Cargo.lock
+++ b/packages/rust/extensions/goldenembed/Cargo.lock
@@ -15,15 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,12 +125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,17 +145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,17 +153,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -226,8 +189,8 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -808,26 +771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +788,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -1112,20 +1061,23 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "typed-path",
  "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/packages/rust/extensions/goldenembed/Cargo.toml
+++ b/packages/rust/extensions/goldenembed/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1"
 anyhow = "1"
 redb = "2"
 sha2 = "0.10"
-zip = { version = "2", default-features = false, features = ["deflate"] }
+zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
## Summary

**Plan item #2** — `zip 2 → 8`. Investigated rather than blind-bumped:

- `zip` is declared in **exactly one** crate — `goldenembed` (`zip = { version = "2", default-features = false, features = ["deflate"] }`). `datafusion-udf` + `embed-py` only pull it **transitively** via the `goldenembed` path dep and carry no committed lock, so the 3 separate Dependabot PRs collapse to a single real change.
- The **only usage** is `goldenembed/src/model_id.rs` → `ZipArchive::new` + `ZipError::FileNotFound` — both unchanged in zip 8 — and the `deflate` feature survives the major bump. Confirmed compile-clean via Dependabot #922's CI on this exact change.

Change:
- `goldenembed/Cargo.toml`: `zip = "2"` → `"8"` (keeps `default-features=false` + `deflate`).
- `Cargo.lock`: regenerated via `cargo update -p zip --precise 8.6.0` (2.4.2 → 8.6.0; drops arbitrary/thiserror/displaydoc, adds typed-path/zlib-rs) — byte-identical to what Dependabot #922 resolved.

## Test Plan
- [x] `cargo update` regenerated the lock cleanly to zip 8.6.0.
- [x] zip-8 API surface (`ZipArchive::new`, `ZipError::FileNotFound`) + `deflate` feature verified compatible (Dependabot #922 CI on the same change).
- [x] **This PR's CI rebuilds `goldenembed` + the `embed-py` wheel** (path filters fire), re-validating the compile here.

Supersedes #915, #919, #922.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_