### PR TITLE
ci(docs): doc-lockstep automation — consistency gate + staleness advisory + release-sweep marker

### DIFF
--- a/.claude/doc-surfaces.md
+++ b/.claude/doc-surfaces.md
@@ -76,6 +76,47 @@ thing to grep for.
   docs, but the place a rollout's hard-won lesson belongs).
 - **GitHub About / topics**, **`CITATION.cff`** — only on a notable capability change.
 
+## Automated gates
+
+Three tiers of automation keep these surfaces in lockstep as the repo advances.
+All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
+
+- **Tier 1 - `scripts/check_docs_consistency.py`** (REQUIRED CI gate, `--check`
+  default). The single umbrella entry point for "all doc gates". It (a) runs
+  `check_version_consistency.py` and `sync_readme_callouts.py --check` as
+  subprocesses; (b) **roster matrix** - derives the published-package roster from
+  the `publish-*.yml` workflows (cross-checked against
+  `scripts/suite_download_badges.py`) and asserts each CORE package name appears
+  in the root `README.md` and the `docs-site/docs.json` nav; (c) **docs-nav
+  integrity** - `docs.json` parses, every nav page ref resolves to an `.mdx`, and
+  every `.mdx` under `docs-site/<group>/` is referenced (orphan detection); (d)
+  **changelog<->version** - each `packages/python/<pkg>/CHANGELOG.md` most-recent
+  *released* version heading equals its `pyproject.toml` version (packages whose
+  CHANGELOG has no versioned heading, or only an `unreleased` top entry, are
+  reported, not failed). Wired as the `docs_consistency` job in `ci.yml` (in the
+  `ci-required` needs list), gated on the `docs` path filter. To satisfy it: add
+  the missing README table row / `docs.json` nav entry / fix the broken nav link
+  or orphan page, or bump the lagging CHANGELOG/version.
+
+- **Tier 2 - `scripts/check_docs_staleness.py`** (ADVISORY CI job, `--base`/
+  `--head`, default `origin/main..HEAD`). Diff-aware. The **flag rule** (gating
+  within the job): adding/removing a `GOLDENMATCH_*` env flag in
+  `packages/python/**/*.py` without touching `docs-site/goldenmatch/tuning.mdx`
+  emits `::error::` and exits 1. The **public-symbol rule** (warning only): a
+  package `__init__.py` `__all__`/re-export change with no doc surface touched
+  emits `::warning::`. Wired as the `docs_staleness` job with
+  `continue-on-error: true` (NOT in `ci-required`) - it surfaces annotations,
+  never blocks a clean PR.
+
+- **Tier 3 - `scripts/check_docs_sweep.py`** + `docs/.docs-sweep.json` (RELEASE /
+  manual gate, NOT run on every PR). Asserts `docs/.docs-sweep.json` `.version`
+  equals the current `packages/python/goldenmatch` version. A bump of the
+  headline package since the last recorded sweep reds the gate. **At the END of a
+  docs sweep, bump `docs/.docs-sweep.json`** (`version` to the new goldenmatch
+  version, refresh `commit`/`date`). Run this manually before tagging a release,
+  or wire it into the publish/release workflow. It exists to catch "cut a release
+  but never swept the prose surfaces" that the structural gates can't author.
+
 ## Sweep mechanics for this repo
 
 - Grep the whole repo (minus `_archive/`) for every symbol/flag/endpoint the rollout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
       distributed: ${{ steps.filter.outputs.distributed }}
       sail: ${{ steps.filter.outputs.sail }}
       readme_callouts: ${{ steps.filter.outputs.readme_callouts }}
+      docs: ${{ steps.filter.outputs.docs }}
       wasm_score: ${{ steps.filter.outputs.wasm_score }}
       analysis_wasm: ${{ steps.filter.outputs.analysis_wasm }}
       ts_parity: ${{ steps.filter.outputs.ts_parity }}
@@ -304,6 +305,24 @@ jobs:
               - 'packages/python/goldenmatch/README.md'
               - 'packages/python/goldenmatch/CHANGELOG.md'
               - 'scripts/sync_readme_callouts.py'
