### PR TITLE
ER-KG-Bench Phase 2: spaCy real-inproc row + embedder (emb) rows + elementId fidelity finding

### DIFF
--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -67,6 +67,20 @@ jobs:
         # so the pip-less uv venv installs it WITHOUT `spacy download`).
         run: uv pip install -r "$BENCH_DIR/requirements-embed.txt"
 
+      - name: Pre-fetch MiniLM (retry transient HF 429s)
+        # sentence-transformers downloads all-MiniLM-L6-v2 from HF at first use;
+        # shared CI runners intermittently get 429s (Too Many Requests). Fetch it once
+        # with backoff so the offline + keyed board runs hit the local cache instead of
+        # re-downloading per run -- otherwise the whole lane flakes on a transient 429.
+        run: |
+          set -uo pipefail
+          for i in 1 2 3 4 5; do
+            "$GITHUB_WORKSPACE/.venv/bin/python" -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" && exit 0
+            echo "HF fetch attempt $i failed; backing off $((i*15))s..." >&2
+            sleep $((i*15))
+          done
+          echo "::error::could not fetch all-MiniLM-L6-v2 from HF after 5 retries"; exit 1
+
       - name: Run benchmark (offline -- the committed table)
         working-directory: ${{ env.BENCH_DIR }}
         # --embedder st activates the (emb) rows + the spaCy real row on the committed

--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -60,9 +60,17 @@ jobs:
         # `uv pip install -e`); it installs into the project .venv.
         run: uv pip install -r "$BENCH_DIR/requirements-real.txt"
 
+      - name: Install embedder + spaCy model (Phase 2; offline lane, no key)
+        # sentence-transformers (MiniLM, --embedder st cosine terms) + spacy + the
+        # en_core_web_lg vector model (pinned as a wheel URL in requirements-embed.txt
+        # so the pip-less uv venv installs it WITHOUT `spacy download`).
+        run: uv pip install -r "$BENCH_DIR/requirements-embed.txt"
+
       - name: Run benchmark (offline -- the committed table)
         working-directory: ${{ env.BENCH_DIR }}
-        run: "$GITHUB_WORKSPACE/.venv/bin/python erkgbench/run.py"
+        # --embedder st activates the (emb) rows + the spaCy real row on the committed
+        # board (still key-free): the measured embedder effect, visible side-by-side.
+        run: "$GITHUB_WORKSPACE/.venv/bin/python erkgbench/run.py --embedder st"
       - name: Upload offline results (commit these)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:
@@ -112,7 +120,7 @@ jobs:
             echo "No OPENAI_API_KEY secret; skipping the keyed run." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          "$GITHUB_WORKSPACE/.venv/bin/python" erkgbench/run.py
