### PR TITLE
feat(benchmarks): ER-KG-Bench emb-openai — semantic embedding cracks abbreviation + synonym

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/HANDOFF.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/HANDOFF.md
@@ -11,8 +11,9 @@ runs each framework's *documented-default* dedup rule over a labelled record set
 by 9 failure classes and reports pairwise P/R/F1 per class.
 
 - **Merged:** PR #1023 (the benchmark) → on `main`.
-- **Open (draft):** PR #1025, branch `claude/er-kg-bench-llm-experiment` (the LLM experiment
-  + the `emb-ann` adapter). Rebased clean onto `main`; awaiting the user to mark ready/queue.
+- **Merged:** PR #1025 (the LLM experiment + the offline `emb-ann` adapter) → on `main`.
+- **This branch (`claude/er-kg-bench-emb-openai`):** the semantic-embedding follow-up —
+  `emb-openai` (key-gated, cracks abbreviation + synonym). See "DONE: semantic embedding" below.
 - Location: `packages/python/goldenmatch/benchmarks/er-kg-bench/`.
 
 ## Why this exists (strategic context)
@@ -79,29 +80,30 @@ README.md / TAXONOMY.md           the writeup + the 9-class taxonomy with framew
    knowledge (IBM↔IBM-expansion ~0.05; Coumadin↔warfarin ~0.02).
 
 **Net arc:** string blocking → misses semantics; LLM pair-scorer → wrong tool; embedding-ANN →
-right mechanism, needs a *semantic* embedding to close the last two classes.
+right mechanism, needs a *semantic* embedding to close the last two classes — **and a semantic
+embedding does** (4 below).
 
-## The next task (highest value, explicitly requested direction)
+4. **A semantic embedding closes the last two classes (measured, key-dependent).**
+   `goldenmatch(emb-openai)` swaps OpenAI `text-embedding-3-small` (stdlib HTTP, no torch) into the
+   `emb-ann` path at cosine ≥ 0.55: **abbr 0.18→0.95, synonym 0.0→0.88, overall F1 0.742** (beats
+   the prior leader `auto+fields` 0.674). Only the embedder changed vs `emb-ann`, so the gain is
+   the world knowledge in the vectors. Negative-class precision stays low (`coll_P` 0.39 / `temp_P`
+   0.38 — same as every name-only row; name-only embeddings over-merge colliding surface forms).
+   Key-gated → out of the committed table, recorded as prose in README ("The semantic-embedding
+   result"). Reproduce: `OPENAI_API_KEY=sk-... python erkgbench/run.py`.
 
-**Swap a semantic embedding into `emb-ann` to crack abbreviation + synonym.** The adapter
-(`GoldenMatchEmbAnnAdapter` in `goldenmatch_adapter.py`) is already structured for it: it embeds
-mentions, builds a cosine matrix, thresholds candidate pairs, union-finds. Only the embedder
-needs swapping.
+## DONE: semantic embedding (was "the next task")
 
-Options, in order of "offline-ness":
-- **sentence-transformers** (`all-MiniLM-L6-v2`) — local but needs `torch`. **WARNING: `import
-  torch` hangs/segfaults in this dev environment** (documented in the package CLAUDE.md). You
-  may only be able to validate it in CI / a torch-working box, not interactively here.
-- **goldenmatch inhouse with a TRAINED model** — the in-house embedder can be *trained* from
-  labelled pairs (`goldenmatch.embeddings.inhouse.train_embedder`), but a trained char-n-gram
-  projection still won't learn IBM↔expansion (no shared features) — semantic knowledge is the
-  missing ingredient, not training.
-- **cloud embedding** (OpenAI `text-embedding-3-small` / Vertex) — needs a key/creds.
-
-Add it as a new mode/adapter (e.g. `goldenmatch(emb-st)`), gate it on availability (skip
-gracefully if torch/key absent, like `auto_llm` does), keep it **out of the committed table** if
-it's key/torch-dependent (record as prose, matching how the LLM experiment was handled). Pick the
-threshold by a small sweep but **do not overfit** — report a round, defensible value.
+**Shipped.** `GoldenMatchEmbAnnAdapter` is now parametrised by embedder
+(`provider=None` → the byte-identical offline char-n-gram `emb-ann`; `provider="openai"` → the
+semantic `emb-openai` row via `goldenmatch.embeddings.providers.resolve_provider`). The runner
+adds `emb-openai` (threshold 0.55, from a sweep; flat 0.525–0.6 plateau, not overfit) only when
+`OPENAI_API_KEY` is set, exactly like `auto+llm`. Numbers + the honest precision caveat are in
+finding 4 above and the README. `provider="local"` (sentence-transformers, `all-MiniLM-L6-v2`)
+is wired through the same seam but **unvalidated here** — `import torch` hangs in this dev env, so
+it needs a CI / torch-working box. The OpenAI key lives in Infisical (`OPENAI_API_KEY`, project
+`a99885f0-c5af-4ae1-9dc8-255cc60aa129`, env `dev`); inject via `infisical.cmd run ... -- python ...`
+to avoid leaking it.
 
 ## Other open work (lower priority)
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
@@ -83,7 +83,8 @@ The committed `results/RESULTS.md` is an honest baseline, not a victory lap:
   Machines cosine ~0.05; Coumadin↔warfarin ~0.02). Cracking those two classes
   needs a *semantic* embedding model (sentence-transformers / cloud), i.e. torch
   or a key — the bench says so plainly rather than implying the offline path
