### PR TITLE
release(ts): npm goldenmatch 1.0.0 — first stable release

### DIFF
--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -49,6 +49,11 @@ pip install goldenmatch && goldenmatch dedupe customers.csv
 npm install goldenmatch
 ```
 
+> **Two packages, independent versions.** PyPI `goldenmatch` (2.x) and npm `goldenmatch`
+> (1.x) are the same toolkit on **separate semver lines** — not lockstep. The npm package
+> is an edge-safe subset (no Ray/GPU distributed engine, no web UI); everything else is at
+> core parity. Version map + rationale: [`docs/versioning-policy.md`](docs/versioning-policy.md).
+
 <!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
 > **🆕 v2.0.0** — **GoldenMatch 2.0.0: the first backwards-incompatible major.** It removes four deprecation-window items, each shipped with a 1.x runway: the legacy `:hash:` identity lookup bridge + `GOLDENMATCH_IDENTITY_ID_SCHEME` (run `goldenmatch identity migrate-ids` before upgrading; un-fingerprintable rows keep their `:hash:` id), the `GOLDENMATCH_CLUSTER_FRAMES_OUT` gate + legacy dict cluster path (`build_clusters` stays as a frames-backed adapter), and the `cheapest_healthy` / `_scale_aware_backend` shims. Pipeline behavior is output-equivalent. Migration guide: [Migrating to v2](https://docs.bensevern.dev/goldenmatch/migrating-to-v2).
 >

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -6,6 +6,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-06-15
+
+**First stable release.** The API is now stable: breaking changes only at the next
+major (2.0.0). This is a one-time jump from the `0.x` wave line (`0.13.0 → 1.0.0`) —
+a deliberate "this is stable" signal, not a `2.0.0` product-alignment bump (see
+`docs/versioning-policy.md`; npm and PyPI keep independent semver, not lockstep).
+
+- **AgentSession agent surface ported** (the last undeclared parity gap, 2026-06-15):
+  the edge-safe `AgentSession` decision core + shared `AGENT_SKILLS` registry, 14
+  agent-level MCP tools (MCP **30 → 44**), the A2A skill-union agent card + fail-closed
+  bearer auth + unified dispatch (`/tasks/send`, `/tasks/{id}/cancel`), and node
+  file-loaders (`analyzeFile` / `deduplicateFile` / `matchSourcesFile`). Behavior-fixture
+  parity vs Python (`selectStrategy` decision table). The 3 agent tools with no TS core
+  (`sensitivity` / `incremental` / `certify_recall`) are declared Python-only.
 - **Opt-in WASM scorer backend.** `enableWasm()` / `disableWasm()` register a
   WebAssembly scorer (the Rust `score-core` kernel via the new `score-wasm`
   crate) behind the sync `scoreMatrix` for `jaro_winkler`/`levenshtein`/`exact`.

--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -1,8 +1,8 @@
 # goldenmatch (TypeScript)
 
-npm package `goldenmatch`. Parity port of the Python sibling at `packages/python/goldenmatch/`. Currently at **v0.11.0** (core-algorithm parity catch-up + Phase-5 golden-strategy plugin port). Python sibling is at v1.16; v1.13/v1.14/v1.16 are explicitly not-ported (see CHANGELOG.md for the per-version rationale).
+npm package `goldenmatch`. Parity port of the Python sibling at `packages/python/goldenmatch/`. **At `v1.0.0` — first stable release (2026-06-15).** The API is stable; breaking changes only at the next major. See the wave history below for the road here.
 
-> **Versioning note:** `package.json` was briefly set to `2.0.0` by #463 (the "Phase 5 plugin port" milestone label), but that broke the documented 0.x wave line and was never published (npm stayed at 0.10.0). Corrected to `0.11.0` for the release that ships the plugin port + the core-parity gap closure. The package stays intentionally pre-1.0.
+> **Versioning note:** `package.json` was briefly set to `2.0.0` by #463 (the "Phase 5 plugin port" milestone label) and reverted — see `docs/versioning-policy.md` for why 1.0.0 (a "this is stable" signal), NOT 2.0.0 (PyPI-alignment), was the right cut. npm and PyPI keep **independent semver** (not lockstep): PyPI is at 2.0.x; the npm line is its own. The `0.x → 1.0.0` jump is the one-time stability declaration after the AgentSession/A2A port closed the last undeclared parity gap.
 
 ## Wave history
 | npm | Python parity | Headline |

--- a/packages/typescript/goldenmatch/README.md
+++ b/packages/typescript/goldenmatch/README.md
@@ -18,7 +18,28 @@ npm install goldenmatch
 - **Edge-safe core** — the matching engine runs in browsers, Workers, Vercel Edge Runtime, Deno
 - **Pure TypeScript** — no native dependencies required; peer deps unlock performance (hnswlib, ONNX, piscina)
 - **Feature parity with Python goldenmatch** — same scorers, same clustering, same YAML configs
-- **590 tests, strict TypeScript** — `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`
+- **Strict TypeScript** — `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`
+
+## Compatibility with the Python package
+
+`goldenmatch` (npm) and `goldenmatch` (PyPI) are **independent semver lines** for the
+same toolkit — we do not lockstep the version numbers. The TS package is an **edge-safe
+subset**: it deliberately omits a few Python-only surfaces (below) so it can run in
+browsers, Workers, and edge runtimes. Everything else is at **core parity**
+(scoring, blocking, clustering, golden records, auto-config, identity graph, PPRL,
+learning memory, MCP, A2A, CLI), validated by Python-generated parity fixtures.
+
+| npm | ≈ PyPI | What the npm release covers |
+|-----|--------|-----------------------------|
+| **1.0.0** | 2.0.x | Stable API. Core ER + identity graph + MCP (44 tools) + A2A (bearer auth) + the AgentSession agent surface. |
+| 0.4–0.13 | 1.6–1.30 | Pre-1.0 wave line (see `CHANGELOG.md`). |
+
+**Python-only by design (not in the npm package):**
+- Distributed engine (Ray / GPU / Vertex embeddings) — the npm package is single-node / edge.
+- REST API + React web UI — npm ships a thin programmatic server only.
+- Agent tools `sensitivity` / `incremental` / `certify_recall` — no TS core.
+
+Rationale + the full policy: [`docs/versioning-policy.md`](https://github.com/benseverndev-oss/goldenmatch/blob/main/docs/versioning-policy.md).
 
 ## Quick Start
 

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "0.13.0",
+  "version": "1.0.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Cuts npm `goldenmatch` **1.0.0** — first stable release, per [`docs/versioning-policy.md`](https://github.com/benseverndev-oss/goldenmatch/blob/main/docs/versioning-policy.md).

**Why 1.0.0 (not 2.0.0):** a one-time `0.13.0 → 1.0.0` "this is stable" jump, not a PyPI-alignment bump. npm and PyPI keep independent semver (no lockstep) — the npm package is a deliberate edge-safe subset.

**Preconditions (all met):**
- Parity chain closed: #857, #860, #856, #858.
- Staleness gate live in CI (`ts_parity_freshness` + `regen_ts_parity_fixtures.sh`).
- AgentSession/A2A port complete: #989 / #994 / #995 / #996 — the last undeclared parity gap.

**This PR:** `package.json` 0.13.0 → 1.0.0, CHANGELOG `[1.0.0]` (stability declaration + agent-port summary), compatibility matrix in the TS + Python READMEs (scope deltas: distributed engine / web UI + `sensitivity`/`incremental`/`certify_recall` are Python-only).

**Does NOT publish** — npm publish fires on the `goldenmatch-js-v1.0.0` tag, cut separately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)