+            docs:
+              # Doc-lockstep gates (scripts/check_docs_*.py). Trigger whenever any
+              # tracked doc surface OR the gate scripts themselves change. The
+              # required `docs_consistency` job and the advisory `docs_staleness`
+              # job both gate on this.
+              - 'docs-site/**'
+              - '**/README.md'
+              - '**/CHANGELOG.md'
+              - 'llms*.txt'
+              - '**/llms*.txt'
+              - '**/server.json'
+              - 'scripts/check_docs_consistency.py'
+              - 'scripts/check_docs_staleness.py'
+              - 'scripts/check_docs_sweep.py'
+              - 'scripts/check_version_consistency.py'
+              - 'scripts/sync_readme_callouts.py'
+              - 'scripts/suite_download_badges.py'
+              - 'packages/*/**/__init__.py'
             pyright_slice:
               - 'pyrightconfig.json'
               - 'packages/python/goldenmatch/goldenmatch/core/autoconfig.py'
@@ -1971,6 +1990,47 @@ jobs:
       - name: Verify READMEs are in sync with CHANGELOG callouts
         run: python scripts/sync_readme_callouts.py --check
 
+  # Tier-1 doc-lockstep umbrella gate (REQUIRED). Single entry point for all
+  # structural doc-consistency checks: runs version_consistency +
+  # readme_callouts --check as subprocesses, then adds roster-matrix,
+  # docs.json nav integrity (broken-link + orphan), and changelog<->version.
+  # stdlib-only (~1s). Gated on the `docs` path filter (or force_all).
+  docs_consistency:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Doc consistency (roster matrix + nav integrity + changelog/version)
+        run: python scripts/check_docs_consistency.py
+
+  # Tier-2 doc-staleness ADVISORY. Diff-aware: flags a GOLDENMATCH_* env-flag
+  # change with no tuning.mdx update (gating), and an __all__/re-export change
+  # with no doc surface touched (warning). continue-on-error => never blocks
+  # ci-required; it surfaces annotations only. NOT in the ci-required needs list.
+  docs_staleness:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0  # need the base ref for `git diff`
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Docs staleness (advisory) vs PR base
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || 'origin/main' }}"
+          git fetch origin main --quiet || true
+          python scripts/check_docs_staleness.py --base "$BASE" --head HEAD
+
   ts_parity_freshness:
     needs: changes
     if: needs.changes.outputs.ts_parity == 'true' || needs.changes.outputs.force_all == 'true'
@@ -2039,6 +2099,7 @@ jobs:
       - pyright
       - version_consistency
       - readme_callouts
+      - docs_consistency
       - ts_parity_freshness
     if: always()
     runs-on: ubuntu-latest

