### PR TITLE
Dogfood ast-grep: fix the 11 Math.min/max crash sites + promote the rule to error

### DIFF
--- a/.ast-grep/README.md
+++ b/.ast-grep/README.md
@@ -47,7 +47,7 @@ advisory (reported, non-blocking) so new rules can land gradually.
 | Rule | Severity | Invariant |
 |---|---|---|
 | `ts-no-empty-catch` | error | empty `catch {}` silently swallows errors — log or re-throw |
-| `ts-no-spread-math-min-max` | warning | `Math.min/max(...array)` throws on >65K elements — surfaces **11 real sites** for a follow-up cleanup |
+| `ts-no-spread-math-min-max` | error | `Math.min/max(...array)` throws on >65K elements — the 11 real sites were fixed (this PR), so it's now a hard guard against reintroduction |
 
 **Rust kernels** (`packages/rust/extensions/`):
 
@@ -60,7 +60,8 @@ advisory (reported, non-blocking) so new rules can land gradually.
 > Python tree already comply (the `panic!`/`println!` hits in Rust are all legit:
 > test assertions + the `goldenembed` CLI binary). These Rust rules are *preventive*
 > guards. The TypeScript `ts-no-spread-math-min-max` rule, by contrast, surfaced 11
-> real latent crash sites — fixed in a separate dogfood PR.
+> real latent crash sites — fixed in this PR, and the rule promoted to `error` so
+> the pattern can never come back.
 
 ## Considered but not added (AST can't express them cleanly)
 

--- a/.ast-grep/rules/ts-no-spread-math-min-max.yml
+++ b/.ast-grep/rules/ts-no-spread-math-min-max.yml
@@ -1,6 +1,6 @@
 id: ts-no-spread-math-min-max
 language: typescript
-severity: warning
+severity: error
 message: >-
   Math.min(...array) / Math.max(...array) throws RangeError (call-stack overflow)
   on arrays larger than ~65K elements — a real crash on big inputs. Use a

