### PR TITLE
feat(dbt): goldenmatch_match two-table record linkage (Postgres-first)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1786,9 +1786,11 @@ jobs:
           cargo pgrx install "--pg-config=/usr/lib/postgresql/${PG_VERSION}/bin/pg_config" --release --features "pg${PG_VERSION}" --no-default-features
           # pgrx 0.12.9 doesn't auto-emit the SQL extension file — copy the
           # handwritten ones into PG's extension dir so `CREATE EXTENSION`
-          # (installs default_version, now 0.8.0) and `ALTER EXTENSION ... UPDATE`
+          # (installs default_version, now 0.9.0) and `ALTER EXTENSION ... UPDATE`
           # find them. The schema files are the canonical declaration of public
           # function signatures.
+          cp sql/goldenmatch_pg--0.9.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.8.0--0.9.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.8.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.7.0--0.8.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.7.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
@@ -1898,6 +1900,14 @@ jobs:
                 RAISE NOTICE 'v1.7-v1.12 autoconfig surface not yet on main (waiting on PR #159)';
               END IF;
             END$$;
+          EOSQL
+          # goldenmatch_match_pairs (0.9.0): two-table linkage RETURNS TABLE.
+          # Zero-config ('{}') routes through match_df's auto-config -- a minimal
+          # explicit fuzzy config yields zero candidate pairs (no blocking).
+          sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 <<'EOSQL'
+            CREATE TEMP TABLE t AS SELECT * FROM (VALUES ('John Smith'),('Jane Doe')) v(name);
+            CREATE TEMP TABLE r AS SELECT * FROM (VALUES ('Jon Smith'),('Jayne Doe'),('Bob X')) v(name);
+            SELECT * FROM goldenmatch.goldenmatch_match_pairs('t','r','{}') LIMIT 5;
           EOSQL
           # goldenmatch_autoconfig(table, mode) -- 1-arg back-compat (mode DEFAULT
           # 'standard') + the new 2-arg 'probabilistic' path, then pipe the

--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -105,6 +105,8 @@ jobs:
           # canonical SQL file there. Path layout: <PKG_DIR>/usr/share/postgresql/<N>/extension/
           EXT_DIR="${PKG_DIR}/usr/share/postgresql/${PG_VERSION}/extension"
           mkdir -p "${EXT_DIR}"
+          cp sql/goldenmatch_pg--0.9.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.8.0--0.9.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.8.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.7.0--0.8.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.7.0.sql "${EXT_DIR}/"

--- a/packages/dbt/goldensuite/CHANGELOG.md
+++ b/packages/dbt/goldensuite/CHANGELOG.md
@@ -18,6 +18,12 @@ Suite monorepo and is consumed from there (not published to PyPI).
   (macros) and a `pip install "git+...#subdirectory=..."` for the Python helper.
 
 ### Added
+- **`goldenmatch_match` materialization (two-table record linkage).** Links a target
+  model against a `reference` table and outputs matched pairs `(target_id, reference_id,
+  score)` (best match per target). Backed by a new table-returning `goldenmatch_match_pairs`
+  pgrx UDF (`goldenmatch_pg` 0.8.0 -> 0.9.0). Postgres-first (DuckDB raises a clear error).
+  `match_config` optional (omit for zero-config). `reference_id` is normalized to a 0-based
+  reference-table index.
 - **`goldenmatch_match_quality` dbt test.** A pure-SQL generic test that fails the
   build when a dedupe model's pairwise precision/recall/F1 (vs a ground-truth pairs
   table) drops below configured floors. Handles the `pairs` and `clusters` output

--- a/packages/dbt/goldensuite/README.md
+++ b/packages/dbt/goldensuite/README.md
@@ -87,6 +87,26 @@ models:
   The test fails (returns the metrics row) when any provided floor is violated;
   an empty/garbage model fails rather than silently passing.
 
+### Two-table match (record linkage)
+
+Link a target model against a reference table (the cross-table ER use case: match
+an incoming list against a master). `goldenmatch_match` is a materialization:
+
+```sql
+{{ config(materialized='goldenmatch_match', reference=ref('master_customers')) }}
+SELECT * FROM {{ ref('incoming_leads') }}
+```
+
+The model body is the **target**; `reference` is the master relation. Output is a
+matched-pairs table `(target_id, reference_id, score)` — best match per target.
+`target_id`/`reference_id` are 0-based row indices into the staged target / reference;
+join back via `ROW_NUMBER() OVER (ORDER BY ...) - 1` on the same inputs.
+
+`match_config` is optional: omit it for zero-config auto-matching (the reliable
+default); pass an explicit config (`match_df`'s `exact`/`fuzzy`/`blocking`/`threshold`
+shape — include blocking so candidates are generated) for control. **Postgres-first**
+(DuckDB raises a clear error; use the `goldenmatch_match_tables` JSON UDF on DuckDB).
+
 ## Macros
 
 This package ships macros only (no models/seeds/snapshots). The
@@ -95,6 +115,7 @@ Postgres, DuckDB, and Snowflake extension function shapes; `infermap_apply`
 is pure SQL (works on every adapter):
 
 - **Dedupe materialization** -- `goldenmatch_dedupe` (`macros/materializations/`)
