### PR TITLE
deploy(sail): GKE infra-as-code + runbook for the S4 100M binding bench

### DIFF
--- a/docs/distributed-sail-cluster-setup.md
+++ b/docs/distributed-sail-cluster-setup.md
@@ -1,0 +1,146 @@
+# Sail tier — GKE cluster setup + the S4 100M binding bench
+
+How to stand up a **distributed Sail (LakeSail / Spark Connect) cluster on GKE**
+and run the S4 binding bench (`bench-sail-100m.yml` / `scripts/bench_sail_100m.py`).
+Mirrors the Ray posture in [`distributed-ray-cluster-setup.md`](distributed-ray-cluster-setup.md):
+**docs-not-bootstrap — you bring the cluster.** Sail is an *additive* scale-out
+option; Ray clustering stays the default
+([`decisions/0004`](../context-network/decisions/0004-sail-tier-scope.md)).
+
+> **STATUS: SCAFFOLD.** Authored from the LakeSail Kubernetes guide without a
+> live GKE shakedown. The manifests + commands are the right *shape*; treat the
+> first real run as a bring-up, and verify the marked points. LakeSail image
+> coordinates and `SAIL_*` env keys drift — check
+> <https://docs.lakesail.com/sail/latest/guide/deployment/kubernetes.html>.
+
+> **COST:** a multi-node GKE cluster + a 100M run is real (modest) spend. Set a
+> budget, and **delete the cluster when done** (last step). This is an
+> outward, billed action — run it deliberately.
+
+## What runs where
+
+- **Driver pod** = the Sail Spark Connect server (`Deployment`, `replicas: 1`),
+  gRPC on `50051`, exposed by a `Service`. It launches **worker pods on demand**.
+- **The bench driver** (`bench_sail_100m.py`) runs *outside* the cluster (your
+  laptop or the GitHub runner) and connects via `SAIL_REMOTE=sc://<host>:50051`.
+- **UDFs run on the workers.** The rapidfuzz scorer (S1) and the R1 native
+  `score_field_pairwise` kernel are PySpark Python UDFs executed in the worker's
+  Python env — so the worker image MUST bundle `goldenmatch[sail,native]`. The
+  custom image ([`deploy/sail/Dockerfile`](../packages/python/goldenmatch/deploy/sail/Dockerfile))
+  is used for BOTH driver and workers (via `SAIL_KUBERNETES__IMAGE`).
+
+## Prerequisites
+
+- `gcloud`, `kubectl`, `docker` installed and authenticated; a GCP project with
+  **billing enabled** and the GKE + Artifact Registry APIs on.
+- A 100M parquet on `gs://` reachable from the cluster (generate via
+  `scripts/generate_phase5_dataset.py`, or reuse the `bench-dataset-v1` release
+  asset the Ray bench uses — upload it to your bucket).
+
+```bash
+export PROJECT=<your-gcp-project>
+export REGION=us-central1
+export REPO=goldenmatch           # Artifact Registry repo
+export IMAGE=${REGION}-docker.pkg.dev/${PROJECT}/${REPO}/sail-goldenmatch:v1
+export BUCKET=gs://<your-bench-bucket>
+gcloud config set project "$PROJECT"
+gcloud services enable container.googleapis.com artifactregistry.googleapis.com
+```
+
+## 1. Create the GKE cluster
+
+```bash
+gcloud container clusters create sail-bench \
+  --region "$REGION" --num-nodes 1 \
+  --machine-type e2-standard-16 \         # 16 vCPU / 64 GB per node; size to the bench
+  --enable-autoscaling --min-nodes 1 --max-nodes 8 \
+  --workload-pool "${PROJECT}.svc.id.goog"   # Workload Identity for GCS access
+gcloud container clusters get-credentials sail-bench --region "$REGION"
+```
+
+## 2. Build + push the custom image
+
+```bash
+gcloud artifacts repositories create "$REPO" --repository-format=docker --location="$REGION" || true
+gcloud auth configure-docker "${REGION}-docker.pkg.dev"
+docker build \
+  --build-arg GOLDENMATCH_VERSION=<pin-a-version> \
+  -t "$IMAGE" packages/python/goldenmatch/deploy/sail
+docker push "$IMAGE"
+```
+
+> VERIFY: the Dockerfile's `SAIL_IMAGE` base must ship a Python 3.11+ interpreter
+> (it runs the UDF workers) and the `sail` CLI. If the LakeSail base is
+> distroless, invert the Dockerfile (Python base + install the `sail` binary).
+
+## 3. Grant the cluster GCS access
+
+The workers read the input parquet and write the WCC lineage-checkpoint dir
+(`--wcc-checkpoint-dir`, the S2 100M fix), both on `gs://`. Bind the
+`sail-user` KSA to a GCS-capable GSA via Workload Identity:
+
+```bash
+gcloud iam service-accounts create sail-gcs --project "$PROJECT"
+gsutil iam ch serviceAccount:sail-gcs@${PROJECT}.iam.gserviceaccount.com:objectAdmin "$BUCKET"
+gcloud iam service-accounts add-iam-policy-binding \
+  sail-gcs@${PROJECT}.iam.gserviceaccount.com \
+  --role roles/iam.workloadIdentityUser \
+  --member "serviceAccount:${PROJECT}.svc.id.goog[sail/sail-user]"
+# annotate the KSA after step 4 applies it:
+#   kubectl -n sail annotate serviceaccount sail-user \
+#     iam.gke.io/gcp-service-account=sail-gcs@${PROJECT}.iam.gserviceaccount.com
+```
+
+## 4. Deploy Sail
+
+```bash
+sed "s#REPLACE_IMAGE#${IMAGE}#g" \
+  packages/python/goldenmatch/deploy/sail/k8s/sail-server.yaml | kubectl apply -f -
+kubectl -n sail rollout status deploy/sail-spark-server
+# (then the Workload-Identity KSA annotation from step 3)
+```
+
+## 5. Connect + run the bench
+
+Local driver via port-forward (simplest; keeps gRPC off the public net):
+
+```bash
+kubectl -n sail port-forward service/sail-spark-server 50051:50051 &
+export SAIL_REMOTE=sc://localhost:50051
+python packages/python/goldenmatch/scripts/bench_sail_100m.py \
+  --input "${BUCKET}/bench_100000000.parquet" \
+  --wcc-checkpoint-dir "${BUCKET}/_wcc_ckpt" \
+  --out .profile_tmp/sail_100m.json
+```
+
+Or via the workflow (set the `SAIL_REMOTE` repo secret to a cluster-reachable
+endpoint — e.g. an internal LoadBalancer, since the GitHub runner can't reach a
+`port-forward`):
+
+```bash
+gh workflow run bench-sail-100m.yml -f input="${BUCKET}/bench_100000000.parquet"
+```
+
+## 6. Read the verdict
+
+Kill criterion (additive, NOT a Ray retirement): completes where one-box
+OOMs/can't, **per-node RSS bounded, wall improves with node count**. Re-run at
+1 / 2 / 4 / 8 max-nodes to see the wall scale. Commit the numbers to
+`docs/superpowers/specs/2026-06-13-sail-tier-past-one-box-roadmap.md` (R4).
+
+## 7. Tear down (do not skip — cost)
+
+```bash
+gcloud container clusters delete sail-bench --region "$REGION" --quiet
+```
+
+## Verify-points (because this is a scaffold)
+
+1. **LakeSail base image + `sail` CLI** — image coords drift; confirm the base
+   has Python 3.11+ for the UDF workers (Dockerfile note).
+2. **`SAIL_*` env keys** — confirm against the current LakeSail K8s guide.
+3. **Worker GCS auth** — Workload Identity is the clean path; a mounted SA key
+   also works. The first run will tell you if the workers can read `gs://`.
+4. **WCC at 100M** — the S2 pointer-jump now checkpoints lineage each round
+   (`--wcc-checkpoint-dir`); watch the first 100M run for plan-growth/hangs and
+   tune `--wcc-checkpoint-interval` if needed.

