### PR TITLE
fix(bench): install published goldenmatch-native wheel (not on-node Rust build)

### DIFF
--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -65,24 +65,24 @@ setup_commands:
     pip install --upgrade pip &&
     pip install "polars>=1.0" "pandas>=2,<3" "pyarrow>=10" "psutil>=5.9" "rapidfuzz>=3.0" "jellyfish>=1.0" &&
     pip install "git+https://github.com/benseverndev-oss/goldenmatch@GOLDENMATCH_GIT_SHA_PLACEHOLDER#subdirectory=packages/python/goldenmatch" &&
-    curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal &&
-    . "$HOME/.cargo/env" &&
-    pip install maturin &&
-    pip install "git+https://github.com/benseverndev-oss/goldenmatch@GOLDENMATCH_GIT_SHA_PLACEHOLDER#subdirectory=packages/rust/extensions/native"
+    pip install "goldenmatch-native>=0.1.3"
 head_setup_commands: []
 worker_setup_commands: []
 
 # Native acceleration is REQUIRED on the cluster. The scoring kernel is the
 # dominant distributed stage (#688); without the native wheel, NATIVE=auto
 # silently falls back to PURE PYTHON on every worker and the run crawls. We
-# BUILD goldenmatch-native from the SAME git SHA on every node (the maturin
-# crate compiles in place in setup_commands above -- exact-SHA kernel, so no
-# published-wheel symbol skew, see #688) and export GOLDENMATCH_NATIVE=1 BELOW
-# so a missing/broken kernel RAISES at the first score call instead of running
-# 100x+ slower in silence. The bench's "Verify native on a worker" step asserts
-# a worker actually loaded it. GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1 keeps the
-# Polars-native address path. Both are exported BEFORE `ray start` so the raylet
-# and the worker processes it spawns inherit them.
+# install the PUBLISHED abi3 `goldenmatch-native` wheel (setup_commands above)
+# -- no on-node Rust build (that broke `ray up` in the ray-docker container:
+# `curl|sh` rustup left no ~/.cargo/env). Skew note (#688): the wheel must be
+# new enough for the scoring symbols this SHA calls; >=0.1.3 has the rayon-park
+# fix and the projection change (#957) is Python-side (adds no kernel symbols).
+# GOLDENMATCH_NATIVE=1 BELOW makes a missing/broken kernel RAISE at the first
+# score call instead of running 100x+ slower in silence, and the bench's
+# "Verify native on a worker" step asserts a worker actually loaded it.
+# GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1 keeps the Polars-native address path.
+# Both are exported BEFORE `ray start` so the raylet and the worker processes
+# it spawns inherit them.
 head_start_ray_commands:
   - ray stop
   - >-


### PR DESCRIPTION
The on-node Rust build (#973) broke `ray up` — in the ray-docker container the `curl|sh` rustup install left no `~/.cargo/env` (a curl failure exits 0 through the pipe), so `. $HOME/.cargo/env` died → "Failed to setup head node." Building Rust on the nodes is too fragile.

Swap it for **`pip install "goldenmatch-native>=0.1.3"`** — the published abi3 wheel (latest 0.1.5; linux x86_64 cp311-abi3 spans py3.11–3.13, fits the ray py312 image). No compiler, no `.cargo/env` dance.

Skew note (#688): the #957 projection is Python-side (adds no kernel symbols), `>=0.1.3` has the rayon-park fix, and `GOLDENMATCH_NATIVE=1` + the verify-native-on-a-worker step still catch a missing/broken kernel before the bench.

Re-dispatched the 100M `distributed=1` run off this branch to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)