+- **Match materialization** -- `goldenmatch_match` two-table record linkage (target model + `reference` ref -> matched pairs). Postgres-first. See [above](#two-table-match-record-linkage).
 - **Identity graph** -- `identity_resolve`, `identity_list`, `identity_view`, `identity_history`, `identity_conflicts`
 - **Learning memory** -- `file_field_correction`, `file_pair_correction`
 - **Quality gates (GoldenCheck)** -- `quality_assert`, `quality_health_gate`, `quality_not_empty`

--- a/packages/dbt/goldensuite/macros/materializations/_helpers.sql
+++ b/packages/dbt/goldensuite/macros/materializations/_helpers.sql
@@ -77,6 +77,31 @@
 {% endmacro %}
 
 
+{#--- Pick the warehouse SQL function name for the two-table match
+       materialization. Two-table record linkage is Postgres-first: the
+       table-returning `goldenmatch_match_pairs(target, reference, config)`
+       UDF ships on the Postgres + Snowflake surfaces. DuckDB has no
+       table-returning match UDF in this release -- raise and direct the
+       caller to the JSON `goldenmatch_match_tables` UDF instead. ---#}
+{% macro goldenmatch_match_fn_name(adapter_type) %}
+    {%- if adapter_type == 'postgres' -%}
+        {{ return('goldenmatch.goldenmatch_match_pairs') }}
+    {%- elif adapter_type == 'snowflake' -%}
+        {{ return('goldenmatch.goldenmatch_match_pairs') }}
+    {%- elif adapter_type == 'duckdb' -%}
+        {{ exceptions.raise_compiler_error(
+            "two-table match materialization is Postgres-first; on DuckDB "
+            "call the goldenmatch_match_tables JSON UDF directly"
+        ) }}
+    {%- else -%}
+        {{ exceptions.raise_compiler_error(
+            "goldenmatch_match materialization is only supported on postgres "
+            "and snowflake; got adapter=" ~ adapter_type
+        ) }}
+    {%- endif -%}
+{% endmacro %}
+
+
 {#--- Adapter-aware name for the autoconfig (plan) UDF. Snowflake intentionally
        raises: the goldenmatch_autoconfig(table, mode) overload is DuckDB/Postgres
        only in this release, so zero-config (which always emits the 2-arg mode

--- a/packages/dbt/goldensuite/macros/materializations/goldenmatch_match.sql
+++ b/packages/dbt/goldensuite/macros/materializations/goldenmatch_match.sql
@@ -1,0 +1,106 @@
+{#-
+  goldenmatch_match -- custom dbt materialization for two-table record
+  linkage. Runs the goldenmatch matcher (`match_df`) between a TARGET
+  (the model body SQL) and a REFERENCE table, materializing the
+  best-match linkage as a (target_id, reference_id, score) table.
+
+  Backed by the table-returning `goldenmatch_match_pairs(target_table,
+  reference_table, config_json)` UDF (Postgres-first; see Task 2).
+
+  Usage:
+
+      {{ config(
+          materialized = 'goldenmatch_match',
+          reference    = ref('master_customers'),  -- Relation: ref() or source()
+          match_config = 'configs/match.yaml',      -- file path or inline dict; OMIT for zero-config (default)
+      ) }}
+
+      SELECT * FROM {{ ref('incoming_customers') }}
+
+  Output columns: target_id, reference_id, score. target_id /
+  reference_id are 0-based row indices into the target / reference
+  inputs respectively. Join back via `ROW_NUMBER() OVER (...) - 1`.
+
+  ## Flow
+
+  1. Body SQL (the TARGET) -> CREATE TEMP TABLE (dbt's standard
+     staging-of-input).
+  2. Resolve the config argument: no match_config -> '{}' (zero-config,
+     the reliable default -- per a Task 1 finding, a minimal explicit
+     fuzzy config yields zero candidate pairs); an explicit match_config
+     -> a JSON string literal (file path read + JSON-stringify, OR dict
+     JSON-stringify, via the shared goldenmatch_dedupe_config_json helper).
+  3. CREATE TABLE <model> AS SELECT * FROM
+     goldenmatch_match_pairs(<staging>, <reference>, <config>).
+  4. DROP TEMP staging table.
+
+  Out of scope:
+  - DuckDB two-table match materialization -- this is Postgres-first.
+    On DuckDB call the goldenmatch_match_tables JSON UDF directly.
+  - match_mode='all' / full-record output / probabilistic match.
+-#}
+
+
+{#- Helper (`goldenmatch_match_fn_name`) lives in `_helpers.sql` -- split
+    so it unit-tests under plain Jinja2 without the materialization block.
+    Config JSON-stringification reuses `goldenmatch_dedupe_config_json`. -#}
+
+
+{% materialization goldenmatch_match, default %}
+    {#- Config -#}
+    {%- set reference = config.require('reference') -%}
+    {%- set match_config = config.get('match_config', none) -%}
+
+    {%- if target.type not in ('postgres', 'snowflake') -%}
+        {{ exceptions.raise_compiler_error(
+            "goldenmatch_match materialization is Postgres-first -- only "
+            "postgres and snowflake are supported today; got adapter=" ~ target.type ~
+            ". On DuckDB call the goldenmatch_match_tables JSON UDF directly."
+        ) }}
+    {%- endif -%}
+
+    {%- set target_relation = this -%}
+    {%- set staging_relation = make_temp_relation(target_relation, '__gm_stage') -%}
+    {%- set fn_name = dbt_goldensuite.goldenmatch_match_fn_name(target.type) -%}
+    {#- Config expression: zero-config '{}' default (reliable; an explicit
+        minimal fuzzy config yields zero candidates per a Task 1 finding),
+        else JSON-stringify the dict/file via the shared dedupe helper. -#}
+    {%- if match_config is none -%}
+        {%- set config_expr = dbt.string_literal('{}') -%}
+    {%- else -%}
+        {%- set config_expr = dbt_goldensuite.goldenmatch_dedupe_config_json(match_config) -%}
+    {%- endif -%}
+
+    {#- Step 1: stash the body SQL (the TARGET) into a TEMP table so the
+        match function has a real table to scan. -#}
+    {%- call statement('create_staging', auto_begin=True) -%}
+        CREATE TEMPORARY TABLE {{ staging_relation }} AS (
+            {{ sql }}
+        );
+    {%- endcall -%}
+
+    {#- Step 2: drop any prior incarnation of the target relation. -#}
+    {%- call statement('drop_target', auto_begin=True) -%}
+        DROP TABLE IF EXISTS {{ target_relation }} CASCADE;
+    {%- endcall -%}
+
+    {#- Step 3: invoke the match function (target, reference, config) +
+        materialize the matched-pairs table. -#}
+    {%- call statement('main', auto_begin=True) -%}
+        CREATE TABLE {{ target_relation }} AS
+        SELECT * FROM {{ fn_name }}(
+            {{ dbt.string_literal(staging_relation.identifier) }},
+            {{ dbt.string_literal(reference.identifier) }},
+            {{ config_expr }}
+        );
+    {%- endcall -%}
+
+    {#- Step 4: drop staging. Inside a transaction so a failure leaves
+        the temp table for diagnosis. -#}
+    {%- call statement('drop_staging', auto_begin=True) -%}
+        DROP TABLE IF EXISTS {{ staging_relation }};
+    {%- endcall -%}
+
+    {{ adapter.commit() }}
+    {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/packages/dbt/goldensuite/tests/test_match_materialization.py
+++ b/packages/dbt/goldensuite/tests/test_match_materialization.py
@@ -1,0 +1,92 @@
+"""Tests for the goldenmatch_match (two-table linkage) materialization.
+
+Like the dedupe materialization, the `{% materialization %}` block
+itself contains dbt-specific Jinja tags (`statement`,
+`make_temp_relation`, `auto_begin`, etc.) that plain Jinja2 can't
+parse. We test the HELPER macro that contains the meaningful logic
+instead -- `goldenmatch_match_fn_name`, which lives in
+`_helpers.sql` and parses cleanly under plain Jinja2.
+
+End-to-end materialization behavior is covered by the `rust_pgrx`
+psql smoke (the `goldenmatch_match_pairs` UDF) and dbt's own
+integration-test harness (out-of-band -- requires a running Postgres
+target).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+_HELPERS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "macros" / "materializations" / "_helpers.sql"
+)
+
+
+class _DbtStub:
+    @staticmethod
+    def string_literal(s):  # noqa: ANN001
+        return "'" + str(s).replace("'", "''") + "'"
+
+
+class _ExceptionsStub:
+    @staticmethod
+    def raise_compiler_error(msg):  # noqa: ANN001
+        raise RuntimeError(msg)
+
+
+def _load_helpers():
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_HELPERS_PATH.parent)),
+        autoescape=False,
+    )
+    env.globals["dbt"] = _DbtStub()
+    env.globals["exceptions"] = _ExceptionsStub()
+    env.globals["return"] = lambda v: v
+    env.globals["tojson"] = lambda v: json.dumps(v)
+    env.globals["load_file_contents"] = lambda p: (
+        '{"exact": ["ssn"]}' if p == "ok.yaml" else None
+    )
+    template = env.get_template(_HELPERS_PATH.name)
+    module = template.module
+    return module
+
+
+# ---------------------------------------------------------------------------
+# goldenmatch_match_fn_name
+# ---------------------------------------------------------------------------
+
+
+def test_match_fn_name_postgres() -> None:
+    helpers = _load_helpers()
+    assert helpers.goldenmatch_match_fn_name("postgres") == \
+        "goldenmatch.goldenmatch_match_pairs"
+
+
+def test_match_fn_name_snowflake() -> None:
+    """Snowflake mirrors Postgres -- schema-qualified UDF."""
+    helpers = _load_helpers()
+    assert helpers.goldenmatch_match_fn_name("snowflake") == \
+        "goldenmatch.goldenmatch_match_pairs"
+
+
+def test_match_fn_name_duckdb_errors() -> None:
+    """Two-table match is Postgres-first -- DuckDB raises a compiler
+    error directing callers to the JSON UDF instead."""
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError, match="Postgres-first"):
+        helpers.goldenmatch_match_fn_name("duckdb")
+
+
+def test_match_fn_name_unknown_adapter_errors() -> None:
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError, match="only supported on postgres"):
+        helpers.goldenmatch_match_fn_name("bigquery")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -435,6 +435,97 @@ pub fn match_tables(
     })
 }
 
+/// A matched pair from two-table record linkage: a target row linked to a
+/// reference row with its match score. `target_id` / `reference_id` are
+/// 0-based row indices into the respective input tables.
+pub struct MatchedPair {
+    pub target_id: i64,
+    pub reference_id: i64,
+    pub score: f64,
+}
+
+/// Match `target` against `reference`, returning the
+/// `(target_id, reference_id, score)` linkage for the matched pairs.
+///
+/// `target_id` / `reference_id` are 0-based row indices into the respective
+/// inputs. `match_df` assigns a single combined `__row_id__` space (target
+/// rows `0..T-1`, reference rows `T..T+R-1`), so the matched frame's
+/// `__ref_row_id__` is offset by `len(target)`; `reference_id` is normalized
+/// back to a 0-based reference index by subtracting that offset. `target_id`
+/// (`__target_row_id__`) needs no adjustment.
+///
+/// Mirrors `match_tables`'s `match_df` call shape (config kwargs +
+/// `result.matched`); returns an empty `Vec` when there are no matches
+/// (`result.matched is None`).
+pub fn match_pairs(
+    target_json: &str,
+    reference_json: &str,
+    config_json: &str,
+) -> Result<Vec<MatchedPair>, BridgeError> {
+    crate::init()?;
+
+    Python::with_gil(|py| {
+        let gm = py.import("goldenmatch")?;
+        let json_mod = py.import("json")?;
+
+        let target_df = convert::json_to_polars_df(py, target_json)?;
+        let ref_df = convert::json_to_polars_df(py, reference_json)?;
+
+        // target rows occupy combined __row_id__ space 0..target_len-1; the
+        // reference's __ref_row_id__ is offset by target_len.
+        let target_len: i64 = target_df.getattr(py, "height")?.extract(py)?;
+
+        let config_dict = json_mod.call_method1("loads", (config_json,))?;
+
+        // Mirror match_tables' config-kwarg handling (exact/fuzzy/blocking),
+        // plus threshold/config which match_df also accepts.
+        let kwargs = PyDict::new(py);
+        for key in ["exact", "fuzzy", "blocking", "threshold", "config"] {
+            if let Ok(v) = config_dict.get_item(key) {
+                if !v.is_none() {
+                    kwargs.set_item(key, v)?;
+                }
+            }
+        }
+
+        let result = gm.call_method("match_df", (target_df, ref_df), Some(&kwargs))?;
+        let matched = result.getattr("matched")?;
+        if matched.is_none() {
+            return Ok(vec![]);
+        }
+
+        // Pull the three linkage columns off the matched Polars DataFrame as
+        // Python lists (matched[col].to_list()). The id columns are Int64; the
+        // score column is float. This mirrors the existing pyo3 column-extract
+        // style used elsewhere in the bridge and avoids a serde dependency in
+        // the runtime crate.
+        let t_ids: Vec<i64> = matched
+            .get_item("__target_row_id__")?
+            .call_method0("to_list")?
+            .extract()?;
+        let r_ids: Vec<i64> = matched
+            .get_item("__ref_row_id__")?
+            .call_method0("to_list")?
+            .extract()?;
+        let scores: Vec<f64> = matched
+            .get_item("__match_score__")?
+            .call_method0("to_list")?
+            .extract()?;
+
+        let mut out = Vec::with_capacity(t_ids.len());
+        for ((target_id, ref_row_id), score) in t_ids.into_iter().zip(r_ids).zip(scores) {
+            out.push(MatchedPair {
+                target_id,
+                // NORMALIZE the combined-space ref row id back to a 0-based
+                // index into the reference table.
+                reference_id: ref_row_id - target_len,
+                score,
+            });
+        }
+        Ok(out)
+    })
+}
+
 /// Score two strings using a named similarity scorer.
 ///
 /// Calls `goldenmatch.score_strings()` under the hood.
@@ -1933,6 +2024,47 @@ mod tests {
                 // the call succeeding (Ok) proves the marshalling round-trip works.
             }
             Err(e) => require_or_skip(e, "match_tables_basic"),
+        }
+    }
+
+    // ── match_pairs ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_match_pairs_reference_id_is_zero_based() {
+        // target has 2 rows; reference rows get __row_id__ offset by 2 in the
+        // combined match_df row-id space -> the bridge must normalize back to a
+        // 0-based reference index by subtracting len(target).
+        let target = r#"[{"name":"John Smith"},{"name":"Jane Doe"}]"#;
+        let reference = r#"[{"name":"Jon Smith"},{"name":"Jayne Doe"},{"name":"Bob X"}]"#;
+        // Empty config -> zero-config match_df (auto-config picks a weighted name
+        // matchkey + multi-pass soundex/substring blocking that groups John/Jon
+        // and Jane/Jayne). The slim `fuzzy` kwarg, by contrast, builds an empty
+        // static blocking that yields zero candidate pairs on this single-column
+        // shape, so it never produces a match here. The bridge only forwards
+        // non-None config keys, so `{}` forwards nothing -> the zero-config path.
+        let config = r#"{}"#;
+        match match_pairs(target, reference, config) {
+            Ok(pairs) => {
+                assert!(!pairs.is_empty(), "expected at least one match");
+                for p in &pairs {
+                    assert!(
+                        p.target_id >= 0 && p.target_id < 2,
+                        "target_id 0-based into target: {}",
+                        p.target_id
+                    );
+                    assert!(
+                        p.reference_id >= 0 && p.reference_id < 3,
+                        "reference_id MUST be 0-based into reference (not offset by len(target)): {}",
+                        p.reference_id
+                    );
+                    assert!(
+                        p.score >= 0.0 && p.score <= 1.0,
+                        "score in [0, 1]: {}",
+                        p.score
+                    );
+                }
+            }
+            Err(e) => require_or_skip(e, "match_pairs_reference_id_is_zero_based"),
         }
     }
 

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.8.0'
+default_version = '0.9.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.8.0--0.9.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.8.0--0.9.0.sql
@@ -1,0 +1,14 @@
+-- goldenmatch_pg 0.8.0 -> 0.9.0 upgrade.
+--
+-- Adds goldenmatch_match_pairs: two-table record linkage that returns the
+-- (target_id, reference_id, score) matched pairs as rows. Backs the
+-- goldenmatch_match dbt materialization. target_id / reference_id are 0-based
+-- row indices into the respective input tables.
+CREATE FUNCTION "goldenmatch_match_pairs"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("target_id" BIGINT, "reference_id" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_pairs_wrapper';

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.9.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.9.0.sql
@@ -1,0 +1,707 @@
+-- goldenmatch_pg SQL extension schema v0.5.0
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline tables (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS goldenmatch._jobs (
+    name TEXT PRIMARY KEY,
+    config_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    last_run_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'configured',
+    -- v1.7-v1.12: most-recent run's AutoConfigController telemetry. NULL when
+    -- the job used an explicit config (controller didn't fire) or hasn't run.
+    last_telemetry_json JSONB
+);
+-- ALTER for upgrades from extension installs that pre-date the telemetry column.
+ALTER TABLE goldenmatch._jobs ADD COLUMN IF NOT EXISTS last_telemetry_json JSONB;
+
+CREATE TABLE IF NOT EXISTS goldenmatch._pairs (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    id_a BIGINT,
+    id_b BIGINT,
+    score DOUBLE PRECISION,
+    matchkey TEXT,
+    field_scores JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_pairs_job ON goldenmatch._pairs(job_name, id_a, id_b);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._clusters (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_id BIGINT,
+    is_golden BOOLEAN DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_clusters_job ON goldenmatch._clusters(job_name, cluster_id);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._golden (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_data JSONB
+);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-based functions (primary interface)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_table"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_table_wrapper';
+
+CREATE FUNCTION "goldenmatch_match_tables"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_tables_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline functions (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "gm_configure"(
+    "job_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_configure_wrapper';
+
+CREATE FUNCTION "gm_run"(
+    "job_name" TEXT,
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_run_wrapper';
+
+CREATE FUNCTION "gm_jobs"() RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_jobs_wrapper';
+
+CREATE FUNCTION "gm_golden"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_golden_wrapper';
+
+CREATE FUNCTION "gm_drop"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_drop_wrapper';
+
+CREATE FUNCTION "gm_pairs"(
+    "job_name" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_pairs_wrapper';
+
+CREATE FUNCTION "gm_clusters"(
+    "job_name" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-returning functions (structured results)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_pairs"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_pairs_wrapper';
+
+CREATE FUNCTION "goldenmatch_dedupe_clusters"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT, "cluster_size" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_clusters_wrapper';
+
+-- Two-table record linkage: match a target table against a reference table,
+-- returning the (target_id, reference_id, score) linkage as rows. target_id /
+-- reference_id are 0-based row indices into the respective input tables.
+CREATE FUNCTION "goldenmatch_match_pairs"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("target_id" BIGINT, "reference_id" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_pairs_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Scalar functions
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_score"(
+    "value_a" TEXT,
+    "value_b" TEXT,
+    "scorer" TEXT DEFAULT 'jaro_winkler'
+) RETURNS DOUBLE PRECISION
+STRICT PARALLEL RESTRICTED
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_wrapper';
+
+CREATE FUNCTION "goldenmatch_score_pair"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_pair_wrapper';
+
+CREATE FUNCTION "goldenmatch_explain"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_explain_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- JSON-based functions (programmatic use)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe"(
+    "rows_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_wrapper';
+
+CREATE FUNCTION "goldenmatch_match"(
+    "target_json" TEXT,
+    "reference_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- AutoConfig + controller telemetry (v1.7-v1.12)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Run AutoConfigController on a table and return the committed GoldenMatchConfig
+-- as JSON. Pipe the output into goldenmatch_dedupe_full to apply it.
+-- `mode` selects the strategy: 'standard' (default, iterative controller) or
+-- 'probabilistic' (Fellegi-Sunter matchkeys). The DEFAULT keeps 1-arg calls.
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT,
+    "mode" TEXT DEFAULT 'standard'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';
+
+-- Same as above but returns the controller telemetry blob (stop_reason,
+-- decisions, health, indicator priors, committed NE).
+CREATE FUNCTION "goldenmatch_autoconfig_telemetry"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_telemetry_wrapper';
+
+-- Deduplicate a table with a *full* GoldenMatchConfig JSON (supports
+-- negative_evidence / Path Y, per-matchkey scorers, standardization, etc.).
+CREATE FUNCTION "goldenmatch_dedupe_full"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_wrapper';
+
+-- Same as above but returns the controller telemetry from that run.
+CREATE FUNCTION "goldenmatch_dedupe_full_telemetry"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_telemetry_wrapper';
+
+-- Retrieve the telemetry from the most recent gm_run of a named job.
+-- Returns '{"available":false}' for jobs that haven't run or used an
+-- explicit config.
+CREATE FUNCTION "gm_telemetry"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_telemetry_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Identity Graph (v2.0)
+-- ══════════════════════════════════════════════════════════════════════
+-- Contract: docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md
+-- All identity functions accept the path to the identity store as an explicit
+-- second arg. For SQLite pass the filesystem path; for Postgres pass the libpq
+-- DSN. Empty-string filters mean "no filter on that dimension".
+
+-- Resolve a `{source}:{source_pk}` record id to its identity view JSON.
+-- Returns {"found": false} when the record has no identity.
+CREATE FUNCTION "goldenmatch_identity_resolve"(
+    "record_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_resolve_wrapper';
+
+-- Return the full identity view JSON for a given entity_id.
+CREATE FUNCTION "goldenmatch_identity_view"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_view_wrapper';
+
+-- Return the temporal event log for an identity as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_history"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_history_wrapper';
+
+-- List `conflicts_with` evidence edges as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_conflicts"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_conflicts_wrapper';
+
+-- List identities filtered by dataset and status (empty = no filter).
+CREATE FUNCTION "goldenmatch_identity_list"(
+    "dataset" TEXT,
+    "status" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Core-API parity (mirrors duckdb/core_apis.py -- 13 UDFs)
+-- ══════════════════════════════════════════════════════════════════════
+-- Wrappers over goldenmatch's function-shaped core APIs. IDENTICAL JSON
+-- in / JSON out contract to the DuckDB `goldenmatch_*` core-API UDFs so the
+-- two backends are interchangeable. Table-input functions read the table via
+-- SPI (`row_to_json`, like goldenmatch_dedupe_table); JSON-in functions take
+-- the payloads directly. All read-only -- no REVOKE.
+
+-- Profile a table (column stats, types, quality signals) as JSON.
+CREATE FUNCTION "goldenmatch_profile_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_profile_table_wrapper';
+
+-- Otsu threshold over a JSON array of scores. Returns SQL NULL when the
+-- distribution is unimodal / too few scores.
+CREATE FUNCTION "goldenmatch_suggest_threshold"(
+    "scores_json" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_suggest_threshold_wrapper';
+
+-- Domain profile for a JSON array of column names, as JSON.
+CREATE FUNCTION "goldenmatch_detect_domain"(
+    "columns_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_domain_wrapper';
+
+-- Extract structured features from text. kind: product/electronics (default),
+-- software, biblio/bibliographic. Returns the features as JSON.
+CREATE FUNCTION "goldenmatch_extract_features"(
+    "text" TEXT,
+    "kind" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_extract_features_wrapper';
+
+-- Evaluate predicted pairs (JSON array) or clusters (JSON object) against a
+-- ground-truth JSON array of [a, b] pairs. Returns EvalResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_evaluate"(
+    "pairs_json" TEXT,
+    "ground_truth_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_evaluate_wrapper';
+
+-- CCMS comparison of two clusterings (JSON objects). Returns
+-- CompareResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_compare_clusters"(
+    "a_json" TEXT,
+    "b_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_compare_clusters_wrapper';
+
+-- Run validation rules (JSON array of ValidationRule) over a table. Returns
+-- {report, valid_rows, quarantine_rows, quarantine} JSON.
+CREATE FUNCTION "goldenmatch_validate_table"(
+    "table_name" TEXT,
+    "rules_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_validate_table_wrapper';
+
+-- Apply auto-fixes to a table. Returns {fixes, fixed_rows, rows} JSON.
+CREATE FUNCTION "goldenmatch_autofix_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autofix_table_wrapper';
+
+-- Flag suspicious records in a table. sensitivity: low/medium/high. Returns
+-- a JSON array of anomaly dicts.
+CREATE FUNCTION "goldenmatch_detect_anomalies"(
+    "table_name" TEXT,
+    "sensitivity" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_anomalies_wrapper';
+
+-- Validate (table, full GoldenMatchConfig JSON) before a run. Returns
+-- {has_errors, config_was_modified, findings} JSON.
+CREATE FUNCTION "goldenmatch_preflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_preflight_wrapper';
+
+-- Post-run signal report for (table, config). Derives pair_scores by running
+-- dedupe_df on the table. Returns {signals, adjustments, advisories} JSON.
+CREATE FUNCTION "goldenmatch_postflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_postflight_wrapper';
+
+-- Train Fellegi-Sunter m/u probabilities via EM. Returns the EMResult JSON;
+-- pass it straight to goldenmatch_score_probabilistic.
+CREATE FUNCTION "goldenmatch_train_em"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "params_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_wrapper';
+
+-- Score record pairs with trained Fellegi-Sunter probabilities. Returns a
+-- JSON array of [a, b, score] triples above the link threshold.
+CREATE FUNCTION "goldenmatch_score_probabilistic"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "em_result_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_probabilistic_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Learning Memory: force a MemoryLearner pass; returns JSON
+-- { "count": N, "adjustments": [...] }. Needs >= 10 corrections per matchkey.
+CREATE FUNCTION "memory_learn"(
+    "matchkey_name" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_learn_wrapper';
+
+-- Learning Memory status: JSON
+-- { "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }.
+CREATE FUNCTION "memory_stats"(
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_stats_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+
+-- memory_learn mutates the store (writes learned adjustments); gate it like
+-- correction_add. memory_stats is read-only status (counts + thresholds, no
+-- correction contents) and stays available to PUBLIC.
+REVOKE EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
+
+-- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────
+--
+-- 8 scalar text -> text wrappers over goldenflow's transform registry,
+-- mirroring the DuckDB goldenflow_* UDFs (goldenmatch_duckdb/goldenflow.py).
+-- Closes the last DuckDB <-> Postgres parity gap. All STRICT (NULL in -> NULL
+-- out); the bridge fails open (passes the input through unchanged when
+-- goldenflow isn't installed / the transform errors), so these are read-only
+-- and safe for PUBLIC -- no REVOKE.
+
+-- Normalize an email address. Wraps goldenflow `email_normalize`.
+CREATE FUNCTION "goldenflow_normalize_email"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_email_wrapper';
+
+-- Normalize a phone number to E.164. Wraps goldenflow `phone_e164`.
+CREATE FUNCTION "goldenflow_normalize_phone"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_phone_wrapper';
+
+-- Normalize a date to ISO-8601. Wraps goldenflow `date_iso8601`.
+CREATE FUNCTION "goldenflow_normalize_date"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_date_wrapper';
+
+-- Proper-case a personal name. Wraps goldenflow `name_proper`.
+CREATE FUNCTION "goldenflow_normalize_name_proper"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_name_proper_wrapper';
+
+-- Canonicalize a URL. Wraps goldenflow `url_normalize`.
+CREATE FUNCTION "goldenflow_canonicalize_url"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_url_wrapper';
+
+-- Standardize a postal address. Wraps goldenflow `address_standardize`.
+CREATE FUNCTION "goldenflow_canonicalize_address"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_address_wrapper';
+
+-- Strip leading/trailing whitespace. Wraps goldenflow `strip`.
+CREATE FUNCTION "goldenflow_strip"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_strip_wrapper';
+
+-- Collapse internal whitespace runs. Wraps goldenflow `collapse_whitespace`.
+CREATE FUNCTION "goldenflow_whitespace_normalize"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_whitespace_normalize_wrapper';
+
+-- ── Native Core graph kernels (#509) ──────────────────────────────────────
+-- Native-direct: these call the pyo3-free goldenmatch-graph-core crate in pure
+-- Rust (NO embedded CPython). DuckDB<->Postgres lockstep with core_kernels.py.
+-- Accept-both: int64 ids on the bare name, string ids on the _str sibling
+-- (a first-seen str<->i64 dictionary wraps the i64 kernel).
+
+-- Canonical max-score pairs over int64 id arrays. Returns (a, b, s) rows.
+CREATE FUNCTION "goldenmatch_pair_dedup"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_wrapper';
+
+-- String-id variant: same kernel via a first-seen str<->i64 dictionary.
+CREATE FUNCTION "goldenmatch_pair_dedup_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" TEXT, "b" TEXT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_str_wrapper';
+
+-- Connected components over int64 edge arrays + an int64 id universe.
+-- Returns (component_index, member) rows.
+CREATE FUNCTION "goldenmatch_connected_components"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" BIGINT[]
+) RETURNS TABLE ("component" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_wrapper';
+
+-- String-id variant of connected components.
+CREATE FUNCTION "goldenmatch_connected_components_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" TEXT[]
+) RETURNS TABLE ("component" BIGINT, "member" TEXT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_str_wrapper';
+
+-- Embed one text with a local in-house model (a saved GoldenEmbedModel dir)
+-- via goldenembed-rs (pure Rust, no embedded CPython). Returns the vector as
+-- float8[].
+CREATE FUNCTION "goldenmatch_embed_local"(
+    "text" TEXT,
+    "model_path" TEXT
+) RETURNS double precision[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
+
+-- Embed one text with the in-house model, model dir from GOLDENEMBED_MODEL_DIR
+-- (loaded once per backend process). Returns real[] (float4) -- parity with the
+-- DataFusion goldenmatch_embed UDF, including NULL -> "" (so NOT STRICT). #737.
+CREATE FUNCTION "gm_embed"(
+    "text" TEXT  /* nullable: NULL -> "" */
+) RETURNS real[]
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_embed_wrapper';
+
+-- Canonical record fingerprint (64 hex) of a JSON record object. The
+-- cross-surface stable record-id hash; matches the DuckDB
+-- goldenmatch_record_fingerprint UDF + the Python identity path.
+CREATE FUNCTION "goldenmatch_record_fingerprint"(
+    "record_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_record_fingerprint_wrapper';

--- a/packages/rust/extensions/postgres/src/quick.rs
+++ b/packages/rust/extensions/postgres/src/quick.rs
@@ -99,6 +99,46 @@ pub fn goldenmatch_dedupe_clusters(
     }
 }
 
+/// Match a target table against a reference table and return the matched
+/// pairs as rows: each target row linked to a reference row with its score.
+///
+/// `target_id` / `reference_id` are 0-based row indices into the respective
+/// input tables (the bridge normalizes match_df's combined `__row_id__`
+/// space back to per-table indices).
+///
+/// ```sql
+/// SELECT * FROM goldenmatch_match_pairs('incoming', 'master', '{}');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_match_pairs(
+    target_table: String,
+    reference_table: String,
+    config_json: String,
+) -> TableIterator<
+    'static,
+    (
+        name!(target_id, i64),
+        name!(reference_id, i64),
+        name!(score, f64),
+    ),
+> {
+    let target_json = spi::read_table_as_json(&target_table)
+        .unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    let ref_json = spi::read_table_as_json(&reference_table)
+        .unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+
+    match goldenmatch_bridge::api::match_pairs(&target_json, &ref_json, &config_json) {
+        Ok(pairs) => {
+            let rows: Vec<(i64, i64, f64)> = pairs
+                .into_iter()
+                .map(|p| (p.target_id, p.reference_id, p.score))
+                .collect();
+            TableIterator::new(rows)
+        }
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
 // ── Scalar functions ───────────────────────────────────────────────────
 
 /// Score two strings using a named similarity algorithm.


### PR DESCRIPTION
**P3 of the dbt parity program** (follows P0 #1020, P1 #1022, P2 #1024). Closes the headline gap: dbt can now **link two tables** (match a target model against a reference), not just dedupe one.

Spec: `docs/superpowers/specs/2026-06-16-dbt-two-table-match-design.md`. Plan: `docs/superpowers/plans/2026-06-16-dbt-two-table-match.md`.

## What it does
```sql
{{ config(materialized='goldenmatch_match', reference=ref('master')) }}
SELECT * FROM {{ ref('incoming') }}
```
Model body = target; `reference` = master relation; output = matched pairs `(target_id, reference_id, score)`, best match per target. `match_config` optional (omit -> zero-config). Postgres-first; DuckDB raises a clear "use the JSON UDF" error.

## Surfaces (mirrors the dedupe_pairs pattern)
- **bridge** `match_pairs(target_json, ref_json, config_json) -> Vec<MatchedPair{target_id, reference_id, score}>` over `match_df`. Extracts the linkage from `result.matched` and **normalizes `reference_id = __ref_row_id__ - len(target)`** (match_df uses a combined `__row_id__` space; without this every pair joins back to the wrong reference row). `cargo test` asserts `reference_id` is 0-based.
- **pgrx** `goldenmatch_match_pairs(target_table, ref_table, config_json) RETURNS TABLE(target_id, reference_id, score)` via `TableIterator` (reads both tables like `goldenmatch_match_tables`, returns a table like `goldenmatch_dedupe_pairs`). Full version ritual `goldenmatch_pg` 0.8.0 -> 0.9.0. Verified CI-only (`rust_pgrx`).
- **DuckDB** unchanged (JSON `goldenmatch_match_tables` stays); match materialization is Postgres-first.
- **dbt** `goldenmatch_match` materialization + adapter-guard helper; render-tested.

## Verification
Bridge `cargo test` passed with real Python (proved the `reference_id` normalization: `__ref_row_id__` 2,3 -> `reference_id` 0,1). dbt suite 153 passed. The `rust_pgrx` lane (PG 15/16/17) is the gate for the Postgres UDF + version ritual + a psql smoke (`goldenmatch_match_pairs('t','r','{}')`).

Out of scope (follow-ups): zero-config/`probabilistic` match config plumbing (`match_mode='all'`, `autoconfig_match`); DuckDB table-returning match; full-record output (returns the linkage; join back via `ROW_NUMBER()`).

Config note (from a build finding): the bridge config is `match_df`'s `exact/fuzzy/blocking/threshold` kwargs shape — a minimal fuzzy config without blocking yields zero candidates, so zero-config (`{}`) is the reliable default.