### PR TITLE
feat(benchmarks): ER-KG-Bench grow dataset to 54 entities + add a CI lane

### DIFF
--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -7,9 +7,10 @@
 # Two runs:
 #   * OFFLINE (no key) -> the committed, reproducible-by-anyone table. Uploaded
 #     as artifact `er-kg-results-offline`; download + commit these.
-#   * KEYED (OPENAI_API_KEY pulled from Infisical) -> the emb-openai + auto+llm
-#     rows that stay OUT of the committed table. Printed to the run summary and
+#   * KEYED (OPENAI_API_KEY Actions secret) -> the emb-openai + auto+llm rows
+#     that stay OUT of the committed table. Printed to the run summary and
 #     uploaded as `er-kg-results-keyed`; use for the README/HANDOFF prose.
+#     (Secret mirrors the Infisical OPENAI_API_KEY; set via `gh secret set`.)
 #
 # Triggers on a push touching the benchmark SOURCE (not results/, so committing
 # regenerated results does not loop) and on manual dispatch.
@@ -60,28 +61,16 @@ jobs:
           name: er-kg-results-offline
           path: ${{ env.BENCH_DIR }}/results/
 
-      - name: Install Infisical CLI
-        run: |
-          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
-          sudo apt-get update && sudo apt-get install -y infisical
       - name: Run benchmark (keyed -- emb-openai + auto+llm; prose only)
         working-directory: ${{ env.BENCH_DIR }}
         env:
