### PR TITLE
feat(qis): score-only workflow to recover a distributed F1 from gs:// assignments

### DIFF
--- a/.github/workflows/score-distributed-assignments.yml
+++ b/.github/workflows/score-distributed-assignments.yml
@@ -1,0 +1,89 @@
+# Oracle-score a distributed Phase-5 run's gs:// cluster assignments against the
+# deterministic QIS ground truth, on a 64 GB runner -- no cluster, no re-run.
+# Used to recover a distributed F1 when the run completed but the result JSON was
+# lost (e.g. the `rsync_down` rename), or to re-score existing assignments.
+name: score-distributed-assignments
+
+on:
+  workflow_dispatch:
+    inputs:
+      assignments_gs:
+        description: "gs:// dir of the assignment parquet files"
+        required: true
+        default: "gs://gm-phase5-844-golden490919/qis-dist/27488902460/qis_assignments_100000000"
+      rows:
+        description: "total rows in the run (N)"
+        required: true
+        default: "100000000"
+      label:
+        description: "artifact tag"
+        required: false
+        default: "dist-100m"
+
+permissions:
+  contents: read
+
+jobs:
+  score:
+    runs-on: large-new-64GB
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install scorer deps + Infisical CLI
+        run: |
+          pip install --upgrade pip
+          pip install "polars>=1.25" "numpy>=1.26"
+          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+          sudo apt-get update && sudo apt-get install -y infisical
+
+      - name: Fetch GCP creds from Infisical
+        env:
+          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
+          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          INFISICAL_TOKEN=$(infisical login --silent --plain \
+            --method=universal-auth \
+            --client-id="$INFISICAL_CLIENT_ID" \
+            --client-secret="$INFISICAL_CLIENT_SECRET")
+          echo "::add-mask::$INFISICAL_TOKEN"
+          GCP_PROJECT_ID=$(infisical secrets get GCP_RAY_BENCH_PROJECT_ID \
+            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN")
+          echo "::add-mask::$GCP_PROJECT_ID"
+          infisical secrets get GCP_SA_KEY_B64 \
+            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN" \
+            | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
+          chmod 600 "$HOME/gcp-sa.json"
+          gcloud auth activate-service-account --key-file="$HOME/gcp-sa.json" --project="$GCP_PROJECT_ID"
+
+      - name: Download assignments + score
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/assign
+          gcloud storage cp -r "${{ inputs.assignments_gs }}/*" /tmp/assign/
+          echo "downloaded $(ls /tmp/assign/*.parquet | wc -l) parquet files"
+          python scripts/score_distributed_assignments.py \
+            --dir /tmp/assign --rows ${{ inputs.rows }} \
+            --out "/tmp/score_${{ inputs.label }}.json" | tee /tmp/score_stdout.txt
+
+      - name: Headline to step summary
+        if: always()
+        run: |
+          {
+            echo '## Distributed ${{ inputs.rows }}-row quality'
+            echo '```'
+            grep -E "pairwise:|b_cubed:|cluster:|multi-member" /tmp/score_stdout.txt || cat /tmp/score_stdout.txt || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: "score-${{ inputs.label }}"
+          path: "/tmp/score_${{ inputs.label }}.json"
+          if-no-files-found: warn

--- a/scripts/score_distributed_assignments.py
+++ b/scripts/score_distributed_assignments.py
@@ -1,0 +1,106 @@
+"""Oracle-score a distributed Phase-5 run's cluster assignments (parquet dir)
+against the deterministic QIS realistic ground truth, WITHOUT re-running the
+cluster. The assignments ({member_id, cluster_id, ...}) are what the distributed
+WCC produced; GT is deterministic (cids = repeat(arange(n_clusters), 5), so
+gt_cids[i] = i // 5). Streams one cluster at a time -- no 20M-entry Python dict.
+
+Usage: score_distributed_assignments.py --dir <parquet_dir> --rows <N> [--out f.json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import numpy as np
+import polars as pl
+
+ROWS_PER_CLUSTER = 5
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dir", required=True, help="local dir of assignment parquet files")
+    ap.add_argument("--rows", type=int, required=True, help="total rows in the run (N)")
+    ap.add_argument("--out", default=None, help="write metrics JSON here")
+    args = ap.parse_args()
+
+    n_rows = (args.rows // ROWS_PER_CLUSTER) * ROWS_PER_CLUSTER
+    t0 = time.time()
+    gt_cids = np.arange(n_rows, dtype=np.int64) // ROWS_PER_CLUSTER
+    gt_sizes_arr = np.bincount(gt_cids)
+    gt_multi_total = int((gt_sizes_arr > 1).sum())
+    gt_pair_total = int(np.sum(gt_sizes_arr * (gt_sizes_arr - 1) // 2))
+    print(f"[score] GT ready ({time.time()-t0:.0f}s): {n_rows:,} rows, "
+          f"{len(gt_sizes_arr):,} gt clusters", flush=True)
+
+    grouped = (
+        pl.scan_parquet(f"{args.dir}/*.parquet")
+        .select(["member_id", "cluster_id"])
+        .group_by("cluster_id")
+        .agg(pl.col("member_id"))
+        .collect(engine="streaming")
+    )
+    print(f"[score] grouped {grouped.height:,} predicted clusters "
+          f"({time.time()-t0:.0f}s)", flush=True)
+
+    in_multi = np.zeros(n_rows, dtype=bool)
+    pred_tp = pred_pair_total = exact_cluster_matches = pred_multi_total = 0
+    bp_acc = br_acc = 0.0
+    for members_s in grouped["member_id"]:
+        arr = members_s.to_numpy()
+        sz = arr.shape[0]
+        if sz <= 1:
+            continue
+        pred_multi_total += 1
+        in_multi[arr] = True
+        uniq, counts = np.unique(gt_cids[arr], return_counts=True)
+        pred_tp += int(np.sum(counts * (counts - 1) // 2))
+        pred_pair_total += sz * (sz - 1) // 2
+        sq = counts.astype(np.float64) ** 2
+        bp_acc += float(np.sum(sq) / sz)
+        br_acc += float(np.sum(sq / gt_sizes_arr[uniq]))
+        if uniq.size == 1 and sz == int(gt_sizes_arr[uniq[0]]):
+            exact_cluster_matches += 1
+    print(f"[score] streamed clusters ({time.time()-t0:.0f}s)", flush=True)
+
+    singleton_mask = ~in_multi
+    n_single = int(singleton_mask.sum())
+    if n_single:
+        gt_single = gt_cids[singleton_mask]
+        bp_acc += float(n_single)
+        br_acc += float(np.sum(1.0 / gt_sizes_arr[gt_single]))
+
+    pp = pred_tp / pred_pair_total if pred_pair_total else 0.0
+    pr = pred_tp / gt_pair_total if gt_pair_total else 0.0
+    pf1 = (2 * pp * pr / (pp + pr)) if (pp + pr) else 0.0
+    bp = bp_acc / n_rows
+    br = br_acc / n_rows
+    bf1 = (2 * bp * br / (bp + br)) if (bp + br) else 0.0
+    cp = exact_cluster_matches / pred_multi_total if pred_multi_total else 0.0
+    cr = exact_cluster_matches / gt_multi_total if gt_multi_total else 0.0
+    cf1 = (2 * cp * cr / (cp + cr)) if (cp + cr) else 0.0
+
+    res = {
+        "rows": n_rows,
+        "engine": "distributed-phase5",
+        "pairwise": {"f1": pf1, "p": pp, "r": pr},
+        "b_cubed": {"f1": bf1, "p": bp, "r": br},
+        "cluster": {"f1": cf1, "p": cp, "r": cr, "exact": exact_cluster_matches},
+        "multi_member_predicted": pred_multi_total,
+        "multi_member_gt": gt_multi_total,
+    }
+    print("\n=== DISTRIBUTED %d-ROW QUALITY (from assignments) ===" % n_rows)
+    print(f"pairwise: f1={pf1:.4f}  p={pp:.4f}  r={pr:.4f}")
+    print(f"b_cubed:  f1={bf1:.4f}  p={bp:.4f}  r={br:.4f}")
+    print(f"cluster:  f1={cf1:.4f}  p={cp:.4f}  r={cr:.4f}  exact={exact_cluster_matches:,}")
+    print(f"multi-member predicted: {pred_multi_total:,}  gt: {gt_multi_total:,}")
+    print(f"[score] total {time.time()-t0:.0f}s", flush=True)
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(res, f, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Score a completed distributed run's gs:// assignments against the deterministic QIS GT on a 64 GB runner -- no cluster, no re-run. Standalone (1 workflow + 1 script). Needed on main so workflow_dispatch can trigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)