### PR TITLE
R2 ADR: record first-slice + recalibration (R5 retired); SQL gate already live; pprl_bloom held

### DIFF
--- a/context-network/decisions/0016-single-kernel-collapse-spike.md
+++ b/context-network/decisions/0016-single-kernel-collapse-spike.md
@@ -225,6 +225,60 @@ form, not the base64 universal loader. Per the reversibility commitment, R2 (col
 first scorer behind a reversible default-flip flag) may proceed — still additive, parity-gated,
 one reversible flag per step.
 
+### R2 (2026-06-15): executed first slice + a value RECALIBRATION
+
+Executing R2 on the levenshtein tracer surfaced a material recalibration of the whole
+collapse, and two of the four "pending" items turned out to be already-resolved or
+must-hold. Recorded here so R3+ is scoped to reality, not the original framing.
+
+**The recalibration (the reward is narrower than "delete N reimplementations"):**
+- **Python is already collapsed.** The default polars-direct path
+  (`_fuzzy_score_matrix` → `_native_field_matrix`) already prefers the `score-core`
+  kernel over rapidfuzz for jaro_winkler / levenshtein / token_sort / exact /
+  soundex_match when the wheel is importable; parity is already gated
+  (`test_native_field_matrix_parity.py`). R2 on Python is governance, not a risky flip.
+- **TS cannot flip default.** WASM stays opt-in for edge-safety, so the pure-TS scorer
+  MUST remain the default + fallback. R2 doesn't reduce TS maintenance.
+- **The pure paths are load-bearing fallbacks** (Python no-wheel installs; TS always),
+  so **R5 "decommission" cannot delete the default-path scorers.** Realistic end-state:
+  *kernel = governed canonical fast path; pure = fallback; the parity harnesses stay as
+  kernel-vs-pure equivalence gates* (not cross-language reimplementation gates).
+  **R5 (deletion) is retired.**
+
+**R2 first slice — SHIPPED (#980):** brought field scoring under the reversible
+`GOLDENMATCH_NATIVE` gate. `_native_field_matrix` previously checked only
+`native is not None`, so `GOLDENMATCH_NATIVE=0` did NOT force the pure path — a latent
+reversibility gap. Now it consults `native_enabled("field_scoring")` (`=0` forces pure,
+`=1` requires native, `auto` uses native iff signed off), and `field_scoring` is in
+`_GATED_ON` so the default is unchanged. Output is byte-identical (proven); only WHICH
+path runs is now reversible + telemetered. Verified 138/138 scorer + 11/11 field-matrix
+parity (incl. 3 new gate tests).
+
+**Kill-criterion (1) SQL surface — was NOT pending; it is GATED (correction to the R1
+verdict above).** `tests/test_datafusion_ffi_udf.py::test_ffi_string_scorers_match_rapidfuzz`
+already stands up a real DataFusion `SessionContext`, registers the FFI scalar UDFs, runs
+`SELECT jaro_winkler/token_sort/levenshtein(a,b)` and asserts each == rapidfuzz (the pure
+lib) at 1e-6 (token_sort `/100` accounted). It runs LIVE in CI (`ci.yml` installs
+`datafusion>=53,<54`, builds + installs the `goldenmatch_datafusion_udf` wheel, hard-imports
+it). So **all three bindings — Python, TS/WASM, SQL — have a live runtime `==pure` gate**;
+kill-criterion (1) is fully cleared, not partial.
+
+**`pprl_bloom` — investigated for the R2 governance set, deliberately HELD default-off.**
+Parity battery green (26 tests) and the kernel is **7.08× faster, byte-identical output**
+(measure-first). BUT `native/src/bloom.rs` fans out with an **unconditional
+`prepared.par_iter()`** — no `GOLDENMATCH_NATIVE_RAYON_MIN_*` threshold guard, unlike the
+#692 fix in `score.rs`. That is the exact **#688 rayon-`LockLatch` futex-park class**, and
+it reproduces only on the 8-core EPYC `ubuntu-latest-xlarge` runner that **R1-B confirmed
+won't provision** — so it cannot be cleared in this org's CI. Flipping `pprl_bloom` into
+`_GATED_ON` would ship an unvalidatable #688-class risk; it stays default-off (`=1` opt-in)
+until the kernel gets the #692-style calling-thread-below-threshold guard (a kernel change +
+wheel republish, NOT a cheap follow-up).
+
+**R2 verdict:** the concrete win (governed reversibility on field scoring + the confirmation
+that all three bindings are gated) is banked; the grand R3–R5 program is reframed to
+"govern any remaining ungoverned kernel defaults; keep parity gated" with **deletion (R5)
+retired** and `pprl_bloom`'s flip blocked on the unguarded-rayon fix.
+
 Two backward-compatible script flags back the gate: `--require-kernel`
 (kernel-absence → exit 1) and `--assert-not-slower` (perf cliff → exit 1); with
 neither flag the scripts keep the spike's skip-on-absent / exit-0 default. NO

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,27 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-15 — Single-kernel-collapse R2: first slice shipped + value recalibration (R5 retired)
+- **R2 first slice SHIPPED (#980, merged):** field scoring brought under the reversible
+  `GOLDENMATCH_NATIVE` gate. `_native_field_matrix` had preferred the `score-core` kernel
+  ungoverned (ignored the flag), so `GOLDENMATCH_NATIVE=0` did not force the pure path — a
+  latent reversibility gap. Now gates on `native_enabled("field_scoring")` + `field_scoring`
+  in `_GATED_ON` (default unchanged, output byte-identical, reversible + telemetered).
+  Verified 138/138 + 11/11 parity in-env.
+- **Recalibration (recorded in ADR 0016):** Python is already kernel-default; TS can't flip
+  (edge-safety keeps pure-TS the default + fallback); the pure paths are load-bearing
+  fallbacks, so **R5 "decommission" is retired** — the realistic end-state is "kernel =
+  governed canonical fast path; pure = fallback; parity harnesses stay as kernel-vs-pure
+  gates." The reward is narrower than the original "delete N reimplementations" framing.
+- **Two cheap follow-ups investigated → no code needed:** (1) the **SQL-binding equivalence
+  gate already EXISTS and runs live in CI** (`test_datafusion_ffi_udf.py` asserts the
+  DataFusion FFI UDFs == rapidfuzz at 1e-6; `ci.yml` installs `datafusion` + builds the
+  wheel + hard-imports) — so kill-criterion (1)'s SQL surface was never pending, a correction
+  to the R1 verdict; all three bindings are gated. (2) **`pprl_bloom` HELD default-off** —
+  26 parity tests green + 7.08× faster byte-identical, BUT `bloom.rs` uses an unguarded
+  `par_iter()` (the #688 futex-park class) on the EPYC runner that won't provision; flipping
+  it default-on is an unvalidatable #688 risk. Needs the #692-style threshold guard first.
+
 ## 2026-06-15 — Single-kernel-collapse R1 COMPLETE: GO to R2 (two documented residuals)
 - **Kill-criterion (2) cleared — all four JS targets GREEN in CI.** `r1-kernel-js-targets.yml`
   run [#27518182208](https://github.com/benseverndev-oss/goldenmatch/actions/runs/27518182208)


### PR DESCRIPTION
## What

Docs-only. Records the R2 outcome in ADR 0016 + `meta/updates.md` after executing the first slice (#980, merged) and investigating the two cheap follow-ups. No code.

## The recalibration (R5 retired)

Executing R2 confirmed the collapse's reward is narrower than the original "delete N reimplementations" framing:
- **Python is already kernel-default** (`_fuzzy_score_matrix` → `_native_field_matrix`, parity already gated).
- **TS can't flip default** — WASM stays opt-in for edge-safety; pure-TS remains the default + fallback.
- **The pure paths are load-bearing fallbacks** → **R5 "decommission" is retired.** End-state: *kernel = governed canonical fast path; pure = fallback; parity harnesses stay as kernel-vs-pure gates.*

## The two follow-ups → neither needs new code

1. **SQL-binding equivalence gate already exists and runs live in CI.** `test_datafusion_ffi_udf.py` stands up a real DataFusion `SessionContext`, registers the FFI UDFs, and asserts `jaro_winkler`/`token_sort`/`levenshtein` == rapidfuzz (the pure lib) at 1e-6; `ci.yml` installs `datafusion>=53,<54`, builds + installs the UDF wheel, and hard-imports it. **Correction to the R1 verdict: kill-criterion (1)'s SQL surface was never pending — all three bindings (Python/TS/SQL) are gated.**
2. **`pprl_bloom` held default-off.** 26 parity tests green + **7.08× faster, byte-identical output**, but `native/src/bloom.rs` uses an **unguarded `par_iter()`** — the #688 rayon-`LockLatch` futex-park class — on the EPYC runner R1-B confirmed won't provision. Flipping it default-on is an unvalidatable #688 risk. Needs the #692-style threshold guard first (kernel change + wheel republish), not a cheap flip.

## R2 verdict

Bank the concrete win (governed reversibility on field scoring + confirmation all three bindings are gated); reframe R3+ to "govern any remaining ungoverned kernel defaults, keep parity gated," with deletion (R5) retired and `pprl_bloom`'s flip blocked on the unguarded-rayon fix.

`check_docs_consistency.py` passes.

https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5M99WvEQwkLz2HfCygA55)_