### PR TITLE
feat(dbt): zero-config Fellegi-Sunter (probabilistic) dedupe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1786,9 +1786,11 @@ jobs:
           cargo pgrx install "--pg-config=/usr/lib/postgresql/${PG_VERSION}/bin/pg_config" --release --features "pg${PG_VERSION}" --no-default-features
           # pgrx 0.12.9 doesn't auto-emit the SQL extension file — copy the
           # handwritten ones into PG's extension dir so `CREATE EXTENSION`
-          # (installs default_version, now 0.7.0) and `ALTER EXTENSION ... UPDATE`
+          # (installs default_version, now 0.8.0) and `ALTER EXTENSION ... UPDATE`
           # find them. The schema files are the canonical declaration of public
           # function signatures.
+          cp sql/goldenmatch_pg--0.8.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.7.0--0.8.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.7.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.6.0--0.7.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.6.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
@@ -1896,6 +1898,15 @@ jobs:
                 RAISE NOTICE 'v1.7-v1.12 autoconfig surface not yet on main (waiting on PR #159)';
               END IF;
             END$$;
+          EOSQL
+          # goldenmatch_autoconfig(table, mode) -- 1-arg back-compat (mode DEFAULT
+          # 'standard') + the new 2-arg 'probabilistic' path, then pipe the
+          # probabilistic config straight into goldenmatch_dedupe_full.
+          sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 <<'EOSQL'
+            CREATE TEMP TABLE p AS SELECT * FROM (VALUES ('John Smith','Austin'),('Jon Smith','Austin'),('Jane Doe','Dallas')) t(name, city);
+            SELECT goldenmatch.goldenmatch_autoconfig('p');
+            SELECT goldenmatch.goldenmatch_autoconfig('p','probabilistic');
+            SELECT * FROM goldenmatch.goldenmatch_dedupe_full('p', (SELECT goldenmatch.goldenmatch_autoconfig('p','probabilistic'))) LIMIT 1;
           EOSQL
           # In-house embed (#737): proves `ort`/onnxruntime loads inside the
           # Postgres backend process (the new surface vs the proven DataFusion

--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -105,6 +105,8 @@ jobs:
           # canonical SQL file there. Path layout: <PKG_DIR>/usr/share/postgresql/<N>/extension/
           EXT_DIR="${PKG_DIR}/usr/share/postgresql/${PG_VERSION}/extension"
           mkdir -p "${EXT_DIR}"
+          cp sql/goldenmatch_pg--0.8.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.7.0--0.8.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.7.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.6.0--0.7.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.6.0.sql "${EXT_DIR}/"

--- a/docs-site/goldenmatch/installation.mdx
+++ b/docs-site/goldenmatch/installation.mdx
@@ -127,6 +127,15 @@ packages:
 
 then run `dbt deps`. The package provides macros for running entity resolution, quality gates, transforms, and identity-graph reads inside dbt pipelines (DuckDB, Postgres, and Snowflake).
 
