### PR TITLE
Issue-audit wave: graph-layout CI (#1026), carceral aliases (#1010), native telemetry + bucket multipass fix (#1048/#957)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1080,6 +1080,7 @@ jobs:
             packages/rust/extensions
             packages/rust/extensions/graph-core
             packages/rust/extensions/score-core
+            packages/rust/extensions/graph-layout
       - run: cargo test --workspace
         # Bridge tests now hard-require goldenmatch (installed above) -- a Python
         # import/marshalling failure fails the lane instead of silently skipping.
@@ -1095,6 +1096,11 @@ jobs:
       - run: cargo clippy --manifest-path graph-core/Cargo.toml -- -D warnings
       - run: cargo test --manifest-path score-core/Cargo.toml
       - run: cargo clippy --manifest-path score-core/Cargo.toml -- -D warnings
+      # graph-layout is its own [workspace] too (demo binary, in the parent
+      # `exclude` list), so `cargo test --workspace` never builds it. The rust
+      # paths-filter already covers it (packages/rust/**). See #1026.
+      - run: cargo test --manifest-path graph-layout/Cargo.toml
+      - run: cargo clippy --manifest-path graph-layout/Cargo.toml -- -D warnings
 
   # Measured Rust line coverage (cargo-llvm-cov). The structural audit's unit
   # tests (graph-core / score-core / fingerprint-core / native / bridge) are now

--- a/packages/python/goldenflow/goldenflow/domains/carceral.py
+++ b/packages/python/goldenflow/goldenflow/domains/carceral.py
@@ -21,9 +21,14 @@ problems this pack solves are:
 3. **State-prison-complex aliases.** Arizona's HIFLD names start with
    ``ASPC-`` while ECHO files them as ``ASP -`` / ``APS-`` (typo).
    Without aliasing, Jaro-Winkler on those names drops below 0.65;
-   with aliasing, real positives clear 0.97. Empirically the dominant
-   pattern in AZ; equivalent state-specific aliases for TX TDCJ, PA
-   SCI, CA CDCR remain TODO and are a natural extension here.
+   with aliasing, real positives clear 0.97. The same HIFLD-vs-ECHO
+   abbreviation split holds for PA (``SCI`` vs ``STATE CORRECTIONAL
+   INSTITUTION``) and CA (``CSP``/``CCI``/``CIM``/``CIW``/``CTF`` vs
+   their CDCR long forms), which are aliased here too. TX (TDCJ) units
+   have no analogous facility abbreviation — they're ``<name> Unit`` on
+   both sides — so the TX win comes from the operator-prefix stripper
+   recognizing the spelled-out ``TEXAS DEPARTMENT OF CRIMINAL JUSTICE``
+   (see ``_OPERATOR_PHRASE_RE``), not from an alias.
 
 The pack does **not** redefine address / ZIP / state / unit
 normalization — it composes the existing ``address_standardize``,
@@ -60,7 +65,10 @@ CARCERAL_OPERATOR_ORGS: frozenset[str] = frozenset({
 _OPERATOR_PHRASE_RE = re.compile(
     r"^(?:"
     r"(?:[A-Z]{2}|TEXAS|CALIFORNIA|FLORIDA|MISSISSIPPI|GEORGIA|INDIANA)"
-    r"\s+DEPT?\s+OF\s+(?:CORR(?:ECTIONS?)?|CRIM(?:INAL)?\s+JUST(?:ICE)?)"
+    # DEP / DEPT / DEPARTMENT — ECHO spells the agency out in full
+    # ("TEXAS DEPARTMENT OF CRIMINAL JUSTICE - ALLRED UNIT") while HIFLD
+    # ships just the unit name; both must strip to the same stem.
+    r"\s+DEP(?:T|ARTMENT)?\s+OF\s+(?:CORR(?:ECTIONS?)?|CRIM(?:INAL)?\s+JUST(?:ICE)?)"
     r")\s*[,\-:/]\s*"
 )
 
@@ -85,10 +93,28 @@ CARCERAL_BOP_ABBREVIATIONS: dict[str, str] = {
 #: uses a different one (sometimes a typo). Both sides are mapped to the
 #: long form so the name scorer sees a common prefix. Add more here as
 #: per-state patterns are discovered.
+#:
+#: Note these are word-bounded global expansions, not state-scoped — a
+#: token that means different things in two states (e.g. CA's Avenal
+#: State Prison is also "ASP") will be expanded to the listed long form
+#: regardless of state. That can mislabel a name but never fuses two
+#: *different* facilities: if both sides genuinely refer to the same
+#: place they expand identically; if they don't, they still differ.
 CARCERAL_STATE_COMPLEX_ALIASES: dict[str, str] = {
+    # Arizona (HIFLD "ASPC-" vs ECHO "ASP -" / "APS-" typo)
     "ASPC": "ARIZONA STATE PRISON COMPLEX",
     "ASP": "ARIZONA STATE PRISON",
     "APS": "ARIZONA STATE PRISON",  # observed ECHO typo for "ASP"
+    # Pennsylvania (HIFLD "SCI <name>" vs ECHO "STATE CORRECTIONAL
+    # INSTITUTION <name>")
+    "SCI": "STATE CORRECTIONAL INSTITUTION",
+    # California CDCR facility-type abbreviations (HIFLD short vs ECHO
+    # long form). Multi-letter, so word-bounded expansion is safe.
+    "CSP": "CALIFORNIA STATE PRISON",
+    "CCI": "CALIFORNIA CORRECTIONAL INSTITUTION",
+    "CIM": "CALIFORNIA INSTITUTION FOR MEN",
+    "CIW": "CALIFORNIA INSTITUTION FOR WOMEN",
+    "CTF": "CORRECTIONAL TRAINING FACILITY",
 }
 
 _OPERATOR_SUFFIX_RE = re.compile(r"\b(LLC|INC|CORP|CO|LTD)\b\.?\s*$")

--- a/packages/python/goldenflow/tests/domains/test_carceral.py
+++ b/packages/python/goldenflow/tests/domains/test_carceral.py
@@ -42,6 +42,10 @@ def test_constants_are_frozen():
     assert "GEO" in CARCERAL_OPERATOR_ORGS
     assert "USP" in CARCERAL_BOP_ABBREVIATIONS
     assert "ASPC" in CARCERAL_STATE_COMPLEX_ALIASES
+    # PA + CA aliases (HIFLD short form vs ECHO long form)
+    assert CARCERAL_STATE_COMPLEX_ALIASES["SCI"] == "STATE CORRECTIONAL INSTITUTION"
+    assert CARCERAL_STATE_COMPLEX_ALIASES["CSP"] == "CALIFORNIA STATE PRISON"
+    assert "CIW" in CARCERAL_STATE_COMPLEX_ALIASES
 
 
 # ── carceral_org_strip ─────────────────────────────────────────────────
@@ -188,6 +192,51 @@ def test_name_normalize_arizona_aspc_pattern():
     assert "ARIZONA STATE PRISON" in out[1]
     assert "LEWIS" in out[0]
     assert "LEWIS" in out[1]
+
+
+# ── Per-state HIFLD-vs-ECHO collapse (TX / PA / CA) ─────────────────────
+#
+# One pair per state where the two sources name the same facility
+# differently enough that raw Jaro-Winkler falls below the match
+# threshold, and `carceral_name_normalize` collapses both to an identical
+# string (JW = 1.0). The `raw[0] != raw[1]` asserts capture the
+# "diverges before" half; the normalized equality captures "clears after".
+
+
+def test_name_normalize_pennsylvania_sci_pattern():
+    """PA: HIFLD ``SCI ALBION`` vs ECHO ``STATE CORRECTIONAL INSTITUTION
+    ALBION`` — the ``SCI`` abbreviation is the only difference."""
+    raw = ["SCI ALBION", "STATE CORRECTIONAL INSTITUTION ALBION"]
+    assert raw[0] != raw[1]
+    out = carceral_name_normalize(pl.Series("name", raw))
+    assert out[0] == out[1] == "STATE CORRECTIONAL INSTITUTION ALBION"
+
+
+def test_name_normalize_california_csp_pattern():
+    """CA: HIFLD ``CSP SOLANO`` vs ECHO ``CALIFORNIA STATE PRISON SOLANO``."""
+    raw = ["CSP SOLANO", "CALIFORNIA STATE PRISON SOLANO"]
+    assert raw[0] != raw[1]
+    out = carceral_name_normalize(pl.Series("name", raw))
+    assert out[0] == out[1] == "CALIFORNIA STATE PRISON SOLANO"
+
+
+def test_name_normalize_california_ciw_pattern():
+    """CA, second facility abbreviation: ``CIW`` vs the CDCR long form."""
+    raw = ["CIW CHINO", "CALIFORNIA INSTITUTION FOR WOMEN CHINO"]
+    assert raw[0] != raw[1]
+    out = carceral_name_normalize(pl.Series("name", raw))
+    assert out[0] == out[1] == "CALIFORNIA INSTITUTION FOR WOMEN CHINO"
+
+
+def test_name_normalize_texas_tdcj_full_department_prefix():
+    """TX: TDCJ units have no facility abbreviation, so the win is the
+    operator-prefix stripper recognizing the spelled-out agency name.
+    HIFLD ``ALLRED UNIT`` vs ECHO ``TEXAS DEPARTMENT OF CRIMINAL JUSTICE
+    - ALLRED UNIT`` (full word ``DEPARTMENT``, previously unstripped)."""
+    raw = ["ALLRED UNIT", "TEXAS DEPARTMENT OF CRIMINAL JUSTICE - ALLRED UNIT"]
+    assert raw[0] != raw[1]
+    out = carceral_name_normalize(pl.Series("name", raw))
+    assert out[0] == out[1] == "ALLRED UNIT"
 
 
 # ── latlng_pack ────────────────────────────────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -30,6 +30,7 @@ except ImportError:  # pragma: no cover
 from goldenmatch.core.autoconfig_verify import PostflightReport
 
 if TYPE_CHECKING:
+    from goldenmatch.core._native_loader import NativeDispatchSummary
     from goldenmatch.core.memory.corrections import CorrectionStats
     from goldenmatch.core.recall_certificate import RecallEstimate
 
@@ -157,6 +158,11 @@ class DedupeResult:
     # config; goldenmatch.core.config_lint.Finding). Empty unless the linter
     # flagged something. Advisory in the default warn mode.
     lint_findings: list = field(default_factory=list)
+    # Native-kernel dispatch summary for THIS run (#1048, #957): did the scoring
+    # hot path dispatch to the Rust kernel, or fall back to pure Python?
+    # `result.native.hot_path_native` confirms dispatch directly instead of
+    # inferring it from wall-clock. None only if telemetry capture was skipped.
+    native: NativeDispatchSummary | None = None
 
     def to_csv(self, path: str, which: str = "golden") -> Path:
         """Write results to CSV.
@@ -253,6 +259,8 @@ class MatchResult:
     memory_stats: CorrectionStats | None = None
     # Pre-flight config-lint findings (see DedupeResult.lint_findings).
     lint_findings: list = field(default_factory=list)
+    # Native-kernel dispatch summary for THIS run (see DedupeResult.native).
+    native: NativeDispatchSummary | None = None
 
     def to_csv(self, path: str) -> Path:
         """Write matched results to CSV."""
@@ -444,6 +452,9 @@ def dedupe_df(
     # OR'd in by the resolver itself; here we only propagate the kwarg
     # so it's visible even when the user passes a hand-written config.
     _kwarg_token = None
+    # Native-dispatch baseline; set just before the full-data pipeline so the
+    # summary reflects the real dedupe scoring, not auto-config sample runs.
+    _native_baseline: dict[str, dict[str, int]] = {}
     if exclude_columns:
         _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(exclude_columns))
 
@@ -521,6 +532,8 @@ def dedupe_df(
             _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(cfg_excl))
 
         _lint_findings = _run_config_lint(df, config)
+        from goldenmatch.core._native_loader import native_dispatch_report
+        _native_baseline = native_dispatch_report()
         result = run_dedupe_df(
             df, config, source_name=source_name,
             auto_config=False,
@@ -575,6 +588,12 @@ def dedupe_df(
 
     _capture_run("dedupe_run", df, config, had_reference=False)
 
+    # Native-dispatch telemetry (#1048, #957): summarize whether scoring went
+    # native this run and WARN if the kernel was importable but scoring fell back.
+    from goldenmatch.core._native_loader import summarize_native_dispatch, warn_if_slow_path
+    _native = summarize_native_dispatch(baseline=_native_baseline)
+    warn_if_slow_path(_native, logger)
+
     return DedupeResult(
         golden=result.get("golden"),
         clusters=result.get("clusters", {}),
@@ -587,6 +606,7 @@ def dedupe_df(
         memory_stats=_mem,
         recall_certificate=_recall_cert,
         lint_findings=_lint_findings,
+        native=_native,
     )
 
 
@@ -638,6 +658,7 @@ def match_df(
     # Same exclude_columns plumbing as dedupe_df -- ContextVar before any
     # pipeline step so auto-config + GoldenFlow transforms both see it.
     _kwarg_token = None
+    _native_baseline: dict[str, dict[str, int]] = {}
     if exclude_columns:
         _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(exclude_columns))
 
@@ -692,6 +713,8 @@ def match_df(
             _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(cfg_excl))
 
         _lint_findings = _run_config_lint(target, config)
+        from goldenmatch.core._native_loader import native_dispatch_report
+        _native_baseline = native_dispatch_report()
         result = run_match_df(target, reference, config, auto_config=False)
     finally:
         if _kwarg_token is not None:
@@ -724,6 +747,10 @@ def match_df(
 
     _capture_run("match_run", target, config, had_reference=True)
 
+    from goldenmatch.core._native_loader import summarize_native_dispatch, warn_if_slow_path
+    _native = summarize_native_dispatch(baseline=_native_baseline)
+    warn_if_slow_path(_native, logger)
+
     return MatchResult(
         matched=result.get("matched"),
         unmatched=result.get("unmatched"),
@@ -731,6 +758,7 @@ def match_df(
         postflight_report=pf,
         memory_stats=_mem,
         lint_findings=_lint_findings,
+        native=_native,
     )
 
 

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -487,7 +487,17 @@ def score_buckets(
     """
     if prepared_df.height == 0:
         return []
-    if not blocking_config.keys:
+    # Resolve the block-key list HONORING multi-pass blocking: a `multi_pass`
+    # config carries its keys in `.passes` with `.keys` empty (the schema
+    # explicitly allows keys-OR-passes), so the empty-config guard must check
+    # the RESOLVED pass list, not `.keys` alone. Guarding on `.keys` made an
+    # explicit multi-pass union config (e.g. soundex(surname) + exact(email))
+    # silently return zero pairs -> 0 clusters, while a single-key static config
+    # worked -- issue #1048. `passes` is None for static/single-key configs, so
+    # fall back to `keys`; only a config with NEITHER (nothing to block on)
+    # returns empty, matching the no-candidate-pairs semantics.
+    pass_keys = blocking_config.passes or blocking_config.keys
+    if not pass_keys:
         return []
 
     # Probabilistic (Fellegi-Sunter) matchkeys ride the same bucket
@@ -500,9 +510,6 @@ def score_buckets(
             "score_buckets: probabilistic matchkey requires a trained em_result."
         )
 
-    # Multi-pass blocking: iterate every pass and accumulate pairs. `passes`
-    # is None for static / single-key configs, so fall back to `keys`.
-    pass_keys = blocking_config.passes or blocking_config.keys
 
     # Oversized-block skip (parity with polars-direct's build_blocks in
     # core/blocker.py). Read once and close over in the nested scoring

--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -168,3 +169,159 @@ def native_enabled(component: str) -> bool:
     result = _native is not None and component in _GATED_ON
     _record_dispatch(component, result)
     return result
+
+
+# Components that constitute the scoring "hot path" -- the per-field / per-block
+# kernels whose dispatch determines throughput. ``field_scoring`` is the
+# polars-direct default's cdist-shaped score matrix; ``block_scoring`` is the
+# bucket backend's per-block kernel. Whether THESE went native is the question
+# #1048 / #957 ask (clustering / hashing / featurize are not throughput-shaped
+# scoring, so they don't gate the slow-path warning).
+_HOT_PATH_COMPONENTS: frozenset[str] = frozenset({"block_scoring", "field_scoring"})
+
+# Process-level "warn once" guard, keyed by call site, so a distributed run
+# doesn't log the slow-path WARNING once per scored batch.
+_SLOW_PATH_WARNED: set[str] = set()
+
+
+@dataclass(frozen=True)
+class NativeDispatchSummary:
+    """Whether THIS run's scoring dispatched to the native kernel.
+
+    Attached to ``DedupeResult.native`` / ``MatchResult.native`` so a caller can
+    *confirm* native dispatch (``hot_path_native``) instead of inferring it from
+    wall-clock (#1048). Built from the per-component dispatch counts via
+    :func:`summarize_native_dispatch`.
+
+    Attributes:
+        available: the native kernel was importable this process.
+        mode: the resolved ``GOLDENMATCH_NATIVE`` mode (``auto`` / ``0`` / ``1``).
+        components: per-component ``{native, fallback}`` counts for this run.
+        ran_native: any component dispatched to the kernel at least once.
+        hot_path_exercised: a scoring hot-path component ran at all this run
+            (False for e.g. a pure exact-match dedupe with no fuzzy scoring).
+        hot_path_native: the scoring hot path ran ENTIRELY on the kernel (every
+            hot-path dispatch went native, none fell back). The signal #1048
+            wanted: ``True`` means scoring really used the kernel.
+    """
+
+    available: bool
+    mode: str
+    components: dict[str, dict[str, int]] = field(default_factory=dict)
+    ran_native: bool = False
+    hot_path_exercised: bool = False
+    hot_path_native: bool = False
+
+    @property
+    def hot_path_native_calls(self) -> int:
+        return sum(
+            self.components.get(c, {}).get("native", 0) for c in _HOT_PATH_COMPONENTS
+        )
+
+    @property
+    def hot_path_fallback_calls(self) -> int:
+        return sum(
+            self.components.get(c, {}).get("fallback", 0) for c in _HOT_PATH_COMPONENTS
+        )
+
+    def slow_path_active(self) -> bool:
+        """The kernel was importable and scoring ran, but the hot path used the
+        pure-Python fallback (wholly or partly). NOT triggered when the user
+        forced Python with ``GOLDENMATCH_NATIVE=0`` (that's an explicit choice,
+        not a silent slow path)."""
+        return (
+            self.available
+            and self.mode != "0"
+            and self.hot_path_exercised
+            and not self.hot_path_native
+        )
+
+    def __str__(self) -> str:
+        comps = ", ".join(
+            f"{c} n={v.get('native', 0)}/f={v.get('fallback', 0)}"
+            for c, v in sorted(self.components.items())
+        )
+        return (
+            f"native(available={self.available}, mode={self.mode}, "
+            f"ran_native={self.ran_native}, hot_path_native={self.hot_path_native}"
+            f"{'; ' + comps if comps else ''})"
+        )
+
+
+def summarize_native_dispatch(
+    baseline: dict[str, dict[str, int]] | None = None,
+) -> NativeDispatchSummary:
+    """Build a :class:`NativeDispatchSummary` from the dispatch counters.
+
+    Pass ``baseline`` (a prior :func:`native_dispatch_report` snapshot) to scope
+    the summary to the dispatches that happened SINCE that snapshot -- the API
+    entry points snapshot just before the full-data pipeline so the summary
+    reflects the real dedupe scoring, not the auto-config sample iterations.
+    Counters only grow, so the delta is always non-negative.
+    """
+    current = native_dispatch_report()
+    if baseline:
+        report: dict[str, dict[str, int]] = {}
+        for comp, counts in current.items():
+            base = baseline.get(comp, {})
+            nat = counts.get("native", 0) - base.get("native", 0)
+            fb = counts.get("fallback", 0) - base.get("fallback", 0)
+            if nat or fb:
+                report[comp] = {"native": nat, "fallback": fb}
+    else:
+        report = current
+
+    ran_native = any(c.get("native", 0) > 0 for c in report.values())
+    hot = {c: report[c] for c in _HOT_PATH_COMPONENTS if c in report}
+    hot_exercised = any(
+        (v.get("native", 0) + v.get("fallback", 0)) > 0 for v in hot.values()
+    )
+    # Fully native iff every hot-path component that ran went native with no
+    # fallback. A single fallback (an ungated/uncompiled scorer) flips this off.
+    hot_native = hot_exercised and all(
+        v.get("fallback", 0) == 0 and v.get("native", 0) > 0 for v in hot.values()
+    )
+    mode = os.environ.get("GOLDENMATCH_NATIVE", "auto").lower()
+    return NativeDispatchSummary(
+        available=native_available(),
+        mode=mode,
+        components=report,
+        ran_native=ran_native,
+        hot_path_exercised=hot_exercised,
+        hot_path_native=hot_native,
+    )
+
+
+def warn_if_slow_path(
+    summary: NativeDispatchSummary,
+    log: logging.Logger | None = None,
+    *,
+    once_key: str | None = None,
+) -> bool:
+    """Log a WARNING when ``summary.slow_path_active()`` -- the kernel is
+    importable but scoring ran on the pure-Python fallback (#957: never silently
+    eat the slow path; #1048: make the slow path diagnosable). Returns whether a
+    warning was emitted. ``once_key`` de-dupes per process (used by the
+    distributed workers so each logs at most once)."""
+    if not summary.slow_path_active():
+        return False
+    if once_key is not None:
+        if once_key in _SLOW_PATH_WARNED:
+            return False
+        _SLOW_PATH_WARNED.add(once_key)
+    (log or logger).warning(
+        "goldenmatch native kernel is importable but the scoring hot path ran "
+        "on the pure-Python fallback this run (hot-path native=%d, fallback=%d). "
+        "Throughput is the slow path. Likely causes: a matchkey scorer with no "
+        "native kernel, or a component off the GOLDENMATCH_NATIVE=auto allowlist "
+        "-- set GOLDENMATCH_NATIVE=1 to require native on every supported "
+        "component. Inspect result.native for the per-component breakdown.",
+        summary.hot_path_native_calls,
+        summary.hot_path_fallback_calls,
+    )
+    return True
+
+
+def reset_slow_path_warned() -> None:
+    """Clear the per-process slow-path warn-once guard (test isolation)."""
+    _SLOW_PATH_WARNED.clear()

--- a/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
@@ -109,6 +109,33 @@ def _apply_ray_data_resource_tuning() -> None:
         logger.warning("Ray Data resource tuning failed (ignored): %s", e)
 
 
+def _native_worker_baseline() -> dict[str, dict[str, int]]:
+    """Snapshot the worker process's native-dispatch counters before scoring a
+    partition, so :func:`_warn_worker_slow_path` can summarize just this batch."""
+    try:
+        from goldenmatch.core._native_loader import native_dispatch_report
+        return native_dispatch_report()
+    except Exception:  # telemetry must never break a scoring task
+        return {}
+
+
+def _warn_worker_slow_path(baseline: dict[str, dict[str, int]]) -> None:
+    """#957: each Ray worker self-reports (once) if its scoring hot path fell
+    back to pure Python while the native kernel was importable -- so a silently
+    slow distributed run is visible in worker logs rather than only inferable
+    from a low cluster-CPU utilization curve. Worker-local: each worker process
+    has its own dispatch counters + warn-once guard."""
+    try:
+        from goldenmatch.core._native_loader import (
+            summarize_native_dispatch,
+            warn_if_slow_path,
+        )
+        summary = summarize_native_dispatch(baseline=baseline)
+        warn_if_slow_path(summary, logger, once_key="distributed_score")
+    except Exception:  # telemetry must never break a scoring task
+        pass
+
+
 def _project_to_scoring_columns(df: Any, config: GoldenMatchConfig) -> Any:
     """Drop columns scoring never reads, BEFORE the block-shuffle (#957).
 
@@ -234,11 +261,13 @@ def _score_blocks_legacy(
             local_cfg = copy.deepcopy(config)
         local_cfg.backend = "bucket"
 
+        _native_base = _native_worker_baseline()
         try:
             pairs = _score_partition_with_config(df, local_cfg)
         except Exception as e:
             logger.warning("partition scoring failed: %s", e)
             return pa.table({"id_a": [], "id_b": [], "score": []})
+        _warn_worker_slow_path(_native_base)
 
         if not pairs:
             return pa.table({"id_a": [], "id_b": [], "score": []})
@@ -463,7 +492,9 @@ def _score_blocks_block_shuffle(
         import pyarrow as pa
         df = pl.from_arrow(batch)
         assert isinstance(df, pl.DataFrame)
+        _native_base = _native_worker_baseline()
         pairs = _score_colocated_groups(df, config)
+        _warn_worker_slow_path(_native_base)
         if not pairs:
             return pa.table({"id_a": [], "id_b": [], "score": []})
         return pa.table({

--- a/packages/python/goldenmatch/tests/test_native_dispatch_telemetry.py
+++ b/packages/python/goldenmatch/tests/test_native_dispatch_telemetry.py
@@ -1,0 +1,153 @@
+"""Native-dispatch telemetry on the result object (#1048, #957).
+
+Covers the per-run ``NativeDispatchSummary`` builder, the slow-path WARNING
+("never silently eat the slow path"), and that ``dedupe_df`` / ``match_df``
+attach the summary so callers can CONFIRM native dispatch instead of inferring
+it from wall-clock.
+"""
+from __future__ import annotations
+
+import logging
+
+import goldenmatch as gm
+import polars as pl
+import pytest
+from goldenmatch.core import _native_loader as nl
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dispatch_log():
+    """Each test starts from clean per-process dispatch + warn-once state."""
+    nl.reset_native_dispatch_log()
+    nl.reset_slow_path_warned()
+    yield
+    nl.reset_native_dispatch_log()
+    nl.reset_slow_path_warned()
+
+
+# ── summarize_native_dispatch ───────────────────────────────────────────
+
+
+def test_summary_booleans_from_native_dispatch():
+    nl._record_dispatch("field_scoring", True)
+    nl._record_dispatch("field_scoring", True)
+    s = nl.summarize_native_dispatch()
+    assert s.ran_native is True
+    assert s.hot_path_exercised is True
+    assert s.hot_path_native is True
+    assert s.hot_path_native_calls == 2
+    assert s.hot_path_fallback_calls == 0
+
+
+def test_summary_fallback_flips_hot_path_native_off():
+    nl._record_dispatch("field_scoring", True)
+    nl._record_dispatch("field_scoring", False)  # one block fell back
+    s = nl.summarize_native_dispatch()
+    assert s.hot_path_exercised is True
+    assert s.hot_path_native is False  # any fallback => not fully native
+    assert s.hot_path_native_calls == 1
+    assert s.hot_path_fallback_calls == 1
+
+
+def test_summary_baseline_delta_scopes_to_this_run():
+    nl._record_dispatch("field_scoring", True)  # belongs to a prior run
+    baseline = nl.native_dispatch_report()
+    nl._record_dispatch("field_scoring", False)  # this run
+    s = nl.summarize_native_dispatch(baseline=baseline)
+    # Only the post-baseline dispatch is counted.
+    assert s.components["field_scoring"] == {"native": 0, "fallback": 1}
+
+
+def test_summary_non_hot_path_component_not_counted_as_hot():
+    nl._record_dispatch("clustering", False)
+    s = nl.summarize_native_dispatch()
+    assert s.hot_path_exercised is False  # clustering is not the scoring hot path
+    assert s.slow_path_active() is False
+
+
+def test_summary_str_is_readable():
+    nl._record_dispatch("field_scoring", True)
+    assert "field_scoring" in str(nl.summarize_native_dispatch())
+
+
+# ── warn_if_slow_path ───────────────────────────────────────────────────
+
+
+def test_warn_fires_when_available_but_fell_back(monkeypatch, caplog):
+    monkeypatch.setattr(nl, "native_available", lambda: True)
+    monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)  # auto
+    nl._record_dispatch("field_scoring", False)
+    s = nl.summarize_native_dispatch()
+    assert s.slow_path_active() is True
+    with caplog.at_level(logging.WARNING):
+        assert nl.warn_if_slow_path(s, once_key="t") is True
+    assert any("pure-Python fallback" in r.message for r in caplog.records)
+    # once_key de-dupes: a second call with the same key is silent.
+    assert nl.warn_if_slow_path(s, once_key="t") is False
+
+
+def test_no_warn_when_fully_native(monkeypatch):
+    monkeypatch.setattr(nl, "native_available", lambda: True)
+    monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+    nl._record_dispatch("block_scoring", True)
+    s = nl.summarize_native_dispatch()
+    assert s.slow_path_active() is False
+    assert nl.warn_if_slow_path(s, once_key="x") is False
+
+
+def test_no_warn_when_forced_python(monkeypatch):
+    monkeypatch.setattr(nl, "native_available", lambda: True)
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")  # explicit user choice
+    nl._record_dispatch("block_scoring", False)
+    s = nl.summarize_native_dispatch()
+    assert s.mode == "0"
+    assert s.slow_path_active() is False
+
+
+def test_no_warn_when_native_unavailable(monkeypatch):
+    monkeypatch.setattr(nl, "native_available", lambda: False)
+    monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+    nl._record_dispatch("field_scoring", False)
+    s = nl.summarize_native_dispatch()
+    assert s.available is False
+    assert s.slow_path_active() is False  # nothing to warn about
+
+
+# ── dedupe_df / match_df integration ────────────────────────────────────
+
+
+def _fuzzy_frame(n: int = 400) -> pl.DataFrame:
+    """A blocked fuzzy shape large enough to drive the cdist score-matrix path
+    (the hot path that records ``field_scoring``)."""
+    import random
+
+    random.seed(1)
+    first = ["John", "Jon", "Alice", "Alyce", "Bob", "Rob", "Mary", "Mari"]
+    last = ["Smith", "Smyth", "Lee", "Lea", "Jones", "Jonas"]
+    rows = [
+        {
+            "id": i,
+            "name": f"{random.choice(first)} {random.choice(last)}",
+            "zip": f"{random.randint(1000, 1010)}",
+        }
+        for i in range(n)
+    ]
+    return pl.DataFrame(rows)
+
+
+def test_dedupe_df_attaches_native_summary():
+    res = gm.dedupe_df(_fuzzy_frame(), fuzzy={"name": 0.85}, blocking=["zip"])
+    assert res.native is not None
+    # A fuzzy matchkey over a blocked frame exercises the scoring hot path; the
+    # cdist field-score matrix records `field_scoring` whether it dispatched to
+    # the kernel (native build present) or fell back to rapidfuzz.
+    assert res.native.hot_path_exercised is True
+    assert "field_scoring" in res.native.components
+
+
+def test_match_df_attaches_native_summary():
+    target = pl.DataFrame({"id": [1, 2], "name": ["John Smith", "Mary Jones"]})
+    reference = pl.DataFrame({"id": [10, 11], "name": ["Jon Smith", "Mary Jones"]})
+    res = gm.match_df(target, reference, fuzzy={"name": 0.8})
+    assert res.native is not None
+    assert isinstance(res.native.ran_native, bool)

--- a/packages/python/goldenmatch/tests/test_score_buckets_multipass.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_multipass.py
@@ -140,3 +140,30 @@ def test_missing_pass_field_is_skipped():
     )
     bucket = _multi_member_clusters(df, cfg, "bucket")  # must not raise
     assert frozenset({10, 11}) in bucket
+
+
+def test_bucket_honors_multipass_with_empty_keys():
+    """#1048 part 1: a multi_pass config with EMPTY ``keys`` (the keys live in
+    ``.passes`` -- the schema explicitly allows keys-OR-passes) silently
+    returned 0 clusters from the bucket backend, because score_buckets guarded
+    on ``blocking_config.keys`` alone instead of the resolved pass list. Every
+    OTHER parity test in this file sets a non-empty ``keys`` alongside
+    ``passes``, so none exercised this shape -- which is exactly the showcase's
+    config (soundex(surname) + exact(email) union passes, no static key).
+    """
+    df = _fixture_df()
+    from goldenmatch.core.autoconfig import auto_configure_df
+    cfg = auto_configure_df(df)
+    cfg.blocking = BlockingConfig(
+        strategy="multi_pass",
+        keys=[],  # the showcase shape: keys empty, passes carry the blocking
+        passes=[BlockingKeyConfig(fields=["city"]), BlockingKeyConfig(fields=["zip"])],
+    )
+    cfg.matchkeys = [_name_matchkey()]
+    assert not cfg.blocking.keys and cfg.blocking.passes and len(cfg.blocking.passes) == 2
+
+    bucket = _multi_member_clusters(df, cfg, "bucket")
+    polars = _multi_member_clusters(df, cfg, "polars-direct")
+    # Rows 10/11 ("john smith", shared zip 99999) must cluster; was 0 before fix.
+    assert frozenset({10, 11}) in bucket
+    assert bucket == polars

--- a/packages/rust/extensions/graph-layout/src/layout.rs
+++ b/packages/rust/extensions/graph-layout/src/layout.rs
@@ -54,18 +54,18 @@ pub fn step(g: &Graph, pos: &mut [V2], k: f32, theta: f32, temp: f32) {
     // --- attraction along edges: F = (d^2 / k) * weight, toward each other ---
     for &(a, b, w) in &g.edges {
         let (a, b) = (a as usize, b as usize);
-        let d = pos[b].sub(pos[a]);
+        let d = pos[b] - pos[a];
         let dist = d.len() + EPS;
         let mag = (dist / k) * w; // (d^2/k)/d * w, as a unit-vector scale
-        forces[a] = forces[a].add(d.scale(mag));
-        forces[b] = forces[b].sub(d.scale(mag));
+        forces[a] = forces[a] + d.scale(mag);
+        forces[b] = forces[b] - d.scale(mag);
     }
 
     // --- integrate with a temperature cap on displacement (cooling) ---
     for (p, f) in pos.iter_mut().zip(&forces) {
         let len = f.len() + EPS;
         let scale = len.min(temp) / len;
-        *p = p.add(f.scale(scale));
+        *p = *p + f.scale(scale);
     }
 }
 
@@ -122,7 +122,7 @@ pub fn run(g: &Graph, p: &Params, mut on_frame: impl FnMut(&[V2], u32)) -> Vec<V
             pos = (0..lvl.n)
                 .map(|i| {
                     prev[map[i] as usize]
-                        .add(V2::new(rng.unit() * p.k * 0.15, rng.unit() * p.k * 0.15))
+                        + V2::new(rng.unit() * p.k * 0.15, rng.unit() * p.k * 0.15)
                 })
                 .collect();
         }
@@ -165,17 +165,17 @@ mod tests {
         let centroid = |lo: usize, hi: usize| {
             let mut c = V2::ZERO;
             for i in lo..hi {
-                c = c.add(pos[i]);
+                c = c + pos[i];
             }
             c.scale(1.0 / (hi - lo) as f32)
         };
         let c0 = centroid(0, 25);
         let c1 = centroid(25, 50);
-        let inter = c1.sub(c0).len();
+        let inter = (c1 - c0).len();
         // Mean intra-cluster spread of blob 0.
         let mut spread = 0.0;
         for i in 0..25 {
-            spread += pos[i].sub(c0).len();
+            spread += (pos[i] - c0).len();
         }
         spread /= 25.0;
         assert!(

--- a/packages/rust/extensions/graph-layout/src/main.rs
+++ b/packages/rust/extensions/graph-layout/src/main.rs
@@ -176,7 +176,7 @@ fn main() {
     let synthetic = args.input.is_none();
     let (graph, source) = match &args.input {
         Some(path) => match Graph::read_edge_list(path) {
-            Ok((g, _labels)) => (g, format!("{path}")),
+            Ok((g, _labels)) => (g, path.to_string()),
             Err(e) => {
                 eprintln!("failed to read {path}: {e}");
                 exit(1);

--- a/packages/rust/extensions/graph-layout/src/quadtree.rs
+++ b/packages/rust/extensions/graph-layout/src/quadtree.rs
@@ -70,14 +70,14 @@ impl BarnesHut {
             if leaf && c.body == i as i32 {
                 continue; // never repel a body from itself
             }
-            let d = c.com.sub(pi);
+            let d = c.com - pi;
             let dist2 = d.len2() + EPS;
             let width = 2.0 * c.half;
             // Treat the cell as one body when it's a leaf, or far enough that
             // (width / dist) < theta  <=>  width^2 < theta^2 * dist^2.
             if leaf || width * width < theta2 * dist2 {
                 let mag = kk * c.mass / dist2; // k^2 * mass / d^2, away from com
-                f = f.sub(d.scale(mag));
+                f = f - d.scale(mag);
             } else {
                 for &ch in &c.kids {
                     if ch != NO_CHILD && sp < stack.len() {
@@ -121,7 +121,7 @@ fn build_rec(
         // Coincident-ish cluster: aggregate into a single leaf pseudo-body.
         let mut com = V2::ZERO;
         for &b in idx.iter() {
-            com = com.add(pos[b as usize]);
+            com = com + pos[b as usize];
         }
         let n = idx.len() as f32;
         let cell = &mut cells[me as usize];
@@ -154,7 +154,7 @@ fn build_rec(
         let ci = build_rec(cells, pos, bucket, nc, h, depth + 1);
         kids[k] = ci;
         let kid = &cells[ci as usize];
-        com = com.add(kid.com.scale(kid.mass));
+        com = com + kid.com.scale(kid.mass);
         mass += kid.mass;
     }
 
@@ -203,9 +203,9 @@ mod tests {
                 if j == i {
                     continue;
                 }
-                let d = pj.sub(pos[i]);
+                let d = pj - pos[i];
                 let dist2 = d.len2() + EPS;
-                f = f.sub(d.scale(k * k / dist2));
+                f = f - d.scale(k * k / dist2);
             }
             f
         };

--- a/packages/rust/extensions/graph-layout/src/vec2.rs
+++ b/packages/rust/extensions/graph-layout/src/vec2.rs
@@ -1,6 +1,8 @@
 //! Minimal 2D vector math (f32). No external dep; kept tiny so the hot loops
 //! inline cleanly.
 
+use std::ops::{Add, Sub};
+
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct V2 {
     pub x: f32,
@@ -15,14 +17,6 @@ impl V2 {
         V2 { x, y }
     }
     #[inline]
-    pub fn add(self, o: V2) -> V2 {
-        V2::new(self.x + o.x, self.y + o.y)
-    }
-    #[inline]
-    pub fn sub(self, o: V2) -> V2 {
-        V2::new(self.x - o.x, self.y - o.y)
-    }
-    #[inline]
     pub fn scale(self, s: f32) -> V2 {
         V2::new(self.x * s, self.y * s)
     }
@@ -33,5 +27,21 @@ impl V2 {
     #[inline]
     pub fn len(self) -> f32 {
         self.len2().sqrt()
+    }
+}
+
+impl Add for V2 {
+    type Output = V2;
+    #[inline]
+    fn add(self, o: V2) -> V2 {
+        V2::new(self.x + o.x, self.y + o.y)
+    }
+}
+
+impl Sub for V2 {
+    type Output = V2;
+    #[inline]
+    fn sub(self, o: V2) -> V2 {
+        V2::new(self.x - o.x, self.y - o.y)
     }
 }


### PR DESCRIPTION
Clears four issues from the audit, smallest-blast-radius first.

## #1026 — wire `goldenmatch-graph-layout` into the rust CI lane
- Adds explicit `--manifest-path` build/test/clippy lines (mirroring the `graph-core`/`score-core` precedent) plus a rust-cache workspace entry. The rust paths-filter (`packages/rust/**`) already covers the crate, so no `changes`-job edit was needed.
- Unblocked the `-D warnings` clippy line: implemented `std::ops::Add`/`Sub` for `V2` (was two `should_implement_trait` lints) and converted call sites to operators; also fixed a `useless_format` in `main.rs` that the pinned clippy 1.94 flags.
- Verified locally: `cargo test` (7 passed) + the exact CI clippy recipe (exit 0).

## #1010 — carceral state-prison aliases for PA + CA, TX prefix fix
Extends the carceral domain pack's HIFLD↔ECHO name reconciliation beyond Arizona, per the module docstring's TODO. Abbreviations grounded against real HIFLD/ECHO + CDCR/TDCJ naming:
- **PA**: `SCI` → `STATE CORRECTIONAL INSTITUTION`.
- **CA**: CDCR facility-type abbreviations `CSP`/`CCI`/`CIM`/`CIW`/`CTF` → long forms (multi-letter, so word-bounded expansion is safe; the Avenal-`ASP` collision with the existing AZ alias is noted but left as-is — pre-existing, and never fuses distinct facilities).
- **TX**: TDCJ units have no facility abbreviation, so the win is broadening the operator-prefix stripper to recognize the spelled-out `TEXAS DEPARTMENT OF CRIMINAL JUSTICE` (`DEPT?` → `DEP(T|ARTMENT)?`).
- One HIFLD-vs-ECHO collapse test per new state; full carceral suite green (22 passed).

## #1048 part 1 — bucket backend honors multi-pass union blocking (silent 0-clusters bug)
`dedupe_df(df, config=, backend="bucket")` with an explicit weighted matchkey + multi-pass **union** blocking config silently returned 0 clusters (too fast, no candidate pairs). Root cause: `score_buckets` guarded on `blocking_config.keys` alone and early-returned `[]` when empty — but a `multi_pass` config carries its keys in `.passes` (the schema explicitly allows keys-OR-passes), so the valid showcase config (soundex(surname) + exact(email) passes, no static key) was honored everywhere **except** that guard.
- Guard now checks the resolved pass list (`passes or keys` — the same value the scoring loop already iterates); only a config with neither returns empty. Single-key/static configs are byte-identical.
- The existing multi-pass parity tests all set a non-empty `keys` alongside `passes`, so none exercised the empty-keys shape — added a regression test (verified red before the fix) asserting the bucket path recovers the clusters and matches polars-direct.

## #1048 part 2 + #957 — native-dispatch telemetry on the result object
Callers could not tell whether scoring actually dispatched to the Rust kernel — `result.native` was absent, so wall-clock was the only signal. And on the distributed path a worker silently running the slow path was invisible.
- `_native_loader`: new `NativeDispatchSummary` (`ran_native` / `hot_path_native` / per-component native+fallback counts), `summarize_native_dispatch(baseline=)` (scopes to one run via a counter delta), and `warn_if_slow_path()` (WARNs when the kernel is importable but the scoring hot path fell back; `GOLDENMATCH_NATIVE=0` and native-unavailable never warn).
- `_api`: `dedupe_df` / `match_df` snapshot counters just before the full-data pipeline, attach the summary as `result.native`, and emit the slow-path WARNING. The baseline-delta excludes auto-config sample scoring.
- `distributed/scoring`: each Ray worker self-reports once per process.
- Tests: `tests/test_native_dispatch_telemetry.py` (11 cases).

**Remaining out of scope:** full driver-side aggregation of distributed worker native counts (per-worker WARNING covers #957's "never silently eat the slow path"; threading counts back through Ray Data is a larger, Ray-only change).

### Test plan
- `cargo test`/`clippy` on graph-layout ✅
- `pytest packages/python/goldenflow/tests/domains/test_carceral.py` → 22 passed
- `pytest .../tests/test_score_buckets_multipass.py` → 6 passed (new empty-keys case verified red without the fix); all bucket test files → 54 passed
- `pytest .../tests/{test_native_dispatch_telemetry,test_native_surface,test_api}.py` → 85 passed
- distributed scoring tests green (ray-gated cases skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)