### PR TITLE
R1 Workstream A: fix workers harness host-transform (plain .wasm import)

### DIFF
--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -123,9 +123,17 @@ npx vitest run tests/parity/        # parity-only suite
 - **Workers caveat (real constraint):** workerd BANS runtime WASM codegen
   (`WebAssembly.instantiate`/`new WebAssembly.Module` from bytes both throw "Wasm
   code generation disallowed by embedder"). So Workers does NOT use the base64-bytes
-  universal path — it needs a BUILD-TIME CompiledWasm `.wasm?module` import (the
-  vitest-pool-workers convention). A Workers consumer of `enableWasm` must likewise
-  ship the kernel as a build-time module, not via `{ universal: true }`.
+  universal path — it needs a BUILD-TIME CompiledWasm `.wasm` module import (the
+  vitest-pool-workers convention; `modulesRules: [{ type: "CompiledWasm", include:
+  ["**/*.wasm"] }]`). A Workers consumer of `enableWasm` must likewise ship the
+  kernel as a build-time module, not via `{ universal: true }`.
+- **Workers harness host-config gotcha:** the `workers-kernel-equivalence.test.ts`
+  static `.wasm` import is parsed by the HOST vite `import-analysis` before the pool
+  resolves it. Import the artifact as a **plain `.wasm`** (NOT `.wasm?module` — that
+  suffix makes host import-analysis try to parse the bytes as JS, collecting 0 tests)
+  and list `assetsInclude: ["**/*.wasm"]` in `vitest.workers.config.ts` so the host
+  treats it as an opaque asset. `server.deps.inline` does NOT help — it only covers
+  node_modules, never a local `src/**/*.wasm`.
 
 ## Parity contract
 - **Scorer output:** 4-decimal tolerance vs Python (`tests/parity/scorer-ground-truth.test.ts`).

--- a/packages/typescript/goldenmatch/tests/spike/workers-kernel-equivalence.test.ts
+++ b/packages/typescript/goldenmatch/tests/spike/workers-kernel-equivalence.test.ts
@@ -35,20 +35,19 @@ import { runEquivalence, type ScoreWasmGlue } from "./kernel-equivalence-core.js
 // Because the import is static, this file requires the built artifact present at
 // transform time. The CI `workers` job builds it first; the absent-artifact skip
 // the other targets keep doesn't apply to a static-import target (a default
-// checkout simply doesn't run this config). The `.wasm?module` specifier + the
-// config's `modulesRules: [{ type: "CompiledWasm", include: ["**\/*.wasm"] }]` is
-// the @cloudflare/vitest-pool-workers convention; its resolver special-cases
-// `*.wasm?module` and externalizes it to a workerd CompiledWasm module.
+// checkout simply doesn't run this config).
 //
-// IN-ENV NOTE (honest): under the in-env vitest 4.1 / pool 0.16 combo, vite's
-// host-side import-analysis intercepts `.wasm?module` before the pool's worker
-// resolver, so this harness is WROTE-pending-CI: the pool RUNS in workerd in-env
-// (verified — the test body executed and surfaced workerd's "Wasm code generation
-// disallowed by embedder" for the runtime-bytes path, which is exactly why a
-// build-time CompiledWasm import is required), but the green run needs the
-// pool/vitest versions the CI `workers` job pins. See the workflow comment.
-// @ts-expect-error — the `*.wasm?module` default-export Module type is the Workers env's, not tsc's.
-import scoreWasmModule from "../../src/core/wasm/artifacts/score_wasm_bg.wasm?module";
+// PLAIN `.wasm` import (no `?module` suffix) — the canonical
+// @cloudflare/vitest-pool-workers form. The pool's plugin resolves a bare `.wasm`
+// import to a precompiled CompiledWasm `WebAssembly.Module` (default export) in
+// the worker module graph. The earlier `.wasm?module` spelling tripped the HOST
+// Vite `import-analysis` plugin (it tried to parse the `.wasm` as JS and the suite
+// collected 0 tests) — `server.deps.inline` does NOT cover local source files, so
+// the suffix had to go and `vitest.workers.config.ts` now lists the artifact dir
+// in `assetsInclude` so the host treats it as an opaque asset, leaving resolution
+// to the pool.
+// @ts-expect-error — the `.wasm` default-export Module type is the Workers env's, not tsc's.
+import scoreWasmModule from "../../src/core/wasm/artifacts/score_wasm_bg.wasm";
 
 describe("workers: pure-TS == score-wasm kernel (4dp)", () => {
   it("kernel instantiates + reproduces the frozen pure-TS reference in workerd", async () => {

--- a/packages/typescript/goldenmatch/vitest.workers.config.ts
+++ b/packages/typescript/goldenmatch/vitest.workers.config.ts
@@ -39,15 +39,14 @@ export default defineConfig({
       },
     }),
   ],
+  // Treat the built `.wasm` as an opaque static asset on the HOST so vite's
+  // `import-analysis` does NOT try to parse it as JS (that's what made the suite
+  // collect 0 tests). Resolution of the actual CompiledWasm module is left to the
+  // pool's worker module graph (the `modulesRules` above). `server.deps.inline`
+  // only covers node_modules, never a local `src/**/*.wasm`, so the asset rule is
+  // the host-side half of the fix; the plain `.wasm` import is the test-side half.
+  assetsInclude: ["**/*.wasm"],
   test: {
     include: ["tests/spike/workers-kernel-equivalence.test.ts"],
-    server: {
-      deps: {
-        // Inline the artifacts so the pool's worker module graph (not vite's
-        // host transform) resolves the `.wasm?module` import — that's where the
-        // CompiledWasm rule applies.
-        inline: [/score_wasm/],
-      },
-    },
   },
 });


### PR DESCRIPTION
## What

Fixes the `workers` leg of `r1-kernel-js-targets.yml` (R1 Workstream A, kill-criterion 2). The first dispatch ([run 27515943709](https://github.com/benseverndev-oss/goldenmatch/actions/runs/27515943709)) went **3/4 green** — node ✅, deno ✅, browser/chromium ✅ — and the **workers/workerd** job failed at the equivalence step.

## Root cause (config, not kernel)

The kernel never ran. The workers test file's **static** `import ... from "...score_wasm_bg.wasm?module"` was parsed by the **host** Vite `import-analysis` plugin, which can't parse `.wasm` bytes as JS:

```
vite:import-analysis — Failed to parse source for import analysis...
add "**/*.wasm?module" to assetsInclude
File: .../score_wasm_bg.wasm?module
→ 0 tests collected
```

`server.deps.inline: [/score_wasm/]` (the prior attempt) doesn't help — `inline` only covers `node_modules`, never a local `src/**/*.wasm`, so the host transform always ran.

## Fix (test-harness only)

- Import the artifact as a **plain `.wasm`** (the canonical `@cloudflare/vitest-pool-workers` form) — the `?module` suffix is what made host import-analysis try to parse it.
- Add `assetsInclude: ["**/*.wasm"]` to `vitest.workers.config.ts` so the host treats the artifact as an opaque asset, leaving the CompiledWasm resolution to the pool's worker module graph (the existing `modulesRules`).
- Doc the gotcha in the goldenmatch TS CLAUDE.md.

No product code, no default flipped, dispatch-only workflow. The node/deno/browser legs already pass.

## After merge

I'll re-dispatch the workflow once. If the workers leg goes green, kill-criterion (2) is fully cleared (Workers via build-time CompiledWasm module). If it still reds on a deeper pool/vitest-version issue, the architectural finding stands either way (Workers needs a build-time module, not the base64-bytes path) and I'll record it as the documented residual rather than loop on CI.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_