### PR TITLE
fix(distributed): project to scoring columns before block-shuffle (#957)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
@@ -47,6 +47,46 @@ logger = logging.getLogger(__name__)
 # Override via GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS for different shapes.
 _SCORE_NUM_CPUS = int(os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS", "2"))
 
+# #957: project to scoring-relevant columns BEFORE the block-shuffle so the
+# shuffle moves narrow blocks, not full records. The block-shuffle `_explode`
+# copies the FULL record per co-location key; on wide records that inflates the
+# shuffled block size -> Ray object-store backpressure -> `_score` pinned to a
+# few tasks (~6 of 80 CPU at 100M) while workers sit idle. Scoring reads only
+# __row_id__ + config-referenced columns, so dropping unreferenced raw columns
+# is output-invariant (parity-tested). Kill via GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT=0.
+_SCORE_PROJECT = os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT", "1") != "0"
+
+# #957: optional explicit concurrency for the `_score` map_batches. Ray Data's
+# streaming executor otherwise caps in-flight tasks by object-store budget; the
+# projection above relieves that, and this pins the target task count to
+# saturate worker CPU. Unset (default) = let Ray decide; the optimal value is
+# cluster-shaped, tuned at the 100M re-measure.
+_raw_score_conc = os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY")
+_SCORE_CONCURRENCY = int(_raw_score_conc) if _raw_score_conc else None
+
+
+def _project_to_scoring_columns(df: Any, config: GoldenMatchConfig) -> Any:
+    """Drop columns scoring never reads, BEFORE the block-shuffle (#957).
+
+    Keeps every config-referenced column (matchkeys + blocking keys/passes, via
+    ``_collect_referenced_columns``) plus all synthetic ``__...__`` columns
+    (``__row_id__``, domain-extracted keys, etc.), and drops only unreferenced
+    RAW user columns (the wide address / description / free-text fields that
+    bloat the shuffle). Output-invariant: ``_score_colocated_groups`` scores via
+    the bucket kernel, which reads only the matchkey/blocking fields -- it
+    already ignores the dropped columns.
+    """
+    from goldenmatch.core.autoconfig_verify import _collect_referenced_columns
+
+    referenced = _collect_referenced_columns(config)
+    keep = [
+        c for c in df.columns
+        if c in referenced or (c.startswith("__") and c.endswith("__"))
+    ]
+    if not keep or len(keep) == len(df.columns):
+        return df  # nothing droppable -> skip a pointless copy
+    return df.select(keep)
+
 
 def _block_shuffle_enabled() -> bool:
     """Gate for the blocking-key-aware shuffle scoring path (issue #844).
@@ -340,16 +380,18 @@ def _score_blocks_block_shuffle(
        pass -- the bucket backend already groups by the blocking key internally,
        so the loop was redundant. See ``_score_colocated_groups``.
 
-    2. FULL-RECORD SHUFFLE -- still open (secondary). ``_explode`` emits a copy
-       of the FULL record per co-location key (#passes + #exact matchkeys), so
-       the shuffle moves ``N_keys x N_rows x full_record_width`` (~13-27 GB at
-       100M). ``_score`` only needs ``__row_id__`` + config-referenced fields.
-       Fix (deferred behind the backend-parity gate + a wide-record bench):
-       project ``df`` to ``{__row_id__} U columns referenced by
-       matchkeys/blocking/standardization`` BEFORE ``_attach_colocation_keys``
-       (big win on wide records). Secondary: dedupe the explode when an exact
-       matchkey's key equals a blocking pass's key (block + exact-match the same
-       field doubles the copies).
+    2. FULL-RECORD SHUFFLE -- FIXED (#957). ``_explode`` used to emit a copy of
+       the FULL record per co-location key (#passes + #exact matchkeys), so the
+       shuffle moved ``N_keys x N_rows x full_record_width`` (~13-27 GB at 100M)
+       -> object-store backpressure pinned ``_score`` to ~6 of 80 CPU. It now
+       projects ``df`` to ``{__row_id__} U config-referenced columns U synthetic
+       __-cols`` via ``_project_to_scoring_columns`` BEFORE
+       ``_attach_colocation_keys`` (output-invariant; the bucket kernel reads
+       only the matchkey/blocking fields). Set
+       ``GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT=0`` to disable. An explicit
+       ``GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY`` further pins the ``_score``
+       task count once blocks are narrow. Secondary (still open): dedupe the
+       explode when an exact matchkey's key equals a blocking pass's key.
     """
     # Shuffle partition count. Default derives from the DRIVER cpu count, but the
     # block-shuffle explodes each record per co-location key (wide records ->
@@ -366,6 +408,8 @@ def _score_blocks_block_shuffle(
         import polars as pl
         df = pl.from_arrow(batch)
         assert isinstance(df, pl.DataFrame)
+        if _SCORE_PROJECT:
+            df = _project_to_scoring_columns(df, config)
         return _attach_colocation_keys(df, config).to_arrow()
 
     def _score(batch: Any) -> Any:  # pa.Table -> pa.Table
@@ -387,12 +431,18 @@ def _score_blocks_block_shuffle(
     logger.info(
         "score_blocks_distributed: BLOCK-SHUFFLE path (opt-in via "
         "GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE); %d shuffle partitions, "
-        "num_cpus=%d per task",
-        n_parts, _SCORE_NUM_CPUS,
+        "num_cpus=%d per task, project=%s, concurrency=%s",
+        n_parts, _SCORE_NUM_CPUS, _SCORE_PROJECT,
+        _SCORE_CONCURRENCY if _SCORE_CONCURRENCY is not None else "auto",
     )
-    return colocated.map_batches(
-        _score, batch_format="pyarrow", batch_size=None, num_cpus=_SCORE_NUM_CPUS,
-    )
+    _mb_kwargs: dict[str, Any] = {
+        "batch_format": "pyarrow",
+        "batch_size": None,
+        "num_cpus": _SCORE_NUM_CPUS,
+    }
+    if _SCORE_CONCURRENCY is not None:
+        _mb_kwargs["concurrency"] = _SCORE_CONCURRENCY
+    return colocated.map_batches(_score, **_mb_kwargs)
 
 
 def _dedup_num_partitions() -> int:

--- a/packages/python/goldenmatch/tests/test_distributed_score_projection.py
+++ b/packages/python/goldenmatch/tests/test_distributed_score_projection.py
@@ -1,0 +1,102 @@
+"""#957: column projection before the block-shuffle must be output-invariant.
+
+The block-shuffle `_explode` used to move a copy of the FULL record per
+co-location key; `_project_to_scoring_columns` now drops columns scoring never
+reads BEFORE the shuffle. These tests pin that the projection keeps exactly the
+right columns and never changes the scored pair set.
+
+Polars-only (no Ray): `goldenmatch.distributed.scoring` defers all ray imports,
+and `_score_colocated_groups` scores via the in-memory kernel.
+"""
+from __future__ import annotations
+
+import polars as pl
+
+
+def _cfg():
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["last_name"])],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="fn", type="weighted", threshold=0.80,
+                fields=[MatchkeyField(
+                    field="first_name", scorer="jaro_winkler", weight=1.0,
+                )],
+            )
+        ],
+    )
+
+
+def test_project_keeps_referenced_and_synthetic_drops_wide():
+    """Keep __row_id__ + config-referenced cols + synthetic __-cols; drop only
+    unreferenced raw user columns."""
+    from goldenmatch.distributed.scoring import _project_to_scoring_columns
+
+    df = pl.DataFrame({
+        "__row_id__":     [0, 1],
+        "first_name":     ["alice", "alyce"],   # matchkey field (referenced)
+        "last_name":      ["surA", "surA"],     # blocking field (referenced)
+        "__domain_key__": ["d", "d"],           # synthetic upstream col
+        "free_text_blob": ["x" * 200, "y" * 200],  # wide, unreferenced -> dropped
+        "notes":          ["n1", "n2"],         # unreferenced -> dropped
+    })
+
+    out = _project_to_scoring_columns(df, _cfg())
+
+    assert set(out.columns) == {
+        "__row_id__", "first_name", "last_name", "__domain_key__"
+    }
+    assert "free_text_blob" not in out.columns
+    assert "notes" not in out.columns
+    # rows untouched
+    assert out.height == 2
+
+
+def test_project_noop_when_nothing_droppable():
+    """All columns referenced/synthetic -> the same frame back (no copy churn)."""
+    from goldenmatch.distributed.scoring import _project_to_scoring_columns
+
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "first_name": ["alice", "alyce"],
+        "last_name":  ["surA", "surA"],
+    })
+    out = _project_to_scoring_columns(df, _cfg())
+    assert set(out.columns) == set(df.columns)
+
+
+def test_projection_is_score_invariant():
+    """Scoring the co-located partition yields the SAME pairs with or without
+    the unreferenced wide column -- the whole justification for projecting."""
+    from goldenmatch.distributed.scoring import (
+        _project_to_scoring_columns,
+        _score_colocated_groups,
+    )
+
+    cfg = _cfg()
+    # Shape as it enters _score_colocated_groups: __keyid__/__block_key__ (it
+    # drops them), __row_id__, the fields, + a wide unreferenced column.
+    full = pl.DataFrame({
+        "__row_id__":     [0, 1],
+        "__keyid__":      ["k", "k"],
+        "__block_key__":  ["surA", "surA"],
+        "first_name":     ["alice", "alyce"],
+        "last_name":      ["surA", "surA"],
+        "free_text_blob": ["x" * 200, "y" * 200],
+    })
+    projected = _project_to_scoring_columns(full, cfg)
+
+    pairs_full = sorted(_score_colocated_groups(full, cfg))
+    pairs_proj = sorted(_score_colocated_groups(projected, cfg))
+
+    assert pairs_full == pairs_proj


