### PR TITLE
fix(datafusion-udf): pin brotli alloc-no-stdlib deps to 2.x (unblocks CI)

### DIFF
--- a/packages/rust/extensions/datafusion-udf/Cargo.toml
+++ b/packages/rust/extensions/datafusion-udf/Cargo.toml
@@ -49,6 +49,19 @@ goldenembed = { path = "../goldenembed" }
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13 (matches the
 # sibling `native` crate; the example uses abi3-py310 but we floor at 3.11).
 pyo3 = { version = "0.29", features = ["extension-module", "abi3", "abi3-py311"] }
+# Pin to dodge an upstream brotli 8.0.3 build break (2026-06). brotli 8.0.3 uses
+# alloc-no-stdlib 2.x, but two of its deps bumped to alloc-no-stdlib 3.0.0:
+# alloc-stdlib 0.2.3 and brotli-decompressor 5.0.2. That links two
+# semver-incompatible alloc-no-stdlib versions into brotli (StandardAlloc vs
+# Allocator -> rustc E0277, "could not compile brotli"). Pinning BOTH back to
+# their 2.x-using releases keeps alloc-no-stdlib unified at 2.0.4 so brotli (via
+# parquet -> datafusion) compiles. Neither is used directly; these force the
+# transitive versions. Cargo.lock is gitignored here (CI resolves fresh), so
+# these explicit pins ARE the fix — verified: a fresh `cargo generate-lockfile`
+# resolves a single alloc-no-stdlib 2.0.4 and brotli compiles.
+# Remove once brotli/parquet upstream ships a consistent set.
+alloc-stdlib = "=0.2.2"
+brotli-decompressor = "=5.0.1"
 
 [build-dependencies]
 pyo3-build-config = "0.29"


### PR DESCRIPTION
Fixes the Rust build break that's turning **`python_goldenmatch` (and `ci-required`) red across every PR** — including #950 and #951, neither of which touches Rust.

## Root cause (upstream, not us)
`brotli 8.0.3` uses `alloc-no-stdlib 2.x`, but **two of its own dependencies bumped to `alloc-no-stdlib 3.0.0`** in the last few days:
- `alloc-stdlib 0.2.3`
- `brotli-decompressor 5.0.2`

A fresh cargo resolve then links two semver-incompatible `alloc-no-stdlib` versions into `brotli`, so `StandardAlloc` (from 3.0.0) doesn't implement `Allocator` (from 2.0.4):
```
error[E0277]: the trait bound `StandardAlloc: alloc::Allocator<u8>` is not satisfied
error: could not compile `brotli` due to 36 previous errors
💥 maturin failed: ... packages/rust/extensions/datafusion-udf
```
`brotli` comes in transitively via `parquet → datafusion → datafusion-ffi`. The maturin build of the `datafusion-udf` cdylib runs in the python lanes' setup, so its failure fails every python-touching CI lane.

## Fix
`Cargo.lock` is **gitignored** for this crate (`packages/rust/extensions/.gitignore`), so CI resolves fresh every build — which is why it broke the moment the bad releases landed. Pin both offending transitives back to their `2.x`-using releases in `Cargo.toml`:
```toml
alloc-stdlib        = "=0.2.2"
brotli-decompressor = "=5.0.1"
```
Neither is used directly; they force the transitive versions so `alloc-no-stdlib` unifies at `2.0.4`. Documented inline with removal criteria (once brotli/parquet upstream ships a consistent set).

## Verified
- A fresh `cargo generate-lockfile` (what CI does) now resolves **exactly one** `alloc-no-stdlib` (2.0.4).
- `cargo build -p brotli` **compiles** (was 36 errors → builds in ~4s), including `brotli-decompressor 5.0.1`.

This is the unblocker for #950 + #951 + any other python PR. Ready to merge as soon as you're comfortable — flagged draft per default policy.

https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr)_