### PR TITLE
feat(dbt): goldenmatch_match_quality generic test (pure-SQL P/R/F1 floors)

### DIFF
--- a/packages/dbt/goldensuite/CHANGELOG.md
+++ b/packages/dbt/goldensuite/CHANGELOG.md
@@ -18,6 +18,10 @@ Suite monorepo and is consumed from there (not published to PyPI).
   (macros) and a `pip install "git+...#subdirectory=..."` for the Python helper.
 
 ### Added
+- **`goldenmatch_match_quality` dbt test.** A pure-SQL generic test that fails the
+  build when a dedupe model's pairwise precision/recall/F1 (vs a ground-truth pairs
+  table) drops below configured floors. Handles the `pairs` and `clusters` output
+  shapes; portable (no UDF); `input: clusters|pairs`, `min_f1`/`min_precision`/`min_recall`.
 - **Zero-config Fellegi-Sunter dedupe.** `probabilistic=true` on the
   `goldenmatch_dedupe` materialization (and `run_goldenmatch_dedupe(probabilistic=True)`)
   builds an FS model from the data with no hand-written config; `match_config` is

--- a/packages/dbt/goldensuite/README.md
+++ b/packages/dbt/goldensuite/README.md
@@ -62,6 +62,31 @@ raises a clear error; use an explicit `match_config` there). The Python helper
 takes the same flag: `run_goldenmatch_dedupe(..., probabilistic=True)` (no
 `config_path`).
 
+### Match-quality test
+
+Gate a dbt build on entity-resolution quality. `goldenmatch_match_quality` is a
+pure-SQL generic test (portable across adapters, no UDF) that compares a dedupe
+model's predicted pairs against a ground-truth pairs table and fails the build
+when precision/recall/F1 drops below the configured floors:
+
+```yaml
+models:
+  - name: deduped_customers
+    tests:
+      - goldenmatch_match_quality:
+          ground_truth: ref('customer_truth')   # table of true matching pairs
+          input: clusters                        # 'clusters' (default) | 'pairs'
+          min_f1: 0.90
+          min_precision: 0.80                    # set any subset; at least one required
+```
+
+- `input: clusters` expands within-cluster pairs (model columns `record_id`,
+  `cluster_id`); `input: pairs` uses the model's `id_a`/`id_b` pairs. Column
+  names are overridable (`record_id`/`cluster_id`/`pairs_a`/`pairs_b`/`gt_a`/`gt_b`).
+- Metrics are pairwise (clusters expanded to pairs, canonicalized `(min,max)`).
+  The test fails (returns the metrics row) when any provided floor is violated;
+  an empty/garbage model fails rather than silently passing.
+
 ## Macros
 
 This package ships macros only (no models/seeds/snapshots). The
@@ -73,6 +98,7 @@ is pure SQL (works on every adapter):
 - **Identity graph** -- `identity_resolve`, `identity_list`, `identity_view`, `identity_history`, `identity_conflicts`
 - **Learning memory** -- `file_field_correction`, `file_pair_correction`
 - **Quality gates (GoldenCheck)** -- `quality_assert`, `quality_health_gate`, `quality_not_empty`
