### PR TITLE
feat(ts): agent file-loaders + ported declaration — Wave 4 (final) of AgentSession/A2A port

### DIFF
--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -15,8 +15,9 @@ npm package `goldenmatch`. Parity port of the Python sibling at `packages/python
 | 0.9.0 | v1.15 + persistent IdentityStore | `SqliteIdentityStore` in `src/node/identity/` — full IdentityStore interface (19 methods), schema byte-identical with Python so a `.goldenmatch/identity.db` is cross-toolkit readable. Pipeline-driven population + MCP identity tools deferred to v0.10. |
 | 0.10.0 | v1.15 CLI + REST surface | `goldenmatch identity {list,show,history,conflicts,merge,split}` CLI subcommands + matching `/identities/*` REST routes (bound via `setServerIdentityStore`). Web UI / TUI / MCP-identity-tools / pipeline-driven `resolveClusters` still deferred. |
 | 0.11.0 | core-algo catch-up + Phase 5 | Continuous-EM probabilistic (`trainEMContinuous`/`scoreProbabilisticContinuous`), `embedding`/`record_embedding` scorers (pluggable embedder shim — structural parity, not numeric), software/biblio domain extractors, autoconfig v3 planner + 3 tuners + `AutoConfigMemory`, and the golden-strategy plugin port (#208). Parity harness broadened with Python-generated goldens for blocker / clustering / golden-survivorship / discrete-EM. Still gappy: embedding numeric values (no torch/Vertex), cluster-threshold tuner is logic-parity only, `DOMAIN_EXTRACTED_COLS` still 3 vs Python's 12. |
+| 0.14.0 (pending) | agent surface (AgentSession + A2A) | **AgentSession/A2A port (2026-06-15, the last undeclared parity gap).** Edge-safe `AgentSession` decision core + the shared `AGENT_SKILLS` registry + `dispatchSkill` (`src/core/agent/`); 14 agent-level MCP tools (MCP 30→44); A2A skill-union agent card + fail-closed bearer auth (`GOLDENMATCH_AGENT_TOKEN`) + unified `dispatchAnySkill` + `/tasks/send` + `/tasks/{id}/cancel`; node file-loaders (`analyzeFile`/`deduplicateFile`/`matchSourcesFile`). Behavior-fixture parity vs Python (`selectStrategy` decision table is the keystone). 4 waves, PRs #989/#994/#995 + this one. |
 
-Each wave's spec/plan: `docs/superpowers/specs/2026-05-10-ts-parity-arc-design.md` + per-wave plans.
+Each wave's spec/plan: `docs/superpowers/specs/2026-05-10-ts-parity-arc-design.md`, `docs/superpowers/specs/2026-06-15-ts-agentsession-a2a-port-design.md` + per-wave plans.
 
 ## Deliberately not ported (Python deltas)
 - **Python v1.13 (typed accessors).** TS strict mode (`noUncheckedIndexedAccess` + `exactOptionalPropertyTypes`) already enforces the same invariants at compile time.
@@ -40,11 +41,17 @@ than a multi-month port, mirroring the SQL "deferred-by-design" boundary in
   natural home is the Python package. TS already ships a thin programmatic
   `node/api/server.ts` for embedding in a Node service; the full browser UI is **not**
   ported and not planned. Run `goldenmatch serve-ui` (Python) for the UI.
+- **Agent tools `sensitivity` / `incremental` / `certify_recall`** (2026-06-15) — the
+  three agent-level tools whose Python implementations (`run_sensitivity` /
+  `run_incremental` / `certify_recall`) have no TS core. The other **14** agent tools
+  ARE ported (see the 0.14.0 wave row). Porting these three is a separate effort; for
+  now they are Python-only and **NOT advertised** on the TS MCP/A2A surface (no silent
+  gap — the card and tool list expose only what is wired).
 
 Everything else (core scoring/blocking/clustering/golden, auto-config controller,
-identity graph, PPRL, memory, MCP/A2A, CLI, connectors) IS ported — see the wave
-history above. This closes the cross-surface parity roadmap (Waves 0–3, 5 shipped;
-Wave 4 = this declaration).
+identity graph, PPRL, memory, MCP/A2A **incl. the AgentSession agent surface
+(2026-06-15)**, CLI, connectors) IS ported — see the wave history above. This closes
+the cross-surface parity roadmap.
 
 ## Commands
 ```bash

--- a/packages/typescript/goldenmatch/src/node/agent/session-file.ts
+++ b/packages/typescript/goldenmatch/src/node/agent/session-file.ts
@@ -1,0 +1,41 @@
+/**
+ * session-file.ts — Node file-loading entry points for the agent surface.
+ *
+ * Mirrors the `dedupe` (core, rows) vs `dedupeFile` (node, loads) split: the
+ * edge-safe core `AgentSession` operates on `Row[]`; this node layer reads
+ * CSV/JSON from disk via `readFile` and delegates to a fresh session.
+ */
+import type {
+  AnalyzeResult,
+  DeduplicateResult,
+  MatchSourcesResult,
+} from "../../core/agent/index.js";
+import { AgentSession } from "../../core/agent/index.js";
+import type { GoldenMatchConfig } from "../../core/index.js";
+import { readFile } from "../connectors/file.js";
+
+/** Profile a file + recommend a strategy (sync; mirrors `AgentSession.analyze`). */
+export function analyzeFile(path: string): AnalyzeResult {
+  return new AgentSession().analyze(readFile(path));
+}
+
+/** Run the full agent dedupe pipeline on a file. */
+export function deduplicateFile(
+  path: string,
+  config?: GoldenMatchConfig,
+): Promise<DeduplicateResult> {
+  return new AgentSession().deduplicate(readFile(path), config);
+}
+
+/** Match two files via the agent session. */
+export function matchSourcesFile(
+  pathA: string,
+  pathB: string,
+  config?: GoldenMatchConfig,
+): Promise<MatchSourcesResult> {
+  return new AgentSession().matchSources(
+    readFile(pathA),
+    readFile(pathB),
+    config,
+  );
+}

