### PR TITLE
ER-KG-Bench: real-framework rows + per-row fidelity audit (Phase 0/1)

### DIFF
--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -56,7 +56,8 @@ jobs:
           uv pip install -e packages/python/goldenmatch
 
       - name: Install optional real-framework deps
-        run: "$GITHUB_WORKSPACE/.venv/bin/pip" install -r "$BENCH_DIR/requirements-real.txt"
+        run: |
+          "$GITHUB_WORKSPACE/.venv/bin/pip" install -r "$BENCH_DIR/requirements-real.txt"
 
       - name: Run benchmark (offline -- the committed table)
         working-directory: ${{ env.BENCH_DIR }}

--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -25,6 +25,8 @@ on:
       - "packages/python/goldenmatch/benchmarks/er-kg-bench/dataset/**"
       - "packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/**"
       - "packages/python/goldenmatch/benchmarks/er-kg-bench/demo/**"
+      - "packages/python/goldenmatch/benchmarks/er-kg-bench/tests/**"
+      - "packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-real.txt"
       - ".github/workflows/bench-er-kg.yml"
 
 permissions:
@@ -53,6 +55,9 @@ jobs:
           uv sync --all-packages
           uv pip install -e packages/python/goldenmatch
 
+      - name: Install optional real-framework deps
+        run: "$GITHUB_WORKSPACE/.venv/bin/pip" install -r "$BENCH_DIR/requirements-real.txt"
+
       - name: Run benchmark (offline -- the committed table)
         working-directory: ${{ env.BENCH_DIR }}
         run: "$GITHUB_WORKSPACE/.venv/bin/python erkgbench/run.py"
@@ -65,6 +70,10 @@ jobs:
       - name: Demo unit tests (offline narrative logic)
         working-directory: ${{ env.BENCH_DIR }}
         run: "$GITHUB_WORKSPACE/.venv/bin/python -m pytest demo/test_demo.py -v"
+
+      - name: Real-adapter bench tests (fidelity gate + F1 pin)
+        working-directory: ${{ env.BENCH_DIR }}
+        run: "$GITHUB_WORKSPACE/.venv/bin/python -m pytest tests/test_real_resolvers.py tests/test_fidelity_column.py -v"
 
       - name: Regenerate demo DEMO.md (Tier 1)
         working-directory: ${{ env.BENCH_DIR }}

--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -56,8 +56,9 @@ jobs:
           uv pip install -e packages/python/goldenmatch
 
       - name: Install optional real-framework deps
-        run: |
-          "$GITHUB_WORKSPACE/.venv/bin/pip" install -r "$BENCH_DIR/requirements-real.txt"
+        # uv-created venvs ship no `pip`, so use uv's pip (same as the sync step's
+        # `uv pip install -e`); it installs into the project .venv.
+        run: uv pip install -r "$BENCH_DIR/requirements-real.txt"
 
       - name: Run benchmark (offline -- the committed table)
         working-directory: ${{ env.BENCH_DIR }}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/FIDELITY.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/FIDELITY.md