--- a/docs/.docs-sweep.json
+++ b/docs/.docs-sweep.json
@@ -1,0 +1,6 @@
+{
+  "version": "2.0.0",
+  "commit": "81a6000a",
+  "date": "2026-06-14",
+  "note": "Set by the rollout-docs-sweep skill when a docs sweep completes for a release. The check_docs_sweep.py gate asserts version == current packages/python/goldenmatch version; bump this marker at the END of a docs sweep."
+}

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Tier-1 documentation-lockstep gate: the single required doc-consistency check.
+
+This is the umbrella entry point for "are all the structural doc surfaces in
+lockstep with the published-package roster?". It is deterministic, stdlib-only,
+and exits non-zero on any FAIL so it can gate CI without flaking on clean PRs.
+
+It does FOUR things (see ``.claude/doc-surfaces.md`` for the surface inventory):
+
+1. Runs the two existing doc gates as subprocesses so there is one command for
+   "all doc gates": ``check_version_consistency.py`` and
+   ``sync_readme_callouts.py --check``.
+
+2. roster-matrix: derive the canonical published-package roster from the
+   ``publish-<pkg>.yml`` (PyPI) and ``publish-<pkg>-js.yml`` (npm) workflow
+   callers -- the same authoritative set ``scripts/suite_download_badges.py``
+   tracks -- and cross-check the two agree. Then assert each roster package's
+   NAME is present in the structural surfaces it is expected to have:
+     - every PyPI roster package name appears in the root ``README.md``;
+     - every roster package that has a ``docs-site/<pkg>/`` page directory also
+       appears in the ``docs-site/docs.json`` navigation.
+   (server.json / llms.txt presence is reported, not asserted -- those surfaces
+   only exist for a subset of packages, and version_consistency already gates
+   server.json content.)
+
+3. docs-nav integrity: ``docs.json`` parses; every page referenced in the nav
+   resolves to an existing ``.mdx`` under ``docs-site/``; every ``.mdx`` under a
+   ``docs-site/<group>/`` directory is referenced somewhere in the nav (orphan
+   detection). Fully deterministic, high value.
+
+4. changelog<->version: for each ``packages/python/<pkg>/CHANGELOG.md`` parse the
+   most-recent RELEASED version heading (Keep-a-Changelog ``## [X.Y.Z]`` or the
+   bare ``## X.Y.Z (date)`` variant; ``unreleased`` headings are skipped) and
+   assert it equals the package's ``pyproject.toml`` version. Packages whose
+   CHANGELOG has no versioned heading are REPORTED, not failed.
+
+``--check`` (the default) only reports + exits 1 on drift. ``--fix`` performs the
+narrow MECHANICAL reconciliations that are safe to automate (adding a missing
+roster package as a docs-nav ``SQL extensions`` entry is NOT auto-fixable -- that
+needs human prose -- so --fix is limited to nothing today; reconciliations on the
+current tree were done by hand in the lockstep branch). It is kept as a stub so
+the flag exists and future mechanical fixes have a home.
+
+Run: ``python scripts/check_docs_consistency.py``
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+DOCS_SITE = ROOT / "docs-site"
+PY_PKGS = ROOT / "packages" / "python"
+
+_VERSIONED_HEADING_RE = re.compile(
+    r"^##\s+\[?(?P<ver>\d+\.\d+\.\d+(?:[.\-][0-9A-Za-z.]+)?)\]?", re.MULTILINE
+)
+# A heading whose label/date marks it as not-yet-released. We skip these and look
+# for the next released heading below it.
+_UNRELEASED_RE = re.compile(r"unreleased", re.IGNORECASE)
+
+
+class Result:
+    def __init__(self) -> None:
+        self.checks: list[tuple[str, bool, str]] = []
+
+    def record(self, name: str, ok: bool, detail: str = "") -> None:
+        self.checks.append((name, ok, detail))
+
+    @property
+    def ok(self) -> bool:
+        return all(ok for _, ok, _ in self.checks)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Run the existing gates as subprocesses
+# --------------------------------------------------------------------------- #
+def run_subgate(res: Result, name: str, argv: list[str]) -> None:
+    proc = subprocess.run(
+        [sys.executable, *argv],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    ok = proc.returncode == 0
+    detail = ""
+    if not ok:
+        tail = (proc.stdout + proc.stderr).strip().splitlines()
+        detail = tail[-1] if tail else f"exit {proc.returncode}"
+    res.record(name, ok, detail)
+
+
+# --------------------------------------------------------------------------- #
+# Roster derivation
+# --------------------------------------------------------------------------- #
+def _publish_stems() -> list[str]:
+    return sorted(
+        p.name[len("publish-"):-len(".yml")]
+        for p in (ROOT / ".github" / "workflows").glob("publish-*.yml")
+    )
+
+
+# Stems that are NOT a per-distribution PyPI/npm publisher.
+_NON_DIST_STEMS = {"containers", "mcp"}
+
+
+def derive_roster() -> tuple[list[str], list[str], list[str]]:
+    """Return (core_pypi, ext_pypi, npm) derived from publish-*.yml callers.
+
+    ``core_pypi``  -- publishers backed by a ``packages/python/<stem>`` directory
+                      (the distribution packages that get a README row + nav group).
+    ``ext_pypi``   -- the remaining PyPI publishers (SQL / rust-extension extras
+                      like goldenmatch-duckdb / -embed / -pg). Reported, not gated
+                      structurally -- they live inside parent docs, not their own
+                      nav group.
+    ``npm``        -- ``publish-<pkg>-js.yml`` stems.
+    """
+    core: list[str] = []
+    ext: list[str] = []
+    npm: list[str] = []
+    for stem in _publish_stems():
+        if stem in _NON_DIST_STEMS:
+            continue
+        if stem.endswith("-native"):
+            continue  # compiled extras tracked separately; not a doc-nav surface
+        if stem.endswith("-js"):
+            npm.append(stem[: -len("-js")])
+        elif (PY_PKGS / stem).is_dir():
+            core.append(stem)
+        else:
+            ext.append(stem)
+    return sorted(set(core)), sorted(set(ext)), sorted(set(npm))
+
+
+def _badge_tokens() -> set[str] | None:
+    """All quoted suite-package-shaped tokens in suite_download_badges.py.
+
+    We scan the whole file rather than the bracket span: the PYPI_PACKAGES list
+    carries inline comments containing ``goldenmatch[native]`` etc., so a naive
+    ``\\[ .*? \\]`` capture stops early. Every real entry is a quoted token, so a
+    file-wide quoted-token scan is robust and still catches "added a core
+    package but forgot to add it to the badge totals".
+    """
+    badge = SCRIPTS / "suite_download_badges.py"
+    if not badge.exists():
+        return None
+    text = badge.read_text(encoding="utf-8")
+    return {
+        t for t in re.findall(r'["\']([A-Za-z][\w-]+)["\']', text)
+        if t.startswith(("golden", "infermap"))
+    }
+
+
+# --------------------------------------------------------------------------- #
+# docs.json helpers
+# --------------------------------------------------------------------------- #
+def _iter_nav_pages(node: object, out: list[str]) -> None:
+    if isinstance(node, str):
+        out.append(node)
+    elif isinstance(node, dict):
+        for v in node.values():
+            _iter_nav_pages(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _iter_nav_pages(v, out)
+
+
+def _collect_page_refs(node: object, out: list[str]) -> None:
+    """Collect only strings that are PAGE references (inside a ``pages`` array).
+
+    Mintlify nav: a group/tab is a dict with a ``pages`` list whose entries are
+    either a page-slug string or a nested group dict. Labels live under ``tab`` /
+    ``group`` keys and are deliberately NOT collected here.
+    """
+    if isinstance(node, dict):
+        for key, val in node.items():
+            if key == "pages" and isinstance(val, list):
+                for item in val:
+                    if isinstance(item, str):
+                        out.append(item)
+                    else:
+                        _collect_page_refs(item, out)
+            else:
+                _collect_page_refs(val, out)
+    elif isinstance(node, list):
+        for v in node:
+            _collect_page_refs(v, out)
+
+
+def _iter_nav_groups(node: object, out: list[str]) -> None:
+    if isinstance(node, dict):
+        if "group" in node and isinstance(node["group"], str):
+            out.append(node["group"])
+        for v in node.values():
+            _iter_nav_groups(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _iter_nav_groups(v, out)
+
+
+def load_docs_json() -> dict | None:
+    path = DOCS_SITE / "docs.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------- #
+# 2. roster matrix
+# --------------------------------------------------------------------------- #
+def check_roster_matrix(res: Result) -> None:
+    core, ext, npm = derive_roster()
+    badge_tokens = _badge_tokens()
+
+    # Cross-check: every CORE roster package must be tracked by the badge script
+    # (the documented suite-totals single-source-of-truth). A core package the
+    # workflows publish but the badge script forgot is real drift.
+    if badge_tokens is None:
+        res.record("roster cross-check vs badge script", True, "(badge script absent -- skipped)")
+    else:
+        missing = sorted(set(core) - badge_tokens)
+        res.record(
+            "roster cross-check vs badge script",
+            not missing,
+            f"core packages published but not in suite_download_badges totals: {missing}"
+            if missing
+            else "",
+        )
+
+    # README presence: every CORE roster package name must appear in README.md.
+    # (Extension extras goldenmatch-{duckdb,embed,pg} are reported below, not gated
+    #  -- pg ships as a GitHub-release tarball and isn't an overview-table row.)
+    readme = (ROOT / "README.md").read_text(encoding="utf-8").lower()
+    missing_readme = [p for p in core if p.lower() not in readme]
+    res.record(
+        "roster -> README.md presence",
+        not missing_readme,
+        f"missing from README package overview: {missing_readme}" if missing_readme else "",
+    )
+    ext_missing = [p for p in ext if p.lower() not in readme]
+    if ext_missing:
+        res.record(
+            "extension extras README presence (report-only)",
+            True,
+            f"reported, not gated -- extension distributions not named in README: {ext_missing}",
+        )
+
+    # docs-nav presence: roster packages that have a docs-site/<pkg>/ directory
+    # must appear in the docs.json navigation (group name or page path).
+    docs = load_docs_json()
+    if docs is None:
+        res.record("roster -> docs.json nav presence", False, "docs-site/docs.json missing")
+        return
+    groups: list[str] = []
+    pages: list[str] = []
+    _iter_nav_groups(docs.get("navigation"), groups)
+    _iter_nav_pages(docs.get("navigation"), pages)
+    nav_blob = " ".join(g.lower() for g in groups) + " " + " ".join(p.lower() for p in pages)
+    have_docs_dir = [p for p in core if (DOCS_SITE / p).is_dir()]
+    missing_nav = [p for p in have_docs_dir if p.lower() not in nav_blob]
+    res.record(
+        "roster -> docs.json nav presence",
+        not missing_nav,
+        f"package has docs-site/<pkg>/ dir but no nav reference: {missing_nav}"
+        if missing_nav
+        else "",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. docs-nav integrity
+# --------------------------------------------------------------------------- #
+def check_docs_nav_integrity(res: Result) -> None:
+    docs = load_docs_json()
+    if docs is None:
+        res.record("docs.json parses", False, "docs-site/docs.json missing")
+        return
+    res.record("docs.json parses", True, "")
+
+    # The nav-page walker collects every string in the navigation tree: real
+    # page refs AND group/tab label strings ("Documentation", "GoldenMatch").
+    # Page refs live in a `"pages": [...]` array; labels live under `"tab"` /
+    # `"group"` keys. Walk the structure key-aware so we test ONLY page refs for
+    # file existence (a page ref with no matching .mdx is a broken link).
+    page_refs: list[str] = []
+    _collect_page_refs(docs.get("navigation"), page_refs)
+
+    referenced: set[str] = set()
+    broken: list[str] = []
+    for ref in page_refs:
+        if (DOCS_SITE / f"{ref}.mdx").exists():
+            referenced.add(ref)
+        else:
+            broken.append(ref)
+    res.record(
+        "docs.json nav -> every page resolves to an .mdx",
+        not broken,
+        f"nav page refs with no matching .mdx: {broken}" if broken else "",
+    )
+
+    # Orphan detection: every .mdx under docs-site/<group>/ must be referenced.
+    orphans: list[str] = []
+    for mdx in sorted(DOCS_SITE.rglob("*.mdx")):
+        rel = mdx.relative_to(DOCS_SITE)
+        parts = rel.parts
+        # Skip snippet/partial conventions if they ever appear.
+        if any(p in {"snippets", "_partials"} for p in parts) or rel.name.startswith("_"):
+            continue
+        slug = str(rel.with_suffix(""))
+        if slug not in referenced:
+            orphans.append(slug)
+    res.record(
+        "docs-site .mdx orphan detection",
+        not orphans,
+        f"unreferenced .mdx pages (add to docs.json nav or delete): {orphans}"
+        if orphans
+        else "",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 4. changelog <-> version
+# --------------------------------------------------------------------------- #
+def _latest_released_changelog_version(text: str) -> str | None:
+    """Return the most-recent RELEASED version from a Keep-a-Changelog file.
+
+    Skips headings marked 'unreleased'. Returns None if no versioned heading.
+    """
+    for m in _VERSIONED_HEADING_RE.finditer(text):
+        # Grab the rest of the heading line to test for an 'unreleased' marker.
+        line_end = text.find("\n", m.start())
+        line = text[m.start(): line_end if line_end != -1 else len(text)]
+        if _UNRELEASED_RE.search(line):
+            continue
+        return m.group("ver")
+    return None
+
+
+def check_changelog_versions(res: Result) -> None:
+    mismatches: list[str] = []
+    reported_no_version: list[str] = []
+    for pyproject in sorted(PY_PKGS.glob("*/pyproject.toml")):
+        pkg = pyproject.parent.name
+        changelog = pyproject.parent / "CHANGELOG.md"
+        if not changelog.exists():
+            continue
+        proj_ver = tomllib.loads(pyproject.read_text(encoding="utf-8")).get("project", {}).get("version")
+        if proj_ver is None:
+            continue
+        cl_ver = _latest_released_changelog_version(changelog.read_text(encoding="utf-8"))
+        if cl_ver is None:
+            reported_no_version.append(pkg)
+            continue
+        if cl_ver != proj_ver:
+            mismatches.append(f"{pkg}: CHANGELOG top released={cl_ver} != pyproject={proj_ver}")
+    detail = ""
+    if mismatches:
+        detail = "; ".join(mismatches)
+    if reported_no_version:
+        note = f"(reported, not failed -- no versioned heading: {reported_no_version})"
+        detail = f"{detail} {note}".strip()
+    res.record("CHANGELOG top version == pyproject version", not mismatches, detail)
+
+
+# --------------------------------------------------------------------------- #
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", default=True,
+                        help="Report drift and exit 1 if any (default).")
+    parser.add_argument("--fix", action="store_true",
+                        help="Apply the narrow mechanical reconciliations (none auto-fixable today).")
+    args = parser.parse_args(argv)
+
+    res = Result()
+
+    run_subgate(res, "version_consistency (subprocess)",
+                [str(SCRIPTS / "check_version_consistency.py")])
+    run_subgate(res, "readme_callouts --check (subprocess)",
+                [str(SCRIPTS / "sync_readme_callouts.py"), "--check"])
+    check_roster_matrix(res)
+    check_docs_nav_integrity(res)
+    check_changelog_versions(res)
+
+    if args.fix:
+        print("--fix: no auto-fixable mechanical reconciliations pending; "
+              "all current-tree drift was reconciled by hand. Running checks.\n")
+
+    print("Documentation consistency checks:")
+    width = max(len(n) for n, _, _ in res.checks)
+    for name, ok, detail in res.checks:
+        status = "PASS" if ok else "FAIL"
+        line = f"  [{status}] {name.ljust(width)}"
+        if detail:
+            line += f"  -- {detail}"
+        print(line)
+
+    if not res.ok:
+        print("\nDocs consistency FAILED. Reconcile the surfaces above (see "
+              ".claude/doc-surfaces.md -> 'Automated gates').")
+        return 1
+    print("\nAll documentation consistency checks PASS.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_docs_staleness.py
+++ b/scripts/check_docs_staleness.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Tier-2 documentation-staleness advisory: diff-aware doc-drift detector.
+
+Given a git diff range (default ``origin/main..HEAD``), apply a small set of
+HIGH-signal, LOW-false-positive rules that catch the most common "code changed
+but its doc surface didn't" drift. Designed to run as an ADVISORY CI job
+(``continue-on-error: true``) so it surfaces warnings/annotations without ever
+blocking a clean PR -- with ONE exception that is high-signal enough to gate.
+
+Rules
+-----
+1. flag rule (GATING):
+   If the diff adds or removes a ``GOLDENMATCH_[A-Z0-9_]+`` env flag in
+   ``packages/python/**/*.py``, the canonical flag reference
+   ``docs-site/goldenmatch/tuning.mdx`` MUST also be in the diff. If not ->
+   ``::error::`` annotation + exit 1. (Per .claude/doc-surfaces.md, tuning.mdx is
+   the authoritative GOLDENMATCH_* reference; an added/removed flag is the single
+   highest-signal doc drift.)
+
+2. public-symbol rule (ADVISORY):
+   If the diff changes a package ``__init__.py`` ``__all__`` / re-export and NO
+   doc surface is touched (``docs-site/``, any ``README.md``, ``CHANGELOG.md``,
+   ``llms.txt``, ``context-network/``) -> ``::warning::`` only (never fails).
+
+Only the flag rule can change the exit code. Everything else is informational.
+
+Run: ``python scripts/check_docs_staleness.py [--base <ref>] [--head <ref>]``
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TUNING_MDX = "docs-site/goldenmatch/tuning.mdx"
+
+_FLAG_RE = re.compile(r"GOLDENMATCH_[A-Z0-9_]+")
+_ALL_LINE_RE = re.compile(r"__all__")
+
+
+def _git(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=ROOT, capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    out = _git("diff", "--name-only", f"{base}...{head}")
+    return [ln for ln in out.splitlines() if ln.strip()]
+
+
+def diff_for(base: str, head: str, pathspec: list[str]) -> str:
+    return _git("diff", "--unified=0", f"{base}...{head}", "--", *pathspec)
+
+
+def _added_removed_flags(diff_text: str) -> tuple[set[str], set[str]]:
+    """Flags appearing on added (+) vs removed (-) diff lines.
+
+    A flag is considered *introduced/removed* only if it nets out: a flag that
+    moves within a file (present on both + and - lines) is not drift.
+    """
+    added: set[str] = set()
+    removed: set[str] = set()
+    for line in diff_text.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            added.update(_FLAG_RE.findall(line))
+        elif line.startswith("-"):
+            removed.update(_FLAG_RE.findall(line))
+    net_added = added - removed
+    net_removed = removed - added
+    return net_added, net_removed
+
+
+def check_flag_rule(base: str, head: str, files: list[str]) -> tuple[bool, list[str]]:
+    """Return (ok, messages). ok=False means gate failure."""
+    py_files = [f for f in files if f.startswith("packages/python/") and f.endswith(".py")]
+    if not py_files:
+        return True, ["flag rule: no packages/python/**/*.py changes -- skipped"]
+
+    diff_text = diff_for(base, head, py_files)
+    net_added, net_removed = _added_removed_flags(diff_text)
+    touched_flags = sorted(net_added | net_removed)
+    if not touched_flags:
+        return True, ["flag rule: no GOLDENMATCH_* flag added/removed -- OK"]
+
+    tuning_touched = TUNING_MDX in files
+    if tuning_touched:
+        return True, [
+            f"flag rule: flags changed ({touched_flags}) and {TUNING_MDX} is in the "
+            f"diff -- OK"
+        ]
+    # Drift: flag changed but tuning.mdx untouched.
+    msgs = [
+        f"::error file={TUNING_MDX}::GOLDENMATCH_* flag(s) "
+        f"{touched_flags} added/removed in this diff but {TUNING_MDX} (the canonical "
+        f"flag reference) was not updated. Add/remove the flag in tuning.mdx."
+    ]
+    return False, msgs
+
+
+def check_public_symbol_rule(base: str, head: str, files: list[str]) -> list[str]:
+    """Advisory only. Return ::warning:: messages (never affects exit code)."""
+    init_files = [
+        f for f in files
+        if f.startswith("packages/") and f.endswith("__init__.py")
+    ]
+    if not init_files:
+        return ["public-symbol rule: no __init__.py changes -- skipped"]
+
+    diff_text = diff_for(base, head, init_files)
+    changes_all = any(
+        _ALL_LINE_RE.search(ln)
+        for ln in diff_text.splitlines()
+        if ln.startswith(("+", "-")) and not ln.startswith(("+++", "---"))
+    )
+    if not changes_all:
+        return ["public-symbol rule: no __all__/re-export lines changed -- skipped"]
+
+    doc_touched = any(
+        f.startswith("docs-site/")
+        or f.endswith("README.md")
+        or f.endswith("CHANGELOG.md")
+        or f.endswith("llms.txt")
+        or f.startswith("context-network/")
+        for f in files
+    )
+    if doc_touched:
+        return ["public-symbol rule: __all__ changed and a doc surface was touched -- OK"]
+    return [
+        "::warning::A package __all__/re-export changed but no doc surface "
+        "(docs-site/, README.md, CHANGELOG.md, llms.txt, context-network/) was "
+        "updated. Public-API changes usually need a doc note. (advisory only)"
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main", help="Base ref (default origin/main).")
+    parser.add_argument("--head", default="HEAD", help="Head ref (default HEAD).")
+    args = parser.parse_args(argv)
+
+    try:
+        files = changed_files(args.base, args.head)
+    except RuntimeError as exc:
+        print(f"::warning::docs-staleness: could not compute diff ({exc}); skipping.")
+        return 0
+
+    print(f"Docs staleness advisory: {args.base}...{args.head} "
+          f"({len(files)} changed file(s))")
+
+    gate_ok, flag_msgs = check_flag_rule(args.base, args.head, files)
+    symbol_msgs = check_public_symbol_rule(args.base, args.head, files)
+
+    for m in flag_msgs + symbol_msgs:
+        print(m)
+
+    if not gate_ok:
+        print("\nDocs staleness FAILED (flag rule). Update "
+              f"{TUNING_MDX} in the same PR.")
+        return 1
+    print("\nDocs staleness OK (gating flag rule passed; symbol rule advisory only).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_docs_sweep.py
+++ b/scripts/check_docs_sweep.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tier-3 release-sweep gate: has a docs sweep been run for the current release?
+
+A "docs sweep" is the manual/skill-driven pass (the ``rollout-docs-sweep`` skill,
+guided by ``.claude/doc-surfaces.md``) that updates the PROSE doc surfaces -- the
+feature paragraphs, tuning descriptions, llms.txt capability counts -- that no
+deterministic gate can author. Tier-1 / Tier-2 catch STRUCTURAL drift; this gate
+catches "we cut a release but never swept the docs".
+
+It compares the marker in ``docs/.docs-sweep.json`` against the current
+``packages/python/goldenmatch`` version. They match => a sweep has been recorded
+for this version => exit 0. They differ => the headline package was bumped since
+the last recorded sweep => exit 1 with instructions.
+
+This is intended to run on RELEASE / version-bump (NOT on every PR): it would
+otherwise red every feature PR that bumps the version before the sweep happens.
+Wire it into the publish/release workflow, or run it manually before tagging.
+
+Run: ``python scripts/check_docs_sweep.py``
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MARKER = ROOT / "docs" / ".docs-sweep.json"
+GM_PYPROJECT = ROOT / "packages" / "python" / "goldenmatch" / "pyproject.toml"
+
+
+def current_goldenmatch_version() -> str:
+    return tomllib.loads(GM_PYPROJECT.read_text(encoding="utf-8"))["project"]["version"]
+
+
+def main() -> int:
+    gm_version = current_goldenmatch_version()
+
+    if not MARKER.exists():
+        print(f"Docs-sweep gate FAILED: {MARKER.relative_to(ROOT)} is missing.")
+        print("Run the rollout-docs-sweep skill, then create the marker with the "
+              f"current goldenmatch version ({gm_version}).")
+        return 1
+
+    try:
+        marker = json.loads(MARKER.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"Docs-sweep gate FAILED: {MARKER.relative_to(ROOT)} is not valid JSON ({exc}).")
+        return 1
+
+    marked = marker.get("version")
+    if marked == gm_version:
+        print(f"Docs-sweep gate OK: marker version {marked} == goldenmatch {gm_version}.")
+        return 0
+
+    print(f"Docs-sweep gate FAILED: marker version {marked!r} != goldenmatch "
+          f"{gm_version!r}.")
+    print("goldenmatch was bumped since the last recorded docs sweep. Run the "
+          "rollout-docs-sweep skill to update the prose doc surfaces, then bump "
+          f"docs/.docs-sweep.json `version` to {gm_version} (and refresh commit/date).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Keeping the doc surfaces (Mintlify, READMEs, CHANGELOGs, `llms.txt`, `server.json`, context-network) in lockstep as the repo advances was manual — and it bit us (e.g. #944 had to *regenerate* README callouts after the 2.0 cut drifted them). This generalizes the repo's existing **single-source-of-truth → generate → `--check`** pattern (`sync_readme_callouts.py`, `check_version_consistency.py`) into a 3-tier system. **6 files, +760, zero runtime/product code.**

## Tier 1 — `scripts/check_docs_consistency.py` (one **required** gate)
Umbrella that runs the existing gates as subprocesses (`check_version_consistency.py` + `sync_readme_callouts.py --check`) plus three new deterministic checks:
- **roster matrix** — the published-package roster (derived from `publish-*.yml`, cross-checked against `suite_download_badges.py`) must appear in the root README table + `docs.json` nav.
- **docs-nav integrity** — `docs.json` parses; every nav page resolves to an `.mdx`; no orphan `.mdx` (the "new page invisible until added to nav" footgun).
- **CHANGELOG ↔ version** — each package's most-recent *released* heading matches its `pyproject` version (handles both `## [X.Y.Z]` and `## X.Y.Z (date)`; skips `unreleased`).

Verified **10/10 PASS on the current tree** — and notably **no drift had to be reconciled** (the tree's already consistent post-2.0).

## Tier 2 — `scripts/check_docs_staleness.py` (**advisory**, never blocks)
Diffs `base..head` for high-signal drift:
- **flag rule** (gating *within* the advisory job): a `GOLDENMATCH_*` flag added/removed in `packages/python/**/*.py` with no `tuning.mdx` touch → error. *(self-tested: it actually fires on a synthetic flag-add — not a no-op gate.)*
- **public-symbol rule** (warning only): an `__all__`/re-export change with no doc surface touched.

## Tier 3 — release-sweep gate
`docs/.docs-sweep.json` marker (the version the `rollout-docs-sweep` skill last swept) + `scripts/check_docs_sweep.py` asserting it equals the current goldenmatch version. Enforces that the agent prose-sweep *ran* for a release **without trying to mechanize the prose itself** — initialized to `2.0.0` so it passes today. Not wired into PR CI (documented as a release/manual gate in `.claude/doc-surfaces.md`).

## CI wiring
- New `docs` path filter on the `changes` job.
- **`docs_consistency`** job → added to `ci-required` `needs` (enforced), gated on `docs || force_all`.
- **`docs_staleness`** job → `continue-on-error: true`, **not** in `ci-required` (advisory; `fetch-depth: 0` for the diff). New gates land gradually, per the ast-grep lane precedent.

## Verified
- [x] All three checks exit 0 on the branch (Tier 1 10/10 PASS, Tier 3 marker matches, Tier 2 skips clean on this infra-only diff).
- [x] `py_compile` all scripts; `ci.yml` parses; existing `version_consistency`/`readme_callouts` gates still green.
- [x] `docs_consistency` confirmed in `ci-required`; `docs_staleness` confirmed non-blocking.

## Report-only findings (handled, not gated — no prose fabricated)
- `goldenmatch-pg` isn't named in the README (correct — GitHub-release tarball, deliberately excluded from the badge roster). Surfaced as a report-only line, excluded from the hard gate.
- `goldencheck-types` has no versioned CHANGELOG heading; `goldenanalysis` has an `unreleased` top entry over a released match — both reported, not failed.

The honest boundary stands: Tier 1 makes the **structured** surfaces true-lockstep, Tier 2 **flags** drift it can't auto-fix, Tier 3 **enforces the human/agent sweep ran** — the prose last mile is still the `rollout-docs-sweep` skill, just now gated.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_