### PR TITLE
fix(ts): bundle goldenmatch-wasm-runtime into npm consumers (unblock goldenanalysis publish)

### DIFF
--- a/.github/workflows/publish-goldenanalysis-js.yml
+++ b/.github/workflows/publish-goldenanalysis-js.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/_publish-js.yml
     with:
       package: goldenanalysis
-      build_deps: false
+      build_deps: true
       ref: ${{ inputs.ref || '' }}
       dry_run: ${{ inputs.dry_run || 'false' }}
     secrets: inherit

--- a/.github/workflows/publish-goldenmatch-js.yml
+++ b/.github/workflows/publish-goldenmatch-js.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/_publish-js.yml
     with:
       package: goldenmatch
-      build_deps: false
+      build_deps: true
       ref: ${{ inputs.ref || '' }}
       dry_run: ${{ inputs.dry_run || 'false' }}
     secrets: inherit

--- a/packages/typescript/goldenanalysis/package.json
+++ b/packages/typescript/goldenanalysis/package.json
@@ -67,11 +67,11 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "commander": "^15.0.0",
-    "goldenmatch-wasm-runtime": "workspace:^"
+    "commander": "^15.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",
+    "goldenmatch-wasm-runtime": "workspace:^",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/typescript/goldenanalysis/tsup.config.ts
+++ b/packages/typescript/goldenanalysis/tsup.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],
-  dts: true,
+  // resolve: roll the bundled goldenmatch-wasm-runtime types up INTO our .d.ts
+  // (noExternal inlines the JS, but tsup keeps a bare `import ... from
+  // 'goldenmatch-wasm-runtime'` in the dts otherwise — unresolvable for a
+  // downstream TS consumer now that the package is a devDependency).
+  dts: { resolve: ["goldenmatch-wasm-runtime"] },
   sourcemap: true,
   clean: true,
   target: "node20",

--- a/packages/typescript/goldenanalysis/tsup.config.ts
+++ b/packages/typescript/goldenanalysis/tsup.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
   loader: { ".wasm": "copy" },
   publicDir: false,
   onSuccess: "node scripts/copy_wasm_artifact.mjs",