-          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
-          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${INFISICAL_CLIENT_ID:-}" ]; then
-            echo "No Infisical creds available; skipping the keyed run." >> "$GITHUB_STEP_SUMMARY"
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "No OPENAI_API_KEY secret; skipping the keyed run." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          TOKEN=$(infisical login --silent --plain --method=universal-auth \
-            --client-id="$INFISICAL_CLIENT_ID" --client-secret="$INFISICAL_CLIENT_SECRET")
-          echo "::add-mask::$TOKEN"
-          OPENAI_API_KEY=$(infisical secrets get OPENAI_API_KEY \
-            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --path=/ --plain --token="$TOKEN")
-          echo "::add-mask::$OPENAI_API_KEY"
-          export OPENAI_API_KEY
           "$GITHUB_WORKSPACE/.venv/bin/python" erkgbench/run.py
           {
             echo '## ER-KG-Bench (keyed run: emb-openai + auto+llm rows included)'

--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -1,0 +1,96 @@
+# ER-KG-Bench runner. Regenerates results/{RESULTS.md,results.json} on a real
+# runner because the goldenmatch auto / auto+fields / auto+llm rows (full
+# dedupe_df + auto-config controller, each run twice for the determinism check)
+# are too memory-heavy for a dev laptop. The benchmark dir sits OUTSIDE the main
+# CI path filters, so this is its only CI lane.
+#
+# Two runs:
+#   * OFFLINE (no key) -> the committed, reproducible-by-anyone table. Uploaded
+#     as artifact `er-kg-results-offline`; download + commit these.
+#   * KEYED (OPENAI_API_KEY pulled from Infisical) -> the emb-openai + auto+llm
+#     rows that stay OUT of the committed table. Printed to the run summary and
+#     uploaded as `er-kg-results-keyed`; use for the README/HANDOFF prose.
+#
+# Triggers on a push touching the benchmark SOURCE (not results/, so committing
+# regenerated results does not loop) and on manual dispatch.
+#
+# To run: push to the er-kg-bench source, or Actions -> "bench-er-kg" -> Run.
+name: bench-er-kg
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "packages/python/goldenmatch/benchmarks/er-kg-bench/dataset/**"
+      - "packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/**"
+      - ".github/workflows/bench-er-kg.yml"
+
+permissions:
+  contents: read
+
+env:
+  BENCH_DIR: packages/python/goldenmatch/benchmarks/er-kg-bench
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"  # no cross-run memory writes in CI
+
+jobs:
+  bench:
+    # Tiny dataset (~171 records); ubuntu-latest (16 GB) provisions fast and has
+    # ample headroom -- the cost is the controller, not data size.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+      - name: Sync workspace + editable goldenmatch
+        run: |
+          uv sync --all-packages
+          uv pip install -e packages/python/goldenmatch
+
+      - name: Run benchmark (offline -- the committed table)
+        working-directory: ${{ env.BENCH_DIR }}
+        run: "$GITHUB_WORKSPACE/.venv/bin/python erkgbench/run.py"
+      - name: Upload offline results (commit these)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: er-kg-results-offline
+          path: ${{ env.BENCH_DIR }}/results/
+
+      - name: Install Infisical CLI
+        run: |
+          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+          sudo apt-get update && sudo apt-get install -y infisical
+      - name: Run benchmark (keyed -- emb-openai + auto+llm; prose only)
+        working-directory: ${{ env.BENCH_DIR }}
+        env:
+          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
+          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${INFISICAL_CLIENT_ID:-}" ]; then
+            echo "No Infisical creds available; skipping the keyed run." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          TOKEN=$(infisical login --silent --plain --method=universal-auth \
+            --client-id="$INFISICAL_CLIENT_ID" --client-secret="$INFISICAL_CLIENT_SECRET")
+          echo "::add-mask::$TOKEN"
+          OPENAI_API_KEY=$(infisical secrets get OPENAI_API_KEY \
+            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --path=/ --plain --token="$TOKEN")
+          echo "::add-mask::$OPENAI_API_KEY"
+          export OPENAI_API_KEY
+          "$GITHUB_WORKSPACE/.venv/bin/python" erkgbench/run.py
+          {
+            echo '## ER-KG-Bench (keyed run: emb-openai + auto+llm rows included)'
+            echo '```'
+            cat results/RESULTS.md
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload keyed results (prose source -- do NOT commit)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: er-kg-results-keyed
+          path: ${{ env.BENCH_DIR }}/results/

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/HANDOFF.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/HANDOFF.md
@@ -41,8 +41,8 @@ Outputs: `results/RESULTS.md` + `results/results.json`. Lint with `ruff check .`
 ## Layout
 
 ```
-seeds.jsonl                       32 ground-truth entities, mentions tagged by failure_class
-dataset/generate.py               seeds -> records.csv (105 records)
+seeds.jsonl                       54 ground-truth entities, mentions tagged by failure_class
+dataset/generate.py               seeds -> records.csv (171 records)
 erkgbench/metrics.py              pairwise P/R/F1 per class + determinism check
 erkgbench/adapters/base.py        Adapter protocol, Record, union-find clustering helpers
 erkgbench/adapters/modeled.py     the 7 framework default-rule models (exact constants + source citations)
@@ -55,13 +55,13 @@ README.md / TAXONOMY.md           the writeup + the 9-class taxonomy with framew
 
 | System | F1 | note |
 |---|---|---|
-| goldenmatch(auto+fields) | **0.674** | leads; only system scoring non-zero on `synonym` (via the context field) |
-| Neo4j-KGBuilder | 0.636 | cosine 0.97 / edit-dist<3 / substring |
-| neo4j-graphrag(fuzzy) | 0.548 | rapidfuzz WRatio≥0.8 |
-| goldenmatch(emb-ann) | 0.529 | offline char-embedding ANN; beats string-only auto (0.418) |
-| LlamaIndex-PGI | 0.486 | KNN-10 + word-dist<5 + cosine>0.9 |
-| goldenmatch(auto) | 0.418 | string-only zero-config |
-| MS-GraphRAG / LightRAG / Cognee / mem0 | ~0.18 | exact-match family; precision **0.0** on `same_name_collision` |
+| goldenmatch(auto+fields) | **0.629** | leads committed rows; only one scoring non-zero on `synonym` (via the context field) |
+| Neo4j-KGBuilder | 0.593 | cosine 0.97 / edit-dist<3 / substring |
+| goldenmatch(auto) | 0.485 | string-only zero-config |
+| goldenmatch(emb-ann) | 0.479 | offline char-embedding ANN; ~level with string-only auto |
+| neo4j-graphrag(fuzzy) | 0.366 | rapidfuzz WRatio≥0.8; precision collapses on the collisions |
+| LlamaIndex-PGI | 0.237 | KNN-10 + word-dist<5 + cosine>0.9 |
+| MS-GraphRAG / LightRAG / Cognee / mem0 | ~0.15 | exact-match family; precision **0.0** on `same_name_collision` |
 
 ## The three load-bearing findings (don't re-derive these)
 
@@ -70,13 +70,14 @@ README.md / TAXONOMY.md           the writeup + the 9-class taxonomy with framew
    constants in `modeled.py` (each cites the source file + GitHub issue).
 2. **The LLM scorer is the WRONG tool for the semantic classes** (measured, key-dependent, kept
    out of the committed table). `goldenmatch(auto+llm)` *lowered* abbr/synonym/cross-lingual
-   (F1 0.674→0.607) because `llm_scorer` is a **precision filter on borderline candidate pairs
-   blocking already produced** — it can confirm/reject a candidate, never create one. It never
-   sees "IBM"↔"International Business Machines" because blocking doesn't pair them.
+   (synonym stays 0.0, abbreviation flat, overall ~flat 0.629→0.632) because `llm_scorer` is a
+   **precision filter on borderline candidate pairs blocking already produced** — it can
+   confirm/reject a candidate, never create one. It never sees "IBM"↔"International Business
+   Machines" because blocking doesn't pair them.
 3. **Embedding-ANN is the RIGHT mechanism, but the offline embedder is char-based.** The shipped
    `goldenmatch(emb-ann)` uses goldenmatch's in-house char-n-gram embedder (pure numpy, no key,
    no torch). It beats string blocking on cross-lingual transliteration / typo / org-suffix, but
-   **abbreviation (~0.18) and synonym (0.0) stay unsolved** — char-n-gram cosine has no world
+   **abbreviation (~0.13) and synonym (0.0) stay unsolved** — char-n-gram cosine has no world
    knowledge (IBM↔IBM-expansion ~0.05; Coumadin↔warfarin ~0.02).
 
 **Net arc:** string blocking → misses semantics; LLM pair-scorer → wrong tool; embedding-ANN →
@@ -85,10 +86,11 @@ embedding does** (4 below).
 
 4. **A semantic embedding closes the last two classes (measured, key-dependent).**
    `goldenmatch(emb-openai)` swaps OpenAI `text-embedding-3-small` (stdlib HTTP, no torch) into the
-   `emb-ann` path at cosine ≥ 0.55: **abbr 0.18→0.95, synonym 0.0→0.88, overall F1 0.742** (beats
-   the prior leader `auto+fields` 0.674). Only the embedder changed vs `emb-ann`, so the gain is
-   the world knowledge in the vectors. Negative-class precision stays low (`coll_P` 0.39 / `temp_P`
-   0.38 — same as every name-only row; name-only embeddings over-merge colliding surface forms).
+   `emb-ann` path at cosine ≥ 0.55: **abbr 0.13→0.98, synonym 0.0→0.73, overall F1 0.721** (beats
+   the committed leader `auto+fields` 0.629). Only the embedder changed vs `emb-ann`, so the gain
+   is the world knowledge in the vectors. Negative-class precision stays low (`coll_P` 0.39 /
+   `temp_P` 0.38 — same as every name-only row; name-only embeddings over-merge colliding surface
+   forms).
    Key-gated → out of the committed table, recorded as prose in README ("The semantic-embedding
    result"). Reproduce: `OPENAI_API_KEY=sk-... python erkgbench/run.py`.
 
@@ -109,9 +111,12 @@ to avoid leaking it.
 
 - **Live-framework adapters** for the deterministic resolvers (neo4j-graphrag rapidfuzz/spaCy,
   LlamaIndex Cypher) behind an optional extra, to corroborate the models in `modeled.py`.
-- **More seed entities** — `seeds.jsonl` is small (32 entities / 105 records). Keep adding the
-  precision-critical negative classes (`same_name_collision`, `temporal_version` — distinct
-  entities with colliding surface forms). Re-run `generate.py` after editing.
+- **More seed entities** — grown to 54 entities / 171 records (was 32 / 105), with extra weight
+  on the precision-critical negatives. Keep adding `same_name_collision` / `temporal_version`
+  (distinct entities, colliding surface forms) and harder `synonym_brand`. Re-run `generate.py`
+  after editing, then regenerate results via the **`bench-er-kg` CI lane** (the goldenmatch
+  rows are too memory-heavy for a laptop; offline artifact = committed table, keyed run = the
+  emb-openai/auto+llm prose via the `OPENAI_API_KEY` Actions secret).
 - **The before/after GraphRAG demo** — build a KG, show the agent answering wrong from
   fragmented/over-merged entities, resolve, show it correct. Draws its numbers from this harness.
   This is the shareable artifact (Show-HN / blog).

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
@@ -61,11 +61,13 @@ The committed `results/RESULTS.md` is an honest baseline, not a victory lap:
   `same_name_collision`** — it merges the two distinct "First National Bank"s
   (#1133 reproduced). Its `temporal_version` precision of 1.0 is trivial: it
   merges so little that it never wrongly merges anything.
-* **Fuzzy resolvers** (neo4j variants) trade that for recall but score **0.37–
-  0.44 precision** — they over-merge collisions *and* BTC-2020-vs-2024.
-* **goldenmatch(auto+fields) leads overall F1 and is the only system scoring
-  non-zero on `synonym_brand`**, with the top `cross_lingual` and
-  `abbreviation` — because multi-field auto-config exploits the `context` field
+* **Fuzzy resolvers** (neo4j-graphrag / LlamaIndex) trade that for recall but
+  score **0.14–0.25 precision** — they over-merge collisions *and*
+  BTC-2020-vs-2024.
+* **goldenmatch(auto+fields) leads overall F1 among the committed rows and is
+  the only one scoring non-zero on `synonym_brand`**, with the top
+  `cross_lingual` and near-top `abbreviation` — because multi-field auto-config
+  exploits the `context` field
   the frameworks' name-only dedup ignores. **Read the magnitude as optimistic:**
   this synthetic dataset's per-entity context is cleanly separable, so context
   acts almost like a hidden label; real extracted context is noisier. The
@@ -76,15 +78,17 @@ The committed `results/RESULTS.md` is an honest baseline, not a victory lap:
   threshold + the quality-gated review path are the fix.
 * **`goldenmatch(emb-ann)` shows the offline embedding lever** — candidate
   generation via goldenmatch's in-house char-n-gram embedder (no key, no torch),
-  name only. It beats the string-only `auto` (F1 0.529 vs 0.418) by catching
-  cross-lingual transliteration, typos and org-suffixes the string blocker
-  misses — but **abbreviation (~0.18) and synonym (0.0) stay unsolved**, because
-  a char-n-gram embedding has no world knowledge (IBM↔International Business
-  Machines cosine ~0.05; Coumadin↔warfarin ~0.02). Cracking those two classes
-  needs a *semantic* embedding model (sentence-transformers / cloud), i.e. torch
-  or a key — the bench says so plainly rather than implying the offline path
-  closes the gap. The keyed `emb-openai` row below does exactly this and cracks
-  both (abbr 0.95, synm 0.88) — see "The semantic-embedding result".
+  name only. It lands about level with string-only `auto` (F1 0.479 vs 0.485):
+  it catches the cross-lingual transliteration and typos the string blocker
+  misses, but gives the edge back on the precision-critical surface-form
+  collisions — and **abbreviation (~0.13) and synonym (0.0) stay unsolved**,
+  because a char-n-gram embedding has no world knowledge (IBM↔International
+  Business Machines cosine ~0.05; Coumadin↔warfarin ~0.02). Cracking those two
+  classes needs a *semantic* embedding model (sentence-transformers / cloud),
+  i.e. torch or a key — the bench says so plainly rather than implying the
+  offline path closes the gap. The keyed `emb-openai` row below does exactly
+  this and cracks both (abbr 0.98, synm 0.73) — see "The semantic-embedding
+  result".
 
 So the bench localises goldenmatch's differentiation (multi-field evidence the
 name-only frameworks can't use) honestly, alongside its current gaps
@@ -100,16 +104,18 @@ opposite of the intuition, and it is the most useful finding here:
 
 | config | abbr | synm | xling | P | R | overall F1 |
 |---|---|---|---|---|---|---|
-| `goldenmatch(auto+fields)` (no key) | 0.667 | 0.20 | 0.839 | 0.624 | 0.732 | **0.674** |
-| `goldenmatch(auto+llm)` (with key)  | 0.462 | 0.00 | 0.500 | 0.762 | 0.504 | **0.607** |
+| `goldenmatch(auto+fields)` (no key) | 0.409 | 0.105 | 0.865 | 0.556 | 0.724 | **0.629** |
+| `goldenmatch(auto+llm)` (with key)  | 0.414 | 0.000 | 0.500 | 0.704 | 0.573 | **0.632** |
 
-The LLM made the semantic classes **worse** and lowered overall F1. Reason:
-goldenmatch's `llm_scorer` is a **precision filter on borderline candidate
-pairs (0.75–0.95) that blocking already produced** — it can confirm or reject a
-candidate, never create one. It never saw "IBM" / "International Business
-Machines" as a pair (blocking didn't generate it), so it could not merge them;
-and it *pruned* some context-bridged matches `auto+fields` had kept (precision
-up, recall down). The lever for the semantic classes is therefore semantic
+The LLM **does not move the semantic classes it is supposed to** — synonym stays
+0.0, abbreviation flat, cross-lingual *drops* — even though overall F1 lands
+flat (0.632 vs 0.629; it just trades recall for precision, P 0.70 vs 0.56 / R
+0.57 vs 0.72). Reason: goldenmatch's `llm_scorer` is a **precision filter on
+borderline candidate pairs (0.75–0.95) that blocking already produced** — it can
+confirm or reject a candidate, never create one. It never saw "IBM" /
+"International Business Machines" as a pair (blocking didn't generate it), so it
+could not merge them; it only re-weighted pairs `auto+fields` had already found.
+The lever for the semantic classes is therefore semantic
 **candidate generation** (embedding ANN blocking / `emb+ANN`), not an LLM pair
 scorer. The committed table stays the offline, reproducible-by-anyone run; the
 `auto+llm` row only appears when the runner sees a key.
@@ -119,19 +125,19 @@ scorer. The committed table stays the offline, reproducible-by-anyone run; the
 The LLM experiment named the lever: semantic **candidate generation**, not an LLM
 pair filter. So we swapped a semantic embedder into the `emb-ann` path —
 `goldenmatch(emb-openai)`, OpenAI `text-embedding-3-small` (stdlib HTTP, no torch),
-name only, cosine ≥ 0.55 (a small threshold sweep; the overall-F1 peak sits on a
-flat 0.525–0.6 plateau, so 0.55 is a round, non-overfit cut). It is the proof the
-arc points to:
+name only, cosine ≥ 0.55 (a round value from a threshold sweep on a flat
+0.525–0.6 overall-F1 plateau; it transfers cleanly here — peak overall F1 and
+abbreviation 0.98). It is the proof the arc points to:
 
 | config | abbr | synm | xling | P | R | overall F1 |
 |---|---|---|---|---|---|---|
-| `goldenmatch(emb-ann)` (offline, char-n-gram) | 0.182 | 0.00 | 0.560 | 0.434 | 0.677 | **0.529** |
-| `goldenmatch(auto+fields)` (no key, prior leader) | 0.667 | 0.20 | 0.839 | 0.624 | 0.732 | **0.674** |
-| `goldenmatch(emb-openai)` (with key) | **0.947** | **0.875** | 0.909 | 0.640 | 0.882 | **0.742** |
+| `goldenmatch(emb-ann)` (offline, char-n-gram) | 0.133 | 0.00 | 0.552 | 0.372 | 0.673 | **0.479** |
+| `goldenmatch(auto+fields)` (no key, committed leader) | 0.409 | 0.105 | 0.865 | 0.556 | 0.724 | **0.629** |
+| `goldenmatch(emb-openai)` (with key) | **0.978** | **0.732** | 0.923 | 0.595 | 0.915 | **0.721** |
 
-It **cracks the two classes the offline path can't** — abbreviation 0.18 → 0.95,
-synonym 0.0 → 0.88 — and is the only row strong on *both*, lifting overall F1 past
-the prior leader (0.742 vs 0.674). Same embedding-ANN mechanism the offline
+It **cracks the two classes the offline path can't** — abbreviation 0.13 → 0.98,
+synonym 0.0 → 0.73 — and is the only row strong on *both*, lifting overall F1 past
+the committed leader (0.721 vs 0.629). Same embedding-ANN mechanism the offline
 `emb-ann` row demonstrates; only the embedder changed, so the gain is attributable
 to *world knowledge in the vectors* (IBM ↔ its expansion, Coumadin ↔ warfarin),
 exactly what a char-n-gram cosine lacks. It is deterministic on this set
@@ -139,7 +145,7 @@ exactly what a char-n-gram cosine lacks. It is deterministic on this set
 
 The honest cost is unchanged from every other name-only row: precision on the
 negative classes stays low (`coll_P` 0.39, `temp_P` 0.38 — comparable to `emb-ann`
-0.39/0.35 and `neo4j-graphrag` 0.39/0.38), because a name-only embedding *over-*
+0.39/0.37 and `neo4j-graphrag` 0.39/0.38), because a name-only embedding *over-*
 merges distinct entities that share a surface form. Multi-field evidence
 (`auto+fields`) or a real probability threshold is the lever there, not the
 embedder. Because it needs a key it is **not reproducible by everyone**, so it
@@ -165,7 +171,7 @@ TAXONOMY.md            the nine failure classes, with framework citations
   the precision tests — keep adding them.
 * **Crack abbreviation + synonym (done, key-gated):** the `emb-openai` mode swaps a
   semantic embedder (`text-embedding-3-small`, no torch) into the `emb-ann` path and
-  cracks both classes (abbr 0.95, synm 0.88; overall F1 0.742) — see "The
+  cracks both classes (abbr 0.98, synm 0.73; overall F1 0.721) — see "The
   semantic-embedding result". `GoldenMatchEmbAnnAdapter(provider=...)` is the seam;
   pass `provider="local"` for a torch-free-of-cloud sentence-transformers run, or any
   `goldenmatch.embeddings.providers` name. Reproduce with `OPENAI_API_KEY` set. The

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/dataset/records.csv
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/dataset/records.csv
@@ -104,3 +104,69 @@ record_id,mention,entity_type,context,entity_id,failure_class
 102,Oscorp,org,identical name multiple chunks,doc_oscorp_xdoc,cross_document_exact
 103,Oscorp,org,identical name multiple chunks,doc_oscorp_xdoc,cross_document_exact
 104,Oscorp,org,identical name multiple chunks,doc_oscorp_xdoc,cross_document_exact
+105,WHO,org,public health agency geneva switzerland,org_who,abbreviation
+106,World Health Organization,org,public health agency geneva switzerland,org_who,abbreviation
+107,W.H.O.,org,public health agency geneva switzerland,org_who,abbreviation
+108,World Health Organisation,org,public health agency geneva switzerland,org_who,abbreviation
+109,FBI,org,law enforcement agency united states,org_fbi,abbreviation
+110,Federal Bureau of Investigation,org,law enforcement agency united states,org_fbi,abbreviation
+111,F.B.I.,org,law enforcement agency united states,org_fbi,abbreviation
+112,MIT,org,university cambridge massachusetts,org_mit,abbreviation
+113,Massachusetts Institute of Technology,org,university cambridge massachusetts,org_mit,abbreviation
+114,NATO,org,military alliance brussels,org_nato,abbreviation
+115,North Atlantic Treaty Organization,org,military alliance brussels,org_nato,abbreviation
+116,N.A.T.O.,org,military alliance brussels,org_nato,abbreviation
+117,ibuprofen,drug,nsaid analgesic anti-inflammatory,drug_ibuprofen,synonym_brand
+118,Advil,drug,nsaid analgesic anti-inflammatory,drug_ibuprofen,synonym_brand
+119,Motrin,drug,nsaid analgesic anti-inflammatory,drug_ibuprofen,synonym_brand
+120,sildenafil,drug,vasodilator pde5 inhibitor,drug_sildenafil,synonym_brand
+121,Viagra,drug,vasodilator pde5 inhibitor,drug_sildenafil,synonym_brand
+122,Revatio,drug,vasodilator pde5 inhibitor,drug_sildenafil,synonym_brand
+123,fluoxetine,drug,antidepressant ssri,drug_fluoxetine,synonym_brand
+124,Prozac,drug,antidepressant ssri,drug_fluoxetine,synonym_brand
+125,metformin,drug,antidiabetic biguanide blood sugar,drug_metformin,synonym_brand
+126,Glucophage,drug,antidiabetic biguanide blood sugar,drug_metformin,synonym_brand
+127,Michael Jordan,person,basketball player chicago bulls,per_mjordan_athlete,same_name_collision
+128,Michael Jeffrey Jordan,person,basketball player chicago bulls,per_mjordan_athlete,same_name_collision
+129,MJ,person,basketball player chicago bulls,per_mjordan_athlete,same_name_collision
+130,Michael Jordan,person,machine learning professor berkeley,per_mjordan_prof,same_name_collision
+131,Michael I. Jordan,person,machine learning professor berkeley,per_mjordan_prof,same_name_collision
+132,M. Jordan,person,machine learning professor berkeley,per_mjordan_prof,same_name_collision
+133,Apple,org,technology company cupertino california,org_apple_tech,same_name_collision
+134,Apple Inc,org,technology company cupertino california,org_apple_tech,same_name_collision
+135,Apple Computer,org,technology company cupertino california,org_apple_tech,same_name_collision
+136,Apple,org,record label the beatles london,org_apple_records,same_name_collision
+137,Apple Corps,org,record label the beatles london,org_apple_records,same_name_collision
+138,Apple Records,org,record label the beatles london,org_apple_records,same_name_collision
+139,FIFA World Cup 2018,event,association football world cup russia 2018,ev_wc2018,temporal_version
+140,World Cup 2018,event,association football world cup russia 2018,ev_wc2018,temporal_version
+141,2018 World Cup,event,association football world cup russia 2018,ev_wc2018,temporal_version
+142,FIFA World Cup 2022,event,association football world cup qatar 2022,ev_wc2022,temporal_version
+143,World Cup 2022,event,association football world cup qatar 2022,ev_wc2022,temporal_version
+144,2022 World Cup,event,association football world cup qatar 2022,ev_wc2022,temporal_version
+145,Python 2,event,programming language major version legacy,sw_python2,temporal_version
+146,Python 2.7,event,programming language major version legacy,sw_python2,temporal_version
+147,Python 3,event,programming language major version current,sw_python3,temporal_version
+148,Python 3.12,event,programming language major version current,sw_python3,temporal_version
+149,Google,org,search engine mountain view california,org_google_typo,typo
+150,Googel,org,search engine mountain view california,org_google_typo,typo
+151,Gogle,org,search engine mountain view california,org_google_typo,typo
+152,Google,org,search engine mountain view california,org_google_typo,typo
+153,Mark Zuckerberg,person,technology executive menlo park,per_zuckerberg,typo
+154,Mark Zuckerburg,person,technology executive menlo park,per_zuckerberg,typo
+155,Mark Zukerberg,person,technology executive menlo park,per_zuckerberg,typo
+156,Katherine Johnson,person,mathematician nasa langley,per_kjohnson,nickname_alias
+157,Kate Johnson,person,mathematician nasa langley,per_kjohnson,nickname_alias
+158,Katie Johnson,person,mathematician nasa langley,per_kjohnson,nickname_alias
+159,Kathy Johnson,person,mathematician nasa langley,per_kjohnson,nickname_alias
+160,Vienna,place,capital austria danube,city_vienna,cross_lingual
+161,Wien,place,capital austria danube,city_vienna,cross_lingual
+162,Vienne,place,capital austria danube,city_vienna,cross_lingual
+163,Umbrella,org,pharmaceutical conglomerate raccoon city,org_umbrella,org_suffix
+164,Umbrella Corp,org,pharmaceutical conglomerate raccoon city,org_umbrella,org_suffix
+165,Umbrella Corporation,org,pharmaceutical conglomerate raccoon city,org_umbrella,org_suffix
+166,Umbrella Inc,org,pharmaceutical conglomerate raccoon city,org_umbrella,org_suffix
+167,Umbrella Co,org,pharmaceutical conglomerate raccoon city,org_umbrella,org_suffix
+168,Cyberdyne Systems,org,same entity repeated across ingests,doc_cyberdyne_xdoc,cross_document_exact
+169,Cyberdyne Systems,org,same entity repeated across ingests,doc_cyberdyne_xdoc,cross_document_exact
+170,Cyberdyne Systems,org,same entity repeated across ingests,doc_cyberdyne_xdoc,cross_document_exact

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/dataset/seeds.jsonl
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/dataset/seeds.jsonl
@@ -30,3 +30,25 @@
 {"entity_id": "doc_acme_xdoc", "type": "org", "failure_class": "cross_document_exact", "context": "same entity repeated across documents", "mentions": ["Stark Industries", "Stark Industries", "Stark Industries", "Stark Industries"]}
 {"entity_id": "doc_wayne_xdoc", "type": "org", "failure_class": "cross_document_exact", "context": "same entity repeated across ingests", "mentions": ["Wayne Enterprises", "Wayne Enterprises", "Wayne Enterprises"]}
 {"entity_id": "doc_oscorp_xdoc", "type": "org", "failure_class": "cross_document_exact", "context": "identical name multiple chunks", "mentions": ["Oscorp", "Oscorp", "Oscorp"]}
+{"entity_id": "org_who", "type": "org", "failure_class": "abbreviation", "context": "public health agency geneva switzerland", "mentions": ["WHO", "World Health Organization", "W.H.O.", "World Health Organisation"]}
+{"entity_id": "org_fbi", "type": "org", "failure_class": "abbreviation", "context": "law enforcement agency united states", "mentions": ["FBI", "Federal Bureau of Investigation", "F.B.I."]}
+{"entity_id": "org_mit", "type": "org", "failure_class": "abbreviation", "context": "university cambridge massachusetts", "mentions": ["MIT", "Massachusetts Institute of Technology"]}
+{"entity_id": "org_nato", "type": "org", "failure_class": "abbreviation", "context": "military alliance brussels", "mentions": ["NATO", "North Atlantic Treaty Organization", "N.A.T.O."]}
+{"entity_id": "drug_ibuprofen", "type": "drug", "failure_class": "synonym_brand", "context": "nsaid analgesic anti-inflammatory", "mentions": ["ibuprofen", "Advil", "Motrin"]}
+{"entity_id": "drug_sildenafil", "type": "drug", "failure_class": "synonym_brand", "context": "vasodilator pde5 inhibitor", "mentions": ["sildenafil", "Viagra", "Revatio"]}
+{"entity_id": "drug_fluoxetine", "type": "drug", "failure_class": "synonym_brand", "context": "antidepressant ssri", "mentions": ["fluoxetine", "Prozac"]}
+{"entity_id": "drug_metformin", "type": "drug", "failure_class": "synonym_brand", "context": "antidiabetic biguanide blood sugar", "mentions": ["metformin", "Glucophage"]}
+{"entity_id": "per_mjordan_athlete", "type": "person", "failure_class": "same_name_collision", "context": "basketball player chicago bulls", "mentions": ["Michael Jordan", "Michael Jeffrey Jordan", "MJ"]}
+{"entity_id": "per_mjordan_prof", "type": "person", "failure_class": "same_name_collision", "context": "machine learning professor berkeley", "mentions": ["Michael Jordan", "Michael I. Jordan", "M. Jordan"]}
+{"entity_id": "org_apple_tech", "type": "org", "failure_class": "same_name_collision", "context": "technology company cupertino california", "mentions": ["Apple", "Apple Inc", "Apple Computer"]}
+{"entity_id": "org_apple_records", "type": "org", "failure_class": "same_name_collision", "context": "record label the beatles london", "mentions": ["Apple", "Apple Corps", "Apple Records"]}
+{"entity_id": "ev_wc2018", "type": "event", "failure_class": "temporal_version", "context": "association football world cup russia 2018", "mentions": ["FIFA World Cup 2018", "World Cup 2018", "2018 World Cup"]}
+{"entity_id": "ev_wc2022", "type": "event", "failure_class": "temporal_version", "context": "association football world cup qatar 2022", "mentions": ["FIFA World Cup 2022", "World Cup 2022", "2022 World Cup"]}
+{"entity_id": "sw_python2", "type": "event", "failure_class": "temporal_version", "context": "programming language major version legacy", "mentions": ["Python 2", "Python 2.7"]}
+{"entity_id": "sw_python3", "type": "event", "failure_class": "temporal_version", "context": "programming language major version current", "mentions": ["Python 3", "Python 3.12"]}
+{"entity_id": "org_google_typo", "type": "org", "failure_class": "typo", "context": "search engine mountain view california", "mentions": ["Google", "Googel", "Gogle", "Google"]}
+{"entity_id": "per_zuckerberg", "type": "person", "failure_class": "typo", "context": "technology executive menlo park", "mentions": ["Mark Zuckerberg", "Mark Zuckerburg", "Mark Zukerberg"]}
+{"entity_id": "per_kjohnson", "type": "person", "failure_class": "nickname_alias", "context": "mathematician nasa langley", "mentions": ["Katherine Johnson", "Kate Johnson", "Katie Johnson", "Kathy Johnson"]}
+{"entity_id": "city_vienna", "type": "place", "failure_class": "cross_lingual", "context": "capital austria danube", "mentions": ["Vienna", "Wien", "Vienne"]}
+{"entity_id": "org_umbrella", "type": "org", "failure_class": "org_suffix", "context": "pharmaceutical conglomerate raccoon city", "mentions": ["Umbrella", "Umbrella Corp", "Umbrella Corporation", "Umbrella Inc", "Umbrella Co"]}
+{"entity_id": "doc_cyberdyne_xdoc", "type": "org", "failure_class": "cross_document_exact", "context": "same entity repeated across ingests", "mentions": ["Cyberdyne Systems", "Cyberdyne Systems", "Cyberdyne Systems"]}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
@@ -241,9 +241,12 @@ def main() -> None:
 
     report = run("st" if args.embedder == "st" else None)
     RESULTS_DIR.mkdir(exist_ok=True)
-    (RESULTS_DIR / "results.json").write_text(json.dumps(report, indent=2))
+    # Explicit utf-8: the markdown carries em dashes / accented exonyms, and
+    # Path.write_text defaults to the locale encoding (cp1252 on Windows), which
+    # would mojibake them and diverge from a Linux/CI regeneration.
+    (RESULTS_DIR / "results.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
     md = to_markdown(report)
-    (RESULTS_DIR / "RESULTS.md").write_text(md)
+    (RESULTS_DIR / "RESULTS.md").write_text(md, encoding="utf-8")
     print(md)
 
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
@@ -1,6 +1,6 @@
 # ER-KG-Bench results
 
-Dataset: **105 records / 32 entities / 9 failure classes**. Embedder: `none (string predicates only)`.
+Dataset: **171 records / 54 entities / 9 failure classes**. Embedder: `none (string predicates only)`.
 
 `*` = precision-critical negative class (distinct entities with colliding surface forms; lower precision = wrong merges).
 
@@ -8,31 +8,31 @@ Dataset: **105 records / 32 entities / 9 failure classes**. Embedder: `none (str
 
 | System | P | R | F1 | coll&nbsp;P* | temp&nbsp;P* | ms | det-floor |
 |---|---|---|---|---|---|---|---|
-| goldenmatch(auto) | 0.74 | 0.291 | **0.418** | 0.333 | 0.0 | 220.6 | yes |
-| goldenmatch(auto+fields) | 0.624 | 0.732 | **0.674** | 0.37 | 0.353 | 970.2 | yes |
-| goldenmatch(emb-ann) | 0.434 | 0.677 | **0.529** | 0.385 | 0.353 | 18.8 | yes |
-| MS-GraphRAG | 0.722 | 0.102 | **0.179** | 0.0 | 1.0 | 0.1 | yes |
-| LightRAG | 0.722 | 0.102 | **0.179** | 0.0 | 1.0 | 0.0 | yes |
-| Cognee | 0.722 | 0.102 | **0.179** | 0.0 | 1.0 | 0.0 | yes |
-| mem0 | 0.812 | 0.102 | **0.182** | 0.0 | 1.0 | 0.1 | yes |
-| Neo4j-KGBuilder | 0.782 | 0.535 | **0.636** | 0.333 | 0.0 | 2.2 | yes |
-| neo4j-graphrag(fuzzy) | 0.444 | 0.717 | **0.548** | 0.389 | 0.381 | 14.7 | yes |
-| LlamaIndex-PGI | 0.374 | 0.693 | **0.486** | 0.357 | 0.286 | 1.8 | yes |
+| goldenmatch(auto) | 0.735 | 0.362 | **0.485** | 0.368 | 0.267 | 866.2 | yes |
+| goldenmatch(auto+fields) | 0.556 | 0.724 | **0.629** | 0.375 | 0.368 | 2654.3 | yes |
+| goldenmatch(emb-ann) | 0.372 | 0.673 | **0.479** | 0.392 | 0.368 | 68.4 | yes |
+| MS-GraphRAG | 0.708 | 0.085 | **0.152** | 0.0 | 1.0 | 0.2 | yes |
+| LightRAG | 0.708 | 0.085 | **0.152** | 0.0 | 1.0 | 0.1 | yes |
+| Cognee | 0.708 | 0.085 | **0.152** | 0.0 | 1.0 | 0.1 | yes |
+| mem0 | 0.773 | 0.085 | **0.154** | 0.0 | 1.0 | 0.3 | yes |
+| Neo4j-KGBuilder | 0.703 | 0.513 | **0.593** | 0.353 | 0.25 | 10.1 | yes |
+| neo4j-graphrag(fuzzy) | 0.248 | 0.698 | **0.366** | 0.393 | 0.381 | 53.0 | yes |
+| LlamaIndex-PGI | 0.144 | 0.673 | **0.237** | 0.293 | 0.3 | 5.5 | yes |
 
 ## Per-class F1
 
 | System | abbr | nick | synm | coll* | xling | typo | suffix | temp* | xdoc |
 |---|---|---|---|---|---|---|---|---|---|
-| goldenmatch(auto) | 0.462 | 0.235 | 0.0 | 0.267 | 0.2 | 0.75 | 0.37 | 0.0 | 1.0 |
-| goldenmatch(auto+fields) | 0.667 | 0.75 | 0.2 | 0.444 | 0.839 | 1.0 | 1.0 | 0.48 | 1.0 |
-| goldenmatch(emb-ann) | 0.182 | 0.929 | 0.0 | 0.455 | 0.56 | 1.0 | 0.688 | 0.48 | 1.0 |
-| MS-GraphRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.125 | 0.0 | 0.0 | 1.0 |
-| LightRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.125 | 0.0 | 0.0 | 1.0 |
-| Cognee | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.125 | 0.0 | 0.0 | 1.0 |
-| mem0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.125 | 0.0 | 0.0 | 1.0 |
-| Neo4j-KGBuilder | 0.182 | 0.421 | 0.0 | 0.333 | 0.615 | 1.0 | 1.0 | 0.0 | 1.0 |
-| neo4j-graphrag(fuzzy) | 0.571 | 0.8 | 0.0 | 0.519 | 0.5 | 1.0 | 1.0 | 0.552 | 1.0 |
-| LlamaIndex-PGI | 0.385 | 0.636 | 0.0 | 0.435 | 0.455 | 1.0 | 1.0 | 0.267 | 1.0 |
+| goldenmatch(auto) | 0.414 | 0.552 | 0.0 | 0.286 | 0.25 | 0.857 | 0.512 | 0.258 | 1.0 |
+| goldenmatch(auto+fields) | 0.409 | 0.833 | 0.105 | 0.462 | 0.865 | 1.0 | 0.762 | 0.519 | 1.0 |
+| goldenmatch(emb-ann) | 0.133 | 0.95 | 0.0 | 0.494 | 0.552 | 1.0 | 0.496 | 0.519 | 1.0 |
+| MS-GraphRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.154 | 0.0 | 0.0 | 1.0 |
+| LightRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.154 | 0.0 | 0.0 | 1.0 |
+| Cognee | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.154 | 0.0 | 0.0 | 1.0 |
+| mem0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.154 | 0.0 | 0.0 | 1.0 |
+| Neo4j-KGBuilder | 0.154 | 0.5 | 0.0 | 0.375 | 0.6 | 0.933 | 1.0 | 0.25 | 1.0 |
+| neo4j-graphrag(fuzzy) | 0.25 | 0.865 | 0.0 | 0.527 | 0.5 | 1.0 | 0.496 | 0.552 | 1.0 |
+| LlamaIndex-PGI | 0.175 | 0.765 | 0.0 | 0.386 | 0.353 | 1.0 | 0.533 | 0.333 | 1.0 |
 
 ## Documented defaults (what each row runs)
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
@@ -1,7 +1,7 @@
 {
   "dataset": {
-    "records": 105,
-    "entities": 32,
+    "records": 171,
+    "entities": 54,
     "classes": [
       "abbreviation",
       "nickname_alias",
@@ -24,108 +24,108 @@
       "name": "goldenmatch(auto)",
       "defaults": "zero-config dedupe_df(name) -- auto-config picks the strategy",
       "overall": {
-        "precision": 0.74,
-        "recall": 0.291,
-        "f1": 0.418
+        "precision": 0.735,
+        "recall": 0.362,
+        "f1": 0.485
       },
       "per_class_f1": {
-        "abbreviation": 0.462,
-        "nickname_alias": 0.235,
+        "abbreviation": 0.414,
+        "nickname_alias": 0.552,
         "synonym_brand": 0.0,
-        "same_name_collision": 0.267,
-        "cross_lingual": 0.2,
-        "typo": 0.75,
-        "org_suffix": 0.37,
-        "temporal_version": 0.0,
+        "same_name_collision": 0.286,
+        "cross_lingual": 0.25,
+        "typo": 0.857,
+        "org_suffix": 0.512,
+        "temporal_version": 0.258,
         "cross_document_exact": 1.0
       },
       "per_class_precision": {
         "abbreviation": 1.0,
         "nickname_alias": 1.0,
         "synonym_brand": 1.0,
-        "same_name_collision": 0.333,
+        "same_name_collision": 0.368,
         "cross_lingual": 1.0,
         "typo": 1.0,
         "org_suffix": 1.0,
-        "temporal_version": 0.0,
+        "temporal_version": 0.267,
         "cross_document_exact": 1.0
       },
-      "time_ms": 220.6,
+      "time_ms": 866.2,
       "deterministic_floor": true
     },
     {
       "name": "goldenmatch(auto+fields)",
       "defaults": "zero-config dedupe_df(name+type+context) -- auto-config, multi-field",
       "overall": {
-        "precision": 0.624,
-        "recall": 0.732,
-        "f1": 0.674
+        "precision": 0.556,
+        "recall": 0.724,
+        "f1": 0.629
       },
       "per_class_f1": {
-        "abbreviation": 0.667,
-        "nickname_alias": 0.75,
-        "synonym_brand": 0.2,
-        "same_name_collision": 0.444,
-        "cross_lingual": 0.839,
+        "abbreviation": 0.409,
+        "nickname_alias": 0.833,
+        "synonym_brand": 0.105,
+        "same_name_collision": 0.462,
+        "cross_lingual": 0.865,
         "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 0.48,
+        "org_suffix": 0.762,
+        "temporal_version": 0.519,
         "cross_document_exact": 1.0
       },
       "per_class_precision": {
-        "abbreviation": 1.0,
+        "abbreviation": 0.429,
         "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
-        "same_name_collision": 0.37,
+        "synonym_brand": 0.5,
+        "same_name_collision": 0.375,
         "cross_lingual": 1.0,
         "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 0.353,
+        "org_suffix": 0.615,
+        "temporal_version": 0.368,
         "cross_document_exact": 1.0
       },
-      "time_ms": 970.2,
+      "time_ms": 2654.3,
       "deterministic_floor": true
     },
     {
       "name": "goldenmatch(emb-ann)",
       "defaults": "inhouse char-ngram embedding (no key/torch) -> cosine>=0.5 candidate pairs (ANN at scale) -> union-find; name only",
       "overall": {
-        "precision": 0.434,
-        "recall": 0.677,
-        "f1": 0.529
+        "precision": 0.372,
+        "recall": 0.673,
+        "f1": 0.479
       },
       "per_class_f1": {
-        "abbreviation": 0.182,
-        "nickname_alias": 0.929,
+        "abbreviation": 0.133,
+        "nickname_alias": 0.95,
         "synonym_brand": 0.0,
-        "same_name_collision": 0.455,
-        "cross_lingual": 0.56,
+        "same_name_collision": 0.494,
+        "cross_lingual": 0.552,
         "typo": 1.0,
-        "org_suffix": 0.688,
-        "temporal_version": 0.48,
+        "org_suffix": 0.496,
+        "temporal_version": 0.519,
         "cross_document_exact": 1.0
       },
       "per_class_precision": {
-        "abbreviation": 1.0,
+        "abbreviation": 0.286,
         "nickname_alias": 1.0,
         "synonym_brand": 1.0,
-        "same_name_collision": 0.385,
+        "same_name_collision": 0.392,
         "cross_lingual": 1.0,
         "typo": 1.0,
-        "org_suffix": 0.524,
-        "temporal_version": 0.353,
+        "org_suffix": 0.33,
+        "temporal_version": 0.368,
         "cross_document_exact": 1.0
       },
-      "time_ms": 18.8,
+      "time_ms": 68.4,
       "deterministic_floor": true
     },
     {
       "name": "MS-GraphRAG",
       "defaults": "exact title match; ER step removed (finalize_entities seen_titles set; discussion #778, data-loss #1718)",
       "overall": {
-        "precision": 0.722,
-        "recall": 0.102,
-        "f1": 0.179
+        "precision": 0.708,
+        "recall": 0.085,
+        "f1": 0.152
       },
       "per_class_f1": {
         "abbreviation": 0.0,
@@ -133,7 +133,7 @@
         "synonym_brand": 0.0,
         "same_name_collision": 0.0,
         "cross_lingual": 0.0,
-        "typo": 0.125,
+        "typo": 0.154,
         "org_suffix": 0.0,
         "temporal_version": 0.0,
         "cross_document_exact": 1.0
@@ -149,16 +149,16 @@
         "temporal_version": 1.0,
         "cross_document_exact": 1.0
       },
-      "time_ms": 0.1,
+      "time_ms": 0.2,
       "deterministic_floor": true
     },
     {
       "name": "LightRAG",
       "defaults": "exact normalized-name dict key, no fuzzy/embedding at merge (operate.py _merge_nodes_then_upsert; #1323, cross-doc #485)",
       "overall": {
-        "precision": 0.722,
-        "recall": 0.102,
-        "f1": 0.179
+        "precision": 0.708,
+        "recall": 0.085,
+        "f1": 0.152
       },
       "per_class_f1": {
         "abbreviation": 0.0,
@@ -166,73 +166,7 @@
         "synonym_brand": 0.0,
         "same_name_collision": 0.0,
         "cross_lingual": 0.0,
-        "typo": 0.125,
-        "org_suffix": 0.0,
-        "temporal_version": 0.0,
-        "cross_document_exact": 1.0
-      },
-      "per_class_precision": {
-        "abbreviation": 1.0,
-        "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 1.0,
-        "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 1.0,
-        "cross_document_exact": 1.0
-      },
-      "time_ms": 0.0,
-      "deterministic_floor": true
-    },
-    {
-      "name": "Cognee",
-      "defaults": "content-hash + exact name; difflib cutoff=0.8 only vs a user ontology (empty by default) (matching_strategies.py; #1831)",
-      "overall": {
-        "precision": 0.722,
-        "recall": 0.102,
-        "f1": 0.179
-      },
-      "per_class_f1": {
-        "abbreviation": 0.0,
-        "nickname_alias": 0.0,
-        "synonym_brand": 0.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 0.0,
-        "typo": 0.125,
-        "org_suffix": 0.0,
-        "temporal_version": 0.0,
-        "cross_document_exact": 1.0
-      },
-      "per_class_precision": {
-        "abbreviation": 1.0,
-        "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 1.0,
-        "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 1.0,
-        "cross_document_exact": 1.0
-      },
-      "time_ms": 0.0,
-      "deterministic_floor": true
-    },
-    {
-      "name": "mem0",
-      "defaults": "MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE prompt (main.py md5; contradictions #4896, 37.6% near-dupes #4573)",
-      "overall": {
-        "precision": 0.812,
-        "recall": 0.102,
-        "f1": 0.182
-      },
-      "per_class_f1": {
-        "abbreviation": 0.0,
-        "nickname_alias": 0.0,
-        "synonym_brand": 0.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 0.0,
-        "typo": 0.125,
+        "typo": 0.154,
         "org_suffix": 0.0,
         "temporal_version": 0.0,
         "cross_document_exact": 1.0
@@ -252,21 +186,21 @@
       "deterministic_floor": true
     },
     {
-      "name": "Neo4j-KGBuilder",
-      "defaults": "same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py; over-merge #1133, missed alias #912)",
+      "name": "Cognee",
+      "defaults": "content-hash + exact name; difflib cutoff=0.8 only vs a user ontology (empty by default) (matching_strategies.py; #1831)",
       "overall": {
-        "precision": 0.782,
-        "recall": 0.535,
-        "f1": 0.636
+        "precision": 0.708,
+        "recall": 0.085,
+        "f1": 0.152
       },
       "per_class_f1": {
-        "abbreviation": 0.182,
-        "nickname_alias": 0.421,
+        "abbreviation": 0.0,
+        "nickname_alias": 0.0,
         "synonym_brand": 0.0,
-        "same_name_collision": 0.333,
-        "cross_lingual": 0.615,
-        "typo": 1.0,
-        "org_suffix": 1.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 0.0,
+        "typo": 0.154,
+        "org_suffix": 0.0,
         "temporal_version": 0.0,
         "cross_document_exact": 1.0
       },
@@ -274,80 +208,146 @@
         "abbreviation": 1.0,
         "nickname_alias": 1.0,
         "synonym_brand": 1.0,
-        "same_name_collision": 0.333,
+        "same_name_collision": 0.0,
         "cross_lingual": 1.0,
         "typo": 1.0,
         "org_suffix": 1.0,
+        "temporal_version": 1.0,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 0.1,
+      "deterministic_floor": true
+    },
+    {
+      "name": "mem0",
+      "defaults": "MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE prompt (main.py md5; contradictions #4896, 37.6% near-dupes #4573)",
+      "overall": {
+        "precision": 0.773,
+        "recall": 0.085,
+        "f1": 0.154
+      },
+      "per_class_f1": {
+        "abbreviation": 0.0,
+        "nickname_alias": 0.0,
+        "synonym_brand": 0.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 0.0,
+        "typo": 0.154,
+        "org_suffix": 0.0,
         "temporal_version": 0.0,
         "cross_document_exact": 1.0
       },
-      "time_ms": 2.2,
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 1.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 1.0,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 0.3,
+      "deterministic_floor": true
+    },
+    {
+      "name": "Neo4j-KGBuilder",
+      "defaults": "same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py; over-merge #1133, missed alias #912)",
+      "overall": {
+        "precision": 0.703,
+        "recall": 0.513,
+        "f1": 0.593
+      },
+      "per_class_f1": {
+        "abbreviation": 0.154,
+        "nickname_alias": 0.5,
+        "synonym_brand": 0.0,
+        "same_name_collision": 0.375,
+        "cross_lingual": 0.6,
+        "typo": 0.933,
+        "org_suffix": 1.0,
+        "temporal_version": 0.25,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 0.667,
+        "nickname_alias": 1.0,
+        "synonym_brand": 1.0,
+        "same_name_collision": 0.353,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 0.25,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 10.1,
       "deterministic_floor": true
     },
     {
       "name": "neo4j-graphrag(fuzzy)",
       "defaults": "FuzzyMatchResolver: rapidfuzz WRatio/100 >= 0.8, all-pairs O(n^2) (resolver.py BasePropertySimilarityResolver; rapidfuzz extra #336)",
       "overall": {
-        "precision": 0.444,
-        "recall": 0.717,
-        "f1": 0.548
+        "precision": 0.248,
+        "recall": 0.698,
+        "f1": 0.366
       },
       "per_class_f1": {
-        "abbreviation": 0.571,
-        "nickname_alias": 0.8,
+        "abbreviation": 0.25,
+        "nickname_alias": 0.865,
         "synonym_brand": 0.0,
-        "same_name_collision": 0.519,
+        "same_name_collision": 0.527,
         "cross_lingual": 0.5,
         "typo": 1.0,
-        "org_suffix": 1.0,
+        "org_suffix": 0.496,
         "temporal_version": 0.552,
         "cross_document_exact": 1.0
       },
       "per_class_precision": {
-        "abbreviation": 1.0,
+        "abbreviation": 0.294,
         "nickname_alias": 1.0,
         "synonym_brand": 1.0,
-        "same_name_collision": 0.389,
+        "same_name_collision": 0.393,
         "cross_lingual": 1.0,
         "typo": 1.0,
-        "org_suffix": 1.0,
+        "org_suffix": 0.33,
         "temporal_version": 0.381,
         "cross_document_exact": 1.0
       },
-      "time_ms": 14.7,
+      "time_ms": 53.0,
       "deterministic_floor": true
     },
     {
       "name": "LlamaIndex-PGI",
       "defaults": "same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)",
       "overall": {
-        "precision": 0.374,
-        "recall": 0.693,
-        "f1": 0.486
+        "precision": 0.144,
+        "recall": 0.673,
+        "f1": 0.237
       },
       "per_class_f1": {
-        "abbreviation": 0.385,
-        "nickname_alias": 0.636,
+        "abbreviation": 0.175,
+        "nickname_alias": 0.765,
         "synonym_brand": 0.0,
-        "same_name_collision": 0.435,
-        "cross_lingual": 0.455,
+        "same_name_collision": 0.386,
+        "cross_lingual": 0.353,
         "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 0.267,
+        "org_suffix": 0.533,
+        "temporal_version": 0.333,
         "cross_document_exact": 1.0
       },
       "per_class_precision": {
-        "abbreviation": 0.312,
+        "abbreviation": 0.113,
         "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
-        "same_name_collision": 0.357,
-        "cross_lingual": 0.312,
+        "synonym_brand": 0.0,
+        "same_name_collision": 0.293,
+        "cross_lingual": 0.222,
         "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 0.286,
+        "org_suffix": 0.364,
+        "temporal_version": 0.3,
         "cross_document_exact": 1.0
       },
-      "time_ms": 1.8,
+      "time_ms": 5.5,
       "deterministic_floor": true
     }
   ]


### PR DESCRIPTION
Follow-up to #1023 / #1025 / #1032. Grows the benchmark and gives it a reproducible CI lane, per the handoff's "more seed entities" item.

## Dataset
- `seeds.jsonl` 32 → **54 entities** (105 → **171 records**), balanced across all 9 failure classes with extra weight on the four that matter most:
  - **abbreviation** +4 (WHO, FBI, MIT, NATO)
  - **synonym_brand** +4 (ibuprofen/Advil, sildenafil/Viagra, fluoxetine/Prozac, metformin/Glucophage)
  - **same_name_collision** +4 — incl. the canonical Apple Inc / Apple Corps and Michael Jordan (athlete vs ML professor) collisions (precision-critical negatives)
  - **temporal_version** +4 — incl. World Cup 2018/2022 and Python 2/3

## CI lane (new)
The benchmark dir is outside the main CI path filters, and the goldenmatch `auto`/`auto+fields`/`auto+llm` rows (full `dedupe_df` + controller, run twice for the determinism check) are too memory-heavy to regenerate on a laptop. `bench-er-kg.yml` runs it on a runner:
- **offline** → the committed table (artifact `er-kg-results-offline`).
- **keyed** (via `OPENAI_API_KEY` Actions secret, mirroring Infisical) → the `emb-openai`/`auto+llm` prose rows, printed to the run summary. Out of the committed table.

All numbers in this PR were regenerated by that lane (run `27633067952`).

## Re-baselined results (committed, offline)
The bigger, collision-heavier set shifts the leaders honestly:
| row | before (105/32) | after (171/54) |
|---|---|---|
| auto+fields (committed leader) | 0.674 | 0.629 |
| emb-ann | 0.529 | 0.479 (now ~level with auto 0.485) |
| neo4j-graphrag(fuzzy) | 0.548 | 0.366 (precision collapses on the new collisions) |
| exact family | ~0.18 | ~0.15 |

Keyed prose (not committed): **emb-openai abbr 0.13→0.98, synonym 0.0→0.73, F1 0.721** (still cracks both, still beats the committed leader). `auto+llm` 0.632, synonym still 0.0 — LLM-experiment finding reframed (on the bigger set it trades recall for precision rather than dropping F1, but still can't create the semantic pairs).

## Other
- `run.py` writes results as explicit UTF-8 (Windows `Path.write_text` defaults to cp1252 and mojibakes the em dashes / exonyms).
- README + HANDOFF prose fully re-baselined to the new numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)