### PR TITLE
Chunked PPRL trusted-third-party linkage (#1040)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/pprl/protocol.py
+++ b/packages/python/goldenmatch/goldenmatch/pprl/protocol.py
@@ -35,6 +35,13 @@ class PPRLConfig:
     ngram_size: int = 2
     protocol: str = "trusted_third_party"  # trusted_third_party or smc
     scorer: str = "dice"  # dice or jaccard
+    # #1040: stream Party B in blocks of this many records instead of
+    # materializing the full N_a x N_b score matrix in one allocation (50k x 50k
+    # float32 ~= 10 GB -> OOM). None (default) = single block = byte-identical to
+    # the dense path. When set, peak memory is bounded to mat_a + one block's
+    # (N_a x chunk_size) score slice. Output (clusters / match_count) is
+    # invariant to chunk_size -- only the allocation profile changes.
+    chunk_size: int | None = None
 
 
 @dataclass
@@ -92,6 +99,13 @@ def link_trusted_third_party(
 
     The coordinator receives bloom filters from both parties and computes
     similarity directly. Simple and fast, but requires trusting the coordinator.
+
+    Memory: ``mat_a`` (the Party A bit matrix) stays resident; Party B is
+    streamed in blocks of ``config.chunk_size`` (#1040). The full
+    ``N_a x N_b`` score matrix is never materialized when ``chunk_size`` is set,
+    so two ~50k-row lists link without the ~10 GB dense allocation. With
+    ``chunk_size=None`` (default) the loop runs once over all of Party B, which
+    is byte-for-byte the original dense path.
     """
     from goldenmatch.core.scorer import _hex_to_bits
 
@@ -100,39 +114,46 @@ def link_trusted_third_party(
     ids_b = sorted(party_b.bloom_filters.keys())
     total_comparisons = len(ids_a) * len(ids_b)
 
-    # Build bit matrices (N x filter_bits) as float32 for matrix multiply
+    # Party A bit matrix stays resident across all Party B blocks.
     mat_a = np.array(
         [np.unpackbits(_hex_to_bits(party_a.bloom_filters[rid])) for rid in ids_a],
         dtype=np.float32,
     )
-    mat_b = np.array(
-        [np.unpackbits(_hex_to_bits(party_b.bloom_filters[rid])) for rid in ids_b],
-        dtype=np.float32,
-    )
-
-    # Intersection via matrix multiply: mat_a @ mat_b.T
-    intersection = mat_a @ mat_b.T  # (n_a, n_b)
     pop_a = mat_a.sum(axis=1)  # (n_a,)
-    pop_b = mat_b.sum(axis=1)  # (n_b,)
 
-    if config.scorer == "dice":
-        denom = pop_a[:, None] + pop_b[None, :]
-        with np.errstate(divide="ignore", invalid="ignore"):
-            scores = np.where(denom > 0, 2.0 * intersection / denom, 0.0)
-    else:  # jaccard
-        union = pop_a[:, None] + pop_b[None, :] - intersection
-        with np.errstate(divide="ignore", invalid="ignore"):
-            scores = np.where(union > 0, intersection / union, 0.0)
+    # Block size over Party B. None / <=0 -> one block = the dense path.
+    chunk = config.chunk_size if (config.chunk_size and config.chunk_size > 0) else len(ids_b)
 
-    # Extract pairs above threshold
-    match_indices = np.argwhere(scores >= config.threshold)
     pairs = []
-    for idx_a, idx_b in match_indices:
-        rid_a = ids_a[idx_a]
-        rid_b = ids_b[idx_b]
-        composite_a = rid_a * 1000000
-        composite_b = rid_b * 1000000 + 500000
-        pairs.append((composite_a, composite_b, float(scores[idx_a, idx_b])))
+    for j0 in range(0, len(ids_b), chunk):
+        block_ids = ids_b[j0 : j0 + chunk]
+        if not block_ids:
+            continue
+        mat_b = np.array(
+            [np.unpackbits(_hex_to_bits(party_b.bloom_filters[rid])) for rid in block_ids],
+            dtype=np.float32,
+        )
+        pop_b = mat_b.sum(axis=1)  # (block,)
+        intersection = mat_a @ mat_b.T  # (n_a, block)
+
+        if config.scorer == "dice":
+            denom = pop_a[:, None] + pop_b[None, :]
+            with np.errstate(divide="ignore", invalid="ignore"):
+                scores = np.where(denom > 0, 2.0 * intersection / denom, 0.0)
+        else:  # jaccard
+            union = pop_a[:, None] + pop_b[None, :] - intersection
+            with np.errstate(divide="ignore", invalid="ignore"):
+                scores = np.where(union > 0, intersection / union, 0.0)
+
+        # Extract pairs above threshold within this block. block_ids[idx_b]
+        # maps the local block column back to the global Party B record id, so
+        # the composite encoding is identical regardless of chunk_size.
+        for idx_a, idx_b in np.argwhere(scores >= config.threshold):
+            rid_a = ids_a[idx_a]
+            rid_b = block_ids[idx_b]
+            composite_a = rid_a * 1000000
+            composite_b = rid_b * 1000000 + 500000
+            pairs.append((composite_a, composite_b, float(scores[idx_a, idx_b])))
 
     # Cluster matches
     all_composite_ids = (

--- a/packages/python/goldenmatch/tests/test_pprl.py
+++ b/packages/python/goldenmatch/tests/test_pprl.py
@@ -124,6 +124,77 @@ class TestTrustedThirdParty:
                 assert party_id in ("hospital_a", "hospital_b")
 
 
+class TestChunkedTrustedThirdParty:
+    """#1040: chunk_size streams Party B in blocks instead of materializing the
+    full N_a x N_b matrix. Output must be invariant to chunk_size."""
+
+    @staticmethod
+    def _two_party_overlap(n: int = 60):
+        """Party A and Party B each n records; the first ~half overlap (B is a
+        lower-cased / lightly-perturbed copy of A), the rest are disjoint."""
+        names = [
+            f"{first} {last}"
+            for first in ["John", "Jane", "Bob", "Alice", "Carol", "Dave",
+                          "Erin", "Frank", "Grace", "Henry"]
+            for last in ["Smith", "Jones", "Brown", "Davis", "Miller", "Wilson"]
+        ][:n]
+        df_a = pl.DataFrame({"__row_id__": list(range(n)), "name": names})
+        # B: lower-case the first half (still matches), replace the rest.
+        b_names = [s.lower() if i < n // 2 else f"Zztop Person{i}" for i, s in enumerate(names)]
+        df_b = pl.DataFrame({"__row_id__": list(range(n)), "name": b_names})
+        config = PPRLConfig(fields=["name"], threshold=0.7)
+        fa = compute_bloom_filters(df_a, ["name"], config)
+        fb = compute_bloom_filters(df_b, ["name"], config)
+        return (
+            PartyData(party_id="a", bloom_filters=fa, record_count=n),
+            PartyData(party_id="b", bloom_filters=fb, record_count=n),
+        )
+
+    @staticmethod
+    def _membership(result):
+        """Multi-member clusters as a hashable set-of-frozensets of members."""
+        return frozenset(
+            frozenset(members) for members in result.clusters.values() if len(members) >= 2
+        )
+
+    def test_chunked_matches_dense(self):
+        party_a, party_b = self._two_party_overlap()
+        dense = link_trusted_third_party(
+            party_a, party_b, PPRLConfig(fields=["name"], threshold=0.7, chunk_size=None)
+        )
+        # The dense run must actually find the planted overlaps.
+        assert dense.match_count > 0
+        assert self._membership(dense)
+        for cs in (1, 3, 7, 16, 1000):
+            chunked = link_trusted_third_party(
+                party_a, party_b, PPRLConfig(fields=["name"], threshold=0.7, chunk_size=cs)
+            )
+            assert chunked.match_count == dense.match_count, f"match_count drift at chunk_size={cs}"
+            assert chunked.total_comparisons == dense.total_comparisons
+            assert self._membership(chunked) == self._membership(dense), (
+                f"cluster membership drift at chunk_size={cs}"
+            )
+
+    def test_chunk_size_larger_than_party_b(self):
+        """chunk_size >= len(B) is a single block == dense."""
+        party_a, party_b = self._two_party_overlap(n=20)
+        dense = link_trusted_third_party(party_a, party_b, PPRLConfig(fields=["name"], threshold=0.7))
+        big = link_trusted_third_party(
+            party_a, party_b, PPRLConfig(fields=["name"], threshold=0.7, chunk_size=10_000)
+        )
+        assert self._membership(big) == self._membership(dense)
+        assert big.match_count == dense.match_count
+
+    def test_chunk_size_one_is_valid(self):
+        """The pathological chunk_size=1 (one Party B record per block) works."""
+        party_a, party_b = self._two_party_overlap(n=12)
+        dense = link_trusted_third_party(party_a, party_b, PPRLConfig(fields=["name"], threshold=0.7))
+        per_row = link_trusted_third_party(
+            party_a, party_b, PPRLConfig(fields=["name"], threshold=0.7, chunk_size=1)
+        )
+        assert self._membership(per_row) == self._membership(dense)
+
+
 class TestSMC:
     def test_smc_matches_ttp(self):
         """SMC should produce the same match decisions as TTP."""


### PR DESCRIPTION
Closes #1040.

## #1040 — chunked PPRL trusted-third-party linkage

`goldenmatch.pprl.protocol.link_trusted_third_party` built the full `mat_a @ mat_b.T` score matrix in one allocation. At 50k × 50k float32 that's ~10 GB → OOM, and there was no way to link two large lists without re-implementing a chunk loop in every consumer (the showcase shipped one as `link_chunked`).

**Fix:** add `PPRLConfig.chunk_size`. Party A's bit matrix stays resident; Party B is streamed in blocks of `chunk_size`, computing per-block `(N_a × chunk_size)` score slices and accumulating pairs, then clustering once at the end. Peak memory drops to `mat_a + one block`.

- **`chunk_size=None` (default) runs a single block = byte-for-byte the original dense path.** `block_ids[idx]` maps each block column back to the global Party B record id, so the `*1_000_000` / `+500_000` composite encoding, the `>= threshold` test, and the cluster output are invariant to `chunk_size`.
- Output (clusters / `match_count` / `total_comparisons`) is identical regardless of `chunk_size` — only the allocation profile changes.

### Measured (tracemalloc, 4000 × 4000 disjoint lists, ~0 matches so the matrix dominates)
| chunk_size | peak | result |
|---|---|---|
| None (dense) | 304.9 MB | 0 matches |
| 200 | 34.1 MB (~9×) | 0 matches |
| 50 | 21.2 MB (~14×) | 0 matches |

### Test plan
- `tests/test_pprl.py::TestChunkedTrustedThirdParty` — chunked == dense cluster membership + `match_count` + `total_comparisons` across `chunk_size ∈ {1, 3, 7, 16, 1000, >len(B)}`.
- Full PPRL suite green: `pytest tests/test_pprl.py` → 22 passed.

### Notes
- Scoped to `link_trusted_third_party` (the OOM path in the issue). `link_smc` and the score-helper are separate and unchanged.
- A real CLK blocking strategy (LSH/minhash banding on the bloom bits, to prune the O(n·m) comparison count rather than just bound memory) is the issue's "bonus" — left as a follow-up; this PR removes the hard OOM ceiling.

Split out of the issue-audit wave (separate from #1052, which merged) so the two land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)