### PR TITLE
ast-grep: flesh out the rule set (3 → 12, incl. Rust kernels)

### DIFF
--- a/.ast-grep/README.md
+++ b/.ast-grep/README.md
@@ -19,14 +19,35 @@ advisory (reported, non-blocking) so new rules can land gradually.
 
 ## Current rules (`.ast-grep/rules/`)
 
+**Python — repo footguns** (the "bit us in PR #N" lessons):
+
 | Rule | Severity | Invariant |
 |---|---|---|
 | `no-clirunner-mix-stderr` | error | `CliRunner(mix_stderr=...)` raises on click>=8.3 — drop the kwarg |
 | `no-toplevel-import-torch` | warning | unguarded top-level `import torch` hangs/segfaults on GPU-less boxes — import lazily or guard |
 | `no-bare-relative-test-fixture-path` | warning | `Path("tests/...")` resolves off CWD (differs local vs CI) — anchor to `__file__` |
+
+**Polars** (the repo is Polars-native):
+
+| Rule | Severity | Invariant |
+|---|---|---|
 | `polars-read-excel-needs-engine` | warning | `pl.read_excel(path)` with no `engine=` — pass `engine="openpyxl"` (caught a real one in goldencheck) |
-| `ts-no-empty-catch` | error | empty `catch {}` silently swallows errors — log or re-throw (TS ports) |
-| `ts-no-spread-math-min-max` | warning | `Math.min/max(...array)` throws on >65K elements — surfaces **11 real sites** in the TS ports for a follow-up cleanup |
+| `polars-no-deprecated-apply` | warning | `pl.col(x).apply(...)` is deprecated/slow — use `.map_elements(..., return_dtype=...)` or a vectorized expr |
+
+**Python — security** (clean guards, no current call sites):
+
+| Rule | Severity | Invariant |
+|---|---|---|
+| `py-no-eval` | error | `eval(...)` executes arbitrary code — use `ast.literal_eval` / `json.loads` / a dispatch dict |
+| `py-no-exec` | error | `exec(...)` runs arbitrary code strings — use real functions / a dispatch table |
+| `py-no-subprocess-shell-true` | error | `subprocess.*(..., shell=True)` is a shell-injection risk — pass an argv list, `shell=False` |
+
+**TypeScript ports**:
+
+| Rule | Severity | Invariant |
+|---|---|---|
+| `ts-no-empty-catch` | error | empty `catch {}` silently swallows errors — log or re-throw |
+| `ts-no-spread-math-min-max` | warning | `Math.min/max(...array)` throws on >65K elements — surfaces **11 real sites** for a follow-up cleanup |
 
 ## Considered but not added (AST can't express them cleanly)
 
@@ -44,6 +65,13 @@ semantic linter):
   `open(encoding="utf-8")`.
 - **`pl.read_csv(path)` missing `encoding=`** — 17 legit single-arg call sites, so
   a rule would be pure noise.
