### PR TITLE
fix(domain): don't classify generic `name`-only schemas as 'product' (#1037)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/domain.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain.py
@@ -49,7 +49,12 @@ class DomainProfile:
 
 # Domain detection heuristics
 _PRODUCT_SIGNALS = re.compile(
-    r"(product|title|name|description|brand|manufacturer|mfr|sku|model|price|upc|ean|asin)",
+    # `name` is intentionally NOT a product signal: it is domain-ambiguous (person,
+    # place, org and product all have a `name`), so a name-only schema scored
+    # product@1.0 and ran product feature extraction it shouldn't (#1037). Product
+    # detection relies on the product-specific tokens below; real product data still
+    # matches via title/description/brand/manufacturer/price/etc.
+    r"(product|title|description|brand|manufacturer|mfr|sku|model|price|upc|ean|asin)",
     re.IGNORECASE,
 )
 _PERSON_SIGNALS = re.compile(

--- a/packages/python/goldenmatch/tests/test_domain.py
+++ b/packages/python/goldenmatch/tests/test_domain.py
@@ -35,6 +35,17 @@ class TestDomainDetection:
         profile = detect_domain(["product_name", "description", "sku", "price"])
         assert "product_name" in profile.text_columns or "description" in profile.text_columns
 
+    def test_generic_name_only_not_product(self):
+        # Regression for #1037: a bare `name` column is domain-ambiguous (a person,
+        # place, org or product all have a `name`), so it must NOT be confidently
+        # classified as 'product'. It used to score product@1.0 because `name` was a
+        # product signal and nothing else matched.
+        assert detect_domain(["name"]).name != "product"
+        # The ER-KG-Bench shape (name + generic fields, no domain signal) -> unknown.
+        ekg = detect_domain(["name", "entity_type", "context"])
+        assert ekg.name == "unknown"
+        assert ekg.confidence == 0.0
+
 
 class TestProductFeatureExtraction:
     def test_extract_model_number(self):


### PR DESCRIPTION
Closes #1037.

`detect_domain` scored any schema whose only name-ish column is `name` as **product** at **confidence 1.0** — `name` was a `_PRODUCT_SIGNALS` token and no other domain matches a bare `name`, so `product = 1/1 = 1.0`. That ran software/electronics feature extraction on non-product data (people, places, orgs).

**Fix:** remove the bare `name` token from `_PRODUCT_SIGNALS`. `name` is domain-ambiguous (a person, place, org and product all have one). A bare-`name` schema now resolves to `unknown` (correct); real product data still detects via `title`/`description`/`brand`/`manufacturer`/`price`.

**No benchmark regression:** Abt-Buy (`name` + `description` + `price`) and Amazon-Google (`title` + `description` + `manufacturer` + `price`) both still detect `product` via their other columns (confirmed against `run_domain_bench.py`).

**Test:** added `test_generic_name_only_not_product` — `detect_domain(["name"])` is not `product`, and the name-only ER-KG shape → `unknown@0.0`. `tests/test_domain.py` is green (31 passed; the pre-existing `test_pipeline_with_domain` stale-native-wheel skew on the dev box passes under `GOLDENMATCH_NATIVE=0`).

Triage on the issue: #1037. Scope is just the bare-`name` token; the secondary "single-signal → confidence 1.0" formula quirk is left as a separate, higher-blast-radius change.