--- a/packages/typescript/goldenanalysis/src/core/analyzers/clusterDist.ts
+++ b/packages/typescript/goldenanalysis/src/core/analyzers/clusterDist.ts
@@ -67,7 +67,7 @@ export class ClusterDistributionAnalyzer implements Analyzer {
       { key: "cluster.singleton_ratio", value: count ? singletons / count : 0, unit: "ratio", direction: "neutral" },
       { key: "cluster.size_p50", value: quantile(sizes, 0.5), unit: "rows", direction: "neutral" },
       { key: "cluster.size_p95", value: quantile(sizes, 0.95), unit: "rows", direction: "neutral" },
-      { key: "cluster.size_max", value: sizes.length ? Math.max(...sizes) : 0, unit: "rows", direction: "neutral" },
+      { key: "cluster.size_max", value: sizes.length ? sizes.reduce((m, v) => (v > m ? v : m), -Infinity) : 0, unit: "rows", direction: "neutral" },
       {
         key: "cluster.reduction_ratio",
         value: recordCount ? 1 - count / recordCount : 0,

--- a/packages/typescript/goldenmatch/src/core/explain.ts
+++ b/packages/typescript/goldenmatch/src/core/explain.ts
@@ -264,8 +264,8 @@ export function explainCluster(
   // Score statistics.
   const scores: number[] = [];
   pairScores.forEach((s) => scores.push(s));
-  const minScore = scores.length > 0 ? Math.min(...scores) : 0;
-  const maxScore = scores.length > 0 ? Math.max(...scores) : 0;
+  const minScore = scores.length > 0 ? scores.reduce((m, v) => (v < m ? v : m), Infinity) : 0;
+  const maxScore = scores.length > 0 ? scores.reduce((m, v) => (v > m ? v : m), -Infinity) : 0;
   const avgScore =
     scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : 0;
 

--- a/packages/typescript/goldenmatch/src/core/memory/learner.ts
+++ b/packages/typescript/goldenmatch/src/core/memory/learner.ts
@@ -100,11 +100,10 @@ export class MemoryLearner {
     rejected: number[],
     all: readonly Correction[],
   ): number {
-    // Math.max/min via spread is fine here: corrections per matchkey is
-    // typically small (<100). For PR 2 row-count paths, the spec bans this
-    // pattern; the learner only sees correction scores.
-    const maxRejected = Math.max(...rejected);
-    const minApproved = Math.min(...approved);
+    // Loop-based min/max — never spread an array into Math.min/max (it throws
+    // RangeError past ~65K elements; banned by ast-grep ts-no-spread-math-min-max).
+    const maxRejected = rejected.reduce((m, v) => (v > m ? v : m), -Infinity);
+    const minApproved = approved.reduce((m, v) => (v < m ? v : m), Infinity);
     if (maxRejected < minApproved) {
       return (maxRejected + minApproved) / 2;
     }

--- a/packages/typescript/goldenmatch/src/core/probabilistic.ts
+++ b/packages/typescript/goldenmatch/src/core/probabilistic.ts
@@ -694,8 +694,8 @@ export function scoreProbabilistic(
   for (const f of fields) {
     const w = em.matchWeights[f.field];
     if (!w || w.length === 0) continue;
-    maxWeight += Math.max(...w);
-    minWeight += Math.min(...w);
+    maxWeight += w.reduce((m, v) => (v > m ? v : m), -Infinity);
+    minWeight += w.reduce((m, v) => (v < m ? v : m), Infinity);
   }
   const weightRange = maxWeight - minWeight;
 
@@ -759,8 +759,8 @@ export function scoreProbabilisticPair(
   for (const f of fields) {
     const w = em.matchWeights[f.field];
     if (!w || w.length === 0) continue;
-    maxWeight += Math.max(...w);
-    minWeight += Math.min(...w);
+    maxWeight += w.reduce((m, v) => (v > m ? v : m), -Infinity);
+    minWeight += w.reduce((m, v) => (v < m ? v : m), Infinity);
   }
   const weightRange = maxWeight - minWeight;
   if (weightRange <= 0) return 0.5;

--- a/packages/typescript/goldenmatch/tests/unit/learned-blocking.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/learned-blocking.test.ts
@@ -61,7 +61,7 @@ describe("learnBlockingRules", () => {
       predicateDepth: 3,
     });
     // At least one predicate should retain some useful recall.
-    const bestRecall = Math.max(...rules.predicates.map((p) => p.recall));
+    const bestRecall = rules.predicates.map((p) => p.recall).reduce((m, v) => (v > m ? v : m), -Infinity);
     expect(bestRecall).toBeGreaterThan(0);
   });
 

--- a/packages/typescript/infermap/src/core/engine.ts
+++ b/packages/typescript/infermap/src/core/engine.ts
@@ -31,7 +31,7 @@ export function commonAffixTokens(
   atStart: boolean
 ): string {
   if (names.length < 2) return "";
-  const shortest = Math.min(...names.map((n) => n.length));
+  const shortest = names.map((n) => n.length).reduce((m, v) => (v < m ? v : m), Infinity);
   let i = 0;
   if (atStart) {
     while (i < shortest && names.every((n) => n[i] === names[0]![i])) i++;


### PR DESCRIPTION
**Closes the dogfood loop end-to-end.** The `ts-no-spread-math-min-max` rule (#960) flagged **11 real latent bugs** — `Math.min/max(...array)` throws a `RangeError` (call-stack overflow) past ~65K elements. This PR fixes all 11 **and** promotes the rule from `warning` → `error`, so the pattern can never come back.

## 1. The fix (11 sites, 3 packages)
| Package | Files | Arrays spread |
|---|---|---|
| goldenmatch-js (9) | `memory/learner.ts`, `probabilistic.ts` (×4), `explain.ts` (×2), `learned-blocking.test.ts` | correction labels, EM weights, pair scores, recall list |
| goldenanalysis (1) | `analyzers/clusterDist.ts` | cluster sizes |
| infermap (1) | `core/engine.ts` | name lengths |

Each `Math.min/max(...arr)` → `arr.reduce((m, v) => (v < m ? v : m), Infinity)` (`-Infinity` for max). **Semantically identical**, including empty-array semantics — verified in `node` across `[3,1,2]/[5]/[]/[-2,-9,4]`.

## 2. The promotion (the loop)
With the tree now clean, `.ast-grep/rules/ts-no-spread-math-min-max.yml` is bumped to `severity: error`. Any future `Math.min/max(...array)` now **fails the `ast-grep` CI lane** — the one-time cleanup is now a permanent guard.

## Verification
- `ast-grep run -p 'Math.min/max(...$A)'` → **0 hits**.
- `ast-grep test` → 12/12; `ast-grep scan` → **exit 0** (rule is `error`, 0 hits).
- `tsc --noEmit`: no new errors in any edited file (fresh-workspace errors are pre-existing unbuilt-sibling module resolution; CI builds siblings first). The `typescript` + `ts_parity_freshness` lanes verify behavior.

Built on the merged #960 rule set. Draft.

https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr