### PR TITLE
r1(kernel-wheels): native-arm aarch64 runtime + macos-x86_64 build-only (harness fixes)

### DIFF
--- a/.github/workflows/r1-kernel-wheels.yml
+++ b/.github/workflows/r1-kernel-wheels.yml
@@ -62,29 +62,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # linux x86_64 (manylinux 2_28) — the #688 host family.
+          # linux x86_64 (manylinux 2_28) — the #688 host family. Native runtime.
           - name: linux-x86_64
             runner: ubuntu-latest
             target: x86_64
             manylinux: "2_28"
-          # linux aarch64 (manylinux 2_28, cross-built via maturin-action's qemu).
+            runtime: true
+          # linux aarch64 (manylinux 2_28) — NATIVE on the GA arm64 Linux runner, so
+          # the just-built aarch64 wheel actually runs the equivalence + perf gate
+          # (no QEMU, no cross-arch skip).
           - name: linux-aarch64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: "2_28"
+            runtime: true
           # macOS arm64 (native on the Apple Silicon runner).
           - name: macos-arm64
             runner: macos-14
             target: aarch64
-          # macOS x86_64 (cross-compile on macos-14 — macos-13 Intel runners queue
-          # indefinitely in this org; Apple ships the x86_64 SDK slice).
+            runtime: true
+          # macOS x86_64 — BUILD-ONLY. Cross-compiled on the macos-14 arm64 runner;
+          # an x86_64 wheel can't import/run on arm64, and macos-13 Intel runners
+          # queue indefinitely in this org. The BUILD succeeding is the
+          # kill-criterion-(3) signal; runtime equivalence is covered by macos-arm64.
           - name: macos-x86_64
             runner: macos-14
             target: x86_64
-          # windows x64.
+            runtime: false
+          # windows x64. Native runtime.
           - name: windows-x64
             runner: windows-latest
             target: x64
+            runtime: true
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
@@ -114,12 +123,12 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          # The aarch64 wheel is cross-built and not installable on the x86_64
-          # runner; on that leg the gate can't run, so we don't attempt install/run
-          # (the BUILD succeeding is the signal that aarch64 manylinux is producible
-          # without firefighting — the matter kill-criterion (3) probes).
-          if [ "${{ matrix.name }}" = "linux-aarch64" ]; then
-            echo "linux-aarch64 wheel is cross-built (not runnable on this x86 runner) — build-only leg." \
+          # Build-only legs (runtime: false) ship a wheel for an arch this runner
+          # can't execute (e.g. an x86_64 wheel on the arm64 macOS runner). The BUILD
+          # succeeding is the kill-criterion-(3) signal; runtime equivalence for that
+          # arch is covered by a sibling native leg. Don't attempt install/run.
+          if [ "${{ matrix.runtime }}" != "true" ]; then
+            echo "${{ matrix.name }} is a build-only leg (cross-built, not runnable on this runner) — BUILD OK is the signal." \
               | tee -a "$GITHUB_STEP_SUMMARY"
             ls -la dist
             exit 0
@@ -128,7 +137,7 @@ jobs:
           python -m pip install -e packages/python/goldenmatch
 
       - name: Equivalence gate (REQUIRE-KERNEL) + bench (ASSERT-NOT-SLOWER)
-        if: matrix.name != 'linux-aarch64'
+        if: matrix.runtime
         shell: bash
         run: |
           set -euo pipefail

--- a/context-network/decisions/0016-single-kernel-collapse-spike.md
+++ b/context-network/decisions/0016-single-kernel-collapse-spike.md
@@ -126,17 +126,30 @@ Workstream B adds a `workflow_dispatch` CI workflow,
 [`.github/workflows/r1-kernel-wheels.yml`](../../.github/workflows/r1-kernel-wheels.yml),
 that directly probes the two pending platform-reliability items:
 
