### PR TITLE
release(native): bump goldenmatch-native 0.1.5 → 0.1.6 to ship R1 score_field_pairwise

### DIFF
--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arrow",
  "blake2",

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.5"
+version = "0.1.6"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -20,4 +20,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.5"
+    __version__ = "0.1.6"


### PR DESCRIPTION
## Why

R1 (#985, merged) added the `score::score_field_pairwise` native kernel but **did not bump
the wheel version** — so the *published* `goldenmatch-native` is still **0.1.5** and lacks the
symbol. Per the wheel/caller-skew lesson (root `CLAUDE.md`): every `pip install
goldenmatch[native]` environment — **including the GKE Sail workers** (the `deploy/sail`
Dockerfile installs the published wheel from PyPI) — keeps hitting the pure rapidfuzz floor
until the wheel is republished with the new symbol. Republishing **0.1.5** would `skip-existing`
no-op, so a version bump is mandatory.

## What

Bump `goldenmatch-native` **0.1.5 → 0.1.6** in lockstep:
- `packages/rust/extensions/native/pyproject.toml` `[project].version` (maturin reads this)
- `packages/rust/extensions/native/Cargo.toml`
- `packages/rust/extensions/native/Cargo.lock` (self-entry)

Built clean offline as `goldenmatch-native v0.1.6`; all three locations confirmed in lockstep.
The `goldenmatch[native]` extra pins `>=0.1.0`, so 0.1.6 satisfies it (no change). The
`sail_scoring` component stays **default-off** — this only makes the kernel *reachable* via
`GOLDENMATCH_NATIVE=1` on published-wheel installs.

## Publish step (after merge)

The wheel ships when `publish-goldenmatch-native.yml` fires — either:
- tag a **`goldenmatch-native-v0.1.6`** release at `main` HEAD, **or**
- `workflow_dispatch` it with `publish=true`, `ref=main` (reads the bumped `pyproject` version).

I can trigger the `workflow_dispatch` once this is merged (you authorized the republish).

https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNtkvbL2ysMYALnkgTELvr)_