+  // Inline the tiny internal WASM plumbing (loader / enable-skeleton / registry)
+  // so it is NOT a published runtime dep — it is not on npm and consumers never
+  // import it directly. This bundles ONLY the plumbing; the wasm-bindgen glue
+  // (analysis_wasm.js) and the .wasm artifact stay external (see `external`).
+  noExternal: ["goldenmatch-wasm-runtime"],
   external: [
     // The wasm-bindgen glue is loaded at RUNTIME (dynamic import inside
     // enableAnalysisWasm) and is absent in a default checkout. Mark it external

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -21,8 +21,7 @@
     "sync:refdata": "node scripts/sync_ts_refdata.mjs"
   },
   "dependencies": {
-    "commander": "^15.0.0",
-    "goldenmatch-wasm-runtime": "workspace:^"
+    "commander": "^15.0.0"
   },
   "peerDependencies": {
     "yaml": "*",
@@ -55,6 +54,7 @@
   "devDependencies": {
     "@types/node": "^25.9.3",
     "fast-check": "^4.8.0",
+    "goldenmatch-wasm-runtime": "workspace:^",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/typescript/goldenmatch/tsup.config.ts
+++ b/packages/typescript/goldenmatch/tsup.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
     "node/backends/score-worker": "src/node/backends/score-worker.ts",
   },
   format: ["esm", "cjs"],
-  dts: true,
+  // resolve: roll the bundled goldenmatch-wasm-runtime types up INTO our .d.ts
+  // (noExternal inlines the JS, but tsup keeps a bare `import ... from
+  // 'goldenmatch-wasm-runtime'` in the dts otherwise — unresolvable for a
+  // downstream TS consumer now that the package is a devDependency).
+  dts: { resolve: ["goldenmatch-wasm-runtime"] },
   sourcemap: true,
   clean: true,
   target: "node20",

--- a/packages/typescript/goldenmatch/tsup.config.ts
+++ b/packages/typescript/goldenmatch/tsup.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
   treeshake: true,
   loader: { ".wasm": "copy" },
   onSuccess: "node scripts/copy_wasm_artifact.mjs",
+  // Inline the tiny internal WASM plumbing (loader / enable-skeleton / registry)
+  // so it is NOT a published runtime dep — it is not on npm and consumers never
+  // import it directly. This bundles ONLY the plumbing; the wasm-bindgen glue
+  // (score_wasm.js) and the .wasm artifact stay external (see `external`).
+  noExternal: ["goldenmatch-wasm-runtime"],
   external: [
     // The opt-in WASM glue is loaded at RUNTIME (dynamic import inside
     // enableWasm) and is absent in a default checkout. Mark it external so

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,13 +105,13 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
-      goldenmatch-wasm-runtime:
-        specifier: workspace:^
-        version: link:../goldenmatch-wasm-runtime
     devDependencies:
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3
+      goldenmatch-wasm-runtime:
+        specifier: workspace:^
+        version: link:../goldenmatch-wasm-runtime
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -211,9 +211,6 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
-      goldenmatch-wasm-runtime:
-        specifier: workspace:^
-        version: link:../goldenmatch-wasm-runtime
     devDependencies:
       '@types/node':
         specifier: ^25.9.3
@@ -224,6 +221,9 @@ importers:
       fast-check:
         specifier: ^4.8.0
         version: 4.8.0
+      goldenmatch-wasm-runtime:
+        specifier: workspace:^
+        version: link:../goldenmatch-wasm-runtime
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3


### PR DESCRIPTION
## Why

Publishing `goldenanalysis` to npm (which you asked for) failed because it declares `goldenmatch-wasm-runtime` (the shared opt-in-WASM plumbing) as a runtime `dependency`, but that package **isn't published to npm** and tsup externalizes it — so `npm i goldenanalysis` would 404 on its own dep. The immediate symptom was a `TS2307` typecheck failure (the publish caller had `build_deps: false`, so the workspace dep was never built).

**`goldenmatch` has the identical latent bug:** current `main` added the same dep; the live `goldenmatch@0.13.0` predates it (only dep = `commander`), so it works today — but its *next* npm release would break the same way. This PR fixes both.

## Fix — bundle the internal plumbing (chosen approach: A)
`goldenmatch-wasm-runtime` is tiny internal glue consumers never import directly, so it's bundled rather than published as a standalone package:
- **`tsup.config.ts`** (goldenanalysis + goldenmatch): `noExternal: ["goldenmatch-wasm-runtime"]` (inline the JS) + `dts: { resolve: [...] }` (roll its types into the `.d.ts` so the published type surface is self-contained).
- **`package.json`** (both): moved `goldenmatch-wasm-runtime` from `dependencies` → `devDependencies` — so it's no longer a published runtime dep.
- **`publish-goldenanalysis-js.yml` + `publish-goldenmatch-js.yml`**: `build_deps: false → true` (build the workspace dep so the publish typecheck/build resolve it).

## WASM stays strictly opt-in (verified)
Only the dormant plumbing is bundled. The wasm-bindgen glue (`analysis_wasm.js` / `score_wasm.js`) stays a **runtime dynamic import**, the `.wasm` artifact is still resolved via `import.meta.url` at runtime, and **no `.wasm` binary lands in any dist**. `enableAnalysisWasm()` / `enableWasm()` paths are unchanged — pure-TS remains the default + fallback.

## Test plan (verified locally)
- [x] `turbo build/typecheck/test` for goldenanalysis + goldenmatch → green, no `TS2307`. goldenmatch suite 1842 pass / 1 expected-fail / 16 skipped; `wasm-scorer.test.ts` correctly skips (artifact absent).
- [x] **Bundled:** no bare `from "goldenmatch-wasm-runtime"` import in either dist's JS **or `.d.ts`**.
- [x] **Opt-in preserved:** wasm-bindgen glue stays external; no `.wasm` in dist.
- [x] **Published shape** (`pnpm pack`): both packages' published `dependencies` = `{commander}` only — `goldenmatch-wasm-runtime` absent (now devDep).

The npm `goldenanalysis` publish has been re-triggered off this branch to land it with the bundled build.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_