### PR TITLE
feat(ts): A2A parity (skill union + bearer auth) — Wave 3 of AgentSession/A2A port

### DIFF
--- a/docs/superpowers/plans/2026-06-15-ts-agentsession-a2a-wave3-a2a.md
+++ b/docs/superpowers/plans/2026-06-15-ts-agentsession-a2a-wave3-a2a.md
@@ -1,0 +1,53 @@
+# TS AgentSession Port — Wave 3 (A2A) Implementation Plan
+
+> **For agentic workers:** REQUIRED: superpowers:subagent-driven-development. Checkbox steps.
+
+**Goal:** Bring the existing TS A2A server (`src/node/a2a/server.ts`, ~10 skills, no auth) to parity with Python: advertise the union of all tool registries on the agent card, route `/tasks` dispatch to the right registry, and add fail-closed bearer auth.
+
+**Architecture:** Build `AGENT_CARD.skills` from the union (existing A2A base skills + the 14 `AGENT_SKILLS` + `MEMORY_TOOLS` + `IDENTITY_TOOLS`). The task dispatcher routes by skill id: agent→core `dispatchSkill` (node ctx), memory→`handleMemoryTool`, identity→`handleIdentityTool`, else the existing base `dispatchSkill`. Add bearer-auth middleware keyed on `GOLDENMATCH_AGENT_TOKEN`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-ts-agentsession-a2a-port-design.md`. Python ref: `goldenmatch/a2a/server.py` (build_agent_card + auth middleware + routes).
+
+## Box constraints
+- No TS toolchain (CI is the only typecheck+test gate). No pnpm/vitest/tsc/tsup. Write+commit only; use exact contracts read from source.
+- Node surface (`src/node/a2a/**`) — node imports are fine here (it's not edge core).
+
+---
+
+## Tasks
+
+### Task 1: Fail-closed bearer auth
+**Files:** `src/node/a2a/server.ts`, `tests/unit/a2a-*.test.ts`
+
+- [ ] Read Python `a2a/server.py` auth middleware: `GOLDENMATCH_AGENT_TOKEN` env; if set, require `Authorization: Bearer <token>` on all routes EXCEPT `/health` and `/.well-known/agent.json`; 401 otherwise. Binding to a non-loopback host (host !== "127.0.0.1"/"localhost"/"::1") with NO token set → throw at `startA2aServer` start (fail-closed), mirroring the MCP/REST token discipline (root CLAUDE.md).
+- [ ] Implement: at request entry (before route matching, ~line 393), check the token for non-public paths; respond 401 `{error:"Unauthorized"}` if mismatch. Add the startup guard in `startA2aServer`.
+- [ ] Tests (extract the auth check into a testable pure fn, e.g. `isAuthorized(pathname, header, token)`): public paths pass without token; with token set, a non-public path requires the matching Bearer; the non-loopback-without-token guard throws.
+- [ ] Commit.
+
+### Task 2: Agent card = union of registries
+**Files:** `src/node/a2a/server.ts`, `tests/unit/a2a-card.test.ts`
+
+- [ ] Read the current `AGENT_CARD` (~line 44) skill shape (`AgentSkill`). Read `AGENT_SKILLS` (`../../core/agent/index.js`), `MEMORY_TOOLS` (`../mcp/memory-tools.js`), `IDENTITY_TOOLS` (`../mcp/identity-tools.js`) — each entry has `id`/`name` + description.
+- [ ] Build `AGENT_CARD.skills` from the union: existing base skills + agent (map `AGENT_SKILLS` id→skill) + memory + identity. De-dup by id if any collide. Match Python's card shape (name/description/url/version/provider/capabilities{streaming:false,pushNotifications:false}/skills/authentication{schemes:["bearer"]}). Add the `authentication` field (currently absent).
+- [ ] Test: card `.skills` contains the agent ids (e.g. `analyze_data`), a memory id, an identity id, and a base id; `.authentication.schemes` includes "bearer"; `.capabilities.streaming === false`.
+- [ ] Commit.
+
+### Task 3: Unified task dispatch by registry
+**Files:** `src/node/a2a/server.ts`, `tests/unit/a2a-dispatch.test.ts`
+
+- [ ] In the POST `/tasks` (and alias `/tasks/send`) handler, route `skill` by id:
+  - `AGENT_TOOL_NAMES.has(skill)` → `handleAgentTool(skill, input)` (from `../mcp/agent-tools.js` — reuses the node ctx/loadTable wiring from Wave 2).
+  - memory id → `handleMemoryTool(skill, input)`; identity id → `await handleIdentityTool(skill, input)` (these return `TextContent[]` — unwrap `.text` → JSON.parse, or store the text as the result).
+  - else → existing base `dispatchSkill(skill, input)`.
+- [ ] Add Python-parity routes: `POST /tasks/send` (same handler as POST `/tasks`), `POST /tasks/{id}/cancel` (mark task cancelled). Keep existing `POST /tasks` + `GET /tasks/{id}`.
+- [ ] Test (extract a pure `dispatchAnySkill(skill, input)` that does the routing): an agent skill (`analyze_data` with `{rows}`) returns a strategy; an unknown skill throws/errors; a base skill still works.
+- [ ] Commit.
+
+### Task 4: Verify + CI
+- [ ] Push; CI is the gate. Fix strict-TS nits (`exactOptionalPropertyTypes`/`noUncheckedIndexedAccess`); ensure `.js` import suffixes.
+- [ ] Final review.
+
+## Notes
+- **YAGNI:** no node file-loaders (Wave 4), no CLAUDE.md/parity-matrix changes (Wave 4). Just A2A.
+- Memory/identity handlers return `TextContent[]` (`[{type:"text",text:JSON.stringify(...)}]`); agent `dispatchSkill`/`handleAgentTool` return plain objects. Normalize both to a plain result for the task `result` field.
+- Keep the existing 10 base A2A skills working (don't regress their dispatch).

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -4,9 +4,18 @@
  * Node-only: uses node:http, node:crypto. NOT edge-safe.
  *
  * Endpoints:
- *   GET  /.well-known/agent.json   - agent card (10+ skills)
+ *   GET  /.well-known/agent.json   - agent card (union of all registries)
+ *   GET  /health                   - liveness probe (public)
  *   POST /tasks                    - create a task (skill + input)
+ *   POST /tasks/send               - alias for POST /tasks (Python parity)
  *   GET  /tasks/{id}               - fetch task status/result
+ *   POST /tasks/{id}/cancel        - cancel a task
+ *
+ * Bearer auth mirrors goldenmatch/a2a/server.py: when
+ * GOLDENMATCH_AGENT_TOKEN is set, every route except /health and
+ * /.well-known/agent.json requires `Authorization: Bearer <token>`.
+ * Binding to a non-loopback host without a token throws at startup
+ * (fail-closed).
  *
  * Ports ideas from goldenmatch/a2a/server.py. This is a simpler
  * synchronous variant (no SSE streaming, no persistent store).
@@ -18,6 +27,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { randomUUID } from "node:crypto";
+import { env } from "node:process";
 import { dedupe, match, scoreStrings } from "../../core/api.js";
 import { profileRows } from "../../core/profiler.js";
 import { explainPair } from "../../core/explain.js";
@@ -29,6 +39,18 @@ import {
   VALID_TRANSFORMS,
   VALID_STRATEGIES,
 } from "../../core/types.js";
+import { AGENT_SKILLS } from "../../core/agent/index.js";
+import { AGENT_TOOL_NAMES, handleAgentTool } from "../mcp/agent-tools.js";
+import {
+  MEMORY_TOOLS,
+  MEMORY_TOOL_NAMES,
+  handleMemoryTool,
+} from "../mcp/memory-tools.js";
+import {
+  IDENTITY_TOOLS,
+  IDENTITY_TOOL_NAMES,
+  handleIdentityTool,
+} from "../mcp/identity-tools.js";
 
 // ---------------------------------------------------------------------------
 // Agent card
@@ -41,7 +63,7 @@ export interface AgentSkill {
   readonly outputModes: readonly string[];
 }
 
-export const AGENT_CARD: {
+export interface AgentCard {
   readonly name: string;
   readonly description: string;
   readonly version: string;
@@ -51,7 +73,115 @@ export const AGENT_CARD: {
   };
   readonly capabilities: Readonly<Record<string, boolean>>;
   readonly skills: readonly AgentSkill[];
-} = {
+  readonly authentication: {
+    readonly schemes: readonly string[];
+  };
+}
+
+/**
+ * The 10 native A2A skills. These dispatch through the local `dispatchSkill`
+ * switch below (not the MCP registries). Their `name` doubles as the skill id.
+ */
+const BASE_SKILLS: readonly AgentSkill[] = [
+  {
+    name: "dedupe",
+    description: "Deduplicate a list of records and return golden records plus clusters.",
+    inputModes: ["data/json"],
+    outputModes: ["data/json"],
+  },
+  {
+    name: "match",
+    description: "Match target records against reference records.",
+    inputModes: ["data/json"],
+    outputModes: ["data/json"],
+  },
+  {
+    name: "score",
+    description: "Score similarity between two strings.",
+    inputModes: ["text"],
+    outputModes: ["text"],
+  },
+  {
+    name: "profile",
+    description: "Profile a dataset (types, null rates, cardinality).",
+    inputModes: ["data/json"],
+    outputModes: ["data/json"],
+  },
+  {
+    name: "suggest_config",
+    description: "Auto-generate a shorthand dedupe config from a dataset profile.",
+    inputModes: ["data/json"],
+    outputModes: ["data/json"],
+  },
+  {
+    name: "explain_pair",
+    description: "Explain why two records match using weighted field scorers.",
+    inputModes: ["data/json"],
+    outputModes: ["data/json"],
+  },
+  {
+    name: "evaluate",
+    description: "Evaluate predicted pairs vs ground truth (precision/recall/F1).",
+    inputModes: ["data/json"],
+    outputModes: ["data/json"],
+  },
+  {
+    name: "list_scorers",
+    description: "List all available similarity scorers.",
+    inputModes: ["text"],
+    outputModes: ["data/json"],
+  },
+  {
+    name: "list_transforms",
+    description: "List all available field transforms.",
+    inputModes: ["text"],
+    outputModes: ["data/json"],
+  },
+  {
+    name: "list_strategies",
+    description: "List all golden-record survivorship strategies.",
+    inputModes: ["text"],
+    outputModes: ["data/json"],
+  },
+];
+
+/** Map any registry entry (id/name + description) to the `AgentSkill` shape. */
+function toAgentSkill(entry: {
+  readonly name: string;
+  readonly description: string;
+}): AgentSkill {
+  return {
+    name: entry.name,
+    description: entry.description,
+    inputModes: ["application/json"],
+    outputModes: ["application/json"],
+  };
+}
+
+/**
+ * Build the card's skill list from the union of every registry: the 10 base
+ * A2A skills + the 14 `AGENT_SKILLS` + the memory tools + the identity tools.
+ * De-duped by skill id (`name`); first occurrence wins, so a base skill
+ * shadows a same-named registry entry.
+ */
+function buildCardSkills(): readonly AgentSkill[] {
+  const out: AgentSkill[] = [];
+  const seen = new Set<string>();
+  const push = (skill: AgentSkill): void => {
+    if (seen.has(skill.name)) return;
+    seen.add(skill.name);
+    out.push(skill);
+  };
+  for (const skill of BASE_SKILLS) push(skill);
+  for (const def of AGENT_SKILLS) {
+    push(toAgentSkill({ name: def.id, description: def.description }));
+  }
+  for (const tool of MEMORY_TOOLS) push(toAgentSkill(tool));
+  for (const tool of IDENTITY_TOOLS) push(toAgentSkill(tool));
+  return out;
+}
+
+export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
@@ -65,68 +195,10 @@ export const AGENT_CARD: {
     pushNotifications: false,
     stateTransitionHistory: false,
   },
