### PR TITLE
chore: add .github/FUNDING.yml (GitHub Sponsors button)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Configures the "Sponsor" button on the repo.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: [benzsevern]


### PR DESCRIPTION
Adds the repo Sponsor button pointing at GitHub Sponsors (`@benzsevern`). Split from #1009 since that PR was already in the merge queue.

Note: the button only renders if GitHub Sponsors is enabled on the `benzsevern` account; otherwise it is inert (no 404).