### PR TITLE
ci: merge-queue support + stop forcing the full matrix on ci.yml edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+  workflow_dispatch:
+    inputs:
+      run_all:
+        description: "Run the full job matrix (bypass path filters)"
+        type: boolean
+        default: true
 
 # Locked-down by default. Individual jobs escalate as needed.
 # OpenSSF Scorecard / Token-Permissions check requires this top-level scope.
@@ -35,6 +42,12 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       action: ${{ steps.filter.outputs.action }}
       ci_workflow: ${{ steps.filter.outputs.ci_workflow }}
+      # force_all: true on merge_group (the authoritative batched gate) and on a
+      # workflow_dispatch with run_all=true. Drives the full job matrix + the
+      # dynamic python matrix independently of the path filters (which can't diff
+      # on merge_group anyway). Decoupled from ci_workflow so a PR-level ci.yml
+      # edit no longer forces every lane — workflow_lint covers that cheaply.
+      force_all: ${{ steps.flags.outputs.force_all }}
       pyright_slice: ${{ steps.filter.outputs.pyright_slice }}
       # goldenmatch runs as its own sharded jobs (python_goldenmatch / _heavy /
       # _coverage), NOT in the generic `python` matrix, so expose its filter
@@ -60,6 +73,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: filter
+        # paths-filter diffs PR head vs base (or push head vs prev). merge_group
+        # and workflow_dispatch have no such diff base, so skip it there and let
+        # the `flags` step below force the full matrix instead.
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
         with:
           # `filters` runs against the diff between the PR head and base
           # (or push head and the previous push for branch builds). Per-path
@@ -301,13 +318,25 @@ jobs:
               - 'packages/python/goldenmatch/goldenmatch/core/complexity_profile.py'
               - 'packages/python/goldenmatch/goldenmatch/core/scorer.py'
               - 'packages/python/goldenmatch/goldenmatch/config/**'
+      # Always-on flag step: force the full matrix on merge_group (the
+      # authoritative batched gate) and on a workflow_dispatch run_all=true.
+      # Runs unconditionally (the `filter` step above is skipped on those
+      # events), so downstream `force_all` gates resolve on every event.
+      - id: flags
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ] || { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.run_all }}" = "true" ]; }; then
+            echo "force_all=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "force_all=false" >> "$GITHUB_OUTPUT"
+          fi
       # Build the python matrix dynamically: only include packages whose code
       # actually changed. A workflow-file or root-pyproject change expands to
       # all packages so dependency-resolution changes can't slip through.
       - id: set_python
         shell: bash
         env:
-          ALL: ${{ steps.filter.outputs.ci_workflow == 'true' || steps.filter.outputs.python_root == 'true' }}
+          ALL: ${{ steps.flags.outputs.force_all == 'true' || steps.filter.outputs.python_root == 'true' }}
         run: |
           set -euo pipefail
           # NB: goldenmatch is intentionally absent here — it runs as the
@@ -334,6 +363,24 @@ jobs:
             json="${json%,}]"
             echo "pkgs=$json" >> "$GITHUB_OUTPUT"
           fi
+
+  # Fast required check for workflow edits. PR-level ci.yml changes no longer
+  # force the full job matrix (that's now merge_group/dispatch-only via
+  # force_all), so this cheap lane gives `.github/workflows/ci.yml` edits a
+  # required signal at PR time: it parses every workflow file as YAML. The full
+  # matrix still re-validates the filter wiring at merge-queue time (force_all).
+  workflow_lint:
+    needs: changes
+    if: needs.changes.outputs.ci_workflow == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Validate workflow YAML + lint
+        shell: bash
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 -c "import sys,glob,yaml; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('all workflow YAML parses')"
 
   python:
     needs: changes
@@ -407,7 +454,7 @@ jobs:
   # ---------------------------------------------------------------------------
   python_goldenmatch:
     needs: changes
-    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -506,7 +553,7 @@ jobs:
   # datafusion runtime (these files don't import it).
   python_goldenmatch_heavy:
     needs: changes
-    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -576,7 +623,7 @@ jobs:
     # Run when goldenmatch python changed OR the workflow itself changed.
     # Matrix runs all lanes regardless of which prereqs are configured;
     # each lane self-reports its prereq state.
-    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -661,7 +708,7 @@ jobs:
     needs: changes
     if: |
       needs.changes.outputs.python_goldenmatch_postgres == 'true' ||
-      needs.changes.outputs.ci_workflow == 'true'
+      needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
@@ -711,7 +758,7 @@ jobs:
   # benchmarks.yml workflow (schedule + workflow_dispatch).
   synthetic_benchmarks:
     needs: changes
-    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -759,7 +806,7 @@ jobs:
   # workflow.
   benchmark_runner_smoke:
     needs: changes