@@ -1,0 +1,260 @@
+# Adapter fidelity audit (Phase 1)
+
+Every adapter declares a `fidelity` tier so a reader can tell, at a glance, how
+close a row is to the framework it claims to represent:
+
+- **`real`** -- the actual system runs (the goldenmatch rows).
+- **`real-inproc`** -- a real framework's actual Python decision code executes
+  in-process (e.g. neo4j-graphrag's `FuzzyMatchResolver.compute_similarity` +
+  `_consolidate_sets`); only the I/O (live Neo4j) is stubbed.
+- **`validated`** -- a MODEL of the framework's rule, confirmed line-by-line
+  against the framework's real merge source (predicate + constants +
+  normalization all match). Where the run is only partial (an OR-term is
+  inactive in our default config), that is called out explicitly.
+- **`modeled`** -- a model that could NOT be confirmed against maintained
+  source, OR that diverges from the real rule. A documented divergence is a
+  finding, not a failure.
+
+This audit read each framework's real merge/dedup source on GitHub and compared
+it to our model. The exact-match family's shared normalization is
+`_norm(s) = " ".join(s.lower().split())` (lowercase + internal-whitespace
+collapse, NO quote/apostrophe strip, NO unicode fold).
+
+## Verdict table
+
+| Framework | adapter | real source checked | exact real rule | matches our model? | tier |
+|---|---|---|---|---|---|
+| Microsoft GraphRAG | `GraphRAGModeled` | [finalize_entities.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/operations/finalize_entities.py) + [graph_extractor.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/operations/extract_graph/graph_extractor.py) + [string.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/utils/string.py) | exact `title in seen_titles`; `title = clean_str(name.upper())` (uppercases + `.strip()` + html-unescape + control-char strip; **no internal-whitespace collapse, no quote strip**) | NO (case dir is clustering-equivalent, but we collapse internal whitespace and it does not) | **modeled** |
+| LightRAG | `LightRAGModeled` | [operate.py](https://github.com/HKUDS/LightRAG/blob/main/lightrag/operate.py) + [utils.py `normalize_extracted_info`](https://github.com/HKUDS/LightRAG/blob/main/lightrag/utils.py) | exact `entity_name` dict key; name is `sanitize_and_normalize_extracted_text(.., remove_inner_quotes=True)` -> **case-PRESERVING** (no upper/lower), strips outer quotes, CJK fold, `.strip()` | NO (we lowercase -> case-INSENSITIVE; real is case-SENSITIVE; we don't strip quotes/CJK-fold) | **modeled** |
+| Cognee | `CogneeModeled` | [generate_node_name.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/engine/utils/generate_node_name.py) + [expand_with_nodes_and_edges.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/graph/utils/expand_with_nodes_and_edges.py) + [get_default_ontology_resolver.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/get_default_ontology_resolver.py) + [matching_strategies.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/matching_strategies.py) | entity node key = `generate_node_name(name) = name.lower().replace("'", "")` -> lowercases + strips apostrophes, **no whitespace collapse**. Default ontology empty (`ontology_file=None`) so the difflib cutoff=0.8 never fires | NO (we lowercase too, but we collapse whitespace it doesn't, and it strips apostrophes we don't) | **modeled** |
+| mem0 | `Mem0Modeled` | [memory/main.py](https://github.com/mem0ai/mem0/blob/main/mem0/memory/main.py) | `hashlib.md5(text.encode()).hexdigest()` over RAW memory text, case-sensitive, no normalization (`_add_to_vector_store` + `_create_memory`) | YES (byte-identical to our `md5(r.mention.encode())`) -- MD5 floor only; LLM ADD/UPDATE layer out of scope | **validated** |
+| Neo4j LLM KG Builder | `Neo4jBuilderModeled` | [graphDB_dataAccess.py](https://github.com/neo4j-labs/llm-graph-builder/blob/main/backend/src/graphDB_dataAccess.py) | `labels(n)=labels(other)` AND ( CONTAINS guard `size>2` both dirs, `toLower` OR `apoc.text.distance < 3` guard `size(n.id)>5` OR `vector.similarity.cosine > 0.97` ); `DUPLICATE_TEXT_DISTANCE=3`, `DUPLICATE_SCORE_VALUE=0.97` | YES on string predicates + constants (2 caveats below) | **validated** (partial w/o embedder) |
+| neo4j-graphrag (fuzzy, model) | `Neo4jGraphRAGFuzzyModeled` | [resolver.py](https://github.com/neo4j/neo4j-graphrag-python/blob/main/src/neo4j_graphrag/experimental/components/resolver.py) | `fuzz.WRatio(a, b, processor=utils.default_process)/100 >= 0.8` | per-pair predicate matches, but MODEL F1 0.403 vs REAL in-proc F1 0.470 (-6.7pp) -> DIVERGENT in clustering | **modeled** |
+| neo4j-graphrag (fuzzy, real) | `RealNeo4jGraphRAGFuzzy` (`*`) | same | real `compute_similarity` + `_consolidate_sets` per entity-label run in-process | runs the library's real decision code | **real-inproc** |
+| neo4j-graphrag (exact) | `RealNeo4jGraphRAGExact` | same | `SinglePropertyExactMatchResolver`: Cypher exact `name` equality per label, null skipped, NO normalization; no Python decision method | Cypher re-expressed + confirmed | **validated** |
+| LlamaIndex PGI | `LlamaIndexModeled` | [llama_index property_graph](https://github.com/run-llama/llama_index/tree/main/llama-index-core/llama_index/core/indices/property_graph) + Bratanic property-graph blog | model: same-label AND (contains OR Levenshtein<5 OR cosine>0.9), KNN top-10 | constants come from a BLOG, not maintained source; library default is exact name+label upsert (no fuzzy dedup) -> CANNOT confirm | **modeled** |
+| spaCy semantic resolver | (not built) | -- | `SpaCySemanticMatchResolver` needs the `en_core_web_lg` model download | DEFERRED to Phase 2 (model dep) | n/a |
+
+## Per-framework detail
+
+### 1. Microsoft GraphRAG -- `modeled`
+
+`finalize_entities` deduplicates by exact title:
+
+```python
+seen_titles: set[str] = set()
+async for row in entities_table:
+    title = row.get("title")
+    if not title or title in seen_titles:
+        continue
+    seen_titles.add(title)
+```
+
+The title comes from extraction (`graph_extractor.py`):
+
+```python
+entity_name = clean_str(record_attributes[1].upper())   # <-- UPPERCASES
+...
+"title": entity_name,
+```
+
+`clean_str` (`index/utils/string.py`):
+
+```python
+result = html.unescape(input.strip())                    # leading/trailing strip only
+return re.sub(r"[\x00-\x1f\x7f-\x9f]", "", result)        # control-char strip
+```
+
+So the real key is `clean_str(name.upper())`: uppercase, trailing/leading strip,
+html-unescape, control-char strip. **No internal-whitespace collapse, no quote
+strip.** Our `_norm` lowercases + collapses internal whitespace. The case
+direction (upper vs lower) is clustering-equivalent (both fold every string to a
+single canonical case). The **internal-whitespace collapse is a real divergence**:
+`"New  York"` (two spaces) vs `"New York"` merge under our `_norm` but NOT under
+GraphRAG. -> stays `modeled`.
+
+### 2. LightRAG -- `modeled`
+
+`_merge_nodes_then_upsert` uses `entity_name` as the merge key with no further
+transform; the name was normalized at extraction (`operate.py`):
+
+```python
+entity_name = sanitize_and_normalize_extracted_text(
+    record_attributes[1], remove_inner_quotes=True
+)
+```
+
+`normalize_extracted_info` (`utils.py`) strips OUTER quotes (`"`, `'`, CJK
+quotes), folds CJK full-width chars to half-width, removes spaces between CJK
+chars, and `.strip()`s -- but applies **no `.upper()`/`.lower()`** (only
+`entity_type` gets `.replace(" ", "").lower()`, not the name). So LightRAG's
+merge key is **case-SENSITIVE** (`"Apple"` != `"apple"`). Our `_norm`
+lowercases (case-insensitive) and never strips quotes / CJK-folds. Divergent on
+two axes -> stays `modeled`.
+
+### 3. Cognee -- `modeled`
+
+Entity node dedup (`expand_with_nodes_and_edges.py`) keys on
+`generate_node_name(node_name)` and merges when the key is already in
+`added_nodes_map`:
+
+```python
+generated_node_name = generate_node_name(node_name)
+...
+if entity_node_key in added_nodes_map or entity_node_key in key_mapping:
+    return added_nodes_map.get(entity_node_key) ...
+```
+
+```python
+def generate_node_name(name: str) -> str:
+    return name.lower().replace("'", "")      # lowercase + apostrophe strip
+```
+
+The default resolver is `RDFLibOntologyResolver(ontology_file=None,
+matching_strategy=FuzzyMatchingStrategy())`; with `ontology_file=None` the
+ontology candidate list is empty, so `FuzzyMatchingStrategy.find_match`
+(difflib `cutoff=0.8`) has no candidates and never merges anything -- confirming
+the model's "exact name, ontology off by default" framing.
+
+Our `_norm` lowercases (matches) but **collapses internal whitespace** (Cognee
+does not) and does **not strip apostrophes** (Cognee does). E.g. `"O'Brien"` vs
+`"OBrien"` merge in Cognee but not our model. Divergent on the key -> stays
+`modeled`.
+
+> All three exact-match subclasses diverge from `_norm`, each differently, so
+> the base `_ExactNormalized.fidelity` stays `"modeled"` (the safe default) and
+> NO subclass got a `validated` override. The clustering algorithm is exact
+> bucketing in all three; only the bucket KEY normalization differs.
+
+### 4. mem0 -- `validated` (MD5 floor)
+
+`mem0/memory/main.py`:
+
+```python
+mem_hash = hashlib.md5(text.encode()).hexdigest()              # _add_to_vector_store
+new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()  # _create_memory
+```
+
+MD5 over the raw memory text, case-sensitive, no normalization, used as a hard
+content-dedup fingerprint -- byte-identical to our model
+`md5(r.mention.encode()).hexdigest()`. The deterministic MD5 FLOOR is
+**`validated`**.
+
+> **Out of scope (Phase 3):** mem0's real semantic merge is an LLM ADD/UPDATE
+> prompt layered on top of this MD5 floor. That layer is non-deterministic and
+> per-pair LLM-costed; it is NOT modeled here. This row represents only the
+> deterministic dedup floor mem0 ships.
+
+### 5. Neo4j LLM Knowledge Graph Builder -- `validated` (partial without embedder)
+
+Real `get_duplicate_nodes` Cypher (`backend/src/graphDB_dataAccess.py`):
+
+```cypher
+MATCH (n:!Chunk&!Session&!Document&!`__Community__`)
+WHERE n.embedding is not null and n.id is not null
+...
+WHERE elementId(n) < elementId(other) and labels(n) = labels(other)
+AND (
+  (size(toString(other.id)) > 2 AND toLower(toString(n.id)) CONTAINS toLower(toString(other.id))) OR
+  (size(toString(n.id)) > 2 AND toLower(toString(other.id)) CONTAINS toLower(toString(n.id))) OR
+  (size(toString(n.id))>5 AND apoc.text.distance(toLower(toString(n.id)), toLower(toString(other.id))) < $duplicate_text_distance) OR
+  vector.similarity.cosine(other.embedding, n.embedding) > $duplicate_score_value
+)
+```
+
+Constants confirmed:
+
+```python
+text_distance = get_value_from_env("DUPLICATE_TEXT_DISTANCE", 3, "int")    # 3 (README stale at 5)
+score_value   = get_value_from_env("DUPLICATE_SCORE_VALUE", 0.97, "float") # 0.97
+```
+
+`apoc.text.distance` is Levenshtein. The same-label gate, the bidirectional
+`CONTAINS` with the `size > 2` guard, the `Levenshtein < 3` with a length guard,
+and the `cosine > 0.97` term all match our model, and the constants are exact.
+The string predicates are **`validated`**. Two documented caveats:
+
+- **(a) edit-distance length guard is one-sided.** Real Cypher guards on
+  `size(toString(n.id)) > 5` (one side of the pair), our model guards on
+  `min(len(na), len(nb)) > 5` (stricter). They differ only on pairs where one
+  name is <=5 chars and the other is >5 -- a near-edge divergence, not a
+  structural one.
+- **(b) cosine OR-term is inactive in our default run.** The real query
+  pre-filters `n.embedding is not null`, i.e. it always runs over embedded
+  nodes and the cosine term is part of the real default. Our default run
+  supplies no embedder, so the cosine OR-term is dropped and only the string
+  predicates fire -- a **partial** instantiation of the real rule. Pass
+  `--embedder` to activate it. This understates recall on
+  paraphrase/cosine-similar pairs (but the abbreviation/synonym/cross-lingual
+  classes that dominate this corpus sit below a 0.97 cutoff anyway).
+
+### 6. neo4j-graphrag fuzzy -- MODEL `modeled`, REAL `real-inproc`
+
+`resolver.py`:
+
+```python
+return fuzz.WRatio(text_a, text_b, processor=utils.default_process) / 100.0
+# similarity_threshold default 0.8 (BasePropertySimilarityResolver)
+```
+
+The MODELED adapter's per-pair predicate is byte-identical to this. **It still
+diverges from a real run on this corpus:**
+
+- `neo4j-graphrag(fuzzy)*` (`RealNeo4jGraphRAGFuzzy`, **`real-inproc`**) runs the
+  library's real `compute_similarity` + `_consolidate_sets`, grouped per entity
+  label, with only the Neo4j/APOC I/O stubbed. Measured **F1 0.470**.
+- `neo4j-graphrag(fuzzy)` (`Neo4jGraphRAGFuzzyModeled`, **`modeled`**) measures
+  **F1 0.403** (-6.7pp).
+
+The two are kept side by side deliberately for the model-vs-real contrast. The
+divergence is in the consolidation/grouping behavior, not the WRatio predicate.
+
+### 7. neo4j-graphrag exact -- `validated`
+
+`SinglePropertyExactMatchResolver` has **no callable Python decision method**;
+its entire rule is the Cypher in `run()`:
+
+```cypher
+WITH entity, entity.name as prop
+WITH entity, prop WHERE prop IS NOT NULL
+UNWIND labels(entity) as lab
+WITH lab, prop, entity WHERE NOT lab IN ['__Entity__', '__KGBuilder__']
+WITH prop, lab, collect(entity) AS entities
+```
+
+i.e. exact `name` equality per label, null/missing names skipped, NO
+normalization, merge via `apoc.refactor.mergeNodes`. We re-expressed that Cypher
+in `real_resolvers.neo4j_graphrag_exact_clusters` and confirmed it line-by-line
+against source. Because there is no real Python decision code to execute, this
+is **`validated`** (a confirmed re-expression), not `real-inproc`. Measured
+**F1 0.066** (P 0.875 / R 0.034) -- exact-name-per-label is high-precision and
+low-recall on this hard corpus by construction.
+
+### 8. LlamaIndex PropertyGraphIndex -- `modeled`
+
+The model's rule -- same-label gate AND (contains OR Levenshtein<5 OR
+cosine>0.9), KNN top-10 when embedded, with `TEXT_DISTANCE=5` / `COSINE=0.9` --
+comes from a Neo4j/Bratanic *property-graph blog* using a hand-written Cypher
+over `Neo4jPropertyGraphStore`, NOT from maintained library code. The maintained
+`run-llama/llama_index` property-graph code ships **no automatic fuzzy
+entity-dedup default** (no `apoc.text.distance` / `edit_distance` /
+`word_edit_distance` in the property_graph modules; the library default is exact
+`name`+`label` upsert at the graph store). So this model both (a) cannot pin its
+constants to maintained source, and (b) likely over-states the library's default
+behavior. Because the citation is a blog rather than maintainable source we can
+pin a constant to, it stays **`modeled`** (conservative -- cannot confirm).
+
+## Deferred
+
+- **`SpaCySemanticMatchResolver`** (neo4j-graphrag) is DEFERRED to Phase 2: it
+  needs the `en_core_web_lg` spaCy model download (an embedding/model dep). Not
+  built here.
+- **mem0 LLM ADD/UPDATE merge** is Phase 3 (see mem0 section).
+
+## Could-not-confirm summary
+
+Only one adapter stayed `modeled` purely for **lack of confirmable source**
+(not measured divergence): **LlamaIndex PGI** -- its constants live in a blog,
+and the maintained library ships no equivalent default. The exact-match family
+(GraphRAG, LightRAG, Cognee) and the fuzzy model stayed `modeled` because they
+**diverge** from confirmed real source, which is a recorded finding.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/FIDELITY.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/FIDELITY.md
@@ -9,11 +9,12 @@ close a row is to the framework it claims to represent:
   `_consolidate_sets`); only the I/O (live Neo4j) is stubbed.
 - **`validated`** -- a MODEL of the framework's rule, confirmed line-by-line
   against the framework's real merge source (predicate + constants +
-  normalization all match). Where the run is only partial (an OR-term is
-  inactive in our default config), that is called out explicitly.
+  normalization all match) AND faithfully reproducing the real DEFAULT rule in
+  full. The bar is deliberately high: a model that only matches part of the
+  default rule (e.g. an OR-term inactive in our config) does NOT earn it.
 - **`modeled`** -- a model that could NOT be confirmed against maintained
-  source, OR that diverges from the real rule. A documented divergence is a
-  finding, not a failure.
+  source, OR that diverges from the real rule, OR that reproduces only part of
+  the real default rule. A documented divergence is a finding, not a failure.
 
 This audit read each framework's real merge/dedup source on GitHub and compared
 it to our model. The exact-match family's shared normalization is
@@ -28,7 +29,7 @@ collapse, NO quote/apostrophe strip, NO unicode fold).
 | LightRAG | `LightRAGModeled` | [operate.py](https://github.com/HKUDS/LightRAG/blob/main/lightrag/operate.py) + [utils.py `normalize_extracted_info`](https://github.com/HKUDS/LightRAG/blob/main/lightrag/utils.py) | exact `entity_name` dict key; name is `sanitize_and_normalize_extracted_text(.., remove_inner_quotes=True)` -> **case-PRESERVING** (no upper/lower), strips outer quotes, CJK fold, `.strip()` | NO (we lowercase -> case-INSENSITIVE; real is case-SENSITIVE; we don't strip quotes/CJK-fold) | **modeled** |
 | Cognee | `CogneeModeled` | [generate_node_name.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/engine/utils/generate_node_name.py) + [expand_with_nodes_and_edges.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/graph/utils/expand_with_nodes_and_edges.py) + [get_default_ontology_resolver.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/get_default_ontology_resolver.py) + [matching_strategies.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/matching_strategies.py) | entity node key = `generate_node_name(name) = name.lower().replace("'", "")` -> lowercases + strips apostrophes, **no whitespace collapse**. Default ontology empty (`ontology_file=None`) so the difflib cutoff=0.8 never fires | NO (we lowercase too, but we collapse whitespace it doesn't, and it strips apostrophes we don't) | **modeled** |
 | mem0 | `Mem0Modeled` | [memory/main.py](https://github.com/mem0ai/mem0/blob/main/mem0/memory/main.py) | `hashlib.md5(text.encode()).hexdigest()` over RAW memory text, case-sensitive, no normalization (`_add_to_vector_store` + `_create_memory`) | YES (byte-identical to our `md5(r.mention.encode())`) -- MD5 floor only; LLM ADD/UPDATE layer out of scope | **validated** |
-| Neo4j LLM KG Builder | `Neo4jBuilderModeled` | [graphDB_dataAccess.py](https://github.com/neo4j-labs/llm-graph-builder/blob/main/backend/src/graphDB_dataAccess.py) | `labels(n)=labels(other)` AND ( CONTAINS guard `size>2` both dirs, `toLower` OR `apoc.text.distance < 3` guard `size(n.id)>5` OR `vector.similarity.cosine > 0.97` ); `DUPLICATE_TEXT_DISTANCE=3`, `DUPLICATE_SCORE_VALUE=0.97` | YES on string predicates + constants (2 caveats below) | **validated** (partial w/o embedder) |
+| Neo4j LLM KG Builder | `Neo4jBuilderModeled` | [graphDB_dataAccess.py](https://github.com/neo4j-labs/llm-graph-builder/blob/main/backend/src/graphDB_dataAccess.py) | `labels(n)=labels(other)` AND ( CONTAINS guard `size>2` both dirs, `toLower` OR `apoc.text.distance < 3` guard `size(n.id)>5` OR `vector.similarity.cosine > 0.97` ); `DUPLICATE_TEXT_DISTANCE=3`, `DUPLICATE_SCORE_VALUE=0.97` | string predicates + constants confirmed, but default run is PARTIAL (cosine OR-term needs embedder) + a one-sided length-guard divergence | **modeled** |
 | neo4j-graphrag (fuzzy, model) | `Neo4jGraphRAGFuzzyModeled` | [resolver.py](https://github.com/neo4j/neo4j-graphrag-python/blob/main/src/neo4j_graphrag/experimental/components/resolver.py) | `fuzz.WRatio(a, b, processor=utils.default_process)/100 >= 0.8` | per-pair predicate matches, but MODEL F1 0.403 vs REAL in-proc F1 0.470 (-6.7pp) -> DIVERGENT in clustering | **modeled** |
 | neo4j-graphrag (fuzzy, real) | `RealNeo4jGraphRAGFuzzy` (`*`) | same | real `compute_similarity` + `_consolidate_sets` per entity-label run in-process | runs the library's real decision code | **real-inproc** |
 | neo4j-graphrag (exact) | `RealNeo4jGraphRAGExact` | same | `SinglePropertyExactMatchResolver`: Cypher exact `name` equality per label, null skipped, NO normalization; no Python decision method | Cypher re-expressed + confirmed | **validated** |
@@ -145,7 +146,7 @@ content-dedup fingerprint -- byte-identical to our model
 > per-pair LLM-costed; it is NOT modeled here. This row represents only the
 > deterministic dedup floor mem0 ships.
 
-### 5. Neo4j LLM Knowledge Graph Builder -- `validated` (partial without embedder)
+### 5. Neo4j LLM Knowledge Graph Builder -- `modeled` (partial default rule)
 
 Real `get_duplicate_nodes` Cypher (`backend/src/graphDB_dataAccess.py`):
 
@@ -170,23 +171,29 @@ score_value   = get_value_from_env("DUPLICATE_SCORE_VALUE", 0.97, "float") # 0.9
 ```
 
 `apoc.text.distance` is Levenshtein. The same-label gate, the bidirectional
-`CONTAINS` with the `size > 2` guard, the `Levenshtein < 3` with a length guard,
-and the `cosine > 0.97` term all match our model, and the constants are exact.
-The string predicates are **`validated`**. Two documented caveats:
+`CONTAINS` with the `size > 2` guard, the `Levenshtein < 3` term, and the
+`cosine > 0.97` term all map to our model, and the constants are exact. But the
+DEFAULT run does not faithfully reproduce the real default rule, on two counts,
+so the row stays **`modeled`**:
 
-- **(a) edit-distance length guard is one-sided.** Real Cypher guards on
-  `size(toString(n.id)) > 5` (one side of the pair), our model guards on
-  `min(len(na), len(nb)) > 5` (stricter). They differ only on pairs where one
-  name is <=5 chars and the other is >5 -- a near-edge divergence, not a
-  structural one.
-- **(b) cosine OR-term is inactive in our default run.** The real query
-  pre-filters `n.embedding is not null`, i.e. it always runs over embedded
-  nodes and the cosine term is part of the real default. Our default run
-  supplies no embedder, so the cosine OR-term is dropped and only the string
-  predicates fire -- a **partial** instantiation of the real rule. Pass
-  `--embedder` to activate it. This understates recall on
-  paraphrase/cosine-similar pairs (but the abbreviation/synonym/cross-lingual
-  classes that dominate this corpus sit below a 0.97 cutoff anyway).
+- **(a) cosine OR-term is inactive in our default run.** The real query
+  pre-filters `n.embedding is not null`, i.e. it runs over embedded nodes and
+  the `cosine > 0.97` term is part of the real default (the builder embeds
+  nodes at ingest). Our default run supplies no embedder, so the cosine
+  OR-term is dropped and only 2 of the 3 OR-branches fire -- a **partial**
+  instantiation of the real default rule. This is the SAME embedder-gating
+  reason LlamaIndex stays `modeled`. Pass `--embedder` to activate it (the
+  abbreviation/synonym/cross-lingual classes that dominate this corpus sit
+  below a 0.97 cutoff anyway, so it barely moves them).
+- **(b) edit-distance length guard is one-sided.** Real Cypher guards on
+  `size(toString(n.id)) > 5` (one side of the pair); our model guards on
+  `min(len(na), len(nb)) > 5` (stricter). They differ on pairs where one name
+  is <=5 chars and the other is >5 -- a predicate divergence, near-edge but
+  real.
+
+The string predicates and constants ARE source-confirmed (so the row is a
+well-grounded floor), but a partial + divergent default run is not a faithful
+reproduction of the framework's default, which is what `validated` requires.
 
 ### 6. neo4j-graphrag fuzzy -- MODEL `modeled`, REAL `real-inproc`
 
@@ -257,4 +264,12 @@ Only one adapter stayed `modeled` purely for **lack of confirmable source**
 (not measured divergence): **LlamaIndex PGI** -- its constants live in a blog,
 and the maintained library ships no equivalent default. The exact-match family
 (GraphRAG, LightRAG, Cognee) and the fuzzy model stayed `modeled` because they
-**diverge** from confirmed real source, which is a recorded finding.
+**diverge** from confirmed real source. **Neo4j-KGBuilder** stayed `modeled`
+because, although its string predicates + constants are source-confirmed, our
+default run reproduces only **part** of the real default rule (the cosine
+OR-branch is embedder-gated and off by default) plus a one-sided length-guard
+divergence -- the same partial-default reasoning that keeps LlamaIndex
+`modeled`. Net: of the modeled-family adapters, **only mem0** (a byte-identical,
+cleanly-scoped MD5 floor) earned `validated`; every other framework default is
+either divergent, partial, or unconfirmable -- which is itself the headline
+finding (real built-in dedup defaults are shallow and inconsistent).

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/base.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/base.py
@@ -30,6 +30,10 @@ class Adapter(Protocol):
     #: (Graphiti / mem0) are non-deterministic by construction -- see the note
     #: each adapter carries.
     deterministic: bool
+    #: Fidelity tier of this row: "real" (the actual system, e.g. goldenmatch),
+    #: "real-inproc"/"real-live" (real framework run), "validated" (modeled but
+    #: confirmed vs source), or "modeled" (modeled, unverified).
+    fidelity: str
 
     def resolve(self, records: list[Record]) -> list[list[int]]:
         ...

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldenmatch_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldenmatch_adapter.py
@@ -50,6 +50,7 @@ class GoldenMatchAdapter:
     # Auto-config has mild EM-order non-determinism; the runner's re-run check
     # reports what actually happened rather than trusting this flag.
     deterministic = True
+    fidelity = "real"
 
     def __init__(self, mode: str = "auto") -> None:
         if mode not in _MODES:
@@ -111,6 +112,7 @@ class GoldenMatchEmbAnnAdapter:
 
     name = "goldenmatch(emb-ann)"
     deterministic = True
+    fidelity = "real"
 
     def __init__(
         self,

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
@@ -154,14 +154,20 @@ class Neo4jBuilderModeled:
     #   size(n.id)>5  AND apoc.text.distance(toLower,toLower) < $duplicate_text_distance
     #   vector.similarity.cosine(...) > $duplicate_score_value
     # Defaults: DUPLICATE_TEXT_DISTANCE=3 (README stale at 5), DUPLICATE_SCORE_VALUE=0.97.
-    # apoc.text.distance == Levenshtein. Two documented caveats (see FIDELITY.md):
-    #   (a) the real edit-distance length guard is ONE-SIDED (size(n.id)>5), ours is
-    #       min(len(na),len(nb))>5 -- a near-edge divergence on mixed-length pairs;
-    #   (b) the cosine OR-term needs an embedder (real query pre-filters
-    #       n.embedding IS NOT NULL); our default run supplies none, so the string
-    #       predicates run ALONE -> a PARTIAL match of the real rule.
-    # String predicates `validated`; the run is partial-by-default w/o --embedder.
-    fidelity = "validated"
+    # apoc.text.distance == Levenshtein. BUT our default run does NOT reproduce the
+    # real DEFAULT rule, on two counts (see FIDELITY.md):
+    #   (a) the cosine OR-term needs an embedder; the real query pre-filters
+    #       `n.embedding IS NOT NULL` (the builder embeds nodes at ingest), so the
+    #       cosine branch is part of the real default -- our no-embedder run drops it
+    #       and fires only 2 of the 3 OR-branches -> a PARTIAL rule (same reason
+    #       LlamaIndex stays modeled); and
+    #   (b) the edit-distance length guard is ONE-SIDED in the real Cypher
+    #       (size(n.id)>5), ours is min(len(na),len(nb))>5 -- a predicate divergence
+    #       on mixed-length pairs.
+    # Constants + string-predicates are source-confirmed, but a partial + divergent
+    # default run is not a faithful reproduction -> stays `modeled` (conservative;
+    # only mem0's byte-identical, cleanly-scoped floor earns `validated`).
+    fidelity = "modeled"
 
     # DUPLICATE_TEXT_DISTANCE default = 3 in code (README stale at 5); the
     # edit-distance rule only fires when len(name) > 5. DUPLICATE_SCORE_VALUE = 0.97.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
@@ -60,6 +60,7 @@ class _ExactNormalized:
     GraphRAG, LightRAG and Cognee (ontology off, the default)."""
 
     deterministic = True
+    fidelity = "modeled"
 
     def resolve(self, records: list[Record]) -> list[list[int]]:
         return cluster_by_key(records, lambda r: _norm(r.mention))
@@ -96,6 +97,7 @@ class Mem0Modeled:
         "prompt (main.py md5; contradictions #4896, 37.6% near-dupes #4573)"
     )
     deterministic = True  # the modelled MD5 floor is; the LLM layer is not
+    fidelity = "modeled"
 
     def resolve(self, records: list[Record]) -> list[list[int]]:
         # MD5 is over the raw text -> case-sensitive exact match.
@@ -115,6 +117,7 @@ class Neo4jBuilderModeled:
         "(graphDB_dataAccess.py; over-merge #1133, missed alias #912)"
     )
     deterministic = True
+    fidelity = "modeled"
 
     # DUPLICATE_TEXT_DISTANCE default = 3 in code (README stale at 5); the
     # edit-distance rule only fires when len(name) > 5. DUPLICATE_SCORE_VALUE = 0.97.
@@ -165,6 +168,7 @@ class Neo4jGraphRAGFuzzyModeled:
         "(resolver.py BasePropertySimilarityResolver; rapidfuzz extra #336)"
     )
     deterministic = True
+    fidelity = "modeled"
     THRESHOLD = 0.8
 
     def _pred(self, a: Record, b: Record) -> bool:
@@ -187,6 +191,7 @@ class LlamaIndexModeled:
         "BTC Halving 2020/2024)"
     )
     deterministic = True
+    fidelity = "modeled"
     TEXT_DISTANCE = 5
     COSINE = 0.9
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
@@ -56,8 +56,14 @@ def _cosine(u: list[float], v: list[float]) -> float:
 
 
 class _ExactNormalized:
-    """Exact match on the normalised name -- the rule shared by Microsoft
-    GraphRAG, LightRAG and Cognee (ontology off, the default)."""
+    """Exact match on the normalised name -- the exact-string-bucketing family
+    (Microsoft GraphRAG, LightRAG, Cognee). ``_norm`` = lowercase +
+    whitespace-collapse. Base stays ``modeled``: the Phase-1 audit found ALL
+    THREE frameworks diverge from ``_norm`` in their REAL normalization (see
+    adapters/FIDELITY.md), each in a different way, so no per-subclass promotion
+    to ``validated`` was warranted. The clustering is still exact-bucket in all
+    three, but the bucket KEY differs (case direction, quote/apostrophe strip,
+    internal-whitespace handling, CJK fold)."""
 
     deterministic = True
     fidelity = "modeled"
@@ -68,36 +74,59 @@ class _ExactNormalized:
 
 class GraphRAGModeled(_ExactNormalized):
     name = "MS-GraphRAG"
+    # AUDIT (FIDELITY.md): real key = clean_str(name.UPPER()) -> uppercases (vs
+    # our lower; clustering-equivalent) BUT does NOT collapse internal whitespace
+    # (our _norm does). Divergent -> stays modeled.
     defaults = (
         "exact title match; ER step removed "
-        "(finalize_entities seen_titles set; discussion #778, data-loss #1718)"
+        "(finalize_entities seen_titles set, title=clean_str(name.upper()); "
+        "discussion #778, data-loss #1718)"
     )
 
 
 class LightRAGModeled(_ExactNormalized):
     name = "LightRAG"
+    # AUDIT (FIDELITY.md): real key is CASE-SENSITIVE (no .upper()/.lower() on
+    # entity_name) and strips OUTER quotes + CJK-folds (normalize_extracted_info).
+    # Our _norm lowercases + collapses whitespace. Divergent -> stays modeled.
     defaults = (
-        "exact normalized-name dict key, no fuzzy/embedding at merge "
-        "(operate.py _merge_nodes_then_upsert; #1323, cross-doc #485)"
+        "exact case-SENSITIVE name dict key, outer-quote strip + CJK fold, no "
+        "fuzzy/embedding at merge "
+        "(operate.py _merge_nodes_then_upsert + normalize_extracted_info; "
+        "#1323, cross-doc #485)"
     )
 
 
 class CogneeModeled(_ExactNormalized):
     name = "Cognee"
+    # AUDIT (FIDELITY.md): real key = generate_node_name(name) = name.lower()
+    # .replace("'", "") -> lowercases (matches ours) AND strips apostrophes (ours
+    # does not), does NOT collapse whitespace (ours does). Default ontology is
+    # empty (RDFLibOntologyResolver(ontology_file=None)) so the difflib cutoff=0.8
+    # never fires. Divergent on the key -> stays modeled.
     defaults = (
-        "content-hash + exact name; difflib cutoff=0.8 only vs a user ontology "
-        "(empty by default) (matching_strategies.py; #1831)"
+        "exact generate_node_name key = name.lower().replace(\"'\",\"\"); "
+        "difflib cutoff=0.8 only vs a user ontology (empty by default) "
+        "(generate_node_name.py / matching_strategies.py; #1831)"
     )
 
 
 class Mem0Modeled:
     name = "mem0"
+    # AUDIT (FIDELITY.md): CONFIRMED line-by-line. memory/main.py computes
+    #   mem_hash = hashlib.md5(text.encode()).hexdigest()        (_add_to_vector_store)
+    #   new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()  (_create_memory)
+    # over the RAW memory text, case-sensitive, no normalization -- byte-identical
+    # to our model's md5(r.mention.encode()).hexdigest(). The deterministic MD5
+    # FLOOR is `validated`; the LLM ADD/UPDATE semantic-merge layer is OUT OF
+    # SCOPE (Phase 3) and not modeled here.
     defaults = (
         "MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE "
-        "prompt (main.py md5; contradictions #4896, 37.6% near-dupes #4573)"
+        "prompt (memory/main.py md5 over raw text; contradictions #4896, "
+        "37.6% near-dupes #4573)"
     )
     deterministic = True  # the modelled MD5 floor is; the LLM layer is not
-    fidelity = "modeled"
+    fidelity = "validated"  # MD5 floor confirmed vs source; LLM layer out of scope
 
     def resolve(self, records: list[Record]) -> list[list[int]]:
         # MD5 is over the raw text -> case-sensitive exact match.
@@ -114,10 +143,25 @@ class Neo4jBuilderModeled:
     defaults = (
         "same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) "
         "OR cosine>0.97 ); human-review-gated "
-        "(graphDB_dataAccess.py; over-merge #1133, missed alias #912)"
+        "(graphDB_dataAccess.py get_duplicate_nodes Cypher; over-merge #1133, "
+        "missed alias #912)"
     )
     deterministic = True
-    fidelity = "modeled"
+    # AUDIT (FIDELITY.md): string predicates + constants CONFIRMED vs the real
+    # Cypher WHERE clause:
+    #   labels(n)=labels(other)  (same-label gate)
+    #   size(other.id)>2 AND toLower(n.id) CONTAINS toLower(other.id)  (+reverse)
+    #   size(n.id)>5  AND apoc.text.distance(toLower,toLower) < $duplicate_text_distance
+    #   vector.similarity.cosine(...) > $duplicate_score_value
+    # Defaults: DUPLICATE_TEXT_DISTANCE=3 (README stale at 5), DUPLICATE_SCORE_VALUE=0.97.
+    # apoc.text.distance == Levenshtein. Two documented caveats (see FIDELITY.md):
+    #   (a) the real edit-distance length guard is ONE-SIDED (size(n.id)>5), ours is
+    #       min(len(na),len(nb))>5 -- a near-edge divergence on mixed-length pairs;
+    #   (b) the cosine OR-term needs an embedder (real query pre-filters
+    #       n.embedding IS NOT NULL); our default run supplies none, so the string
+    #       predicates run ALONE -> a PARTIAL match of the real rule.
+    # String predicates `validated`; the run is partial-by-default w/o --embedder.
+    fidelity = "validated"
 
     # DUPLICATE_TEXT_DISTANCE default = 3 in code (README stale at 5); the
     # edit-distance rule only fires when len(name) > 5. DUPLICATE_SCORE_VALUE = 0.97.
@@ -168,6 +212,14 @@ class Neo4jGraphRAGFuzzyModeled:
         "(resolver.py BasePropertySimilarityResolver; rapidfuzz extra #336)"
     )
     deterministic = True
+    # AUDIT (FIDELITY.md): the per-pair predicate here is byte-identical to the
+    # library's real compute_similarity (fuzz.WRatio(.., processor=
+    # utils.default_process)/100.0, threshold 0.8). BUT this model still DIVERGES
+    # from a real in-process run on THIS corpus: real `neo4j-graphrag(fuzzy)*`
+    # (real-inproc, runs compute_similarity + _consolidate_sets grouped per
+    # entity-label) measures F1 0.470, while this MODEL measures F1 0.403
+    # (-6.7pp). Kept as `modeled` (DIVERGENT) for the model-vs-real contrast; the
+    # real run ships as the separate `neo4j-graphrag(fuzzy)*` row.
     fidelity = "modeled"
     THRESHOLD = 0.8
 
@@ -191,6 +243,14 @@ class LlamaIndexModeled:
         "BTC Halving 2020/2024)"
     )
     deterministic = True
+    # AUDIT (FIDELITY.md): COULD NOT CONFIRM against maintained source. The
+    # constants (TEXT_DISTANCE=5, COSINE=0.9) and the (contains OR Levenshtein OR
+    # cosine) Cypher come from a Neo4j/Bratanic *blog*, not pinnable library code.
+    # run-llama/llama_index core ships NO automatic fuzzy entity-dedup default
+    # (no apoc.text.distance / edit_distance in the property_graph code; library
+    # default is exact name+label upsert at the graph store). So this model both
+    # (a) can't pin its constants to maintained source and (b) likely OVER-states
+    # the library default. Stays `modeled` for lack of confirmation.
     fidelity = "modeled"
     TEXT_DISTANCE = 5
     COSINE = 0.9

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
@@ -1,0 +1,17 @@
+"""Real-framework adapters, each behind an optional dependency.
+
+available_real_adapters() returns only the adapters whose optional deps are
+installed; a missing dep degrades to "skipped" (the adapter is absent), never a
+hard failure -- mirrors the keyed-row pattern.
+"""
+from __future__ import annotations
+
+
+def available_real_adapters() -> list:
+    out = []
+    try:
+        from erkgbench.adapters.real.neo4j_graphrag import RealNeo4jGraphRAGFuzzy
+        out.append(RealNeo4jGraphRAGFuzzy())
+    except ImportError:
+        pass  # neo4j-graphrag not installed -> skip this real row
+    return out

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
@@ -14,4 +14,12 @@ def available_real_adapters() -> list:
         out.append(RealNeo4jGraphRAGFuzzy())
     except ImportError:
         pass  # neo4j-graphrag not installed -> skip this real row
+    # The exact resolver is a `validated` model of the library's Cypher (no library
+    # call), so it has no optional dep -- still grouped here with neo4j-graphrag's
+    # resolvers for presentation. Own try-block so one failure can't suppress the other.
+    try:
+        from erkgbench.adapters.real.neo4j_graphrag import RealNeo4jGraphRAGExact
+        out.append(RealNeo4jGraphRAGExact())
+    except ImportError:
+        pass
     return out

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/neo4j_graphrag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/neo4j_graphrag.py
@@ -1,0 +1,19 @@
+"""Real neo4j-graphrag FuzzyMatchResolver as a benchmark adapter (in-process)."""
+from __future__ import annotations
+
+from erkgbench.adapters.base import Record
+from erkgbench.real_resolvers import neo4j_graphrag_fuzzy_clusters
+
+
+class RealNeo4jGraphRAGFuzzy:
+    name = "neo4j-graphrag(fuzzy)*"
+    defaults = (
+        "REAL FuzzyMatchResolver: rapidfuzz WRatio/100>=0.8 per entity-label, "
+        "_consolidate_sets (library decision code; Neo4j+APOC storage stubbed)"
+    )
+    deterministic = True
+    fidelity = "real-inproc"
+
+    def resolve(self, records: list[Record]) -> list[list[int]]:
+        items = [(r.index, r.mention, r.entity_type) for r in records]
+        return neo4j_graphrag_fuzzy_clusters(items)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/neo4j_graphrag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/neo4j_graphrag.py
@@ -1,8 +1,11 @@
-"""Real neo4j-graphrag FuzzyMatchResolver as a benchmark adapter (in-process)."""
+"""Real neo4j-graphrag resolvers as benchmark adapters (in-process)."""
 from __future__ import annotations
 
 from erkgbench.adapters.base import Record
-from erkgbench.real_resolvers import neo4j_graphrag_fuzzy_clusters
+from erkgbench.real_resolvers import (
+    neo4j_graphrag_exact_clusters,
+    neo4j_graphrag_fuzzy_clusters,
+)
 
 
 class RealNeo4jGraphRAGFuzzy:
@@ -17,3 +20,22 @@ class RealNeo4jGraphRAGFuzzy:
     def resolve(self, records: list[Record]) -> list[list[int]]:
         items = [(r.index, r.mention, r.entity_type) for r in records]
         return neo4j_graphrag_fuzzy_clusters(items)
+
+
+class RealNeo4jGraphRAGExact:
+    name = "neo4j-graphrag(exact)"
+    defaults = (
+        "SinglePropertyExactMatchResolver: exact `name` equality per entity-label, "
+        "null names skipped (logic is a Cypher query in run(); no in-process decision "
+        "method exists, so this is the Cypher re-expressed + confirmed -> validated)"
+    )
+    deterministic = True
+    # NOT real-inproc: unlike FuzzyMatchResolver (compute_similarity/_consolidate_sets),
+    # SinglePropertyExactMatchResolver has NO callable Python decision code -- its rule
+    # lives entirely in a Cypher query. We re-express that query and confirm it against
+    # source (see adapters/FIDELITY.md), which is the `validated` tier, not a real run.
+    fidelity = "validated"
+
+    def resolve(self, records: list[Record]) -> list[list[int]]:
+        items = [(r.index, r.mention, r.entity_type) for r in records]
+        return neo4j_graphrag_exact_clusters(items)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
@@ -1,0 +1,46 @@
+"""Run neo4j-graphrag-python's REAL resolver decision code, no live Neo4j.
+
+The real FuzzyMatchResolver needs Neo4j+APOC end-to-end, but the CLUSTERING is
+decided purely by the library's own `compute_similarity` (rapidfuzz WRatio/100) and
+`_consolidate_sets`, grouped by node label. Neo4j only persists the merge; it cannot
+change which nodes merge. So we call those real methods over the corpus (grouped by
+entity_type = label). neo4j-graphrag is imported lazily so this module stays
+importable (and unit-testable) without the dependency.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+
+
+def neo4j_graphrag_fuzzy_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
+    """items: (record_id, mention, entity_type). Returns clusters of record_ids
+    (full partition incl. singletons), via the real FuzzyMatchResolver methods."""
+    from unittest.mock import MagicMock
+
+    from neo4j_graphrag.experimental.components.resolver import (  # pyright: ignore[reportMissingImports]
+        FuzzyMatchResolver,
+    )
+
+    resolver = FuzzyMatchResolver(driver=MagicMock())  # driver is I/O only, unused for clustering
+    threshold = resolver.similarity_threshold  # library default 0.8
+
+    mention = {rid: m for rid, m, _t in items}
+    groups: dict[str, list[int]] = {}
+    for rid, _m, t in items:
+        groups.setdefault(t, []).append(rid)
+
+    clusters: list[list[int]] = []
+    for ids in groups.values():
+        # Faithful to BasePropertySimilarityResolver.run: skip empty combined_text.
+        usable = [i for i in ids if mention[i] and str(mention[i]).strip()]
+        pairs: list[set[int]] = []
+        for i, j in combinations(usable, 2):
+            if resolver.compute_similarity(mention[i], mention[j]) >= threshold:
+                pairs.append({i, j})
+        merged = resolver._consolidate_sets(pairs)  # the library's REAL consolidation
+        seen: set[int] = set()
+        for s in merged:
+            clusters.append(sorted(s))
+            seen |= s
+        clusters.extend([i] for i in ids if i not in seen)  # singletons (incl skipped-empty)
+    return clusters

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
@@ -6,6 +6,17 @@ decided purely by the library's own `compute_similarity` (rapidfuzz WRatio/100) 
 change which nodes merge. So we call those real methods over the corpus (grouped by
 entity_type = label). neo4j-graphrag is imported lazily so this module stays
 importable (and unit-testable) without the dependency.
+
+SinglePropertyExactMatchResolver: groups by entity label then merges records whose
+`name` property (= mention in our corpus) is exactly equal AND non-null. The Cypher
+query in the real resolver reads:
+    WITH entity, entity.name as prop
+    WITH entity, prop WHERE prop IS NOT NULL
+    UNWIND labels(entity) as lab
+    WITH lab, prop, entity WHERE NOT lab IN ['__Entity__', '__KGBuilder__']
+    WITH prop, lab, collect(entity) AS entities
+i.e. exact string equality on the raw `name` value, per-label, skipping null/missing.
+No normalization is applied — the stored `name` is compared as-is.
 """
 from __future__ import annotations
 
@@ -43,4 +54,37 @@ def neo4j_graphrag_fuzzy_clusters(items: list[tuple[int, str, str]]) -> list[lis
             clusters.append(sorted(s))
             seen |= s
         clusters.extend([i] for i in ids if i not in seen)  # singletons (incl skipped-empty)
+    return clusters
+
+
+def neo4j_graphrag_exact_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
+    """In-process model of SinglePropertyExactMatchResolver.
+
+    items: (record_id, mention, entity_type).
+
+    The real resolver groups entities by label, then merges those with the same
+    `name` property value (exact equality, no normalization). Entities with a
+    null/empty `name` are skipped (WHERE prop IS NOT NULL in the Cypher query).
+    Returns a full partition (multi-member clusters + singletons).
+    """
+    mention = {rid: m for rid, m, _t in items}
+    groups: dict[str, list[int]] = {}
+    for rid, _m, t in items:
+        groups.setdefault(t, []).append(rid)
+
+    clusters: list[list[int]] = []
+    for ids in groups.values():
+        # Faithful to the real resolver: skip records where name is null/empty.
+        usable = [i for i in ids if mention[i] and str(mention[i]).strip()]
+        # Group by exact name value (no normalization -- the real resolver stores
+        # and compares the `name` property as-is).
+        by_name: dict[str, list[int]] = {}
+        for rid in usable:
+            by_name.setdefault(mention[rid], []).append(rid)
+        seen: set[int] = set()
+        for name_ids in by_name.values():
+            clusters.append(sorted(name_ids))
+            seen.update(name_ids)
+        # Singletons: usable records that had a unique name + skipped-empty records.
+        clusters.extend([i] for i in ids if i not in seen)
     return clusters

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
@@ -28,6 +28,7 @@ from erkgbench.adapters import (  # noqa: E402
     Record,
     all_modeled,
 )
+from erkgbench.adapters.real import available_real_adapters  # noqa: E402
 
 DATASET = _BENCH_ROOT / "dataset" / "records.csv"
 RESULTS_DIR = _BENCH_ROOT / "results"
@@ -112,6 +113,7 @@ def run(embedder_kind: str | None) -> dict:
         adapters.append(GoldenMatchEmbAnnAdapter(threshold=0.55, provider="openai"))
         adapters.append(GoldenMatchAdapter(mode="auto_llm"))
     adapters += list(all_modeled(embed_fn=embed_fn))
+    adapters += available_real_adapters()
 
     rows = []
     for ad in adapters:
@@ -122,7 +124,7 @@ def run(embedder_kind: str | None) -> dict:
             # Determinism: identical partition on a re-run.
             deterministic = metrics.clusterings_equal(clustering, ad.resolve(records))
         except Exception as exc:  # noqa: BLE001 - a flaky adapter must not sink the board
-            rows.append({"name": ad.name, "defaults": ad.defaults, "error": str(exc)[:200]})
+            rows.append({"name": ad.name, "defaults": ad.defaults, "fidelity": getattr(ad, "fidelity", "modeled"), "error": str(exc)[:200]})
             print(f"  [skip] {ad.name}: {type(exc).__name__}: {str(exc)[:120]}", file=sys.stderr)
             continue
         by_class = metrics.score_by_class(entity_ids, failure_classes, clustering)
@@ -131,6 +133,7 @@ def run(embedder_kind: str | None) -> dict:
             {
                 "name": ad.name,
                 "defaults": ad.defaults,
+                "fidelity": getattr(ad, "fidelity", "modeled"),
                 "overall": {
                     "precision": round(overall.precision, 3),
                     "recall": round(overall.recall, 3),
@@ -189,19 +192,19 @@ def to_markdown(report: dict) -> str:
         "",
         "## Headline (pairwise, full set)",
         "",
-        "| System | P | R | F1 | coll&nbsp;P* | temp&nbsp;P* | ms | det-floor |",
-        "|---|---|---|---|---|---|---|---|",
+        "| System | P | R | F1 | fid | coll&nbsp;P* | temp&nbsp;P* | ms | det-floor |",
+        "|---|---|---|---|---|---|---|---|---|",
     ]
     for r in report["results"]:
         if "error" in r:
-            lines.append(f"| {r['name']} | _error_ | | | | | | {r['error'][:40]} |")
+            lines.append(f"| {r['name']} | _error_ | | | {r.get('fidelity', '-')} | | | | {r['error'][:40]} |")
             continue
         o = r["overall"]
         cp = r["per_class_precision"].get("same_name_collision", "-")
         tp = r["per_class_precision"].get("temporal_version", "-")
         lines.append(
             f"| {r['name']} | {o['precision']} | {o['recall']} | **{o['f1']}** | "
-            f"{cp} | {tp} | {r['time_ms']} | {'yes' if r['deterministic_floor'] else 'no'} |"
+            f"{r.get('fidelity', '-')} | {cp} | {tp} | {r['time_ms']} | {'yes' if r['deterministic_floor'] else 'no'} |"
         )
 
     lines += ["", "## Per-class F1", "", "| System | " + " | ".join(

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-real.txt
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-real.txt
@@ -1,0 +1,6 @@
+# Optional real-framework dependencies for ER-KG-Bench.
+# These are BENCH-ONLY deps -- never a core goldenmatch dependency.
+# Install with: pip install -r requirements-real.txt
+# When installed, available_real_adapters() returns the real framework rows;
+# when absent, those rows are silently skipped (degraded to "missing", not error).
+neo4j-graphrag>=1.17

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
@@ -6,18 +6,20 @@ Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `none (str
 
 ## Headline (pairwise, full set)
 
-| System | P | R | F1 | coll&nbsp;P* | temp&nbsp;P* | ms | det-floor |
-|---|---|---|---|---|---|---|---|
-| goldenmatch(auto) | 0.849 | 0.374 | **0.52** | 0.438 | 0.4 | 814.1 | yes |
-| goldenmatch(auto+fields) | 0.786 | 0.488 | **0.602** | 0.471 | 0.4 | 4949.8 | yes |
-| goldenmatch(emb-ann) | 0.455 | 0.426 | **0.44** | 0.471 | 0.4 | 57.2 | yes |
-| MS-GraphRAG | 0.875 | 0.034 | **0.066** | 0.0 | 1.0 | 0.2 | yes |
-| LightRAG | 0.875 | 0.034 | **0.066** | 0.0 | 1.0 | 0.1 | yes |
-| Cognee | 0.875 | 0.034 | **0.066** | 0.0 | 1.0 | 0.1 | yes |
-| mem0 | 0.875 | 0.034 | **0.066** | 0.0 | 1.0 | 0.3 | yes |
-| Neo4j-KGBuilder | 0.826 | 0.315 | **0.456** | 0.448 | 0.286 | 12.1 | yes |
-| neo4j-graphrag(fuzzy) | 0.345 | 0.485 | **0.403** | 0.451 | 0.4 | 64.6 | yes |
-| LlamaIndex-PGI | 0.141 | 0.51 | **0.221** | 0.452 | 0.286 | 6.9 | yes |
+| System | P | R | F1 | fid | coll&nbsp;P* | temp&nbsp;P* | ms | det-floor |
+|---|---|---|---|---|---|---|---|---|
+| goldenmatch(auto) | 0.849 | 0.374 | **0.52** | real | 0.438 | 0.4 | 639.9 | yes |
+| goldenmatch(auto+fields) | 0.786 | 0.488 | **0.602** | real | 0.471 | 0.4 | 3804.3 | yes |
+| goldenmatch(emb-ann) | 0.455 | 0.426 | **0.44** | real | 0.471 | 0.4 | 41.6 | yes |
+| MS-GraphRAG | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.1 | yes |
+| LightRAG | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.1 | yes |
+| Cognee | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.1 | yes |
+| mem0 | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 0.2 | yes |
+| Neo4j-KGBuilder | 0.826 | 0.315 | **0.456** | modeled | 0.448 | 0.286 | 9.3 | yes |
+| neo4j-graphrag(fuzzy) | 0.345 | 0.485 | **0.403** | modeled | 0.451 | 0.4 | 50.7 | yes |
+| LlamaIndex-PGI | 0.141 | 0.51 | **0.221** | modeled | 0.452 | 0.286 | 5.2 | yes |
+| neo4j-graphrag(fuzzy)* | 0.491 | 0.451 | **0.47** | real-inproc | 0.471 | 0.4 | 531.7 | yes |
+| neo4j-graphrag(exact) | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 0.2 | yes |
 
 ## Per-class F1
 
@@ -33,18 +35,22 @@ Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `none (str
 | Neo4j-KGBuilder | 0.412 | 0.406 | 0.034 | 0.456 | 0.588 | 0.714 | 1.0 | 0.308 | 1.0 |
 | neo4j-graphrag(fuzzy) | 0.898 | 0.854 | 0.078 | 0.582 | 0.345 | 0.667 | 0.444 | 0.571 | 1.0 |
 | LlamaIndex-PGI | 0.533 | 0.478 | 0.093 | 0.543 | 0.405 | 0.667 | 0.706 | 0.308 | 0.571 |
+| neo4j-graphrag(fuzzy)* | 0.898 | 0.854 | 0.045 | 0.516 | 0.286 | 0.75 | 0.444 | 0.571 | 1.0 |
+| neo4j-graphrag(exact) | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
 
 ## Documented defaults (what each row runs)
 
 - **goldenmatch(auto)** — zero-config dedupe_df(name) -- auto-config picks the strategy
 - **goldenmatch(auto+fields)** — zero-config dedupe_df(name+type+context) -- auto-config, multi-field
 - **goldenmatch(emb-ann)** — inhouse char-ngram embedding (no key/torch) -> cosine>=0.5 candidate pairs (ANN at scale) -> union-find; name only
-- **MS-GraphRAG** — exact title match; ER step removed (finalize_entities seen_titles set; discussion #778, data-loss #1718)
-- **LightRAG** — exact normalized-name dict key, no fuzzy/embedding at merge (operate.py _merge_nodes_then_upsert; #1323, cross-doc #485)
-- **Cognee** — content-hash + exact name; difflib cutoff=0.8 only vs a user ontology (empty by default) (matching_strategies.py; #1831)
-- **mem0** — MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE prompt (main.py md5; contradictions #4896, 37.6% near-dupes #4573)
-- **Neo4j-KGBuilder** — same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py; over-merge #1133, missed alias #912)
+- **MS-GraphRAG** — exact title match; ER step removed (finalize_entities seen_titles set, title=clean_str(name.upper()); discussion #778, data-loss #1718)
+- **LightRAG** — exact case-SENSITIVE name dict key, outer-quote strip + CJK fold, no fuzzy/embedding at merge (operate.py _merge_nodes_then_upsert + normalize_extracted_info; #1323, cross-doc #485)
+- **Cognee** — exact generate_node_name key = name.lower().replace("'",""); difflib cutoff=0.8 only vs a user ontology (empty by default) (generate_node_name.py / matching_strategies.py; #1831)
+- **mem0** — MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE prompt (memory/main.py md5 over raw text; contradictions #4896, 37.6% near-dupes #4573)
+- **Neo4j-KGBuilder** — same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py get_duplicate_nodes Cypher; over-merge #1133, missed alias #912)
 - **neo4j-graphrag(fuzzy)** — FuzzyMatchResolver: rapidfuzz WRatio/100 >= 0.8, all-pairs O(n^2) (resolver.py BasePropertySimilarityResolver; rapidfuzz extra #336)
 - **LlamaIndex-PGI** — same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)
+- **neo4j-graphrag(fuzzy)*** — REAL FuzzyMatchResolver: rapidfuzz WRatio/100>=0.8 per entity-label, _consolidate_sets (library decision code; Neo4j+APOC storage stubbed)
+- **neo4j-graphrag(exact)** — SinglePropertyExactMatchResolver: exact `name` equality per entity-label, null names skipped (logic is a Cypher query in run(); no in-process decision method exists, so this is the Cypher re-expressed + confirmed -> validated)
 
 > Modelled rows reproduce each framework's deterministic default rule (exact constants + source in `adapters/modeled.py`). LLM-judge layers (Graphiti, mem0) are out of scope: non-deterministic, O(n)-in-LLM-calls, and ~$0.80/40-chats — see the module docstring.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
@@ -23,6 +23,7 @@
     {
       "name": "goldenmatch(auto)",
       "defaults": "zero-config dedupe_df(name) -- auto-config picks the strategy",
+      "fidelity": "real",
       "overall": {
         "precision": 0.849,
         "recall": 0.374,
@@ -50,12 +51,13 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 814.1,
+      "time_ms": 639.9,
       "deterministic_floor": true
     },
     {
       "name": "goldenmatch(auto+fields)",
       "defaults": "zero-config dedupe_df(name+type+context) -- auto-config, multi-field",
+      "fidelity": "real",
       "overall": {
         "precision": 0.786,
         "recall": 0.488,
@@ -83,12 +85,13 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 4949.8,
+      "time_ms": 3804.3,
       "deterministic_floor": true
     },
     {
       "name": "goldenmatch(emb-ann)",
       "defaults": "inhouse char-ngram embedding (no key/torch) -> cosine>=0.5 candidate pairs (ANN at scale) -> union-find; name only",
+      "fidelity": "real",
       "overall": {
         "precision": 0.455,
         "recall": 0.426,
@@ -116,12 +119,13 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 57.2,
+      "time_ms": 41.6,
       "deterministic_floor": true
     },
     {
       "name": "MS-GraphRAG",
-      "defaults": "exact title match; ER step removed (finalize_entities seen_titles set; discussion #778, data-loss #1718)",
+      "defaults": "exact title match; ER step removed (finalize_entities seen_titles set, title=clean_str(name.upper()); discussion #778, data-loss #1718)",
+      "fidelity": "modeled",
       "overall": {
         "precision": 0.875,
         "recall": 0.034,
@@ -149,12 +153,13 @@
         "temporal_version": 1.0,
         "cross_document_exact": 1.0
       },
-      "time_ms": 0.2,
+      "time_ms": 0.1,
       "deterministic_floor": true
     },
     {
       "name": "LightRAG",
-      "defaults": "exact normalized-name dict key, no fuzzy/embedding at merge (operate.py _merge_nodes_then_upsert; #1323, cross-doc #485)",
+      "defaults": "exact case-SENSITIVE name dict key, outer-quote strip + CJK fold, no fuzzy/embedding at merge (operate.py _merge_nodes_then_upsert + normalize_extracted_info; #1323, cross-doc #485)",
+      "fidelity": "modeled",
       "overall": {
         "precision": 0.875,
         "recall": 0.034,
@@ -187,7 +192,8 @@
     },
     {
       "name": "Cognee",
-      "defaults": "content-hash + exact name; difflib cutoff=0.8 only vs a user ontology (empty by default) (matching_strategies.py; #1831)",
+      "defaults": "exact generate_node_name key = name.lower().replace(\"'\",\"\"); difflib cutoff=0.8 only vs a user ontology (empty by default) (generate_node_name.py / matching_strategies.py; #1831)",
+      "fidelity": "modeled",
       "overall": {
         "precision": 0.875,
         "recall": 0.034,
@@ -220,7 +226,8 @@
     },
     {
       "name": "mem0",
-      "defaults": "MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE prompt (main.py md5; contradictions #4896, 37.6% near-dupes #4573)",
+      "defaults": "MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE prompt (memory/main.py md5 over raw text; contradictions #4896, 37.6% near-dupes #4573)",
+      "fidelity": "validated",
       "overall": {
         "precision": 0.875,
         "recall": 0.034,
@@ -248,12 +255,13 @@
         "temporal_version": 1.0,
         "cross_document_exact": 1.0
       },
-      "time_ms": 0.3,
+      "time_ms": 0.2,
       "deterministic_floor": true
     },
     {
       "name": "Neo4j-KGBuilder",
-      "defaults": "same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py; over-merge #1133, missed alias #912)",
+      "defaults": "same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py get_duplicate_nodes Cypher; over-merge #1133, missed alias #912)",
+      "fidelity": "modeled",
       "overall": {
         "precision": 0.826,
         "recall": 0.315,
@@ -281,12 +289,13 @@
         "temporal_version": 0.286,
         "cross_document_exact": 1.0
       },
-      "time_ms": 12.1,
+      "time_ms": 9.3,
       "deterministic_floor": true
     },
     {
       "name": "neo4j-graphrag(fuzzy)",
       "defaults": "FuzzyMatchResolver: rapidfuzz WRatio/100 >= 0.8, all-pairs O(n^2) (resolver.py BasePropertySimilarityResolver; rapidfuzz extra #336)",
+      "fidelity": "modeled",
       "overall": {
         "precision": 0.345,
         "recall": 0.485,
@@ -314,12 +323,13 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 64.6,
+      "time_ms": 50.7,
       "deterministic_floor": true
     },
     {
       "name": "LlamaIndex-PGI",
       "defaults": "same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)",
+      "fidelity": "modeled",
       "overall": {
         "precision": 0.141,
         "recall": 0.51,
@@ -347,7 +357,75 @@
         "temporal_version": 0.286,
         "cross_document_exact": 0.4
       },
-      "time_ms": 6.9,
+      "time_ms": 5.2,
+      "deterministic_floor": true
+    },
+    {
+      "name": "neo4j-graphrag(fuzzy)*",
+      "defaults": "REAL FuzzyMatchResolver: rapidfuzz WRatio/100>=0.8 per entity-label, _consolidate_sets (library decision code; Neo4j+APOC storage stubbed)",
+      "fidelity": "real-inproc",
+      "overall": {
+        "precision": 0.491,
+        "recall": 0.451,
+        "f1": 0.47
+      },
+      "per_class_f1": {
+        "abbreviation": 0.898,
+        "nickname_alias": 0.854,
+        "synonym_brand": 0.045,
+        "same_name_collision": 0.516,
+        "cross_lingual": 0.286,
+        "typo": 0.75,
+        "org_suffix": 0.444,
+        "temporal_version": 0.571,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 0.8,
+        "same_name_collision": 0.471,
+        "cross_lingual": 1.0,
+        "typo": 0.6,
+        "org_suffix": 0.286,
+        "temporal_version": 0.4,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 531.7,
+      "deterministic_floor": true
+    },
+    {
+      "name": "neo4j-graphrag(exact)",
+      "defaults": "SinglePropertyExactMatchResolver: exact `name` equality per entity-label, null names skipped (logic is a Cypher query in run(); no in-process decision method exists, so this is the Cypher re-expressed + confirmed -> validated)",
+      "fidelity": "validated",
+      "overall": {
+        "precision": 0.875,
+        "recall": 0.034,
+        "f1": 0.066
+      },
+      "per_class_f1": {
+        "abbreviation": 0.0,
+        "nickname_alias": 0.0,
+        "synonym_brand": 0.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 0.0,
+        "typo": 0.0,
+        "org_suffix": 0.0,
+        "temporal_version": 0.0,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 1.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 1.0,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 0.2,
       "deterministic_floor": true
     }
   ]

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_fidelity_column.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_fidelity_column.py
@@ -1,0 +1,28 @@
+"""The runner must emit a valid fidelity tier for EVERY adapter row."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+VALID = {"real", "real-inproc", "real-live", "validated", "modeled"}
+
+
+def test_every_row_has_valid_fidelity():
+    from erkgbench import run  # pyright: ignore[reportMissingImports]
+    report = run.run(None)  # offline; no key
+    assert report["results"], "no adapter rows"
+    for r in report["results"]:
+        assert r.get("fidelity") in VALID, f"{r.get('name')!r} -> {r.get('fidelity')!r}"
+
+
+def test_real_neo4j_row_present_and_real():
+    from erkgbench import run  # pyright: ignore[reportMissingImports]
+    report = run.run(None)
+    real = [r for r in report["results"] if r["name"] == "neo4j-graphrag(fuzzy)*"]
+    assert real, "real neo4j-graphrag row missing"
+    assert real[0]["fidelity"] == "real-inproc"
+    assert round(real[0]["overall"]["f1"], 3) == 0.470

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -9,7 +9,7 @@ _BENCH_ROOT = Path(__file__).resolve().parent.parent
 if str(_BENCH_ROOT) not in sys.path:
     sys.path.insert(0, str(_BENCH_ROOT))
 
-from erkgbench import metrics                              # pyright: ignore[reportMissingImports]
+from erkgbench import metrics  # pyright: ignore[reportMissingImports]
 from erkgbench.real_resolvers import (  # pyright: ignore[reportMissingImports]
     neo4j_graphrag_exact_clusters,
     neo4j_graphrag_fuzzy_clusters,

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -10,7 +10,10 @@ if str(_BENCH_ROOT) not in sys.path:
     sys.path.insert(0, str(_BENCH_ROOT))
 
 from erkgbench import metrics                              # pyright: ignore[reportMissingImports]
-from erkgbench.real_resolvers import neo4j_graphrag_fuzzy_clusters  # pyright: ignore[reportMissingImports]
+from erkgbench.real_resolvers import (  # pyright: ignore[reportMissingImports]
+    neo4j_graphrag_exact_clusters,
+    neo4j_graphrag_fuzzy_clusters,
+)
 
 DATASET = _BENCH_ROOT / "dataset" / "records.csv"
 
@@ -42,3 +45,35 @@ def test_empty_mention_is_skipped_faithfully():
     clustering = neo4j_graphrag_fuzzy_clusters(items)
     assert [2] in clustering                     # empty -> singleton
     assert any(set(c) == {0, 1} for c in clustering)  # identical non-empty merge
+
+
+# -- SinglePropertyExactMatchResolver (validated model of the Cypher) ----------
+
+def test_exact_reproduces_observed_f1():
+    items, entity_ids, classes = _load()
+    clustering = neo4j_graphrag_exact_clusters(items)
+    f1 = metrics.score_by_class(entity_ids, classes, clustering)["__overall__"].f1
+    # Exact `name` equality per label recalls almost nothing on real surface-form
+    # variation (R~0.03); high precision, near-zero recall. Pinned once observed.
+    assert round(f1, 3) == 0.066
+
+def test_exact_is_deterministic():
+    items, _, _ = _load()
+    assert metrics.clusterings_equal(
+        neo4j_graphrag_exact_clusters(items), neo4j_graphrag_exact_clusters(items)
+    )
+
+def test_exact_merges_identical_skips_null_and_no_normalization():
+    # exact merges byte-identical names per label; null/empty skipped; case-SENSITIVE
+    # (no normalization) -> "Acme" and "acme" stay distinct, unlike the fuzzy resolver.
+    items = [
+        (0, "Acme Inc", "org"), (1, "Acme Inc", "org"),  # identical -> merge
+        (2, "acme inc", "org"),                            # different case -> own cluster
+        (3, "", "org"),                                    # null/empty -> singleton
+        (4, "Acme Inc", "person"),                         # same name, different label -> not merged with 0/1
+    ]
+    clustering = neo4j_graphrag_exact_clusters(items)
+    assert any(set(c) == {0, 1} for c in clustering)   # identical, same label -> merged
+    assert [2] in clustering                            # case differs -> not merged
+    assert [3] in clustering                            # empty -> singleton
+    assert [4] in clustering                            # different label -> not merged

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -1,0 +1,44 @@
+"""Goldenmatch-free unit test for the real neo4j-graphrag resolver helper."""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench import metrics                              # pyright: ignore[reportMissingImports]
+from erkgbench.real_resolvers import neo4j_graphrag_fuzzy_clusters  # pyright: ignore[reportMissingImports]
+
+DATASET = _BENCH_ROOT / "dataset" / "records.csv"
+
+
+def _load():
+    items, entity_ids, classes = [], [], []
+    with DATASET.open(encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            items.append((int(row["record_id"]), row["mention"], row["entity_type"]))
+            entity_ids.append(row["entity_id"])
+            classes.append(row["failure_class"])
+    return items, entity_ids, classes
+
+
+def test_reproduces_poc_f1():
+    items, entity_ids, classes = _load()
+    clustering = neo4j_graphrag_fuzzy_clusters(items)
+    f1 = metrics.score_by_class(entity_ids, classes, clustering)["__overall__"].f1
+    assert round(f1, 3) == 0.470  # the POC's measured real number, pinned
+
+def test_no_empty_mentions_in_corpus():
+    items, _, _ = _load()
+    assert all(m and m.strip() for _i, m, _t in items)
+
+def test_empty_mention_is_skipped_faithfully():
+    # the real resolver skips entities whose combined_text is empty; a blank mention
+    # must become a singleton, never merged.
+    items = [(0, "Acme Inc", "org"), (1, "Acme Inc", "org"), (2, "", "org")]
+    clustering = neo4j_graphrag_fuzzy_clusters(items)
+    assert [2] in clustering                     # empty -> singleton
+    assert any(set(c) == {0, 1} for c in clustering)  # identical non-empty merge


### PR DESCRIPTION
Re-grounds ER-KG-Bench's framework numbers on real runs, and labels every row with how close it is to the real framework.

## What changed

**Phase 0 - fidelity model + a real in-process row**
- Every adapter now declares a `fidelity` tier; `run.py` emits it per row and renders a `fid` column in `RESULTS.md`.
- New real adapter `neo4j-graphrag(fuzzy)*` (`real-inproc`): runs the library's actual decision code (`FuzzyMatchResolver.compute_similarity` + `_consolidate_sets`, grouped per entity-label) with only the Neo4j/APOC I/O stubbed. Measured F1 **0.470** vs the modeled `neo4j-graphrag(fuzzy)` row at **0.403** (+6.7pp) - i.e. the modeled adapters were not as faithful as assumed, which is the whole reason for this work.
- Pure helper at `erkgbench/real_resolvers.py` (goldenmatch-free, lazy-imports neo4j-graphrag) so its unit test stays dependency-light; `neo4j-graphrag` is an optional bench dep (`requirements-real.txt`), import-guarded.

**Phase 1 - a second real row + a source audit**
- New `neo4j-graphrag(exact)` row (`validated`): `SinglePropertyExactMatchResolver` has no callable Python decision code (its rule is a Cypher query), so we re-express that Cypher and confirm it against source - that is `validated`, not `real-inproc`. F1 **0.066** (P 0.875 / R 0.034): exact name equality per label recalls almost nothing on real surface-form variation.
- `adapters/FIDELITY.md`: audited every modeled adapter against the framework's real merge source (links + quoted source in the file). Result: only **mem0** (byte-identical MD5 floor) earns `validated`; GraphRAG / LightRAG / Cognee each diverge from our `_norm` in a documented way; Neo4j-KGBuilder's default run reproduces only 2 of 3 OR-branches (cosine is embedder-gated) plus a length-guard divergence; LlamaIndex's rule is only pinnable to a blog. Every divergence is recorded as a finding, not hidden.

## Fidelity tiers
`real` (goldenmatch) > `real-inproc` (library decision code runs) > `validated` (model confirmed line-by-line + reproduces the full default rule) > `modeled` (unconfirmed, divergent, or partial).

## CI / results
The `bench-er-kg` lane installs `requirements-real.txt`, runs the new bench tests (`tests/test_real_resolvers.py` pins F1 0.470 + 0.066; `tests/test_fidelity_column.py` asserts every row carries a valid tier and the real row is present), and regenerates `results/RESULTS.md` + `results/results.json` with the real rows + `fid` column. A follow-up commit lands the regenerated offline results from the `er-kg-results-offline` artifact (same bootstrap flow the demo used). The bench dir is `--ignore`d by the goldenmatch unit suite, so these run only in the bench lane.

Spec + plan are local-only (`docs/superpowers/`, gitignored).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)