--- a/packages/python/goldenmatch/deploy/sail/Dockerfile
+++ b/packages/python/goldenmatch/deploy/sail/Dockerfile
@@ -1,0 +1,29 @@
+# Custom Sail image = LakeSail Spark Connect server + goldenmatch[sail] + the R1
+# native kernel, so BOTH the rapidfuzz scorer and `score_field_pairwise` resolve
+# on the driver pod AND the on-demand worker pods (PySpark Python UDFs run in the
+# worker's own Python env -- a stock `sail` image has no goldenmatch).
+#
+# SCAFFOLD -- authored without a GKE cluster to shake it down. VERIFY before use:
+#   * LakeSail base-image coordinates DRIFT. Check the current published tag at
+#     https://docs.lakesail.com/sail/latest/guide/deployment/kubernetes.html and
+#     https://github.com/lakehq/sail . The base MUST ship a Python 3.11+ interp
+#     (it executes the PySpark UDF workers); if it doesn't, invert this image:
+#     FROM python:3.12-slim + install the `sail` binary, then pip-install below.
+#   * If the base python is "externally managed" (PEP 668), add
+#     `--break-system-packages` to the pip install.
+ARG SAIL_IMAGE=ghcr.io/lakehq/sail:latest
+FROM ${SAIL_IMAGE}
+
+# [sail] -> pysail + pyspark[connect]; [native] -> the published R1 wheel
+# (goldenmatch-native, which carries score_field_pairwise once #985's wheel is
+# released; until then the sail scorer falls back to the pure rapidfuzz floor --
+# safe, just slower). Pin a version at deploy time for reproducible benches.
+ARG GOLDENMATCH_VERSION=""
+RUN pip install --no-cache-dir "goldenmatch[sail,native]${GOLDENMATCH_VERSION:+==$GOLDENMATCH_VERSION}" \
+ && python -c "import goldenmatch, rapidfuzz; print('goldenmatch', goldenmatch.__version__)" \
+ && python -c "from goldenmatch.core._native_loader import native_module as n; m=n(); print('native score_field_pairwise:', bool(m) and hasattr(m,'score_field_pairwise'))"
+
+# Turn the R1 native scorer ON for the cluster (default-off otherwise: the
+# `sail_scoring` component isn't in the loader's _GATED_ON allowlist). If the
+# published wheel lacks the symbol, the scorer transparently uses the pure floor.
+ENV GOLDENMATCH_NATIVE=1

