### PR TITLE
docs(benchmarks): regenerate ER-KG-Bench RESULTS after drug scaling

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
@@ -1,6 +1,6 @@
 # ER-KG-Bench results
 
-Dataset: **147 records / 33 entities / 9 failure classes**. Embedder: `none (string predicates only)`.
+Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `none (string predicates only)`.
 
 `*` = precision-critical negative class (distinct entities with colliding surface forms; lower precision = wrong merges).
 
@@ -8,31 +8,31 @@ Dataset: **147 records / 33 entities / 9 failure classes**. Embedder: `none (str
 
 | System | P | R | F1 | coll&nbsp;P* | temp&nbsp;P* | ms | det-floor |
 |---|---|---|---|---|---|---|---|
-| goldenmatch(auto) | 0.844 | 0.487 | **0.617** | 0.438 | 0.4 | 762.4 | yes |
-| goldenmatch(auto+fields) | 0.869 | 0.617 | **0.721** | 0.471 | 0.4 | 2421.0 | yes |
-| goldenmatch(emb-ann) | 0.447 | 0.547 | **0.492** | 0.471 | 0.4 | 49.5 | yes |
-| MS-GraphRAG | 0.875 | 0.047 | **0.089** | 0.0 | 1.0 | 0.1 | yes |
-| LightRAG | 0.875 | 0.047 | **0.089** | 0.0 | 1.0 | 0.1 | yes |
-| Cognee | 0.875 | 0.047 | **0.089** | 0.0 | 1.0 | 0.1 | yes |
-| mem0 | 0.875 | 0.047 | **0.089** | 0.0 | 1.0 | 0.2 | yes |
-| Neo4j-KGBuilder | 0.828 | 0.417 | **0.554** | 0.448 | 0.286 | 5.6 | yes |
-| neo4j-graphrag(fuzzy) | 0.346 | 0.637 | **0.448** | 0.451 | 0.4 | 38.7 | yes |
-| LlamaIndex-PGI | 0.219 | 0.56 | **0.315** | 0.452 | 0.286 | 3.4 | yes |
+| goldenmatch(auto) | 0.849 | 0.374 | **0.52** | 0.438 | 0.4 | 814.1 | yes |
+| goldenmatch(auto+fields) | 0.786 | 0.488 | **0.602** | 0.471 | 0.4 | 4949.8 | yes |
+| goldenmatch(emb-ann) | 0.455 | 0.426 | **0.44** | 0.471 | 0.4 | 57.2 | yes |
+| MS-GraphRAG | 0.875 | 0.034 | **0.066** | 0.0 | 1.0 | 0.2 | yes |
+| LightRAG | 0.875 | 0.034 | **0.066** | 0.0 | 1.0 | 0.1 | yes |
+| Cognee | 0.875 | 0.034 | **0.066** | 0.0 | 1.0 | 0.1 | yes |
+| mem0 | 0.875 | 0.034 | **0.066** | 0.0 | 1.0 | 0.3 | yes |
+| Neo4j-KGBuilder | 0.826 | 0.315 | **0.456** | 0.448 | 0.286 | 12.1 | yes |
+| neo4j-graphrag(fuzzy) | 0.345 | 0.485 | **0.403** | 0.451 | 0.4 | 64.6 | yes |
+| LlamaIndex-PGI | 0.141 | 0.51 | **0.221** | 0.452 | 0.286 | 6.9 | yes |
 
 ## Per-class F1
 
 | System | abbr | nick | synm | coll* | xling | typo | suffix | temp* | xdoc |
 |---|---|---|---|---|---|---|---|---|---|
-| goldenmatch(auto) | 0.412 | 0.741 | 0.06 | 0.318 | 0.4 | 0.875 | 1.0 | 0.571 | 1.0 |
-| goldenmatch(auto+fields) | 0.773 | 0.854 | 0.141 | 0.356 | 0.769 | 1.0 | 1.0 | 0.571 | 1.0 |
-| goldenmatch(emb-ann) | 0.214 | 0.786 | 0.116 | 0.516 | 0.4 | 0.667 | 0.444 | 0.571 | 1.0 |
+| goldenmatch(auto) | 0.412 | 0.741 | 0.089 | 0.318 | 0.4 | 0.875 | 1.0 | 0.571 | 1.0 |
+| goldenmatch(auto+fields) | 0.773 | 0.854 | 0.167 | 0.356 | 0.769 | 1.0 | 1.0 | 0.571 | 1.0 |
+| goldenmatch(emb-ann) | 0.214 | 0.786 | 0.138 | 0.516 | 0.4 | 0.667 | 0.444 | 0.571 | 1.0 |
 | MS-GraphRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
 | LightRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
 | Cognee | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
 | mem0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
-| Neo4j-KGBuilder | 0.412 | 0.406 | 0.0 | 0.456 | 0.588 | 0.714 | 1.0 | 0.308 | 1.0 |
-| neo4j-graphrag(fuzzy) | 0.898 | 0.854 | 0.03 | 0.582 | 0.345 | 0.667 | 0.444 | 0.571 | 1.0 |
-| LlamaIndex-PGI | 0.533 | 0.478 | 0.055 | 0.543 | 0.405 | 0.667 | 0.706 | 0.308 | 0.571 |
+| Neo4j-KGBuilder | 0.412 | 0.406 | 0.034 | 0.456 | 0.588 | 0.714 | 1.0 | 0.308 | 1.0 |
+| neo4j-graphrag(fuzzy) | 0.898 | 0.854 | 0.078 | 0.582 | 0.345 | 0.667 | 0.444 | 0.571 | 1.0 |
+| LlamaIndex-PGI | 0.533 | 0.478 | 0.093 | 0.543 | 0.405 | 0.667 | 0.706 | 0.308 | 0.571 |
 
 ## Documented defaults (what each row runs)
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
@@ -1,7 +1,7 @@
 {
   "dataset": {
-    "records": 147,
-    "entities": 33,
+    "records": 206,
+    "entities": 48,
     "classes": [
       "abbreviation",
       "nickname_alias",
@@ -24,14 +24,14 @@
       "name": "goldenmatch(auto)",
       "defaults": "zero-config dedupe_df(name) -- auto-config picks the strategy",
       "overall": {
-        "precision": 0.844,
-        "recall": 0.487,
-        "f1": 0.617
+        "precision": 0.849,
+        "recall": 0.374,
+        "f1": 0.52
       },
       "per_class_f1": {
         "abbreviation": 0.412,
         "nickname_alias": 0.741,
-        "synonym_brand": 0.06,
+        "synonym_brand": 0.089,
         "same_name_collision": 0.318,
         "cross_lingual": 0.4,
         "typo": 0.875,
@@ -50,21 +50,21 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 762.4,
+      "time_ms": 814.1,
       "deterministic_floor": true
     },
     {
       "name": "goldenmatch(auto+fields)",
       "defaults": "zero-config dedupe_df(name+type+context) -- auto-config, multi-field",
       "overall": {
-        "precision": 0.869,
-        "recall": 0.617,
-        "f1": 0.721
+        "precision": 0.786,
+        "recall": 0.488,
+        "f1": 0.602
       },
       "per_class_f1": {
         "abbreviation": 0.773,
         "nickname_alias": 0.854,
-        "synonym_brand": 0.141,
+        "synonym_brand": 0.167,
         "same_name_collision": 0.356,
         "cross_lingual": 0.769,
         "typo": 1.0,
@@ -75,7 +75,7 @@
       "per_class_precision": {
         "abbreviation": 1.0,
         "nickname_alias": 1.0,
-        "synonym_brand": 0.833,
+        "synonym_brand": 0.4,
         "same_name_collision": 0.471,
         "cross_lingual": 1.0,
         "typo": 1.0,
@@ -83,21 +83,21 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 2421.0,
+      "time_ms": 4949.8,
       "deterministic_floor": true
     },
     {
       "name": "goldenmatch(emb-ann)",
       "defaults": "inhouse char-ngram embedding (no key/torch) -> cosine>=0.5 candidate pairs (ANN at scale) -> union-find; name only",
       "overall": {
-        "precision": 0.447,
-        "recall": 0.547,
-        "f1": 0.492
+        "precision": 0.455,
+        "recall": 0.426,
+        "f1": 0.44
       },
       "per_class_f1": {
         "abbreviation": 0.214,
         "nickname_alias": 0.786,
-        "synonym_brand": 0.116,
+        "synonym_brand": 0.138,
         "same_name_collision": 0.516,
         "cross_lingual": 0.4,
         "typo": 0.667,
@@ -108,7 +108,7 @@
       "per_class_precision": {
         "abbreviation": 0.207,
         "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
+        "synonym_brand": 0.765,
         "same_name_collision": 0.471,
         "cross_lingual": 1.0,
         "typo": 0.5,
@@ -116,7 +116,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 49.5,
+      "time_ms": 57.2,
       "deterministic_floor": true
     },
     {
@@ -124,8 +124,8 @@
       "defaults": "exact title match; ER step removed (finalize_entities seen_titles set; discussion #778, data-loss #1718)",
       "overall": {
         "precision": 0.875,
-        "recall": 0.047,
-        "f1": 0.089
+        "recall": 0.034,
+        "f1": 0.066
       },
       "per_class_f1": {
         "abbreviation": 0.0,
@@ -149,7 +149,7 @@
         "temporal_version": 1.0,
         "cross_document_exact": 1.0
       },
-      "time_ms": 0.1,
+      "time_ms": 0.2,
       "deterministic_floor": true
     },
     {
@@ -157,8 +157,8 @@
       "defaults": "exact normalized-name dict key, no fuzzy/embedding at merge (operate.py _merge_nodes_then_upsert; #1323, cross-doc #485)",
       "overall": {
         "precision": 0.875,
-        "recall": 0.047,
-        "f1": 0.089
+        "recall": 0.034,
+        "f1": 0.066
       },
       "per_class_f1": {
         "abbreviation": 0.0,
@@ -190,8 +190,8 @@
       "defaults": "content-hash + exact name; difflib cutoff=0.8 only vs a user ontology (empty by default) (matching_strategies.py; #1831)",
       "overall": {
         "precision": 0.875,
-        "recall": 0.047,
-        "f1": 0.089
+        "recall": 0.034,
+        "f1": 0.066
       },
       "per_class_f1": {
         "abbreviation": 0.0,
@@ -223,8 +223,8 @@
       "defaults": "MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE prompt (main.py md5; contradictions #4896, 37.6% near-dupes #4573)",
       "overall": {
         "precision": 0.875,
-        "recall": 0.047,
-        "f1": 0.089
+        "recall": 0.034,
+        "f1": 0.066
       },
       "per_class_f1": {
         "abbreviation": 0.0,
@@ -248,21 +248,21 @@
         "temporal_version": 1.0,
         "cross_document_exact": 1.0
       },
-      "time_ms": 0.2,
+      "time_ms": 0.3,
       "deterministic_floor": true
     },
     {
       "name": "Neo4j-KGBuilder",
       "defaults": "same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py; over-merge #1133, missed alias #912)",
       "overall": {
-        "precision": 0.828,
-        "recall": 0.417,
-        "f1": 0.554
+        "precision": 0.826,
+        "recall": 0.315,
+        "f1": 0.456
       },
       "per_class_f1": {
         "abbreviation": 0.412,
         "nickname_alias": 0.406,
-        "synonym_brand": 0.0,
+        "synonym_brand": 0.034,
         "same_name_collision": 0.456,
         "cross_lingual": 0.588,
         "typo": 0.714,
@@ -273,7 +273,7 @@
       "per_class_precision": {
         "abbreviation": 1.0,
         "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
+        "synonym_brand": 0.75,
         "same_name_collision": 0.448,
         "cross_lingual": 1.0,
         "typo": 1.0,
@@ -281,21 +281,21 @@
         "temporal_version": 0.286,
         "cross_document_exact": 1.0
       },
-      "time_ms": 5.6,
+      "time_ms": 12.1,
       "deterministic_floor": true
     },
     {
       "name": "neo4j-graphrag(fuzzy)",
       "defaults": "FuzzyMatchResolver: rapidfuzz WRatio/100 >= 0.8, all-pairs O(n^2) (resolver.py BasePropertySimilarityResolver; rapidfuzz extra #336)",
       "overall": {
-        "precision": 0.346,
-        "recall": 0.637,
-        "f1": 0.448
+        "precision": 0.345,
+        "recall": 0.485,
+        "f1": 0.403
       },
       "per_class_f1": {
         "abbreviation": 0.898,
         "nickname_alias": 0.854,
-        "synonym_brand": 0.03,
+        "synonym_brand": 0.078,
         "same_name_collision": 0.582,
         "cross_lingual": 0.345,
         "typo": 0.667,
@@ -306,7 +306,7 @@
       "per_class_precision": {
         "abbreviation": 1.0,
         "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
+        "synonym_brand": 0.875,
         "same_name_collision": 0.451,
         "cross_lingual": 1.0,
         "typo": 0.5,
@@ -314,21 +314,21 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 38.7,
+      "time_ms": 64.6,
       "deterministic_floor": true
     },
     {
       "name": "LlamaIndex-PGI",
       "defaults": "same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)",
       "overall": {
-        "precision": 0.219,
-        "recall": 0.56,
-        "f1": 0.315
+        "precision": 0.141,
+        "recall": 0.51,
+        "f1": 0.221
       },
       "per_class_f1": {
         "abbreviation": 0.533,
         "nickname_alias": 0.478,
-        "synonym_brand": 0.055,
+        "synonym_brand": 0.093,
         "same_name_collision": 0.543,
         "cross_lingual": 0.405,
         "typo": 0.667,
@@ -339,7 +339,7 @@
       "per_class_precision": {
         "abbreviation": 0.417,
         "nickname_alias": 1.0,
-        "synonym_brand": 0.25,
+        "synonym_brand": 0.058,
         "same_name_collision": 0.452,
         "cross_lingual": 0.283,
         "typo": 0.5,
@@ -347,7 +347,7 @@
         "temporal_version": 0.286,
         "cross_document_exact": 0.4
       },
-      "time_ms": 3.4,
+      "time_ms": 6.9,
       "deterministic_floor": true
     }
   ]


### PR DESCRIPTION
Regenerates the committed `results/RESULTS.md` + `results.json` after the 15-drug `synonym_brand` scaling (#1038), which changed the corpus (147 -> 206 records) but not the committed numbers. Pulled from the canonical `bench-er-kg` run on main HEAD (run `27643853380`).

**Headline shifts (honest consequence of tripling the hardest class):**
- `goldenmatch(auto+fields)` F1 **0.721 -> 0.602** — still leads the best framework default (Neo4j-KGBuilder 0.456) by **+14.6pp**.
- exact-match family (GraphRAG/LightRAG/Cognee/mem0) **0.089 -> 0.066** (still collapses).
- `synonym_brand` now measured on **22 entities** (was 7); `auto+fields` synm F1 0.141 -> 0.167. Collision precision unchanged (0.471).

The competitive story holds; the lower headline is the price of a less selection-biased corpus in goldenmatch's weakest class. `results/` is excluded from the bench-er-kg push trigger, so this does not re-run the lane.