--- a/packages/typescript/goldenmatch/src/node/index.ts
+++ b/packages/typescript/goldenmatch/src/node/index.ts
@@ -31,6 +31,13 @@ export type {
 export { dedupeFile, matchFiles } from "./dedupe-file.js";
 export type { FileDedupeOptions, FileSpec } from "./dedupe-file.js";
 
+// Agent surface — file-loading entry points (load CSV/JSON -> AgentSession)
+export {
+  analyzeFile,
+  deduplicateFile,
+  matchSourcesFile,
+} from "./agent/session-file.js";
+
 // YAML config file I/O
 export { loadConfigFile, writeConfigFile } from "./config-file.js";
 

--- a/packages/typescript/goldenmatch/tests/unit/agent-file.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/agent-file.test.ts
@@ -1,0 +1,36 @@
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeFile, deduplicateFile } from "../../src/node/agent/session-file.js";
+
+function withCsv(body: string, fn: (path: string) => void | Promise<void>): void | Promise<void> {
+  const path = join(tmpdir(), `gm-agent-${process.pid}-${Math.random().toString(36).slice(2)}.csv`);
+  writeFileSync(path, body, "utf-8");
+  try {
+    return fn(path);
+  } finally {
+    rmSync(path, { force: true });
+  }
+}
+
+describe("agent file loaders", () => {
+  it("analyzeFile profiles a CSV + recommends a strategy", () => {
+    withCsv("id,name\n1,John Smith\n2,Jon Smith\n3,Mary Jones\n", (path) => {
+      const out = analyzeFile(path);
+      expect(out.profile.row_count).toBe(3);
+      expect(out.strategy).toBeDefined();
+      expect(Array.isArray(out.alternatives)).toBe(true);
+    });
+  });
+
+  it("deduplicateFile runs the agent pipeline on a CSV", async () => {
+    await withCsv("id,name\n1,John Smith\n2,John Smith\n3,Mary Jones\n", async (path) => {
+      const out = await deduplicateFile(path);
+      expect(out.confidence_distribution).toHaveProperty("total_pairs");
+      expect(out.storage).toBe("memory");
+    });
+  });
+});


### PR DESCRIPTION
## Wave 4 of 4 (final) — node loaders + docs

Closes the AgentSession/A2A port (Waves 1 #989, 2 #994, 3 #995).

- **Node file-loaders** `src/node/agent/session-file.ts`: `analyzeFile` / `deduplicateFile` / `matchSourcesFile` (read CSV/JSON via `readFile` → core `AgentSession`), exported from `src/node/index.ts`. Mirrors the `dedupe`/`dedupeFile` split.
- **CLAUDE.md**: added the 0.14.0 wave row (agent surface ported); flipped the parity declaration — `MCP/A2A incl. the AgentSession agent surface` is now ported; **declared `sensitivity`/`incremental`/`certify_recall` Python-only** (no TS core; not advertised — no silent gap).

The last undeclared parity gap is now closed: 14 of 17 agent tools ported, 3 declared Python-only.

> Note: the standalone `docs/versioning-policy.md` draft (cut npm 1.0.0 not 2.0.0; compatibility matrix not lockstep) is a separate doc to land; the TS CLAUDE.md is the operative parity record and is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)