### PR TITLE
R2 (first slice): bring field scoring under the reversible GOLDENMATCH_NATIVE gate

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -64,6 +64,17 @@ except Exception:  # noqa: BLE001 - any import/load failure falls back below
 #     and Python -- asserted byte-for-byte (incl. pinned golden vectors) in
 #     tests/test_record_fingerprint.py. Native vs Python produce the same id,
 #     so gating native on/off never changes a record id.
+#   - field_scoring: the cdist-shaped per-field score matrix (score_field_matrix
+#     -> score-core) behind the default polars-direct path's _fuzzy_score_matrix
+#     for jaro_winkler / levenshtein / token_sort / exact / soundex_match. The
+#     kernel IS rapidfuzz (same as the pure path); parity asserted to 1e-4 in
+#     tests/test_native_field_matrix_parity.py and bit-identical on the
+#     levenshtein tracer in the single-kernel-collapse spike (ADR 0016, max abs
+#     diff 0.0). This path already preferred the kernel when importable; adding it
+#     here (single-kernel-collapse R2) brings that long-standing default UNDER the
+#     reversible GOLDENMATCH_NATIVE flag (=0 now actually forces pure) + the
+#     dispatch telemetry, with no output change. Bench: kernel not-slower
+#     (1.44x faster per-pair) -- the measure-first gate in the spike.
 #
 # NOT yet gated on (ships default-off; reachable via GOLDENMATCH_NATIVE=1):
 #   - pprl_bloom: the CLK bloom-filter hash loop (bloom_clk_batch). Python does
@@ -76,7 +87,7 @@ except Exception:  # noqa: BLE001 - any import/load failure falls back below
 #     (a republish must ship the new symbol -- see the goldenmatch-native wheel-
 #     skew note in the root CLAUDE.md) and a wall-clock bench confirms the lift.
 _GATED_ON: frozenset[str] = frozenset(
-    {"clustering", "block_scoring", "pairs", "featurize", "hashing"}
+    {"clustering", "block_scoring", "pairs", "featurize", "hashing", "field_scoring"}
 )
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -399,11 +399,19 @@ def _native_field_matrix(values: list, scorer_name: str) -> np.ndarray | None:
     scorer_id = _NATIVE_FIELD_SCORER_IDS.get(scorer_name)
     if scorer_id is None:
         return None
-    try:
-        from goldenmatch.core._native_loader import native_module
-        native = native_module()
-    except Exception:
+    # Reversible gate (single-kernel-collapse R2): field scoring honors the same
+    # GOLDENMATCH_NATIVE flag every other native component reads -- `0` forces the
+    # pure rapidfuzz path, `1` requires native (raises if absent -- the CI parity
+    # contract, intentionally NOT swallowed here), `auto`/unset uses native iff
+    # importable AND signed off (`field_scoring` in _GATED_ON). Output is identical
+    # either way (pure==kernel is byte/4dp-parity, asserted in
+    # tests/test_native_field_matrix_parity.py); the gate only governs WHICH path
+    # runs, and makes the long-standing kernel default reversible + telemetered.
+    from goldenmatch.core._native_loader import native_enabled, native_module
+
+    if not native_enabled("field_scoring"):
         return None
+    native = native_module()
     if native is None or not hasattr(native, "score_field_matrix"):
         return None
     try:

--- a/packages/python/goldenmatch/tests/test_native_field_matrix_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_field_matrix_parity.py
@@ -118,3 +118,38 @@ def test_unknown_scorer_returns_none():
     """Unsupported names fall through to None so the caller stays on rapidfuzz."""
     assert _native_field_matrix(_VALUES, "embedding") is None
     assert _native_field_matrix(_VALUES, "totally_made_up") is None