-    if: needs.changes.outputs.benchmark_runner == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.benchmark_runner == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
@@ -826,7 +873,7 @@ jobs:
 
   typescript:
     needs: changes
-    if: needs.changes.outputs.typescript == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.typescript == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -858,7 +905,7 @@ jobs:
 
   wasm_score:
     needs: changes
-    if: needs.changes.outputs.wasm_score == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.wasm_score == 'true' || needs.changes.outputs.force_all == 'true'
     # Opt-in WASM scorer lane: builds the score-wasm artifact, then runs the
     # parity test UN-skipped (it skips elsewhere with no artifact) + an
     # informational benchmark. The artifact-free wasm-backend/wasm-fallback unit
@@ -897,7 +944,7 @@ jobs:
 
   analysis_wasm:
     needs: changes
-    if: needs.changes.outputs.analysis_wasm == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.analysis_wasm == 'true' || needs.changes.outputs.force_all == 'true'
     # Opt-in WASM aggregate lane: builds the analysis-wasm artifact, then runs the
     # parity test UN-skipped (it skips elsewhere with no artifact) + an
     # informational benchmark. The artifact-free goldenanalysis tests + the
@@ -935,7 +982,7 @@ jobs:
 
   web_ui_e2e:
     needs: changes
-    if: needs.changes.outputs.web_ui_e2e == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.web_ui_e2e == 'true' || needs.changes.outputs.force_all == 'true'
     # End-to-end smoke for the goldenmatch[web] UI: builds the frontend,
     # boots the FastAPI backend against the pytest fixture project, runs
     # one Playwright scenario covering home → run → cluster.
@@ -979,7 +1026,7 @@ jobs:
 
   rust:
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -1036,7 +1083,7 @@ jobs:
   # tests run under instrumentation (a skipped test would understate coverage).
   rust_coverage:
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     defaults:
@@ -1096,7 +1143,7 @@ jobs:
   # path matches the pure-Python path bit-for-bit (GOLDENMATCH_NATIVE 0 vs 1).
   native:
     needs: changes
-    if: needs.changes.outputs.native == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.native == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1167,7 +1214,7 @@ jobs:
   # integer-exact), incl. a GOLDENCHECK_NATIVE=1 required-mode run.
   goldencheck_native:
     needs: changes
-    if: needs.changes.outputs.goldencheck_native == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.goldencheck_native == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1224,7 +1271,7 @@ jobs:
   # not yet wired into the pure path (the wall-verified flip is a follow-up).
   goldenanalysis_native:
     needs: changes
-    if: needs.changes.outputs.analysis_native == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.analysis_native == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1271,7 +1318,7 @@ jobs:
   # back to `goldenmatch_native._native` from the installed wheel.
   native_wheel:
     needs: changes
-    if: needs.changes.outputs.native == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.native == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1315,7 +1362,7 @@ jobs:
   # asserted byte-identical to the pure phonenumbers reference. Mirrors `native`.
   native_flow:
     needs: changes
-    if: needs.changes.outputs.native_flow == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.native_flow == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1362,7 +1409,7 @@ jobs:
   # loader must fall back to `goldenflow_native._native` from the wheel.
   native_flow_wheel:
     needs: changes
-    if: needs.changes.outputs.native_flow == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.native_flow == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1407,7 +1454,7 @@ jobs:
   # trained model; the unit tests cover the deterministic featurizer here.
   goldenembed:
     needs: changes
-    if: needs.changes.outputs.goldenembed == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.goldenembed == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1432,7 +1479,7 @@ jobs:
   # normalizes the dist name `goldenmatch-embed` -> `goldenmatch_embed`.
   embed_wheel:
     needs: changes
-    if: needs.changes.outputs.embed == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.embed == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1486,7 +1533,7 @@ jobs:
   # build_clusters AND are invariant to Ray partition count (1/2/3/7).
   distributed:
     needs: changes
-    if: needs.changes.outputs.distributed == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.distributed == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     # 30 (was 20): the #844 randomized-contraction WCC ray gate adds a ~3.5 min
     # blocking step on top of the invariance gate (~5.5 min) + broad coverage
@@ -1559,7 +1606,7 @@ jobs:
   # docs/superpowers/specs/2026-06-03-sail-tier-design.md (Stage S1).
   sail:
     needs: changes
-    if: needs.changes.outputs.sail == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.sail == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1611,7 +1658,7 @@ jobs:
 
   action:
     needs: changes
-    if: needs.changes.outputs.action == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.action == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1633,7 +1680,7 @@ jobs:
   # postgres/, bridge/, or workspace files actually change.
   rust_pgrx:
     needs: changes
