### PR TITLE
deps: bump sha2 0.10 → 0.11 (native + fingerprint-core) — plan item #3 part 1

### DIFF
--- a/packages/rust/extensions/fingerprint-core/Cargo.toml
+++ b/packages/rust/extensions/fingerprint-core/Cargo.toml
@@ -17,7 +17,7 @@ name = "goldenmatch_fingerprint_core"
 
 [dependencies]
 # Must match Python hashlib.sha256 byte-for-byte (see core/_hashing.py).
-sha2 = "0.10"
+sha2 = "0.11"
 # JSON parsing for non-Python callers (pgrx / DuckDB / C ABI). arbitrary_precision
 # preserves integer literals exactly so big ints match the Python-str() path.
 serde_json = { version = "1", features = ["arbitrary_precision"] }

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -237,7 +237,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -247,6 +247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -289,6 +298,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,9 +337,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -365,14 +386,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -508,11 +559,20 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1008,13 +1068,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -49,8 +49,8 @@ rayon = "1.12.0"
 # CLK bloom-filter hashing (bloom.rs) -- MUST match Python hashlib.sha256 /
 # hmac.new(..., sha256) byte-for-byte. sha2 is also a transitive dep via
 # fingerprint-core; pinned here explicitly because bloom.rs uses it directly.
-sha2 = "0.10"
-hmac = "0.12"
+sha2 = "0.11"
+hmac = "0.13"
 # Arrow C Data Interface for zero-copy kernel input (see score.rs
 # score_block_pairs_arrow). `pyarrow` brings the PyArrowType FFI bridge;
 # default features (csv/ipc/json/compute) are off — we only read array buffers.

--- a/packages/rust/extensions/native/src/bloom.rs
+++ b/packages/rust/extensions/native/src/bloom.rs
@@ -15,7 +15,7 @@
 //! removes the `str.lower()`/`str.strip()` parity hazard (Python casing/whitespace
 //! rules != Rust `to_lowercase()`/`trim()`), so the kernel is byte-exact by
 //! construction. See `docs/design/2026-05-25-native-acceleration-decision-matrix.md`.
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};


### PR DESCRIPTION
## Summary

**Plan item #3, part 1** — `sha2 0.10 → 0.11`. This is the move to the `digest 0.11` trait family, which is the *real* break (the "green" sha2 PRs elsewhere were just the one-shot `Sha256::digest` path).

**`native`** — sha2 0.10→0.11 **and** hmac 0.12→0.13 in lockstep: hmac 0.12 wants the digest-0.10 `Sha256`, so `Hmac<Sha256>` won't accept sha2 0.11 without the matching hmac major — **this was the #924 CI failure**. `cargo check` pinpointed the single code change: `new_from_slice` moved to the `KeyInit` trait in hmac 0.13, so `src/bloom.rs` now imports it. `update`/`finalize`/`into_bytes` are unchanged. `blake2 0.10` (digest 0.10, used independently in `featurize.rs`) coexists fine — no need to drag it along. Lock regenerated; **`cargo check` passes clean locally.**

**`fingerprint-core`** — sha2 0.10→0.11 (one-shot `Sha256::digest`, no API change, no committed lock). Compiles as a native dependency.

## Test Plan
- [x] `cargo check` on `native` — clean after the `KeyInit` import (the one and only error).
- [x] `fingerprint-core` compiles (built as a `native` dep in the same check).
- [x] Lock regenerated to sha2 0.11.0 + hmac 0.13.0; this PR's CI rebuilds both crates' native lanes.

## Scope / coordination
Supersedes **#920** (fingerprint-core) + **#924** (native). The **goldenembed-cluster** sha2 bumps — #913 (datafusion-udf), #918 (embed-py), #921 (goldenembed), all of which get sha2 *via* goldenembed — are **deferred to a follow-up after #930 merges**, so they don't collide with #930's `goldenembed/Cargo.lock` change. I'll pick them up cleanly once #930 lands.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_