--- a/packages/python/goldenmatch/deploy/sail/k8s/sail-server.yaml
+++ b/packages/python/goldenmatch/deploy/sail/k8s/sail-server.yaml
@@ -1,0 +1,120 @@
+# Sail Spark Connect server (cluster mode) for the GoldenMatch S4 100M bench.
+# SCAFFOLD -- authored from the LakeSail K8s deployment guide
+# (https://docs.lakesail.com/sail/latest/guide/deployment/kubernetes.html),
+# NOT yet shaken down on a live GKE cluster. VERIFY the SAIL_* keys + the
+# replicas/RBAC against the current LakeSail docs before applying.
+#
+# Replace REPLACE_IMAGE with your pushed custom image (deploy/sail/Dockerfile),
+# e.g. <region>-docker.pkg.dev/<project>/<repo>/sail-goldenmatch:<tag>. The SAME
+# image is used for the driver pod AND (via SAIL_KUBERNETES__IMAGE) the on-demand
+# worker pods, so the rapidfuzz + R1 native UDFs resolve everywhere.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sail
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sail-user
+  namespace: sail
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sail-worker-manager
+  namespace: sail
+rules:
+  # The driver launches/terminates worker pods on demand.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sail-user-worker-manager
+  namespace: sail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sail-worker-manager
+subjects:
+  - kind: ServiceAccount
+    name: sail-user
+    namespace: sail
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sail-spark-server
+  namespace: sail
+  labels:
+    app: sail-spark-server
+spec:
+  # LakeSail: exactly one replica -- each Spark session is tied to a single pod.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sail-spark-server
+  template:
+    metadata:
+      labels:
+        app: sail-spark-server
+    spec:
+      serviceAccountName: sail-user
+      containers:
+        - name: sail
+          image: REPLACE_IMAGE
+          command: ["sail", "spark", "server", "--ip", "0.0.0.0", "--port", "50051"]
+          ports:
+            - name: grpc
+              containerPort: 50051
+          env:
+            - name: SAIL_MODE
+              value: "kubernetes-cluster"
+            - name: SAIL_CLUSTER__DRIVER_LISTEN_HOST
+              value: "0.0.0.0"
+            - name: SAIL_CLUSTER__DRIVER_EXTERNAL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # Workers use the SAME custom image -> goldenmatch[sail]+native present.
+            - name: SAIL_KUBERNETES__IMAGE
+              value: REPLACE_IMAGE
+            - name: SAIL_KUBERNETES__NAMESPACE
+              value: "sail"
+            - name: SAIL_KUBERNETES__DRIVER_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SAIL_KUBERNETES__WORKER_SERVICE_ACCOUNT_NAME
+              value: "sail-user"
+            # Turn the R1 native scorer ON cluster-wide (else default-off).
+            - name: GOLDENMATCH_NATIVE
+              value: "1"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "8Gi"
+            limits:
+              cpu: "4"
+              memory: "16Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sail-spark-server
+  namespace: sail
+spec:
+  # ClusterIP: reach the driver via `kubectl port-forward` (see the runbook), or
+  # switch type to LoadBalancer with the GKE internal-LB annotation for an
+  # in-VPC `sc://` endpoint (keeps the gRPC port off the public internet).
+  type: ClusterIP
+  selector:
+    app: sail-spark-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50051
+      targetPort: 50051


