### PR TITLE
perf(sail): edge-node WCC seeding + stage-boundary lineage barriers

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -19,6 +19,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   `benchmarks/collective-er/`. Phase 2 (negative evidence) and Phase 3 (learned
   weights) are planned follow-ups.
 
+### Performance
+- **Sail distributed WCC: edge-node seeding + stage-boundary lineage barriers.**
+  `connected_components_scale` now seeds the pointer-jump iteration from the
+  edge-endpoint subgraph instead of the full id universe, re-attaching singletons
+  after convergence — the partition is byte-identical but every per-round shuffle
+  is proportional to the connected component count, not the row count (avoids
+  dragging isolated nodes through the loop; helps any engine). `run_sail_pipeline`
+  also materializes `pairs` before WCC and `assignments` before survivorship when
+  `wcc_checkpoint_dir` is set, so the lazy plan is truncated at each stage
+  boundary. Motivated by the 2026-06-16 100M GKE run, which wedged the driver
+  building the whole `load→score→dedup→WCC` plan in one action. The boundary
+  barriers are a stopgap for Sail's missing lineage-truncation primitive
+  (lakehq/sail#482); the proper fix is upstream `localCheckpoint`. Default (no
+  checkpoint dir) is byte-identical.
+
 ## [2.0.0] - 2026-06-14
 
 <!-- README-callout

--- a/packages/python/goldenmatch/goldenmatch/sail/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/clustering.py
@@ -130,8 +130,12 @@ def connected_components_scale(
     root each round -> O(log n)).
 
     Same output as ``connected_components``: ``(cluster_id, member_id)`` where
