### PR TITLE
fix(bench): verify native per-node via NodeAffinity (not head-packing fan-out)

### DIFF
--- a/scripts/verify_cluster_native.py
+++ b/scripts/verify_cluster_native.py
@@ -1,59 +1,74 @@
 #!/usr/bin/env python3
-"""Assert the goldenmatch native scoring kernel loaded on the Ray cluster WORKERS.
+"""Assert the goldenmatch native scoring kernel loaded on EVERY Ray cluster node.
 
 Shipped to the head via `ray submit` from bench-ray-cluster.yml. The scoring
-kernel is the dominant distributed stage (#688); without it, NATIVE=auto/1 on
-the cluster either silently falls back to pure Python (100x+ slower) or only
-raises 20+ min into the run at the first score call. This catches a failed
-native build BEFORE the bench, by scheduling tasks across the cluster and
-asserting at least one WORKER (not just the head) loaded `goldenmatch._native`.
+kernel is the dominant distributed stage (#688); without it, NATIVE=1 on the
+cluster only raises 20+ min into the run at the first score call. This catches
+a failed/absent native install BEFORE the bench.
 
-Exit 0 if a worker has native; exit 1 (with a GH `::error::`) otherwise.
+Probing correctly is the trick: a plain fan-out of `num_cpus=1` tasks PACKS onto
+the head (which has plenty of CPUs) and never reaches a worker -- a false
+negative that skips the whole bench. So we pin ONE probe to EACH alive node via
+NodeAffinitySchedulingStrategy(soft=False) and require every node to report
+`goldenmatch._native` loaded. Exit 1 (with a GH `::error::`) on any miss.
 """
 from __future__ import annotations
 
-import socket
 import sys
+import time
 
 
 def main() -> int:
     import ray
+    from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
     ray.init(address="auto")
-    head_host = socket.gethostname()
 
     @ray.remote(num_cpus=1)
     def _probe() -> tuple[str, bool]:
-        import socket as _s
+        import socket
 
         from goldenmatch.core._native_loader import native_available
 
-        return _s.gethostname(), bool(native_available())
+        return socket.gethostname(), bool(native_available())
 
-    # Fan out enough tasks that some land on workers, not just the head.
-    results = ray.get([_probe.remote() for _ in range(16)])
+    # Workers may be RUNNING (the bench's worker-join check passed) but still
+    # finishing setup_commands -> not yet joined the Ray cluster. Give them a
+    # short window so we actually probe a worker, then probe whatever is alive.
+    deadline = time.time() + 180
+    while time.time() < deadline:
+        if len([n for n in ray.nodes() if n.get("Alive")]) >= 2:
+            break
+        time.sleep(15)
 
-    worker_ok = False
-    any_ok = False
-    for host, ok in sorted(set(results)):
-        where = "head" if host == head_host else "worker"
-        print(f"  {where} {host}: native_available={ok}")
-        any_ok = any_ok or ok
-        if ok and host != head_host:
-            worker_ok = True
+    nodes = [n for n in ray.nodes() if n.get("Alive")]
+    if not nodes:
+        print("::error::no alive Ray nodes -- cannot verify native.")
+        return 1
 
-    if not worker_ok:
-        # No worker confirmed native. If only the head has it, the workers
-        # (which do the scoring) would still run pure-Python.
+    # Pin one probe to each alive node so workers are actually checked.
+    results = ray.get([
+        _probe.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                node_id=n["NodeID"], soft=False
+            )
+        ).remote()
+        for n in nodes
+    ])
+
+    missing = [host for host, ok in results if not ok]
+    for host, ok in results:
+        print(f"  node {host}: native_available={ok}")
+
+    if missing:
         print(
-            "::error::goldenmatch._native did NOT load on any Ray WORKER -- "
-            "distributed scoring would run pure-Python (100x+ slower). The "
-            "native build in cluster-gce.yaml setup_commands failed on the "
-            "workers, or GOLDENMATCH_NATIVE=1 isn't exported before ray start."
+            f"::error::goldenmatch._native did NOT load on node(s) {missing} -- "
+            "distributed scoring there would run pure-Python (100x+ slower). "
+            "Check the goldenmatch-native install in cluster-gce.yaml setup_commands."
         )
         return 1
 
-    print("native scoring kernel confirmed on a worker.")
+    print(f"native scoring kernel confirmed on all {len(results)} alive node(s).")
     return 0
 
 


### PR DESCRIPTION
Follow-up to #975. The worker native-verify step false-negatived and skipped the 100M bench: a plain fan-out of `num_cpus=1` probe tasks all packed onto the head's 32 CPUs, so no **worker** was probed (head reported `native_available=True`; the step then failed "no worker"). The cluster itself was healthy — `Ray up` + worker-join + head-native all passed (the published-wheel install works).

Fix: pin one probe to **each alive node** via `NodeAffinitySchedulingStrategy(soft=False)` so workers are actually checked, with a short wait for workers to ray-join, and require every node to have native. Re-dispatched the 100M `distributed=1` run off this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)