### PR TITLE
ER-KG-Bench recall lever: probe tooling + findings (semantic candidate generation)

### DIFF
--- a/.github/workflows/embed-recall-probe.yml
+++ b/.github/workflows/embed-recall-probe.yml
@@ -1,0 +1,43 @@
+# One-off measurement (workflow_dispatch): does a FREE downloadable semantic model
+# (MiniLM / multilingual-MiniLM) crack the recall-bound ER-KG-Bench classes
+# (abbreviation / cross_lingual) that the in-house char-ngram embedder misses?
+# torch hangs on the dev box, so the free tiers can only be measured here. Results
+# go to the run summary; nothing is committed. See scripts/embed_recall_probe.py.
+name: embed-recall-probe
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BENCH: packages/python/goldenmatch/benchmarks/er-kg-bench
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install probe deps (sentence-transformers pulls CPU torch)
+        run: pip install sentence-transformers numpy
+      - name: Run recall-lever probe (free tiers: MiniLM + multilingual MiniLM)
+        working-directory: ${{ env.BENCH }}
+        run: |
+          set -uo pipefail
+          python scripts/embed_recall_probe.py st st-multi | tee /tmp/probe.out
+          {
+            echo '## Recall-lever probe -- free downloadable embedders'
+            echo ''
+            echo 'Does a free semantic model crack abbreviation / cross_lingual?'
+            echo '(local baselines: in-house char-ngram best F1 0.451; paid OpenAI best F1 0.558,'
+            echo 'abbreviation 0.800 / cross_lingual 0.769)'
+            echo ''
+            echo '```'
+            cat /tmp/probe.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/embed-recall-probe.yml
+++ b/.github/workflows/embed-recall-probe.yml
@@ -7,9 +7,6 @@ name: embed-recall-probe
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - claude/embed-recall-probe
 
 permissions:
   contents: read

--- a/.github/workflows/embed-recall-probe.yml
+++ b/.github/workflows/embed-recall-probe.yml
@@ -7,6 +7,11 @@ name: embed-recall-probe
 
 on:
   workflow_dispatch:
+  # Branch-scoped push trigger so this one-off can run before it lands on the
+  # default branch (workflow_dispatch requires default-branch registration).
+  push:
+    branches:
+      - claude/embed-recall-probe
 
 permissions:
   contents: read

--- a/.github/workflows/embed-recall-probe.yml
+++ b/.github/workflows/embed-recall-probe.yml
@@ -7,11 +7,6 @@ name: embed-recall-probe
 
 on:
   workflow_dispatch:
-  # Branch-scoped push trigger so this one-off can run before it lands on the
-  # default branch (workflow_dispatch requires default-branch registration).
-  push:
-    branches:
-      - claude/embed-recall-probe
 
 permissions:
   contents: read

--- a/.github/workflows/embed-recall-probe.yml
+++ b/.github/workflows/embed-recall-probe.yml
@@ -7,6 +7,9 @@ name: embed-recall-probe
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - claude/embed-recall-probe
 
 permissions:
   contents: read
@@ -25,7 +28,7 @@ jobs:
           python-version: "3.12"
       - name: Install probe deps (sentence-transformers pulls CPU torch)
         run: pip install sentence-transformers numpy
-      - name: Run recall-lever probe (free tiers: MiniLM + multilingual MiniLM)
+      - name: "Run recall-lever probe (free tiers - MiniLM + multilingual MiniLM)"
         working-directory: ${{ env.BENCH }}
         run: |
           set -uo pipefail

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/RECALL-LEVER.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/RECALL-LEVER.md
@@ -1,0 +1,89 @@
+# The recall lever: semantic candidate generation on ER-KG-Bench
+
+> Measurement summary. Reproduce with `scripts/embed_recall_probe.py` (in-house /
+> openai locally; the free downloadable tiers via the `embed-recall-probe`
+> `workflow_dispatch`, since they need torch). Not a committed board row -- this
+> records *why* the hard classes fail and *what* moves them, to gate a future
+> product change (semantic blocking) on measured need.
+
+## The wall
+
+ER-KG-Bench scores how well a tool recognizes that two differently-written names
+are the same entity. Every system on the board -- goldenmatch included -- fails the
+same three classes: **abbreviation** (`IBM` = `International Business Machines`),
+**synonym/brand** (`Coumadin` = `warfarin`), and **cross-lingual** (`München` =
+`Monaco di Baviera`).
+
+These fail at **candidate generation, not scoring.** Every tool only compares names
+that look alike *by spelling*. `IBM` and `International Business Machines` share
+almost no characters, so they are never put in front of the matcher -- the correct
+pair is never generated. Three independent measurements all landed here:
+
+- **Phase-2 embedder** (cosine OR-term on framework rows): byte-identical on the
+  dominant classes -- a measured no-op.
+- **Keyed `auto+llm`** (LLM pair filter): can't create a pair that blocking never
+  generated -- a precision filter, not a recall generator.
+- **Phase-3 mem0 LLM merge layer**: net-negative (0.048 < its 0.066 floor); it
+  recognizes variants but stores them separately. (See `adapters/FIDELITY.md`.)
+
+The lever they all point at: **generate candidate pairs by *meaning*, not spelling**
+-- a semantic embedding that "knows" `IBM` ≈ `International Business Machines`.
+
+## What we measured
+
+`goldenmatch(emb-ann)` already does embedding-ANN candidate generation; the embedder
+is swappable. We swept the cosine threshold per embedder tier over the 206-record
+corpus and scored per failure class. Best-overall-F1 row per tier:
+
+| candidate-gen embedder | overall F1 | abbreviation | cross-lingual | synonym/brand |
+|---|---|---|---|---|
+| in-house char-ngram (free, **no world knowledge** -- today's `emb-ann`) | 0.451 | 0.21 | 0.35 | 0.12 |
+| MiniLM English (free download: `all-MiniLM-L6-v2`) | 0.515 | **0.85** | 0.21 | 0.08 |
+| MiniLM multilingual (free download: `paraphrase-multilingual-MiniLM-L12-v2`) | 0.451 | 0.50 | **0.91** | 0.02 |
+| OpenAI semantic (paid: `resolve_provider("openai")`) | 0.558 | 0.80 | 0.77 | 0.18 |
+
+(in-house / OpenAI measured locally; free tiers from CI run `27715172974`.)
+
+## Findings
+
+1. **The lever is real and large.** World-knowledge candidate generation lifts the
+   wall classes ~2-4x over the char-ngram baseline: abbreviation 0.21 → 0.80-0.85,
+   cross-lingual 0.35 → 0.77-0.91.
+
+2. **The win is FREE -- and free even beats paid, per class.** The free English
+   model tops abbreviation (0.85 > OpenAI 0.80); the free multilingual model tops
+   cross-lingual (0.91 > OpenAI 0.77). No paid key is required.
+
+3. **No single free model does *both* as well as OpenAI does both at once** (English
+   misses cross-lingual; multilingual is softer on abbreviation). The natural free
+   answer is to **ensemble** the two (union their candidate pairs), which should
+   beat OpenAI on both for $0 -- to be confirmed.
+
+4. **synonym/brand is walled for *every* embedder** (max 0.18, even paid).
+   `Coumadin` ↔ `warfarin` is specialized domain knowledge a general embedding does
+   not carry. That class is a different problem (a knowledge base / domain model),
+   not "a bigger embedder."
+
+## Two constraints for any product change
+
+- **Free ≠ zero-dependency.** These free models need torch/sentence-transformers;
+  goldenmatch's true *zero-config* default is the torch-free char-ngram embedder.
+  So semantic candidate generation is a **free, opt-in capability** (install an
+  extra / enable a flag), not the no-deps default -- unless a torch-free (ONNX)
+  semantic embedder is added later. On this benchmark it is a committable free row
+  (CI installs the extra).
+
+- **Name-only emb-ANN (best free 0.515) is still below goldenmatch's `auto+fields`
+  (0.602).** The headline only moves if semantic candidate generation is wired
+  **into** the multi-field auto pipeline, so `auto+fields` also gets the
+  abbreviation/cross-lingual recall on top of its existing scoring.
+
+## Next (NOT built -- gate on measured need)
+
+Wire semantic-ANN candidate generation into goldenmatch's blocking as an opt-in
+"semantic blocking" pass (free multilingual model, or a two-model ensemble by
+default), so the multi-field auto pipeline gains the abbreviation/cross-lingual
+recall. **Gate on a measurement:** `auto+fields` + semantic blocking must clear
+0.602 to count as a headline move. The synonym/brand class will remain walled
+regardless and should be scoped out (or addressed separately via a domain/knowledge
+source). This is a real product change and gets its own spec + plan before any code.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/scripts/embed_recall_probe.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/scripts/embed_recall_probe.py
@@ -1,0 +1,132 @@
+"""Recall-lever probe: does semantic-embedding candidate generation crack the
+recall-bound ER-KG-Bench classes (abbreviation / synonym / cross_lingual) that
+string blocking + char-ngram embeddings miss?
+
+For each embedder tier: embed the corpus mentions, sweep the cosine threshold,
+cluster (union-find over pairs >= thr), score per-class. Reports the best-overall
+threshold + the recall-bound classes specifically. This is a MEASUREMENT (not a
+committed board row) -- it quantifies the lever before we wire it into the pipeline.
+
+    python scripts/embed_recall_probe.py st st-multi      # free downloadable models
+    python scripts/embed_recall_probe.py inhouse openai   # local: no-knowledge vs paid
+
+Tiers:
+  inhouse  goldenmatch char-ngram embedder (no world knowledge) -- today's emb-ann. Local.
+  openai   goldenmatch resolve_provider("openai") semantic embedder. Needs OPENAI_API_KEY.
+  st       sentence-transformers all-MiniLM-L6-v2 (free, English). Needs torch -> CI.
+  st-multi sentence-transformers paraphrase-multilingual-MiniLM-L12-v2 (free, multilingual).
+"""
+from __future__ import annotations
+
+import csv
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+BENCH = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("erkg_metrics", BENCH / "erkgbench" / "metrics.py")
+assert _spec is not None and _spec.loader is not None
+metrics = importlib.util.module_from_spec(_spec)
+sys.modules["erkg_metrics"] = metrics
+_spec.loader.exec_module(metrics)
+
+records, eids, classes = [], [], []
+with open(BENCH / "dataset" / "records.csv", encoding="utf-8") as fh:
+    for row in csv.DictReader(fh):
+        records.append((int(row["record_id"]), row["mention"], row["entity_type"]))
+        eids.append(row["entity_id"])
+        classes.append(row["failure_class"])
+MENTIONS = [m for _, m, _ in records]
+N = len(records)
+
+_CLASS_ORDER = [
+    "abbreviation", "synonym_brand", "cross_lingual", "nickname_alias",
+    "org_suffix", "typo", "temporal_version", "same_name_collision",
+    "cross_document_exact",
+]
+_RECALL_BOUND = ("abbreviation", "synonym_brand", "cross_lingual")
+_ST_MODELS = {
+    "st": "sentence-transformers/all-MiniLM-L6-v2",
+    "st-multi": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+}
+
+
+def embed(tier: str) -> np.ndarray:
+    if tier == "inhouse":
+        from goldenmatch.embeddings.inhouse.model import GoldenEmbedModel
+        return np.asarray(GoldenEmbedModel().embed(MENTIONS), dtype=np.float32)
+    if tier == "openai":
+        from goldenmatch.embeddings.providers import resolve_provider
+        return np.asarray(resolve_provider("openai").embed(MENTIONS), dtype=np.float32)
+    if tier in _ST_MODELS:
+        from sentence_transformers import SentenceTransformer
+        model = SentenceTransformer(_ST_MODELS[tier])
+        return np.asarray(model.encode(MENTIONS, normalize_embeddings=False), dtype=np.float32)
+    raise SystemExit(f"unknown tier {tier!r}")
+
+
+def clusters_at(sim: np.ndarray, thr: float) -> list[list[int]]:
+    parent = list(range(N))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for i in range(N):
+        row = sim[i]
+        for j in range(i + 1, N):
+            if row[j] >= thr:
+                ri, rj = find(i), find(j)
+                if ri != rj:
+                    parent[rj] = ri
+    groups: dict[int, list[int]] = {}
+    for i in range(N):
+        groups.setdefault(find(i), []).append(i)
+    return [sorted(v) for v in groups.values()]
+
+
+def sweep(tier: str) -> None:
+    print(f"\n=== {tier} ===", flush=True)
+    vecs = embed(tier)
+    norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+    vecs = vecs / np.where(norms == 0.0, 1.0, norms)
+    sim = vecs @ vecs.T
+    best_f1, best_thr, best_p, best_r = -1.0, 0.0, 0.0, 0.0
+    best_perclass: dict[str, float] = {}
+    for thr in [round(float(x), 2) for x in np.arange(0.30, 0.96, 0.05)]:
+        clustering = clusters_at(sim, thr)
+        bc = metrics.score_by_class(eids, classes, clustering)
+        o = bc["__overall__"]
+        rb = float(np.mean([bc[c].f1 for c in _RECALL_BOUND if c in bc]))
+        print(f"  thr={thr:.2f}  P={o.precision:.3f} R={o.recall:.3f} F1={o.f1:.3f}  "
+              f"recall-bound-F1={rb:.3f}", flush=True)
+        if o.f1 > best_f1:
+            best_f1, best_thr, best_p, best_r = o.f1, thr, o.precision, o.recall
+            best_perclass = {
+                str(c): float(bc[c].f1) for c in bc if c != "__overall__"
+            }
+    print(f"  -> BEST overall thr={best_thr:.2f}  P={best_p:.3f} "
+          f"R={best_r:.3f} F1={best_f1:.3f}", flush=True)
+    for c in _CLASS_ORDER:
+        if c in best_perclass:
+            mark = "  <- recall-bound" if c in _RECALL_BOUND else ""
+            print(f"       {c:20s} {best_perclass[c]:.3f}{mark}", flush=True)
+
+
+def main() -> None:
+    tiers = sys.argv[1:] or ["inhouse"]
+    print(f"corpus: {N} records / {len(set(eids))} entities", flush=True)
+    for tier in tiers:
+        if tier == "openai" and not os.environ.get("OPENAI_API_KEY"):
+            print(f"\n[skip {tier}: no OPENAI_API_KEY]", flush=True)
+            continue
+        sweep(tier)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds reproducible tooling to measure whether **semantic-embedding candidate generation** cracks the recall-bound ER-KG-Bench classes (abbreviation / synonym / cross_lingual) that string blocking + the in-house char-ngram embedder miss. This is the lever three prior measurements (Phase-2 embedder, auto+llm, mem0) all pointed at.

- `scripts/embed_recall_probe.py` — embeds the corpus per embedder tier (inhouse / openai / st / st-multi), sweeps cosine thresholds, scores per-class.
- `.github/workflows/embed-recall-probe.yml` — `workflow_dispatch` to measure the FREE downloadable tiers (MiniLM + multilingual MiniLM) in CI (torch hangs on the dev box).

**Measured locally already:** in-house char-ngram best F1 **0.451** (abbreviation 0.208 / cross_lingual 0.345); OpenAI semantic best F1 **0.558** (abbreviation **0.800** / cross_lingual **0.769**, synonym/brand stays ~flat 0.18 — specialized knowledge a general embedder lacks). This PR lets us fill in the free tier: does MiniLM (and a multilingual variant) get the abbreviation/cross-lingual win without a key?

No board row changes; pure measurement tooling. Result informs whether to wire semantic candidate generation into goldenmatch's blocking as a free default or a keyed opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)