### PR TITLE
docs(tuning): Fast path at scale — distribute only the stage that doesn't fit

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -170,6 +170,26 @@ This is the knob most people get wrong, so read the contract before you run a 10
   You bring the Ray cluster — GoldenMatch ships the pipeline, not the bootstrap. The GCP recipe is in [`docs/distributed-ray-cluster-setup.md`](https://github.com/benseverndev-oss/goldenmatch/blob/main/docs/distributed-ray-cluster-setup.md). At single-box scale the `bucket` backend is validated through 200M and is simpler — use it unless the data won't fit one box.
 </Note>
 
+### Fast path at scale (distribute only what doesn't fit)
+
+The single most expensive distributed-tuning mistake is distributing a *stage* that fits in memory. **"The job is big" does not mean "every stage must be distributed."** Ask it per stage:
+
+| Stage | Fits one node at 100M? | Fast path | Slow trap |
+|-------|------------------------|-----------|-----------|
+| Scoring | No — 100M rows | **Distributed** across workers, **native kernel on** (`GOLDENMATCH_NATIVE=1` + `goldenmatch-native` installed on every node) | pure-Python (cluster installs plain `goldenmatch`); ~6 of 80 CPU if the shuffle blocks are oversized |
+| Clustering (WCC) | **Yes** — the scored pair set is small (~1.76 GB / 110M edges at 100M) | **In-memory** driver-side `scipy.csgraph` connected-components (~60s) | the distributed randomized-contraction WCC — its O(log N) `gs://`-checkpoint rounds are a multi-hour tail when forced on a pair set that fits |
+| Golden | depends | distributed groupby, or **skip it** if you only need cluster membership | building golden you then discard |
+
+**Concrete: don't force the distributed WCC on a pair set that fits.** `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` (default `50000000`) routes pair counts **below** it to the fast in-memory `scipy.csgraph` path. So at 100M (~110M pairs) the default sends clustering to the *distributed* WCC. If your pairs fit the driver (they do up to a few hundred million edges on a 64–256 GB head), **set the threshold above your pair count** so clustering stays in-memory:
+
+```bash
+export GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD=2000000000  # > your pair count -> in-memory WCC
+```
+
+Setting it to `0` does the **opposite** — it forces the slow distributed WCC on everything. (Making this routing memory-aware by default is tracked in [#956](https://github.com/benseverndev-oss/goldenmatch/issues/956).)
+
+**Recover a result without re-running.** The Phase-5 connected-components clustering is independent of the WCC algorithm, so a completed run's cluster *assignments* (written to gs:// via the `assignments_output_path` hook) **are** the result. If a run finishes but the output is lost, or you want to re-score, download the assignments and score them against your ground truth on a 64 GB box — no cluster, no re-run. The 100M `group_by` for that scoring OOMs a 16 GB box, so run it on a large runner, not your laptop.
+
 ---
 
 ## Prep & scoring perf opt-ins
@@ -244,6 +264,9 @@ Read these before a big run. Each is a real trap that produces a slow or wrong r
   </Accordion>
   <Accordion title="The prep stage dominated wall on address-heavy data">
     The per-row Python address-normalize plugin is a real bottleneck at scale. Set `GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1` to use the Polars-native expression instead. It's off by default, so you have to opt in.
+  </Accordion>
+  <Accordion title="A distributed 100M run took hours instead of minutes">
+    The scored pair set is small (~1.76 GB at 100M) and fits one node, but the default `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD=50000000` routes 50M+ pairs to the *distributed* WCC, whose `gs://`-checkpoint rounds are a multi-hour tail. Set the threshold **above** your pair count so clustering runs in-memory (`scipy.csgraph`, ~60s) — see [Fast path at scale](#fast-path-at-scale-distribute-only-what-doesnt-fit). Distribute the *scoring* (the rows don't fit), not the *clustering* (the pairs do). And never set the threshold to `0` — that forces the slow path on everything.
   </Accordion>
   <Accordion title="Results changed between runs for no reason">
     Cross-run auto-config memory (`GOLDENMATCH_AUTOCONFIG_MEMORY=1`, the default) lets a prior run influence the next. For reproducible benchmarks set `GOLDENMATCH_AUTOCONFIG_MEMORY=0`.


### PR DESCRIPTION
Adds a 'Fast path at scale' subsection + gotcha to the Tuning & opt-ins doc, capturing the per-stage rule the distributed drive proved the hard way: distribute SCORING (rows don't fit), cluster IN-MEMORY (pairs do). Documents the CLUSTERING_THRESHOLD in-memory-WCC default trap (cross-links #956) and the recover-from-gs://-assignments pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)