### PR TITLE
fix(bench): scale scorer-columnar workload cardinality with N (was O(N^2))

### DIFF
--- a/packages/python/goldenmatch/scripts/bench_scorer_columnar.py
+++ b/packages/python/goldenmatch/scripts/bench_scorer_columnar.py
@@ -2,12 +2,19 @@
 
 Legacy list[tuple] scorer (GOLDENMATCH_COLUMNAR_PIPELINE=0) vs columnar DataFrame
 scorer (=1), on an EXPLICIT single-weighted-fuzzy-matchkey config (auto-config is
-ineligible). Each variant runs in its own subprocess for a clean peak RSS; the
-legacy path is expected to OOM at 5M+ (recorded as a result). Parity (pair-set
-identity) is checked in-process at a capped small scale.
+ineligible). Each variant runs in its own subprocess for a clean peak RSS. The
+verdict is: columnar faster + pair-parity where both run; columnar lower peak RSS
+(the DataFrame pair representation is ~3x more compact than list[tuple], so at high
+pair volume the legacy path OOMs first -- recorded as a result when it happens).
+
+`make_workload` scales surname cardinality with N (bounded block size), so the
+candidate volume is LINEAR in N -- a fixed surname pool makes the scorer O(N^2) and
+wedges the box well before any signal (see make_workload). Target scales are 1M and
+5M; 25M+ fuzzy RECORD-scoring is impractical (hours) and unnecessary -- the columnar
+win is already visible at 1M/5M.
 
 Local smoke: python scripts/bench_scorer_columnar.py --rows 2000 --runs 1
-Workflow: bench-scorer-columnar.yml (large-new-64GB) passes --rows 1000000,5000000 / 25000000.
+Workflow: bench-scorer-columnar.yml (large-new-64GB) passes --rows 1000000,5000000.
 """
 from __future__ import annotations
 
@@ -30,20 +37,32 @@ _FIRST = ["James", "Mary", "Robert", "Patricia", "John", "Jennifer", "Michael",
           "Linda", "David", "Elizabeth", "William", "Susan", "Richard", "Karen"]
 
 
-def make_workload(rows: int, dupe_rate: float = 0.2, seed: int = 7):
+def make_workload(rows: int, dupe_rate: float = 0.2, seed: int = 7, block_target: int = 64):
     """Return a polars DataFrame of `rows` person records, ~dupe_rate of which are
-    lightly-corrupted near-duplicates of an earlier record."""
+    lightly-corrupted near-duplicates of an earlier record.
+
+    Surname CARDINALITY scales with `rows` (~= n_base / block_target distinct
+    surnames) so the exact-surname blocking keeps block size ~constant (~block_target)
+    as N grows -- candidate-pair volume is then LINEAR in N. A FIXED surname pool would
+    make block size = N / pool_size, so the per-block fuzzy cdist is O((N/pool)^2) and
+    the whole scorer O(N^2): at 1M+ that builds multi-GB per-block score matrices and
+    wedges/OOMs the box BEFORE the columnar-vs-legacy signal exists. Surname is the
+    exact block key (always scores 1.0 within a block); given_name carries the fuzzy
+    signal that drives the threshold decisions."""
     import random
 
     import polars as pl
 
     rng = random.Random(seed)
+    n_base = max(1, int(rows * (1 - dupe_rate)))
+    # Distinct, surname-shaped block keys sized to N (suffix keeps them unique).
+    n_surnames = max(len(_SURNAMES), n_base // block_target)
+    surname_pool = [f"{_SURNAMES[i % len(_SURNAMES)]}{i}" for i in range(n_surnames)]
     given: list[str] = []
     surname: list[str] = []
-    n_base = max(1, int(rows * (1 - dupe_rate)))
     for _ in range(n_base):
         given.append(rng.choice(_FIRST))
-        surname.append(rng.choice(_SURNAMES))
+        surname.append(rng.choice(surname_pool))
     while len(given) < rows:
         src = rng.randrange(n_base)
         g = given[src]

--- a/packages/python/goldenmatch/tests/test_bench_scorer_columnar_smoke.py
+++ b/packages/python/goldenmatch/tests/test_bench_scorer_columnar_smoke.py
@@ -2,6 +2,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # scripts/ is not a package; import the bench module by path.
 _SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(_SCRIPTS))
@@ -23,6 +25,20 @@ def test_workload_has_duplicates_and_spread_surnames():
     assert df["surname"].n_unique() >= 20
 
 
+def test_block_size_bounded_at_scale():
+    """The fix: surname cardinality scales with N so exact-surname blocks stay
+    ~constant -- the candidate volume is LINEAR in N, not O(N^2). Without this the
+    bench wedges/OOMs the box at 1M+ (fixed 30-surname pool -> N/30 per block)."""
+    n = 100_000
+    df = B.make_workload(rows=n)
+    max_block = df.group_by("surname").len()["len"].max()
+    # block_target=64 + dups -> a few hundred at most; assert bounded, NOT ~N/30.
+    assert max_block < 400, f"max block {max_block} not bounded -> O(N^2) pathology"
+    # cardinality scales with N (would be a fixed 30 in the buggy version):
+    assert df["surname"].n_unique() >= n // 200
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")  # bench pins CLUSTER_FRAMES_OUT=0 by design
 def test_bench_runs_end_to_end(tmp_path):
     """Run the whole bench (parent) at a tiny scale; both variants complete,
     parity holds, a table is produced."""


### PR DESCRIPTION
## Summary

Fixes a scale pathology in `bench_scorer_columnar.py` (from #929) caught before dispatching the at-scale verdict: `make_workload` used a fixed 30-surname pool with exact-surname blocking, so **block size = N/30 grew linearly with N** → the per-block fuzzy `cdist` is O((N/30)²) and the whole bench **O(N²)**. At 1M that's ~33K-row blocks → ~8.9 GB per-block score matrices → the box wedges/OOMs *before* any columnar-vs-legacy signal exists. The 2K smoke passed because 67-row blocks are trivial — a classic reproduce-at-scale gap.

**Fix:** surname cardinality scales with N (`~ n_base / block_target` distinct surnames) so block size stays ~constant (~64) and candidate volume is **linear** in N — the realistic dedup shape (block *count* grows, not block *size*). Regression test asserts `max block size < 400` at 100K (would be ~3,300 in the buggy version). Verified tractable at 20K (1.3s/variant, pair-set parity holds, columnar marginally faster). Docstring re-scoped to **1M/5M** (25M+ fuzzy *record*-scoring is impractical/hours and unnecessary — the win is visible at 1M/5M).

No change to the scorer/pipeline/defaults — bench-only.

## Test Plan
- [x] 4 smoke tests incl. the new `test_block_size_bounded_at_scale` (bounded-block invariant)
- [x] 20K bench runs tractably with parity PASS; ruff clean
- [ ] After merge: dispatch `bench-scorer-columnar.yml` at `rows=1000000,5000000` → verdict table

🤖 Generated with [Claude Code](https://claude.com/claude-code)