-  closes the gap.
+  closes the gap. The keyed `emb-openai` row below does exactly this and cracks
+  both (abbr 0.95, synm 0.88) — see "The semantic-embedding result".
 
 So the bench localises goldenmatch's differentiation (multi-field evidence the
 name-only frameworks can't use) honestly, alongside its current gaps
@@ -113,6 +114,39 @@ up, recall down). The lever for the semantic classes is therefore semantic
 scorer. The committed table stays the offline, reproducible-by-anyone run; the
 `auto+llm` row only appears when the runner sees a key.
 
+## The semantic-embedding result (measured, key-dependent — not in the committed table)
+
+The LLM experiment named the lever: semantic **candidate generation**, not an LLM
+pair filter. So we swapped a semantic embedder into the `emb-ann` path —
+`goldenmatch(emb-openai)`, OpenAI `text-embedding-3-small` (stdlib HTTP, no torch),
+name only, cosine ≥ 0.55 (a small threshold sweep; the overall-F1 peak sits on a
+flat 0.525–0.6 plateau, so 0.55 is a round, non-overfit cut). It is the proof the
+arc points to:
+
+| config | abbr | synm | xling | P | R | overall F1 |
+|---|---|---|---|---|---|---|
+| `goldenmatch(emb-ann)` (offline, char-n-gram) | 0.182 | 0.00 | 0.560 | 0.434 | 0.677 | **0.529** |
+| `goldenmatch(auto+fields)` (no key, prior leader) | 0.667 | 0.20 | 0.839 | 0.624 | 0.732 | **0.674** |
+| `goldenmatch(emb-openai)` (with key) | **0.947** | **0.875** | 0.909 | 0.640 | 0.882 | **0.742** |
+
+It **cracks the two classes the offline path can't** — abbreviation 0.18 → 0.95,
+synonym 0.0 → 0.88 — and is the only row strong on *both*, lifting overall F1 past
+the prior leader (0.742 vs 0.674). Same embedding-ANN mechanism the offline
+`emb-ann` row demonstrates; only the embedder changed, so the gain is attributable
+to *world knowledge in the vectors* (IBM ↔ its expansion, Coumadin ↔ warfarin),
+exactly what a char-n-gram cosine lacks. It is deterministic on this set
+(`det-floor: yes`).
+
+The honest cost is unchanged from every other name-only row: precision on the
+negative classes stays low (`coll_P` 0.39, `temp_P` 0.38 — comparable to `emb-ann`
+0.39/0.35 and `neo4j-graphrag` 0.39/0.38), because a name-only embedding *over-*
+merges distinct entities that share a surface form. Multi-field evidence
+(`auto+fields`) or a real probability threshold is the lever there, not the
+embedder. Because it needs a key it is **not reproducible by everyone**, so it
+stays out of the committed table and lives here as prose — same posture as the LLM
+experiment. Reproduce with `OPENAI_API_KEY=sk-... python erkgbench/run.py` (the
+runner adds the `emb-openai` and `auto+llm` rows only when it sees a key).
+
 ## Layout
 
 ```
@@ -129,13 +163,15 @@ TAXONOMY.md            the nine failure classes, with framework citations
 * **Add a failure class / more entities:** edit `seeds.jsonl`, re-run
   `generate.py`. Negative classes (distinct entities, colliding strings) are
   the precision tests — keep adding them.
-* **Crack abbreviation + synonym (the last offline gap):** swap a *semantic*
-  embedding into `emb-ann` in place of the char-n-gram in-house model — a
-  sentence-transformers model (needs torch) or a cloud embedding (needs creds).
-  The shipped `emb-ann` proves the candidate-generation *mechanism* offline and
-  isolates exactly the two classes a semantic model is required for; this is the
-  one remaining lever for them. (`auto+llm` via `OPENAI_API_KEY` is the contrast
-  showing an LLM *pair filter* is the wrong tool — it can't generate the pair.)
+* **Crack abbreviation + synonym (done, key-gated):** the `emb-openai` mode swaps a
+  semantic embedder (`text-embedding-3-small`, no torch) into the `emb-ann` path and
+  cracks both classes (abbr 0.95, synm 0.88; overall F1 0.742) — see "The
+  semantic-embedding result". `GoldenMatchEmbAnnAdapter(provider=...)` is the seam;
+  pass `provider="local"` for a torch-free-of-cloud sentence-transformers run, or any
+  `goldenmatch.embeddings.providers` name. Reproduce with `OPENAI_API_KEY` set. The
+  offline char-n-gram `emb-ann` still ships as the no-key proof of the *mechanism*.
+  (`auto+llm` via `OPENAI_API_KEY` is the contrast showing an LLM *pair filter* is
+  the wrong tool — it can't generate the pair.)
 * **Add a *live* adapter:** for systems that resolve deterministically without
   an LLM (neo4j-graphrag rapidfuzz/spaCy resolvers, LlamaIndex Cypher), a real
   adapter behind an optional extra can corroborate the model.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldenmatch_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldenmatch_adapter.py
@@ -98,24 +98,61 @@ class GoldenMatchEmbAnnAdapter:
     At benchmark scale this computes exact cosine; the ANN index is the scale-out
     form of the same candidate-generation step. Name only, to isolate what the
     embedding itself bridges (apples-to-apples with the frameworks' name dedup).
+
+    Swapping the embedder is the lever the LLM experiment pointed at to crack
+    the two classes the offline path leaves open. ``provider`` selects it:
+    ``None`` keeps the offline char-ngram model (the committed ``emb-ann`` row);
+    a name like ``"openai"`` routes through ``goldenmatch.embeddings.providers``
+    to a *semantic* embedder with world knowledge (``IBM`` <-> its expansion,
+    ``Coumadin`` <-> ``warfarin``). Semantic providers cost a key or torch, so
+    the runner gates them on availability and keeps them out of the committed,
+    reproducible-by-anyone table -- recorded as prose, like the LLM experiment.
     """
 
     name = "goldenmatch(emb-ann)"
     deterministic = True
 
-    def __init__(self, threshold: float = 0.5) -> None:
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        *,
+        provider: str | None = None,
+        name: str | None = None,
+        defaults: str | None = None,
+    ) -> None:
         self.threshold = threshold
-        self.defaults = (
-            f"inhouse char-ngram embedding (no key/torch) -> cosine>={threshold} "
-            "candidate pairs (ANN at scale) -> union-find; name only"
-        )
+        self.provider = provider
+        if name is not None:
+            self.name = name
+        elif provider is not None:
+            self.name = f"goldenmatch(emb-{provider})"
+        # else: keep the class-level "goldenmatch(emb-ann)" default.
+        if defaults is not None:
+            self.defaults = defaults
+        elif provider is None:
+            self.defaults = (
+                f"inhouse char-ngram embedding (no key/torch) -> cosine>={threshold} "
+                "candidate pairs (ANN at scale) -> union-find; name only"
+            )
+        else:
+            self.defaults = (
+                f"{provider} semantic embedding -> cosine>={threshold} candidate "
+                "pairs (ANN at scale) -> union-find; name only"
+            )
+
+    def _embed(self, texts: list[str]) -> np.ndarray:
+        if self.provider is None:
+            # fixed-seed random projection -> deterministic; no key, no torch.
+            from goldenmatch.embeddings.inhouse.model import GoldenEmbedModel
+
+            return np.asarray(GoldenEmbedModel().embed(texts), dtype=np.float32)
+        from goldenmatch.embeddings.providers import resolve_provider
+
+        return np.asarray(resolve_provider(self.provider).embed(texts), dtype=np.float32)
 
     def resolve(self, records: list[Record]) -> list[list[int]]:
-        from goldenmatch.embeddings.inhouse.model import GoldenEmbedModel
-
         ordered = sorted(records, key=lambda r: r.index)
-        model = GoldenEmbedModel()  # fixed-seed random projection -> deterministic
-        vecs = np.asarray(model.embed([r.mention for r in ordered]), dtype=np.float32)
+        vecs = self._embed([r.mention for r in ordered])
         norms = np.linalg.norm(vecs, axis=1, keepdims=True)
         vecs = vecs / np.where(norms == 0.0, 1.0, norms)
         sim = vecs @ vecs.T  # cosine; index i == record i (ordered 0..n-1)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
@@ -101,9 +101,15 @@ def run(embedder_kind: str | None) -> dict:
         # no-torch) in-house embedder -- the lever the LLM experiment pointed at.
         GoldenMatchEmbAnnAdapter(),
     ]
-    # The semantic-class attacker only activates with a key (else it is the same
-    # as auto+fields with a per-pair LLM step). Skip rather than fake it.
+    # The semantic-class attackers only activate with a key. Skip rather than
+    # fake it; both stay out of the committed table (recorded as prose), since
+    # they are not reproducible without a key.
     if os.environ.get("OPENAI_API_KEY"):
+        # Embedding-ANN with a SEMANTIC embedder (world knowledge), the lever
+        # the offline char-ngram path can't pull: it generates the candidate
+        # pairs string blocking misses for abbreviation + synonym. Threshold
+        # 0.55 from a small sweep (peak overall F1; stable 0.525-0.6 plateau).
+        adapters.append(GoldenMatchEmbAnnAdapter(threshold=0.55, provider="openai"))
         adapters.append(GoldenMatchAdapter(mode="auto_llm"))
     adapters += list(all_modeled(embed_fn=embed_fn))
 


### PR DESCRIPTION
Follow-up to #1023 (benchmark) and #1025 (offline `emb-ann` + the LLM experiment). Closes the last offline gap the handoff flagged: **abbreviation + synonym**.

## What
- `GoldenMatchEmbAnnAdapter` is now parametrised by embedder. `provider=None` keeps the **byte-identical** offline char-n-gram `emb-ann` row; `provider="openai"` routes through `goldenmatch.embeddings.providers.resolve_provider` (stdlib HTTP, no torch).
- The runner adds `goldenmatch(emb-openai)` (`text-embedding-3-small`, cosine ≥ 0.55) **only when `OPENAI_API_KEY` is set** — gated and kept **out of the committed table**, exactly like `auto+llm`. Numbers recorded as prose in `README.md`.

## Result (measured with a key; not in the committed table)
| | abbr | synm | xling | P | R | overall F1 |
|---|---|---|---|---|---|---|
| `emb-ann` (offline) | 0.18 | 0.00 | 0.56 | 0.43 | 0.68 | 0.529 |
| `auto+fields` (prior leader) | 0.67 | 0.20 | 0.84 | 0.62 | 0.73 | 0.674 |
| **`emb-openai` (key)** | **0.95** | **0.88** | 0.91 | 0.64 | 0.88 | **0.742** |

Only the embedder changed vs `emb-ann`, so the gain is the world knowledge in the vectors. It is the only row strong on **both** semantic classes, and it confirms the LLM-experiment finding: the lever is semantic *candidate generation*, not an LLM pair filter. Deterministic (`det-floor: yes`). Threshold 0.55 is from a sweep (flat 0.525–0.6 plateau, not overfit).

Honest caveat: negative-class precision is unchanged (`coll_P` 0.39 / `temp_P` 0.38 — same as every name-only row; name-only embeddings over-merge colliding surface forms). Multi-field evidence / a real probability threshold is the lever there.

## Safety / scope
- Committed `RESULTS.md` + `results.json` unchanged (verified: offline run reproduces the committed table byte-for-byte). `ruff check` clean.
- No change to the `goldenmatch` library — `OpenAIProvider` already shipped; this only touches the benchmark dir.
- `provider="local"` (sentence-transformers) is wired through the same seam but unvalidated locally (`import torch` hangs in the dev env); validate in CI / a torch box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)