+- **`node:fs`/`process.env` in `src/core/`** (TS edge-safety) — the invariant is
+  real, but `src/core/engine/{history,scheduler}.ts` are *documented* intentional
+  exceptions (their functions aren't re-exported from `core/index.ts`), and
+  `require()`/`process.env` are deliberate lazy patterns elsewhere — so a rule
+  fires on correct code. Needs a per-file allowlist a flat AST rule can't carry.
+- **`import pandas` in goldencheck** (Polars-native) — the one hit is a *lazy*
+  interop import in `engine/db_scanner.py`, not a violation.
 
 ## Add a rule
 

--- a/.ast-grep/README.md
+++ b/.ast-grep/README.md
@@ -25,6 +25,8 @@ advisory (reported, non-blocking) so new rules can land gradually.
 | `no-toplevel-import-torch` | warning | unguarded top-level `import torch` hangs/segfaults on GPU-less boxes — import lazily or guard |
 | `no-bare-relative-test-fixture-path` | warning | `Path("tests/...")` resolves off CWD (differs local vs CI) — anchor to `__file__` |
 | `polars-read-excel-needs-engine` | warning | `pl.read_excel(path)` with no `engine=` — pass `engine="openpyxl"` (caught a real one in goldencheck) |
+| `ts-no-empty-catch` | error | empty `catch {}` silently swallows errors — log or re-throw (TS ports) |
+| `ts-no-spread-math-min-max` | warning | `Math.min/max(...array)` throws on >65K elements — surfaces **11 real sites** in the TS ports for a follow-up cleanup |
 
 ## Considered but not added (AST can't express them cleanly)
 

--- a/.ast-grep/README.md
+++ b/.ast-grep/README.md
@@ -24,6 +24,24 @@ advisory (reported, non-blocking) so new rules can land gradually.
 | `no-clirunner-mix-stderr` | error | `CliRunner(mix_stderr=...)` raises on click>=8.3 — drop the kwarg |
 | `no-toplevel-import-torch` | warning | unguarded top-level `import torch` hangs/segfaults on GPU-less boxes — import lazily or guard |
 | `no-bare-relative-test-fixture-path` | warning | `Path("tests/...")` resolves off CWD (differs local vs CI) — anchor to `__file__` |
+| `polars-read-excel-needs-engine` | warning | `pl.read_excel(path)` with no `engine=` — pass `engine="openpyxl"` (caught a real one in goldencheck) |
+
+## Considered but not added (AST can't express them cleanly)
+
+These repo invariants need **dataflow / intent**, not just structure, so a pure
+AST pattern would be too noisy or impossible — left to review (or a future
+semantic linter):
+
+- **full-frame `df.to_dicts()` in a per-row/hot loop** (the #904 O(N)/probe bug) —
+  "whole frame" + "hot loop" aren't structural; a blanket `.to_dicts()` ban
+  carpet-bombs legit uses.
+- **pair canonicalization `(min(a,b), max(a,b))`** — "this tuple is a stored pair"
+  is intent, not shape.
+- **`encoding="utf-8"` only inside `pl.read_csv`/`scan_csv`** — the kwarg-string
+  match is unreliable in tree-sitter and a broad ban wrongly flags legit stdlib
+  `open(encoding="utf-8")`.
+- **`pl.read_csv(path)` missing `encoding=`** — 17 legit single-arg call sites, so
+  a rule would be pure noise.
 
 ## Add a rule
 

--- a/.ast-grep/README.md
+++ b/.ast-grep/README.md
@@ -49,6 +49,19 @@ advisory (reported, non-blocking) so new rules can land gradually.
 | `ts-no-empty-catch` | error | empty `catch {}` silently swallows errors — log or re-throw |
 | `ts-no-spread-math-min-max` | warning | `Math.min/max(...array)` throws on >65K elements — surfaces **11 real sites** for a follow-up cleanup |
 
+**Rust kernels** (`packages/rust/extensions/`):
+
+| Rule | Severity | Invariant |
+|---|---|---|
+| `rust-no-dbg-macro` | error | `dbg!()` is a debug macro — never commit it (and it prints on the kernel hot path) |
+| `rust-no-todo-unimplemented` | warning | `todo!()`/`unimplemented!()` panic at runtime — must not reach a shipped kernel path |
+
+> Dogfood note: scanning Rust + Python found **0 real violations** — the kernels and
+> Python tree already comply (the `panic!`/`println!` hits in Rust are all legit:
+> test assertions + the `goldenembed` CLI binary). These Rust rules are *preventive*
+> guards. The TypeScript `ts-no-spread-math-min-max` rule, by contrast, surfaced 11
+> real latent crash sites — fixed in a separate dogfood PR.
+
 ## Considered but not added (AST can't express them cleanly)
 
 These repo invariants need **dataflow / intent**, not just structure, so a pure

--- a/.ast-grep/rule-tests/__snapshots__/polars-no-deprecated-apply-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/polars-no-deprecated-apply-snapshot.yml
@@ -1,0 +1,14 @@
+id: polars-no-deprecated-apply
+snapshots:
+  df.select(pl.col('x').apply(f)):
+    labels:
+    - source: pl.col('x').apply(f)
+      style: primary
+      start: 10
+      end: 30
+  'pl.col(''name'').apply(lambda s: s.upper())':
+    labels:
+    - source: 'pl.col(''name'').apply(lambda s: s.upper())'
+      style: primary
+      start: 0
+      end: 41

--- a/.ast-grep/rule-tests/__snapshots__/polars-read-excel-needs-engine-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/polars-read-excel-needs-engine-snapshot.yml
@@ -1,0 +1,14 @@
+id: polars-read-excel-needs-engine
+snapshots:
+  df = pl.read_excel('x.xlsx'):
+    labels:
+    - source: pl.read_excel('x.xlsx')
+      style: primary
+      start: 5
+      end: 28
+  df = pl.read_excel(path):
+    labels:
+    - source: pl.read_excel(path)
+      style: primary
+      start: 5
+      end: 24

--- a/.ast-grep/rule-tests/__snapshots__/py-no-eval-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/py-no-eval-snapshot.yml
@@ -1,0 +1,14 @@
+id: py-no-eval
+snapshots:
+  v = eval(expr, {}, {}):
+    labels:
+    - source: eval(expr, {}, {})
+      style: primary
+      start: 4
+      end: 22
+  v = eval(s):
+    labels:
+    - source: eval(s)
+      style: primary
+      start: 4
+      end: 11

--- a/.ast-grep/rule-tests/__snapshots__/py-no-exec-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/py-no-exec-snapshot.yml
@@ -1,0 +1,14 @@
+id: py-no-exec
+snapshots:
+  exec(code):
+    labels:
+    - source: exec(code)
+      style: primary
+      start: 0
+      end: 10
+  exec(src, globals()):
+    labels:
+    - source: exec(src, globals())
+      style: primary
+      start: 0
+      end: 20

--- a/.ast-grep/rule-tests/__snapshots__/py-no-subprocess-shell-true-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/py-no-subprocess-shell-true-snapshot.yml
@@ -1,0 +1,20 @@
+id: py-no-subprocess-shell-true
+snapshots:
+  subprocess.Popen(cmd, shell=True):
+    labels:
+    - source: subprocess.Popen(cmd, shell=True)
+      style: primary
+      start: 0
+      end: 33
+  subprocess.Popen(cmd, shell=True, cwd=d):
+    labels:
+    - source: subprocess.Popen(cmd, shell=True, cwd=d)
+      style: primary
+      start: 0
+      end: 40
+  subprocess.run(cmd, shell=True):
+    labels:
+    - source: subprocess.run(cmd, shell=True)
+      style: primary
+      start: 0
+      end: 31

--- a/.ast-grep/rule-tests/__snapshots__/rust-no-dbg-macro-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/rust-no-dbg-macro-snapshot.yml
@@ -1,0 +1,14 @@
+id: rust-no-dbg-macro
+snapshots:
+  dbg!(a, b);:
+    labels:
+    - source: dbg!(a, b)
+      style: primary
+      start: 0
+      end: 10
+  let x = dbg!(compute(y));:
+    labels:
+    - source: dbg!(compute(y))
+      style: primary
+      start: 8
+      end: 24

--- a/.ast-grep/rule-tests/__snapshots__/rust-no-todo-unimplemented-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/rust-no-todo-unimplemented-snapshot.yml
@@ -1,0 +1,14 @@
+id: rust-no-todo-unimplemented
+snapshots:
+  fn f() -> i32 { todo!() }:
+    labels:
+    - source: todo!()
+      style: primary
+      start: 16
+      end: 23
+  fn f() { unimplemented!("later") }:
+    labels:
+    - source: unimplemented!("later")
+      style: primary
+      start: 9
+      end: 32

--- a/.ast-grep/rule-tests/__snapshots__/ts-no-empty-catch-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/ts-no-empty-catch-snapshot.yml
@@ -1,0 +1,14 @@
+id: ts-no-empty-catch
+snapshots:
+  try { f(); } catch (e) { }:
+    labels:
+    - source: try { f(); } catch (e) { }
+      style: primary
+      start: 0
+      end: 26
+  try { f(); } catch { }:
+    labels:
+    - source: try { f(); } catch { }
+      style: primary
+      start: 0
+      end: 22

--- a/.ast-grep/rule-tests/__snapshots__/ts-no-spread-math-min-max-snapshot.yml
+++ b/.ast-grep/rule-tests/__snapshots__/ts-no-spread-math-min-max-snapshot.yml
@@ -1,0 +1,14 @@
+id: ts-no-spread-math-min-max
+snapshots:
+  const m = Math.max(...xs.map((x) => x.n));:
+    labels:
+    - source: Math.max(...xs.map((x) => x.n))
+      style: primary
+      start: 10
+      end: 41
+  const m = Math.min(...arr);:
+    labels:
+    - source: Math.min(...arr)
+      style: primary
+      start: 10
+      end: 26

--- a/.ast-grep/rule-tests/polars-no-deprecated-apply-test.yml
+++ b/.ast-grep/rule-tests/polars-no-deprecated-apply-test.yml
@@ -1,0 +1,7 @@
+id: polars-no-deprecated-apply
+valid:
+  - "df.select(pl.col('x').map_elements(f, return_dtype=pl.Int64))"
+  - "df.with_columns((pl.col('a') + 1).alias('b'))"
+invalid:
+  - "df.select(pl.col('x').apply(f))"
+  - "pl.col('name').apply(lambda s: s.upper())"

--- a/.ast-grep/rule-tests/polars-read-excel-needs-engine-test.yml
+++ b/.ast-grep/rule-tests/polars-read-excel-needs-engine-test.yml
@@ -1,0 +1,7 @@
+id: polars-read-excel-needs-engine
+valid:
+  - "df = pl.read_excel('x.xlsx', engine='openpyxl')"
+  - "df = pl.read_excel(path, engine='openpyxl', sheet_name='S')"
+invalid:
+  - "df = pl.read_excel('x.xlsx')"
+  - "df = pl.read_excel(path)"

--- a/.ast-grep/rule-tests/py-no-eval-test.yml
+++ b/.ast-grep/rule-tests/py-no-eval-test.yml
@@ -1,0 +1,7 @@
+id: py-no-eval
+valid:
+  - "import ast; v = ast.literal_eval(s)"
+  - "v = json.loads(s)"
+invalid:
+  - "v = eval(s)"
+  - "v = eval(expr, {}, {})"

--- a/.ast-grep/rule-tests/py-no-exec-test.yml
+++ b/.ast-grep/rule-tests/py-no-exec-test.yml
@@ -1,0 +1,7 @@
+id: py-no-exec
+valid:
+  - "cursor.execute(sql)"
+  - "con.exec(stmt)"
+invalid:
+  - "exec(code)"
+  - "exec(src, globals())"

--- a/.ast-grep/rule-tests/py-no-subprocess-shell-true-test.yml
+++ b/.ast-grep/rule-tests/py-no-subprocess-shell-true-test.yml
@@ -1,0 +1,7 @@
+id: py-no-subprocess-shell-true
+valid:
+  - "subprocess.run(['ls', '-l'])"
+  - "subprocess.run(argv, shell=False)"
+invalid:
+  - "subprocess.run(cmd, shell=True)"
+  - "subprocess.Popen(cmd, shell=True)"

--- a/.ast-grep/rule-tests/rust-no-dbg-macro-test.yml
+++ b/.ast-grep/rule-tests/rust-no-dbg-macro-test.yml
@@ -1,0 +1,7 @@
+id: rust-no-dbg-macro
+valid:
+  - "let x = compute(y);"
+  - "tracing::debug!(\"value {}\", y);"
+invalid:
+  - "let x = dbg!(compute(y));"
+  - "dbg!(a, b);"

--- a/.ast-grep/rule-tests/rust-no-todo-unimplemented-test.yml
+++ b/.ast-grep/rule-tests/rust-no-todo-unimplemented-test.yml
@@ -1,0 +1,7 @@
+id: rust-no-todo-unimplemented
+valid:
+  - "return Err(Error::NotSupported);"
+  - "fn f() -> i32 { 42 }"
+invalid:
+  - "fn f() -> i32 { todo!() }"
+  - "fn f() { unimplemented!(\"later\") }"

--- a/.ast-grep/rule-tests/ts-no-empty-catch-test.yml
+++ b/.ast-grep/rule-tests/ts-no-empty-catch-test.yml
@@ -1,0 +1,7 @@
+id: ts-no-empty-catch
+valid:
+  - "try { f(); } catch (e) { log(e); }"
+  - "try { f(); } catch { return null; }"
+invalid:
+  - "try { f(); } catch { }"
+  - "try { f(); } catch (e) { }"

--- a/.ast-grep/rule-tests/ts-no-spread-math-min-max-test.yml
+++ b/.ast-grep/rule-tests/ts-no-spread-math-min-max-test.yml
@@ -1,0 +1,7 @@
+id: ts-no-spread-math-min-max
+valid:
+  - "const m = Math.min(a, b);"
+  - "const m = minOf(arr);"
+invalid:
+  - "const m = Math.min(...arr);"
+  - "const m = Math.max(...xs.map((x) => x.n));"

--- a/.ast-grep/rules/polars-no-deprecated-apply.yml
+++ b/.ast-grep/rules/polars-no-deprecated-apply.yml
@@ -1,0 +1,9 @@
+id: polars-no-deprecated-apply
+language: python
+severity: warning
+message: >-
+  Polars Expr.apply is deprecated and slow — use .map_elements(..., return_dtype=...)
+  for per-element UDFs, or (better) a native vectorized expression.
+note: Polars deprecation; repo is Polars-native.
+rule:
+  pattern: pl.col($C).apply($$$)

--- a/.ast-grep/rules/polars-read-excel-needs-engine.yml
+++ b/.ast-grep/rules/polars-read-excel-needs-engine.yml
@@ -1,0 +1,9 @@
+id: polars-read-excel-needs-engine
+language: python
+severity: warning
+message: >-
+  pl.read_excel(...) needs an explicit engine on this stack: pass
+  engine="openpyxl". Without it the read can fail or pick a missing engine.
+note: "See packages/python/goldenmatch/CLAUDE.md (read_excel needs engine=openpyxl)."
+rule:
+  pattern: pl.read_excel($PATH)

--- a/.ast-grep/rules/py-no-eval.yml
+++ b/.ast-grep/rules/py-no-eval.yml
@@ -1,0 +1,9 @@
+id: py-no-eval
+language: python
+severity: error
+message: >-
+  eval() executes arbitrary code — a security/footgun risk. Parse explicitly
+  (ast.literal_eval for literals, json.loads for JSON, a dispatch dict for
+  names). There are no legitimate eval() call sites in this repo.
+rule:
+  pattern: eval($$$)

--- a/.ast-grep/rules/py-no-exec.yml
+++ b/.ast-grep/rules/py-no-exec.yml
@@ -1,0 +1,8 @@
+id: py-no-exec
+language: python
+severity: error
+message: >-
+  exec() runs arbitrary code strings — disallowed. Use real functions / a
+  dispatch table instead. (Matches the builtin exec(...), not obj.exec(...).)
+rule:
+  pattern: exec($$$)

--- a/.ast-grep/rules/py-no-subprocess-shell-true.yml
+++ b/.ast-grep/rules/py-no-subprocess-shell-true.yml
@@ -1,0 +1,12 @@
+id: py-no-subprocess-shell-true
+language: python
+severity: error
+message: >-
+  subprocess with shell=True is a shell-injection risk on any non-constant
+  argument. Pass an argv list and shell=False (the default).
+rule:
+  any:
+    - pattern: subprocess.run($$$, shell=True)
+    - pattern: subprocess.call($$$, shell=True)
+    - pattern: subprocess.check_output($$$, shell=True)
+    - pattern: subprocess.Popen($$$, shell=True)

--- a/.ast-grep/rules/rust-no-dbg-macro.yml
+++ b/.ast-grep/rules/rust-no-dbg-macro.yml
@@ -1,0 +1,8 @@
+id: rust-no-dbg-macro
+language: rust
+severity: error
+message: >-
+  dbg!() is a debug macro — never commit it. In the perf-critical kernels it
+  also prints to stderr on the hot path. Remove it (or use tracing/log).
+rule:
+  pattern: dbg!($$$)

--- a/.ast-grep/rules/rust-no-todo-unimplemented.yml
+++ b/.ast-grep/rules/rust-no-todo-unimplemented.yml
@@ -1,0 +1,10 @@
+id: rust-no-todo-unimplemented
+language: rust
+severity: warning
+message: >-
+  todo!()/unimplemented!() panic at runtime — they must not reach a shipped
+  kernel path. Implement it, or return a proper Result error instead.
+rule:
+  any:
+    - pattern: todo!($$$)
+    - pattern: unimplemented!($$$)

--- a/.ast-grep/rules/ts-no-empty-catch.yml
+++ b/.ast-grep/rules/ts-no-empty-catch.yml
@@ -1,0 +1,11 @@
+id: ts-no-empty-catch
+language: typescript
+severity: error
+message: >-
+  Empty catch {} silently swallows errors — always log the error or let it
+  propagate. (Bare catch blocks are prohibited in the TS ports.)
+note: See packages/typescript/goldencheck/CLAUDE.md (bare catch prohibited).
+rule:
+  any:
+    - pattern: try { $$$ } catch { }
+    - pattern: try { $$$ } catch ($E) { }

--- a/.ast-grep/rules/ts-no-spread-math-min-max.yml
+++ b/.ast-grep/rules/ts-no-spread-math-min-max.yml
@@ -1,0 +1,12 @@
+id: ts-no-spread-math-min-max
+language: typescript
+severity: warning
+message: >-
+  Math.min(...array) / Math.max(...array) throws RangeError (call-stack overflow)
+  on arrays larger than ~65K elements — a real crash on big inputs. Use a
+  loop-based min/max instead (the TS ports have a documented helper pattern).
+note: See packages/typescript/goldencheck/CLAUDE.md (Math.min/max spread footgun).
+rule:
+  any:
+    - pattern: Math.min(...$A)
+    - pattern: Math.max(...$A)

--- a/packages/python/goldencheck/goldencheck/engine/reader.py
+++ b/packages/python/goldencheck/goldencheck/engine/reader.py
@@ -40,7 +40,7 @@ def read_file(path: Path) -> pl.DataFrame:
         return pl.read_parquet(path)
     elif ext in (".xlsx", ".xls"):
         try:
-            return pl.read_excel(path)
+            return pl.read_excel(path, engine="openpyxl")
         except Exception as e:
             if "password" in str(e).lower() or "encrypted" in str(e).lower():
                 raise ValueError("File appears to be password-protected. GoldenCheck cannot read encrypted files.") from e


### PR DESCRIPTION
Builds the ast-grep rule set from #950's 3 starters to a **categorized 12** spanning Python, Polars, security, TypeScript, **and the Rust kernels** — each prototyped against the real tree (kept only clean guards or real-bug-surfacers) with `valid`/`invalid` self-tests.

## The 12 rules
- **Python footguns**: `no-clirunner-mix-stderr` (err), `no-toplevel-import-torch`, `no-bare-relative-test-fixture-path`
- **Polars**: `polars-read-excel-needs-engine` *(caught a real bug)*, `polars-no-deprecated-apply`
- **Security**: `py-no-eval` (err), `py-no-exec` (err), `py-no-subprocess-shell-true` (err)
- **TypeScript**: `ts-no-empty-catch` (err), `ts-no-spread-math-min-max` *(surfaced 11 real crash sites — fixed in #963)*
- **Rust kernels**: `rust-no-dbg-macro` (err), `rust-no-todo-unimplemented`

## Dogfood results (ran it on every language)
| Language | Outcome |
|---|---|
| **TypeScript** | 11 **real latent crash bugs** found (`Math.min/max(...array)` >65K) → fixed in **#963** |
| **Polars/Python** | 1 real bug (`read_excel` no-engine in goldencheck) → fixed here; everything else **0 violations** |
| **Rust kernels** | **0 violations** — `panic!`/`println!` hits are all legit (test asserts + the `goldenembed` CLI). Rust rules are *preventive* guards |

## Methodology
Every candidate was counted against the tree first; noisy/unexpressible ones were **rejected and documented** in `.ast-grep/README.md` ("Considered but not added"): the #904 `df.to_dicts` hot-loop bug + pair-canonicalization (need dataflow), the `utf-8`/`read_csv` kwarg matches (unreliable/noisy), TS `node:fs`-in-`src/core` (documented exceptions), goldencheck `pandas` (legit lazy interop).

## Validation
`ast-grep test`: **12/12** pass. `ast-grep scan`: **exit 0** (only output is the 11 advisory TS warnings, which #963 clears). CI `ast-grep.yml` lane fails only on error-severity rules.

https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr