### PR TITLE
fix(goldenanalysis): add mcp-name marker + smithery.yaml, prep 0.2.0 release

### DIFF
--- a/packages/python/goldenanalysis/CHANGELOG.md
+++ b/packages/python/goldenanalysis/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to GoldenAnalysis are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
-## [0.2.0] - unreleased
+## [0.2.0] - 2026-06-17
 
 Phase 2a — suite consumption. Produce an `AnalysisReport` from real suite outputs.
 

--- a/packages/python/goldenanalysis/README.md
+++ b/packages/python/goldenanalysis/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.benseverndev-oss/goldenanalysis -->
 # GoldenAnalysis
 
 **Measure and report across the Golden Suite.** A read-only, cross-cutting

--- a/packages/python/goldenanalysis/goldenanalysis/__init__.py
+++ b/packages/python/goldenanalysis/goldenanalysis/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "analyze",

--- a/packages/python/goldenanalysis/pyproject.toml
+++ b/packages/python/goldenanalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldenanalysis"
-version = "0.1.0"
+version = "0.2.0"
 description = "Read-only cross-cutting analysis, metrics, and reporting engine for the Golden Suite"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/python/goldenanalysis/server.json
+++ b/packages/python/goldenanalysis/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenAnalysis",
   "description": "Read-only cross-cutting analysis, metrics, and reporting across the Golden Suite.",
   "websiteUrl": "https://github.com/benseverndev-oss/goldenmatch/tree/main/packages/python/goldenanalysis#readme",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenanalysis",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenanalysis/smithery.yaml
+++ b/packages/python/goldenanalysis/smithery.yaml
@@ -1,0 +1,13 @@
+name: goldenanalysis
+description: Read-only cross-cutting analysis, metrics, and reporting across the Golden Suite -- trend and regression detection over any stage's outputs.
+icon: "\U0001F4CA"
+startCommand: goldenanalysis mcp-serve
+tools:
+  - name: list_analyzers
+    description: List the discoverable GoldenAnalysis analyzers.
+  - name: analyze_frame
+    description: Analyze a .parquet/.csv frame (or re-render a .json AnalysisReport) into a metrics report.
+  - name: get_trend
+    description: Trend a metric over a run history (.jsonl/.db ReportHistory).
+  - name: detect_regressions
+    description: Detect metric regressions vs a baseline over a run history.

--- a/packages/python/goldenanalysis/tests/test_smoke.py
+++ b/packages/python/goldenanalysis/tests/test_smoke.py
@@ -6,4 +6,4 @@ from __future__ import annotations
 def test_import_and_version() -> None:
     import goldenanalysis
 
-    assert goldenanalysis.__version__ == "0.1.0"
+    assert goldenanalysis.__version__ == "0.2.0"


### PR DESCRIPTION
## Why

I re-audited all six suite MCP servers against the **official MCP Registry** (`registry.modelcontextprotocol.io`) and **Smithery**. The registry side is healthy for 5 of 6; **goldenanalysis is the only server missing**.

### Official MCP Registry — verified live
| Package | Registry | Repo `server.json` | OK |
|---|---|---|---|
| goldenmatch | 2.0.0 | 2.0.0 | ✅ |
| goldencheck | 1.3.0 | 1.3.0 | ✅ |
| goldenflow | 1.2.0 | 1.2.0 | ✅ |
| goldenpipe | 1.2.1 | 1.2.1 | ✅ |
| infermap | 0.5.0 | 0.5.0 | ✅ |
| **goldenanalysis** | **NOT FOUND** | 0.1.0 → 0.2.0 | ❌ |

### Root cause (confirmed from the failed dispatch log)
The `publish-mcp.yml` dispatch for goldenanalysis fails with:

> `PyPI package 'goldenanalysis' ownership validation failed. The server name 'io.github.benseverndev-oss/goldenanalysis' must appear as 'mcp-name: io.github.benseverndev-oss/goldenanalysis' in the package README`

The registry proves PyPI ownership via an `<!-- mcp-name: … -->` marker in the published long-description. The other five packages carry it on line 1; goldenanalysis (newest, scaffolded later) does not. Since PyPI releases are immutable, the marker only reaches PyPI on the **next** release.

## What this PR does (self-contained fix)
- **`README.md`**: add the `mcp-name` marker on line 1 (matches the five siblings).
- **Bump 0.1.0 → 0.2.0** in `pyproject.toml`, `goldenanalysis/__init__.py`, `server.json`, and the smoke test — so the already-staged `[0.2.0]` CHANGELOG entry ships and carries the marker to PyPI.
- **`CHANGELOG.md`**: date the `[0.2.0]` entry.
- **Add `smithery.yaml`** (stdio, modeled on infermap — goldenanalysis has no Railway remote) so the metadata is ready for the manual Smithery dashboard add.

This **supersedes** the README-only change in #1044 — that PR can be closed once this merges.

## Remaining step (human-driven)
1. Merge this PR.
2. Cut a `goldenanalysis-v0.2.0` release → `publish-goldenanalysis.yml` ships it to PyPI **with the marker**, then `publish-mcp.yml` auto-syncs the registry (ownership validation now passes). The 0.2.0 code (`analyze_match`, `analyze_pipeline`, cross-run trend/regressions) is already in-tree.

## Smithery — separate, manual
Smithery listings live under `benzsevern/*` as remote servers. **4 of 6 are listed** (goldenmatch, goldencheck, goldenflow, goldenpipe); **infermap and goldenanalysis are not.** Smithery registration is a dashboard action — no repo file or CI drives it (infermap already has a `smithery.yaml` and is still unlisted), so it can't be done from this environment. Flagging for a manual add next time you're in the Smithery dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkcJhg84jhMuPBGEsTgY6y

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkcJhg84jhMuPBGEsTgY6y)_