### PR TITLE
fix(sail): truncate label-prop WCC lineage (real-cluster hang) + GKE proof kit

### DIFF
--- a/packages/python/goldenmatch/deploy/sail-gke/Dockerfile
+++ b/packages/python/goldenmatch/deploy/sail-gke/Dockerfile
@@ -1,0 +1,37 @@
+# Sail driver+worker image for the GKE smoke proof.
+# One image is used for BOTH the driver (runs `sail spark server`) and the
+# ephemeral worker pods it spawns, so the rapidfuzz scorer UDF and the
+# goldenmatch survivorship UDF resolve natively on the executors.
+#
+# pysail ships the `sail` binary as a wheel (no Rust build); goldenmatch[sail]
+# pulls the pipeline code + rapidfuzz + the Spark Connect client. The 300k-row
+# smoke dataset is generated AT BUILD TIME and baked in at /data/smoke (so the
+# distributed read needs no object-store credentials for the smoke).
+FROM python:3.12-slim
+
+ARG PYSAIL_VERSION=0.6.4
+ARG SMOKE_ROWS=300000
+ARG SMOKE_PARTS=8
+
+# setuptools: Python 3.12 dropped distutils; pyspark 3.5's pandas check imports
+#   distutils.version.LooseVersion -> setuptools provides the shim.
+# pandas/pyarrow pinned to ranges pyspark 3.5's pandas-UDF path expects (the
+#   unconstrained resolve pulled pandas 3.0 + pyarrow 24, both too new for it).
+RUN pip install --no-cache-dir \
+        "pysail==${PYSAIL_VERSION}" \
+        "goldenmatch[sail]" \
+        "pyspark[connect]>=3.5,<4" \
+        "setuptools>=70" \
+        "pandas>=2.0,<2.3" \
+        "pyarrow>=14,<18"
+
+# Prove what actually resolved (versions land in the build log).
+RUN pip list 2>/dev/null | grep -Ei "pysail|pyspark|goldenmatch|rapidfuzz|polars|pyarrow" || true
+
+COPY gen_sail_smoke.py run_smoke.py /app/
+
+RUN python /app/gen_sail_smoke.py /data/smoke ${SMOKE_ROWS} ${SMOKE_PARTS}
+
+# pysail's entrypoint is /usr/local/bin/sail; the k8s manifest overrides
+# command/args for the driver and the bench Job sets its own command.
+ENTRYPOINT ["/usr/local/bin/sail"]

