### PR TITLE
fix(bench): native on the Ray cluster + fail-loud + worker verify-load

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -243,6 +243,18 @@ jobs:
             sleep 30
           done
 
+      - name: Verify native loaded on a worker
+        # The scoring kernel is the dominant distributed stage; if the native
+        # wheel didn't build on the workers, NATIVE=1 (set in cluster-gce.yaml)
+        # would only RAISE at the first score call -- 20+ min into the run.
+        # Catch it here: ship a check via `ray submit` (same mechanism the bench
+        # uses) that schedules tasks across the cluster and asserts a WORKER
+        # actually loaded goldenmatch._native. Fail loud + tear down rather than
+        # burn a full run scoring in pure Python.
+        run: |
+          set -euo pipefail
+          ray submit .ray/cluster-gce.yaml scripts/verify_cluster_native.py
+
       - name: Submit bench
         # `ray submit` ships the script to the head node and runs it.
         # The script writes its JSON output to /tmp on the head; we

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -64,17 +64,29 @@ setup_commands:
   - >-
     pip install --upgrade pip &&
     pip install "polars>=1.0" "pandas>=2,<3" "pyarrow>=10" "psutil>=5.9" "rapidfuzz>=3.0" "jellyfish>=1.0" &&
-    pip install "git+https://github.com/benseverndev-oss/goldenmatch@GOLDENMATCH_GIT_SHA_PLACEHOLDER#subdirectory=packages/python/goldenmatch"
+    pip install "git+https://github.com/benseverndev-oss/goldenmatch@GOLDENMATCH_GIT_SHA_PLACEHOLDER#subdirectory=packages/python/goldenmatch" &&
+    curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal &&
+    . "$HOME/.cargo/env" &&
+    pip install maturin &&
+    pip install "git+https://github.com/benseverndev-oss/goldenmatch@GOLDENMATCH_GIT_SHA_PLACEHOLDER#subdirectory=packages/rust/extensions/native"
 head_setup_commands: []
 worker_setup_commands: []
 
-# Export GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1 BEFORE `ray start` so the raylet
-# and the worker processes it spawns inherit it -- per-partition scoring re-preps
-# the `address` field, and the native (Polars-expression) address-normalize path
-# avoids the per-row Python refdata plugin slog. Pure-Polars, no native wheel.
+# Native acceleration is REQUIRED on the cluster. The scoring kernel is the
+# dominant distributed stage (#688); without the native wheel, NATIVE=auto
+# silently falls back to PURE PYTHON on every worker and the run crawls. We
+# BUILD goldenmatch-native from the SAME git SHA on every node (the maturin
+# crate compiles in place in setup_commands above -- exact-SHA kernel, so no
+# published-wheel symbol skew, see #688) and export GOLDENMATCH_NATIVE=1 BELOW
+# so a missing/broken kernel RAISES at the first score call instead of running
+# 100x+ slower in silence. The bench's "Verify native on a worker" step asserts
+# a worker actually loaded it. GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1 keeps the
+# Polars-native address path. Both are exported BEFORE `ray start` so the raylet
+# and the worker processes it spawns inherit them.
 head_start_ray_commands:
   - ray stop
   - >-
+    export GOLDENMATCH_NATIVE=1 &&
     export GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1 &&
     ulimit -n 65536 && ray start --head --port=6379
     --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
@@ -82,6 +94,7 @@ head_start_ray_commands:
 worker_start_ray_commands:
   - ray stop
   - >-
+    export GOLDENMATCH_NATIVE=1 &&
     export GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1 &&
     ulimit -n 65536 && ray start --address=$RAY_HEAD_IP:6379
     --object-manager-port=8076

--- a/scripts/verify_cluster_native.py
+++ b/scripts/verify_cluster_native.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Assert the goldenmatch native scoring kernel loaded on the Ray cluster WORKERS.
+
+Shipped to the head via `ray submit` from bench-ray-cluster.yml. The scoring
+kernel is the dominant distributed stage (#688); without it, NATIVE=auto/1 on
+the cluster either silently falls back to pure Python (100x+ slower) or only
+raises 20+ min into the run at the first score call. This catches a failed
+native build BEFORE the bench, by scheduling tasks across the cluster and
+asserting at least one WORKER (not just the head) loaded `goldenmatch._native`.
+
+Exit 0 if a worker has native; exit 1 (with a GH `::error::`) otherwise.
+"""
+from __future__ import annotations
+
+import socket
+import sys
+
+
+def main() -> int:
+    import ray
+
+    ray.init(address="auto")
+    head_host = socket.gethostname()
+
+    @ray.remote(num_cpus=1)
+    def _probe() -> tuple[str, bool]:
+        import socket as _s
+
+        from goldenmatch.core._native_loader import native_available
+
+        return _s.gethostname(), bool(native_available())
+
+    # Fan out enough tasks that some land on workers, not just the head.
+    results = ray.get([_probe.remote() for _ in range(16)])
+
+    worker_ok = False
+    any_ok = False
+    for host, ok in sorted(set(results)):
+        where = "head" if host == head_host else "worker"
+        print(f"  {where} {host}: native_available={ok}")
+        any_ok = any_ok or ok
+        if ok and host != head_host:
+            worker_ok = True
+
+    if not worker_ok:
+        # No worker confirmed native. If only the head has it, the workers
+        # (which do the scoring) would still run pure-Python.
+        print(
+            "::error::goldenmatch._native did NOT load on any Ray WORKER -- "
+            "distributed scoring would run pure-Python (100x+ slower). The "
+            "native build in cluster-gce.yaml setup_commands failed on the "
+            "workers, or GOLDENMATCH_NATIVE=1 isn't exported before ray start."
+        )
+        return 1
+
+    print("native scoring kernel confirmed on a worker.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The distributed `bench-ray-cluster` ran **scoring in pure Python on the workers** — the cluster `setup_commands` installed plain `goldenmatch` (no `[native]`, no build) and `GOLDENMATCH_NATIVE` was never `1` on the nodes, so `NATIVE=auto` silently fell back to Python for the dominant distributed stage (#688). The cluster yaml literally said *"no native wheel."* This is a perf trap and it **invalidated the #957 scoring-saturation re-measure** (you'd be measuring Python slowness, not the projection's effect).

## Fix
- **`cluster-gce.yaml` setup_commands** — install rustup (minimal) + maturin and **build `goldenmatch-native` from the same git SHA on every node**. Exact-SHA kernel → no published-wheel symbol skew (#688).
- **`cluster-gce.yaml` start_ray_commands** (head + worker) — `export GOLDENMATCH_NATIVE=1` before `ray start`, so a missing/broken kernel **raises at the first score call** instead of running 100x+ slower silently.
- **`bench-ray-cluster.yml`** — new **"Verify native loaded on a worker"** step after the worker-join check: ships `scripts/verify_cluster_native.py` via `ray submit`, fans tasks across the cluster, and asserts a **worker** (not just the head) loaded `goldenmatch._native`. Fails the run *before* the bench otherwise.

## Validation
- YAML parses; script ruff + py_compile clean.
- **workflow_dispatch-only** — merging triggers nothing. The on-node Rust build + native load needs a real cluster dispatch to validate end-to-end. The build adds a few min/node (rustup + compile) — the price of an exact-SHA, skew-free kernel.

## Note (separate, not changed here)
The `distributed` input still defaults to `0` (legacy non-distributing). For the #957 re-measure, dispatch with **`distributed=1`** (real PIPELINE=2 engine). Happy to flip that default in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)