### PR TITLE
docs: 1.0->2.0 evolution + at-a-glance pages + repo doc-surface inventory

### DIFF
--- a/.claude/doc-surfaces.md
+++ b/.claude/doc-surfaces.md
@@ -1,0 +1,86 @@
+# Doc surfaces — Golden Suite monorepo
+
+Machine-and-human checklist of every documentation surface that must be swept
+when a feature/rollout lands. Consumed by the `rollout-docs-sweep` skill (it looks
+for this file before falling back to generic discovery). Keep it current when a
+new surface is added.
+
+Repo: `benseverndev-oss/goldenmatch` (polyglot monorepo). "Sweep" = for each
+surface, check whether the rollout added/renamed/removed anything the surface
+documents, and update it. A removed flag/symbol/endpoint is the highest-signal
+thing to grep for.
+
+## 1. Mintlify docs site (`docs-site/`)
+
+- **`docs-site/docs.json`** — navigation. A NEW page is invisible until added to a
+  group's `pages` array. Validate it still parses (`json.load`) after editing.
+- **`docs-site/<package>/*.mdx`** — the per-package pages. Highest-churn:
+  - `goldenmatch/tuning.mdx` — the canonical `GOLDENMATCH_*` env-var reference.
+    Any added/removed/renamed flag MUST be reflected here. (Keep the separate
+    `GOLDENMATCH_SAIL_*` flags distinct from the non-Sail ones.)
+  - `goldenmatch/configuration.mdx` — config YAML fields.
+  - `goldenmatch/identity-graph.mdx` — identity scheme/behavior.
+  - `goldenmatch/migrating-to-v2.mdx`, `v1-to-v2.mdx`, `v1-vs-v2.mdx` — upgrade docs.
+  - feature pages under each package group (auto-config, scoring, blocking, ...).
+- The site auto-serves **`/llms.txt`** and **`/llms-full.txt`** at `docs.bensevern.dev`
+  (Mintlify-generated). The repo-root `llms.txt` family is the GitHub/raw supplement.
+
+## 2. READMEs
+
+- **`README.md`** (root) and **`packages/python/goldenmatch/README.md`** — the
+  homepage "what's new" callout block is **single-sourced from CHANGELOG markers**.
+  Do NOT hand-edit the block between `<!-- README-callouts:start -->` and `:end -->`.
+  Instead add a `<!-- README-callout ... -->` block under the version heading in
+  `packages/python/goldenmatch/CHANGELOG.md`, then run:
+  `python scripts/sync_readme_callouts.py` (regenerates both; `--check` is a CI gate).
+- **`packages/python/<pkg>/README.md`** — each package's PyPI long description.
+- **`packages/typescript/<pkg>/README.md`**, `packages/actions/<pkg>/README.md`.
+
+## 3. CHANGELOGs
+
+- **`packages/python/<pkg>/CHANGELOG.md`** (Keep-a-Changelog). The release section
+  is the source of truth; the homepage callout + version-consistency gate read it.
+- The `version_consistency` CI gate requires `pyproject.toml` == `<pkg>/__init__.py`
+  == `server.json` (`.version` + `packages[].version`) in lockstep. Bump all three.
+
+## 4. Context network (`context-network/`)
+
+- **`context-network/decisions/NNNN-*.md`** — add an ADR for any load-bearing
+  architectural decision (numbered sequentially; current max wins). House style:
+  `# NNNN — Title`, a `**Status:** ... • **Shipped:** ...` line, then
+  `## Context` / `## Decision` / `## Consequence`.
+- **`context-network/discovery.md`** — the nav hub; add a one-line link to any new
+  decision/architecture node.
+- **`context-network/meta/updates.md`** — newest-first log; add a dated entry.
+- **`context-network/architecture/*.md`**, **`planning/roadmap.md`** — update if the
+  rollout changes an active technical surface or the roadmap.
+- (There is ALSO an older `docs/adr/` set, 0000+. `context-network/decisions/` is the
+  primary; only touch `docs/adr/` if you are extending that specific series.)
+
+## 5. Examples (`examples/` and `packages/python/<pkg>/examples/`)
+
+- Runnable scripts + `examples/{python,sql,typescript,airflow}/`. If a rollout
+  changed a public API signature, an env var, or a CLI command an example uses,
+  update the example AND its README. Removed flags/symbols are the thing to grep.
+
+## 6. Agent / discovery surfaces
+
+- **`llms.txt`** family (root + per-package + suite root) — keep capability/feature
+  counts and links honest (MCP tool counts, A2A skill counts, perf claims).
+- **`server.json`** per package (MCP registry manifest) — version + capabilities.
+- Agent card `_SKILLS` / MCP tool registrations if tools were added/removed.
+
+## 7. Top-level
+
+- **Root `CLAUDE.md` + per-package `CLAUDE.md`** — durable dev gotchas (not feature
+  docs, but the place a rollout's hard-won lesson belongs).
+- **GitHub About / topics**, **`CITATION.cff`** — only on a notable capability change.
+
+## Sweep mechanics for this repo
+
+- Grep the whole repo (minus `_archive/`) for every symbol/flag/endpoint the rollout
+  REMOVED or RENAMED — that single grep finds most stale docs at once.
+- `scripts/sync_readme_callouts.py --check`, `version_consistency`, and `readme_callouts`
+  are CI gates; run their local equivalents before pushing.
+- Docs-only PRs run a fast CI subset (path-filtered). Auth dance: push as `benzsevern`,
+  switch back to `benzsevern-mjh` (see root `CLAUDE.md`).

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -42,7 +42,9 @@
                   "goldenmatch/installation",
                   "goldenmatch/cli",
                   "goldenmatch/tui",
-                  "goldenmatch/migrating-to-v2"
+                  "goldenmatch/migrating-to-v2",
+                  "goldenmatch/v1-to-v2",
+                  "goldenmatch/v1-vs-v2"
                 ]
               },
               {

--- a/docs-site/goldenmatch/v1-to-v2.mdx
+++ b/docs-site/goldenmatch/v1-to-v2.mdx
@@ -1,0 +1,74 @@
+---
+title: "What changed from 1.0 to 2.0"
+description: "The full arc from GoldenMatch 1.0 (March 2026) to 2.0 (June 2026): the capabilities that landed across the 1.x line, plus the four breaking removals in the 2.0 major."
+keywords: ["upgrade", "v1", "v2", "2.0", "changelog", "identity graph", "distributed", "native", "fellegi-sunter", "splink", "what's new"]
+---
+
+This is the wide-angle view of everything between GoldenMatch **1.0.0** (2026-03-23) and **2.0.0** (2026-06-14). If you just want the upgrade steps, read [Migrating to v2](/goldenmatch/migrating-to-v2). For a one-screen comparison, see [v1 vs v2 at a glance](/goldenmatch/v1-vs-v2).
+
+<Note>
+  The 2.0 **major** is a small, clean break: four removed legacy paths, and the pipeline's output is unchanged. The real difference between a 1.0 install and a 2.0 install is the entire **1.x feature accumulation** below. You are not upgrading into a rewrite; you are upgrading into three months of additive capability with a tidy semver line drawn under it.
+</Note>
+
+## What actually breaks in 2.0
+
+Four items, each with a 1.x deprecation runway. Full steps in [Migrating to v2](/goldenmatch/migrating-to-v2).
+
+- **`GOLDENMATCH_IDENTITY_ID_SCHEME` + the legacy `:hash:` lookup bridge** are gone. Fingerprintable records resolve to a single canonical `:h1:` id. If you persist an identity DB, run `goldenmatch identity migrate-ids --path <db>` **before** upgrading. Un-fingerprintable rows keep their `:hash:` id.
+- **`GOLDENMATCH_CLUSTER_FRAMES_OUT`** is gone. The Arrow frames-out clustering path is the only path now (it has been the default and output-equivalent since 1.x). Public `build_clusters` still works as a frames-backed adapter.
+- **`RunHistory.cheapest_healthy()`** removed. Use `pick_committed()`.
+- **`_scale_aware_backend`** (internal shim) removed. The public `auto_configure_df` / `dedupe_df` API routes through the v3 planner.
+
+That is the whole break surface. Everything else below is what you *gain* by moving off an older 1.x.
+
+## Where 1.0 started (2026-03-23)
+
+GoldenMatch 1.0 was already a complete, production-stable entity-resolution toolkit, not a preview:
+
+- A frozen public API: `gm.dedupe()`, `gm.match()`, `gm.pprl_link()`, `gm.evaluate()` with typed results, 96 public exports, 21 CLI commands, a config YAML schema, a REST API + client, MCP tools, and Jupyter `_repr_html_()` display.
+- Accuracy as a first-class gate: `goldenmatch evaluate --min-f1 0.90` exits non-zero in CI, plus `goldenmatch label` for interactive ground-truth building.
+- A Ray distributed backend for large workloads, LLM-assisted scoring, PPRL (privacy-preserving record linkage), domain packs, and match explanations.
+
+If you are on 1.0 today, dedupe/match/PPRL/evaluate all still work the same way in 2.0. What changed is everything around them.
+
+## What landed across 1.x
+
+### Zero-config and the introspective planner
+
+The headline posture of the suite, "find duplicates in 30 seconds with no config," hardened across 1.x. The **v3 controller/planner** replaced single-threshold heuristics with a rule table over runtime + complexity profiles that picks the execution plan (backend, scale path, confidence handling) for you. At large row counts it refuses to silently guess, raising rather than committing a low-confidence config. You set nothing for correctness; the planner chooses.
+
+### Identity Graph (v1.15)
+
+`dedupe()` returns run-local clusters whose IDs mean nothing across runs. **v1.15 (2026-05-12)** added a durable, queryable **Identity Graph**: stable `entity_id`s (UUIDv7) that survive re-runs, evidence edges that record *why* two records linked, an append-only event log, and the **same JSON view from six surfaces** (Python, CLI, REST, MCP, A2A, SQL, web UI). Off by default; opt in with an `identity:` config block. See [Identity Graph](/goldenmatch/identity-graph).
+
+### Scale: single-box at scale, then distributed 100M
+
+- **Arrow-native groundwork (v1.25, 2026-06-01):** columnar pair-stream and two-frame cluster representations, plus optional Rust/Arrow-C kernels behind the `goldenmatch[native]` wheel, with the pure-Python + Polars pipeline kept as the byte-for-byte reference.
+- **Distributed 100M (v1.26, 2026-06-04):** the Phase-5 streaming pipeline (`GOLDENMATCH_DISTRIBUTED_PIPELINE=2`) ran a full 100,000,000-row dedupe end to end in ~213s with the driver peaking at 0.30 GB RSS, by removing every driver-side collect. Later validated on a real 5-node GCP cluster (100M in ~9.2 min, clusters recovered exactly).
+
+### Native acceleration, signed off
+
+The optional native kernel matured into a **signed-off set** (`clustering`, `block_scoring`, `pairs`, `featurize`, `hashing`) that runs automatically under the default `GOLDENMATCH_NATIVE=auto` when the wheel is installed, each cleared to bit/ULP parity against the Python reference so flipping native on or off never changes output. See [Tuning & opt-ins](/goldenmatch/tuning).
+
+### Probabilistic Fellegi-Sunter that beats Splink
+
+The `type: probabilistic` matchkey grew from a scorer into a **Splink-class Fellegi-Sunter engine**: supervised `m` estimation, a match-weight waterfall, calibration, and accuracy analysis. By **v1.29/1.30 (2026-06-09)**, zero-training FS auto-config beat hand-rolled, expert-tuned Splink on every dataset Splink scores, on one shared evaluator (`historical_50k` pairwise F1 0.778 vs 0.757, `febrl3` 0.991 vs 0.965), made reproducible by an EM training-pair determinism fix.
+
+### New surfaces and engines
+
+- **SQL-native UDFs** for DuckDB, Postgres, and DataFusion (identity resolve/view/history/conflicts/list as in-database functions).
+- An opt-in **Sail (Spark Connect) distributed tier** as a buildable, Sail-native alternative to Ray (`goldenmatch[sail]`).
+- Opt-in **WASM acceleration** for the TypeScript port, so the edge-safe pure-TS packages can optionally reach the same Rust `*-core` kernels.
+
+## Which 1.x are you coming from?
+
+- **From a recent 1.2x (>= 1.25):** the upgrade is essentially just the [migration steps](/goldenmatch/migrating-to-v2). Your identity ids are already `:h1:`; you mostly remove two now-ignored env vars.
+- **From an older 1.x (< 1.25) with a persisted identity DB:** run `goldenmatch identity migrate-ids` first, then upgrade. Your DB may still hold legacy `:hash:` ids that 2.0 will otherwise treat as new entities.
+- **From 1.0 with no identity graph:** there is nothing to migrate. `pip install --upgrade goldenmatch` and you pick up every capability above; dedupe/match/PPRL/evaluate are unchanged.
+
+## See also
+
+- [Migrating to v2](/goldenmatch/migrating-to-v2) — the step-by-step upgrade.
+- [v1 vs v2 at a glance](/goldenmatch/v1-vs-v2) — the one-screen comparison tables.
+- [Tuning & opt-ins](/goldenmatch/tuning) — every `GOLDENMATCH_*` knob in 2.0.
+- The full per-version detail lives in `packages/python/goldenmatch/CHANGELOG.md`.

--- a/docs-site/goldenmatch/v1-vs-v2.mdx
+++ b/docs-site/goldenmatch/v1-vs-v2.mdx
@@ -1,0 +1,42 @@
+---
+title: "v1 vs v2 at a glance"
+description: "One-screen comparison of GoldenMatch 1.0 and 2.0: what breaks in the 2.0 major, and the capability deltas that accumulated across the 1.x line."
+keywords: ["v1", "v2", "2.0", "comparison", "breaking changes", "upgrade", "at a glance"]
+---
+
+The scannable version. For the narrative, see [What changed from 1.0 to 2.0](/goldenmatch/v1-to-v2); for the upgrade steps, see [Migrating to v2](/goldenmatch/migrating-to-v2).
+
+<Note>
+  The 2.0 major is a **small, clean break** (four removed legacy paths, output unchanged). The big delta is the 1.x capability accumulation in the second table.
+</Note>
+
+## What breaks in 2.0
+
+| Removed in 2.0 | Replacement | Action needed |
+|---|---|---|
+| `GOLDENMATCH_IDENTITY_ID_SCHEME` + legacy `:hash:` lookup bridge | Canonical `:h1:` scheme (only scheme) | Run `goldenmatch identity migrate-ids` **before** upgrading if you persist an identity DB. Un-fingerprintable rows keep `:hash:`. |
+| `GOLDENMATCH_CLUSTER_FRAMES_OUT` | Arrow frames-out path (the only path now) | Remove the env var; it is silently ignored. Output is unchanged. |
+| `RunHistory.cheapest_healthy()` | `pick_committed()` | Rename the call. |
+| `_scale_aware_backend` (internal shim) | `auto_configure_df` / `dedupe_df` (v3 planner) | Switch to the public API if you imported it directly. |
+
+Nothing else in the public API changed. `dedupe()`, `match()`, `pprl_link()`, `evaluate()` behave identically.
+
+## Capabilities: 1.0 vs 2.0
+
+| Area | GoldenMatch 1.0 (2026-03-23) | GoldenMatch 2.0 (2026-06-14) |
+|---|---|---|
+| Core API | `dedupe` / `match` / `pprl_link` / `evaluate`, 96 exports, 21 CLI commands, REST + MCP | Same surface, unchanged |
+| Config | Zero-config + YAML schema | Zero-config + the **v3 introspective planner** (auto backend/plan, refuses low-confidence at scale) |
+| Identity | Run-local cluster IDs only | **Durable Identity Graph** (v1.15): stable `entity_id`s, evidence edges, event log, 6 surfaces |
+| Single-box scale | Polars in-memory | Planner-selected `bucket` path + signed-off **native Rust kernels** (`GOLDENMATCH_NATIVE=auto`) |
+| Distributed | Ray backend (basic) | **Phase-5 streaming pipeline**: 100M rows end-to-end, ~0.3 GB driver RSS; validated on a real 5-node cluster |
+| Probabilistic matching | Scorer-level | **Splink-class Fellegi-Sunter** that beats hand-rolled Splink on every shared-evaluator dataset (zero training) |
+| Acceleration | Pure Python / Polars | Optional `goldenmatch[native]` Rust/Arrow kernels; bit-parity to the Python reference |
+| SQL | — | **In-database UDFs** for DuckDB / Postgres / DataFusion |
+| Other engines | Ray only | Opt-in **Sail (Spark Connect)** tier; opt-in **WASM** acceleration for the TypeScript port |
+
+## See also
+
+- [What changed from 1.0 to 2.0](/goldenmatch/v1-to-v2) — the full story behind this table.
+- [Migrating to v2](/goldenmatch/migrating-to-v2) — the upgrade steps.
+- [Tuning & opt-ins](/goldenmatch/tuning) — every `GOLDENMATCH_*` knob in 2.0.


### PR DESCRIPTION
Two follow-ups requested after the 2.0.0 cut.

## 1. "What's different between v1.0 and v2.0" docs

The existing `migrating-to-v2.mdx` is the narrow how-to-upgrade guide. These add the wide-angle view, cross-linked to it:

- **`goldenmatch/v1-to-v2.mdx`** -- the full narrative arc: what 1.0 (2026-03-23) shipped, the capabilities that accumulated across 1.x (Identity Graph v1.15, distributed 100M v1.26, native kernels v1.25, Fellegi-Sunter Splink-parity v1.29/1.30, Sail/SQL/WASM surfaces), and the four 2.0 breaking removals. Leads with the honest framing: the 2.0 major is a small clean break; the real delta is the 1.x accumulation.
- **`goldenmatch/v1-vs-v2.mdx`** -- the scannable at-a-glance tables (what breaks + capability deltas per area).

Both wired into `docs.json` Guides (validated parse). The two pages and the migration guide cross-reference each other.

## 2. Repo doc-surface inventory (`.claude/doc-surfaces.md`)

The thin repo-local list of every documentation surface that must be swept on a rollout (docs site + nav, READMEs + the CHANGELOG-sourced callout sync, version lockstep, context network, examples, llms.txt/server.json). It backs a new reusable end-of-rollout docs-sweep workflow so the "did you update the docs/context network/readme?" prompt becomes a repeatable pass.

Docs-only (+ one repo-meta file); no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)