### PR TITLE
chore(deps): arrow 55->59 + pyo3 0.28 for the 3 independent pyarrow crates (Phase 2)

### DIFF
--- a/packages/rust/extensions/analysis-native/Cargo.toml
+++ b/packages/rust/extensions/analysis-native/Cargo.toml
@@ -22,14 +22,14 @@ crate-type = ["cdylib"]
 [dependencies]
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
 # extension-module: don't link libpython (this .so is imported BY CPython).
-pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = ">=0.28, <0.29", features = ["extension-module", "abi3-py311"] }
 # Pyo3-free histogram/quantile kernels; the #[pyfunction] shims below are thin
 # Arrow-reading wrappers over this crate.
 analysis-core = { path = "../analysis-core" }
 # Arrow C Data Interface for zero-copy kernel input (mirrors goldencheck-native).
 # `pyarrow` brings the PyArrowType FFI bridge; default features (csv/ipc/json/
 # compute) are off -- we only read array buffers.
-arrow = { version = "55", default-features = false, features = ["pyarrow"] }
+arrow = { version = "59", default-features = false, features = ["pyarrow"] }
 
 [profile.release]
 opt-level = 3

--- a/packages/rust/extensions/goldencheck-native/Cargo.toml
+++ b/packages/rust/extensions/goldencheck-native/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
 # extension-module: don't link libpython (this .so is imported BY CPython).
-pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = ">=0.28, <0.29", features = ["extension-module", "abi3-py311"] }
 # Pyo3-free deep-profiling kernels (Benford, composite-key & FD mining). The
 # #[pyfunction] shims below are thin Arrow-reading wrappers over this crate.
 goldencheck-core = { path = "../goldencheck-core" }
@@ -31,7 +31,7 @@ rustc-hash = "2"
 # Arrow C Data Interface for zero-copy kernel input (mirrors goldenmatch's
 # native crate). `pyarrow` brings the PyArrowType FFI bridge; default features
 # (csv/ipc/json/compute) are off -- we only read array buffers.
-arrow = { version = "55", default-features = false, features = ["pyarrow"] }
+arrow = { version = "59", default-features = false, features = ["pyarrow"] }
 
 [profile.release]
 opt-level = 3

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -20,11 +20,11 @@ crate-type = ["cdylib"]
 [dependencies]
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
 # extension-module: don't link libpython (this .so is imported BY CPython).
-pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = ">=0.28, <0.29", features = ["extension-module", "abi3-py311"] }
 # Arrow C Data Interface for zero-copy kernel input/output (Utf8 / LargeUtf8
 # string buffers in, string/int/bool buffers out). default features off — we
 # only read/build array buffers, no csv/ipc/json/compute.
-arrow = { version = "55", default-features = false, features = ["pyarrow"] }
+arrow = { version = "59", default-features = false, features = ["pyarrow"] }
 # Phone parsing/formatting: a Rust port of Google's libphonenumber. Backs the
 # international phone kernel (E.164 / national / country-code / validity). Its
 # E.164 output is metadata-driven and matches the Python `phonenumbers`

--- a/packages/rust/extensions/native-flow/src/util.rs
+++ b/packages/rust/extensions/native-flow/src/util.rs
@@ -38,7 +38,7 @@ where
 {
     let len = make_array(data.clone()).len();
     let mut builder = StringBuilder::with_capacity(len, len * 12);
-    py.allow_threads(|| -> PyResult<()> {
+    py.detach(|| -> PyResult<()> {
         for_each_str(&data, |_, v| match v {
             Some(s) => match f(s) {
                 Some(out) => builder.append_value(out),
@@ -56,7 +56,7 @@ where
 {
     let len = make_array(data.clone()).len();
     let mut builder = Int64Builder::with_capacity(len);
-    py.allow_threads(|| -> PyResult<()> {
+    py.detach(|| -> PyResult<()> {
         for_each_str(&data, |_, v| match v.and_then(&f) {
             Some(out) => builder.append_value(out),
             None => builder.append_null(),
@@ -71,7 +71,7 @@ where
 {
     let len = make_array(data.clone()).len();
     let mut builder = BooleanBuilder::with_capacity(len);
-    py.allow_threads(|| -> PyResult<()> {
+    py.detach(|| -> PyResult<()> {
         for_each_str(&data, |_, v| match v.and_then(&f) {
             Some(out) => builder.append_value(out),
             None => builder.append_null(),


### PR DESCRIPTION
Phase 2 of the arrow 55->59 pyarrow upgrade (spec+plan under `docs/superpowers/`, landed with Phase 1 #1003).

Bumps the three **independent** pyarrow crates to arrow 59 + pyo3 0.28:
- `analysis-native` (version-only; no GIL/downcast usage)
- `goldencheck-native` (version-only)
- `native-flow` (+ 3 `allow_threads`->`detach` in util.rs)

None of the three use the `numpy` crate, so this is lighter than Phase 1 (native). datafusion-udf stays on arrow 58 (insulated). Not enqueued yet -- validating each crate's wheel build against arrow 59 + pyo3 0.28 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