+- **Match-quality test** -- `goldenmatch_match_quality` generic test: gate a dbt build on pairwise precision/recall/F1 vs ground truth. Pure SQL (portable, no UDF). See [below](#match-quality-test).
 - **Transforms (GoldenFlow)** -- `transforms.sql`
 - **Schema mapping (InferMap)** -- `infermap_apply(relation, column_map)` applies a
   Python-computed `infermap` column mapping as a plain projecting SELECT.

--- a/packages/dbt/goldensuite/macros/test_match_quality.sql
+++ b/packages/dbt/goldensuite/macros/test_match_quality.sql
@@ -1,0 +1,12 @@
+{% macro goldenmatch_predicted_pairs_sql(model, input, pairs_a, pairs_b, record_id, cluster_id) %}
+    {%- if input == 'pairs' -%}
+        {{ return("SELECT DISTINCT LEAST(" ~ pairs_a ~ ", " ~ pairs_b ~ ") AS a, GREATEST("
+            ~ pairs_a ~ ", " ~ pairs_b ~ ") AS b FROM " ~ model ~ " WHERE " ~ pairs_a ~ " <> " ~ pairs_b) }}
+    {%- elif input == 'clusters' -%}
+        {{ return("SELECT DISTINCT LEAST(x." ~ record_id ~ ", y." ~ record_id ~ ") AS a, GREATEST(x."
+            ~ record_id ~ ", y." ~ record_id ~ ") AS b FROM " ~ model ~ " x JOIN " ~ model ~ " y ON x."
+            ~ cluster_id ~ " = y." ~ cluster_id ~ " AND x." ~ record_id ~ " < y." ~ record_id) }}
+    {%- else -%}
+        {{ exceptions.raise_compiler_error("goldenmatch_match_quality: input must be 'pairs' or 'clusters'; got " ~ input) }}
+    {%- endif -%}
+{% endmacro %}

--- a/packages/dbt/goldensuite/macros/test_match_quality.sql
+++ b/packages/dbt/goldensuite/macros/test_match_quality.sql
@@ -10,3 +10,49 @@
         {{ exceptions.raise_compiler_error("goldenmatch_match_quality: input must be 'pairs' or 'clusters'; got " ~ input) }}
     {%- endif -%}
 {% endmacro %}
+
+{% macro goldenmatch_match_quality_sql(model, ground_truth, input, pairs_a, pairs_b,
+        record_id, cluster_id, gt_a, gt_b, min_f1, min_precision, min_recall) %}
+    {%- if min_f1 is none and min_precision is none and min_recall is none -%}
+        {{ exceptions.raise_compiler_error("goldenmatch_match_quality: set at least one of min_f1 / min_precision / min_recall") }}
+    {%- endif -%}
+    {%- set pred = goldenmatch_predicted_pairs_sql(model, input, pairs_a, pairs_b, record_id, cluster_id) -%}
+    {%- set truth = "SELECT DISTINCT LEAST(" ~ gt_a ~ ", " ~ gt_b ~ ") AS a, GREATEST("
+        ~ gt_a ~ ", " ~ gt_b ~ ") AS b FROM " ~ ground_truth ~ " WHERE " ~ gt_a ~ " <> " ~ gt_b -%}
+    {%- set conds = [] -%}
+    {%- if min_f1 is not none -%}{%- do conds.append("(f1 IS NULL OR f1 < " ~ min_f1 ~ ")") -%}{%- endif -%}
+    {%- if min_precision is not none -%}{%- do conds.append("(precision IS NULL OR precision < " ~ min_precision ~ ")") -%}{%- endif -%}
+    {%- if min_recall is not none -%}{%- do conds.append("(recall IS NULL OR recall < " ~ min_recall ~ ")") -%}{%- endif -%}
+    {{ return(
+"WITH pred AS (" ~ pred ~ "),
+truth AS (" ~ truth ~ "),
+tp_fp AS (
+  SELECT
+    COALESCE(SUM(CASE WHEN t.a IS NOT NULL THEN 1 ELSE 0 END), 0) AS tp,
+    COALESCE(SUM(CASE WHEN t.a IS NULL THEN 1 ELSE 0 END), 0) AS fp
+  FROM pred p LEFT JOIN truth t ON p.a = t.a AND p.b = t.b
+),
+fn_c AS (
+  SELECT COALESCE(SUM(CASE WHEN p.a IS NULL THEN 1 ELSE 0 END), 0) AS fn
+  FROM truth t LEFT JOIN pred p ON p.a = t.a AND p.b = t.b
+),
+m AS (
+  SELECT tp_fp.tp, tp_fp.fp, fn_c.fn,
+    1.0 * tp_fp.tp / NULLIF(tp_fp.tp + tp_fp.fp, 0) AS precision,
+    1.0 * tp_fp.tp / NULLIF(tp_fp.tp + fn_c.fn, 0) AS recall
+  FROM tp_fp CROSS JOIN fn_c
+),
+scored AS (
+  SELECT tp, fp, fn, precision, recall,
+    2.0 * precision * recall / NULLIF(precision + recall, 0) AS f1
+  FROM m
+)
+SELECT tp, fp, fn, precision, recall, f1 FROM scored WHERE " ~ (conds | join(" OR "))) }}
+{% endmacro %}
+
+{% test goldenmatch_match_quality(model, ground_truth, input='clusters',
+        pairs_a='id_a', pairs_b='id_b', record_id='record_id', cluster_id='cluster_id',
+        gt_a='id_a', gt_b='id_b', min_f1=none, min_precision=none, min_recall=none) %}
+{{ dbt_goldensuite.goldenmatch_match_quality_sql(model, ground_truth, input, pairs_a, pairs_b,
+    record_id, cluster_id, gt_a, gt_b, min_f1, min_precision, min_recall) }}
+{% endtest %}

--- a/packages/dbt/goldensuite/tests/test_match_quality.py
+++ b/packages/dbt/goldensuite/tests/test_match_quality.py
@@ -136,5 +136,66 @@ def test_match_quality_sql_no_floor_errors():
             gt_a="id_a", gt_b="id_b", min_f1=none, min_precision=none, min_recall=none)
 
 
+# ---------------------------------------------------------------------------
+# Task 3: DuckDB execution tests (the load-bearing correctness check)
+# ---------------------------------------------------------------------------
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _run(sql_for):
+    con = duckdb.connect()
+    con.execute("CREATE TABLE pred AS SELECT * FROM (VALUES (1,2),(2,3),(4,5)) v(id_a,id_b)")
+    con.execute("CREATE TABLE gt AS SELECT * FROM (VALUES (1,2),(2,3),(6,7)) v(id_a,id_b)")
+    return con.sql(sql_for).fetchall()
+
+
+def test_metrics_fail_below_floor():
+    h = _load_match_quality_macros()
+    sql = h.goldenmatch_match_quality_sql(model="pred", ground_truth="gt", input="pairs",
+        pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id",
+        gt_a="id_a", gt_b="id_b", min_f1=0.9, min_precision=none, min_recall=none)
+    rows = _run(sql)                      # f1 = 2/3 ~= 0.667 < 0.9 -> 1 failing row
+    assert len(rows) == 1
+    tp, fp, fn, precision, recall, f1 = rows[0]
+    assert (tp, fp, fn) == (2, 1, 1)
+    assert abs(f1 - 2/3) < 1e-9
+
+
+def test_metrics_pass_above_floor():
+    h = _load_match_quality_macros()
+    sql = h.goldenmatch_match_quality_sql(model="pred", ground_truth="gt", input="pairs",
+        pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id",
+        gt_a="id_a", gt_b="id_b", min_f1=0.5, min_precision=none, min_recall=none)
+    assert len(_run(sql)) == 0            # f1 0.667 >= 0.5 -> pass (0 rows)
+
+
+def test_clusters_input_expands_pairs():
+    h = _load_match_quality_macros()
+    con = duckdb.connect()
+    # cluster 10 = {1,2,3} -> pairs (1,2)(1,3)(2,3); cluster 20 = {4,5} -> (4,5)
+    con.execute("CREATE TABLE c AS SELECT * FROM (VALUES (10,1),(10,2),(10,3),(20,4),(20,5)) v(cluster_id,record_id)")
+    con.execute("CREATE TABLE gt AS SELECT * FROM (VALUES (1,2),(1,3),(2,3),(4,5)) v(id_a,id_b)")
+    sql = h.goldenmatch_match_quality_sql(model="c", ground_truth="gt", input="clusters",
+        pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id",
+        gt_a="id_a", gt_b="id_b", min_f1=0.99, min_precision=none, min_recall=none)
+    assert len(con.sql(sql).fetchall()) == 0   # perfect match -> f1=1.0 -> pass
+
+
+def test_empty_predictions_fails():
+    h = _load_match_quality_macros()
+    con = duckdb.connect()
+    con.execute("CREATE TABLE pred(id_a BIGINT, id_b BIGINT)")   # empty
+    con.execute("CREATE TABLE gt AS SELECT * FROM (VALUES (1,2),(2,3)) v(id_a,id_b)")
+    sql = h.goldenmatch_match_quality_sql(model="pred", ground_truth="gt", input="pairs",
+        pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id",
+        gt_a="id_a", gt_b="id_b", min_recall=0.01, min_f1=none, min_precision=none)
+    rows = con.sql(sql).fetchall()
+    assert len(rows) == 1                       # recall 0.0 < 0.01 -> fail
+    tp, fp, fn, precision, recall, f1 = rows[0]
+    assert (tp, fp, fn) == (0, 0, 2)
+    assert recall == 0.0 and precision is None and f1 is None   # COALESCE -> tp=0; recall=0.0; P/f1 NULL
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/packages/dbt/goldensuite/tests/test_match_quality.py
+++ b/packages/dbt/goldensuite/tests/test_match_quality.py
@@ -1,0 +1,91 @@
+"""Tests for the goldenmatch_match_quality generic test.
+
+The `{% test goldenmatch_match_quality(...) %}` block is a thin
+one-line wrapper that delegates to the `goldenmatch_match_quality_sql`
+helper macro (and uses the `dbt_goldensuite.` namespace, which plain
+Jinja2 doesn't provide). We therefore test the two pure-return HELPER
+macros directly:
+
+  * `goldenmatch_predicted_pairs_sql`  -- render-tests (SQL shape)
+  * `goldenmatch_match_quality_sql`    -- render-tests + DuckDB execution
+
+The DuckDB execution tests are the load-bearing correctness check:
+they run the emitted SQL against real tables and assert the exact
+metric numbers (tp/fp/fn/precision/recall/f1).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+# `none` in the plan's call sites is Jinja's null; in this Python harness
+# the helpers are invoked as plain functions, so map it to Python None.
+none = None
+
+_MACROS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "macros" / "test_match_quality.sql"
+)
+
+
+class _DbtStub:
+    @staticmethod
+    def string_literal(s):  # noqa: ANN001
+        return "'" + str(s).replace("'", "''") + "'"
+
+
+class _ExceptionsStub:
+    @staticmethod
+    def raise_compiler_error(msg):  # noqa: ANN001
+        raise RuntimeError(msg)
+
+
+def _load_match_quality_macros():
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_MACROS_PATH.parent)),
+        autoescape=False,
+        extensions=["jinja2.ext.do"],
+    )
+    env.globals["dbt"] = _DbtStub()
+    env.globals["exceptions"] = _ExceptionsStub()
+    env.globals["return"] = lambda v: v
+    env.globals["tojson"] = lambda v: json.dumps(v)
+    env.globals["load_file_contents"] = lambda p: None
+    template = env.get_template(_MACROS_PATH.name)
+    module = template.module
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Task 1: goldenmatch_predicted_pairs_sql
+# ---------------------------------------------------------------------------
+
+
+def test_predicted_pairs_pairs_input():
+    h = _load_match_quality_macros()
+    sql = h.goldenmatch_predicted_pairs_sql(model="m", input="pairs",
+        pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id")
+    assert "LEAST(id_a, id_b)" in sql and "GREATEST(id_a, id_b)" in sql
+    assert "FROM m" in sql and "id_a <> id_b" in sql
+
+
+def test_predicted_pairs_clusters_input():
+    h = _load_match_quality_macros()
+    sql = h.goldenmatch_predicted_pairs_sql(model="m", input="clusters",
+        pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id")
+    assert "x.cluster_id = y.cluster_id" in sql and "x.record_id < y.record_id" in sql
+
+
+def test_predicted_pairs_invalid_input_errors():
+    h = _load_match_quality_macros()
+    with pytest.raises(RuntimeError):
+        h.goldenmatch_predicted_pairs_sql(model="m", input="bogus",
+            pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/dbt/goldensuite/tests/test_match_quality.py
+++ b/packages/dbt/goldensuite/tests/test_match_quality.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 jinja2 = pytest.importorskip("jinja2")
+import jinja2.ext  # noqa: E402
 
 # `none` in the plan's call sites is Jinja's null; in this Python harness
 # the helpers are invoked as plain functions, so map it to Python None.
@@ -30,6 +31,29 @@ _MACROS_PATH = (
     Path(__file__).resolve().parents[1]
     / "macros" / "test_match_quality.sql"
 )
+
+
+class _TestTagExtension(jinja2.ext.Extension):
+    """No-op parser for dbt's custom `{% test ... %}` tag.
+
+    The single `test_match_quality.sql` file holds both the pure-return
+    helper macros (which we render-test) AND the thin
+    `{% test goldenmatch_match_quality(...) %}` wrapper. dbt registers
+    `test` as a custom Jinja tag; plain Jinja2 does not, so the file
+    won't parse without this. The wrapper is intentionally NOT
+    render-tested (it's a one-line delegate to the helper), so we just
+    consume the block body and emit nothing.
+    """
+
+    tags = {"test"}
+
+    def parse(self, parser):  # noqa: ANN001
+        # Consume the rest of the opening `{% test ... %}` tag header.
+        while parser.stream.current.type != "block_end":
+            next(parser.stream)
+        # Drop the body up to and including `{% endtest %}`.
+        parser.parse_statements(["name:endtest"], drop_needle=True)
+        return []
 
 
 class _DbtStub:
@@ -48,7 +72,7 @@ def _load_match_quality_macros():
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(str(_MACROS_PATH.parent)),
         autoescape=False,
-        extensions=["jinja2.ext.do"],
+        extensions=["jinja2.ext.do", _TestTagExtension],
     )
     env.globals["dbt"] = _DbtStub()
     env.globals["exceptions"] = _ExceptionsStub()
@@ -85,6 +109,31 @@ def test_predicted_pairs_invalid_input_errors():
     with pytest.raises(RuntimeError):
         h.goldenmatch_predicted_pairs_sql(model="m", input="bogus",
             pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id")
+
+
+# ---------------------------------------------------------------------------
+# Task 2: goldenmatch_match_quality_sql
+# ---------------------------------------------------------------------------
+
+
+def test_match_quality_sql_emits_metrics_and_floor():
+    h = _load_match_quality_macros()
+    sql = h.goldenmatch_match_quality_sql(model="m", ground_truth="gt", input="pairs",
+        pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id",
+        gt_a="id_a", gt_b="id_b", min_f1=0.9, min_precision=none, min_recall=none)
+    assert "COALESCE(SUM(CASE WHEN" in sql      # tp/fp counted as 0 not NULL on empty
+    assert "1.0 *" in sql                        # float division
+    assert "NULLIF(" in sql
+    assert "f1 IS NULL OR f1 < 0.9" in sql       # only the provided floor's clause
+    assert "precision IS NULL" not in sql        # unset floors omitted
+
+
+def test_match_quality_sql_no_floor_errors():
+    h = _load_match_quality_macros()
+    with pytest.raises(RuntimeError):
+        h.goldenmatch_match_quality_sql(model="m", ground_truth="gt", input="pairs",
+            pairs_a="id_a", pairs_b="id_b", record_id="record_id", cluster_id="cluster_id",
+            gt_a="id_a", gt_b="id_b", min_f1=none, min_precision=none, min_recall=none)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
**P2 of the dbt parity program** (follows P0 #1020, P1 #1022). Adds `goldenmatch_match_quality` — a pure-SQL dbt generic test that gates a build on entity-resolution quality.

Spec: `docs/superpowers/specs/2026-06-16-dbt-match-quality-test-design.md`. Plan: `docs/superpowers/plans/2026-06-16-dbt-match-quality-test.md` (both local).

## What it does
```yaml
models:
  - name: deduped_customers
    tests:
      - goldenmatch_match_quality:
          ground_truth: ref('customer_truth')
          input: clusters          # 'clusters' (default) | 'pairs'
          min_f1: 0.90
          min_precision: 0.80      # any subset; at least one required
```
Derives predicted pairs from the model's `pairs` output or `clusters` output (within-cluster pairs via self-join), compares against a ground-truth pairs table, and fails the build (returns the metrics row) when pairwise precision/recall/F1 drops below the floors.

## Why pure SQL (no UDF)
`LEAST/GREATEST` canonicalization + `LEFT JOIN` counting + `COALESCE(SUM(CASE WHEN..),0)` + `1.0 *` float division + `NULLIF` guards. **Adapter-portable** (Snowflake/BigQuery/Redshift included), **transparent**, **zero extension work**. The JSON `goldenmatch_evaluate` UDF (not table-shaped) stays for programmatic use. Logic lives in two render-testable helper macros; the `{% test %}` block is a thin wrapper.

## Verification
Render-tests for the SQL shape + compile errors, plus **real DuckDB execution tests** on hand-computed fixtures: the 2/3 case (`tp=2,fp=1,fn=1,f1=0.667`) fails `min_f1=0.9` / passes `min_f1=0.5`; perfect cluster expansion → f1=1.0 → passes; empty predictions → `tp=0,recall=0.0,precision/f1 NULL` → fails (proves `COALESCE` gives 0 not NULL). Full package suite: 149 passed. Gating CI lane: `dbt`.

Out of scope (follow-ups): cluster-level metrics beyond pairwise P/R/F1 (TWI/CCMS/B-cubed); non-pair ground-truth formats.