-    if: needs.changes.outputs.rust_pgrx == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.rust_pgrx == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -1843,7 +1890,7 @@ jobs:
   # enumerates packages/python/<pkg>). This lane fills that gap.
   duckdb_extensions:
     needs: changes
-    if: needs.changes.outputs.duckdb_extensions == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.duckdb_extensions == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     defaults:
@@ -1878,7 +1925,7 @@ jobs:
   # `include` and the `pyright_slice` filter above.
   pyright:
     needs: changes
-    if: needs.changes.outputs.pyright_slice == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.pyright_slice == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1921,7 +1968,7 @@ jobs:
 
   ts_parity_freshness:
     needs: changes
-    if: needs.changes.outputs.ts_parity == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    if: needs.changes.outputs.ts_parity == 'true' || needs.changes.outputs.force_all == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1962,6 +2009,7 @@ jobs:
   ci-required:
     needs:
       - changes
+      - workflow_lint
       - python
       - python_goldenmatch
       - python_goldenmatch_heavy


### PR DESCRIPTION
## Why

Today's "20 PRs stacked behind CI" grind was caused by **"Require branches up to date" + a hot main + long CI** — every merge invalidated every other PR's up-to-date status, forcing serial re-rebases, and the full-matrix PRs (anything editing `ci.yml`) **livelocked** (their 20-min run got cancelled by the next rebase before it could land). The industry fix is a **merge queue** (the "Not Rocket Science Rule" without the serial pain): PRs get queued, the queue speculatively tests `main + PR1 + PR2 …` in parallel and **auto-rebases**, so humans never manually re-sync and N PRs land in ~one CI cycle instead of N.

This PR is the **file half**. The companion **settings half is in the repo ruleset** (see below) — there's no API for it, so it's a few clicks for a maintainer.

## File changes (`.github/workflows/ci.yml` only, +76/−28)

1. **`merge_group:` trigger** — CI runs on the queue's speculative branches. On `merge_group` the full matrix runs (the authoritative, **batched** gate — once per batch, not once per PR).
2. **`workflow_dispatch` with a `run_all` input (default true)** — on-demand full-matrix run; also how you validate *this* PR (see rollout).
3. **New `force_all` flag** (`changes.outputs.force_all`) = true only on `merge_group` / `workflow_dispatch+run_all`. The `dorny/paths-filter` step is skipped on those events (no diff base), and a new always-on `flags` step computes `force_all`; `set_python`'s `ALL` now keys off it.
4. **Decoupled the full-matrix force from `ci.yml` edits** — all 27 downstream job gates switched `ci_workflow == 'true'` → `force_all == 'true'`. A PR that edits `ci.yml` no longer drags every lane.
5. **New fast required `workflow_lint` job** — parses every workflow file as YAML (dependency-free; runs on workflow edits + at the gate). The full matrix still re-validates the filter wiring at **merge-queue** time, so filter-logic regressions are still caught before landing — just not on every PR push.

Validated locally with **actionlint v1.7.12 (zero errors)** + YAML parse. `grep` confirms 0 stray `needs.changes.outputs.ci_workflow == 'true'` in downstream jobs; the `ci_workflow` output passthrough is preserved (it feeds `workflow_lint`).

> `workflow_lint` uses a self-contained `yaml.safe_load` rather than a third-party actionlint action, because the repo SHA-pins all external actions and I couldn't verify a current actionlint-action SHA from here. Easy to upgrade to a pinned `actionlint` action later — the local actionlint run already passes, so it's a drop-in.

## Settings half — a maintainer does this (no API tool)
**Settings → Rules → `main` ruleset:**
1. **Enable "Require merge queue"** — merge method **Squash**; leave default build concurrency (≈5) so it batches speculatively.
2. **Disable "Require branches to be up to date before merging"** ← the single line that caused today's livelock; the queue provides that guarantee now.
3. Keep **`ci-required`** as the required status check (it runs on `merge_group` too).

## Rollout order (matters)
1. **Validate this PR via the `Run all` `workflow_dispatch`** on `claude/ci-merge-queue` (Actions → ci → Run workflow → run_all=true) → confirms the full matrix is green under the new wiring. By design this PR won't drag the full matrix itself, so this dispatch is the validation.
2. **Merge it** (harmless until the queue is enabled — `merge_group` just sits unused).
3. **Flip the two ruleset settings.**
4. **Watch the first queue batch** closely (the `merge_group` path can't be exercised until the queue is live — chicken-and-egg), then let it drain itself.

After this, "20 PRs stacked" becomes the queue draining in ~one CI cycle, and `ci.yml` edits stop self-inflicting the 20-min run.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_