+
+
+# --- Reversible gate (single-kernel-collapse R2) -----------------------------
+# Field scoring now honors GOLDENMATCH_NATIVE like every other native component.
+# These run only when the wheel is built (module-level importorskip above), which
+# is exactly when there's something to force OFF.
+from goldenmatch.core._native_loader import (  # noqa: E402
+    native_dispatch_report,
+    reset_native_dispatch_log,
+)
+
+
+def test_gate_zero_forces_pure_even_with_kernel_present(monkeypatch):
+    """GOLDENMATCH_NATIVE=0 must force the pure path -- the reversibility the
+    long-standing ungated kernel default lacked. With the wheel importable, the
+    kernel WOULD answer; the gate must still return None so the caller runs
+    rapidfuzz."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    assert _native_field_matrix(_VALUES, "levenshtein") is None
+
+
+def test_gate_auto_uses_kernel_and_is_telemetered(monkeypatch):
+    """auto/unset routes field scoring to the kernel (field_scoring is signed off)
+    and records the dispatch so telemetry reflects it."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "auto")
+    reset_native_dispatch_log()
+    mat = _native_field_matrix(_VALUES, "levenshtein")
+    assert mat is not None
+    assert native_dispatch_report().get("field_scoring", {}).get("native", 0) >= 1
+
+
+def test_gate_require_uses_kernel(monkeypatch):
+    """GOLDENMATCH_NATIVE=1 uses the kernel when the wheel is present."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "1")
+    assert _native_field_matrix(_VALUES, "levenshtein") is not None


### PR DESCRIPTION
## What

Single-kernel-collapse **R2, first slice** (Python levenshtein tracer). Additive, output-preserving, one reversible flag. **Draft** — first behavior-path governance change, wants your eyes before merge.

## The finding that shaped it

While scoping R2 I confirmed the ground truth: on **Python the scorer collapse is essentially pre-existing**. The default polars-direct path (`_fuzzy_score_matrix` → `_native_field_matrix`) *already* prefers the `score-core` kernel over rapidfuzz for `jaro_winkler`/`levenshtein`/`token_sort`/`exact`/`soundex_match` when the wheel is importable, and parity is already gated (`test_native_field_matrix_parity.py`).

But it did so **ungoverned**: `_native_field_matrix` checked only `native is not None`, ignoring `GOLDENMATCH_NATIVE`. So `GOLDENMATCH_NATIVE=0` did **not** force the pure path for field scoring — a latent reversibility gap, and exactly the "kernel default not behind the one reversible flag" the collapse discipline forbids.

## The change

- `_native_field_matrix` now consults `native_enabled("field_scoring")` — `=0` forces pure, `=1` requires native (raises if absent, the CI parity contract, intentionally not swallowed), `auto`/unset uses native iff importable **and** signed off.
- `field_scoring` added to `_GATED_ON` so `auto`/unset keeps today's kernel default. **Output is unchanged** (pure==kernel is byte/4dp parity, proven in ADR 0016 + the parity test); only *which path runs* becomes reversible + telemetered (now in `native_dispatch_report()`).

## Verification (in-env)

- Native wheel built (`scripts/build_native.py`, abi3).
- `test_native_field_matrix_parity.py` **11/11** (8 existing parity + 3 new gate tests: `=0` forces pure even with kernel present, `auto` uses kernel + telemeters, `=1` uses kernel).
- `test_scorer.py` + `test_native_parity.py` **138/138**.

## Strategic note (please read before R3+)

R1 cleared the platform gates, but executing R2 surfaced a real recalibration of the collapse's value, worth your steer before we go further:

1. **Python scorers are already collapsed** onto the kernel by default — this slice is governance/reversibility, not a risky new flip. Low remaining R2 work on Python.
2. **TS scorers cannot flip default** — WASM stays opt-in for edge-safety, so the hand-rolled pure-TS scorer *must remain* the default + fallback. R2 doesn't reduce TS maintenance.
3. **The pure paths are load-bearing fallbacks** (Python: no-wheel installs; TS: always) — so R5 "decommission" can't actually delete the default-path scorers. Realistic end-state: *kernel = canonical fast path; pure = fallback; the parity harness stays as a kernel-vs-pure equivalence gate* (not a cross-language reimplementation gate).

Net: the **reward is narrower than the original "delete N reimplementations" framing** — it's "make the kernel the governed, reversible, canonical compute path + keep parity gated," not "remove the pure code." I'd recommend we treat R2 as *this governance slice + the equivalent for any other ungoverned kernel default*, and reframe R3–R5 around that reality rather than deletion. Happy to write that up as an ADR amendment if you agree.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_