-  skills: [
-    {
-      name: "dedupe",
-      description: "Deduplicate a list of records and return golden records plus clusters.",
-      inputModes: ["data/json"],
-      outputModes: ["data/json"],
-    },
-    {
-      name: "match",
-      description: "Match target records against reference records.",
-      inputModes: ["data/json"],
-      outputModes: ["data/json"],
-    },
-    {
-      name: "score",
-      description: "Score similarity between two strings.",
-      inputModes: ["text"],
-      outputModes: ["text"],
-    },
-    {
-      name: "profile",
-      description: "Profile a dataset (types, null rates, cardinality).",
-      inputModes: ["data/json"],
-      outputModes: ["data/json"],
-    },
-    {
-      name: "suggest_config",
-      description: "Auto-generate a shorthand dedupe config from a dataset profile.",
-      inputModes: ["data/json"],
-      outputModes: ["data/json"],
-    },
-    {
-      name: "explain_pair",
-      description: "Explain why two records match using weighted field scorers.",
-      inputModes: ["data/json"],
-      outputModes: ["data/json"],
-    },
-    {
-      name: "evaluate",
-      description: "Evaluate predicted pairs vs ground truth (precision/recall/F1).",
-      inputModes: ["data/json"],
-      outputModes: ["data/json"],
-    },
-    {
-      name: "list_scorers",
-      description: "List all available similarity scorers.",
-      inputModes: ["text"],
-      outputModes: ["data/json"],
-    },
-    {
-      name: "list_transforms",
-      description: "List all available field transforms.",
-      inputModes: ["text"],
-      outputModes: ["data/json"],
-    },
-    {
-      name: "list_strategies",
-      description: "List all golden-record survivorship strategies.",
-      inputModes: ["text"],
-      outputModes: ["data/json"],
-    },
-  ],
+  skills: buildCardSkills(),
+  authentication: {
+    schemes: ["bearer"],
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -136,11 +208,48 @@ export const AGENT_CARD: {
 interface Task {
   readonly id: string;
   readonly skill: string;
-  status: "pending" | "running" | "completed" | "failed";
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
   readonly createdAt: string;
   completedAt?: string;
   result?: unknown;
   error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Auth (mirrors goldenmatch/a2a/server.py auth middleware)
+// ---------------------------------------------------------------------------
+
+/** Endpoints reachable without a bearer token (liveness + discovery). */
+const PUBLIC_PATHS: ReadonlySet<string> = new Set([
+  "/health",
+  "/.well-known/agent.json",
+]);
+
+/** Hosts considered loopback for the fail-closed startup guard. */
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set([
+  "127.0.0.1",
+  "localhost",
+  "::1",
+]);
+
+/**
+ * Decide whether a request is authorized.
+ *
+ * - Public paths (`/health`, `/.well-known/agent.json`) always pass.
+ * - When `token` is unset/empty, every path passes (auth disabled).
+ * - Otherwise a non-public path requires `Authorization: Bearer <token>`.
+ *
+ * Pure + side-effect free so it can be unit-tested without a live server.
+ */
+export function isAuthorized(
+  pathname: string,
+  authHeader: string | undefined,
+  token: string | undefined,
+): boolean {
+  if (PUBLIC_PATHS.has(pathname)) return true;
+  if (!token) return true;
+  const header = authHeader ?? "";
+  return header.startsWith("Bearer ") && header.slice("Bearer ".length) === token;
 }
 
 // ---------------------------------------------------------------------------
@@ -332,6 +441,52 @@ async function dispatchSkill(
   }
 }
 
+/**
+ * Unwrap a memory/identity handler's `TextContent[]` into a plain object.
+ *
+ * Those handlers return `[{ type: "text", text: JSON.stringify(payload) }]`;
+ * we parse the first element's text back into the payload so the A2A task
+ * `result` field carries structured JSON (matching the agent/base skills,
+ * which return plain objects). If the text is missing or unparseable we fall
+ * back to wrapping the raw text.
+ */
+function unwrapTextContent(
+  content: readonly { readonly type: string; readonly text: string }[],
+): unknown {
+  const first = content[0];
+  if (first === undefined) return {};
+  try {
+    return JSON.parse(first.text);
+  } catch {
+    return { text: first.text };
+  }
+}
+
+/**
+ * Route a skill id to the correct registry:
+ *   - `AGENT_TOOL_NAMES` -> `handleAgentTool` (Wave 2 node ctx)
+ *   - memory id          -> `handleMemoryTool` (TextContent -> parsed)
+ *   - identity id        -> `handleIdentityTool` (TextContent -> parsed)
+ *   - else               -> the local base `dispatchSkill` switch
+ *
+ * Unknown ids fall through to `dispatchSkill`, which throws.
+ */
+export async function dispatchAnySkill(
+  skill: string,
+  input: Record<string, unknown>,
+): Promise<unknown> {
+  if (AGENT_TOOL_NAMES.has(skill)) {
+    return handleAgentTool(skill, input);
+  }
+  if (MEMORY_TOOL_NAMES.has(skill)) {
+    return unwrapTextContent(await handleMemoryTool(skill, input));
+  }
+  if (IDENTITY_TOOL_NAMES.has(skill)) {
+    return unwrapTextContent(await handleIdentityTool(skill, input));
+  }
+  return dispatchSkill(skill, input);
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -385,12 +540,86 @@ export function startA2aServer(options: StartA2aOptions = {}): ReturnType<typeof
   const host = options.host ?? "127.0.0.1";
   const tasks = new Map<string, Task>();
 
+  // Fail-closed startup guard (mirrors Python create_app): binding to a
+  // non-loopback host without GOLDENMATCH_AGENT_TOKEN is refused so an exposed
+  // agent server is never unauthenticated by accident.
+  const token = env["GOLDENMATCH_AGENT_TOKEN"];
+  if (!token && !LOOPBACK_HOSTS.has(host)) {
+    throw new Error(
+      `Refusing to start an unauthenticated A2A server on host '${host}'. ` +
+        "Set GOLDENMATCH_AGENT_TOKEN, or bind to 127.0.0.1 for local use.",
+    );
+  }
+
+  // Shared handler for POST /tasks and its POST /tasks/send alias.
+  const handleSendTask = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<void> => {
+    const body = await readJsonBody(req);
+    const skill = String(body["skill"] ?? "");
+    const input =
+      (body["input"] as Record<string, unknown> | undefined) ??
+      (body["params"] as Record<string, unknown> | undefined) ??
+      {};
+    if (!skill) {
+      sendJson(res, 400, { error: "skill is required" });
+      return;
+    }
+    const id = randomUUID();
+    const createdAt = new Date().toISOString();
+    const task: Task = {
+      id,
+      skill,
+      status: "running",
+      createdAt,
+    };
+    tasks.set(id, task);
+
+    try {
+      const result = await dispatchAnySkill(skill, input);
+      task.status = "completed";
+      task.completedAt = new Date().toISOString();
+      task.result = result;
+      sendJson(res, 200, {
+        id,
+        status: task.status,
+        skill,
+        created_at: createdAt,
+        completed_at: task.completedAt,
+        result,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      task.status = "failed";
+      task.completedAt = new Date().toISOString();
+      task.error = msg;
+      sendJson(res, 200, {
+        id,
+        status: task.status,
+        skill,
+        created_at: createdAt,
+        completed_at: task.completedAt,
+        error: msg,
+      });
+    }
+  };
+
   const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
     const pathname = url.pathname;
     const methodName = req.method ?? "GET";
 
     try {
+      // Bearer auth (mirrors Python _auth_middleware): public paths always
+      // pass; everything else needs the matching token when one is set.
+      const authHeader = req.headers["authorization"];
+      const headerStr = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+      if (!isAuthorized(pathname, headerStr, token)) {
+        sendJson(res, 401, { error: "Unauthorized" });
+        return;
+      }
+
       if (pathname === "/.well-known/agent.json" && methodName === "GET") {
         sendJson(res, 200, AGENT_CARD);
         return;
@@ -401,54 +630,32 @@ export function startA2aServer(options: StartA2aOptions = {}): ReturnType<typeof
         return;
       }
 
-      if (pathname === "/tasks" && methodName === "POST") {
-        const body = await readJsonBody(req);
-        const skill = String(body["skill"] ?? "");
-        const input =
-          (body["input"] as Record<string, unknown> | undefined) ??
-          (body["params"] as Record<string, unknown> | undefined) ??
-          {};
-        if (!skill) {
-          sendJson(res, 400, { error: "skill is required" });
+      if (
+        (pathname === "/tasks" || pathname === "/tasks/send") &&
+        methodName === "POST"
+      ) {
+        await handleSendTask(req, res);
+        return;
+      }
+
+      if (
+        pathname.startsWith("/tasks/") &&
+        pathname.endsWith("/cancel") &&
+        methodName === "POST"
+      ) {
+        const id = pathname.slice("/tasks/".length, -"/cancel".length);
+        const task = tasks.get(id);
+        if (!task) {
+          sendJson(res, 404, { error: `Task not found: ${id}` });
           return;
         }
-        const id = randomUUID();
-        const createdAt = new Date().toISOString();
-        const task: Task = {
-          id,
-          skill,
-          status: "running",
-          createdAt,
-        };
-        tasks.set(id, task);
-
-        try {
-          const result = await dispatchSkill(skill, input);
-          task.status = "completed";
-          task.completedAt = new Date().toISOString();
-          task.result = result;
-          sendJson(res, 200, {
-            id,
-            status: task.status,
-            skill,
-            created_at: createdAt,
-            completed_at: task.completedAt,
-            result,
-          });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          task.status = "failed";
-          task.completedAt = new Date().toISOString();
-          task.error = msg;
-          sendJson(res, 200, {
-            id,
-            status: task.status,
-            skill,
-            created_at: createdAt,
-            completed_at: task.completedAt,
-            error: msg,
-          });
-        }
+        task.status = "cancelled";
+        task.completedAt = new Date().toISOString();
+        sendJson(res, 200, {
+          id: task.id,
+          skill: task.skill,
+          status: task.status,
+        });
         return;
       }
 

--- a/packages/typescript/goldenmatch/tests/unit/a2a-auth.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/a2a-auth.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { isAuthorized, startA2aServer } from "../../src/node/a2a/server.js";
+
+describe("A2A bearer auth — isAuthorized", () => {
+  const TOKEN = "s3cret-token";
+
+  it("public paths pass without a token (auth disabled)", () => {
+    expect(isAuthorized("/health", undefined, undefined)).toBe(true);
+    expect(isAuthorized("/.well-known/agent.json", undefined, undefined)).toBe(
+      true,
+    );
+  });
+
+  it("public paths pass even when a token is set, regardless of header", () => {
+    expect(isAuthorized("/health", undefined, TOKEN)).toBe(true);
+    expect(isAuthorized("/health", "Bearer wrong", TOKEN)).toBe(true);
+    expect(
+      isAuthorized("/.well-known/agent.json", undefined, TOKEN),
+    ).toBe(true);
+  });
+
+  it("non-public paths pass without a token when auth is disabled", () => {
+    expect(isAuthorized("/tasks", undefined, undefined)).toBe(true);
+    expect(isAuthorized("/tasks", "Bearer anything", undefined)).toBe(true);
+    expect(isAuthorized("/tasks/abc", undefined, "")).toBe(true);
+  });
+
+  it("non-public path requires the matching Bearer token when a token is set", () => {
+    expect(isAuthorized("/tasks", `Bearer ${TOKEN}`, TOKEN)).toBe(true);
+    expect(isAuthorized("/tasks/abc/cancel", `Bearer ${TOKEN}`, TOKEN)).toBe(
+      true,
+    );
+  });
+
+  it("non-public path is rejected on missing / wrong / malformed header", () => {
+    expect(isAuthorized("/tasks", undefined, TOKEN)).toBe(false);
+    expect(isAuthorized("/tasks", "", TOKEN)).toBe(false);
+    expect(isAuthorized("/tasks", "Bearer wrong-token", TOKEN)).toBe(false);
+    expect(isAuthorized("/tasks", TOKEN, TOKEN)).toBe(false); // no "Bearer " prefix
+    expect(isAuthorized("/tasks", `bearer ${TOKEN}`, TOKEN)).toBe(false); // case-sensitive
+  });
+});
+
+describe("A2A bearer auth — startup guard (fail-closed)", () => {
+  it("throws when binding a non-loopback host without a token", () => {
+    const prev = process.env["GOLDENMATCH_AGENT_TOKEN"];
+    delete process.env["GOLDENMATCH_AGENT_TOKEN"];
+    try {
+      expect(() => startA2aServer({ port: 0, host: "0.0.0.0" })).toThrow(
+        /Refusing to start an unauthenticated A2A server/,
+      );
+    } finally {
+      if (prev !== undefined) process.env["GOLDENMATCH_AGENT_TOKEN"] = prev;
+    }
+  });
+
+  it("loopback host without a token starts fine", () => {
+    const prev = process.env["GOLDENMATCH_AGENT_TOKEN"];
+    delete process.env["GOLDENMATCH_AGENT_TOKEN"];
+    let server: ReturnType<typeof startA2aServer> | undefined;
+    try {
+      expect(() => {
+        server = startA2aServer({ port: 0, host: "127.0.0.1" });
+      }).not.toThrow();
+    } finally {
+      server?.close();
+      if (prev !== undefined) process.env["GOLDENMATCH_AGENT_TOKEN"] = prev;
+    }
+  });
+
+  it("non-loopback host WITH a token starts fine", () => {
+    const prev = process.env["GOLDENMATCH_AGENT_TOKEN"];
+    process.env["GOLDENMATCH_AGENT_TOKEN"] = "s3cret-token";
+    let server: ReturnType<typeof startA2aServer> | undefined;
+    try {
+      expect(() => {
+        server = startA2aServer({ port: 0, host: "0.0.0.0" });
+      }).not.toThrow();
+    } finally {
+      server?.close();
+      if (prev !== undefined) process.env["GOLDENMATCH_AGENT_TOKEN"] = prev;
+      else delete process.env["GOLDENMATCH_AGENT_TOKEN"];
+    }
+  });
+});
+
+describe("A2A bearer auth — live 401", () => {
+  it("rejects a non-public path without the token and allows /health", async () => {
+    const prev = process.env["GOLDENMATCH_AGENT_TOKEN"];
+    process.env["GOLDENMATCH_AGENT_TOKEN"] = "live-token";
+    const server = startA2aServer({ port: 0, host: "127.0.0.1" });
+    try {
+      await new Promise<void>((resolveFn) => {
+        if (server.listening) resolveFn();
+        else server.once("listening", () => resolveFn());
+      });
+      const addr = server.address();
+      const port =
+        typeof addr === "object" && addr !== null && "port" in addr
+          ? addr.port
+          : 8200;
+      const base = `http://127.0.0.1:${port}`;
+
+      // /health is public -> 200 even without the token.
+      const health = await fetch(base + "/health");
+      expect(health.status).toBe(200);
+
+      // /tasks without token -> 401.
+      const noAuth = await fetch(base + "/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ skill: "list_scorers", input: {} }),
+      });
+      expect(noAuth.status).toBe(401);
+      const errBody = (await noAuth.json()) as { error: string };
+      expect(errBody.error).toBe("Unauthorized");
+
+      // /tasks with the right token -> 200.
+      const withAuth = await fetch(base + "/tasks", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer live-token",
+        },
+        body: JSON.stringify({ skill: "list_scorers", input: {} }),
+      });
+      expect(withAuth.status).toBe(200);
+    } finally {
+      await new Promise<void>((resolveFn) => server.close(() => resolveFn()));
+      if (prev !== undefined) process.env["GOLDENMATCH_AGENT_TOKEN"] = prev;
+      else delete process.env["GOLDENMATCH_AGENT_TOKEN"];
+    }
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/a2a-card.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/a2a-card.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { AGENT_CARD } from "../../src/node/a2a/server.js";
+
+describe("A2A agent card — union of registries", () => {
+  const names = new Set(AGENT_CARD.skills.map((s) => s.name));
+
+  it("includes a base A2A skill", () => {
+    expect(names.has("dedupe")).toBe(true);
+  });
+
+  it("includes an agent skill (analyze_data)", () => {
+    expect(names.has("analyze_data")).toBe(true);
+  });
+
+  it("includes a memory tool id", () => {
+    expect(names.has("list_corrections")).toBe(true);
+  });
+
+  it("includes an identity tool id", () => {
+    expect(names.has("identity_resolve")).toBe(true);
+  });
+
+  it("advertises bearer authentication", () => {
+    expect(AGENT_CARD.authentication.schemes).toContain("bearer");
+  });
+
+  it("does not advertise streaming", () => {
+    expect(AGENT_CARD.capabilities["streaming"]).toBe(false);
+  });
+
+  it("de-dups skills by name (no duplicate ids)", () => {
+    expect(names.size).toBe(AGENT_CARD.skills.length);
+  });
+
+  it("every skill keeps the AgentSkill shape", () => {
+    for (const skill of AGENT_CARD.skills) {
+      expect(typeof skill.name).toBe("string");
+      expect(skill.name.length).toBeGreaterThan(0);
+      expect(typeof skill.description).toBe("string");
+      expect(Array.isArray(skill.inputModes)).toBe(true);
+      expect(skill.inputModes.length).toBeGreaterThan(0);
+      expect(Array.isArray(skill.outputModes)).toBe(true);
+      expect(skill.outputModes.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/a2a-dispatch.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/a2a-dispatch.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { dispatchAnySkill } from "../../src/node/a2a/server.js";
+
+describe("A2A unified dispatch — dispatchAnySkill", () => {
+  it("routes an agent skill (analyze_data) and returns a strategy", async () => {
+    const result = (await dispatchAnySkill("analyze_data", {
+      rows: [
+        { id: 1, email: "a@x.com", name: "Alice" },
+        { id: 2, email: "b@x.com", name: "Bob" },
+        { id: 3, email: "c@x.com", name: "Carol" },
+      ],
+    })) as Record<string, unknown>;
+    // dispatchSkill never throws; on success the analyze payload carries a
+    // top-level `strategy` string.
+    expect(result["error"]).toBeUndefined();
+    expect(typeof result["strategy"]).toBe("string");
+    expect((result["strategy"] as string).length).toBeGreaterThan(0);
+  });
+
+  it("still routes a base A2A skill (list_scorers)", async () => {
+    const result = (await dispatchAnySkill("list_scorers", {})) as Record<
+      string,
+      unknown
+    >;
+    expect(Array.isArray(result["scorers"])).toBe(true);
+    expect((result["scorers"] as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("routes a base scoring skill (score)", async () => {
+    const result = (await dispatchAnySkill("score", {
+      a: "John",
+      b: "Jon",
+      scorer: "jaro_winkler",
+    })) as Record<string, unknown>;
+    expect(typeof result["score"]).toBe("number");
+  });
+
+  it("throws on an unknown skill id", async () => {
+    await expect(
+      dispatchAnySkill("not_a_real_skill", {}),
+    ).rejects.toThrow(/Unknown skill/);
+  });
+});


### PR DESCRIPTION
## Wave 3 of 4 — A2A server parity

Builds on Waves 1 (#989) + 2 (#994). Brings the TS A2A server to parity with Python.

- **Fail-closed bearer auth**: `GOLDENMATCH_AGENT_TOKEN` gates all routes except `/health` + `/.well-known/agent.json`; binding to a non-loopback host without a token throws at startup (mirrors the MCP/REST token discipline).
- **Agent card = union of registries**: `.skills` now built from base + the 14 `AGENT_SKILLS` + memory + identity tools (de-duped); adds `authentication: {schemes:["bearer"]}`.
- **Unified dispatch**: `dispatchAnySkill` routes a task's `skill` by id — agent → `handleAgentTool`, memory/identity → their handlers (TextContent unwrapped), else the existing base dispatch.
- **Python-parity routes**: added `POST /tasks/send` + `POST /tasks/{id}/cancel`; kept the existing `POST /tasks` + `GET /tasks/{id}`. The 10 base skills are untouched.

No local TS toolchain on the build box → CI is the first typecheck+test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)