### PR TITLE
chore: contribution infra (issue templates, CoC, CODEOWNERS, PR template, pre-commit)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# EditorConfig - consistent whitespace across editors. https://editorconfig.org
+# Mirrors the conventions ruff (Python) and the TS/JSON/Rust tooling already
+# assume, so editors stop fighting CI over indentation and line endings.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.py]
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc,yml,yaml,toml}]
+indent_size = 2
+
+[*.rs]
+indent_size = 4
+
+[*.md]
+# Preserve trailing-whitespace hard line breaks in Markdown.
+trim_trailing_whitespace = false
+
+[*.{bat,cmd}]
+# Windows batch scripts require CRLF.
+end_of_line = crlf
+
+[Makefile]
+indent_style = tab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners - default reviewer for the whole monorepo. Single maintainer
+# today; split this by area (per-package handles or teams) as more land.
+# Note: this only auto-requests review. It enforces review only if branch
+# protection has "Require review from Code Owners" enabled.
+# Docs: https://docs.github.com/articles/about-code-owners
+* @benzsevern

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Report a reproducible problem in a Golden Suite package.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Fill in the fields below so it can be reproduced
+        on the first try. Do NOT report security issues here - use a private
+        advisory (see SECURITY.md).
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which package is affected?
+      options:
+        - goldenmatch (Python)
+        - goldencheck (Python)
+        - goldenflow (Python)
+        - goldenpipe (Python)
+        - infermap (Python)
+        - goldenanalysis (Python)
+        - goldensuite-mcp / MCP server
+        - TypeScript port (*-js)
+        - Rust extension (native / datafusion / pgrx / embed)
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Installed version, or commit SHA if built from source.
+      placeholder: "goldenmatch==2.0.0"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What went wrong, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproducer
+      description: >-
+        The smallest command or code snippet that triggers it. Include the input
+        shape if the bug is data-dependent.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python/Node/Rust version, and install method (pip / npm / source).
+      placeholder: |
+        OS: Windows 11
+        Python: 3.12
+        Installed via: pip
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go to a private advisory).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# Disable blank issues so reporters land on a form (or a contact link).
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/benseverndev-oss/goldenmatch/security/advisories/new
+    about: >-
+      Do NOT open a public issue for security reports. Open a private GitHub
+      Security Advisory instead. See SECURITY.md for scope and response targets.
+  - name: Question or usage help
+    url: https://github.com/benseverndev-oss/goldenmatch/discussions
+    about: >-
+      Ask in Discussions. Issues are for reproducible bugs and concrete feature
+      requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Suggest a capability or improvement for a Golden Suite package.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Describe the problem first - the use case matters
+        more than a specific implementation.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which package would this affect?
+      options:
+        - goldenmatch (Python)
+        - goldencheck (Python)
+        - goldenflow (Python)
+        - goldenpipe (Python)
+        - infermap (Python)
+        - goldenanalysis (Python)
+        - goldensuite-mcp / MCP server
+        - TypeScript port (*-js)
+        - Rust extension (native / datafusion / pgrx / embed)
+        - Cross-cutting / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that is hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? An API sketch is welcome but not required.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why they fall short.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Keep PRs scoped. CI is path-filtered, so only the areas you touch will run.
+Release notes / changelog text must be ASCII (no em-dashes) - the Release API
+rejects them.
+-->
+
+## What and why
+
+<!-- One or two sentences: what changed and the reason. Link the issue if any. -->
+
+## Changes
+
+-
+
+## Testing
+
+<!-- Commands you ran (e.g. `uv run pytest packages/python/<pkg>`,
+`cargo test`, `pnpm turbo run test`) and the result. -->
+
+## Checklist
+
+- [ ] Tests added/updated and passing locally for the changed package
+- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
+- [ ] Package `CHANGELOG.md` updated if behavior changed
+- [ ] No secrets, tokens, or `.env` files committed
+- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# Pre-commit hooks - shift lint + secret checks left so they fail on `git commit`
+# instead of after a CI round-trip. Install once per clone:
+#   uv tool install pre-commit      (or: pipx install pre-commit)
+#   pre-commit install
+# Run against the whole tree on demand: pre-commit run --all-files
+#
+# Scope is deliberately FAST. Slow gates (clippy, tsc, pytest, the full ruff
+# rule set, ruff-format) stay in CI so the commit hook never tempts anyone into
+# `git commit --no-verify`. The `ruff` hook below uses the SAME root
+# pyproject.toml [tool.ruff.lint] config CI enforces, so it can't diverge.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.2
+    hooks:
+      # Lint only (mirrors CI's `ruff check`). --fix auto-applies safe fixes.
+      # ruff-format is intentionally NOT wired here: CI does not format today,
+      # so adding it would impose a formatter the codebase hasn't adopted.
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        # Keep Markdown hard line breaks (two trailing spaces) intact.
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        # The only legitimately-large files are LFS-tracked fixtures
+        # (synthetic_1m.csv). Cap accidental data/binary commits well under that.
+        args: [--maxkb=1024]
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-toml
+      - id: check-json
+      # Security backstop: block committing a private key. gitleaks (CI, see
+      # .github/workflows/secret-scan.yml) covers the broader token surface
+      # such as the .mcpregistry_* bearer tokens.
+      - id: detect-private-key

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at ben@bensevern.dev (subject: [conduct]). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,14 @@ cargo test --workspace --manifest-path packages/rust/extensions/Cargo.toml
 python scripts/build_native.py
 ```
 
+**Pre-commit hooks** (fast lint + secret checks, shifted left of CI):
+
+```bash
+uv tool install pre-commit   # or: pipx install pre-commit
+pre-commit install           # runs ruff + whitespace + private-key check on commit
+pre-commit run --all-files   # run against the whole tree on demand
+```
+
 ## Branches, commits, and PRs
 
 - Branch off `main`; open a **pull request** back into `main` (draft until ready).
@@ -92,5 +100,11 @@ Cut the version bump (lockstep, above) in a PR first, merge, then tag.
 - Anchor fixture paths to `__file__`, not the CWD (CWD differs between local and
   CI runs).
 - `ruff` (Python) and `tsc --noEmit` (TypeScript) must pass.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By taking
+part you agree to uphold it. Report unacceptable behavior to `ben@bensevern.dev`
+(subject: `[conduct]`).
 
 Thanks for contributing!


### PR DESCRIPTION
## What and why

Lands the contribution-infra files that were missing from `main`. Lowers the friction for a first-time contributor and routes security/question traffic away from public bug issues.

`main` already has `CONTRIBUTING.md` and `SECURITY.md`, so this does **not** rewrite them. CONTRIBUTING gains only two pointers (pre-commit + Code of Conduct).

## Changes

- **Issue templates** (`.github/ISSUE_TEMPLATE/`): `bug_report.yml` + `feature_request.yml` issue forms, and `config.yml` with `blank_issues_enabled: false`. Security reports are routed to a private GitHub Security Advisory; questions to Discussions.
- **CODE_OF_CONDUCT.md**: Contributor Covenant 2.1, reporting contact `ben@bensevern.dev` (matches `SECURITY.md`). Pulled verbatim from the canonical source.
- **.github/CODEOWNERS** and **.github/pull_request_template.md**.
- **.pre-commit-config.yaml** (ruff lint + whitespace + private-key detect) and **.editorconfig**.
- **CONTRIBUTING.md**: add a pre-commit-hooks block and a Code of Conduct section. No other prose changed.

## Testing

- Issue-form + pre-commit YAML validated with `yaml.safe_load` (all parse).
- Diff is purely additive: `+345 / -0`.

## Checklist

- [x] No behavior change in any package (infra/docs only)
- [x] No secrets or tokens committed
- [x] ASCII content (Release-API safe)