-    cluster_id is the component's min member id. Isolated nodes (singletons)
-    seeded from the DISTRIBUTED ``ids_df`` (the rehydration-OOM trap).
+    cluster_id is the component's min member id. The iteration is seeded from the
+    EDGE-ENDPOINT subgraph only (not the full ``ids_df`` universe); singletons
+    are re-attached as their own component after convergence, so the partition is
+    identical but every per-round shuffle is proportional to the connected
+    subgraph -- avoids dragging isolated nodes through the loop (the old
+    full-universe seed's "rehydration-OOM trap").
 
     Each round: (1) PROPAGATE -- each node adopts min(own label, min neighbor
     label); (2) SHORTCUT -- ``label[v] = label[label[v]]`` (jump to the label's
@@ -166,10 +170,18 @@ def connected_components_scale(
     rev = pairs_df.select(F.col("b").alias("node"), F.col("a").alias("nbr"))
     edges = fwd.unionByName(rev)
 
-    # Labels seeded from the DISTRIBUTED universe (singletons -> own label).
-    labels = ids_df.select(
-        F.col(id_col).cast("long").alias("node")
-    ).withColumn("label", F.col("node"))
+    # EDGE-NODE SEEDING: only nodes that appear in an edge can ever change
+    # label; the (usually vast majority of) singletons trivially form their own
+    # component. Seeding the iteration from the edge-endpoint subgraph instead of
+    # the full ids_df universe keeps every per-round shuffle proportional to the
+    # CONNECTED subgraph, not |ids| -- this is the literal "rehydration-OOM trap"
+    # the old full-universe seed warned about (at 100M, ~75M singletons were
+    # dragged through every propagate/shortcut join). Singletons are re-attached
+    # after the loop, so the output partition is byte-identical; this is a pure,
+    # engine-agnostic speedup (helps the Ray and one-box WCC paths too).
+    labels = edges.select(F.col("node")).distinct().withColumn(
+        "label", F.col("node")
+    )
 
     # Spark Connect discipline: join on a SHARED NAME, other side renamed; no
     # df["col"] cross-handle refs (the S2 AMBIGUOUS_REFERENCE lesson).
@@ -214,6 +226,17 @@ def connected_components_scale(
         if checkpoint_dir and checkpoint_interval and (round_idx + 1) % checkpoint_interval == 0:
             labels = _truncate_lineage(labels, checkpoint_dir, f"wcc_round_{round_idx + 1}")
 
-    return labels.select(
+    # The iteration produced final labels for edge-nodes only. Re-attach every
+    # id NOT in any edge as its own singleton component (cluster_id = self) so
+    # the output contract is unchanged: every member id present, exactly the
+    # partition the full-universe seed produced. left_anti finds ids absent from
+    # the edge-node set; the union is a single non-iterative pass (no shuffle
+    # growth), so the lineage barrier discipline above is unaffected.
+    edge_assign = labels.select(
         F.col("label").alias("cluster_id"), F.col("node").alias("member_id")
     )
+    all_ids = ids_df.select(F.col(id_col).cast("long").alias("member_id"))
+    singletons = all_ids.join(
+        edge_assign.select("member_id"), on="member_id", how="left_anti"
+    ).select(F.col("member_id").alias("cluster_id"), F.col("member_id"))
+    return edge_assign.unionByName(singletons)

--- a/packages/python/goldenmatch/goldenmatch/sail/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/clustering.py
@@ -232,8 +232,15 @@ def connected_components_scale(
     # partition the full-universe seed produced. left_anti finds ids absent from
     # the edge-node set; the union is a single non-iterative pass (no shuffle
     # growth), so the lineage barrier discipline above is unaffected.
+    # Cast to long so edge_assign, the left_anti join key, the singleton union,
+    # and the downstream build_golden join (on source row_id, long) all see one
+    # consistent schema. `labels` columns come from `pairs` (uncast); mixing them
+    # with the cast-long singletons left a union whose physical schema diverged
+    # from its logical schema -> Sail errors on the downstream join (the
+    # full-universe seed avoided this by seeding from ids_df.cast("long")).
     edge_assign = labels.select(
-        F.col("label").alias("cluster_id"), F.col("node").alias("member_id")
+        F.col("label").cast("long").alias("cluster_id"),
+        F.col("node").cast("long").alias("member_id"),
     )
     all_ids = ids_df.select(F.col(id_col).cast("long").alias("member_id"))
     singletons = all_ids.join(

--- a/packages/python/goldenmatch/goldenmatch/sail/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/clustering.py
@@ -226,24 +226,26 @@ def connected_components_scale(
         if checkpoint_dir and checkpoint_interval and (round_idx + 1) % checkpoint_interval == 0:
             labels = _truncate_lineage(labels, checkpoint_dir, f"wcc_round_{round_idx + 1}")
 
-    # The iteration produced final labels for edge-nodes only. Re-attach every
-    # id NOT in any edge as its own singleton component (cluster_id = self) so
-    # the output contract is unchanged: every member id present, exactly the
-    # partition the full-universe seed produced. left_anti finds ids absent from
-    # the edge-node set; the union is a single non-iterative pass (no shuffle
-    # growth), so the lineage barrier discipline above is unaffected.
-    # Cast to long so edge_assign, the left_anti join key, the singleton union,
-    # and the downstream build_golden join (on source row_id, long) all see one
-    # consistent schema. `labels` columns come from `pairs` (uncast); mixing them
-    # with the cast-long singletons left a union whose physical schema diverged
-    # from its logical schema -> Sail errors on the downstream join (the
-    # full-universe seed avoided this by seeding from ids_df.cast("long")).
-    edge_assign = labels.select(
-        F.col("label").cast("long").alias("cluster_id"),
+    # The iteration produced final labels for edge-nodes only. Re-attach every id
+    # NOT in any edge as its own singleton component (cluster_id = self) so the
+    # output contract is unchanged: every member id present, exactly the partition
+    # the full-universe seed produced.
+    #
+    # Done with a single LEFT JOIN + coalesce (NOT a union): left-join the full id
+    # universe to the edge-node labels and coalesce a missing label to the node
+    # itself. A unionByName here tripped a Sail bug -- the union's cluster_id field
+    # carried divergent physical-vs-logical metadata ("SPARK::metadata::json"),
+    # which the parity tests' bare .collect() tolerated but build_golden's
+    # downstream join crashed on. (Candidate upstream Sail report; real Spark
+    # doesn't desync union field metadata.) Cast to long so the join key and
+    # output match build_golden's source row_id; one non-iterative join, so the
+    # lineage-barrier discipline above is unaffected.
+    edge_labels = labels.select(
         F.col("node").cast("long").alias("member_id"),
+        F.col("label").cast("long").alias("edge_label"),
     )
     all_ids = ids_df.select(F.col(id_col).cast("long").alias("member_id"))
-    singletons = all_ids.join(
-        edge_assign.select("member_id"), on="member_id", how="left_anti"
-    ).select(F.col("member_id").alias("cluster_id"), F.col("member_id"))
-    return edge_assign.unionByName(singletons)
+    return all_ids.join(edge_labels, on="member_id", how="left").select(
+        F.coalesce(F.col("edge_label"), F.col("member_id")).alias("cluster_id"),
+        F.col("member_id"),
+    )

--- a/packages/python/goldenmatch/goldenmatch/sail/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/pipeline.py
@@ -90,6 +90,7 @@ def run_sail_pipeline(
     _validate_sail_pipeline_supported(scorer_name=scorer_name, wcc=wcc)
 
     from goldenmatch.sail.clustering import (
+        _truncate_lineage,
         connected_components,
         connected_components_scale,
     )
@@ -104,6 +105,18 @@ def run_sail_pipeline(
         scorer_name=scorer_name,
         threshold=threshold,
     )
+    # STAGE-BOUNDARY LINEAGE BARRIERS (Sail stopgap; the proper fix is upstream
+    # `localCheckpoint`/`persist` -- lakehq/sail#482). Spark Connect is lazy, so
+    # without a barrier the first WCC action must plan the ENTIRE upstream DAG
+    # (load -> block -> self-join score -> dedup) in one shot; at 100M that
+    # overwhelms Sail's driver optimizer and the run wedges BEFORE WCC round 1
+    # (observed on the 2026-06-16 GKE run: driver silent 6+ min, no checkpoint
+    # ever written). Materializing `pairs` to parquet and reading it back resets
+    # the plan so the graph stage starts from a small fresh scan. Gated on
+    # wcc_checkpoint_dir (default None = off, byte-identical); when Sail ships a
+    # working localCheckpoint this collapses to `pairs = pairs.localCheckpoint()`.
+    if wcc_checkpoint_dir:
+        pairs = _truncate_lineage(pairs, wcc_checkpoint_dir, "pairs")
     ids_df = source_df.select(id_col)
     if wcc == "scale":
         assignments = connected_components_scale(
@@ -115,6 +128,13 @@ def run_sail_pipeline(
         )
     else:
         assignments = connected_components(pairs, ids_df, id_col=id_col)
+    # Second boundary barrier before survivorship: `assignments` feeds BOTH
+    # build_golden and (S5) build_identity_graph, so materialize once -- truncates
+    # the WCC lineage and avoids recomputing the whole graph stage twice.
+    if wcc_checkpoint_dir:
+        assignments = _truncate_lineage(
+            assignments, wcc_checkpoint_dir, "assignments"
+        )
     golden = build_golden(
         assignments,
         source_df,

--- a/packages/python/goldenmatch/tests/test_sail_clustering_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_clustering_parity.py
@@ -143,3 +143,37 @@ def test_sail_wcc_scale_junction(spark):
     pairs_df = spark.createDataFrame(edges, ["a", "b"])
     out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
     assert _sail_partition(out) == _reference_partition(ids, edges)
+
+
+def test_sail_wcc_scale_edge_node_seeding_singleton_heavy(spark):
+    """Edge-node seeding (the 100M scale fix): the iteration runs only over the
+    edge-endpoint subgraph; the (here vast majority of) singletons are
+    re-attached as their own component after the loop. ids 0..9 with a SINGLE
+    edge between two high ids (7,8) -> one {7,8} component + 8 singletons
+    (incl. ids LOWER than the edge nodes). Asserts the re-attach produces the
+    exact full-universe partition, incl. every singleton's cluster_id = self."""
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = list(range(10))
+    edges = [(7, 8)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    part = _sail_partition(out)
+    assert part == _reference_partition(ids, edges)
+    # explicit: 8 singletons + one 2-member component, every id present once.
+    assert sum(len(c) for c in part) == 10
+    assert frozenset({7, 8}) in part
+    assert frozenset({0}) in part and frozenset({9}) in part
+
+
+def test_sail_wcc_scale_no_edges_all_singletons(spark):
+    """Degenerate edge case: zero matches -> empty edge-node seed -> every id is
+    re-attached as its own singleton (no rows lost)."""
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = list(range(5))
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame([], "a long, b long")
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == {frozenset({i}) for i in ids}


### PR DESCRIPTION
## Summary

The 2026-06-16 100M Sail-on-GKE binding run wedged the **driver** before WCC
round 1: Spark Connect is lazy, so the first WCC action had to plan the entire
`load → block → score (~1.2B pairs) → dedup → WCC` DAG in one shot, which
overwhelms Sail's query optimizer at 100M (workers sat idle, no checkpoint
barrier was ever written, the operation timed out). Findings:
`docs/superpowers/specs/2026-06-16-sail-gke-100m-binding-run.md`.

Two fixes, split by owner (per the upstream-vs-local discipline):

1. **Edge-node WCC seeding (goldenmatch's algorithm — engine-agnostic).**
   `connected_components_scale` seeds the pointer-jump iteration from the
   edge-endpoint subgraph instead of the full id universe, and re-attaches
   singletons (`left_anti` + `unionByName`) after convergence. The output
   partition is **byte-identical**, but every per-round shuffle is now
   proportional to the connected subgraph, not `|ids|` — the old full-universe
   seed dragged ~75M singletons through every propagate/shortcut join (its own
   docstring's "rehydration-OOM trap"). Helps the Ray and one-box WCC paths too.

2. **Stage-boundary lineage barriers (a Sail stopgap — proper fix is upstream).**
   `run_sail_pipeline` materializes `pairs` before WCC and `assignments` before
   survivorship when `wcc_checkpoint_dir` is set, truncating the lazy plan at
   each boundary so no single action plans the whole DAG. This is a workaround
   for Sail's missing lineage-truncation primitive (`cache`/`persist`/
   `checkpoint` are no-ops — lakehq/sail #476/#482/#484); when Sail ships a
   working `localCheckpoint` these collapse to `pairs = pairs.localCheckpoint()`.
   Default (no checkpoint dir) is **byte-identical**.

## Test plan

- [ ] `sail` CI lane green (the pysail parity oracle — not runnable on the
  Windows dev box). Existing scale fixtures (chain / junction / singletons) gate
  the re-attach; two new cases added: singleton-heavy (one high-id edge + 8
  isolated nodes) and zero-edge (all singletons).
- [ ] ruff + py_compile clean (done locally).
- [ ] 100M GKE re-run confirms the driver no longer wedges (binding perf check,
  done out-of-band before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