-- **Kill-criterion (3) — all-platform abi3 wheels:** PROBED BY `r1-kernel-wheels.yml`
-  `wheels` matrix (linux x86_64 manylinux 2_28 / linux aarch64 / macOS arm64 / macOS
-  x86_64 cross / windows x64) — each leg builds the abi3 wheel (same SHA-pinned
-  `maturin-action` + manifest as `publish-goldenmatch-native.yml`) and runs the
-  equivalence gate `--require-kernel` + the bench `--assert-not-slower` on a clean
-  Python 3.11. **Status: PENDING-RUN** (the workflow is committed but not yet
-  dispatched; the parent runs it and collects the per-platform PASS/FAIL).
-- **The #688 perf cliff:** PROBED BY the `perf_cliff` job on `ubuntu-latest-xlarge`
-  (the 8-core AMD EPYC shape #688 wedged on; `cliff_runner`-parameterized) — runs the
-  per-pair bench AND `scripts/bench_issue_688.py`, asserting the kernel does not
-  regress into the rayon `LockLatch` futex park. **Status: PENDING-RUN.**
+- **Kill-criterion (3) — all-platform abi3 wheels:** **RESULT — PASS (GO-with-residual).**
+  Run [#27509949013](https://github.com/benseverndev-oss/goldenmatch/actions/runs/27509949013)
+  + the harness-fixed re-run [#27514052267](https://github.com/benseverndev-oss/goldenmatch/actions/runs/27514052267)
+  (PR #971, which moved aarch64 to the native `ubuntu-24.04-arm` runner and marked
+  macOS-x86_64 build-only): the abi3 wheel **builds on 5/5** platforms, and runtime
+  `pure==kernel` at 4dp + bench `--assert-not-slower` **passed on 4/5** — linux-x86_64,
+  **linux-aarch64 (native arm)**, macOS-arm64, windows-x64. macOS-x86_64 is build-only
+  (no Intel-mac runner in this org; the x86 mac slice is sunsetting) — a documented
+  residual, not a defect. No per-release firefighting was needed to produce any wheel.
+- **The #688 perf cliff:** **RESULT — INFRA-BLOCKED (accepted 2026-06-14).** The
+  `perf_cliff` job on `ubuntu-latest-xlarge` failed to allocate a runner on **both**
+  attempts (queued 66 min, then 34 min, runner never assigned) — exactly the
+  larger-runner stall the root CLAUDE.md documents. The EPYC-specific rayon-`LockLatch`
+  futex scenario therefore **cannot be reproduced in this org's CI**. Per the maintainer
+  decision, this is ACCEPTED as an infra gap (not a code finding): mitigated by the
+  already-shipped `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS` fix (#692) and by the kernel
+  measuring **not-slower on every platform we could run** (4/5). If a self-hosted 8-core
+  EPYC ever becomes available, re-dispatch with `cliff_runner` set to it.
+
+**R1-B verdict: GO-with-residual.** Kill-criterion (3) is cleared for the four
+mainstream arches; the macOS-x86_64 runtime gap and the un-reproducible #688 EPYC cliff
+are documented *infra* residuals, not code blockers. The remaining R1 gate before any
+default flip is **Workstream A** — cross-JS-target WASM (Node ✅ already; browser /
+Workers / Deno pending), kill-criterion (2).
 
 Two backward-compatible script flags back the gate: `--require-kernel`
 (kernel-absence → exit 1) and `--assert-not-slower` (perf cliff → exit 1); with


### PR DESCRIPTION
Two harness fixes to the R1-B wheel matrix (`r1-kernel-wheels.yml`) from the first evidence run ([#27509949013](https://github.com/benseverndev-oss/goldenmatch/actions/runs/27509949013)), where the wheel *builds* were 5/5 green and runtime `pure==kernel`+perf passed on linux-x86_64/macOS-arm64/windows-x64, but two legs were harness-limited:

- **`linux-aarch64`** now runs on the **GA arm64 Linux runner** (`ubuntu-24.04-arm`) instead of cross-building on x86 and skipping — so the equivalence + perf gate **actually exercises the aarch64 wheel natively** (real runtime evidence, no QEMU).
- **`macos-x86_64`** is marked **build-only** (`runtime: false`): an x86_64 wheel can't import/run on the arm64 `macos-14` runner, so its first-run red was an arch mismatch in the *harness*, not a wheel defect. BUILD-OK is the kill-criterion-(3) signal; macOS runtime equivalence is covered by the native `macos-arm64` leg.

Generalized the cross-arch skip from a name match to a per-leg `runtime` flag. The `perf_cliff` (#688) probe is unchanged — its "fix" is the re-dispatch (a non-EPYC runner wouldn't reproduce the cliff). Still additive, `workflow_dispatch`-only.

I've re-dispatched the workflow on this branch to gather the corrected evidence.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_