### PR TITLE
fix(distributed): memory-aware clustering routing (#956)

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -154,6 +154,10 @@ This is the knob most people get wrong, so read the contract before you run a 10
 
 **Recall-complete clustering at scale (#844, shipped 2026-06-11).** Phase 5's default path now block-shuffles scoring so true duplicates co-locate, then runs a relational **randomized-contraction** weakly-connected-components pass that clusters correctly across input-partition boundaries. This replaced two earlier WCC implementations that died at 100M (a driver head-wedge and a Ray streaming-executor deadlock). It is **default-on** and validated end-to-end at 100M (9.2 min, 20M clusters exact). On a **multi-node** cluster the WCC checkpoints each round to `GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH`, which **must be a shared path** (e.g. `gs://...`) — a node-local scratch breaks the cross-node parquet reads and now raises rather than silently under-merging.
 
+<Note>
+  **Only scoring needs distribution at this scale; clustering usually doesn't.** The scored pair set is small (~`(id_a, id_b, score)` per match), so at 100M rows it's ~1.8 GB — it fits one node. Clustering therefore routes to the in-memory scipy connected-components pass (seconds) automatically whenever the pairs fit driver RAM, and only falls back to the distributed WCC (a multi-hour tail) when they genuinely don't. You don't need to set `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` for this — it's the default.
+</Note>
+
 **Distributed sub-knobs** (only relevant on a real Ray cluster):
 
 | Variable | Default | Effect |
@@ -162,7 +166,7 @@ This is the knob most people get wrong, so read the contract before you run a 10
 | `GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH` | unset | Scratch directory the randomized-contraction WCC checkpoints to. **Must be shared (e.g. `gs://...`) on a multi-node cluster** or the run raises. |
 | `GOLDENMATCH_DISTRIBUTED_WCC` | `two_phase` | WCC algorithm for `build_clusters_distributed`'s *own* callers (the at-scale Phase-5 path forces `randomized_contraction` and ignores this). `two_phase` is chain-safe; avoid `pointer_jump` (can deadlock). |
 | `GOLDENMATCH_DISTRIBUTED_WCC_SEED` | unset | Seed for the randomized-contraction affine hash (reproducible cluster IDs across runs). |
-| `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` | `50000000` | Pair count above which clustering goes distributed; below, a driver-side scipy.csgraph path. |
+| `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` | unset (memory-aware) | Pair count above which clustering goes distributed. **Unset (default): memory-aware** — clustering stays on the fast driver-side scipy.csgraph path whenever the scored pair set fits available driver RAM, and only distributes when it genuinely won't. Set an explicit integer to force a pair-count boundary either way. |
 | `GOLDENMATCH_DISTRIBUTED_GOLDEN_THRESHOLD` | `5000000` | Multi-member row count above which golden-record building goes distributed. |
 | `GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS` | `2` | CPUs requested per Ray scoring worker. |
 

--- a/docs/superpowers/specs/2026-06-14-956-memory-aware-clustering-routing.md
+++ b/docs/superpowers/specs/2026-06-14-956-memory-aware-clustering-routing.md
@@ -1,0 +1,73 @@
+# #956: memory-aware distributed clustering routing — design
+
+**Goal:** Phase-5 distributed clustering should default to the fast in-memory connected-components path whenever the scored pair set fits in driver RAM, instead of routing to the multi-hour distributed WCC at a fixed 50M-pair threshold. Plus: regression-test the #955 materialize fix, and document the "only scoring needs distribution at scale" rule.
+
+## Problem (from the issue)
+At 100M rows the scored pair set is ~110M edges (~1.76 GB raw) — fits one node comfortably — but `build_clusters_distributed` routes it to the distributed randomized-contraction WCC (multi-hour) because `pair_count (110M) >= threshold (50M)`. An end user only escapes by knowing to raise `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD`. The decision should be memory-aware: distribute only when the pairs genuinely don't fit driver RAM.
+
+## Current code
+`goldenmatch/distributed/clustering.py:230-231`:
+```python
+threshold = _label_prop_threshold()            # 50M default, env-overridable
+pair_count = pairs_ds.count()
+use_label_prop = force_label_propagation or pair_count >= threshold
+```
+`_label_prop_threshold()` (clustering.py:164-173) returns `int(GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD)` if set, else `_LABEL_PROP_PAIR_THRESHOLD = 50_000_000`.
+
+The in-memory path = `_build_clusters_scipy_fallback` (clustering.py:371-433): collects pairs via pyarrow, builds a CSR matrix, `scipy.csgraph.connected_components`. The distributed path = `randomized_contraction_wcc` (forced by `_phase5_cluster` via `algorithm="randomized_contraction"`; the `algorithm` kwarg only selects WHICH distributed algo, it does NOT force distribution — the `use_label_prop` gate still decides).
+
+`#955`'s materialize fix is on main at `pipeline.py:166-167` (`raw_pairs_ds = raw_pairs_ds.materialize()` after `score_blocks_distributed`, before `_phase5_cluster`).
+
+`psutil>=5.9` is a dep; `core/runtime_profile.py:38-40` already uses `psutil.virtual_memory().available`.
+
+## Design
+
+### 1. Memory-aware routing (the core fix)
+New helper in `clustering.py`:
+```python
+_PAIR_PEAK_BYTES = 96  # ~24 B/pair (id_a,id_b,score int64/int64/f64) x ~4 peak
+                       # (arrow table + numpy arrays + CSR + labels live at once)
+
+def _route_distributed(pair_count: int) -> bool:
+    """True => distributed WCC; False => in-memory scipy CC.
+
+    Explicit GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD wins (back-compat,
+    power users forcing the boundary). Unset (default) => memory-aware:
+    in-memory when the estimated peak pair-set bytes fit available driver RAM.
+    """
+    raw = os.environ.get("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD")
+    if raw is not None:
+        try:
+            return pair_count >= int(raw)
+        except ValueError:
+            pass
+    import psutil
+    available = psutil.virtual_memory().available
+    return pair_count * _PAIR_PEAK_BYTES > available
+```
+Decision line becomes:
+```python
+use_label_prop = force_label_propagation or _route_distributed(pair_count)
+```
+Log the decision (est bytes vs available) at INFO so the route is visible (ties into the sibling #956/#957 "never silently take the slow path" theme).
+
+**Precedence chosen:** explicit env var overrides; default is memory-aware. This preserves every existing `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` user's behavior while fixing the default. `force_label_propagation=True` still always distributes (unchanged).
+
+`_label_prop_threshold()` stays (other callers/tests reference it) but the routing no longer calls it directly when the env var is unset.
+
+### 2. Regression test for the #955 materialize fix
+Assert `_run_phase5_pipeline` materializes the scored pair dataset exactly once before clustering (scoring DAG not re-executed per WCC round). Test via a fake `Dataset` whose `.materialize()` increments a counter and whose downstream `_phase5_cluster` is monkeypatched to a no-op; assert `materialize` called once and the dataset passed to `_phase5_cluster` is the materialized one. No real Ray required (monkeypatch `score_blocks_distributed` to return the fake dataset).
+
+### 3. Doc
+Add a short "Only scoring needs distribution at this scale" note to `docs-site/goldenmatch/tuning.mdx` Distributed section: clustering routes in-memory automatically when the pair set fits driver RAM; `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` is the manual override.
+
+## Tests
+- `tests/test_distributed_clustering.py`: add `test_route_distributed_memory_aware_default` (monkeypatch psutil available RAM high → big pair_count routes in-memory; low → routes distributed), `test_route_distributed_env_override_wins` (env set → pair-count threshold honored regardless of RAM), `test_route_distributed_force_label_prop` (force flag always distributes). Pure-function tests, no Ray.
+- `tests/test_phase5_distributed_pipeline.py` (or test_phase5_cluster_routing.py): add `test_phase5_materializes_pairs_once` regression test.
+
+## Out of scope (separate issues)
+- The slow-path WARNING when distributed runs on a fits-in-memory set (#956's sibling comment) — a follow-up; this issue makes the DEFAULT correct, which is the higher-leverage half.
+- `_score` cluster saturation / column projection (#957).
+
+## Risk
+Low. The change only widens when the in-memory path is taken (it was already the path below 50M; now also above 50M when RAM allows). The scipy path is the verified-correct reference. Existing quality-invariance tests cover both routes producing identical components.

--- a/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
@@ -173,6 +173,53 @@ def _label_prop_threshold() -> int:
         return _LABEL_PROP_PAIR_THRESHOLD
 
 
+# Peak driver bytes per scored pair on the in-memory scipy route: ~24 B for the
+# (id_a, id_b, score) = (int64, int64, f64) triple, times ~4 because the arrow
+# table, the numpy id arrays, the CSR matrix, and the labels array are all live
+# at once. Deliberately conservative -- routing in-memory must not OOM the driver.
+_PAIR_PEAK_BYTES = 96
+
+
+def _route_distributed(pair_count: int) -> bool:
+    """Decide the clustering route: True => distributed WCC, False => in-memory scipy.
+
+    The scored pair set fits one node far more often than the legacy fixed 50M
+    threshold assumed (110M pairs ~= 1.76 GB raw), so the slow distributed WCC
+    was the default well below where it was actually needed (#956).
+
+    Precedence:
+      * ``force_label_propagation`` (handled by the caller) always distributes.
+      * An explicit ``GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD`` wins -- it
+        stays a pair-count threshold, preserving every existing user's behavior
+        and letting power users force the boundary either way.
+      * Unset (the default) is MEMORY-AWARE: distribute only when the estimated
+        peak pair-set bytes won't fit available driver RAM. Distribution is for
+        when the pairs genuinely don't fit, not a round-number guess.
+    """
+    import os
+
+    raw = os.environ.get("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD")
+    if raw is not None:
+        try:
+            return pair_count >= int(raw)
+        except ValueError:
+            pass  # malformed env -> fall through to the memory-aware default
+    import psutil
+
+    available = psutil.virtual_memory().available
+    est_peak = pair_count * _PAIR_PEAK_BYTES
+    distribute = est_peak > available
+    logger.info(
+        "build_clusters_distributed route: %d pairs, est peak %.2f GB vs "
+        "%.2f GB available -> %s",
+        pair_count,
+        est_peak / (1024 ** 3),
+        available / (1024 ** 3),
+        "distributed WCC" if distribute else "in-memory scipy",
+    )
+    return distribute
+
+
 def _resolve_use_label_prop(
     pair_count: int,
     clustering_strategy: str | None = None,
@@ -182,7 +229,9 @@ def _resolve_use_label_prop(
     """Decide distributed (label-prop) vs in-memory WCC.
 
     An explicit planner strategy ("in_memory" / "distributed_wcc") wins;
-    otherwise fall back to the env-threshold decision (today's path).
+    otherwise fall back to the memory-aware route decision (#956): in-memory
+    scipy whenever the scored pair set fits driver RAM, distributed WCC when it
+    doesn't (or an explicit CLUSTERING_THRESHOLD says so).
     """
     if force_label_propagation:
         return True
@@ -190,7 +239,7 @@ def _resolve_use_label_prop(
         return False
     if clustering_strategy == "distributed_wcc":
         return True
-    return pair_count >= _label_prop_threshold()
+    return _route_distributed(pair_count)
 
 
 def _derive_touched_ids(pairs_ds: Dataset) -> list[int]:
@@ -223,15 +272,17 @@ def build_clusters_distributed(
 
     Row shape: {member_id, cluster_id, cluster_size, oversized}.
 
-    Routing (Splink-Spark style):
-      - Pair count below threshold (default 50M): driver-side scipy.csgraph.
-        Faster than distributed label propagation until the pair list stops
-        fitting in driver memory.
-      - Pair count above threshold OR force_label_propagation=True:
-        distributed label propagation on Ray Datasets. Falls back to scipy
-        on non-convergence.
+    Routing (Splink-Spark style), memory-aware by default (#956):
+      - Pair set fits available driver RAM: driver-side scipy.csgraph. The
+        in-memory connected-components pass is seconds where the distributed
+        WCC is a multi-hour tail, so it is the default whenever the pairs fit.
+      - Pair set does NOT fit driver RAM, OR force_label_propagation=True:
+        distributed WCC / label propagation on Ray Datasets. Falls back to
+        scipy on non-convergence.
 
-    Override threshold via env var GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD.
+    Setting GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD overrides the
+    memory-aware default with an explicit pair-count threshold (see
+    ``_route_distributed``).
 
     ``algorithm`` (keyword-only) overrides the GOLDENMATCH_DISTRIBUTED_WCC env
     selector for this call (e.g. "randomized_contraction"); None = env default.
@@ -247,7 +298,6 @@ def build_clusters_distributed(
     cluster_id is the minimum member_id in the connected component.
     cluster_size is the count of members sharing that label.
     """
-    threshold = _label_prop_threshold()
     pair_count = pairs_ds.count()
     use_label_prop = _resolve_use_label_prop(
         pair_count, clustering_strategy,
@@ -256,9 +306,9 @@ def build_clusters_distributed(
 
     if not use_label_prop:
         logger.info(
-            "build_clusters_distributed: %d pairs < %d threshold; "
-            "routing to scipy.csgraph (driver-side, faster at this scale).",
-            pair_count, threshold,
+            "build_clusters_distributed: %d pairs route to scipy.csgraph "
+            "(driver-side, fits memory -- faster at this scale).",
+            pair_count,
         )
         ids = all_ids if all_ids is not None else _derive_touched_ids(pairs_ds)
         return _annotate_cluster_sizes(
@@ -275,10 +325,9 @@ def build_clusters_distributed(
 
     if algorithm == "label_propagation":
         logger.info(
-            "build_clusters_distributed: %d pairs >= %d threshold; "
-            "routing to distributed label propagation (env override or "
-            "force_label_propagation=True).",
-            pair_count, threshold,
+            "build_clusters_distributed: %d pairs route to distributed label "
+            "propagation (env override or force_label_propagation=True).",
+            pair_count,
         )
         ids = all_ids if all_ids is not None else _derive_touched_ids(pairs_ds)
         try:
@@ -298,17 +347,16 @@ def build_clusters_distributed(
             )
     elif algorithm == "two_phase":
         logger.info(
-            "build_clusters_distributed: %d pairs >= %d threshold; "
-            "routing to two_phase_wcc (driver-side Phase A/B; wedges the head "
-            "at 100M -- kept for comparison).",
-            pair_count, threshold,
+            "build_clusters_distributed: %d pairs route to two_phase_wcc "
+            "(driver-side Phase A/B; wedges the head at 100M -- kept for comparison).",
+            pair_count,
         )
         labels_ds = two_phase_wcc(pairs_ds, all_ids)
     elif algorithm == "randomized_contraction":
         logger.info(
-            "build_clusters_distributed: %d pairs >= %d threshold; routing to "
+            "build_clusters_distributed: %d pairs route to "
             "randomized_contraction_wcc (relational contraction, parquet checkpoint).",
-            pair_count, threshold,
+            pair_count,
         )
         import os
         _rc_seed_raw = os.environ.get("GOLDENMATCH_DISTRIBUTED_WCC_SEED")
@@ -320,9 +368,9 @@ def build_clusters_distributed(
         )
     else:  # pointer_jump (default): fully distributed, no driver collect.
         logger.info(
-            "build_clusters_distributed: %d pairs >= %d threshold; "
-            "routing to distributed_wcc (pointer-jumping, no driver collect).",
-            pair_count, threshold,
+            "build_clusters_distributed: %d pairs route to distributed_wcc "
+            "(pointer-jumping, no driver collect).",
+            pair_count,
         )
         labels_ds = distributed_wcc(pairs_ds)
 

--- a/packages/python/goldenmatch/tests/test_distributed_clustering.py
+++ b/packages/python/goldenmatch/tests/test_distributed_clustering.py
@@ -226,6 +226,111 @@ def test_build_clusters_distributed_threshold_env_override(monkeypatch, caplog):
     assert not any("scipy" in m for m in routing_msgs)
 
 
+def test_route_distributed_memory_aware_default(monkeypatch):
+    """#956: with the env var unset, routing is memory-aware -- distribute only
+    when the estimated peak pair-set bytes won't fit available driver RAM."""
+    import types
+
+    import psutil
+    from goldenmatch.distributed.clustering import _PAIR_PEAK_BYTES, _route_distributed
+
+    monkeypatch.delenv("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", raising=False)
+
+    # 200 GB available: 110M pairs (the #956 case, ~10 GB peak) FITS -> in-memory.
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: types.SimpleNamespace(available=200 * 1024 ** 3)
+    )
+    assert _route_distributed(110_000_000) is False
+
+    # 1 GB available: even 50M pairs (~4.5 GB peak) does NOT fit -> distributed.
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: types.SimpleNamespace(available=1 * 1024 ** 3)
+    )
+    assert _route_distributed(50_000_000) is True
+
+    # Boundary: just over available -> distribute; just under -> in-memory.
+    avail = 8 * 1024 ** 3
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: types.SimpleNamespace(available=avail)
+    )
+    assert _route_distributed(avail // _PAIR_PEAK_BYTES + 1) is True
+    assert _route_distributed(avail // _PAIR_PEAK_BYTES - 1) is False
+
+
+def test_route_distributed_env_override_wins(monkeypatch):
+    """#956: an explicit GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD overrides
+    the memory heuristic (back-compat); malformed env falls through to it."""
+    import types
+
+    import psutil
+    from goldenmatch.distributed.clustering import _route_distributed
+
+    # Plenty of RAM, but the explicit pair-count threshold still governs.
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: types.SimpleNamespace(available=999 * 1024 ** 3)
+    )
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", "10000000")
+    assert _route_distributed(10_000_000) is True   # >= threshold -> distribute
+    assert _route_distributed(9_999_999) is False   # < threshold -> in-memory
+
+    # Malformed env -> ignored, memory-aware default takes over (999 GB fits).
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", "notanint")
+    assert _route_distributed(50_000_000) is False
+
+
+def test_phase5_materializes_pairs_once_before_clustering(tmp_path, monkeypatch):
+    """#956/#955 regression: the scored pair set is materialized EXACTLY ONCE
+    before clustering, so the WCC rounds reuse it instead of re-executing the
+    whole scoring DAG per round (the fuzzy-config hours-long tail). Stub-based:
+    asserts the materialize-before-cluster wiring without a real cluster. Lives
+    here (not test_phase5_distributed_pipeline.py) so the distributed CI lane
+    actually runs it -- that file matches no CI pytest glob.
+    """
+    from goldenmatch.distributed import pipeline as P
+
+    calls = {"materialize": 0}
+
+    class _FakeMaterialized:
+        """What .materialize() returns -- the dataset clustering must receive."""
+
+    class _FakePairs:
+        def materialize(self):
+            calls["materialize"] += 1
+            return _FakeMaterialized()
+
+    class _FakeAssignments:
+        def write_parquet(self, path):  # the _skip_golden path persists these
+            pass
+
+    received = {}
+
+    # score_blocks_distributed is imported inside _run_phase5_pipeline from its
+    # source module, so patch it there (not on P).
+    monkeypatch.setattr(
+        "goldenmatch.distributed.scoring.score_blocks_distributed",
+        lambda ds, cfg: _FakePairs(),
+    )
+
+    def _fake_cluster(pairs_ds, cfg):
+        received["pairs_ds"] = pairs_ds
+        return _FakeAssignments()
+
+    monkeypatch.setattr(P, "_phase5_cluster", _fake_cluster)
+
+    P._run_phase5_pipeline(
+        object(),                          # ds: only the stubbed scorer touches it
+        config=object(),                   # non-None -> skip auto-config
+        assignments_output_path=str(tmp_path / "asg"),
+        _skip_golden=True,                 # return right after clustering
+    )
+
+    assert calls["materialize"] == 1, "scored pairs must be materialized exactly once"
+    assert isinstance(received["pairs_ds"], _FakeMaterialized), (
+        "_phase5_cluster must receive the MATERIALIZED dataset, not the lazy one "
+        "(else each WCC round re-runs the scoring DAG -- #955)"
+    )
+
+
 # ── Quality-invariant scale validation ──
 #
 # The distributed paths use DIFFERENT algorithms than the in-memory path


### PR DESCRIPTION
Fixes #956 (the higher-leverage half: making the default correct).

## Problem
At 100M rows the scored pair set is ~110M edges (~1.76 GB) -- fits one node -- but `build_clusters_distributed` routed it to the multi-hour distributed randomized-contraction WCC because `pair_count (110M) >= threshold (50M)`. That fixed 50M-pair threshold was THE reason a distributed 100M run took hours instead of ~20 min. "Only scoring needs distribution at this scale; clustering doesn't" should be automatic.

## Change
- **Memory-aware routing** (`_route_distributed`): an explicit `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` still wins (back-compat / power users), but **unset (the default) is now memory-aware** -- in-memory `scipy.csgraph` whenever the estimated peak pair-set bytes fit available driver RAM (`psutil`), distributed WCC only when they genuinely don't. `force_label_propagation=True` still always distributes.
- **Regression test for the #955 materialize fix** -- asserts the scored pairs are materialized exactly once before clustering (not re-scored per WCC round). Stub-based, no cluster.
- **Doc** -- `tuning.mdx` note + the `CLUSTERING_THRESHOLD` row updated to the memory-aware default.

## Test-placement fix (incidental)
The materialize regression test lives in `test_distributed_clustering.py`, not `test_phase5_distributed_pipeline.py` -- the latter matches **no** CI pytest glob (`test_distributed_*` in the distributed lane; main lane has no `ray`), so tests there run nowhere. (Pre-existing gap for the existing phase5 tests too; flagging separately.)

## Out of scope (tracked in #956 / siblings)
- The slow-path WARNING when distributed runs on a fits-in-memory set (#956 sibling) -- a follow-up; this PR makes the DEFAULT correct.
- `_score` cluster saturation / column projection (#957).

## Verification
ruff + py_compile clean locally; routing tests are pure-function (`psutil` monkeypatched). Distributed CI lane runs the new tests against the brotli-fixed main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)