### PR TITLE
ER-KG-Bench Phase 3a: real-execution cutover (GraphRAG/Cognee validated, LightRAG/Graphiti real-inproc)

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
@@ -43,16 +43,21 @@ stdlib only, no key. `--embedder st` additionally needs `sentence-transformers`.
   cited inline (`adapters/modeled.py`). E.g. Neo4j builder = `cosine>0.97 OR
   edit-dist<3 OR substring`; neo4j-graphrag = `rapidfuzz WRatio/100 ≥ 0.8`;
   LlamaIndex = `KNN-10 + word-dist<5 + cosine>0.9`.
-* **Models, on purpose.** Re-implementing the published rule (vs installing 8
-  frameworks + keys + LLMs) keeps the bench reproducible and removes
-  LLM-nondeterminism as a confound. The adapters are small and auditable;
-  correct them against source by PR if a default has moved.
-* **LLM-judge layers are scoped out, not faked.** Graphiti and mem0 add an LLM
-  "same?" prompt over a thin deterministic guard. We model the deterministic
-  *floor* each ships (Graphiti MinHash/Jaccard≥0.9 + exact; mem0 MD5-exact) and
-  flag the LLM layer's known costs (non-determinism; O(n) LLM calls →
-  token-overflow/dropped episodes, Graphiti #1275; ~$0.80/40-chats #467) rather
-  than simulate it.
+* **Real execution where it's honest; models where it isn't.** Each row carries a
+  `fid` tier (see `adapters/FIDELITY.md`). Many framework rows now run the
+  library's REAL decision code in-process (`real-inproc`: neo4j-graphrag
+  fuzzy/spaCy, LightRAG, Graphiti's deterministic floor) or reproduce its exact
+  rule confirmed verbatim vs source (`validated`: neo4j-graphrag exact, GraphRAG,
+  Cognee, mem0's MD5 floor). Only LlamaIndex (blog-sourced rule, unconfirmable) and
+  Neo4j-KGBuilder (an `elementId`-sided guard no commutative predicate can
+  reproduce) remain `modeled`. The optional real-framework deps install behind
+  `requirements-real.txt`; a missing dep degrades the row to "skipped", never an
+  error.
+* **mem0's LLM merge layer is scoped out, not faked.** mem0 adds an LLM ADD/UPDATE
+  "same?" prompt over its MD5-exact floor; we run the deterministic floor and flag
+  the LLM layer's cost/non-determinism (Phase 3) rather than simulate it. Graphiti's
+  floor (MinHash/Jaccard≥0.9 + exact) IS run for real; its LLM fallback is the
+  out-of-scope part.
 * **goldenmatch is dogfooded** — the rows call zero-config `dedupe_df(df)` and
   let auto-config pick the strategy, the same posture as every framework at its
   default. No hand-tuned threshold. `auto` = name only; `auto+fields` = name +

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/demo/run_demo.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/demo/run_demo.py
@@ -24,7 +24,7 @@ from demo import (
     narrative as nv,  # noqa: E402  # pyright: ignore[reportAttributeAccessIssue]  # namespace pkg, resolves at runtime
 )
 from erkgbench.adapters import GoldenMatchAdapter  # noqa: E402
-from erkgbench.adapters.modeled import GraphRAGModeled  # noqa: E402
+from erkgbench.adapters.real.exact_family import RealGraphRAG  # noqa: E402
 from erkgbench.run import load_records  # noqa: E402  (pulls goldenmatch)
 
 if TYPE_CHECKING:
@@ -112,7 +112,7 @@ def _exact_family_f1() -> str:
 def tier1_under_merge(records: list[Record], entity_ids: list[str], failure_classes: list[str]) -> str:
     mentions, eids = _maps(records, entity_ids)
     all_idx = [r.index for r in records]
-    before = nv.complete_partition(GraphRAGModeled().resolve(records), all_idx)
+    before = nv.complete_partition(RealGraphRAG().resolve(records), all_idx)
     after = nv.complete_partition(GoldenMatchAdapter("auto_fields").resolve(records), all_idx)
     eid, query, etype = _pick_under_merge_entity(records, entity_ids, failure_classes, before, after)
     return nv.render_demo_md(

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/FIDELITY.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/FIDELITY.md
@@ -25,17 +25,27 @@ close a row is to the framework it claims to represent:
   the real default rule. A documented divergence is a finding, not a failure.
 
 This audit read each framework's real merge/dedup source on GitHub and compared
-it to our model. The exact-match family's shared normalization is
-`_norm(s) = " ".join(s.lower().split())` (lowercase + internal-whitespace
-collapse, NO quote/apostrophe strip, NO unicode fold).
+it to our model.
+
+> **Phase 3a update (real-execution cutover).** GraphRAG, LightRAG, and Cognee were
+> originally modeled with a SHARED `_norm(s) = " ".join(s.lower().split())` that
+> diverged from each framework's real key (each differently). They are now cut over
+> to faithful rows in `adapters/real/`: **GraphRAG** and **Cognee** reproduce their
+> exact key verbatim (`validated`, `exact_family.py`); **LightRAG** runs the
+> library's real `normalize_extracted_info` key fn (`real-inproc`, `lightrag.py`);
+> and **Graphiti** is a NEW `real-inproc` row running its real deterministic dedup
+> floor. The shared `_norm` survives only inside `Neo4jBuilderModeled` /
+> `LlamaIndexModeled`. The "matches our model?" column below is historical (it
+> records WHY each was modeled); the live tier is in the rightmost column.
 
 ## Verdict table
 
 | Framework | adapter | real source checked | exact real rule | matches our model? | tier |
 |---|---|---|---|---|---|
-| Microsoft GraphRAG | `GraphRAGModeled` | [finalize_entities.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/operations/finalize_entities.py) + [graph_extractor.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/operations/extract_graph/graph_extractor.py) + [string.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/utils/string.py) | exact `title in seen_titles`; `title = clean_str(name.upper())` (uppercases + `.strip()` + html-unescape + control-char strip; **no internal-whitespace collapse, no quote strip**) | NO (case dir is clustering-equivalent, but we collapse internal whitespace and it does not) | **modeled** |
-| LightRAG | `LightRAGModeled` | [operate.py](https://github.com/HKUDS/LightRAG/blob/main/lightrag/operate.py) + [utils.py `normalize_extracted_info`](https://github.com/HKUDS/LightRAG/blob/main/lightrag/utils.py) | exact `entity_name` dict key; name is `sanitize_and_normalize_extracted_text(.., remove_inner_quotes=True)` -> **case-PRESERVING** (no upper/lower), strips outer quotes, CJK fold, `.strip()` | NO (we lowercase -> case-INSENSITIVE; real is case-SENSITIVE; we don't strip quotes/CJK-fold) | **modeled** |
-| Cognee | `CogneeModeled` | [generate_node_name.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/engine/utils/generate_node_name.py) + [expand_with_nodes_and_edges.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/graph/utils/expand_with_nodes_and_edges.py) + [get_default_ontology_resolver.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/get_default_ontology_resolver.py) + [matching_strategies.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/matching_strategies.py) | entity node key = `generate_node_name(name) = name.lower().replace("'", "")` -> lowercases + strips apostrophes, **no whitespace collapse**. Default ontology empty (`ontology_file=None`) so the difflib cutoff=0.8 never fires | NO (we lowercase too, but we collapse whitespace it doesn't, and it strips apostrophes we don't) | **modeled** |
+| Microsoft GraphRAG | `RealGraphRAG` | [finalize_entities.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/operations/finalize_entities.py) + [graph_extractor.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/operations/extract_graph/graph_extractor.py) + [string.py](https://github.com/microsoft/graphrag/blob/main/packages/graphrag/graphrag/index/utils/string.py) | exact `title in seen_titles` (GLOBAL); `title = clean_str(name.upper())` (upper + `.strip()` + html-unescape + control-char strip; **no internal-ws collapse, no quote strip**). Standard pipeline has no ER step | reproduced VERBATIM (`real_resolvers._graphrag_key`). No separable resolver decision object exists, so this is the confirmed key, not a library run -> `validated` | **validated** |
+| LightRAG | `RealLightRAG` (`*`) | [operate.py](https://github.com/HKUDS/LightRAG/blob/main/lightrag/operate.py) + [utils.py `normalize_extracted_info`](https://github.com/HKUDS/LightRAG/blob/main/lightrag/utils.py) | exact `entity_name` dict key (GLOBAL); name = real `normalize_extracted_info(.., remove_inner_quotes=True)` -> **case-PRESERVING** (no upper/lower), outer-quote strip, CJK fold, `.strip()`. LLM only summarizes descriptions, never moves a record | runs the library's REAL key fn in-process (only the graph-store upsert is elided; the merge decision IS the normalized-name equality) -> `real-inproc` | **real-inproc** |
+| Cognee | `RealCognee` | [generate_node_id.py](https://github.com/topoteretes/cognee/blob/main/cognee/infrastructure/engine/utils/generate_node_id.py) + [deduplicate_nodes_and_edges.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/graph/utils/deduplicate_nodes_and_edges.py) + [get_default_ontology_resolver.py](https://github.com/topoteretes/cognee/blob/main/cognee/modules/ontology/get_default_ontology_resolver.py) | exact merge on `generate_node_id = uuid5(NAMESPACE_OID, name.lower().replace(" ","_").replace("'",""))` (GLOBAL). Default ontology empty (`ontology_file=None`) so the difflib cutoff never fires | reproduced VERBATIM (`real_resolvers._cognee_key`). **Fixes the Phase-1 bug**: it cited `generate_node_NAME` (display) + used `_norm`, missing the `" "->"_"` step. Pure stdlib uuid5 -> `validated` | **validated** |
+| Graphiti | `RealGraphiti` (`*`) | [dedup_helpers.py](https://github.com/getzep/graphiti/blob/main/graphiti_core/utils/maintenance/dedup_helpers.py) (`_resolve_with_similarity` + `_build_candidate_indexes`) | DETERMINISTIC FLOOR: exact normalized-name (lower+ws-collapse) OR MinHash/Jaccard>=0.9, with a low-entropy/short-name gate; label-agnostic (no label gate) | runs the library's REAL floor decision code via sequential ingestion. Honest scope: no LLM/embedder (unresolved -> new entity); full existing set fed as candidates (upper bound on the floor). This is the FLOOR, not Graphiti's full LLM-backed default -> `real-inproc` | **real-inproc** |
 | mem0 | `Mem0Modeled` | [memory/main.py](https://github.com/mem0ai/mem0/blob/main/mem0/memory/main.py) | `hashlib.md5(text.encode()).hexdigest()` over RAW memory text, case-sensitive, no normalization (`_add_to_vector_store` + `_create_memory`) | YES (byte-identical to our `md5(r.mention.encode())`) -- MD5 floor only; LLM ADD/UPDATE layer out of scope | **validated** |
 | Neo4j LLM KG Builder | `Neo4jBuilderModeled` | [graphDB_dataAccess.py](https://github.com/neo4j-labs/llm-graph-builder/blob/main/backend/src/graphDB_dataAccess.py) | `labels(n)=labels(other)` AND ( CONTAINS guard `size>2` both dirs, `toLower` OR `apoc.text.distance < 3` guard `size(n.id)>5` OR `vector.similarity.cosine > 0.97` ); `DUPLICATE_TEXT_DISTANCE=3`, `DUPLICATE_SCORE_VALUE=0.97` | string predicates + constants confirmed, but default run is PARTIAL (cosine OR-term needs embedder) + an `elementId`-sided length guard that is IRREPRODUCIBLE by a commutative predicate (Phase-2 verified) | **modeled** |
 | Neo4j-KGBuilder (emb) | `emb_modeled` (`--embedder st`) | same | adds the real cosine>0.97 OR-term (MiniLM); fires all 3 OR-branches | F1 0.456 -> 0.471 (+1.5pp, only `temporal`/`nick` move; dominant classes flat) but still `modeled` -- the `elementId` length guard remains irreproducible | **modeled** |
@@ -48,7 +58,7 @@ collapse, NO quote/apostrophe strip, NO unicode fold).
 
 ## Per-framework detail
 
-### 1. Microsoft GraphRAG -- `modeled`
+### 1. Microsoft GraphRAG -- `validated` (Phase 3a)
 
 `finalize_entities` deduplicates by exact title:
 
@@ -82,9 +92,17 @@ strip.** Our `_norm` lowercases + collapses internal whitespace. The case
 direction (upper vs lower) is clustering-equivalent (both fold every string to a
 single canonical case). The **internal-whitespace collapse is a real divergence**:
 `"New  York"` (two spaces) vs `"New York"` merge under our `_norm` but NOT under
-GraphRAG. -> stays `modeled`.
+GraphRAG.
 
-### 2. LightRAG -- `modeled`
+**Phase 3a:** `RealGraphRAG` (`real_resolvers._graphrag_key` / `graphrag_clusters`)
+reproduces `clean_str(name.upper())` VERBATIM (upper -> edge-strip -> html.unescape
+-> control-char strip; GLOBAL `seen_titles` set, not per-label). GraphRAG has no
+separable resolver decision object to run (the merge is `df.merge(on="title")` +
+the `seen_titles` set inside the LLM-driven Standard pipeline), so the faithful
+tier is **`validated`** -- a confirmed key reproduction, like `neo4j-graphrag(exact)`.
+Observed F1 0.066 (exact-title recalls ~nothing on surface-form variation).
+
+### 2. LightRAG -- `real-inproc` (Phase 3a)
 
 `_merge_nodes_then_upsert` uses `entity_name` as the merge key with no further
 transform; the name was normalized at extraction (`operate.py`):
@@ -99,43 +117,40 @@ entity_name = sanitize_and_normalize_extracted_text(
 quotes), folds CJK full-width chars to half-width, removes spaces between CJK
 chars, and `.strip()`s -- but applies **no `.upper()`/`.lower()`** (only
 `entity_type` gets `.replace(" ", "").lower()`, not the name). So LightRAG's
-merge key is **case-SENSITIVE** (`"Apple"` != `"apple"`). Our `_norm`
-lowercases (case-insensitive) and never strips quotes / CJK-folds. Divergent on
-two axes -> stays `modeled`.
+merge key is **case-SENSITIVE** (`"Apple"` != `"apple"`).
 
-### 3. Cognee -- `modeled`
+**Phase 3a:** `RealLightRAG` (`real_resolvers.lightrag_clusters`) runs the
+library's REAL `normalize_extracted_info(name, remove_inner_quotes=True)` key fn
+(lazy-imported `lightrag.utils`) then groups by the exact key GLOBALLY -- the same
+dict group-by `merge_nodes_and_edges` does. The LLM only summarizes descriptions
+(>=8 fragments) and never moves a record between clusters, so the clustering
+decision runs with NO LLM/key. Tier **`real-inproc`** (the real key fn executes;
+only the graph-store upsert is elided). CI-only (`lightrag-hku`). The low F1 it
+produces is FAITHFUL to LightRAG's case-sensitive key, not a model artifact.
 
-Entity node dedup (`expand_with_nodes_and_edges.py`) keys on
-`generate_node_name(node_name)` and merges when the key is already in
-`added_nodes_map`:
+### 3. Cognee -- `validated` (Phase 3a)
+
+The entity MERGE key is `generate_node_id` (NOT `generate_node_name`, a display
+helper the Phase-1 model wrongly cited):
 
 ```python
-generated_node_name = generate_node_name(node_name)
-...
-if entity_node_key in added_nodes_map or entity_node_key in key_mapping:
-    return added_nodes_map.get(entity_node_key) ...
+# cognee/infrastructure/engine/utils/generate_node_id.py
+def generate_node_id(node_id: str) -> UUID:
+    return uuid5(NAMESPACE_OID, node_id.lower().replace(" ", "_").replace("'", ""))
 ```
 
-```python
-def generate_node_name(name: str) -> str:
-    return name.lower().replace("'", "")      # lowercase + apostrophe strip
-```
+`deduplicate_nodes_and_edges` keeps one node per `str(node.id)` (this UUID), so two
+mentions merge iff their `generate_node_id` matches. The default resolver is
+`RDFLibOntologyResolver(ontology_file=None, ...)`; with no ontology file the
+difflib `cutoff=0.8` strategy has no candidates and never fires.
 
-The default resolver is `RDFLibOntologyResolver(ontology_file=None,
-matching_strategy=FuzzyMatchingStrategy())`; with `ontology_file=None` the
-ontology candidate list is empty, so `FuzzyMatchingStrategy.find_match`
-(difflib `cutoff=0.8`) has no candidates and never merges anything -- confirming
-the model's "exact name, ontology off by default" framing.
-
-Our `_norm` lowercases (matches) but **collapses internal whitespace** (Cognee
-does not) and does **not strip apostrophes** (Cognee does). E.g. `"O'Brien"` vs
-`"OBrien"` merge in Cognee but not our model. Divergent on the key -> stays
-`modeled`.
-
-> All three exact-match subclasses diverge from `_norm`, each differently, so
-> the base `_ExactNormalized.fidelity` stays `"modeled"` (the safe default) and
-> NO subclass got a `validated` override. The clustering algorithm is exact
-> bucketing in all three; only the bucket KEY normalization differs.
+**Phase 3a:** `RealCognee` (`real_resolvers._cognee_key` / `cognee_clusters`)
+reproduces `generate_node_id` VERBATIM (pure stdlib `uuid5`; GLOBAL). This **fixes
+a confirmed Phase-1 bug**: the old model cited `generate_node_name` (= `name.lower()
+.replace("'","")`, no `" "->"_"`) and actually used `_norm` (lower + ws-collapse) --
+neither matched the real key. Reproducing the 1-line pure key + citing source is
+**`validated`** (importing the heavy `cognee` package to call a uuid5 buys zero
+fidelity). Observed F1 0.066.
 
 ### 4. mem0 -- `validated` (MD5 floor)
 
@@ -301,6 +316,35 @@ nickname variants well (`suffix` 0.868, `nick` 0.800) but miss cross-lingual and
 typo classes entirely (`xling` 0.0, `typo` 0.0), a different profile from the
 WRatio fuzzy resolver.
 
+### 10. Graphiti -- `real-inproc` (Phase 3a, NEW row)
+
+Graphiti's deterministic dedup floor is a clean, separable, pure-Python decision
+in `graphiti_core/utils/maintenance/dedup_helpers.py`: `_resolve_with_similarity`
++ `_build_candidate_indexes` resolve each extracted node against existing nodes by
+exact normalized-name (`_normalize_string_exact` = lower + ws-collapse), else a
+MinHash/Jaccard `>= _FUZZY_JACCARD_THRESHOLD (0.9)` fuzzy match, with a
+low-entropy / short-name gate (`_NAME_ENTROPY_THRESHOLD=1.5`, `_MIN_NAME_LENGTH=6`).
+No LLM, DB, or embedder is touched by the floor (stdlib + pydantic only). It is
+**label-agnostic** -- the floor applies no entity-label gate (verified at source).
+
+`RealGraphiti` (`real_resolvers.graphiti_clusters`) runs that real code via
+**sequential ingestion**: each record resolves against the accumulated existing set,
+mirroring Graphiti's real extracted-vs-existing-graph flow (the real code does NO
+intra-batch dedup). Honest scope recorded so a skeptic can't mistake it:
+
+- **No LLM/embedder.** Unresolved nodes (0 exact + no fuzzy hit, >1 exact ambiguous,
+  or low-entropy) become NEW entities -- the deterministic-floor end state. The full
+  default path would escalate those to the LLM; this row is the FLOOR, not that path.
+- **We feed the full existing set as candidates.** The real flow prunes candidates
+  via an embedder semantic search first, so this is an UPPER BOUND on the floor
+  (more candidates, never fewer) -- it can only help recall.
+- The per-label grouping the other framework rows use is NOT applied here (the floor
+  is label-agnostic); this is a harness apples-to-apples choice, not Graphiti behavior.
+
+Tier **`real-inproc`** (the library's real resolution DECISION runs in-process;
+only the embedder candidate-prune, the LLM fallback, and graph persistence are
+elided). CI-only (`graphiti-core`, torch-free, import-guarded).
+
 ## Phase 2 -- embedding terms (measured, not asserted)
 
 `--embedder st` activates the cosine OR-terms (MiniLM `all-MiniLM-L6-v2`, the
@@ -327,17 +371,29 @@ blog-sourced rule -- an embedder closes neither gap).
 
 - **mem0 LLM ADD/UPDATE merge** is Phase 3 (see mem0 section).
 
-## Could-not-confirm summary
+## Still `modeled` after Phase 3a
 
-Only one adapter stayed `modeled` purely for **lack of confirmable source**
-(not measured divergence): **LlamaIndex PGI** -- its constants live in a blog,
-and the maintained library ships no equivalent default. The exact-match family
-(GraphRAG, LightRAG, Cognee) and the fuzzy model stayed `modeled` because they
-**diverge** from confirmed real source. **Neo4j-KGBuilder** stayed `modeled`
-because, although its string predicates + constants are source-confirmed, its
-edit-distance length guard is `elementId`-sided and IRREPRODUCIBLE by a
-commutative predicate (Phase-2 verified) -- so even the cosine-activated
-`--embedder` variant stays `modeled`. Net: of the modeled-family adapters, **only mem0** (a byte-identical,
-cleanly-scoped MD5 floor) earned `validated`; every other framework default is
-either divergent, partial, or unconfirmable -- which is itself the headline
-finding (real built-in dedup defaults are shallow and inconsistent).
+Phase 3a cut the exact-key family (GraphRAG, LightRAG, Cognee) and added Graphiti
+over to faithful rows (see the Phase-3a banner + sections 1-3 + 10). What REMAINS
+`modeled`, and why:
+
+- **LlamaIndex PGI** -- **lack of confirmable source**: its constants live in a
+  Neo4j/Bratanic blog, and maintained `run-llama/llama_index` ships no equivalent
+  fuzzy-dedup default. An embedder does not close a provenance gap -> `(emb)` stays
+  modeled too.
+- **Neo4j-KGBuilder** -- string predicates + constants are source-confirmed, but the
+  default run is PARTIAL (cosine OR-term needs an embedder) AND the edit-distance
+  length guard is `elementId`-sided -> IRREPRODUCIBLE by a commutative predicate
+  (Phase-2 verified). Even the `--embedder` variant stays modeled. The only honest
+  escape is a live-Neo4j run of the real Cypher (Phase 4 / never).
+- **neo4j-graphrag(fuzzy) MODEL** -- kept ALONGSIDE the `real-inproc` `*` row purely
+  for the model-vs-real contrast (model F1 0.403 vs real 0.469, +6.6pp); it is a
+  deliberate teaching row, not an unconfirmed one.
+
+Of the original modeled framework defaults, the Phase 0-3a arc converted every one
+that could be honestly run/confirmed (neo4j-graphrag fuzzy/spaCy `real-inproc`,
+neo4j-graphrag exact + GraphRAG + Cognee `validated`, LightRAG + Graphiti
+`real-inproc`, mem0 MD5 floor `validated`); only LlamaIndex (unconfirmable) and
+Neo4j-KGBuilder (irreproducible guard) remain modeled -- which is itself the
+headline finding: real built-in dedup defaults are shallow, divergent, and
+sometimes irreproducible.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/modeled.py
@@ -53,62 +53,14 @@ def _cosine(u: list[float], v: list[float]) -> float:
 
 
 # ── exact-match family ────────────────────────────────────────────────────
-
-
-class _ExactNormalized:
-    """Exact match on the normalised name -- the exact-string-bucketing family
-    (Microsoft GraphRAG, LightRAG, Cognee). ``_norm`` = lowercase +
-    whitespace-collapse. Base stays ``modeled``: the Phase-1 audit found ALL
-    THREE frameworks diverge from ``_norm`` in their REAL normalization (see
-    adapters/FIDELITY.md), each in a different way, so no per-subclass promotion
-    to ``validated`` was warranted. The clustering is still exact-bucket in all
-    three, but the bucket KEY differs (case direction, quote/apostrophe strip,
-    internal-whitespace handling, CJK fold)."""
-
-    deterministic = True
-    fidelity = "modeled"
-
-    def resolve(self, records: list[Record]) -> list[list[int]]:
-        return cluster_by_key(records, lambda r: _norm(r.mention))
-
-
-class GraphRAGModeled(_ExactNormalized):
-    name = "MS-GraphRAG"
-    # AUDIT (FIDELITY.md): real key = clean_str(name.UPPER()) -> uppercases (vs
-    # our lower; clustering-equivalent) BUT does NOT collapse internal whitespace
-    # (our _norm does). Divergent -> stays modeled.
-    defaults = (
-        "exact title match; ER step removed "
-        "(finalize_entities seen_titles set, title=clean_str(name.upper()); "
-        "discussion #778, data-loss #1718)"
-    )
-
-
-class LightRAGModeled(_ExactNormalized):
-    name = "LightRAG"
-    # AUDIT (FIDELITY.md): real key is CASE-SENSITIVE (no .upper()/.lower() on
-    # entity_name) and strips OUTER quotes + CJK-folds (normalize_extracted_info).
-    # Our _norm lowercases + collapses whitespace. Divergent -> stays modeled.
-    defaults = (
-        "exact case-SENSITIVE name dict key, outer-quote strip + CJK fold, no "
-        "fuzzy/embedding at merge "
-        "(operate.py _merge_nodes_then_upsert + normalize_extracted_info; "
-        "#1323, cross-doc #485)"
-    )
-
-
-class CogneeModeled(_ExactNormalized):
-    name = "Cognee"
-    # AUDIT (FIDELITY.md): real key = generate_node_name(name) = name.lower()
-    # .replace("'", "") -> lowercases (matches ours) AND strips apostrophes (ours
-    # does not), does NOT collapse whitespace (ours does). Default ontology is
-    # empty (RDFLibOntologyResolver(ontology_file=None)) so the difflib cutoff=0.8
-    # never fires. Divergent on the key -> stays modeled.
-    defaults = (
-        "exact generate_node_name key = name.lower().replace(\"'\",\"\"); "
-        "difflib cutoff=0.8 only vs a user ontology (empty by default) "
-        "(generate_node_name.py / matching_strategies.py; #1831)"
-    )
+#
+# GraphRAG, LightRAG, and Cognee were modeled here with a shared `_norm`
+# (lowercase + whitespace-collapse) that DIVERGED from each framework's real key.
+# Phase 3a cut them over to faithful rows in `adapters/real/`: GraphRAG + Cognee
+# reproduce their exact key verbatim (`validated`, exact_family.py); LightRAG runs
+# its real `normalize_extracted_info` key fn (`real-inproc`, lightrag.py). They are
+# no longer modeled here. `_norm` stays -- Neo4jBuilderModeled + LlamaIndexModeled
+# still use it.
 
 
 class Mem0Modeled:
@@ -302,11 +254,14 @@ class LlamaIndexModeled:
 
 
 def all_modeled(embed_fn: EmbedFn | None = None) -> list:
-    """Instantiate every modelled adapter (embedder applied where used)."""
+    """Instantiate every modelled adapter (embedder applied where used).
+
+    GraphRAG/LightRAG/Cognee moved to faithful rows in `adapters/real/` (Phase 3a);
+    they are NOT modeled here anymore. mem0 stays (its MD5 floor is `validated`; the
+    LLM layer is Phase 3). Neo4j-KGBuilder + neo4j-graphrag(fuzzy) MODEL + LlamaIndex
+    stay modeled per FIDELITY.md (irreproducible guard / model-vs-real contrast /
+    blog-sourced rule)."""
     return [
-        GraphRAGModeled(),
-        LightRAGModeled(),
-        CogneeModeled(),
         Mem0Modeled(),
         Neo4jBuilderModeled(embed_fn=embed_fn),
         Neo4jGraphRAGFuzzyModeled(),

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
@@ -9,6 +9,19 @@ from __future__ import annotations
 
 def available_real_adapters() -> list:
     out = []
+    # GraphRAG + Cognee are `validated` reproductions of pure exact-key rules (no
+    # library call, no optional dep), grouped here with the other real rows. Own
+    # try-block each so one import error can't suppress the rest.
+    try:
+        from erkgbench.adapters.real.exact_family import RealGraphRAG
+        out.append(RealGraphRAG())
+    except ImportError:
+        pass
+    try:
+        from erkgbench.adapters.real.exact_family import RealCognee
+        out.append(RealCognee())
+    except ImportError:
+        pass
     try:
         from erkgbench.adapters.real.neo4j_graphrag import RealNeo4jGraphRAGFuzzy
         out.append(RealNeo4jGraphRAGFuzzy())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/__init__.py
@@ -47,4 +47,22 @@ def available_real_adapters() -> list:
         out.append(adapter)
     except Exception:  # noqa: BLE001 - missing spacy/model -> skip this real row
         pass
+    # LightRAG + Graphiti run REAL library decision code (real-inproc); each needs its
+    # optional dep (lightrag-hku / graphiti-core, in requirements-real.txt). Probe with
+    # resolve([]) so a missing dep -> "skipped", never a hard fail. Catch broadly: a
+    # transitive-import error from the optional lib is still a skip, not a board crash.
+    try:
+        from erkgbench.adapters.real.lightrag import RealLightRAG
+        adapter = RealLightRAG()
+        adapter.resolve([])  # triggers the lazy lightrag import now
+        out.append(adapter)
+    except Exception:  # noqa: BLE001 - lightrag not installed -> skip this real row
+        pass
+    try:
+        from erkgbench.adapters.real.graphiti import RealGraphiti
+        adapter = RealGraphiti()
+        adapter.resolve([])  # triggers the lazy graphiti_core import now
+        out.append(adapter)
+    except Exception:  # noqa: BLE001 - graphiti-core not installed -> skip this real row
+        pass
     return out

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/exact_family.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/exact_family.py
@@ -1,0 +1,56 @@
+"""Faithful exact-key reproductions of framework dedup rules (validated tier).
+
+GraphRAG and Cognee both decide entity identity by an exact key with NO separable
+resolver decision object to run in-process (GraphRAG: a `seen_titles` set + a
+pandas `df.merge(on="title")` inside the LLM-driven pipeline; Cognee: a pure
+`uuid5` collision). So unlike the neo4j-graphrag `*` rows (which run real library
+decision code -> `real-inproc`), the honest tier here is `validated`: we reproduce
+the merge KEY verbatim and cite source (the same posture as `RealNeo4jGraphRAGExact`,
+whose rule is a Cypher query with no callable Python decision method).
+"""
+from __future__ import annotations
+
+from erkgbench.adapters.base import Record
+from erkgbench.real_resolvers import cognee_clusters, graphrag_clusters
+
+
+class RealGraphRAG:
+    name = "MS-GraphRAG"
+    defaults = (
+        "exact title-set merge, GLOBAL (not per-label): "
+        "title=clean_str(name.upper()) -> upper + edge-strip + html-unescape + "
+        "control-char strip, NO internal-ws collapse "
+        "(finalize_entities seen_titles + graph_extractor + utils/string.py; "
+        "Standard pipeline has no ER step -> validated reproduction, no separable resolver)"
+    )
+    deterministic = True
+    # validated, NOT real-inproc: GraphRAG has no callable resolver decision object
+    # -- the merge is `df.merge(on="title")` + a `seen_titles` set woven into the
+    # LLM-driven Standard pipeline. We reproduce the title key verbatim + cite source
+    # (FIDELITY.md), which is the `validated` bar (same as neo4j-graphrag(exact)).
+    fidelity = "validated"
+
+    def resolve(self, records: list[Record]) -> list[list[int]]:
+        items = [(r.index, r.mention, r.entity_type) for r in records]
+        return graphrag_clusters(items)
+
+
+class RealCognee:
+    name = "Cognee"
+    defaults = (
+        "exact merge on generate_node_id = "
+        "uuid5(NAMESPACE_OID, name.lower().replace(' ','_').replace(\"'\",'')), "
+        "GLOBAL (not per-label); default ontology empty so the difflib cutoff never "
+        "fires (generate_node_id.py + deduplicate_nodes_and_edges.py -> validated)"
+    )
+    deterministic = True
+    # validated: the decision is a pure stdlib uuid5 1-liner; reproducing it verbatim
+    # + citing source is faithful (importing the heavy `cognee` package to call a
+    # uuid5 buys zero fidelity). NOTE the real merge key is generate_node_ID, NOT the
+    # generate_node_NAME display helper the Phase-1 model wrongly cited (they differ
+    # in the `" " -> "_"` step). See FIDELITY.md.
+    fidelity = "validated"
+
+    def resolve(self, records: list[Record]) -> list[list[int]]:
+        items = [(r.index, r.mention, r.entity_type) for r in records]
+        return cognee_clusters(items)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/graphiti.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/graphiti.py
@@ -1,0 +1,28 @@
+"""Graphiti real deterministic dedup floor as a benchmark adapter (in-process)."""
+from __future__ import annotations
+
+from erkgbench.adapters.base import Record
+from erkgbench.real_resolvers import graphiti_clusters
+
+
+class RealGraphiti:
+    name = "graphiti*"
+    defaults = (
+        "REAL deterministic floor: exact normalized-name (lower+ws-collapse) OR "
+        "MinHash/Jaccard>=0.9, with a low-entropy/short-name gate "
+        "(_resolve_with_similarity + _build_candidate_indexes, dedup_helpers.py); "
+        "sequential ingestion vs the growing existing set. DETERMINISTIC FLOOR ONLY "
+        "-- the full default path escalates unresolved nodes to an LLM (out of scope)"
+    )
+    deterministic = True
+    # real-inproc: Graphiti's real resolution DECISION code runs in-process. Honest
+    # scope (FIDELITY.md): no LLM/embedder, so unresolved nodes become new entities
+    # (the floor's end state); the full existing set is fed as candidates (the real
+    # flow prunes via an embedder first -> this is an upper bound on the floor);
+    # label-agnostic (no label gate). Only the LLM fallback + graph persistence are
+    # elided. This row is the FLOOR, not Graphiti's full LLM-backed default.
+    fidelity = "real-inproc"
+
+    def resolve(self, records: list[Record]) -> list[list[int]]:
+        items = [(r.index, r.mention, r.entity_type) for r in records]
+        return graphiti_clusters(items)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/lightrag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/real/lightrag.py
@@ -1,0 +1,25 @@
+"""LightRAG real entity-merge decision as a benchmark adapter (in-process)."""
+from __future__ import annotations
+
+from erkgbench.adapters.base import Record
+from erkgbench.real_resolvers import lightrag_clusters
+
+
+class RealLightRAG:
+    name = "LightRAG*"
+    defaults = (
+        "REAL normalize_extracted_info key (HTML-strip, CJK fold, outer-quote strip, "
+        "CASE-SENSITIVE -- no lower/upper) + exact name dict group-by, GLOBAL "
+        "(operate.py merge_nodes_and_edges + utils.py; LLM only summarizes "
+        "descriptions, never moves a record; graph-store upsert stubbed)"
+    )
+    deterministic = True
+    # real-inproc: runs LightRAG's real key-derivation fn (normalize_extracted_info);
+    # the merge decision IS exact equality on that key. Only the graph-store upsert is
+    # elided (it cannot change which names are equal). Case-SENSITIVE, unlike the old
+    # _norm model -- see FIDELITY.md.
+    fidelity = "real-inproc"
+
+    def resolve(self, records: list[Record]) -> list[list[int]]:
+        items = [(r.index, r.mention, r.entity_type) for r in records]
+        return lightrag_clusters(items)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
@@ -29,7 +29,10 @@ No normalization is applied — the stored `name` is compared as-is.
 """
 from __future__ import annotations
 
+import html
+import re
 from itertools import combinations
+from uuid import NAMESPACE_OID, uuid5
 
 
 def _merge_overlapping(sets: list[set[int]]) -> list[set[int]]:
@@ -188,3 +191,68 @@ def neo4j_graphrag_spacy_clusters(items: list[tuple[int, str, str]]) -> list[lis
             seen |= s
         clusters.extend([i] for i in ids if i not in seen)  # singletons (incl skipped-empty)
     return clusters
+
+
+# ── Microsoft GraphRAG (validated reproduction; no separable resolver exists) ──
+#
+# GraphRAG's default `Standard` pipeline has NO entity-resolution step (graph
+# pruning is `Fast`-pipeline-only). Its dedup is exact-title-equality, realized as
+# a `seen_titles: set[str]` in `finalize_entities.py` + a `df.merge(on="title")`
+# in `extract_graph.py` -- there is no callable resolver decision object to run
+# (unlike neo4j-graphrag's `FuzzyMatchResolver`), so the faithful tier is
+# `validated`: we reproduce the title KEY verbatim and cite source.
+#
+# The title is built in extraction as `clean_str(record_attributes[1].upper())`
+# (graph_extractor.py), where `clean_str(x) = re.sub(r"[\x00-\x1f\x7f-\x9f]", "",
+# html.unescape(x.strip()))` (index/utils/string.py). So the merge key is:
+#   upper -> strip(edges only) -> html.unescape -> control-char strip.
+# It does NOT collapse internal whitespace and does NOT strip quotes. The merge is
+# GLOBAL (a single `seen_titles` set across all entities), NOT per-label.
+# Source: microsoft/graphrag (Standard pipeline), confirmed for 2.x-3.x.
+_GRAPHRAG_CTRL = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _graphrag_key(s: str) -> str:
+    """GraphRAG `clean_str(name.upper())` title key (no internal-ws collapse)."""
+    return _GRAPHRAG_CTRL.sub("", html.unescape(str(s).upper().strip()))
+
+
+def graphrag_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
+    """items: (record_id, mention, entity_type). Exact-title set merge, GLOBAL
+    (not per-label), reproducing GraphRAG's `finalize_entities` seen_titles dedup."""
+    buckets: dict[str, list[int]] = {}
+    for rid, mention, _t in items:
+        buckets.setdefault(_graphrag_key(mention), []).append(rid)
+    return [sorted(v) for v in buckets.values()]
+
+
+# ── Cognee (validated reproduction of generate_node_id) ───────────────────────
+#
+# Cognee's default entity resolution is a deterministic uuid5 collision: two
+# mentions merge iff `generate_node_id` produces the same UUID. The function is a
+# pure 1-liner (only stdlib `uuid`), so reproducing it verbatim + citing source is
+# `validated` (importing the heavy `cognee` package -- lancedb + LLM clients -- to
+# call a uuid5 buys zero fidelity). The default ontology resolver is a no-op
+# (`RDFLibOntologyResolver(ontology_file=None)`), so the difflib cutoff never fires.
+#
+# Source (verified verbatim @100044123338de01f72f44b9c528e9fd91fbce59):
+#   cognee/infrastructure/engine/utils/generate_node_id.py
+#     uuid5(NAMESPACE_OID, node_id.lower().replace(" ", "_").replace("'", ""))
+# NOTE this is generate_node_ID (the MERGE key), NOT generate_node_NAME (a display
+# helper, name.lower().replace("'","")) -- they differ in the `" " -> "_"` step.
+# The dedup is GLOBAL (one node per UUID via deduplicate_nodes_and_edges), not
+# per-label.
+
+
+def _cognee_key(s: str) -> str:
+    """Cognee `generate_node_id` merge key: lower -> ' '->'_' -> strip apostrophes."""
+    return str(uuid5(NAMESPACE_OID, str(s).lower().replace(" ", "_").replace("'", "")))
+
+
+def cognee_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
+    """items: (record_id, mention, entity_type). Exact merge on the generate_node_id
+    UUID, GLOBAL (not per-label), reproducing Cognee's deduplicate_nodes_and_edges."""
+    buckets: dict[str, list[int]] = {}
+    for rid, mention, _t in items:
+        buckets.setdefault(_cognee_key(mention), []).append(rid)
+    return [sorted(v) for v in buckets.values()]

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/real_resolvers.py
@@ -256,3 +256,82 @@ def cognee_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
     for rid, mention, _t in items:
         buckets.setdefault(_cognee_key(mention), []).append(rid)
     return [sorted(v) for v in buckets.values()]
+
+
+# ── LightRAG (real-inproc: runs the library's real normalize_extracted_info) ──
+#
+# LightRAG's entity merge decision is an exact dict group-by on the normalized
+# entity name (`merge_nodes_and_edges` builds `all_nodes[entity_name]` in
+# operate.py; `_merge_nodes_then_upsert` keys on the same name). The name key is
+# derived by the library's real `normalize_extracted_info(name, remove_inner_quotes
+# =True)` (utils.py) -- HTML-strip, CJK full->half-width fold, outer-quote strip,
+# whitespace handling, but NO .lower()/.upper(), so the key is CASE-SENSITIVE. We
+# call that real key fn (verified @v1.5.3 / 41ee354 it has no torch top-level
+# imports) then group GLOBALLY (LightRAG keys nodes by name across the whole graph,
+# not per-label). The LLM only summarizes descriptions (>=8 fragments) and never
+# moves a record between clusters, so the clustering decision needs no LLM/key. The
+# real key fn runs in-process -> real-inproc; only the graph-store upsert is elided
+# (the merge decision IS the normalized-name equality).
+def lightrag_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
+    """items: (record_id, mention, entity_type). Real normalize_extracted_info key +
+    exact GLOBAL group-by. lightrag is lazy-imported so this module imports without it."""
+    from lightrag.utils import (  # pyright: ignore[reportMissingImports]
+        normalize_extracted_info,
+    )
+
+    buckets: dict[str, list[int]] = {}
+    singletons: list[list[int]] = []
+    for rid, mention, _t in items:
+        key = normalize_extracted_info(mention, remove_inner_quotes=True)
+        if not key:  # short numeric-only names normalize to "" -> not a node -> singleton
+            singletons.append([rid])
+            continue
+        buckets.setdefault(key, []).append(rid)
+    return [sorted(v) for v in buckets.values()] + singletons
+
+
+# ── Graphiti (real-inproc: runs the library's real deterministic dedup floor) ──
+#
+# Graphiti's deterministic dedup floor is `_resolve_with_similarity` +
+# `_build_candidate_indexes` (dedup_helpers.py @v0.29.2 / ff7e29cc): exact
+# normalized-name (lower + ws-collapse) match, else a MinHash/Jaccard>=0.9 fuzzy
+# match, with a low-entropy / short-name gate. We run that REAL decision code via
+# SEQUENTIAL INGESTION -- each record resolves against the accumulated "existing"
+# set, mirroring Graphiti's real extracted-vs-existing-graph flow (there is no
+# intra-batch dedup in the real code). The module is stdlib+pydantic only (no LLM,
+# DB, embedder, or torch). Honest scoping recorded in FIDELITY.md:
+#   * No LLM/embedder. Unresolved nodes (0 exact + no fuzzy hit, >1 exact ambiguous,
+#     or low-entropy) become NEW entities -- the deterministic-floor end state (the
+#     full default path would escalate those to the LLM).
+#   * We feed the FULL existing set as candidates; the real flow prunes candidates
+#     via an embedder semantic search first, so this is an UPPER BOUND on the floor
+#     (more candidates, not fewer) -- it can only help recall, never hurt it.
+#   * label-agnostic: the floor applies no entity-label gate (verified at source).
+# real-inproc: the library's real resolution DECISION runs in-process; only the
+# embedder candidate-prune, the LLM fallback, and graph persistence are elided.
+def graphiti_clusters(items: list[tuple[int, str, str]]) -> list[list[int]]:
+    """items: (record_id, mention, entity_type). Runs Graphiti's real deterministic
+    floor via sequential ingestion. graphiti_core is lazy-imported."""
+    from graphiti_core.nodes import EntityNode  # pyright: ignore[reportMissingImports]
+    from graphiti_core.utils.maintenance.dedup_helpers import (  # pyright: ignore[reportMissingImports]
+        DedupResolutionState,
+        _build_candidate_indexes,
+        _resolve_with_similarity,
+    )
+
+    existing: list = []  # the growing "graph" of canonical EntityNodes
+    uuid_to_records: dict[str, list[int]] = {}
+    for rid, mention, _t in items:
+        node = EntityNode(name=mention, group_id="")
+        indexes = _build_candidate_indexes(existing)
+        state = DedupResolutionState(
+            resolved_nodes=[None], uuid_map={}, unresolved_indices=[]
+        )
+        _resolve_with_similarity([node], indexes, state)
+        canonical = state.uuid_map.get(node.uuid)
+        if canonical is not None and canonical in uuid_to_records:
+            uuid_to_records[canonical].append(rid)  # resolved to an existing entity
+        else:
+            existing.append(node)  # unresolved/new -> a new entity (floor, no LLM)
+            uuid_to_records[node.uuid] = [rid]
+    return [sorted(v) for v in uuid_to_records.values()]

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run.py
@@ -231,10 +231,12 @@ def to_markdown(report: dict) -> str:
         lines.append(f"- **{r['name']}** — {r['defaults']}")
     lines += [
         "",
-        "> Modelled rows reproduce each framework's deterministic default rule "
-        "(exact constants + source in `adapters/modeled.py`). LLM-judge layers "
-        "(Graphiti, mem0) are out of scope: non-deterministic, O(n)-in-LLM-calls, "
-        "and ~$0.80/40-chats — see the module docstring.",
+        "> Each row carries a `fid` tier (see `adapters/FIDELITY.md`): `real-inproc` "
+        "runs the framework's real decision code; `validated` reproduces its exact "
+        "rule confirmed vs source; `modeled` is an unconfirmed/divergent re-impl. "
+        "mem0's LLM ADD/UPDATE merge layer stays out of scope (non-deterministic, "
+        "per-pair LLM cost; Phase 3) -- this board runs each framework's "
+        "deterministic dedup, including Graphiti's MinHash/Jaccard floor.",
         "",
     ]
     return "\n".join(lines)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-real.txt
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/requirements-real.txt
@@ -4,3 +4,10 @@
 # When installed, available_real_adapters() returns the real framework rows;
 # when absent, those rows are silently skipped (degraded to "missing", not error).
 neo4j-graphrag>=1.17
+# LightRAG real entity-merge key (real-inproc row). Import name `lightrag`; torch-free
+# base install. Pinned <1.6 so the public normalize_extracted_info contract is stable.
+lightrag-hku>=1.5,<1.6
+# Graphiti real deterministic dedup floor (real-inproc row). torch-free; dedup_helpers
+# is stdlib+pydantic. Pinned <0.30 -- the floor uses underscore-prefixed (private) fns,
+# so lock the minor to keep the API contract; the F1 pin catches any drift.
+graphiti-core>=0.29,<0.30

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS.md
@@ -8,21 +8,22 @@ Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `st`.
 
 | System | P | R | F1 | fid | coll&nbsp;P* | temp&nbsp;P* | ms | det-floor |
 |---|---|---|---|---|---|---|---|---|
-| goldenmatch(auto) | 0.849 | 0.374 | **0.52** | real | 0.438 | 0.4 | 984.6 | yes |
-| goldenmatch(auto+fields) | 0.786 | 0.488 | **0.602** | real | 0.471 | 0.4 | 4878.1 | yes |
-| goldenmatch(emb-ann) | 0.455 | 0.426 | **0.44** | real | 0.471 | 0.4 | 65.9 | yes |
-| MS-GraphRAG | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.2 | yes |
-| LightRAG | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.1 | yes |
-| Cognee | 0.875 | 0.034 | **0.066** | modeled | 0.0 | 1.0 | 0.1 | yes |
+| goldenmatch(auto) | 0.849 | 0.374 | **0.52** | real | 0.438 | 0.4 | 605.1 | yes |
+| goldenmatch(auto+fields) | 0.786 | 0.488 | **0.602** | real | 0.471 | 0.4 | 4869.4 | yes |
+| goldenmatch(emb-ann) | 0.455 | 0.426 | **0.44** | real | 0.471 | 0.4 | 38.3 | yes |
 | mem0 | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 0.3 | yes |
-| Neo4j-KGBuilder | 0.826 | 0.315 | **0.456** | modeled | 0.448 | 0.286 | 12.3 | yes |
-| neo4j-graphrag(fuzzy) | 0.345 | 0.485 | **0.403** | modeled | 0.451 | 0.4 | 63.6 | yes |
-| LlamaIndex-PGI | 0.141 | 0.51 | **0.221** | modeled | 0.452 | 0.286 | 7.0 | yes |
-| Neo4j-KGBuilder(emb) | 0.795 | 0.335 | **0.471** | modeled | 0.448 | 0.4 | 654.2 | yes |
-| LlamaIndex-PGI(emb) | 0.149 | 0.547 | **0.234** | modeled | 0.452 | 0.4 | 671.3 | yes |
-| neo4j-graphrag(fuzzy)* | 0.477 | 0.461 | **0.469** | real-inproc | 0.471 | 0.4 | 12.6 | yes |
+| Neo4j-KGBuilder | 0.826 | 0.315 | **0.456** | modeled | 0.448 | 0.286 | 12.2 | yes |
+| neo4j-graphrag(fuzzy) | 0.345 | 0.485 | **0.403** | modeled | 0.451 | 0.4 | 61.9 | yes |
+| LlamaIndex-PGI | 0.141 | 0.51 | **0.221** | modeled | 0.452 | 0.286 | 6.8 | yes |
+| Neo4j-KGBuilder(emb) | 0.795 | 0.335 | **0.471** | modeled | 0.448 | 0.4 | 665.2 | yes |
+| LlamaIndex-PGI(emb) | 0.149 | 0.547 | **0.234** | modeled | 0.452 | 0.4 | 653.7 | yes |
+| MS-GraphRAG | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 0.3 | yes |
+| Cognee | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 1.1 | yes |
+| neo4j-graphrag(fuzzy)* | 0.477 | 0.461 | **0.469** | real-inproc | 0.471 | 0.4 | 11.5 | yes |
 | neo4j-graphrag(exact) | 0.875 | 0.034 | **0.066** | validated | 0.0 | 1.0 | 0.2 | yes |
-| neo4j-graphrag(spacy)* | 0.699 | 0.281 | **0.401** | real-inproc | 0.455 | 0.364 | 1943.2 | yes |
+| neo4j-graphrag(spacy)* | 0.699 | 0.281 | **0.401** | real-inproc | 0.455 | 0.364 | 1807.5 | yes |
+| LightRAG* | 0.875 | 0.034 | **0.066** | real-inproc | 0.0 | 1.0 | 9.3 | yes |
+| graphiti* | 0.909 | 0.049 | **0.093** | real-inproc | 0.0 | 1.0 | 7007.5 | yes |
 
 ## Per-class F1
 
@@ -31,35 +32,37 @@ Dataset: **206 records / 48 entities / 9 failure classes**. Embedder: `st`.
 | goldenmatch(auto) | 0.412 | 0.741 | 0.089 | 0.318 | 0.4 | 0.875 | 1.0 | 0.571 | 1.0 |
 | goldenmatch(auto+fields) | 0.773 | 0.854 | 0.167 | 0.356 | 0.769 | 1.0 | 1.0 | 0.571 | 1.0 |
 | goldenmatch(emb-ann) | 0.214 | 0.786 | 0.138 | 0.516 | 0.4 | 0.667 | 0.444 | 0.571 | 1.0 |
-| MS-GraphRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
-| LightRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
-| Cognee | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
 | mem0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
 | Neo4j-KGBuilder | 0.412 | 0.406 | 0.034 | 0.456 | 0.588 | 0.714 | 1.0 | 0.308 | 1.0 |
 | neo4j-graphrag(fuzzy) | 0.898 | 0.854 | 0.078 | 0.582 | 0.345 | 0.667 | 0.444 | 0.571 | 1.0 |
 | LlamaIndex-PGI | 0.533 | 0.478 | 0.093 | 0.543 | 0.405 | 0.667 | 0.706 | 0.308 | 0.571 |
 | Neo4j-KGBuilder(emb) | 0.412 | 0.406 | 0.034 | 0.456 | 0.588 | 0.714 | 1.0 | 0.571 | 1.0 |
 | LlamaIndex-PGI(emb) | 0.533 | 0.622 | 0.093 | 0.543 | 0.405 | 0.667 | 0.706 | 0.571 | 0.571 |
+| MS-GraphRAG | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
+| Cognee | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
 | neo4j-graphrag(fuzzy)* | 0.898 | 0.854 | 0.045 | 0.516 | 0.345 | 0.667 | 0.444 | 0.571 | 1.0 |
 | neo4j-graphrag(exact) | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
 | neo4j-graphrag(spacy)* | 0.457 | 0.8 | 0.104 | 0.256 | 0.0 | 0.0 | 0.868 | 0.471 | 1.0 |
+| LightRAG* | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |
+| graphiti* | 0.071 | 0.038 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.5 | 1.0 |
 
 ## Documented defaults (what each row runs)
 
 - **goldenmatch(auto)** — zero-config dedupe_df(name) -- auto-config picks the strategy
 - **goldenmatch(auto+fields)** — zero-config dedupe_df(name+type+context) -- auto-config, multi-field
 - **goldenmatch(emb-ann)** — inhouse char-ngram embedding (no key/torch) -> cosine>=0.5 candidate pairs (ANN at scale) -> union-find; name only
-- **MS-GraphRAG** — exact title match; ER step removed (finalize_entities seen_titles set, title=clean_str(name.upper()); discussion #778, data-loss #1718)
-- **LightRAG** — exact case-SENSITIVE name dict key, outer-quote strip + CJK fold, no fuzzy/embedding at merge (operate.py _merge_nodes_then_upsert + normalize_extracted_info; #1323, cross-doc #485)
-- **Cognee** — exact generate_node_name key = name.lower().replace("'",""); difflib cutoff=0.8 only vs a user ontology (empty by default) (generate_node_name.py / matching_strategies.py; #1831)
 - **mem0** — MD5-exact only as hard dedup; semantic merge is one LLM ADD/UPDATE prompt (memory/main.py md5 over raw text; contradictions #4896, 37.6% near-dupes #4573)
 - **Neo4j-KGBuilder** — same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py get_duplicate_nodes Cypher; over-merge #1133, missed alias #912)
 - **neo4j-graphrag(fuzzy)** — FuzzyMatchResolver: rapidfuzz WRatio/100 >= 0.8, all-pairs O(n^2) (resolver.py BasePropertySimilarityResolver; rapidfuzz extra #336)
 - **LlamaIndex-PGI** — same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)
 - **Neo4j-KGBuilder(emb)** — same-label gate AND ( substring-contains(len>2) OR Levenshtein<3(len>5) OR cosine>0.97 ); human-review-gated (graphDB_dataAccess.py get_duplicate_nodes Cypher; over-merge #1133, missed alias #912)
 - **LlamaIndex-PGI(emb)** — same-label gate AND ( contains OR Levenshtein<5 OR cosine>0.9 ), KNN top-10 when embedded (property-graph blog; self-documented over-merges: 1963 AFL/NFL, BTC Halving 2020/2024)
+- **MS-GraphRAG** — exact title-set merge, GLOBAL (not per-label): title=clean_str(name.upper()) -> upper + edge-strip + html-unescape + control-char strip, NO internal-ws collapse (finalize_entities seen_titles + graph_extractor + utils/string.py; Standard pipeline has no ER step -> validated reproduction, no separable resolver)
+- **Cognee** — exact merge on generate_node_id = uuid5(NAMESPACE_OID, name.lower().replace(' ','_').replace("'",'')), GLOBAL (not per-label); default ontology empty so the difflib cutoff never fires (generate_node_id.py + deduplicate_nodes_and_edges.py -> validated)
 - **neo4j-graphrag(fuzzy)*** — REAL FuzzyMatchResolver: rapidfuzz WRatio/100>=0.8 per entity-label, _consolidate_sets (library decision code; Neo4j+APOC storage stubbed)
 - **neo4j-graphrag(exact)** — SinglePropertyExactMatchResolver: exact `name` equality per entity-label, null names skipped (logic is a Cypher query in run(); no in-process decision method exists, so this is the Cypher re-expressed + confirmed -> validated)
 - **neo4j-graphrag(spacy)*** — REAL SpaCySemanticMatchResolver: spaCy doc-vector cosine >= 0.8 per entity-label, _consolidate_sets (library decision code; en_core_web_lg vectors; Neo4j+APOC storage stubbed)
+- **LightRAG*** — REAL normalize_extracted_info key (HTML-strip, CJK fold, outer-quote strip, CASE-SENSITIVE -- no lower/upper) + exact name dict group-by, GLOBAL (operate.py merge_nodes_and_edges + utils.py; LLM only summarizes descriptions, never moves a record; graph-store upsert stubbed)
+- **graphiti*** — REAL deterministic floor: exact normalized-name (lower+ws-collapse) OR MinHash/Jaccard>=0.9, with a low-entropy/short-name gate (_resolve_with_similarity + _build_candidate_indexes, dedup_helpers.py); sequential ingestion vs the growing existing set. DETERMINISTIC FLOOR ONLY -- the full default path escalates unresolved nodes to an LLM (out of scope)
 
-> Modelled rows reproduce each framework's deterministic default rule (exact constants + source in `adapters/modeled.py`). LLM-judge layers (Graphiti, mem0) are out of scope: non-deterministic, O(n)-in-LLM-calls, and ~$0.80/40-chats — see the module docstring.
+> Each row carries a `fid` tier (see `adapters/FIDELITY.md`): `real-inproc` runs the framework's real decision code; `validated` reproduces its exact rule confirmed vs source; `modeled` is an unconfirmed/divergent re-impl. mem0's LLM ADD/UPDATE merge layer stays out of scope (non-deterministic, per-pair LLM cost; Phase 3) -- this board runs each framework's deterministic dedup, including Graphiti's MinHash/Jaccard floor.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/results.json
@@ -51,7 +51,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 984.6,
+      "time_ms": 605.1,
       "deterministic_floor": true
     },
     {
@@ -85,7 +85,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 4878.1,
+      "time_ms": 4869.4,
       "deterministic_floor": true
     },
     {
@@ -119,109 +119,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 65.9,
-      "deterministic_floor": true
-    },
-    {
-      "name": "MS-GraphRAG",
-      "defaults": "exact title match; ER step removed (finalize_entities seen_titles set, title=clean_str(name.upper()); discussion #778, data-loss #1718)",
-      "fidelity": "modeled",
-      "overall": {
-        "precision": 0.875,
-        "recall": 0.034,
-        "f1": 0.066
-      },
-      "per_class_f1": {
-        "abbreviation": 0.0,
-        "nickname_alias": 0.0,
-        "synonym_brand": 0.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 0.0,
-        "typo": 0.0,
-        "org_suffix": 0.0,
-        "temporal_version": 0.0,
-        "cross_document_exact": 1.0
-      },
-      "per_class_precision": {
-        "abbreviation": 1.0,
-        "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 1.0,
-        "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 1.0,
-        "cross_document_exact": 1.0
-      },
-      "time_ms": 0.2,
-      "deterministic_floor": true
-    },
-    {
-      "name": "LightRAG",
-      "defaults": "exact case-SENSITIVE name dict key, outer-quote strip + CJK fold, no fuzzy/embedding at merge (operate.py _merge_nodes_then_upsert + normalize_extracted_info; #1323, cross-doc #485)",
-      "fidelity": "modeled",
-      "overall": {
-        "precision": 0.875,
-        "recall": 0.034,
-        "f1": 0.066
-      },
-      "per_class_f1": {
-        "abbreviation": 0.0,
-        "nickname_alias": 0.0,
-        "synonym_brand": 0.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 0.0,
-        "typo": 0.0,
-        "org_suffix": 0.0,
-        "temporal_version": 0.0,
-        "cross_document_exact": 1.0
-      },
-      "per_class_precision": {
-        "abbreviation": 1.0,
-        "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 1.0,
-        "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 1.0,
-        "cross_document_exact": 1.0
-      },
-      "time_ms": 0.1,
-      "deterministic_floor": true
-    },
-    {
-      "name": "Cognee",
-      "defaults": "exact generate_node_name key = name.lower().replace(\"'\",\"\"); difflib cutoff=0.8 only vs a user ontology (empty by default) (generate_node_name.py / matching_strategies.py; #1831)",
-      "fidelity": "modeled",
-      "overall": {
-        "precision": 0.875,
-        "recall": 0.034,
-        "f1": 0.066
-      },
-      "per_class_f1": {
-        "abbreviation": 0.0,
-        "nickname_alias": 0.0,
-        "synonym_brand": 0.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 0.0,
-        "typo": 0.0,
-        "org_suffix": 0.0,
-        "temporal_version": 0.0,
-        "cross_document_exact": 1.0
-      },
-      "per_class_precision": {
-        "abbreviation": 1.0,
-        "nickname_alias": 1.0,
-        "synonym_brand": 1.0,
-        "same_name_collision": 0.0,
-        "cross_lingual": 1.0,
-        "typo": 1.0,
-        "org_suffix": 1.0,
-        "temporal_version": 1.0,
-        "cross_document_exact": 1.0
-      },
-      "time_ms": 0.1,
+      "time_ms": 38.3,
       "deterministic_floor": true
     },
     {
@@ -289,7 +187,7 @@
         "temporal_version": 0.286,
         "cross_document_exact": 1.0
       },
-      "time_ms": 12.3,
+      "time_ms": 12.2,
       "deterministic_floor": true
     },
     {
@@ -323,7 +221,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 63.6,
+      "time_ms": 61.9,
       "deterministic_floor": true
     },
     {
@@ -357,7 +255,7 @@
         "temporal_version": 0.286,
         "cross_document_exact": 0.4
       },
-      "time_ms": 7.0,
+      "time_ms": 6.8,
       "deterministic_floor": true
     },
     {
@@ -391,7 +289,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 654.2,
+      "time_ms": 665.2,
       "deterministic_floor": true
     },
     {
@@ -425,7 +323,75 @@
         "temporal_version": 0.4,
         "cross_document_exact": 0.4
       },
-      "time_ms": 671.3,
+      "time_ms": 653.7,
+      "deterministic_floor": true
+    },
+    {
+      "name": "MS-GraphRAG",
+      "defaults": "exact title-set merge, GLOBAL (not per-label): title=clean_str(name.upper()) -> upper + edge-strip + html-unescape + control-char strip, NO internal-ws collapse (finalize_entities seen_titles + graph_extractor + utils/string.py; Standard pipeline has no ER step -> validated reproduction, no separable resolver)",
+      "fidelity": "validated",
+      "overall": {
+        "precision": 0.875,
+        "recall": 0.034,
+        "f1": 0.066
+      },
+      "per_class_f1": {
+        "abbreviation": 0.0,
+        "nickname_alias": 0.0,
+        "synonym_brand": 0.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 0.0,
+        "typo": 0.0,
+        "org_suffix": 0.0,
+        "temporal_version": 0.0,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 1.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 1.0,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 0.3,
+      "deterministic_floor": true
+    },
+    {
+      "name": "Cognee",
+      "defaults": "exact merge on generate_node_id = uuid5(NAMESPACE_OID, name.lower().replace(' ','_').replace(\"'\",'')), GLOBAL (not per-label); default ontology empty so the difflib cutoff never fires (generate_node_id.py + deduplicate_nodes_and_edges.py -> validated)",
+      "fidelity": "validated",
+      "overall": {
+        "precision": 0.875,
+        "recall": 0.034,
+        "f1": 0.066
+      },
+      "per_class_f1": {
+        "abbreviation": 0.0,
+        "nickname_alias": 0.0,
+        "synonym_brand": 0.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 0.0,
+        "typo": 0.0,
+        "org_suffix": 0.0,
+        "temporal_version": 0.0,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 1.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 1.0,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 1.1,
       "deterministic_floor": true
     },
     {
@@ -459,7 +425,7 @@
         "temporal_version": 0.4,
         "cross_document_exact": 1.0
       },
-      "time_ms": 12.6,
+      "time_ms": 11.5,
       "deterministic_floor": true
     },
     {
@@ -527,7 +493,75 @@
         "temporal_version": 0.364,
         "cross_document_exact": 1.0
       },
-      "time_ms": 1943.2,
+      "time_ms": 1807.5,
+      "deterministic_floor": true
+    },
+    {
+      "name": "LightRAG*",
+      "defaults": "REAL normalize_extracted_info key (HTML-strip, CJK fold, outer-quote strip, CASE-SENSITIVE -- no lower/upper) + exact name dict group-by, GLOBAL (operate.py merge_nodes_and_edges + utils.py; LLM only summarizes descriptions, never moves a record; graph-store upsert stubbed)",
+      "fidelity": "real-inproc",
+      "overall": {
+        "precision": 0.875,
+        "recall": 0.034,
+        "f1": 0.066
+      },
+      "per_class_f1": {
+        "abbreviation": 0.0,
+        "nickname_alias": 0.0,
+        "synonym_brand": 0.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 0.0,
+        "typo": 0.0,
+        "org_suffix": 0.0,
+        "temporal_version": 0.0,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 1.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 1.0,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 9.3,
+      "deterministic_floor": true
+    },
+    {
+      "name": "graphiti*",
+      "defaults": "REAL deterministic floor: exact normalized-name (lower+ws-collapse) OR MinHash/Jaccard>=0.9, with a low-entropy/short-name gate (_resolve_with_similarity + _build_candidate_indexes, dedup_helpers.py); sequential ingestion vs the growing existing set. DETERMINISTIC FLOOR ONLY -- the full default path escalates unresolved nodes to an LLM (out of scope)",
+      "fidelity": "real-inproc",
+      "overall": {
+        "precision": 0.909,
+        "recall": 0.049,
+        "f1": 0.093
+      },
+      "per_class_f1": {
+        "abbreviation": 0.071,
+        "nickname_alias": 0.038,
+        "synonym_brand": 0.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 0.0,
+        "typo": 0.0,
+        "org_suffix": 0.0,
+        "temporal_version": 0.5,
+        "cross_document_exact": 1.0
+      },
+      "per_class_precision": {
+        "abbreviation": 1.0,
+        "nickname_alias": 1.0,
+        "synonym_brand": 1.0,
+        "same_name_collision": 0.0,
+        "cross_lingual": 1.0,
+        "typo": 1.0,
+        "org_suffix": 1.0,
+        "temporal_version": 1.0,
+        "cross_document_exact": 1.0
+      },
+      "time_ms": 7007.5,
       "deterministic_floor": true
     }
   ]

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_fidelity_column.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_fidelity_column.py
@@ -28,6 +28,24 @@ def test_real_neo4j_row_present_and_real():
     assert round(real[0]["overall"]["f1"], 3) == 0.469  # Phase-2 _merge_overlapping fix (was 0.470)
 
 
+def test_phase3a_cutover_board_composition():
+    """Phase 3a: GraphRAG + Cognee are now `validated` faithful rows (not modeled),
+    and the three modeled exact-family rows are gone from all_modeled()."""
+    from erkgbench import run  # pyright: ignore[reportMissingImports]
+    from erkgbench.adapters.modeled import all_modeled  # pyright: ignore[reportMissingImports]
+
+    # The shared-_norm modeled rows were retired (cut over to adapters/real/).
+    modeled_names = {a.name for a in all_modeled()}
+    assert "MS-GraphRAG" not in modeled_names
+    assert "LightRAG" not in modeled_names
+    assert "Cognee" not in modeled_names
+
+    by_name = {r["name"]: r.get("fidelity") for r in run.run(None)["results"]}
+    # GraphRAG + Cognee now ship as faithful `validated` reproductions.
+    assert by_name.get("MS-GraphRAG") == "validated"
+    assert by_name.get("Cognee") == "validated"
+
+
 def test_emb_rows_present_with_correct_tiers():
     # Tier-only check via a tiny deterministic fake embedder (no torch needed).
     # Both embedder variants stay `modeled`: KGBuilder(emb) because its real

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -13,12 +13,25 @@ import pytest
 from erkgbench import metrics  # pyright: ignore[reportMissingImports]
 from erkgbench.real_resolvers import (  # pyright: ignore[reportMissingImports]
     SPACY_MODEL,
+    cognee_clusters,
+    graphrag_clusters,
     neo4j_graphrag_exact_clusters,
     neo4j_graphrag_fuzzy_clusters,
     neo4j_graphrag_spacy_clusters,
 )
 
 DATASET = _BENCH_ROOT / "dataset" / "records.csv"
+
+# Observed real F1 on the corpus, pinned from a CI run (Linux) so a local Windows
+# run that gives the same pure-exact-bucket result also passes. Set to None to
+# observe-then-pin (the test SKIPS reporting the value until pinned).
+# Both = 0.066: an exact key (GraphRAG upper-fold / Cognee uuid5) recalls almost
+# nothing on this surface-form-variation corpus -- the variants differ by more than
+# case/whitespace, so the precise normalization doesn't move F1 (same 0.066 as
+# neo4j-graphrag(exact)). Pure deterministic exact-bucket on string keys -> platform-
+# stable, so the observed local Windows value matches Linux CI.
+_GRAPHRAG_F1_PIN: float | None = 0.066
+_COGNEE_F1_PIN: float | None = 0.066
 
 
 def _load():
@@ -98,6 +111,49 @@ def test_exact_merges_identical_skips_null_and_no_normalization():
     assert [2] in clustering                            # case differs -> not merged
     assert [3] in clustering                            # empty -> singleton
     assert [4] in clustering                            # different label -> not merged
+
+
+# -- GraphRAG + Cognee (validated reproductions of exact-key rules) ------------
+
+def test_graphrag_key_is_faithful():
+    from erkgbench.real_resolvers import _graphrag_key
+    # clean_str(name.upper()): upper + edge-strip + html-unescape + control-char
+    # strip, NO internal-whitespace collapse, NO quote strip.
+    assert _graphrag_key("  Acme &amp; Co  ") == "ACME & CO"
+    assert _graphrag_key("New  York") != _graphrag_key("New York")   # 2 spaces NOT collapsed
+    assert _graphrag_key("acme") == _graphrag_key("ACME")            # case-folded (clustering-equiv)
+    assert _graphrag_key('the "best"') == 'THE "BEST"'              # quotes NOT stripped
+
+
+def test_graphrag_reproduces_observed_f1():
+    items, entity_ids, classes = _load()
+    clustering = graphrag_clusters(items)
+    flat = [i for c in clustering for i in c]
+    assert sorted(flat) == sorted(i for i, _m, _t in items)          # full partition
+    f1 = metrics.score_by_class(entity_ids, classes, clustering)["__overall__"].f1
+    if _GRAPHRAG_F1_PIN is None:
+        pytest.skip(f"GraphRAG F1 observed = {round(f1, 3)} -- set _GRAPHRAG_F1_PIN to lock it")
+    assert round(f1, 3) == _GRAPHRAG_F1_PIN
+
+
+def test_cognee_key_fixes_the_modeled_bug():
+    from erkgbench.real_resolvers import _cognee_key
+    # real generate_node_id: lower -> " "->"_" -> strip "'". The old model used
+    # _norm (lower + whitespace-collapse) citing generate_node_NAME -- this is the FIX.
+    assert _cognee_key("O'Brien") == _cognee_key("OBrien")           # apostrophe stripped
+    assert _cognee_key("John  Smith") != _cognee_key("John Smith")   # 2 spaces -> "__" != "_"
+    assert _cognee_key("Acme") == _cognee_key("acme")                # lowercased
+
+
+def test_cognee_reproduces_observed_f1():
+    items, entity_ids, classes = _load()
+    clustering = cognee_clusters(items)
+    flat = [i for c in clustering for i in c]
+    assert sorted(flat) == sorted(i for i, _m, _t in items)          # full partition
+    f1 = metrics.score_by_class(entity_ids, classes, clustering)["__overall__"].f1
+    if _COGNEE_F1_PIN is None:
+        pytest.skip(f"Cognee F1 observed = {round(f1, 3)} -- set _COGNEE_F1_PIN to lock it")
+    assert round(f1, 3) == _COGNEE_F1_PIN
 
 
 # -- SpaCySemanticMatchResolver (real-inproc; needs the spaCy vector model) -----

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -205,8 +205,11 @@ def test_spacy_is_deterministic():
 
 # -- LightRAG (real-inproc; needs lightrag-hku) ---------------------------------
 
-# Observed real F1 pinned from CI (lightrag-hku installed). Set to None to observe-pin.
-_LIGHTRAG_F1_PIN: float | None = None
+# Observed real F1 pinned from CI (lightrag-hku installed, run 27703432403): P 0.875
+# / R 0.034 / F1 0.066 -- faithful to LightRAG's case-sensitive exact key (same 0.066
+# as the exact family; the key recalls ~nothing on surface-form variation). Pure
+# exact-bucket on the real normalized key -> platform-stable.
+_LIGHTRAG_F1_PIN: float | None = 0.066
 
 
 def _have(mod: str) -> bool:
@@ -250,8 +253,12 @@ def test_lightrag_is_deterministic():
 
 # -- Graphiti (real-inproc deterministic floor; needs graphiti-core) ------------
 
-# Observed real F1 pinned from CI (graphiti-core installed). Set to None to observe-pin.
-_GRAPHITI_F1_PIN: float | None = None
+# Observed real F1 pinned from CI (graphiti-core installed, run 27703432403): P 0.909
+# / R 0.049 / F1 0.093 -- the deterministic MinHash/Jaccard>=0.9 floor recalls a touch
+# more than a pure exact key (abbr 0.071, nick 0.038, temp 0.5) but is still low
+# without the LLM fallback. BLAKE2b MinHash + fixed permutations -> deterministic /
+# platform-stable.
+_GRAPHITI_F1_PIN: float | None = 0.093
 
 
 def test_graphiti_reproduces_observed_f1():

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_resolvers.py
@@ -14,7 +14,9 @@ from erkgbench import metrics  # pyright: ignore[reportMissingImports]
 from erkgbench.real_resolvers import (  # pyright: ignore[reportMissingImports]
     SPACY_MODEL,
     cognee_clusters,
+    graphiti_clusters,
     graphrag_clusters,
+    lightrag_clusters,
     neo4j_graphrag_exact_clusters,
     neo4j_graphrag_fuzzy_clusters,
     neo4j_graphrag_spacy_clusters,
@@ -199,3 +201,90 @@ def test_spacy_is_deterministic():
     assert metrics.clusterings_equal(
         neo4j_graphrag_spacy_clusters(items), neo4j_graphrag_spacy_clusters(items)
     )
+
+
+# -- LightRAG (real-inproc; needs lightrag-hku) ---------------------------------
+
+# Observed real F1 pinned from CI (lightrag-hku installed). Set to None to observe-pin.
+_LIGHTRAG_F1_PIN: float | None = None
+
+
+def _have(mod: str) -> bool:
+    try:
+        import importlib.util
+        return importlib.util.find_spec(mod) is not None
+    except Exception:
+        return False
+
+
+def test_lightrag_reproduces_observed_f1():
+    if not _have("lightrag"):
+        pytest.skip("lightrag-hku not installed (CI-only real-inproc row)")
+    items, entity_ids, classes = _load()
+    clustering = lightrag_clusters(items)
+    flat = [i for c in clustering for i in c]
+    assert sorted(flat) == sorted(i for i, _m, _t in items)  # full partition
+    f1 = metrics.score_by_class(entity_ids, classes, clustering)["__overall__"].f1
+    if _LIGHTRAG_F1_PIN is None:
+        pytest.skip(f"LightRAG F1 observed = {round(f1, 3)} -- set _LIGHTRAG_F1_PIN to lock it")
+    assert round(f1, 3) == _LIGHTRAG_F1_PIN
+
+
+def test_lightrag_key_is_case_sensitive():
+    # LightRAG's real normalize_extracted_info applies NO lower/upper, so "Apple" and
+    # "apple" are DISTINCT entities (unlike the old _norm model that lowercased).
+    if not _have("lightrag"):
+        pytest.skip("lightrag-hku not installed (CI-only real-inproc row)")
+    items = [(0, "Apple", "org"), (1, "apple", "org"), (2, "Apple", "org")]
+    clustering = lightrag_clusters(items)
+    assert any(set(c) == {0, 2} for c in clustering)  # identical case -> merged
+    assert [1] in clustering                          # different case -> own cluster
+
+
+def test_lightrag_is_deterministic():
+    if not _have("lightrag"):
+        pytest.skip("lightrag-hku not installed (CI-only real-inproc row)")
+    items, _, _ = _load()
+    assert metrics.clusterings_equal(lightrag_clusters(items), lightrag_clusters(items))
+
+
+# -- Graphiti (real-inproc deterministic floor; needs graphiti-core) ------------
+
+# Observed real F1 pinned from CI (graphiti-core installed). Set to None to observe-pin.
+_GRAPHITI_F1_PIN: float | None = None
+
+
+def test_graphiti_reproduces_observed_f1():
+    if not _have("graphiti_core"):
+        pytest.skip("graphiti-core not installed (CI-only real-inproc row)")
+    items, entity_ids, classes = _load()
+    clustering = graphiti_clusters(items)
+    flat = [i for c in clustering for i in c]
+    assert sorted(flat) == sorted(i for i, _m, _t in items)  # full partition
+    f1 = metrics.score_by_class(entity_ids, classes, clustering)["__overall__"].f1
+    if _GRAPHITI_F1_PIN is None:
+        pytest.skip(f"Graphiti F1 observed = {round(f1, 3)} -- set _GRAPHITI_F1_PIN to lock it")
+    assert round(f1, 3) == _GRAPHITI_F1_PIN
+
+
+def test_graphiti_floor_merges_exact_and_close_fuzzy():
+    # The deterministic floor merges exact-normalized names and MinHash/Jaccard>=0.9
+    # near-duplicates; unrelated names stay separate (no LLM). Long names so the
+    # entropy/min-length gate (>=6 chars, >=2 tokens) doesn't punt them.
+    if not _have("graphiti_core"):
+        pytest.skip("graphiti-core not installed (CI-only real-inproc row)")
+    items = [
+        (0, "International Business Machines", "org"),
+        (1, "international business machines", "org"),  # case-only -> exact-normalized merge
+        (2, "Completely Unrelated Organization", "org"),
+    ]
+    clustering = graphiti_clusters(items)
+    assert any(set(c) == {0, 1} for c in clustering)
+    assert [2] in clustering
+
+
+def test_graphiti_is_deterministic():
+    if not _have("graphiti_core"):
+        pytest.skip("graphiti-core not installed (CI-only real-inproc row)")
+    items, _, _ = _load()
+    assert metrics.clusterings_equal(graphiti_clusters(items), graphiti_clusters(items))


### PR DESCRIPTION
Cuts the four exact-key / floor framework rows over from divergent deterministic *models* to faithful real-execution (or source-confirmed `validated`) rows — all in the existing offline `bench-er-kg` lane, no keys, no infra. Continues the "real frameworks" arc (Phase 0/1 #1043, Phase 2 #1046).

## The cutover

| Row | Before | After | Mechanism |
|---|---|---|---|
| MS-GraphRAG | `modeled` | **`validated`** | reproduce `clean_str(name.upper())` verbatim (no separable resolver exists) |
| Cognee | `modeled` | **`validated`** | reproduce `generate_node_id` uuid5 — **fixes a confirmed bug** (old model cited `generate_node_name` + missed `" "→"_"`) |
| LightRAG | `modeled` | **`real-inproc`** | run the lib's real `normalize_extracted_info` key fn + exact group-by |
| Graphiti | absent | **`real-inproc`** (NEW) | run the lib's real `_resolve_with_similarity` MinHash/Jaccard≥0.9 floor |

After this, **only LlamaIndex** (blog-sourced, unconfirmable) and **Neo4j-KGBuilder** (irreproducible `elementId` guard) remain `modeled` — the honest residue.

## Notes
- GraphRAG + Cognee are pure-Python (`validated`), locally tested, both observed F1 0.066 (exact key recalls ~nothing on surface-form variation — same as `neo4j-graphrag(exact)`; keeps the demo's under-merge narrative honest).
- LightRAG + Graphiti run real library code (`lightrag-hku` / `graphiti-core`, torch-free, in `requirements-real.txt`, import-guarded → skip without the dep). **F1 observe-then-pin from this CI run.**
- Graphiti row is the DETERMINISTIC FLOOR (no LLM/embedder); honest scope documented in `FIDELITY.md`.
- `demo/run_demo.py` repointed to `RealGraphRAG`; `DEMO.md` + committed `results/` regenerate from this run (follow-up commit).
- Replaces the modeled rows (no contrast row) since there's no informative model-vs-real divergence for these (unlike neo4j-graphrag's +6.6pp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)