### PR DESCRIPTION
## Why

You asked if I can drive the GKE Sail binding run. Honest answer: **not the billed
provisioning** — this environment has no `gcloud`/`kubectl`/GCP credentials, and spinning
up a multi-node GKE cluster + a 100M run is real spend and an outward action that stays
yours. But I *can* author all the infra-as-code so "driving it" collapses to one
authenticated command sequence. That's this PR.

The S4 binding run was the **only** thing left blocking the engine long-pole (R1 ✅, R2 ✅,
R3 ✅ #987, S2 100M checkpoint ✅ #987) — and it was blocked on the *cluster*, which didn't
exist as IaC. Now it does.

## What

- **`deploy/sail/Dockerfile`** — custom image = LakeSail Spark Connect server +
  `goldenmatch[sail,native]`, so the rapidfuzz scorer **and** the R1 `score_field_pairwise`
  kernel resolve on the driver **and** the on-demand worker pods (PySpark UDFs run in the
  worker's Python env — a stock `sail` image has no goldenmatch). `GOLDENMATCH_NATIVE=1`
  turns R1 on cluster-wide.
- **`deploy/sail/k8s/sail-server.yaml`** — `Namespace` + `sail-user` ServiceAccount +
  `Role`/`RoleBinding` (the driver launches worker pods) + `Deployment` (`replicas: 1`, the
  `SAIL_*` cluster-mode env via the downward API) + `Service` (gRPC 50051). One image for
  driver + workers. Validated: 6 docs parse.
- **`docs/distributed-sail-cluster-setup.md`** — the full GKE runbook: cluster create →
  Artifact Registry build/push → Workload-Identity GCS access (for the input parquet **and**
  the S2 WCC checkpoint dir) → deploy → connect via `SAIL_REMOTE` → run the bench → read the
  **additive** verdict → tear down (cost). Mirrors the Ray `distributed-ray-cluster-setup.md`
  docs-not-bootstrap posture.

## Honest scoping

**SCAFFOLD** — authored from the [LakeSail K8s guide](https://docs.lakesail.com/sail/latest/guide/deployment/kubernetes.html)
**without a live GKE shakedown** (no GCP tooling here). The manifests are the right *shape*;
the four verify-points (base image + `sail` CLI, `SAIL_*` keys, worker GCS auth, 100M WCC
plan-growth) are called out inline. Treat the first real run as a bring-up.

Docs/deploy only — no code change, no CI lanes beyond the path-filter gate.

https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr)_