+Zero-config Fellegi-Sunter dedupe needs no hand-written config:
+
+```sql
+{{ config(materialized='goldenmatch_dedupe', probabilistic=true) }}
+SELECT * FROM {{ ref('stg_customers') }}
+```
+
+`probabilistic=true` builds the FS model from the data (DuckDB + Postgres). Omit it for standard zero-config dedupe, or pass an explicit `match_config` for full control.
+
 ## Verify installation
 
 ```bash

--- a/packages/dbt/goldensuite/CHANGELOG.md
+++ b/packages/dbt/goldensuite/CHANGELOG.md
@@ -18,6 +18,13 @@ Suite monorepo and is consumed from there (not published to PyPI).
   (macros) and a `pip install "git+...#subdirectory=..."` for the Python helper.
 
 ### Added
+- **Zero-config Fellegi-Sunter dedupe.** `probabilistic=true` on the
+  `goldenmatch_dedupe` materialization (and `run_goldenmatch_dedupe(probabilistic=True)`)
+  builds an FS model from the data with no hand-written config; `match_config` is
+  now optional (omitting it runs standard zero-config dedupe). Backed by a new
+  `mode` parameter on `goldenmatch_autoconfig` across DuckDB + Postgres
+  (`goldenmatch-duckdb` 0.7.0, `goldenmatch_pg` 0.8.0). Snowflake + `probabilistic`
+  raises a clear error (explicit `match_config` still works there).
 - Restored the CI lane removed in #464: `dbt parse` smoke (in-memory DuckDB
   profile) plus the package's pytest suite now run on changes under `packages/dbt/**`.
 - Standalone `profiles.yml` + `profile:` key so the project parses on its own.

--- a/packages/dbt/goldensuite/README.md
+++ b/packages/dbt/goldensuite/README.md
@@ -38,6 +38,30 @@ result = run_goldenmatch_dedupe(
 print(f"Deduped {result['input_rows']} -> {result['clusters']} clusters")
 ```
 
+### Probabilistic (Fellegi-Sunter) entity resolution -- zero config
+
+```sql
+{{ config(materialized='goldenmatch_dedupe', probabilistic=true) }}
+SELECT * FROM {{ ref('stg_customers') }}
+```
+
+`probabilistic=true` builds a Fellegi-Sunter model from your data with no
+hand-written config (omit `match_config`). Setting both `match_config` and
+`probabilistic=true` is a compile-time error. Inspect the derived model
+directly (the m/u weights + comparison levels):
+
+```sql
+SELECT goldenmatch_autoconfig('stg_customers', 'probabilistic');
+```
+
+Omitting both `match_config` and `probabilistic` runs standard zero-config
+dedupe. Fellegi-Sunter needs enough rows with agreeing fields to train EM; a
+too-small table fails the model with a clear error rather than producing empty
+output. DuckDB + Postgres only in this release (Snowflake + `probabilistic`
+raises a clear error; use an explicit `match_config` there). The Python helper
+takes the same flag: `run_goldenmatch_dedupe(..., probabilistic=True)` (no
+`config_path`).
+
 ## Macros
 
 This package ships macros only (no models/seeds/snapshots). The

--- a/packages/dbt/goldensuite/dbt_goldensuite/materialize.py
+++ b/packages/dbt/goldensuite/dbt_goldensuite/materialize.py
@@ -15,19 +15,26 @@ from goldenmatch.core.pipeline import run_dedupe
 
 def run_goldenmatch_dedupe(
     input_table: str,
-    config_path: str,
-    output_table: str,
+    config_path: str | None = None,
+    output_table: str | None = None,
     database: str = ":memory:",
     memory_db_path: str | None = None,
     dataset: str | None = None,
+    *,
+    probabilistic: bool = False,
 ) -> dict:
     """Run GoldenMatch dedupe on a DuckDB table and write results back.
 
     Args:
         input_table: Source table name in DuckDB
-        config_path: Path to GoldenMatch YAML config
+        config_path: Path to GoldenMatch YAML config. Omit (and pass
+            ``probabilistic=True`` or leave the default deterministic
+            auto-config) to run with zero config file.
         output_table: Destination table name
         database: DuckDB database path
+        probabilistic: When True (and no ``config_path``), build a
+            Fellegi-Sunter config via ``auto_configure_probabilistic_df``
+            with no config file. Mutually exclusive with ``config_path``.
         memory_db_path: Optional MemoryStore SQLite path. When set, any
             field-level corrections (decision='field_correct') matching
             this run's dataset key are applied to the golden output as
@@ -40,6 +47,11 @@ def run_goldenmatch_dedupe(
         Summary dict with record counts, match rate, and (when
         memory_db_path is set) an ``applied_corrections`` count.
     """
+    if output_table is None:
+        raise TypeError("run_goldenmatch_dedupe() requires output_table")
+    if config_path is not None and probabilistic:
+        raise ValueError("pass either config_path or probabilistic=True, not both")
+
     conn = duckdb.connect(database)
 
     # Read input
@@ -51,7 +63,15 @@ def run_goldenmatch_dedupe(
         tmp_path = f.name
         df.write_csv(tmp_path)
 
-    cfg = load_config(config_path)
+    if config_path is not None:
+        cfg = load_config(config_path)
+    else:
+        from goldenmatch.core.autoconfig import (
+            auto_configure_df,
+            auto_configure_probabilistic_df,
+        )
+        cfg = (auto_configure_probabilistic_df(df) if probabilistic
+               else auto_configure_df(df))
     result = run_dedupe([(tmp_path, "source")], cfg)
 
     # Write results to DuckDB. NB: `a or b` triggers DataFrame.__bool__

--- a/packages/dbt/goldensuite/macros/materializations/_helpers.sql
+++ b/packages/dbt/goldensuite/macros/materializations/_helpers.sql
@@ -75,3 +75,49 @@
         ) }}
     {%- endif -%}
 {% endmacro %}
+
+
+{#--- Adapter-aware name for the autoconfig (plan) UDF. Snowflake intentionally
+       raises: the goldenmatch_autoconfig(table, mode) overload is DuckDB/Postgres
+       only in this release, so zero-config (which always emits the 2-arg mode
+       call) is unsupported there -- explicit match_config still works on Snowflake
+       because it never calls this macro. ---#}
+{% macro goldenmatch_autoconfig_fn_name(adapter_type) %}
+    {%- if adapter_type == 'postgres' -%}
+        {{ return('goldenmatch.goldenmatch_autoconfig') }}
+    {%- elif adapter_type == 'duckdb' -%}
+        {{ return('goldenmatch_autoconfig') }}
+    {%- elif adapter_type == 'snowflake' -%}
+        {{ exceptions.raise_compiler_error(
+            "Zero-config dedupe (probabilistic=true, or omitting match_config) is "
+            "not yet supported on Snowflake -- the goldenmatch_autoconfig(table, mode) "
+            "UDF is DuckDB/Postgres only in this release. Pass an explicit "
+            "match_config on Snowflake, or use the Python helper."
+        ) }}
+    {%- else -%}
+        {{ exceptions.raise_compiler_error(
+            "goldenmatch_dedupe is only supported on postgres, duckdb, snowflake; got " ~ adapter_type
+        ) }}
+    {%- endif -%}
+{% endmacro %}
+
+
+{#--- The SQL expression for the dedupe config argument:
+       explicit match_config -> a JSON string literal (today's path);
+       no match_config       -> a scalar-subquery plan call (zero-config). ---#}
+{% macro goldenmatch_dedupe_config_expr(match_config, probabilistic, staging_literal, adapter_type) %}
+    {%- if match_config is not none and probabilistic -%}
+        {{ exceptions.raise_compiler_error(
+            "Set either match_config (explicit config) or probabilistic=true "
+            "(zero-config Fellegi-Sunter), not both. To use FS with an explicit "
+            "config, declare type: probabilistic matchkeys in match_config and drop "
+            "the probabilistic flag."
+        ) }}
+    {%- elif match_config is not none -%}
+        {{ return(goldenmatch_dedupe_config_json(match_config)) }}
+    {%- else -%}
+        {%- set mode = 'probabilistic' if probabilistic else 'standard' -%}
+        {%- set fn = goldenmatch_autoconfig_fn_name(adapter_type) -%}
+        {{ return('(SELECT ' ~ fn ~ '(' ~ staging_literal ~ ", '" ~ mode ~ "'))") }}
+    {%- endif -%}
+{% endmacro %}

--- a/packages/dbt/goldensuite/macros/materializations/goldenmatch_dedupe.sql
+++ b/packages/dbt/goldensuite/macros/materializations/goldenmatch_dedupe.sql
@@ -10,7 +10,8 @@
 
       {{ config(
           materialized = 'goldenmatch_dedupe',
-          match_config = 'configs/customers.yaml',  -- file path or inline dict
+          match_config = 'configs/customers.yaml',  -- file path or inline dict; OMIT for zero-config
+          probabilistic = false,                     -- true => zero-config Fellegi-Sunter (Postgres+DuckDB)
           output = 'golden',                         -- golden|clusters|pairs
           memory_db_path = none,                     -- optional MemoryStore path
       ) }}
@@ -20,8 +21,12 @@
   ## Flow
 
   1. Body SQL -> CREATE TEMP TABLE (dbt's standard staging-of-input).
-  2. Resolve match_config: file path (read + JSON-stringify) OR dict
-     literal (JSON-stringify directly).
+  2. Resolve the config argument: an explicit match_config -> a JSON
+     string literal (file path read + JSON-stringify, OR dict
+     JSON-stringify); no match_config -> a scalar-subquery plan call
+     `goldenmatch_autoconfig(<staging>, <mode>)` where mode is
+     'probabilistic' when probabilistic=true else 'standard'
+     (zero-config; Postgres + DuckDB only).
   3. Pick the right warehouse function for the requested output:
      - golden   -> goldenmatch_dedupe_full     (Postgres + DuckDB + Snowflake)
      - clusters -> goldenmatch_dedupe_clusters (Postgres + Snowflake)
@@ -45,8 +50,9 @@
 
 
 {% materialization goldenmatch_dedupe, default %}
-    {#- Required config -#}
-    {%- set match_config = config.require('match_config') -%}
+    {#- Config -#}
+    {%- set match_config = config.get('match_config', none) -%}
+    {%- set probabilistic = config.get('probabilistic', false) -%}
     {%- set output_kind = config.get('output', 'golden') -%}
     {%- set memory_db_path = config.get('memory_db_path', none) -%}
 
@@ -61,7 +67,7 @@
 
     {%- set target_relation = this -%}
     {%- set staging_relation = make_temp_relation(target_relation, '__gm_stage') -%}
-    {%- set config_json_literal = dbt_goldensuite.goldenmatch_dedupe_config_json(match_config) -%}
+    {%- set config_expr = dbt_goldensuite.goldenmatch_dedupe_config_expr(match_config, probabilistic, dbt.string_literal(staging_relation.identifier), target.type) -%}
     {%- set fn_name = dbt_goldensuite.goldenmatch_dedupe_fn_name(output_kind, target.type) -%}
 
     {#- Step 1: stash body SQL into a TEMP table so the goldenmatch
@@ -82,7 +88,7 @@
         CREATE TABLE {{ target_relation }} AS
         SELECT * FROM {{ fn_name }}(
             {{ dbt.string_literal(staging_relation.identifier) }},
-            {{ config_json_literal }}
+            {{ config_expr }}
         );
     {%- endcall -%}
 

--- a/packages/dbt/goldensuite/tests/test_dedupe_materialization.py
+++ b/packages/dbt/goldensuite/tests/test_dedupe_materialization.py
@@ -169,5 +169,50 @@ def test_fn_name_unknown_adapter_errors() -> None:
         helpers.goldenmatch_dedupe_fn_name("golden", "bigquery")
 
 
+# ---------------------------------------------------------------------------
+# goldenmatch_dedupe_config_expr (zero-config / probabilistic)
+# ---------------------------------------------------------------------------
+
+
+def test_config_expr_probabilistic_renders_scalar_subquery():
+    helpers = _load_helpers()
+    out = helpers.goldenmatch_dedupe_config_expr(
+        match_config=None, probabilistic=True,
+        staging_literal="'stg__gm_stage'", adapter_type="duckdb")
+    assert out.strip() == "(SELECT goldenmatch_autoconfig('stg__gm_stage', 'probabilistic'))"
+
+
+def test_config_expr_standard_zero_config():
+    helpers = _load_helpers()
+    out = helpers.goldenmatch_dedupe_config_expr(
+        match_config=None, probabilistic=False,
+        staging_literal="'stg__gm_stage'", adapter_type="postgres")
+    assert out.strip() == "(SELECT goldenmatch.goldenmatch_autoconfig('stg__gm_stage', 'standard'))"
+
+
+def test_config_expr_explicit_config_uses_literal():
+    helpers = _load_helpers()
+    out = helpers.goldenmatch_dedupe_config_expr(
+        match_config={"matchkeys": []}, probabilistic=False,
+        staging_literal="'stg'", adapter_type="duckdb")
+    assert out.strip().startswith("'")  # JSON string literal, not a subquery
+
+
+def test_config_expr_probabilistic_plus_config_errors():
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError):
+        helpers.goldenmatch_dedupe_config_expr(
+            match_config={"matchkeys": []}, probabilistic=True,
+            staging_literal="'stg'", adapter_type="duckdb")
+
+
+def test_config_expr_snowflake_zero_config_errors():
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError):  # Snowflake has no mode UDF in P1
+        helpers.goldenmatch_dedupe_config_expr(
+            match_config=None, probabilistic=True,
+            staging_literal="'stg'", adapter_type="snowflake")
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/packages/dbt/goldensuite/tests/test_materialize_probabilistic.py
+++ b/packages/dbt/goldensuite/tests/test_materialize_probabilistic.py
@@ -1,0 +1,32 @@
+import duckdb
+from dbt_goldensuite.materialize import run_goldenmatch_dedupe
+
+
+def test_run_dedupe_zero_config_probabilistic(tmp_path):
+    db = str(tmp_path / "wh.duckdb")
+    con = duckdb.connect(db)
+    # ~12 rows with agreeing duplicate clusters so FS EM can train at dedupe time
+    # (autoconfig itself only fails when no column is matchable; `name` is).
+    con.execute(
+        "CREATE TABLE raw AS SELECT * FROM (VALUES "
+        "('John Smith','Austin','1980-01-01'),"
+        "('Jon Smith','Austin','1980-01-01'),"
+        "('John Smyth','Austin','1980-01-01'),"
+        "('Jane Doe','Dallas','1975-05-05'),"
+        "('J Doe','Dallas','1975-05-05'),"
+        "('Jayne Doe','Dallas','1975-05-05'),"
+        "('Robert Brown','Houston','1990-09-09'),"
+        "('Rob Brown','Houston','1990-09-09'),"
+        "('Bob Brown','Houston','1990-09-09'),"
+        "('Mary Jones','Austin','1985-03-03'),"
+        "('Mary Jonez','Austin','1985-03-03'),"
+        "('Maria Jones','Austin','1985-03-03')"
+        ") t(name, city, dob)"
+    )
+    con.close()
+    res = run_goldenmatch_dedupe(
+        input_table="raw", output_table="deduped",
+        database=db, probabilistic=True,   # NOTE: no config_path
+    )
+    assert res["input_rows"] == 12
+    assert res["output_rows"] >= 1

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -302,19 +302,39 @@ pub fn dedupe_full(rows_json: &str, config_json: &str) -> Result<DedupeResult, B
     })
 }
 
-/// Run AutoConfigController on the input rows and return the committed config
-/// plus telemetry. Does NOT run the dedupe pipeline.
+/// Run auto-config on the input rows and return the committed config plus
+/// telemetry. Does NOT run the dedupe pipeline.
+///
+/// `mode` selects the auto-config strategy:
+/// - `"standard"` -> `auto_configure_df` (the iterative AutoConfigController;
+///   exact + weighted matchkeys, sets `_LAST_CONTROLLER_RUN` telemetry).
+/// - `"probabilistic"` -> `auto_configure_probabilistic_df` (Fellegi-Sunter;
+///   a single `type="probabilistic"` matchkey). Non-iterative: it does NOT run
+///   the controller, so `_LAST_CONTROLLER_RUN` is unset and telemetry reports
+///   `{"available": false}`.
+///
+/// Any other `mode` is an `InvalidConfig` error.
 ///
 /// SQL-surface equivalent of the CLI `goldenmatch autoconfig <files>`.
 /// Callers typically pipe the returned `config_json` into a follow-up
 /// `dedupe_full()` call, or store it on a Postgres `_jobs` row.
-pub fn autoconfig(rows_json: &str) -> Result<AutoConfigResult, BridgeError> {
+pub fn autoconfig(rows_json: &str, mode: &str) -> Result<AutoConfigResult, BridgeError> {
     crate::init()?;
+
+    let fn_name = match mode {
+        "standard" => "auto_configure_df",
+        "probabilistic" => "auto_configure_probabilistic_df",
+        other => {
+            return Err(BridgeError::InvalidConfig(format!(
+                "unknown autoconfig mode '{other}' (expected 'standard' or 'probabilistic')"
+            )))
+        }
+    };
 
     Python::with_gil(|py| {
         let df = convert::json_to_polars_df(py, rows_json)?;
         let autoconfig_mod = py.import("goldenmatch.core.autoconfig")?;
-        let cfg = autoconfig_mod.call_method1("auto_configure_df", (df,))?;
+        let cfg = autoconfig_mod.call_method1(fn_name, (df,))?;
 
         // Read controller telemetry off the ContextVar set by auto_configure_df.
         let ctx_var = autoconfig_mod.getattr("_LAST_CONTROLLER_RUN")?;
@@ -1854,7 +1874,7 @@ mod tests {
 
     #[test]
     fn test_autoconfig_returns_config_and_telemetry() {
-        match autoconfig(two_row_json()) {
+        match autoconfig(two_row_json(), "standard") {
             Ok(result) => {
                 assert!(!result.config_json.is_empty(), "config_json empty");
                 assert!(!result.telemetry_json.is_empty(), "telemetry_json empty");
@@ -1868,6 +1888,33 @@ mod tests {
             }
             Err(e) => require_or_skip(e, "autoconfig_returns_config_and_telemetry"),
         }
+    }
+
+    #[test]
+    fn test_autoconfig_mode_probabilistic_builds_probabilistic_matchkeys() {
+        let rows = r#"[
+            {"name":"John Smith","city":"Austin","dob":"1980-01-01"},
+            {"name":"Jon Smith","city":"Austin","dob":"1980-01-01"},
+            {"name":"Jane Doe","city":"Dallas","dob":"1975-05-05"}
+        ]"#;
+        let res = autoconfig(rows, "probabilistic").expect("probabilistic autoconfig");
+        assert!(
+            res.config_json.contains("\"probabilistic\""),
+            "expected a probabilistic matchkey in config_json, got: {}",
+            res.config_json
+        );
+    }
+
+    #[test]
+    fn test_autoconfig_mode_standard_unchanged() {
+        let rows = r#"[{"name":"A","city":"X"},{"name":"A","city":"X"}]"#;
+        autoconfig(rows, "standard").expect("standard autoconfig");
+    }
+
+    #[test]
+    fn test_autoconfig_unknown_mode_errors() {
+        let rows = r#"[{"name":"A"}]"#;
+        assert!(autoconfig(rows, "bogus").is_err());
     }
 
     // ── match_tables ────────────────────────────────────────────────────────

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
@@ -86,10 +86,22 @@ def register(con: duckdb.DuckDBPyConnection) -> None:
     )
 
     # AutoConfig + telemetry (v1.7-v1.12 surface)
+    # DuckDB Python UDFs are fixed-arity (no SQL DEFAULT) and DuckDB 1.x rejects
+    # two scalar functions sharing a name. So register the impl ONCE as a 2-arg
+    # native UDF under an internal name, then expose ``goldenmatch_autoconfig``
+    # as a single multi-arity SQL macro: the 1-arg form (back-compat, always
+    # 'standard') and a 2-arg form taking an explicit mode
+    # ('standard' | 'probabilistic'). The macro overload pair MUST be one
+    # ``CREATE MACRO`` statement -- separate statements collide on the name.
     con.create_function(
-        "goldenmatch_autoconfig",
-        lambda table_name: _autoconfig_table(con, table_name),
-        ["VARCHAR"], "VARCHAR",
+        "_goldenmatch_autoconfig_impl",
+        lambda table_name, mode: _autoconfig_table(con, table_name, mode),
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+    con.execute(
+        "CREATE OR REPLACE MACRO goldenmatch_autoconfig(table_name) AS "
+        "_goldenmatch_autoconfig_impl(table_name, 'standard'), "
+        "(table_name, mode) AS _goldenmatch_autoconfig_impl(table_name, mode)"
     )
     con.create_function(
         "goldenmatch_autoconfig_telemetry",
@@ -383,9 +395,11 @@ def _gm_telemetry(con: duckdb.DuckDBPyConnection, job_name: str) -> str:
 # ── AutoConfig + telemetry (v1.7-v1.12) ──────────────────────────────────
 
 
-def _autoconfig_table(con: duckdb.DuckDBPyConnection, table_name: str) -> str:
+def _autoconfig_table(
+    con: duckdb.DuckDBPyConnection, table_name: str, mode: str = "standard",
+) -> str:
     """Run AutoConfigController on a DuckDB table; return committed config JSON."""
-    cfg = _run_autoconfig(con, table_name)
+    cfg = _run_autoconfig(con, table_name, mode)
     return json.dumps(cfg.model_dump(mode="json", exclude_none=True))
 
 
@@ -427,14 +441,32 @@ def _dedupe_full_table(
     return json.dumps(result.stats)
 
 
-def _run_autoconfig(con: duckdb.DuckDBPyConnection, table_name: str):
-    """Shared helper: read table, run auto_configure_df, return the config."""
-    from goldenmatch.core.autoconfig import auto_configure_df
+def _run_autoconfig(
+    con: duckdb.DuckDBPyConnection, table_name: str, mode: str = "standard",
+):
+    """Shared helper: read table, run auto-config (standard or probabilistic).
+
+    ``mode='standard'`` (default) runs ``auto_configure_df``;
+    ``mode='probabilistic'`` runs ``auto_configure_probabilistic_df``
+    (Fellegi-Sunter). DuckDB Python UDFs are fixed-arity, so the SQL
+    surface registers both a 1-arg (always standard) and a 2-arg overload.
+    """
+    from goldenmatch.core.autoconfig import (
+        auto_configure_df,
+        auto_configure_probabilistic_df,
+    )
     _validate_table_name(table_name)
     cursor = con.cursor()
     df = cursor.sql(f"SELECT * FROM {table_name}").pl()
     cursor.close()
-    return auto_configure_df(df)
+    if mode == "standard":
+        return auto_configure_df(df)
+    if mode == "probabilistic":
+        return auto_configure_probabilistic_df(df)
+    raise ValueError(
+        f"unknown autoconfig mode {mode!r} "
+        "(expected 'standard' or 'probabilistic')"
+    )
 
 
 def _capture_telemetry(committed_config) -> str | None:

--- a/packages/rust/extensions/duckdb/pyproject.toml
+++ b/packages/rust/extensions/duckdb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenmatch-duckdb"
-version = "0.6.0"
+version = "0.7.0"
 description = "GoldenMatch entity resolution functions for DuckDB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/duckdb/tests/test_autoconfig_probabilistic.py
+++ b/packages/rust/extensions/duckdb/tests/test_autoconfig_probabilistic.py
@@ -1,0 +1,53 @@
+import json
+import duckdb
+import pytest
+from goldenmatch_duckdb import functions as gm
+
+
+@pytest.fixture
+def con():
+    c = duckdb.connect()
+    gm.register(c)
+    # ~12 rows with clear duplicate clusters. auto_configure_probabilistic_df only
+    # raises ValueError when there are NO matchable columns (name is matchable);
+    # the agreeing clusters matter for EM training at dedupe time.
+    c.execute(
+        "CREATE TABLE people AS SELECT * FROM (VALUES "
+        "('John Smith','Austin','1980-01-01'),"
+        "('Jon Smith','Austin','1980-01-01'),"
+        "('John Smyth','Austin','1980-01-01'),"
+        "('Jane Doe','Dallas','1975-05-05'),"
+        "('J Doe','Dallas','1975-05-05'),"
+        "('Jayne Doe','Dallas','1975-05-05'),"
+        "('Robert Brown','Houston','1990-09-09'),"
+        "('Rob Brown','Houston','1990-09-09'),"
+        "('Bob Brown','Houston','1990-09-09'),"
+        "('Mary Jones','Austin','1985-03-03'),"
+        "('Mary Jonez','Austin','1985-03-03'),"
+        "('Maria Jones','Austin','1985-03-03')"
+        ") AS t(name, city, dob)"
+    )
+    return c
+
+
+def test_autoconfig_probabilistic_builds_probabilistic_matchkeys(con):
+    cfg = con.sql("SELECT goldenmatch_autoconfig('people', 'probabilistic')").fetchone()[0]
+    data = json.loads(cfg)
+    mks = data.get("matchkeys") or data.get("match_settings", {}).get("matchkeys", [])
+    assert any(mk.get("type") == "probabilistic" for mk in mks), cfg
+
+
+def test_autoconfig_one_arg_still_standard(con):
+    cfg = con.sql("SELECT goldenmatch_autoconfig('people')").fetchone()[0]
+    assert json.loads(cfg)  # parses; back-compat 1-arg form
+
+
+def test_autoconfig_probabilistic_parity_with_python(con):
+    cfg_sql = json.loads(con.sql("SELECT goldenmatch_autoconfig('people','probabilistic')").fetchone()[0])
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+    df = con.sql("SELECT * FROM people").pl()
+    cfg_py = json.loads(auto_configure_probabilistic_df(df).model_dump_json(exclude_none=True))
+    def mk_types(c):
+        mks = c.get("matchkeys") or c.get("match_settings", {}).get("matchkeys", [])
+        return sorted(mk.get("type", "") for mk in mks)
+    assert mk_types(cfg_sql) == mk_types(cfg_py)

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.7.0'
+default_version = '0.8.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.7.0--0.8.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.7.0--0.8.0.sql
@@ -1,0 +1,15 @@
+-- goldenmatch_pg 0.7.0 -> 0.8.0 upgrade.
+--
+-- Generalizes goldenmatch_autoconfig with a `mode` argument: 'standard'
+-- (default, iterative AutoConfigController) or 'probabilistic' (Fellegi-Sunter
+-- matchkeys). The `mode TEXT DEFAULT 'standard'` keeps existing 1-arg calls
+-- working. The new 2-arg signature replaces the old 1-arg function (same
+-- 'goldenmatch_autoconfig_wrapper' symbol -- pgrx threads `mode` through).
+DROP FUNCTION IF EXISTS "goldenmatch_autoconfig"(TEXT);
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT,
+    "mode" TEXT DEFAULT 'standard'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.8.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.8.0.sql
@@ -1,0 +1,695 @@
+-- goldenmatch_pg SQL extension schema v0.5.0
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline tables (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS goldenmatch._jobs (
+    name TEXT PRIMARY KEY,
+    config_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    last_run_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'configured',
+    -- v1.7-v1.12: most-recent run's AutoConfigController telemetry. NULL when
+    -- the job used an explicit config (controller didn't fire) or hasn't run.
+    last_telemetry_json JSONB
+);
+-- ALTER for upgrades from extension installs that pre-date the telemetry column.
+ALTER TABLE goldenmatch._jobs ADD COLUMN IF NOT EXISTS last_telemetry_json JSONB;
+
+CREATE TABLE IF NOT EXISTS goldenmatch._pairs (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    id_a BIGINT,
+    id_b BIGINT,
+    score DOUBLE PRECISION,
+    matchkey TEXT,
+    field_scores JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_pairs_job ON goldenmatch._pairs(job_name, id_a, id_b);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._clusters (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_id BIGINT,
+    is_golden BOOLEAN DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_clusters_job ON goldenmatch._clusters(job_name, cluster_id);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._golden (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_data JSONB
+);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-based functions (primary interface)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_table"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_table_wrapper';
+
+CREATE FUNCTION "goldenmatch_match_tables"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_tables_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline functions (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "gm_configure"(
+    "job_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_configure_wrapper';
+
+CREATE FUNCTION "gm_run"(
+    "job_name" TEXT,
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_run_wrapper';
+
+CREATE FUNCTION "gm_jobs"() RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_jobs_wrapper';
+
+CREATE FUNCTION "gm_golden"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_golden_wrapper';
+
+CREATE FUNCTION "gm_drop"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_drop_wrapper';
+
+CREATE FUNCTION "gm_pairs"(
+    "job_name" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_pairs_wrapper';
+
+CREATE FUNCTION "gm_clusters"(
+    "job_name" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-returning functions (structured results)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_pairs"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_pairs_wrapper';
+
+CREATE FUNCTION "goldenmatch_dedupe_clusters"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT, "cluster_size" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Scalar functions
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_score"(
+    "value_a" TEXT,
+    "value_b" TEXT,
+    "scorer" TEXT DEFAULT 'jaro_winkler'
+) RETURNS DOUBLE PRECISION
+STRICT PARALLEL RESTRICTED
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_wrapper';
+
+CREATE FUNCTION "goldenmatch_score_pair"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_pair_wrapper';
+
+CREATE FUNCTION "goldenmatch_explain"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_explain_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- JSON-based functions (programmatic use)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe"(
+    "rows_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_wrapper';
+
+CREATE FUNCTION "goldenmatch_match"(
+    "target_json" TEXT,
+    "reference_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- AutoConfig + controller telemetry (v1.7-v1.12)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Run AutoConfigController on a table and return the committed GoldenMatchConfig
+-- as JSON. Pipe the output into goldenmatch_dedupe_full to apply it.
+-- `mode` selects the strategy: 'standard' (default, iterative controller) or
+-- 'probabilistic' (Fellegi-Sunter matchkeys). The DEFAULT keeps 1-arg calls.
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT,
+    "mode" TEXT DEFAULT 'standard'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';
+
+-- Same as above but returns the controller telemetry blob (stop_reason,
+-- decisions, health, indicator priors, committed NE).
+CREATE FUNCTION "goldenmatch_autoconfig_telemetry"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_telemetry_wrapper';
+
+-- Deduplicate a table with a *full* GoldenMatchConfig JSON (supports
+-- negative_evidence / Path Y, per-matchkey scorers, standardization, etc.).
+CREATE FUNCTION "goldenmatch_dedupe_full"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_wrapper';
+
+-- Same as above but returns the controller telemetry from that run.
+CREATE FUNCTION "goldenmatch_dedupe_full_telemetry"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_telemetry_wrapper';
+
+-- Retrieve the telemetry from the most recent gm_run of a named job.
+-- Returns '{"available":false}' for jobs that haven't run or used an
+-- explicit config.
+CREATE FUNCTION "gm_telemetry"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_telemetry_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Identity Graph (v2.0)
+-- ══════════════════════════════════════════════════════════════════════
+-- Contract: docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md
+-- All identity functions accept the path to the identity store as an explicit
+-- second arg. For SQLite pass the filesystem path; for Postgres pass the libpq
+-- DSN. Empty-string filters mean "no filter on that dimension".
+
+-- Resolve a `{source}:{source_pk}` record id to its identity view JSON.
+-- Returns {"found": false} when the record has no identity.
+CREATE FUNCTION "goldenmatch_identity_resolve"(
+    "record_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_resolve_wrapper';
+
+-- Return the full identity view JSON for a given entity_id.
+CREATE FUNCTION "goldenmatch_identity_view"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_view_wrapper';
+
+-- Return the temporal event log for an identity as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_history"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_history_wrapper';
+
+-- List `conflicts_with` evidence edges as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_conflicts"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_conflicts_wrapper';
+
+-- List identities filtered by dataset and status (empty = no filter).
+CREATE FUNCTION "goldenmatch_identity_list"(
+    "dataset" TEXT,
+    "status" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Core-API parity (mirrors duckdb/core_apis.py -- 13 UDFs)
+-- ══════════════════════════════════════════════════════════════════════
+-- Wrappers over goldenmatch's function-shaped core APIs. IDENTICAL JSON
+-- in / JSON out contract to the DuckDB `goldenmatch_*` core-API UDFs so the
+-- two backends are interchangeable. Table-input functions read the table via
+-- SPI (`row_to_json`, like goldenmatch_dedupe_table); JSON-in functions take
+-- the payloads directly. All read-only -- no REVOKE.
+
+-- Profile a table (column stats, types, quality signals) as JSON.
+CREATE FUNCTION "goldenmatch_profile_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_profile_table_wrapper';
+
+-- Otsu threshold over a JSON array of scores. Returns SQL NULL when the
+-- distribution is unimodal / too few scores.
+CREATE FUNCTION "goldenmatch_suggest_threshold"(
+    "scores_json" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_suggest_threshold_wrapper';
+
+-- Domain profile for a JSON array of column names, as JSON.
+CREATE FUNCTION "goldenmatch_detect_domain"(
+    "columns_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_domain_wrapper';
+
+-- Extract structured features from text. kind: product/electronics (default),
+-- software, biblio/bibliographic. Returns the features as JSON.
+CREATE FUNCTION "goldenmatch_extract_features"(
+    "text" TEXT,
+    "kind" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_extract_features_wrapper';
+
+-- Evaluate predicted pairs (JSON array) or clusters (JSON object) against a
+-- ground-truth JSON array of [a, b] pairs. Returns EvalResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_evaluate"(
+    "pairs_json" TEXT,
+    "ground_truth_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_evaluate_wrapper';
+
+-- CCMS comparison of two clusterings (JSON objects). Returns
+-- CompareResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_compare_clusters"(
+    "a_json" TEXT,
+    "b_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_compare_clusters_wrapper';
+
+-- Run validation rules (JSON array of ValidationRule) over a table. Returns
+-- {report, valid_rows, quarantine_rows, quarantine} JSON.
+CREATE FUNCTION "goldenmatch_validate_table"(
+    "table_name" TEXT,
+    "rules_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_validate_table_wrapper';
+
+-- Apply auto-fixes to a table. Returns {fixes, fixed_rows, rows} JSON.
+CREATE FUNCTION "goldenmatch_autofix_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autofix_table_wrapper';
+
+-- Flag suspicious records in a table. sensitivity: low/medium/high. Returns
+-- a JSON array of anomaly dicts.
+CREATE FUNCTION "goldenmatch_detect_anomalies"(
+    "table_name" TEXT,
+    "sensitivity" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_anomalies_wrapper';
+
+-- Validate (table, full GoldenMatchConfig JSON) before a run. Returns
+-- {has_errors, config_was_modified, findings} JSON.
+CREATE FUNCTION "goldenmatch_preflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_preflight_wrapper';
+
+-- Post-run signal report for (table, config). Derives pair_scores by running
+-- dedupe_df on the table. Returns {signals, adjustments, advisories} JSON.
+CREATE FUNCTION "goldenmatch_postflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_postflight_wrapper';
+
+-- Train Fellegi-Sunter m/u probabilities via EM. Returns the EMResult JSON;
+-- pass it straight to goldenmatch_score_probabilistic.
+CREATE FUNCTION "goldenmatch_train_em"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "params_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_wrapper';
+
+-- Score record pairs with trained Fellegi-Sunter probabilities. Returns a
+-- JSON array of [a, b, score] triples above the link threshold.
+CREATE FUNCTION "goldenmatch_score_probabilistic"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "em_result_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_probabilistic_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Learning Memory: force a MemoryLearner pass; returns JSON
+-- { "count": N, "adjustments": [...] }. Needs >= 10 corrections per matchkey.
+CREATE FUNCTION "memory_learn"(
+    "matchkey_name" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_learn_wrapper';
+
+-- Learning Memory status: JSON
+-- { "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }.
+CREATE FUNCTION "memory_stats"(
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_stats_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+
+-- memory_learn mutates the store (writes learned adjustments); gate it like
+-- correction_add. memory_stats is read-only status (counts + thresholds, no
+-- correction contents) and stays available to PUBLIC.
+REVOKE EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
+
+-- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────
+--
+-- 8 scalar text -> text wrappers over goldenflow's transform registry,
+-- mirroring the DuckDB goldenflow_* UDFs (goldenmatch_duckdb/goldenflow.py).
+-- Closes the last DuckDB <-> Postgres parity gap. All STRICT (NULL in -> NULL
+-- out); the bridge fails open (passes the input through unchanged when
+-- goldenflow isn't installed / the transform errors), so these are read-only
+-- and safe for PUBLIC -- no REVOKE.
+
+-- Normalize an email address. Wraps goldenflow `email_normalize`.
+CREATE FUNCTION "goldenflow_normalize_email"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_email_wrapper';
+
+-- Normalize a phone number to E.164. Wraps goldenflow `phone_e164`.
+CREATE FUNCTION "goldenflow_normalize_phone"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_phone_wrapper';
+
+-- Normalize a date to ISO-8601. Wraps goldenflow `date_iso8601`.
+CREATE FUNCTION "goldenflow_normalize_date"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_date_wrapper';
+
+-- Proper-case a personal name. Wraps goldenflow `name_proper`.
+CREATE FUNCTION "goldenflow_normalize_name_proper"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_name_proper_wrapper';
+
+-- Canonicalize a URL. Wraps goldenflow `url_normalize`.
+CREATE FUNCTION "goldenflow_canonicalize_url"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_url_wrapper';
+
+-- Standardize a postal address. Wraps goldenflow `address_standardize`.
+CREATE FUNCTION "goldenflow_canonicalize_address"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_address_wrapper';
+
+-- Strip leading/trailing whitespace. Wraps goldenflow `strip`.
+CREATE FUNCTION "goldenflow_strip"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_strip_wrapper';
+
+-- Collapse internal whitespace runs. Wraps goldenflow `collapse_whitespace`.
+CREATE FUNCTION "goldenflow_whitespace_normalize"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_whitespace_normalize_wrapper';
+
+-- ── Native Core graph kernels (#509) ──────────────────────────────────────
+-- Native-direct: these call the pyo3-free goldenmatch-graph-core crate in pure
+-- Rust (NO embedded CPython). DuckDB<->Postgres lockstep with core_kernels.py.
+-- Accept-both: int64 ids on the bare name, string ids on the _str sibling
+-- (a first-seen str<->i64 dictionary wraps the i64 kernel).
+
+-- Canonical max-score pairs over int64 id arrays. Returns (a, b, s) rows.
+CREATE FUNCTION "goldenmatch_pair_dedup"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_wrapper';
+
+-- String-id variant: same kernel via a first-seen str<->i64 dictionary.
+CREATE FUNCTION "goldenmatch_pair_dedup_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" TEXT, "b" TEXT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_str_wrapper';
+
+-- Connected components over int64 edge arrays + an int64 id universe.
+-- Returns (component_index, member) rows.
+CREATE FUNCTION "goldenmatch_connected_components"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" BIGINT[]
+) RETURNS TABLE ("component" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_wrapper';
+
+-- String-id variant of connected components.
+CREATE FUNCTION "goldenmatch_connected_components_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" TEXT[]
+) RETURNS TABLE ("component" BIGINT, "member" TEXT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_str_wrapper';
+
+-- Embed one text with a local in-house model (a saved GoldenEmbedModel dir)
+-- via goldenembed-rs (pure Rust, no embedded CPython). Returns the vector as
+-- float8[].
+CREATE FUNCTION "goldenmatch_embed_local"(
+    "text" TEXT,
+    "model_path" TEXT
+) RETURNS double precision[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
+
+-- Embed one text with the in-house model, model dir from GOLDENEMBED_MODEL_DIR
+-- (loaded once per backend process). Returns real[] (float4) -- parity with the
+-- DataFusion goldenmatch_embed UDF, including NULL -> "" (so NOT STRICT). #737.
+CREATE FUNCTION "gm_embed"(
+    "text" TEXT  /* nullable: NULL -> "" */
+) RETURNS real[]
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_embed_wrapper';
+
+-- Canonical record fingerprint (64 hex) of a JSON record object. The
+-- cross-surface stable record-id hash; matches the DuckDB
+-- goldenmatch_record_fingerprint UDF + the Python identity path.
+CREATE FUNCTION "goldenmatch_record_fingerprint"(
+    "record_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_record_fingerprint_wrapper';

--- a/packages/rust/extensions/postgres/src/quick.rs
+++ b/packages/rust/extensions/postgres/src/quick.rs
@@ -174,14 +174,19 @@ pub fn goldenmatch_match(
 /// — the two functions share the same telemetry blob; this one returns only
 /// the config payload.
 ///
+/// `mode` selects the auto-config strategy: `'standard'` (the default,
+/// iterative AutoConfigController) or `'probabilistic'` (Fellegi-Sunter
+/// matchkeys). The SQL `DEFAULT 'standard'` keeps the 1-arg call working.
+///
 /// ```sql
 /// SELECT goldenmatch_autoconfig('customers');
+/// SELECT goldenmatch_autoconfig('customers', 'probabilistic');
 /// ```
 #[pg_extern]
-pub fn goldenmatch_autoconfig(table_name: String) -> String {
+pub fn goldenmatch_autoconfig(table_name: String, mode: String) -> String {
     let rows_json =
         spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
-    match goldenmatch_bridge::api::autoconfig(&rows_json) {
+    match goldenmatch_bridge::api::autoconfig(&rows_json, &mode) {
         Ok(result) => result.config_json,
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }
@@ -206,7 +211,7 @@ pub fn goldenmatch_autoconfig(table_name: String) -> String {
 pub fn goldenmatch_autoconfig_telemetry(table_name: String) -> String {
     let rows_json =
         spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
-    match goldenmatch_bridge::api::autoconfig(&rows_json) {
+    match goldenmatch_bridge::api::autoconfig(&rows_json, "standard") {
         Ok(result) => result.telemetry_json,
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }


### PR DESCRIPTION
**P1 of the dbt parity program** (follows P0 #1020). Adds a zero-config `probabilistic=true` knob to the dbt `goldenmatch_dedupe` materialization (and `run_goldenmatch_dedupe(probabilistic=True)`), built on a plan/execute separation that keeps the warehouse surface flat for future work.

Spec: `docs/superpowers/specs/2026-06-16-dbt-zero-config-probabilistic-design.md` (local). Plan: `docs/superpowers/plans/2026-06-16-dbt-zero-config-probabilistic.md`.

## Design: plan / execute
Generalize `goldenmatch_autoconfig(table)` with a `mode` parameter (`'standard'` default, new `'probabilistic'` -> `auto_configure_probabilistic_df`). The materialization nests the plan UDF as a **scalar subquery** into the untouched `goldenmatch_dedupe_*` execute UDFs: `dedupe_full(staging, (SELECT autoconfig(staging,'probabilistic')))`. Config JSON is the only interface; new auto-config modes are enum values, never new functions.

## What's in it
- **bridge** (`api.rs`): `autoconfig(rows_json, mode)` dispatch; `InvalidConfig` on unknown mode.
- **DuckDB** (`goldenmatch-duckdb` 0.6.0 -> 0.7.0): `goldenmatch_autoconfig` is now a multi-arity SQL macro over an internal impl UDF (DuckDB 1.5.2 rejects same-name `create_function` overloads) — keeps the 1-arg form AND adds 2-arg `(table, mode)`.
- **Postgres** (`goldenmatch_pg` 0.7.0 -> 0.8.0): `goldenmatch_autoconfig(table, mode TEXT DEFAULT 'standard')` + full version ritual (new base SQL + migration + control + Cargo + cp lines in both workflows) + a `rust_pgrx` psql smoke. Verified CI-only.
- **dbt materialization**: `match_config` optional; new `probabilistic` flag; routing via a new unit-testable `goldenmatch_dedupe_config_expr` helper macro (scalar-subquery for zero-config, literal for explicit config, compile error if both, Snowflake guard). Bonus: standard zero-config dedupe now works (omit `match_config`).
- **Python helper**: `run_goldenmatch_dedupe(probabilistic=True)`, `config_path` optional (positional order preserved).
- Docs + CHANGELOG.

## Verification
Per-task TDD with local passing tests: bridge `cargo test` (4 pass), DuckDB pytest (8 pass incl. Python parity), dbt suite (136 pass), and the Python helper's **real end-to-end DuckDB run** of the FS path (`auto_configure_probabilistic_df` -> `run_dedupe` -> clusters). The `rust_pgrx` lane is the gate for the Postgres surface (can't build pgrx locally) — two low-risk CI-only unknowns flagged in the plan (wrapper symbol name, STRICT+DEFAULT), both exercised by the new psql smoke.

Out of scope (follow-ups): two-table match probabilistic (P3); Snowflake UDF parity for `mode`.