--- a/packages/python/goldenmatch/deploy/sail-gke/README.md
+++ b/packages/python/goldenmatch/deploy/sail-gke/README.md
@@ -1,0 +1,69 @@
+# Sail-on-GKE bring-up kit + smoke proof
+
+Reusable kit for running the `goldenmatch.sail` (Spark Connect) pipeline on a real
+distributed Sail cluster on GKE, plus the diagnostic that motivated the WCC
+lineage-checkpoint fix in this package.
+
+## Result of the 2026-06-15 smoke proof
+The full Sail pipeline runs **end-to-end, distributed, on a real multi-node GKE Sail
+cluster** (driver in `kubernetes-cluster` mode spawns worker pods across nodes; the
+rapidfuzz scorer UDF runs on workers). At N=4000 it produced 747 golden records in
+~35s. It did NOT scale: the WCC stage blew up superlinearly (2.9s @1.5K -> 22.4s @4K
+-> wedged by 12K rows).
+
+## Root cause + fix
+The WCC is `goldenmatch/sail/clustering.py` (ours). It iterates Spark joins and, per
+round, re-joins `labels` against itself, growing the Spark Connect plan unbounded.
+Sail has no working lineage-truncation primitive (`cache` is a no-op; `persist` /
+`localCheckpoint` / `checkpoint` are "planned" -- see Sail issue
+https://github.com/lakehq/sail/issues/482, which we commented on with this benchmark).
+So the loop recomputes all prior rounds (O(rounds^2)) and wedges.
+
+Fix (this package): truncate lineage with a parquet write+read barrier
+(`_truncate_lineage`) every N rounds. `connected_components_scale` already had this;
+this kit's PR brings the label-prop `connected_components` to parity and threads
+`wcc_checkpoint_interval` / `wcc_checkpoint_dir` through `run_sail_pipeline` for both
+algorithms. Opt-in (default off = byte-identical). At scale the checkpoint dir must be
+shared storage reachable by all workers (`gs://...` via Workload Identity).
+
+## Files
+- `Dockerfile` -- driver/worker/bench image: `python:3.12-slim` + `pysail==0.6.4` +
+  `goldenmatch[sail]` + pinned `pandas<2.3` / `pyarrow<18` (pyspark 3.5 needs them) +
+  `setuptools` (py3.12 dropped distutils). Bakes a 300k-row smoke dataset at build.
+- `gen_sail_smoke.py` -- synthetic dataset (soundex-spread surnames; prints block stats).
+- `run_smoke.py` -- in-cluster end-to-end runner (`SMOKE_DATA`, `SMOKE_WCC` env).
+- `diag.py` -- per-stage timing probe (mounted via ConfigMap; how the WCC wall was found).
+- `sail.yaml` -- driver Deployment + Service + RBAC (`${SAIL_IMAGE}` substituted at apply).
+- `bench-job.yaml` / `diag-job.yaml` -- the run + diagnostic Jobs.
+
+## Runbook
+```
+# APIs + tools
+gcloud services enable container.googleapis.com cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com
+gcloud components install kubectl gke-gcloud-auth-plugin
+
+# image (Cloud Build; no local Docker)
+gcloud artifacts repositories create sail --repository-format=docker --location=us-central1
+gcloud builds submit --tag REGION-docker.pkg.dev/PROJECT/sail/sail-goldenmatch:v1 \
+  --timeout=1800 .
+
+# cluster + deploy (render ${SAIL_IMAGE} -> the AR image before apply)
+gcloud container clusters create sail-smoke --zone us-central1-a --num-nodes 3 \
+  --machine-type e2-standard-4
+gcloud container clusters get-credentials sail-smoke --zone us-central1-a
+kubectl apply -f sail.yaml
+kubectl -n sail rollout status deploy/sail-spark-server
+kubectl apply -f bench-job.yaml
+kubectl -n sail logs job/sail-smoke-bench -f
+
+# teardown
+gcloud container clusters delete sail-smoke --zone us-central1-a --quiet
+```
+
+## Operational gotchas
+- Clean up worker pods by `sail-worker-*` name, NEVER by `-l app.kubernetes.io/name=sail`
+  (that label also matches the driver).
+- Deleting the bench Job orphans the driver's worker pods.
+- Sail re-provisions a fresh worker pool per stage (stateless-by-design); the wall-time
+  tax on iterative pipelines is mitigated by lineage truncation, not warm pools.

--- a/packages/python/goldenmatch/deploy/sail-gke/bench-job.yaml
+++ b/packages/python/goldenmatch/deploy/sail-gke/bench-job.yaml
@@ -1,0 +1,35 @@
+# Runs the in-cluster smoke (run_smoke.py) against the Sail driver Service.
+# Same image as the driver/workers, so the baked-in /data/smoke is present and
+# goldenmatch is importable. Image substituted at apply time from $SAIL_IMAGE.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sail-smoke-bench
+  namespace: sail
+spec:
+  backoffLimit: 0
+  completions: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sail
+        app.kubernetes.io/component: smoke-bench
+    spec:
+      restartPolicy: Never
+      serviceAccountName: sail-user
+      containers:
+        - name: bench
+          image: ${SAIL_IMAGE}
+          command: ["python", "/app/run_smoke.py"]
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+          env:
+            - name: SAIL_REMOTE
+              value: "sc://sail-spark-server.sail.svc.cluster.local:50051"
+            - name: SMOKE_DATA
+              value: "/data/smoke"
+            - name: RUST_LOG
+              value: info

--- a/packages/python/goldenmatch/deploy/sail-gke/diag-job.yaml
+++ b/packages/python/goldenmatch/deploy/sail-gke/diag-job.yaml
@@ -1,0 +1,35 @@
+# Diagnostic Job: runs diag.py (from the 'diag' ConfigMap) against the Sail
+# driver to isolate which pipeline stage wedges. Image substituted at apply.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sail-diag
+  namespace: sail
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: diag
+    spec:
+      restartPolicy: Never
+      serviceAccountName: sail-user
+      volumes:
+        - name: diag
+          configMap:
+            name: diag
+      containers:
+        - name: diag
+          image: ${SAIL_IMAGE}
+          command: ["python", "/diag/diag.py"]
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: "300m"
+              memory: "512Mi"
+          volumeMounts:
+            - name: diag
+              mountPath: /diag
+          env:
+            - name: SAIL_REMOTE
+              value: "sc://sail-spark-server.sail.svc.cluster.local:50051"

--- a/packages/python/goldenmatch/deploy/sail-gke/diag.py
+++ b/packages/python/goldenmatch/deploy/sail-gke/diag.py
@@ -1,0 +1,45 @@
+"""Stage-isolation probe for the Sail-on-GKE hang. score_and_dedup was shown
+fast/scaling; this times WCC and golden too, at increasing N, to find which
+stage wedges and at what scale. Mounted via ConfigMap (editable, no rebuild)."""
+import os
+import time
+
+from goldenmatch.sail.clustering import connected_components
+from goldenmatch.sail.golden import build_golden
+from goldenmatch.sail.scoring import score_and_dedup
+from goldenmatch.sail.session import connect
+
+remote = os.environ.get(
+    "SAIL_REMOTE", "sc://sail-spark-server.sail.svc.cluster.local:50051"
+)
+spark = connect(remote)
+print("DIAG connected", flush=True)
+base = spark.read.parquet("/data/smoke/part-00.parquet")
+
+for n in (1500, 4000, 12000, 37500):
+    print(f"DIAG ===== N={n} =====", flush=True)
+    src = base.limit(n)
+    ids = src.select("__row_id__")
+
+    t = time.perf_counter()
+    pairs = score_and_dedup(
+        src, block_col="last_name_soundex", value_col="last_name",
+        id_col="__row_id__", scorer_name="jaro_winkler", threshold=0.85,
+    )
+    npairs = pairs.count()
+    print(f"DIAG  score   pairs={npairs} t={time.perf_counter()-t:.1f}s", flush=True)
+
+    t = time.perf_counter()
+    asg = connected_components(pairs, ids, id_col="__row_id__")
+    nasg = asg.count()
+    print(f"DIAG  wcc     assignments={nasg} t={time.perf_counter()-t:.1f}s", flush=True)
+
+    t = time.perf_counter()
+    golden = build_golden(
+        asg, src, value_cols=["first_name", "email"],
+        source_id_col="__row_id__", strategy="most_complete",
+    )
+    ngold = golden.count()
+    print(f"DIAG  golden  count={ngold} t={time.perf_counter()-t:.1f}s", flush=True)
+
+print("DIAG DONE", flush=True)

--- a/packages/python/goldenmatch/deploy/sail-gke/gen_sail_smoke.py
+++ b/packages/python/goldenmatch/deploy/sail-gke/gen_sail_smoke.py
@@ -1,0 +1,135 @@
+"""Generate a synthetic smoke dataset for the Sail-on-GKE proof.
+
+Writes a DIRECTORY of parquet parts (distributed-read friendly) with the
+columns the Sail bench expects: ``__row_id__`` (int), ``last_name``,
+``last_name_soundex`` (the block key), ``first_name``, ``email``.
+
+Critical invariant (see memory ``feedback_synthetic_surname_fixtures``):
+surnames are drawn from a large pool that spreads across many soundex codes,
+so no single soundex block blows up into an O(block^2) self-join that hangs.
+The script prints the block-size distribution so the build log proves it.
+
+Usage: ``python gen_sail_smoke.py <out_dir> [n_rows] [n_parts]``
+"""
+from __future__ import annotations
+
+import os
+import random
+import sys
+
+
+def soundex(name: str) -> str:
+    """Standard American Soundex (letter + 3 digits)."""
+    s = "".join(ch for ch in name.upper() if ch.isalpha())
+    if not s:
+        return "0000"
+    codes = {}
+    for letters, d in (
+        ("BFPV", "1"),
+        ("CGJKQSXZ", "2"),
+        ("DT", "3"),
+        ("L", "4"),
+        ("MN", "5"),
+        ("R", "6"),
+    ):
+        for ch in letters:
+            codes[ch] = d
+    first = s[0]
+    prev = codes.get(first, "")
+    out = ""
+    for ch in s[1:]:
+        c = codes.get(ch, "")
+        if c and c != prev:
+            out += c
+        if ch in "AEIOUY":
+            prev = ""
+        elif ch not in "HW":
+            prev = c
+        if len(out) >= 3:
+            break
+    return (first + out + "000")[:4]
+
+
+def build_surname_pool() -> list[str]:
+    """A few hundred thousand distinct synthetic surnames -> thousands of
+    distinct soundex codes, so uniform sampling yields small bounded blocks."""
+    cons = "bcdfghjklmnprstvwz"
+    vows = "aeiou"
+    stems = [c + v for c in cons for v in vows]  # 85
+    ends = [
+        "ner", "son", "man", "ton", "ler", "der", "sen", "ley", "ford",
+        "well", "wood", "ham", "by", "ston", "mer", "field", "worth",
+        "ridge", "land", "dale",
+    ]  # 20
+    pool = {(a + b + e).capitalize() for a in stems for b in stems for e in ends}
+    return sorted(pool)
+
+
+def main() -> int:
+    out = sys.argv[1] if len(sys.argv) > 1 else "/data/smoke"
+    n = int(sys.argv[2]) if len(sys.argv) > 2 else 300_000
+    parts = int(sys.argv[3]) if len(sys.argv) > 3 else 8
+
+    import polars as pl
+
+    rng = random.Random(42)
+    pool = build_surname_pool()
+    firsts = [
+        "James", "Mary", "John", "Patricia", "Robert", "Jennifer", "Michael",
+        "Linda", "William", "Elizabeth", "David", "Barbara", "Richard",
+        "Susan", "Joseph", "Jessica", "Thomas", "Sarah", "Charles", "Karen",
+        "Chris", "Nancy", "Daniel", "Lisa", "Matthew", "Betty", "Anthony",
+        "Sandra", "Mark", "Ashley",
+    ]
+    domains = ["example.com", "mail.com", "test.org", "corp.net", "inbox.io"]
+
+    surnames = rng.choices(pool, k=n)
+    firstnames: list[str | None] = rng.choices(firsts, k=n)
+    emails: list[str | None] = []
+    for i in range(n):
+        if rng.random() < 0.30:  # blank ~30% of emails -> survivorship has work
+            emails.append(None)
+        else:
+            fn = firstnames[i].lower()  # type: ignore[union-attr]
+            emails.append(
+                f"{fn}.{surnames[i].lower()}{rng.randrange(1000)}@{rng.choice(domains)}"
+            )
+    for i in range(n):
+        if rng.random() < 0.10:  # blank ~10% of first names
+            firstnames[i] = None
+
+    df = pl.DataFrame(
+        {
+            "__row_id__": list(range(n)),
+            "last_name": surnames,
+            "first_name": firstnames,
+            "email": emails,
+        }
+    ).with_columns(
+        pl.col("last_name")
+        .map_elements(soundex, return_dtype=pl.String)
+        .alias("last_name_soundex")
+    )
+
+    stats = df.group_by("last_name_soundex").len().sort("len", descending=True)
+    print(
+        f"[gen] rows={n} parts={parts} distinct_soundex={stats.height} "
+        f"max_block={stats['len'][0]} "
+        f"top5={stats['len'][:5].to_list()}",
+        flush=True,
+    )
+
+    os.makedirs(out, exist_ok=True)
+    rows_per = (n + parts - 1) // parts
+    written = 0
+    for k in range(parts):
+        sub = df.slice(k * rows_per, rows_per)
+        if sub.height:
+            sub.write_parquet(os.path.join(out, f"part-{k:02d}.parquet"))
+            written += 1
+    print(f"[gen] wrote {written} parquet parts to {out}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/deploy/sail-gke/run_smoke.py
+++ b/packages/python/goldenmatch/deploy/sail-gke/run_smoke.py
@@ -1,0 +1,72 @@
+"""In-cluster Sail smoke runner. Connects to the Sail driver over Spark
+Connect, runs the full distributed pipeline over the baked-in parquet, and
+prints a single ``RESULT {...}`` JSON line plus a connectivity pre-check.
+
+Env:
+  SAIL_REMOTE  Spark Connect URL (default: the in-cluster driver Service).
+  SMOKE_DATA   parquet dir (default: /data/smoke, baked into the image).
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+
+
+def main() -> int:
+    remote = os.environ.get(
+        "SAIL_REMOTE", "sc://sail-spark-server.sail.svc.cluster.local:50051"
+    )
+    data = os.environ.get("SMOKE_DATA", "/data/smoke")
+    # WCC: "label_prop" converges in ~graph-diameter rounds (few stages for
+    # small clusters -> fast under Sail's per-stage worker provisioning);
+    # "scale" is pointer-jumping (fixed ~log2(N) rounds, more stages).
+    wcc = os.environ.get("SMOKE_WCC", "label_prop")
+
+    from goldenmatch.sail.pipeline import run_sail_pipeline
+    from goldenmatch.sail.session import connect
+
+    print(f"[smoke] connecting to {remote}", flush=True)
+    spark = connect(remote)
+
+    # Connectivity pre-check: a trivial distributed count.
+    try:
+        n3 = spark.createDataFrame([(1,), (2,), (3,)], ["x"]).count()
+        print(f"[smoke] connectivity_ok rows={n3}", flush=True)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[smoke] connectivity_check_failed: {exc!r}", flush=True)
+
+    src = spark.read.parquet(data)
+    n_in = src.count()
+    print(f"[smoke] input_rows={n_in}", flush=True)
+
+    t0 = time.perf_counter()
+    golden = run_sail_pipeline(
+        src,
+        id_col="__row_id__",
+        block_col="last_name_soundex",
+        value_col="last_name",
+        golden_cols=["first_name", "email"],
+        wcc=wcc,
+    )
+    n_golden = golden.count()  # forces the full distributed pipeline
+    wall = time.perf_counter() - t0
+
+    payload = {
+        "wall_s": round(wall, 2),
+        "golden_count": n_golden,
+        "input_rows": n_in,
+        "wcc": wcc,
+        "remote": remote,
+        "data": data,
+    }
+    print("RESULT " + json.dumps(payload), flush=True)
+    try:
+        golden.show(5, truncate=False)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[smoke] golden.show failed (non-fatal): {exc!r}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/deploy/sail-gke/sail.yaml
+++ b/packages/python/goldenmatch/deploy/sail-gke/sail.yaml
@@ -1,0 +1,110 @@
+# Sail distributed (kubernetes-cluster mode) on GKE. Adapted from the official
+# LakeSail k8s manifest: the driver Deployment spawns ephemeral worker pods
+# (RBAC: pods/*), both using our sail-goldenmatch image. Image is substituted
+# at apply time from $SAIL_IMAGE.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sail
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sail-user
+  namespace: sail
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sail-spark-server
+  namespace: sail
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sail-spark-server
+  namespace: sail
+subjects:
+  - kind: ServiceAccount
+    name: sail-user
+    namespace: sail
+roleRef:
+  kind: Role
+  name: sail-spark-server
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sail-spark-server
+  namespace: sail
+  labels:
+    app.kubernetes.io/name: sail
+    app.kubernetes.io/component: spark-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sail
+      app.kubernetes.io/component: spark-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sail
+        app.kubernetes.io/component: spark-server
+    spec:
+      serviceAccountName: sail-user
+      containers:
+        - name: server
+          image: ${SAIL_IMAGE}
+          command: ["sail"]
+          args: ["spark", "server", "--ip", "0.0.0.0", "--port", "50051"]
+          ports:
+            - containerPort: 50051
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: SAIL_MODE
+              value: "kubernetes-cluster"
+            - name: SAIL_CLUSTER__DRIVER_LISTEN_HOST
+              value: "0.0.0.0"
+            - name: SAIL_CLUSTER__DRIVER_EXTERNAL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SAIL_KUBERNETES__IMAGE
+              value: ${SAIL_IMAGE}
+            - name: SAIL_KUBERNETES__NAMESPACE
+              value: sail
+            - name: SAIL_KUBERNETES__DRIVER_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SAIL_KUBERNETES__WORKER_SERVICE_ACCOUNT_NAME
+              value: sail-user
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sail-spark-server
+  namespace: sail
+  labels:
+    app.kubernetes.io/name: sail
+    app.kubernetes.io/component: spark-server
+spec:
+  selector:
+    app.kubernetes.io/name: sail
+    app.kubernetes.io/component: spark-server
+  ports:
+    - protocol: TCP
+      port: 50051
+      targetPort: 50051


### PR DESCRIPTION
## What
The Sail label-prop WCC (`connected_components`) now truncates its Spark Connect lineage with an opt-in parquet barrier, matching `connected_components_scale`. Both WCC algorithms accept `wcc_checkpoint_interval` / `wcc_checkpoint_dir` via `run_sail_pipeline`. Default off = byte-identical.

## Why
Running the full Sail pipeline on a real distributed GKE Sail cluster surfaced a hang in the WCC stage. Per-stage timing isolated it:

| input rows | score | wcc | golden |
|---|---|---|---|
| 1,500 | 2.8s | 2.9s | 1.6s |
| 4,000 | 0.1s | 22.4s | 12.3s |
| 12,000 | 0.3s | hung >2min | - |

`connected_components` re-joins `labels` against itself each round; without a lineage barrier the Spark Connect plan grows unbounded (round k recomputes 1..k-1, O(rounds^2)). `connected_components_scale` already had the fix (decisions/0011); this brings the label-prop variant to parity and wires both through the pipeline.

Sail has no native lineage truncation (`cache` is a no-op; `persist` / `checkpoint` / `localCheckpoint` are "planned", lakehq/sail#482 where I posted this repro and offered to help), so the barrier must live in our code.

## Tests
Extends `tests/test_sail_clustering_checkpoint.py` (the `sail` lane): label-prop checkpoint is output-invariant vs no-checkpoint, and `checkpoint_interval>0` without a dir raises. Validated via the `sail` CI lane (pysail / pyspark Connect don't run on the Windows dev box).

## Also
`packages/python/goldenmatch/deploy/sail-gke/` -- the reusable GKE bring-up kit + runbook + the per-stage diagnostic that localized this, with a README capturing the proof result (distributed end-to-end at N=4000 -> 747 golden) and operational gotchas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
