### PR TITLE
deps(ts): bump typescript 5.4 → 6.0 with TS6 baseUrl deprecation opt-out

### DIFF
--- a/packages/python/goldenmatch/web/frontend/package.json
+++ b/packages/python/goldenmatch/web/frontend/package.json
@@ -36,7 +36,7 @@
     "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "tailwindcss": "^3",
-    "typescript": "~6.0.2",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.61.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"

--- a/packages/typescript/goldenanalysis/package.json
+++ b/packages/typescript/goldenanalysis/package.json
@@ -74,7 +74,7 @@
     "@types/node": "^25.9.3",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/typescript/goldenanalysis/tsconfig.json
+++ b/packages/typescript/goldenanalysis/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/typescript/goldencheck-types/package.json
+++ b/packages/typescript/goldencheck-types/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^25.9.3",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
   "license": "MIT",

--- a/packages/typescript/goldencheck-types/tsconfig.json
+++ b/packages/typescript/goldencheck-types/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/typescript/goldencheck/package.json
+++ b/packages/typescript/goldencheck/package.json
@@ -82,7 +82,7 @@
     "nodejs-polars": "^0.25.1",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8",
     "yaml": "^2.9.0"
   }

--- a/packages/typescript/goldencheck/tsconfig.json
+++ b/packages/typescript/goldencheck/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -84,7 +84,7 @@
     "@types/node": "^25.9.3",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8",
     "yaml": "^2.9.0"
   }

--- a/packages/typescript/goldenflow/tsconfig.json
+++ b/packages/typescript/goldenflow/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/typescript/goldenmatch-wasm-runtime/package.json
+++ b/packages/typescript/goldenmatch-wasm-runtime/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^25.9.3",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
   "license": "MIT",

--- a/packages/typescript/goldenmatch-wasm-runtime/tsconfig.json
+++ b/packages/typescript/goldenmatch-wasm-runtime/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -57,7 +57,7 @@
     "fast-check": "^4.8.0",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8",
     "yaml": "^2.9.0",
     "better-sqlite3": "^12.10.1"

--- a/packages/typescript/goldenmatch/tsconfig.json
+++ b/packages/typescript/goldenmatch/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/typescript/goldenpipe/package.json
+++ b/packages/typescript/goldenpipe/package.json
@@ -82,7 +82,7 @@
     "@types/node": "^25.9.3",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8",
     "yaml": "^2.9.0"
   }

--- a/packages/typescript/goldenpipe/tsconfig.json
+++ b/packages/typescript/goldenpipe/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/typescript/infermap/package.json
+++ b/packages/typescript/infermap/package.json
@@ -87,7 +87,7 @@
     "goldenmatch": "workspace:*",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/typescript/infermap/tsconfig.json
+++ b/packages/typescript/infermap/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         specifier: ^3
         version: 3.4.19(yaml@2.9.0)
       typescript:
-        specifier: ~6.0.2
+        specifier: ~6.0.3
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.61.0
@@ -114,10 +114,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.9.0))
@@ -142,10 +142,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.9.0))
@@ -170,10 +170,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.9.0))
@@ -192,10 +192,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.9.0))
@@ -226,10 +226,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.9.0))
@@ -247,10 +247,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.9.0))
@@ -278,10 +278,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.9.0))
@@ -306,10 +306,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.9.0))
@@ -2338,11 +2338,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -4343,7 +4338,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -4364,7 +4359,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -4398,8 +4393,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
## Summary

Completes the **`typescript 5.4 → 6.0`** bump deferred from #934 (the ts-dev safe subset) — the migration half that needs a config change rather than a pure version bump.

### Why it was held back
TS6 promotes the `baseUrl` deprecation to a **hard error**, and tsup injects `baseUrl` into its dts build:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

This reddened every `tsup` dts build (and thus `typescript` / `wasm_score` / `analysis_wasm` in #925).

### Change
- `typescript` → `^6.0.3` across the 8 `packages/typescript/*` packages (all were exactly `^5.4.0`); frontend `~6.0.2 → ~6.0.3`.
- Added `"ignoreDeprecations": "6.0"` to `compilerOptions` in each of the **8** `packages/typescript/*/tsconfig.json`. There is no shared base tsconfig (none of the 8 `extends`), so it's applied per-package. The frontend tsconfig needed no change (already on TS6, doesn't use tsup).

## Test Plan — verified locally (pnpm 9.15.0)
- [x] `pnpm turbo run build typecheck test` → **26/26 tasks green**, no `TS5101`/baseUrl errors; all tsup dts builds compile clean.
- [x] Frontend `tsc -b && vite build` → green (169 modules, 756ms).
- [x] `pnpm-lock.yaml` regenerated.

## Sequencing
Sibling of #934 (branched off `main`, **not** stacked, to avoid the stacked-PR auto-closure footgun). The only overlap with #934 is the `typescript` line + lockfile — whichever of {#934, this} merges second gets a quick rebase + `pnpm install` lock regen. Logically lands **after** #934.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_