### PR DESCRIPTION
Parts 1-2 of #957 (the code; part 3 is a cluster re-measure for you to run).

## Problem
The block-shuffle `_explode` copied the **full record** per co-location key (the code flagged this at `scoring.py:343` "FULL-RECORD SHUFFLE — still open"), moving ~13-27 GB at 100M. That inflated block size → Ray object-store backpressure → `_score` ran ~6 of 80 CPU while workers sat idle. This is the wall for the 200M rung.

## Change (`distributed/scoring.py`)
1. **`_project_to_scoring_columns`** — drops columns scoring never reads BEFORE the shuffle. Keeps `__row_id__` + every config-referenced column (matchkeys + blocking **keys and passes**, reusing `_collect_referenced_columns`) + all synthetic `__…__` columns; drops only unreferenced raw user columns (the wide free-text/address fields). **Output-invariant** — the bucket kernel reads only the matchkey/blocking fields. Default-on; kill via `GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT=0`.
2. **Explicit `_score` concurrency knob** — `GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY` pins the `_score` task count to saturate worker CPU once blocks are narrow. Unset (default) = Ray decides; the optimal value is cluster-shaped.

## Verification
- New `test_distributed_score_projection.py` (the parity gate): the projection keeps exactly the right columns and **never changes the scored pair set**. 3 tests, **green locally** (incl. a non-vacuous scoring-invariance test that actually scored a pair).
- ruff + py_compile clean.

## Needs you (part 3)
The actual CPU-saturation / wall win is only provable on a real cluster. Please dispatch the (now #958-hardened) `bench-ray-cluster` at 100M and check `_score` CPU utilization + wall, then we tune `GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY` and confirm the 200M rung. The projection is output-invariant so it's safe to ship default-on ahead of that; the knob is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)