+          "$GITHUB_WORKSPACE/.venv/bin/python" erkgbench/run.py --embedder st
           "$GITHUB_WORKSPACE/.venv/bin/python" demo/run_demo.py > demo_keyed.txt 2>&1 || true
           {
             echo '## ER-KG demo (Tier 2: over-merge, key-gated prose)'

--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -27,6 +27,7 @@ on:
       - "packages/python/goldenmatch/benchmarks/er-kg-bench/demo/**"
       - "packages/python/goldenmatch/benchmarks/er-kg-bench/tests/**"
       - "packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-real.txt"
+      - "packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-embed.txt"
       - ".github/workflows/bench-er-kg.yml"
 
 permissions:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
@@ -66,34 +66,50 @@ The committed `results/RESULTS.md` runs on the **real corpus** (Wikidata + RxNor
 QID/RxCUI ground truth), so the numbers are defensible rather than invented:
 
 * **The exact-match family collapses.** GraphRAG / LightRAG / Cognee / mem0 score
-  **F1 0.089** — they match only byte-identical strings, so on real surface-form
+  **F1 0.066** — they match only byte-identical strings, so on real surface-form
   variation (IBM vs International Business Machines, München vs Monaco di Baviera)
-  they recall almost nothing (R 0.047); their one non-zero class is
+  they recall almost nothing (R 0.034); their one non-zero class is
   `cross_document_exact` (the same string repeated). Four popular KG/agent-memory
   stacks effectively **cannot resolve real entity variants** — the "built-in dedup
   is shallow" thesis made concrete.
-* **Fuzzy resolvers do better but over-merge.** neo4j-graphrag (0.448) and
-  LlamaIndex (0.315) buy recall with a single similarity threshold and pay in
-  precision (0.35 / 0.22) — they wrongly merge the two distinct "Georgia"s and
-  consecutive World-Cup editions. Neo4j's `cosine>0.97 OR edit-dist<3 OR substring`
-  lands at **0.554, the best framework default**.
-* **goldenmatch(auto+fields) leads at F1 0.721** — **+16.7pp over the best framework
-  default** — because zero-config multi-field ER (name + type + context) is a
-  different mechanism from one threshold: abbreviation 0.77, cross-lingual 0.77,
-  typo / org-suffix 1.0, nickname 0.85. `context` is the real Wikidata one-line
-  description — discriminating, but not a hidden label.
-* **The honest gaps are real and visible.** `synonym_brand` stays hard (0.14 — even
+* **Fuzzy / semantic resolvers do better but over-merge.** neo4j-graphrag fuzzy
+  (model 0.403) and LlamaIndex (0.221) buy recall with a single similarity
+  threshold and pay in precision (0.35 / 0.14) — they wrongly merge the two distinct
+  "Georgia"s and consecutive World-Cup editions. Neo4j's
+  `cosine>0.97 OR edit-dist<3 OR substring` lands at **0.456** (0.471 with the
+  embedder on — see below), the best framework row.
+* **The framework rows are now mostly REAL runs, with a visible fidelity tier.**
+  `neo4j-graphrag(fuzzy)*` (`real-inproc`, the library's own decision code)
+  measures **0.469**, +6.6pp over its model (0.403) — proof the modeled numbers
+  diverge from reality. `neo4j-graphrag(spacy)*` (`real-inproc`, real spaCy
+  doc-vector resolver) measures **0.401**. See `adapters/FIDELITY.md` for the
+  per-row `real` / `real-inproc` / `validated` / `modeled` audit.
+* **goldenmatch(auto+fields) leads at F1 0.602** — **+13.1pp over the best framework
+  row** (Neo4j-KGBuilder(emb) 0.471) — because zero-config multi-field ER (name +
+  type + context) is a different mechanism from one threshold: abbreviation 0.77,
+  cross-lingual 0.77, typo / org-suffix 1.0, nickname 0.85. `context` is the real
+  Wikidata one-line description — discriminating, but not a hidden label.
+* **The honest gaps are real and visible.** `synonym_brand` stays hard (0.17 — even
   multi-field, "Coumadin = warfarin" needs world knowledge), and the
   precision-critical negatives cost everyone (`coll_P` ~0.47): a single score can't
   separate "Apple"/"Apple Inc" (merge) from the country/state "Georgia" (don't).
-* **`emb-ann` (offline char-n-gram, no key) = 0.492** — catches transliteration /
+* **`emb-ann` (offline char-n-gram, no key) = 0.44** — catches transliteration /
   typos the string blocker misses but over-merges short names, and **abbreviation
-  (0.21) / synonym (0.12) stay unsolved** (char overlap has no world knowledge).
+  (0.21) / synonym (0.14) stay unsolved** (char overlap has no world knowledge).
   The keyed semantic + LLM extensions below attack exactly those.
+* **An embedder barely moves the framework rows — measured, not assumed.**
+  `--embedder st` (MiniLM) adds additive `(emb)` rows: Neo4j-KGBuilder 0.456 → 0.471
+  (+1.5pp), LlamaIndex 0.221 → 0.234 (+1.3pp). But the per-class F1 of the dominant
+  classes is **byte-identical** with vs without the embedder (abbreviation, synonym,
+  cross-lingual all flat); the small gain is only `temporal_version` / `nickname`.
+  Those classes sit below a 0.9/0.97 cosine cutoff by construction, so the cosine
+  OR-term can't generate the pairs string blocking misses. Both `(emb)` rows stay
+  `modeled` (see FIDELITY.md).
 
 So on real data the differentiator is clear and defensible: goldenmatch's
 multi-field probabilistic ER, run zero-config, beats every framework's built-in
-default — while the bench keeps goldenmatch's own weak spots (synonym recall,
+default — now measured against the frameworks' REAL resolution code, not just
+models — while the bench keeps goldenmatch's own weak spots (synonym recall,
 collision precision) in plain view.
 
 ## The LLM scorer on real data (measured, key-dependent — not in the committed table)
@@ -104,8 +120,13 @@ precision:**
 
 | config | F1 | coll&nbsp;P* | synm | note |
 |---|---|---|---|---|
-| `goldenmatch(auto+fields)` (committed) | 0.721 | 0.471 | 0.141 | multi-field, no key |
+| `goldenmatch(auto+fields)` (committed) | 0.602 | 0.471 | 0.167 | multi-field, no key |
 | `goldenmatch(auto+llm)` (with key) | 0.661 | **1.000** | 0.116 | LLM confirms/rejects borderline pairs |
+
+> The committed `auto+fields` row is current; the keyed `auto+llm` row is from a
+> keyed run on an earlier corpus snapshot (before the #1039 scaling the committed
+> table reflects), pending a keyed refresh. The qualitative finding (the LLM is a
+> precision tool) holds regardless of the exact F1.
 
 The LLM drives **same-name-collision precision to 1.0** — it correctly refuses to
 merge Georgia-the-country with Georgia-the-state, and Michael Jordan the athlete
@@ -126,13 +147,17 @@ name only, cosine ≥ 0.55:
 
 | config | abbr | synm | xling | P | R | F1 |
 |---|---|---|---|---|---|---|
-| `emb-ann` (offline char-n-gram) | 0.214 | 0.116 | 0.400 | 0.447 | 0.547 | **0.492** |
+| `emb-ann` (offline char-n-gram, committed) | 0.214 | 0.138 | 0.400 | 0.455 | 0.426 | **0.44** |
 | `emb-openai` (with key, name only) | 0.898 | 0.304 | 0.884 | 0.408 | 0.720 | **0.521** |
-| `auto+fields` (committed, multi-field) | 0.773 | 0.141 | 0.769 | 0.869 | 0.617 | **0.721** |
+| `auto+fields` (committed, multi-field) | 0.773 | 0.167 | 0.769 | 0.786 | 0.488 | **0.602** |
+
+> The committed rows (`emb-ann`, `auto+fields`) are current; the keyed `emb-openai`
+> row is from a keyed run on an earlier corpus snapshot (pre-#1039), pending a keyed
+> refresh. The qualitative finding holds regardless of the exact F1.
 
 World knowledge in the vectors **cracks abbreviation** (0.21 → 0.90) and lifts
 cross-lingual to 0.88 — the name-only semantic win the char-n-gram path can't reach.
-But on real multi-field entities it **does not beat `auto+fields`** (0.52 vs 0.72):
+But on real multi-field entities it **does not beat `auto+fields`** (0.52 vs 0.60):
 name-only embedding over-merges (precision 0.41), and goldenmatch's multi-field
 context carries more signal than the name embedding alone. So the honest takeaway
 **flips from the synthetic run** — on real data the lever is **multi-field
@@ -161,8 +186,9 @@ TAXONOMY.md            the nine failure classes, with framework citations
   tests — keep adding them.
 * **Crack abbreviation + synonym (done, key-gated):** the `emb-openai` mode swaps a
   semantic embedder (`text-embedding-3-small`, no torch) into the `emb-ann` path and
-  cracks both classes (abbr 0.98, synm 0.73; overall F1 0.721) — see "The
-  semantic-embedding result". `GoldenMatchEmbAnnAdapter(provider=...)` is the seam;
+  cracks abbreviation (abbr 0.90 keyed) but still does not beat the committed
+  multi-field `auto+fields` (emb-openai 0.52 vs 0.60) — see "Semantic embedding-ANN
+  on real data" (keyed rows pending a corpus refresh). `GoldenMatchEmbAnnAdapter(provider=...)` is the seam;
   pass `provider="local"` for a torch-free-of-cloud sentence-transformers run, or any
   `goldenmatch.embeddings.providers` name. Reproduce with `OPENAI_API_KEY` set. The
   offline char-n-gram `emb-ann` still ships as the no-key proof of the *mechanism*.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/FIDELITY.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/FIDELITY.md
@@ -1,4 +1,12 @@
-# Adapter fidelity audit (Phase 1)
+# Adapter fidelity audit (Phases 1-2)
+
+> **Phase 2 update (see the dedicated section below the verdict table):** the
+> deferred spaCy resolver shipped as a real row (`neo4j-graphrag(spacy)*`,
+> `real-inproc`, F1 0.401); `--embedder st` adds two additive cosine-activated rows
+> (`Neo4j-KGBuilder(emb)` 0.471, `LlamaIndex-PGI(emb)` 0.234, both `modeled`); the
+> Neo4j-KGBuilder length-guard divergence was VERIFIED at source as `elementId`-sided
+> (irreproducible, NOT a fixable min-vs-max gap); and a `_consolidate_sets` overlap bug
+> was fixed (fuzzy real F1 0.470 -> 0.469).
 
 Every adapter declares a `fidelity` tier so a reader can tell, at a glance, how
 close a row is to the framework it claims to represent:
@@ -29,12 +37,14 @@ collapse, NO quote/apostrophe strip, NO unicode fold).
 | LightRAG | `LightRAGModeled` | [operate.py](https://github.com/HKUDS/LightRAG/blob/main/lightrag/operate.py) + [utils.py `normalize_extracted_info`](https://github.com/HKUDS/LightRAG/blob/main/lightrag/utils.py) | exact `entity_name` dict key; name is `sanitize_and_normalize_extracted_text(.., remove_inner_quotes=True)` -> **case-PRESERVING** (no upper/lower), strips outer quotes, CJK fold, `.strip()` | NO (we lowercase -> case-INSENSITIVE; real is case-SENSITIVE; we don't strip quotes/CJK-fold) | **modeled** |
 | Cognee | `CogneeModeled` | [generate_node_name.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/engine/utils/generate_node_name.py) + [expand_with_nodes_and_edges.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/graph/utils/expand_with_nodes_and_edges.py) + [get_default_ontology_resolver.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/get_default_ontology_resolver.py) + [matching_strategies.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/matching_strategies.py) | entity node key = `generate_node_name(name) = name.lower().replace("'", "")` -> lowercases + strips apostrophes, **no whitespace collapse**. Default ontology empty (`ontology_file=None`) so the difflib cutoff=0.8 never fires | NO (we lowercase too, but we collapse whitespace it doesn't, and it strips apostrophes we don't) | **modeled** |
 | mem0 | `Mem0Modeled` | [memory/main.py](https://github.com/mem0ai/mem0/blob/main/mem0/memory/main.py) | `hashlib.md5(text.encode()).hexdigest()` over RAW memory text, case-sensitive, no normalization (`_add_to_vector_store` + `_create_memory`) | YES (byte-identical to our `md5(r.mention.encode())`) -- MD5 floor only; LLM ADD/UPDATE layer out of scope | **validated** |
-| Neo4j LLM KG Builder | `Neo4jBuilderModeled` | [graphDB_dataAccess.py](https://github.com/neo4j-labs/llm-graph-builder/blob/main/backend/src/graphDB_dataAccess.py) | `labels(n)=labels(other)` AND ( CONTAINS guard `size>2` both dirs, `toLower` OR `apoc.text.distance < 3` guard `size(n.id)>5` OR `vector.similarity.cosine > 0.97` ); `DUPLICATE_TEXT_DISTANCE=3`, `DUPLICATE_SCORE_VALUE=0.97` | string predicates + constants confirmed, but default run is PARTIAL (cosine OR-term needs embedder) + a one-sided length-guard divergence | **modeled** |
-| neo4j-graphrag (fuzzy, model) | `Neo4jGraphRAGFuzzyModeled` | [resolver.py](https://github.com/neo4j/neo4j-graphrag-python/blob/main/src/neo4j_graphrag/experimental/components/resolver.py) | `fuzz.WRatio(a, b, processor=utils.default_process)/100 >= 0.8` | per-pair predicate matches, but MODEL F1 0.403 vs REAL in-proc F1 0.470 (-6.7pp) -> DIVERGENT in clustering | **modeled** |
-| neo4j-graphrag (fuzzy, real) | `RealNeo4jGraphRAGFuzzy` (`*`) | same | real `compute_similarity` + `_consolidate_sets` per entity-label run in-process | runs the library's real decision code | **real-inproc** |
+| Neo4j LLM KG Builder | `Neo4jBuilderModeled` | [graphDB_dataAccess.py](https://github.com/neo4j-labs/llm-graph-builder/blob/main/backend/src/graphDB_dataAccess.py) | `labels(n)=labels(other)` AND ( CONTAINS guard `size>2` both dirs, `toLower` OR `apoc.text.distance < 3` guard `size(n.id)>5` OR `vector.similarity.cosine > 0.97` ); `DUPLICATE_TEXT_DISTANCE=3`, `DUPLICATE_SCORE_VALUE=0.97` | string predicates + constants confirmed, but default run is PARTIAL (cosine OR-term needs embedder) + an `elementId`-sided length guard that is IRREPRODUCIBLE by a commutative predicate (Phase-2 verified) | **modeled** |
+| Neo4j-KGBuilder (emb) | `emb_modeled` (`--embedder st`) | same | adds the real cosine>0.97 OR-term (MiniLM); fires all 3 OR-branches | F1 0.456 -> 0.471 (+1.5pp, only `temporal`/`nick` move; dominant classes flat) but still `modeled` -- the `elementId` length guard remains irreproducible | **modeled** |
+| neo4j-graphrag (fuzzy, model) | `Neo4jGraphRAGFuzzyModeled` | [resolver.py](https://github.com/neo4j/neo4j-graphrag-python/blob/main/src/neo4j_graphrag/experimental/components/resolver.py) | `fuzz.WRatio(a, b, processor=utils.default_process)/100 >= 0.8` | per-pair predicate matches, but MODEL F1 0.403 vs REAL in-proc F1 0.469 (-6.6pp) -> DIVERGENT in clustering | **modeled** |
+| neo4j-graphrag (fuzzy, real) | `RealNeo4jGraphRAGFuzzy` (`*`) | same | real `compute_similarity` + `_consolidate_sets` (+ `_merge_overlapping`) per entity-label run in-process | runs the library's real decision code | **real-inproc** |
+| neo4j-graphrag (spaCy, real) | `RealNeo4jGraphRAGSpaCy` (`*`) | same | real `SpaCySemanticMatchResolver.compute_similarity` (spaCy `en_core_web_lg` doc-vector cosine >= 0.8) + `_consolidate_sets` per entity-label, in-process | runs the library's real decision code; F1 0.401 (P 0.699 / R 0.281) | **real-inproc** |
 | neo4j-graphrag (exact) | `RealNeo4jGraphRAGExact` | same | `SinglePropertyExactMatchResolver`: Cypher exact `name` equality per label, null skipped, NO normalization; no Python decision method | Cypher re-expressed + confirmed | **validated** |
 | LlamaIndex PGI | `LlamaIndexModeled` | [llama_index property_graph](https://github.com/run-llama/llama_index/tree/main/llama-index-core/llama_index/core/indices/property_graph) + Bratanic property-graph blog | model: same-label AND (contains OR Levenshtein<5 OR cosine>0.9), KNN top-10 | constants come from a BLOG, not maintained source; library default is exact name+label upsert (no fuzzy dedup) -> CANNOT confirm | **modeled** |
-| spaCy semantic resolver | (not built) | -- | `SpaCySemanticMatchResolver` needs the `en_core_web_lg` model download | DEFERRED to Phase 2 (model dep) | n/a |
+| LlamaIndex PGI (emb) | `emb_modeled` (`--embedder st`) | same | adds the real cosine>0.9 OR-term (MiniLM) | F1 0.221 -> 0.234 (+1.3pp); tier unchanged -- an embedder does not close the blog-provenance gap | **modeled** |
 
 ## Per-framework detail
 
@@ -185,15 +195,25 @@ so the row stays **`modeled`**:
   reason LlamaIndex stays `modeled`. Pass `--embedder` to activate it (the
   abbreviation/synonym/cross-lingual classes that dominate this corpus sit
   below a 0.97 cutoff anyway, so it barely moves them).
-- **(b) edit-distance length guard is one-sided.** Real Cypher guards on
-  `size(toString(n.id)) > 5` (one side of the pair); our model guards on
-  `min(len(na), len(nb)) > 5` (stricter). They differ on pairs where one name
-  is <=5 chars and the other is >5 -- a predicate divergence, near-edge but
-  real.
+- **(b) edit-distance length guard is `elementId`-sided -> IRREPRODUCIBLE
+  (Phase-2 verified verbatim at
+  [`@4a412f46`](https://github.com/neo4j-labs/llm-graph-builder/blob/4a412f4688cf4096976045c019edc0a7f6ddcb6b/backend/src/graphDB_dataAccess.py#L417-L444)).**
+  The guard is `size(toString(n.id)) > 5`, and each pair is oriented by
+  `WHERE elementId(n) < elementId(other)` -- so the guard tests the
+  *smaller-`elementId`* node, an arbitrary INSERTION-ORDER side unrelated to
+  string length. The effective rule is therefore neither `min(len) > 5`
+  (under-fires) nor `max(len) > 5` (over-fires); it is order-dependent on
+  Neo4j-internal `elementId`, which no commutative pairwise predicate can
+  reproduce and which the benchmark's record order cannot be guaranteed to
+  match. We keep the conservative two-sided `min(len) > 5` and RECORD the
+  divergence rather than trade it for an equally-wrong `max`.
 
 The string predicates and constants ARE source-confirmed (so the row is a
-well-grounded floor), but a partial + divergent default run is not a faithful
-reproduction of the framework's default, which is what `validated` requires.
+well-grounded floor), but a partial + irreproducible default run is not a
+faithful reproduction of the framework's default, which is what `validated`
+requires. Crucially, **(b) means even the `--embedder` variant
+(`Neo4j-KGBuilder(emb)`, which fixes (a) by activating the cosine OR-term) stays
+`modeled`** -- the irreproducible guard is not something an embedder can close.
 
 ### 6. neo4j-graphrag fuzzy -- MODEL `modeled`, REAL `real-inproc`
 
@@ -209,12 +229,23 @@ diverges from a real run on this corpus:**
 
 - `neo4j-graphrag(fuzzy)*` (`RealNeo4jGraphRAGFuzzy`, **`real-inproc`**) runs the
   library's real `compute_similarity` + `_consolidate_sets`, grouped per entity
-  label, with only the Neo4j/APOC I/O stubbed. Measured **F1 0.470**.
+  label, with only the Neo4j/APOC I/O stubbed. Measured **F1 0.469**.
 - `neo4j-graphrag(fuzzy)` (`Neo4jGraphRAGFuzzyModeled`, **`modeled`**) measures
-  **F1 0.403** (-6.7pp).
+  **F1 0.403** (-6.6pp).
 
 The two are kept side by side deliberately for the model-vs-real contrast. The
 divergence is in the consolidation/grouping behavior, not the WRatio predicate.
+
+> **Phase-2 `_consolidate_sets` partition fix (F1 0.470 -> 0.469).** The library's
+> `_consolidate_sets` is a SINGLE PASS: a pair bridging two already-separate
+> consolidated sets merges into only the first, leaving them OVERLAPPING (a record
+> in two clusters). The real resolver's sequential Neo4j merges transitively
+> collapse the shared record into one entity; we reproduce that disjoint end-state
+> with `_merge_overlapping` (a no-op when there is no overlap). Phase-1's fuzzy row
+> had 12 duplicate ids and scored F1 0.470 on that malformed partition; the
+> corrected valid partition scores **0.469** (P 0.491->0.477, R 0.451->0.461). The
+> +6.6pp-over-the-model finding is unchanged. spaCy's denser pair graph hit the
+> overlap hard, which is how the bug surfaced.
 
 ### 7. neo4j-graphrag exact -- `validated`
 
@@ -251,11 +282,49 @@ constants to maintained source, and (b) likely over-states the library's default
 behavior. Because the citation is a blog rather than maintainable source we can
 pin a constant to, it stays **`modeled`** (conservative -- cannot confirm).
 
+### 9. neo4j-graphrag spaCy -- `real-inproc` (Phase 2)
+
+`SpaCySemanticMatchResolver` subclasses the same `BasePropertySimilarityResolver`
+as the fuzzy resolver and exposes a callable `compute_similarity` (spaCy
+doc-vector cosine over the `en_core_web_lg` model) + `_consolidate_sets`. We run
+those real library methods in-process per entity-label (only Neo4j/APOC I/O
+stubbed), so the tier is **`real-inproc`** -- the same posture as the fuzzy row,
+NOT `validated` (the exact resolver's tier, which has no callable decision code).
+
+We construct it with `auto_download_spacy_model=False` so a missing model RAISES
+(degrading the row to "skipped" via the import-guarded registry) rather than
+triggering an implicit ~560MB download; CI installs the model explicitly.
+
+Measured **F1 0.401 (P 0.699 / R 0.281)** -- another framework default goldenmatch
+`auto+fields` (0.602) beats. spaCy's semantic vectors recall org-suffix and
+nickname variants well (`suffix` 0.868, `nick` 0.800) but miss cross-lingual and
+typo classes entirely (`xling` 0.0, `typo` 0.0), a different profile from the
+WRatio fuzzy resolver.
+
+## Phase 2 -- embedding terms (measured, not asserted)
+
+`--embedder st` activates the cosine OR-terms (MiniLM `all-MiniLM-L6-v2`, the
+model Neo4j's builder actually uses) on the additive `(emb)` rows, run ALONGSIDE
+the unchanged string-only rows so the board shows the effect side by side:
+
+| row | string-only F1 | (emb) F1 | delta |
+|---|---|---|---|
+| Neo4j-KGBuilder | 0.456 | 0.471 | +1.5pp |
+| LlamaIndex-PGI  | 0.221 | 0.234 | +1.3pp |
+
+**The measured delta confirms the by-construction prediction: the embedder does
+NOT rescue the classes that dominate this corpus.** The per-class F1 of the
+dominant classes is BYTE-IDENTICAL with vs without the embedder -- KGBuilder
+`abbreviation` 0.412=0.412, `synonym` 0.034=0.034, `cross_lingual` 0.588=0.588
+(same for LlamaIndex). The small net gain comes only from `temporal_version` and
+`nickname`. Abbreviations/synonyms/cross-lingual aliases sit below a 0.9/0.97
+cosine cutoff by construction, so the cosine OR-term cannot generate the pairs
+string blocking misses. Both `(emb)` rows stay **`modeled`** (KGBuilder for the
+irreproducible `elementId` guard above; LlamaIndex for the unconfirmable
+blog-sourced rule -- an embedder closes neither gap).
+
 ## Deferred
 
-- **`SpaCySemanticMatchResolver`** (neo4j-graphrag) is DEFERRED to Phase 2: it
-  needs the `en_core_web_lg` spaCy model download (an embedding/model dep). Not
-  built here.
 - **mem0 LLM ADD/UPDATE merge** is Phase 3 (see mem0 section).
 
 ## Could-not-confirm summary
@@ -265,11 +334,10 @@ Only one adapter stayed `modeled` purely for **lack of confirmable source**
 and the maintained library ships no equivalent default. The exact-match family
 (GraphRAG, LightRAG, Cognee) and the fuzzy model stayed `modeled` because they
 **diverge** from confirmed real source. **Neo4j-KGBuilder** stayed `modeled`
-because, although its string predicates + constants are source-confirmed, our
-default run reproduces only **part** of the real default rule (the cosine
-OR-branch is embedder-gated and off by default) plus a one-sided length-guard
-divergence -- the same partial-default reasoning that keeps LlamaIndex
-`modeled`. Net: of the modeled-family adapters, **only mem0** (a byte-identical,
+because, although its string predicates + constants are source-confirmed, its
+edit-distance length guard is `elementId`-sided and IRREPRODUCIBLE by a
+commutative predicate (Phase-2 verified) -- so even the cosine-activated
+`--embedder` variant stays `modeled`. Net: of the modeled-family adapters, **only mem0** (a byte-identical,
 cleanly-scoped MD5 floor) earned `validated`; every other framework default is
 either divergent, partial, or unconfirmable -- which is itself the headline
 finding (real built-in dedup defaults are shallow and inconsistent).

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
@@ -154,19 +154,30 @@ class Neo4jBuilderModeled:
     #   size(n.id)>5  AND apoc.text.distance(toLower,toLower) < $duplicate_text_distance
     #   vector.similarity.cosine(...) > $duplicate_score_value
     # Defaults: DUPLICATE_TEXT_DISTANCE=3 (README stale at 5), DUPLICATE_SCORE_VALUE=0.97.
-    # apoc.text.distance == Levenshtein. BUT our default run does NOT reproduce the
-    # real DEFAULT rule, on two counts (see FIDELITY.md):
+    # apoc.text.distance == Levenshtein. BUT our run does NOT reproduce the real
+    # DEFAULT rule, on two counts (see FIDELITY.md):
     #   (a) the cosine OR-term needs an embedder; the real query pre-filters
     #       `n.embedding IS NOT NULL` (the builder embeds nodes at ingest), so the
-    #       cosine branch is part of the real default -- our no-embedder run drops it
-    #       and fires only 2 of the 3 OR-branches -> a PARTIAL rule (same reason
-    #       LlamaIndex stays modeled); and
-    #   (b) the edit-distance length guard is ONE-SIDED in the real Cypher
-    #       (size(n.id)>5), ours is min(len(na),len(nb))>5 -- a predicate divergence
-    #       on mixed-length pairs.
-    # Constants + string-predicates are source-confirmed, but a partial + divergent
-    # default run is not a faithful reproduction -> stays `modeled` (conservative;
-    # only mem0's byte-identical, cleanly-scoped floor earns `validated`).
+    #       cosine branch is part of the real default -- the no-embedder string-only
+    #       row fires only 2 of the 3 OR-branches -> a PARTIAL rule. Phase 2 adds an
+    #       embedder variant (Neo4j-KGBuilder(emb), emb_modeled()) that DOES fire all
+    #       3 branches -- but it STILL stays modeled, because of (b).
+    #   (b) the edit-distance length guard is IRREPRODUCIBLE by our pairwise model.
+    #       Phase-2 source check (VERIFIED verbatim at
+    #       github.com/neo4j-labs/llm-graph-builder@4a412f46
+    #       backend/src/graphDB_dataAccess.py get_duplicate_nodes_list L417-444): the
+    #       guard is `size(toString(n.id))>5` and each pair is oriented by
+    #       `WHERE elementId(n) < elementId(other)`, so the guard tests the
+    #       SMALLER-elementId node -- an arbitrary INSERTION-ORDER side, unrelated to
+    #       string length. The effective rule is neither min(len)>5 (under-fires) nor
+    #       max(len)>5 (over-fires); it is order-dependent on Neo4j-internal elementId,
+    #       which no commutative pairwise predicate can reproduce and which the
+    #       benchmark's record order cannot be guaranteed to match. We keep our
+    #       conservative two-sided min(len)>5 and record the divergence rather than
+    #       trade it for an equally-wrong max(len)>5.
+    # Constants + string-predicates are source-confirmed, but (a)+(b) mean neither the
+    # string-only NOR the embedder variant is a faithful reproduction -> both stay
+    # `modeled` (only mem0's byte-identical, cleanly-scoped floor earns `validated`).
     fidelity = "modeled"
 
     # DUPLICATE_TEXT_DISTANCE default = 3 in code (README stale at 5); the

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
@@ -312,3 +312,30 @@ def all_modeled(embed_fn: EmbedFn | None = None) -> list:
         Neo4jGraphRAGFuzzyModeled(),
         LlamaIndexModeled(embed_fn=embed_fn),
     ]
+
+
+def emb_modeled(embed_fn: EmbedFn) -> list:
+    """The embedding-activated variants, run ALONGSIDE the string-only rows so the
+    board SHOWS the embedder's effect instead of silently replacing committed numbers.
+
+    Both stay `modeled` -- an embedder activates their cosine OR-term but fixes
+    neither row's fidelity gap:
+      * Neo4j-KGBuilder(emb) now fires all 3 OR-branches (contains, edit-distance,
+        AND the cosine>0.97 term the real builder embeds nodes for at ingest), but its
+        edit-distance length guard is IRREPRODUCIBLE (real Cypher guards the
+        smaller-elementId node, an arbitrary insertion-order side; see
+        Neo4jBuilderModeled audit + FIDELITY.md) -> stays modeled, NOT validated.
+      * LlamaIndex-PGI(emb) activates cosine>0.9 + the KNN-style term, but its rule is
+        blog-sourced/unconfirmable against maintained library code -- a provenance gap
+        an embedder does not close -> stays modeled.
+
+    Instance attrs shadow the class `name`/`fidelity` so the board carries distinct
+    rows without subclassing.
+    """
+    kg = Neo4jBuilderModeled(embed_fn=embed_fn)
+    kg.name = "Neo4j-KGBuilder(emb)"
+    kg.fidelity = "modeled"
+    li = LlamaIndexModeled(embed_fn=embed_fn)
+    li.name = "LlamaIndex-PGI(emb)"
+    li.fidelity = "modeled"
+    return [kg, li]

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
@@ -22,4 +22,16 @@ def available_real_adapters() -> list:
         out.append(RealNeo4jGraphRAGExact())
     except ImportError:
         pass
+    # The spaCy resolver needs both `spacy` AND the vector model (en_core_web_lg).
+    # The adapter module imports fine without them (the helper lazy-imports), so we
+    # PROBE with resolve([]) -- it constructs SpaCySemanticMatchResolver, which loads
+    # the model (auto_download_spacy_model=False -> raises if absent). Catch broadly so
+    # a missing spacy/model degrades to "skipped", never a hard fail or implicit download.
+    try:
+        from erkgbench.adapters.real.neo4j_graphrag import RealNeo4jGraphRAGSpaCy
+        adapter = RealNeo4jGraphRAGSpaCy()
+        adapter.resolve([])  # probe the model loads now, not mid-board
+        out.append(adapter)
+    except Exception:  # noqa: BLE001 - missing spacy/model -> skip this real row
+        pass
     return out

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/neo4j_graphrag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/neo4j_graphrag.py
@@ -5,6 +5,7 @@ from erkgbench.adapters.base import Record
 from erkgbench.real_resolvers import (
     neo4j_graphrag_exact_clusters,
     neo4j_graphrag_fuzzy_clusters,
+    neo4j_graphrag_spacy_clusters,
 )
 
 
@@ -39,3 +40,22 @@ class RealNeo4jGraphRAGExact:
     def resolve(self, records: list[Record]) -> list[list[int]]:
         items = [(r.index, r.mention, r.entity_type) for r in records]
         return neo4j_graphrag_exact_clusters(items)
+
+
+class RealNeo4jGraphRAGSpaCy:
+    name = "neo4j-graphrag(spacy)*"
+    defaults = (
+        "REAL SpaCySemanticMatchResolver: spaCy doc-vector cosine >= 0.8 per "
+        "entity-label, _consolidate_sets (library decision code; en_core_web_lg "
+        "vectors; Neo4j+APOC storage stubbed)"
+    )
+    deterministic = True
+    # real-inproc like FuzzyMatchResolver: SpaCySemanticMatchResolver subclasses
+    # BasePropertySimilarityResolver and exposes a callable compute_similarity
+    # (spaCy doc-vector cosine) + _consolidate_sets, so the library's own decision
+    # code runs in-process (only Neo4j+APOC persistence is stubbed).
+    fidelity = "real-inproc"
+
+    def resolve(self, records: list[Record]) -> list[list[int]]:
+        items = [(r.index, r.mention, r.entity_type) for r in records]
+        return neo4j_graphrag_spacy_clusters(items)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
@@ -7,6 +7,15 @@ change which nodes merge. So we call those real methods over the corpus (grouped
 entity_type = label). neo4j-graphrag is imported lazily so this module stays
 importable (and unit-testable) without the dependency.
 
+NOTE on `_consolidate_sets`: it is a SINGLE-PASS consolidation -- a pair bridging two
+already-separate sets merges into only the first, leaving the two OVERLAPPING (sharing
+a record). The real resolver feeds those sets to sequential Neo4j merges that
+transitively collapse the shared record into one entity; we reproduce that disjoint
+end-state with `_merge_overlapping` so the result is a valid PARTITION (a record can't
+belong to two entities). It is a no-op when no overlap exists (the sparse fuzzy graph),
+so it leaves the fuzzy number essentially unchanged while making the denser spaCy graph
+well-formed.
+
 SinglePropertyExactMatchResolver: groups by entity label then merges records whose
 `name` property (= mention in our corpus) is exactly equal AND non-null. The Cypher
 query in the real resolver reads:
@@ -21,6 +30,36 @@ No normalization is applied — the stored `name` is compared as-is.
 from __future__ import annotations
 
 from itertools import combinations
+
+
+def _merge_overlapping(sets: list[set[int]]) -> list[set[int]]:
+    """Union overlapping sets into disjoint sets (union-find over set memberships).
+
+    `_consolidate_sets` is single-pass and can leave overlapping output sets (see the
+    module docstring); merging them here yields the disjoint partition the real
+    resolver's sequential graph-merges produce. No-op when the input is already
+    disjoint.
+    """
+    parent: dict[int, int] = {}
+
+    def find(x: int) -> int:
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for s in sets:
+        members = list(s)
+        for m in members[1:]:
+            ra, rb = find(members[0]), find(m)
+            if ra != rb:
+                parent[rb] = ra
+
+    groups: dict[int, set[int]] = {}
+    for x in list(parent):
+        groups.setdefault(find(x), set()).add(x)
+    return list(groups.values())
 
 
 def neo4j_graphrag_fuzzy_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
@@ -48,7 +87,10 @@ def neo4j_graphrag_fuzzy_clusters(items: list[tuple[int, str, str]]) -> list[lis
         for i, j in combinations(usable, 2):
             if resolver.compute_similarity(mention[i], mention[j]) >= threshold:
                 pairs.append({i, j})
-        merged = resolver._consolidate_sets(pairs)  # the library's REAL consolidation
+        # Library's REAL consolidation, then merge its single-pass overlaps into a
+        # valid partition (the real resolver's graph-merges collapse them; see module
+        # docstring + _merge_overlapping).
+        merged = _merge_overlapping(resolver._consolidate_sets(pairs))
         seen: set[int] = set()
         for s in merged:
             clusters.append(sorted(s))
@@ -136,7 +178,10 @@ def neo4j_graphrag_spacy_clusters(items: list[tuple[int, str, str]]) -> list[lis
         for i, j in combinations(usable, 2):
             if resolver.compute_similarity(mention[i], mention[j]) >= threshold:
                 pairs.append({i, j})
-        merged = resolver._consolidate_sets(pairs)  # the library's REAL consolidation
+        # Library's REAL consolidation, then merge its single-pass overlaps into a
+        # valid partition (the real resolver's graph-merges collapse them; see module
+        # docstring + _merge_overlapping).
+        merged = _merge_overlapping(resolver._consolidate_sets(pairs))
         seen: set[int] = set()
         for s in merged:
             clusters.append(sorted(s))

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
@@ -88,3 +88,58 @@ def neo4j_graphrag_exact_clusters(items: list[tuple[int, str, str]]) -> list[lis
         # Singletons: usable records that had a unique name + skipped-empty records.
         clusters.extend([i] for i in ids if i not in seen)
     return clusters
+
+
+# The library default for SpaCySemanticMatchResolver.__init__(spacy_model=...)
+# (verified v1.17.0: en_core_web_lg, similarity_threshold=0.8). Faithful = the
+# library default; CI provisions it via `python -m spacy download en_core_web_lg`.
+SPACY_MODEL = "en_core_web_lg"
+
+
+def neo4j_graphrag_spacy_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
+    """Run neo4j-graphrag's REAL SpaCySemanticMatchResolver decision code.
+
+    items: (record_id, mention, entity_type). Like FuzzyMatchResolver, the spaCy
+    resolver subclasses BasePropertySimilarityResolver and exposes a callable
+    `compute_similarity` (spaCy doc-vector cosine) + `_consolidate_sets`; the
+    clustering is decided by those methods, grouped per entity-label (Neo4j+APOC
+    only persists the merge). spaCy + its vector model are imported lazily so this
+    module stays importable without the dependency.
+
+    auto_download_spacy_model=False: a MISSING model must RAISE here (the registry
+    then degrades the row to "skipped"), never trigger an implicit ~560MB download
+    mid-run. CI installs the model explicitly.
+    """
+    from unittest.mock import MagicMock
+
+    from neo4j_graphrag.experimental.components.resolver import (  # pyright: ignore[reportMissingImports]
+        SpaCySemanticMatchResolver,
+    )
+
+    resolver = SpaCySemanticMatchResolver(
+        driver=MagicMock(),  # driver is I/O only, unused for clustering
+        spacy_model=SPACY_MODEL,
+        auto_download_spacy_model=False,
+    )
+    threshold = resolver.similarity_threshold  # library default 0.8
+
+    mention = {rid: m for rid, m, _t in items}
+    groups: dict[str, list[int]] = {}
+    for rid, _m, t in items:
+        groups.setdefault(t, []).append(rid)
+
+    clusters: list[list[int]] = []
+    for ids in groups.values():
+        # Faithful to BasePropertySimilarityResolver.run: skip empty combined_text.
+        usable = [i for i in ids if mention[i] and str(mention[i]).strip()]
+        pairs: list[set[int]] = []
+        for i, j in combinations(usable, 2):
+            if resolver.compute_similarity(mention[i], mention[j]) >= threshold:
+                pairs.append({i, j})
+        merged = resolver._consolidate_sets(pairs)  # the library's REAL consolidation
+        seen: set[int] = set()
+        for s in merged:
+            clusters.append(sorted(s))
+            seen |= s
+        clusters.extend([i] for i in ids if i not in seen)  # singletons (incl skipped-empty)
+    return clusters

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
@@ -112,7 +112,15 @@ def run(embedder_kind: str | None) -> dict:
         # 0.55 from a small sweep (peak overall F1; stable 0.525-0.6 plateau).
         adapters.append(GoldenMatchEmbAnnAdapter(threshold=0.55, provider="openai"))
         adapters.append(GoldenMatchAdapter(mode="auto_llm"))
-    adapters += list(all_modeled(embed_fn=embed_fn))
+    # String-only rows stay canonical/unchanged (embed_fn=None) regardless of
+    # --embedder, so the committed numbers don't silently shift identity. With an
+    # embedder, the cosine-activated variants are ADDED alongside (Neo4j-KGBuilder(emb)
+    # + LlamaIndex-PGI(emb)) so the board SHOWS the embedder's effect side-by-side.
+    adapters += list(all_modeled(embed_fn=None))
+    if embed_fn is not None:
+        from erkgbench.adapters.modeled import emb_modeled  # noqa: E402
+
+        adapters += emb_modeled(embed_fn)
     adapters += available_real_adapters()
 
     rows = []

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-embed.txt
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-embed.txt
@@ -1,0 +1,10 @@
+# Optional embedding/model deps for ER-KG-Bench Phase 2 (offline lane; NO key).
+# Activates `--embedder st` (MiniLM cosine OR-terms for KGBuilder/LlamaIndex) and
+# the real spaCy resolver row. BENCH-ONLY -- never a core goldenmatch dependency.
+# Install with: uv pip install -r requirements-embed.txt
+sentence-transformers>=3,<4
+spacy>=3.8,<3.9
+# spaCy vector model for the real SpaCySemanticMatchResolver, pinned as a wheel URL
+# so the uv venv (which ships NO pip) installs it WITHOUT `spacy download` (which
+# shells out to pip). en_core_web_lg-3.8.0 requires spacy 3.8.x (matched above).
+en_core_web_lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
@@ -1,6 +1,6 @@
 # ER-KG-Bench results
 
-Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `none (string predicates only)`.
+Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `st`.
 
 `*` = precision-critical negative class (distinct entities with colliding surface forms; lower precision = wrong merges).
 
@@ -8,18 +8,21 @@ Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `none (str
 
 | System | P | R | F1 | fid | coll&nbsp;P* | temp&nbsp;P* | ms | det-floor |
 |---|---|---|---|---|---|---|---|---|
-| goldenmatch(auto) | 0.849 | 0.374 | **0.52** | real | 0.438 | 0.4 | 639.9 | yes |
-| goldenmatch(auto+fields) | 0.786 | 0.488 | **0.602** | real | 0.471 | 0.4 | 3804.3 | yes |
-| goldenmatch(emb-ann) | 0.455 | 0.426 | **0.44** | real | 0.471 | 0.4 | 41.6 | yes |
-| MS-GraphRAG | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.1 | yes |
+| goldenmatch(auto) | 0.849 | 0.374 | **0.52** | real | 0.438 | 0.4 | 984.6 | yes |
+| goldenmatch(auto+fields) | 0.786 | 0.488 | **0.602** | real | 0.471 | 0.4 | 4878.1 | yes |
+| goldenmatch(emb-ann) | 0.455 | 0.426 | **0.44** | real | 0.471 | 0.4 | 65.9 | yes |
+| MS-GraphRAG | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.2 | yes |
 | LightRAG | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.1 | yes |
 | Cognee | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.1 | yes |
-| mem0 | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 0.2 | yes |
-| Neo4j-KGBuilder | 0.826 | 0.315 | **0.456** | modeled | 0.448 | 0.286 | 9.3 | yes |
-| neo4j-graphrag(fuzzy) | 0.345 | 0.485 | **0.403** | modeled | 0.451 | 0.4 | 50.7 | yes |
-| LlamaIndex-PGI | 0.141 | 0.51 | **0.221** | modeled | 0.452 | 0.286 | 5.2 | yes |
-| neo4j-graphrag(fuzzy)* | 0.491 | 0.451 | **0.47** | real-inproc | 0.471 | 0.4 | 531.7 | yes |
+| mem0 | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 0.3 | yes |
+| Neo4j-KGBuilder | 0.826 | 0.315 | **0.456** | modeled | 0.448 | 0.286 | 12.3 | yes |
+| neo4j-graphrag(fuzzy) | 0.345 | 0.485 | **0.403** | modeled | 0.451 | 0.4 | 63.6 | yes |
+| LlamaIndex-PGI | 0.141 | 0.51 | **0.221** | modeled | 0.452 | 0.286 | 7.0 | yes |
+| Neo4j-KGBuilder(emb) | 0.795 | 0.335 | **0.471** | modeled | 0.448 | 0.4 | 654.2 | yes |
+| LlamaIndex-PGI(emb) | 0.149 | 0.547 | **0.234** | modeled | 0.452 | 0.4 | 671.3 | yes |
+| neo4j-graphrag(fuzzy)* | 0.477 | 0.461 | **0.469** | real-inproc | 0.471 | 0.4 | 12.6 | yes |
 | neo4j-graphrag(exact) | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 0.2 | yes |
+| neo4j-graphrag(spacy)* | 0.699 | 0.281 | **0.401** | real-inproc | 0.455 | 0.364 | 1943.2 | yes |
 
 ## Per-class F1
 
@@ -35,8 +38,11 @@ Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `none (str
 | Neo4j-KGBuilder | 0.412 | 0.406 | 0.034 | 0.456 | 0.588 | 0.714 | 1.0 | 0.308 | 1.0 |
 | neo4j-graphrag(fuzzy) | 0.898 | 0.854 | 0.078 | 0.582 | 0.345 | 0.667 | 0.444 | 0.571 | 1.0 |
 | LlamaIndex-PGI | 0.533 | 0.478 | 0.093 | 0.543 | 0.405 | 0.667 | 0.706 | 0.308 | 0.571 |
-| neo4j-graphrag(fuzzy)* | 0.898 | 0.854 | 0.045 | 0.516 | 0.286 | 0.75 | 0.444 | 0.571 | 1.0 |
+| Neo4j-KGBuilder(emb) | 0.412 | 0.406 | 0.034 | 0.456 | 0.588 | 0.714 | 1.0 | 0.571 | 1.0 |
+| LlamaIndex-PGI(emb) | 0.533 | 0.622 | 0.093 | 0.543 | 0.405 | 0.667 | 0.706 | 0.571 | 0.571 |
+| neo4j-graphrag(fuzzy)* | 0.898 | 0.854 | 0.045 | 0.516 | 0.345 | 0.667 | 0.444 | 0.571 | 1.0 |
 | neo4j-graphrag(exact) | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
+| neo4j-graphrag(spacy)* | 0.457 | 0.8 | 0.104 | 0.256 | 0.0 | 0.0 | 0.868 | 0.471 | 1.0 |
 
 ## Documented defaults (what each row runs)
 
@@ -50,7 +56,10 @@ Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `none (str
 - **Neo4j-KGBuilder** — same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py get_duplicate_nodes Cypher; over-merge #1133, missed alias #912)
 - **neo4j-graphrag(fuzzy)** — FuzzyMatchResolver: rapidfuzz WRatio/100 >= 0.8, all-pairs O(n^2) (resolver.py BasePropertySimilarityResolver; rapidfuzz extra #336)
 - **LlamaIndex-PGI** — same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)
+- **Neo4j-KGBuilder(emb)** — same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py get_duplicate_nodes Cypher; over-merge #1133, missed alias #912)
+- **LlamaIndex-PGI(emb)** — same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)
 - **neo4j-graphrag(fuzzy)*** — REAL FuzzyMatchResolver: rapidfuzz WRatio/100>=0.8 per entity-label, _consolidate_sets (library decision code; Neo4j+APOC storage stubbed)
 - **neo4j-graphrag(exact)** — SinglePropertyExactMatchResolver: exact `name` equality per entity-label, null names skipped (logic is a Cypher query in run(); no in-process decision method exists, so this is the Cypher re-expressed + confirmed -> validated)
+- **neo4j-graphrag(spacy)*** — REAL SpaCySemanticMatchResolver: spaCy doc-vector cosine >= 0.8 per entity-label, _consolidate_sets (library decision code; en_core_web_lg vectors; Neo4j+APOC storage stubbed)
 
 > Modelled rows reproduce each framework's deterministic default rule (exact constants + source in `adapters/modeled.py`). LLM-judge layers (Graphiti, mem0) are out of scope: non-deterministic, O(n)-in-LLM-calls, and ~$0.80/40-chats — see the module docstring.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
@@ -14,7 +14,7 @@
       "cross_document_exact"
     ]
   },
-  "embedder": "none (string predicates only)",
+  "embedder": "st",
   "precision_critical_classes": [
     "same_name_collision",
     "temporal_version"
@@ -51,7 +51,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 639.9,
+      "time_ms": 984.6,
       "deterministic_floor": true
     },
     {
@@ -85,7 +85,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 3804.3,
+      "time_ms": 4878.1,
       "deterministic_floor": true
     },
     {
@@ -119,7 +119,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 41.6,
+      "time_ms": 65.9,
       "deterministic_floor": true
     },
     {
@@ -153,7 +153,7 @@
         "temporal_version": 1.0,
         "cross_document_exact": 1.0
       },
-      "time_ms": 0.1,
+      "time_ms": 0.2,
       "deterministic_floor": true
     },
     {
@@ -255,7 +255,7 @@
         "temporal_version": 1.0,
         "cross_document_exact": 1.0
       },
-      "time_ms": 0.2,
+      "time_ms": 0.3,
       "deterministic_floor": true
     },
     {
@@ -289,7 +289,7 @@
         "temporal_version": 0.286,
         "cross_document_exact": 1.0
       },
-      "time_ms": 9.3,
+      "time_ms": 12.3,
       "deterministic_floor": true
     },
     {
@@ -323,7 +323,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 50.7,
+      "time_ms": 63.6,
       "deterministic_floor": true
     },
     {
@@ -357,7 +357,75 @@
         "temporal_version": 0.286,
         "cross_document_exact": 0.4
       },
-      "time_ms": 5.2,
+      "time_ms": 7.0,
+      "deterministic_floor": true
+    },
+    {
+      "name": "Neo4j-KGBuilder(emb)",
+      "defaults": "same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py get_duplicate_nodes Cypher; over-merge #1133, missed alias #912)",
+      "fidelity": "modeled",
+      "overall": {
+        "precision": 0.795,
+        "recall": 0.335,
+        "f1": 0.471
+      },
+      "per_class_f1": {
+        "abbreviation": 0.412,
+        "nickname_alias": 0.406,
+        "synonym_brand": 0.034,
+        "same_name_collision": 0.456,
+        "cross_lingual": 0.588,
+        "typo": 0.714,
+        "org_suffix": 1.0,
+        "temporal_version": 0.571,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 0.75,
+        "same_name_collision": 0.448,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 0.4,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 654.2,
+      "deterministic_floor": true
+    },
+    {
+      "name": "LlamaIndex-PGI(emb)",
+      "defaults": "same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)",
+      "fidelity": "modeled",
+      "overall": {
+        "precision": 0.149,
+        "recall": 0.547,
+        "f1": 0.234
+      },
+      "per_class_f1": {
+        "abbreviation": 0.533,
+        "nickname_alias": 0.622,
+        "synonym_brand": 0.093,
+        "same_name_collision": 0.543,
+        "cross_lingual": 0.405,
+        "typo": 0.667,
+        "org_suffix": 0.706,
+        "temporal_version": 0.571,
+        "cross_document_exact": 0.571
+      },
+      "per_class_precision": {
+        "abbreviation": 0.417,
+        "nickname_alias": 1.0,
+        "synonym_brand": 0.058,
+        "same_name_collision": 0.452,
+        "cross_lingual": 0.283,
+        "typo": 0.5,
+        "org_suffix": 0.545,
+        "temporal_version": 0.4,
+        "cross_document_exact": 0.4
+      },
+      "time_ms": 671.3,
       "deterministic_floor": true
     },
     {
@@ -365,17 +433,17 @@
       "defaults": "REAL FuzzyMatchResolver: rapidfuzz WRatio/100>=0.8 per entity-label, _consolidate_sets (library decision code; Neo4j+APOC storage stubbed)",
       "fidelity": "real-inproc",
       "overall": {
-        "precision": 0.491,
-        "recall": 0.451,
-        "f1": 0.47
+        "precision": 0.477,
+        "recall": 0.461,
+        "f1": 0.469
       },
       "per_class_f1": {
         "abbreviation": 0.898,
         "nickname_alias": 0.854,
         "synonym_brand": 0.045,
         "same_name_collision": 0.516,
-        "cross_lingual": 0.286,
-        "typo": 0.75,
+        "cross_lingual": 0.345,
+        "typo": 0.667,
         "org_suffix": 0.444,
         "temporal_version": 0.571,
         "cross_document_exact": 1.0
@@ -386,12 +454,12 @@
         "synonym_brand": 0.8,
         "same_name_collision": 0.471,
         "cross_lingual": 1.0,
-        "typo": 0.6,
+        "typo": 0.5,
         "org_suffix": 0.286,
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 531.7,
+      "time_ms": 12.6,
       "deterministic_floor": true
     },
     {
@@ -426,6 +494,40 @@
         "cross_document_exact": 1.0
       },
       "time_ms": 0.2,
+      "deterministic_floor": true
+    },
+    {
+      "name": "neo4j-graphrag(spacy)*",
+      "defaults": "REAL SpaCySemanticMatchResolver: spaCy doc-vector cosine >= 0.8 per entity-label, _consolidate_sets (library decision code; en_core_web_lg vectors; Neo4j+APOC storage stubbed)",
+      "fidelity": "real-inproc",
+      "overall": {
+        "precision": 0.699,
+        "recall": 0.281,
+        "f1": 0.401
+      },
+      "per_class_f1": {
+        "abbreviation": 0.457,
+        "nickname_alias": 0.8,
+        "synonym_brand": 0.104,
+        "same_name_collision": 0.256,
+        "cross_lingual": 0.0,
+        "typo": 0.0,
+        "org_suffix": 0.868,
+        "temporal_version": 0.471,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 0.275,
+        "same_name_collision": 0.455,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 0.364,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 1943.2,
       "deterministic_floor": true
     }
   ]

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_fidelity_column.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_fidelity_column.py
@@ -26,3 +26,19 @@ def test_real_neo4j_row_present_and_real():
     assert real, "real neo4j-graphrag row missing"
     assert real[0]["fidelity"] == "real-inproc"
     assert round(real[0]["overall"]["f1"], 3) == 0.470
+
+
+def test_emb_rows_present_with_correct_tiers():
+    # Tier-only check via a tiny deterministic fake embedder (no torch needed).
+    # Both embedder variants stay `modeled`: KGBuilder(emb) because its real
+    # edit-distance length guard is irreproducible (elementId-sided; see
+    # modeled.py audit + FIDELITY.md), LlamaIndex(emb) because its rule is
+    # blog-sourced/unconfirmable -- an embedder fixes neither.
+    from erkgbench.adapters.modeled import emb_modeled  # pyright: ignore[reportMissingImports]
+
+    def fake_embed(texts: list[str]) -> list[list[float]]:
+        return [[float(len(t)), 1.0, 0.0] for t in texts]
+
+    by_name = {a.name: a.fidelity for a in emb_modeled(fake_embed)}
+    assert by_name.get("Neo4j-KGBuilder(emb)") == "modeled"
+    assert by_name.get("LlamaIndex-PGI(emb)") == "modeled"

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_fidelity_column.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_fidelity_column.py
@@ -25,7 +25,7 @@ def test_real_neo4j_row_present_and_real():
     real = [r for r in report["results"] if r["name"] == "neo4j-graphrag(fuzzy)*"]
     assert real, "real neo4j-graphrag row missing"
     assert real[0]["fidelity"] == "real-inproc"
-    assert round(real[0]["overall"]["f1"], 3) == 0.470
+    assert round(real[0]["overall"]["f1"], 3) == 0.469  # Phase-2 _merge_overlapping fix (was 0.470)
 
 
 def test_emb_rows_present_with_correct_tiers():

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -102,11 +102,9 @@ def test_exact_merges_identical_skips_null_and_no_normalization():
 
 # -- SpaCySemanticMatchResolver (real-inproc; needs the spaCy vector model) -----
 
-# Observed real F1 of the spaCy resolver on the corpus. None until the first CI run
-# (which has the model) reports it; set it to lock the value against silent drift.
-# Read it from the regenerated results/RESULTS.md `neo4j-graphrag(spacy)*` row or the
-# skip message below, then pin here (Task 8).
-_SPACY_F1_PIN: float | None = None
+# Observed real F1 of the spaCy resolver on the corpus, pinned from the CI run
+# (en_core_web_lg installed): P 0.699 / R 0.281 / F1 0.401. Locks against drift.
+_SPACY_F1_PIN: float | None = 0.401
 
 
 def _spacy_model_available() -> bool:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -35,7 +35,25 @@ def test_reproduces_poc_f1():
     items, entity_ids, classes = _load()
     clustering = neo4j_graphrag_fuzzy_clusters(items)
     f1 = metrics.score_by_class(entity_ids, classes, clustering)["__overall__"].f1
-    assert round(f1, 3) == 0.470  # the POC's measured real number, pinned
+    # 0.469 after the Phase-2 _merge_overlapping fix (was 0.470 on the malformed,
+    # duplicate-id partition `_consolidate_sets` produced; the fix is a valid-partition
+    # correctness change, -0.001 F1). The +6.6pp-over-the-model finding is unchanged.
+    assert round(f1, 3) == 0.469
+    # valid partition: every record id appears exactly once (the bug _merge_overlapping
+    # fixes had 12 duplicate ids from _consolidate_sets' single-pass overlap).
+    flat = [i for c in clustering for i in c]
+    assert sorted(flat) == sorted(i for i, _m, _t in items)
+
+
+def test_merge_overlapping_unifies_consolidate_sets_overlap():
+    from erkgbench.real_resolvers import _merge_overlapping  # pyright: ignore[reportMissingImports]
+    # _consolidate_sets' single pass can emit overlapping sets ({3} in both); merging
+    # must unify them into one disjoint cluster (what the real graph-merges produce).
+    out = _merge_overlapping([{1, 2, 3}, {3, 4}])
+    assert len(out) == 1 and out[0] == {1, 2, 3, 4}
+    # already-disjoint input is a no-op (so the sparse fuzzy graph is unaffected).
+    out2 = sorted(sorted(s) for s in _merge_overlapping([{1, 2}, {3, 4}]))
+    assert out2 == [[1, 2], [3, 4]]
 
 def test_no_empty_mentions_in_corpus():
     items, _, _ = _load()

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -9,10 +9,13 @@ _BENCH_ROOT = Path(__file__).resolve().parent.parent
 if str(_BENCH_ROOT) not in sys.path:
     sys.path.insert(0, str(_BENCH_ROOT))
 
+import pytest
 from erkgbench import metrics  # pyright: ignore[reportMissingImports]
 from erkgbench.real_resolvers import (  # pyright: ignore[reportMissingImports]
+    SPACY_MODEL,
     neo4j_graphrag_exact_clusters,
     neo4j_graphrag_fuzzy_clusters,
+    neo4j_graphrag_spacy_clusters,
 )
 
 DATASET = _BENCH_ROOT / "dataset" / "records.csv"
@@ -77,3 +80,50 @@ def test_exact_merges_identical_skips_null_and_no_normalization():
     assert [2] in clustering                            # case differs -> not merged
     assert [3] in clustering                            # empty -> singleton
     assert [4] in clustering                            # different label -> not merged
+
+
+# -- SpaCySemanticMatchResolver (real-inproc; needs the spaCy vector model) -----
+
+# Observed real F1 of the spaCy resolver on the corpus. None until the first CI run
+# (which has the model) reports it; set it to lock the value against silent drift.
+# Read it from the regenerated results/RESULTS.md `neo4j-graphrag(spacy)*` row or the
+# skip message below, then pin here (Task 8).
+_SPACY_F1_PIN: float | None = None
+
+
+def _spacy_model_available() -> bool:
+    """True only when both spaCy and the vector model are importable. Locally the
+    model is usually absent, so the spaCy parity test SKIPS; CI installs the model
+    (`python -m spacy download en_core_web_lg`) and runs it for real."""
+    try:
+        import importlib.util
+        if importlib.util.find_spec("spacy") is None:
+            return False
+        return importlib.util.find_spec(SPACY_MODEL) is not None
+    except Exception:
+        return False
+
+
+def test_spacy_reproduces_observed_f1():
+    if not _spacy_model_available():
+        pytest.skip(f"spaCy model {SPACY_MODEL} not installed (CI-only real row)")
+    items, entity_ids, classes = _load()
+    clustering = neo4j_graphrag_spacy_clusters(items)
+    # Full partition: every record appears exactly once (no dropped/duplicated ids).
+    flat = [i for c in clustering for i in c]
+    assert sorted(flat) == sorted(i for i, _m, _t in items)
+    f1 = metrics.score_by_class(entity_ids, classes, clustering)["__overall__"].f1
+    # OBSERVE-THEN-PIN: until _SPACY_F1_PIN is set, surface the observed F1 (so the
+    # first CI run reports it) without asserting a guessed value.
+    if _SPACY_F1_PIN is None:
+        pytest.skip(f"spaCy F1 observed = {round(f1, 3)} -- set _SPACY_F1_PIN to lock it")
+    assert round(f1, 3) == _SPACY_F1_PIN
+
+
+def test_spacy_is_deterministic():
+    if not _spacy_model_available():
+        pytest.skip(f"spaCy model {SPACY_MODEL} not installed (CI-only real row)")
+    items, _, _ = _load()
+    assert metrics.clusterings_equal(
+        neo4j_graphrag_spacy_clusters(items), neo4j_graphrag_spacy_clusters(items)
+    )


### PR DESCRIPTION
Phase 2 of the ER-KG-Bench real-frameworks arc (follows Phase 0/1, #1043). Activates the embedding-gated paths and adds the deferred spaCy resolver, in the existing offline `bench-er-kg` lane (no keys, no service infra).

## What lands
- **New real row: `neo4j-graphrag(spacy)*` (`real-inproc`).** Calls the library's real `SpaCySemanticMatchResolver.compute_similarity` + `_consolidate_sets` (same in-process pattern as the fuzzy row; MagicMock driver). Model-gated: a missing `en_core_web_lg` degrades the row to skipped, never an implicit download (`auto_download_spacy_model=False`).
- **Additive `(emb)` rows** via the existing `--embedder st` MiniLM path: `Neo4j-KGBuilder(emb)` + `LlamaIndex-PGI(emb)` run ALONGSIDE the unchanged string-only rows (the offline committed board now runs with the embedder on). Both stay `modeled`.
- **Verified fidelity finding (the honesty payoff):** the real Neo4j-KGBuilder edit-distance length guard is `size(toString(n.id))>5` oriented by `WHERE elementId(n) < elementId(other)` (verified verbatim at `neo4j-labs/llm-graph-builder@4a412f46`). It guards the smaller-`elementId` node, an arbitrary INSERTION-ORDER side unrelated to string length, so the rule is NEITHER `min(len)>5` NOR `max(len)>5` and is irreproducible by any commutative pairwise predicate. KGBuilder therefore CANNOT earn `validated` even with the embedder active. This is the kind of model-vs-real divergence the arc exists to surface.

## Measurement-first
The spaCy F1 + the measured embedder delta are pinned/recorded from the CI regeneration (not guessed). The spaCy parity test surfaces the observed F1 and is pinned in a follow-up commit; FIDELITY.md + README are updated with the real numbers.

## Honesty bar
No `real-*` claim without the framework's own code running; `validated` requires a cited source check. KGBuilder stays `modeled` (irreproducible guard); LlamaIndex stays `modeled` (blog-sourced rule, embedder doesn't fix provenance).

Generated with Claude Code.