### PR TITLE
fix(distributed): tunable Ray Data object-store reservation for _score backpressure (#957)

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -168,7 +168,15 @@ This is the knob most people get wrong, so read the contract before you run a 10
 | `GOLDENMATCH_DISTRIBUTED_WCC_SEED` | unset | Seed for the randomized-contraction affine hash (reproducible cluster IDs across runs). |
 | `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` | unset (memory-aware) | Pair count above which clustering goes distributed. **Unset (default): memory-aware** — clustering stays on the fast driver-side scipy.csgraph path whenever the scored pair set fits available driver RAM, and only distributes when it genuinely won't. Set an explicit integer to force a pair-count boundary either way. |
 | `GOLDENMATCH_DISTRIBUTED_GOLDEN_THRESHOLD` | `5000000` | Multi-member row count above which golden-record building goes distributed. |
-| `GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS` | `2` | CPUs requested per Ray scoring worker. |
+| `GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS` | `2` | CPUs requested per Ray scoring task. |
+| `GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT` | `1` (on) | Project to scoring-relevant columns before the block-shuffle so it moves narrow blocks, not full records (#957). Output-invariant. `0` disables. |
+| `GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS` | `min(256, cpu×4)` | Block-shuffle partition count. **Raise it** to shrink per-partition blocks so more `_score` tasks fit the object-store budget (relieves `_score` `ResourceBudget` backpressure). Co-location stays correct at any value. |
+| `GOLDENMATCH_DISTRIBUTED_OP_RESERVATION` | unset (Ray default ~0.5) | Ray Data per-op object-store reservation ratio. **Lower it** (e.g. `0.2`) to hand the running `_score` op more object-store budget when it's `ResourceBudget`-backpressured below CPU capacity (idle workers, object store not full). Tune at scale. |
+| `GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY` | unset | Explicit `concurrency=` on the `_score` map_batches. Pins the task-pool size once blocks are narrow; the object-store reservation/shuffle-parts knobs above govern the actual `ResourceBudget` cap. |
+
+<Note>
+  **If the distributed score stage leaves workers idle** (`MapBatches(_score): … [backpressured:tasks(ResourceBudget)]` with the object store well under capacity), `_score` is reservation-capped, not CPU-bound. Lower `GOLDENMATCH_DISTRIBUTED_OP_RESERVATION` (→ `0.2`) and/or raise `GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS`, then re-measure — the optimal pair is cluster-shaped. (Shrinking Ray Data's `target_max_block_size` is **not** a safe lever: `_score` keeps each co-located partition whole via `batch_size=None`, so a split block would split a group and under-score.)
+</Note>
 
 <Note>
   You bring the Ray cluster — GoldenMatch ships the pipeline, not the bootstrap. The GCP recipe is in [`docs/distributed-ray-cluster-setup.md`](https://github.com/benseverndev-oss/goldenmatch/blob/main/docs/distributed-ray-cluster-setup.md). At single-box scale the `bucket` backend is validated through 200M and is simpler — use it unless the data won't fit one box.

--- a/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
@@ -64,6 +64,50 @@ _SCORE_PROJECT = os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT", "1") !=
 _raw_score_conc = os.environ.get("GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY")
 _SCORE_CONCURRENCY = int(_raw_score_conc) if _raw_score_conc else None
 
+# #957 (ResourceBudget backpressure follow-up). Ray Data's streaming executor
+# RESERVES a fraction of the cluster object store (default ~0.5, split across
+# ops) so a downstream op can't be starved. On the shuffle -> `_score` handoff
+# that reservation, not CPU, caps the `_score` op's in-flight tasks: the 100M
+# run held `_score` at 30 tasks / 60 CPU with ~20 CPU IDLE while the object
+# store sat at only ~47/66 GiB (`[backpressured:tasks(ResourceBudget)]`).
+# LOWERING the reservation hands the running `_score` op more object-store
+# budget -> more concurrent score tasks -> it uses the idle CPU. Smaller blocks
+# are NOT a safe lever here (`_score` uses batch_size=None to keep each
+# co-located partition whole; splitting a block would split a co-located group
+# and under-score) -- so the safe levers are this reservation and the shuffle
+# partition count (GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS). Unset (default) = Ray
+# default, no change. Tune at scale; ~0.2 frees most of the store for the
+# running op. Version-guarded: no-op on a Ray without the attribute.
+_OP_RESERVATION = os.environ.get("GOLDENMATCH_DISTRIBUTED_OP_RESERVATION")
+
+
+def _apply_ray_data_resource_tuning() -> None:
+    """Apply opt-in Ray Data object-store budget tuning for the distributed score
+    path (#957 ResourceBudget backpressure). No-op unless the env knob is set;
+    version-guarded so it never breaks on a Ray that lacks the attribute."""
+    if _OP_RESERVATION is None:
+        return
+    try:
+        from ray.data import DataContext
+
+        ctx = DataContext.get_current()
+        if not hasattr(ctx, "op_resource_reservation_ratio"):
+            logger.warning(
+                "GOLDENMATCH_DISTRIBUTED_OP_RESERVATION set but this Ray lacks "
+                "DataContext.op_resource_reservation_ratio -- ignored."
+            )
+            return
+        ratio = max(0.0, min(1.0, float(_OP_RESERVATION)))
+        ctx.op_resource_reservation_ratio = ratio
+        logger.info(
+            "Ray Data op_resource_reservation_ratio=%.2f "
+            "(GOLDENMATCH_DISTRIBUTED_OP_RESERVATION) -- frees object-store budget "
+            "for the _score op to relieve ResourceBudget backpressure.",
+            ratio,
+        )
+    except Exception as e:  # never let a tuning knob break the run
+        logger.warning("Ray Data resource tuning failed (ignored): %s", e)
+
 
 def _project_to_scoring_columns(df: Any, config: GoldenMatchConfig) -> Any:
     """Drop columns scoring never reads, BEFORE the block-shuffle (#957).
@@ -393,6 +437,8 @@ def _score_blocks_block_shuffle(
        task count once blocks are narrow. Secondary (still open): dedupe the
        explode when an exact matchkey's key equals a blocking pass's key.
     """
+    # Opt-in Ray Data object-store budget tuning (#957 ResourceBudget backpressure).
+    _apply_ray_data_resource_tuning()
     # Shuffle partition count. Default derives from the DRIVER cpu count, but the
     # block-shuffle explodes each record per co-location key (wide records ->
     # large blocks -> Ray ResourceBudget backpressure that pins _score to ONE

--- a/packages/python/goldenmatch/tests/test_distributed_scoring_tuning.py
+++ b/packages/python/goldenmatch/tests/test_distributed_scoring_tuning.py
@@ -1,0 +1,55 @@
+"""#957 ResourceBudget-backpressure follow-up: the opt-in Ray Data object-store
+reservation knob (GOLDENMATCH_DISTRIBUTED_OP_RESERVATION) sets the DataContext
+when present and is a no-op when unset. Ray-gated (needs ray.data.DataContext).
+"""
+from __future__ import annotations
+
+import pytest
+
+ray = pytest.importorskip("ray")
+
+
+def _ctx_or_skip():
+    from ray.data import DataContext
+
+    ctx = DataContext.get_current()
+    if not hasattr(ctx, "op_resource_reservation_ratio"):
+        pytest.skip("this Ray lacks DataContext.op_resource_reservation_ratio")
+    return ctx
+
+
+def test_op_reservation_knob_sets_datacontext(monkeypatch):
+    import goldenmatch.distributed.scoring as S
+
+    ctx = _ctx_or_skip()
+    orig = ctx.op_resource_reservation_ratio
+    # The knob is read at import time into a module constant; patch the constant.
+    monkeypatch.setattr(S, "_OP_RESERVATION", "0.2")
+    try:
+        S._apply_ray_data_resource_tuning()
+        assert ctx.op_resource_reservation_ratio == pytest.approx(0.2)
+    finally:
+        ctx.op_resource_reservation_ratio = orig
+
+
+def test_op_reservation_knob_noop_when_unset(monkeypatch):
+    import goldenmatch.distributed.scoring as S
+
+    ctx = _ctx_or_skip()
+    monkeypatch.setattr(S, "_OP_RESERVATION", None)
+    orig = ctx.op_resource_reservation_ratio
+    S._apply_ray_data_resource_tuning()
+    assert ctx.op_resource_reservation_ratio == orig  # unchanged
+
+
+def test_op_reservation_knob_clamps_to_unit_interval(monkeypatch):
+    import goldenmatch.distributed.scoring as S
+
+    ctx = _ctx_or_skip()
+    orig = ctx.op_resource_reservation_ratio
+    monkeypatch.setattr(S, "_OP_RESERVATION", "5")  # out of range -> clamp to 1.0
+    try:
+        S._apply_ray_data_resource_tuning()
+        assert ctx.op_resource_reservation_ratio == pytest.approx(1.0)
+    finally:
+        ctx.op_resource_reservation_ratio = orig


### PR DESCRIPTION
Follow-up to the validated #957 100M run, which saturated CPU (80/80) but left `_score` showing `[backpressured:tasks(ResourceBudget)]` — **30 tasks / 60 CPU with ~20 CPU idle** while the object store sat at only **~47/66 GiB**. So `_score` is capped by Ray Data's per-op object-store **reservation** (default ~0.5, held back for downstream ops), **not** by CPU.

## Change
- **`GOLDENMATCH_DISTRIBUTED_OP_RESERVATION`** → sets `DataContext.op_resource_reservation_ratio`. **Lower it** (e.g. `0.2`) to hand the running `_score` op more object-store budget → more concurrent score tasks → uses the idle CPU. **Opt-in** (unset = Ray default, no behavior change), **version-guarded** (no-op if the attribute is absent), applied at the start of the block-shuffle path.
- Documented this + the existing `SHUFFLE_PARTS` / `SCORE_PROJECT` / `SCORE_CONCURRENCY` knobs in `tuning.mdx`, with a "what to do when workers sit idle" note.

## Why not smaller blocks
Shrinking Ray Data's `target_max_block_size` is **unsafe** here: `_score` uses `batch_size=None` to keep each co-located partition whole, so a split block would split a co-located group and **under-score**. The safe levers are this reservation and the shuffle partition count.

## Validation
- ruff + py_compile clean; ray-gated unit tests cover set / no-op / out-of-range-clamp.
- **Default-unchanged**, so safe to ship ahead of a run. The optimal reservation value is cluster-shaped — it gets **measured on the next 100M/200M dispatch** (I won't claim a number I haven't measured). That dispatch is the real validation + the lead-in to the 200M rung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)