### PR TITLE
feat: allow_fill + anchor group-winner strategy (correlated survivorship v2)

### DIFF
--- a/docs-site/goldenmatch/configuration.mdx
+++ b/docs-site/goldenmatch/configuration.mdx
@@ -332,6 +332,29 @@ When a config uses `field_groups` (or conditional/validated `field_rules`), Gold
 
 For plain configs with no `field_groups` and no conditional `field_rules`, output is byte-identical to prior behavior -- none of these surfaces add anything.
 
+#### anchor strategy and allow_fill
+
+**`strategy: anchor`** selects the winning record by first restricting candidates to those where the named `anchor` column is non-null, then applying `most_complete` within that subset. If no record has the anchor present, the group falls back to plain `most_complete`. Use this when one column (such as a plan or product ID) anchors the rest of the group's fields.
+
+```yaml
+field_groups:
+  - name: plan_block
+    columns: [plan_id, plan_name, plan_tier]
+    strategy: anchor
+    anchor: plan_id
+```
+
+**`allow_fill: true`** relaxes strict lock-step for the winning record's null cells. After the winner is selected, each null cell in the winner is back-filled from the best other record (chosen by the group's strategy) that has a value for that cell. The lineage audit records a `<group>: <col> back-filled from record N` line for every filled cell, and the `filled` map in the group provenance tracks which row supplied each value. Off by default; when off, the winner's nulls are kept as-is.
+
+```yaml
+field_groups:
+  - name: plan_block
+    columns: [plan_id, plan_name, plan_tier]
+    strategy: anchor
+    anchor: plan_id
+    allow_fill: true
+```
+
 ### Conditional and validated field rules
 
 A `field_rules` entry can be a list of clauses instead of a single strategy. The first clause whose `when:` predicate is satisfied wins; the last clause must have no `when:` and acts as the default.

--- a/docs/superpowers/plans/2026-06-17-allow-fill-anchor-strategy.md
+++ b/docs/superpowers/plans/2026-06-17-allow-fill-anchor-strategy.md
@@ -1,0 +1,551 @@
+# allow_fill + anchor Group-Winner Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two opt-in group-winner extensions to lock-step `field_groups` survivorship: `allow_fill` (per-cell back-fill of a winner's null group cells from the best other row by the group's strategy) and an `anchor` group strategy (pick the winner by one designated column), with provenance that surfaces through the workstream-1 audit trail. Byte-identical when neither lever is used.
+
+**Architecture:** One unifying refactor in `core/survivorship/winner.py`: compute a strategy-ordered ranking of row indices once; winner = `ranking[0]`, `allow_fill` walks `ranking[1:]` per null cell, `anchor` is a new ranking. `GroupResult`/`GroupProvenance` each gain a `filled` map (positional in the former, row-id in the latter; `resolve.py` remaps). The config gains `anchor` + `allow_fill`. The NL renderer gains a back-fill line; the `golden_records` serializer omits empty `filled`.
+
+**Tech Stack:** Python 3.11+, Pydantic v2 (`config/schemas.py`), dataclasses, pytest. Spec: `docs/superpowers/specs/2026-06-17-allow-fill-anchor-strategy-design.md`.
+
+**Dependency:** Stacks on workstream 1 (GroupProvenance surfacing, PR #1053) which stacks on v1 (merged). Branch off `origin/main` only AFTER #1053 merges (the `render_cluster_provenance_nl` surfacing wiring must be present for the NL tests).
+
+---
+
+## Conventions for every task
+
+- **Run tests** (targeted local runs only, never the full xdist suite locally):
+  `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 <repo>/.venv/Scripts/python.exe -m pytest <path> -v`
+  (set `GOLDENMATCH_NATIVE=0` if a stale native wheel interferes).
+- **Commit** after each green step. Squash-merge via PR at the end.
+- **No em dashes / ASCII only** in committed strings.
+- New tests live in `packages/python/goldenmatch/tests/survivorship/`.
+
+---
+
+## File Structure
+
+**Modified files**
+- `packages/python/goldenmatch/goldenmatch/config/schemas.py` — `GoldenGroupRule` gains `anchor` + `allow_fill`; `_GROUP_STRATEGIES` gains `"anchor"`; `_validate_group` updated.
+- `.../core/survivorship/winner.py` — `_ranking` helper; `group_winner` gains `anchor` + `allow_fill` params + `GroupResult.filled`; confidence counts fills.
+- `.../core/survivorship/resolve.py` — pass `anchor`/`allow_fill`; remap `filled` positional -> row id; thread into `GroupProvenance`; filled-cell `source_row_id`.
+- `.../core/golden.py` — `GroupProvenance.filled` field.
+- `.../core/lineage.py` — `render_group_provenance_line` back-fill lines; `_serialize_golden_records` omits empty `filled`.
+- Docs: `docs-site/goldenmatch/configuration.mdx` (field-groups section).
+
+**New test files**
+- `tests/survivorship/test_allow_fill_anchor.py`
+
+(Existing `tests/survivorship/test_winner.py` is extended for the refactor-parity gate.)
+
+---
+
+## Task 0: Branch setup
+
+- [ ] **Step 1:** Confirm #1053 merged, branch off fresh `origin/main`.
+```bash
+git fetch origin
+git switch -c feat/allow-fill-anchor origin/main
+# sanity: workstream-1 surfacing must be present
+grep -n "def render_cluster_provenance_nl" packages/python/goldenmatch/goldenmatch/core/lineage.py
+grep -n "def golden_provenance_for_run" packages/python/goldenmatch/goldenmatch/core/lineage.py
+```
+- [ ] **Step 2:** Smoke-run the existing group tests green.
+Run: `POLARS_SKIP_CPU_CHECK=1 .venv/Scripts/python.exe -m pytest packages/python/goldenmatch/tests/survivorship/test_winner.py -q`
+Expected: PASS (baseline before any change).
+
+---
+
+## Phase A — Config
+
+### Task A1: `GoldenGroupRule` gains `anchor` + `allow_fill`
+
+**Files:**
+- Modify: `config/schemas.py`
+- Test: `tests/survivorship/test_allow_fill_anchor.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/survivorship/test_allow_fill_anchor.py
+import pytest
+from pydantic import ValidationError
+from goldenmatch.config.schemas import GoldenGroupRule
+
+
+def test_defaults():
+    g = GoldenGroupRule(name="g", columns=["a", "b"])
+    assert g.anchor is None and g.allow_fill is False
+
+
+def test_allow_fill_orthogonal():
+    g = GoldenGroupRule(name="g", columns=["a", "b"], allow_fill=True)
+    assert g.allow_fill is True
+
+
+def test_anchor_strategy_valid():
+    g = GoldenGroupRule(name="g", columns=["plan_id", "plan_name"], strategy="anchor", anchor="plan_id")
+    assert g.strategy == "anchor" and g.anchor == "plan_id"
+
+
+def test_anchor_requires_anchor_column():
+    with pytest.raises(ValidationError):
+        GoldenGroupRule(name="g", columns=["a", "b"], strategy="anchor")   # no anchor
+
+
+def test_anchor_must_be_in_columns():
+    with pytest.raises(ValidationError):
+        GoldenGroupRule(name="g", columns=["a", "b"], strategy="anchor", anchor="c")
+
+
+def test_anchor_with_non_anchor_strategy_rejected():
+    with pytest.raises(ValidationError):
+        GoldenGroupRule(name="g", columns=["a", "b"], strategy="most_complete", anchor="a")
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+
+- [ ] **Step 3: Implement.** Add the fields + `"anchor"` to `_GROUP_STRATEGIES`, and extend `_validate_group`:
+```python
+_GROUP_STRATEGIES = frozenset({"most_complete", "source_priority", "most_recent", "anchor"})
+
+class GoldenGroupRule(BaseModel):
+    name: str
+    columns: list[str]
+    category: str | None = None
+    strategy: str = "most_complete"
+    date_column: str | None = None
+    source_priority: list[str] | None = None
+    anchor: str | None = None
+    allow_fill: bool = False
+
+    @model_validator(mode="after")
+    def _validate_group(self) -> "GoldenGroupRule":
+        # ... keep existing >=2 columns, reserved-prefix, strategy-in-allowlist,
+        #     most_recent->date_column, source_priority->source_priority checks ...
+        if self.strategy == "anchor":
+            if not self.anchor:
+                raise ValueError(f"Group '{self.name}' strategy 'anchor' requires 'anchor'.")
+            if self.anchor not in self.columns:
+                raise ValueError(f"Group '{self.name}' anchor '{self.anchor}' must be one of its columns.")
+        elif self.anchor is not None:
+            raise ValueError(f"Group '{self.name}' sets 'anchor' but strategy is '{self.strategy}' (anchor only valid with strategy 'anchor').")
+        return self
+```
+
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** `feat(config): GoldenGroupRule anchor strategy + allow_fill`.
+
+---
+
+## Phase B — winner.py (core)
+
+### Task B1: ranking refactor (REFACTOR-PARITY)
+
+**Files:**
+- Modify: `core/survivorship/winner.py`
+- Test: `tests/survivorship/test_winner.py` (append a refactor-parity test, incl. TIE clusters)
+
+This refactor must produce the IDENTICAL winner/values/confidence/tie as today for `most_complete`/`source_priority`/`most_recent`. Today's winner is the LOWEST index among ties (`min`/`max` return the first extreme; `most_complete` uses `winners[0]`). **Python's `sorted(..., reverse=True)` is guaranteed STABLE** (equal-key elements keep ascending input order), so `reverse=True` does NOT invert ties; it is correct here. The TIE-cluster parity test below is the guard.
+
+- [ ] **Step 1: Write the failing/guard test** (append to `test_winner.py`)
+```python
+from goldenmatch.core.survivorship.winner import group_winner
+
+
+def _rows(spec):
+    return [{"__pos__": i, **r} for i, r in enumerate(spec)]
+
+
+def test_most_complete_tiebreak_lowest_index():
+    # two rows tie on populated count -> winner is the LOWER index (parity with old winners[0])
+    rows = _rows([{"a": "x", "b": "y"}, {"a": "p", "b": "q"}])
+    res = group_winner(rows, ["a", "b"], strategy="most_complete")
+    assert res.winner_pos == 0
+    assert res.tie is True and res.confidence == 0.7
+
+
+def test_source_priority_winner_and_no_tie():
+    rows = _rows([{"a": "x", "__source__": "billing"}, {"a": "p", "__source__": "crm"}])
+    res = group_winner(rows, ["a"], strategy="source_priority", source_priority=["crm", "billing"])
+    assert res.winner_pos == 1 and res.tie is False
+
+
+def test_most_recent_tie_lowest_index():
+    rows = _rows([{"a": "x"}, {"a": "p"}])
+    res = group_winner(rows, ["a"], strategy="most_recent", dates=["2024-01-01", "2024-01-01"])
+    assert res.winner_pos == 0   # equal dates -> lowest index, parity with old max()
+```
+
+- [ ] **Step 2: Run.** The existing `test_winner.py` cases + these must stay green THROUGHOUT the refactor (this is a refactor, not new behavior).
+
+- [ ] **Step 3: Implement the ranking.** Replace the per-strategy `best`/`tie` block with a `_ranking` helper; keep `values`/confidence identical:
+```python
+def _ranking(rows, columns, strategy, *, source_priority=None, dates=None, anchor=None):
+    n = len(rows)
+    if strategy == "source_priority":
+        rank = {s: i for i, s in enumerate(source_priority or [])}
+        order = sorted(range(n), key=lambda i: rank.get(rows[i].get("__source__"), len(rank)))  # asc; stable ties
+        return order, False
+    if strategy == "most_recent":
+        def keyf(i):
+            d = dates[i] if dates and i < len(dates) else None
+            return (d is not None, d)
+        order = sorted(range(n), key=keyf, reverse=True)  # desc; stable -> ties keep asc index
+        return order, False
+    if strategy == "anchor":
+        counts = [_populated(rows[i], columns) for i in range(n)]
+        present = [rows[i].get(anchor) is not None for i in range(n)]
+        order = sorted(range(n), key=lambda i: (present[i], counts[i]), reverse=True)  # anchor-present first, then most-complete
+        # tie among the TOP group (same present + same count as the winner)
+        w = order[0]
+        top_key = (present[w], counts[w])
+        tie = sum(1 for i in range(n) if (present[i], counts[i]) == top_key) > 1
+        return order, tie
+    # most_complete
+    counts = [_populated(rows[i], columns) for i in range(n)]
+    order = sorted(range(n), key=lambda i: counts[i], reverse=True)
+    top = counts[order[0]]
+    tie = sum(1 for c in counts if c == top) > 1
+    return order, tie
+
+
+def group_winner(rows, columns, strategy="most_complete", *,
+                 source_priority=None, dates=None, anchor=None, allow_fill=False) -> GroupResult:
+    n = len(rows)
+    if n == 0:
+        return GroupResult(-1, {c: None for c in columns}, 0.0, False)
+    ranking, tie = _ranking(rows, columns, strategy, source_priority=source_priority, dates=dates, anchor=anchor)
+    best = ranking[0]
+    values = {c: rows[best].get(c) for c in columns}
+    filled: dict[str, int] = {}
+    # (allow_fill block added in B3)
+    winner_populated = _populated(rows[best], columns)
+    base_conf = (winner_populated + len(filled)) / len(columns) if columns else 0.0
+    conf = base_conf * 0.7 if tie else base_conf
+    return GroupResult(rows[best].get("__pos__", best), values, conf, tie, filled)
+```
+(Note: with `filled` empty, `base_conf` reduces to today's `winner_populated/len`, so B1 alone is byte-identical. `GroupResult.filled` is added in B2/B3 below; for B1 add it as a defaulted field so the dataclass is ready.)
+
+Add to `GroupResult`:
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class GroupResult:
+    winner_pos: int
+    values: dict[str, Any]
+    confidence: float
+    tie: bool
+    filled: dict[str, int] = field(default_factory=dict)
+```
+
+- [ ] **Step 4: Run** `test_winner.py` — ALL existing + new pass (refactor parity).
+- [ ] **Step 5: Commit** `refactor(survivorship): ranking-based group_winner (parity-preserving)`.
+
+### Task B2: `anchor` strategy behavior
+
+**Files:** Modify `winner.py` (already has the anchor branch from B1); Test: `test_allow_fill_anchor.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+from goldenmatch.core.survivorship.winner import group_winner
+
+def _rows(spec):
+    return [{"__pos__": i, **r} for i, r in enumerate(spec)]
+
+
+def test_anchor_picks_anchor_bearing_most_complete():
+    rows = _rows([
+        {"plan_id": None, "plan_name": "Gold", "plan_tier": "G"},   # no anchor
+        {"plan_id": "P1", "plan_name": "Gold", "plan_tier": None},  # anchor, 2/3
+        {"plan_id": "P1", "plan_name": "Gold", "plan_tier": "G"},   # anchor, 3/3 -> winner
+    ])
+    res = group_winner(rows, ["plan_id", "plan_name", "plan_tier"], strategy="anchor", anchor="plan_id")
+    assert res.winner_pos == 2
+    assert res.values["plan_tier"] == "G"
+
+
+def test_anchor_fallback_to_most_complete_when_none_have_anchor():
+    rows = _rows([{"plan_id": None, "plan_name": "A", "plan_tier": "X"},
+                  {"plan_id": None, "plan_name": "B", "plan_tier": None}])
+    res = group_winner(rows, ["plan_id", "plan_name", "plan_tier"], strategy="anchor", anchor="plan_id")
+    assert res.winner_pos == 0   # most-complete fallback
+```
+
+- [ ] **Step 2: Run to verify pass** (the B1 anchor branch should already satisfy these; if a test fails, fix the anchor ranking).
+- [ ] **Step 3:** (no new impl beyond B1's anchor branch unless a test fails).
+- [ ] **Step 4: Commit** `feat(survivorship): anchor group-winner strategy`.
+
+### Task B3: `allow_fill` per-cell back-fill
+
+**Files:** Modify `winner.py`; Test: `test_allow_fill_anchor.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+def test_allow_fill_fills_winner_nulls_from_strategy_best_other_row():
+    # winner (pos 0) most-complete but missing zip; pos 1 has zip
+    rows = _rows([
+        {"street": "1 Main St", "city": "LA", "zip": None},   # 2/3 -> winner
+        {"street": "1 Main", "city": "LA", "zip": "90001"},   # 2/3 (lower rank, has zip)
+    ])
+    res = group_winner(rows, ["street", "city", "zip"], strategy="most_complete", allow_fill=True)
+    assert res.winner_pos == 0
+    assert res.values["zip"] == "90001"        # back-filled
+    assert res.filled == {"zip": 1}            # positional source
+    assert res.confidence == 1.0               # 2 winner + 1 filled = 3/3
+
+
+def test_allow_fill_off_keeps_winner_null():
+    rows = _rows([{"street": "1 Main St", "city": "LA", "zip": None},
+                  {"street": "1 Main", "city": "LA", "zip": "90001"}])
+    res = group_winner(rows, ["street", "city", "zip"], strategy="most_complete")  # allow_fill default False
+    assert res.values["zip"] is None and res.filled == {}
+
+
+def test_allow_fill_nothing_to_fill():
+    rows = _rows([{"a": "x", "b": "y"}, {"a": "p", "b": None}])
+    res = group_winner(rows, ["a", "b"], strategy="most_complete", allow_fill=True)
+    assert res.filled == {}                    # winner already complete
+```
+
+- [ ] **Step 2: Run to verify it fails** (no fill yet).
+- [ ] **Step 3: Implement** the fill block in `group_winner` (between `values = {...}` and the confidence calc):
+```python
+    if allow_fill:
+        for c in columns:
+            if values[c] is None:
+                for j in ranking[1:]:
+                    if rows[j].get(c) is not None:
+                        values[c] = rows[j].get(c)
+                        filled[c] = rows[j].get("__pos__", j)
+                        break
+```
+(The confidence calc from B1 already uses `len(filled)`.)
+
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** `feat(survivorship): allow_fill per-cell back-fill of group nulls`.
+
+---
+
+## Phase C — resolve.py threading
+
+### Task C1: thread anchor/allow_fill + map filled -> row ids
+
+**Files:** Modify `core/survivorship/resolve.py`; Test: `test_allow_fill_anchor.py`
+
+- [ ] **Step 1: Write the failing test** (end-to-end through `resolve_cluster`)
+```python
+import polars as pl
+from goldenmatch.config.schemas import GoldenRulesConfig, GoldenGroupRule
+from goldenmatch.core.survivorship.conditions import build_resolution_order
+from goldenmatch.core.survivorship.resolve import resolve_cluster
+
+
+def test_resolve_allow_fill_records_filled_row_id():
+    df = pl.DataFrame({
+        "__cluster_id__": [5, 5], "__row_id__": [10, 11],
+        "street": ["1 Main St", "1 Main"], "city": ["LA", "LA"], "zip": [None, "90001"],
+    })
+    rules = GoldenRulesConfig(default_strategy="most_complete", field_groups=[
+        GoldenGroupRule(name="addr", columns=["street", "city", "zip"], allow_fill=True)])
+    order = build_resolution_order(rules.field_rules, rules.field_groups, ["street", "city", "zip"])
+    rec, prov = resolve_cluster(df, rules, order, provenance=True, cluster_id=5)
+    gp = prov.groups[0]
+    assert gp.values["zip"] == "90001"
+    assert gp.filled == {"zip": 11}            # mapped positional -> row_id
+    # the resolved golden value is the filled value
+    assert rec["zip"]["value"] == "90001"
+    assert rec["zip"]["source_row_id"] == 11   # filled-cell source points at the fill record
+```
+
+- [ ] **Step 2: Run to verify it fails** (`gp.filled` attr missing until C/D; or filled not mapped).
+- [ ] **Step 3: Implement** in the group branch of `resolve.py`:
+```python
+            res = group_winner(rows, list(g.columns), strategy=g.strategy,
+                               source_priority=g.source_priority, dates=dates,
+                               anchor=g.anchor, allow_fill=g.allow_fill)
+            wid = (row_id_array[res.winner_pos] if (row_id_array is not None and res.winner_pos is not None and res.winner_pos >= 0) else None)
+            wsrc = (source_array[res.winner_pos] if (source_array is not None and res.winner_pos is not None and res.winner_pos >= 0) else None)
+            filled_ids = ({c: row_id_array[p] for c, p in res.filled.items()}
+                          if row_id_array is not None else dict(res.filled))
+            for c in g.columns:
+                v = res.values.get(c)
+                fd = {"value": v, "confidence": res.confidence}
+                if provenance:
+                    fd["source_row_id"] = filled_ids.get(c, wid)   # filled-cell -> fill source, else winner
+                field_dicts[c] = fd
+                resolved[c] = v
+            confidences.append(res.confidence)
+            if provenance:
+                group_provs.append(GroupProvenance(
+                    name=g.name, columns=list(g.columns), strategy=g.strategy,
+                    winner_row_id=wid, winner_source=wsrc,
+                    values=dict(res.values), tie=res.tie, confidence=res.confidence,
+                    filled=filled_ids,
+                ))
+```
+(The `source_row_id`/`filled` writes are inside the existing `if provenance:` guards; the non-provenance path is unchanged for byte-parity. `GroupProvenance.filled` is added in D1.)
+
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** `feat(survivorship): thread anchor/allow_fill + filled provenance through resolve`.
+
+---
+
+## Phase D — provenance + NL
+
+### Task D1: `GroupProvenance.filled`
+
+**Files:** Modify `core/golden.py`; Test: covered by C1 (gp.filled).
+
+- [ ] **Step 1:** Add the field to the `GroupProvenance` dataclass:
+```python
+@dataclass
+class GroupProvenance:
+    name: str
+    columns: list[str]
+    strategy: str
+    winner_row_id: int
+    winner_source: str | None
+    values: dict[str, Any]
+    tie: bool
+    confidence: float
+    filled: dict[str, int] = dataclass_field(default_factory=dict)   # {col: source row id}
+```
+(Use the module's existing `dataclass_field` alias. Defaulted -> existing construction unaffected.)
+
+- [ ] **Step 2: Run** C1's test -> now passes.
+- [ ] **Step 3: Commit** `feat(golden): GroupProvenance.filled field`.
+
+### Task D2: back-fill NL line
+
+**Files:** Modify `core/lineage.py` (`render_group_provenance_line`); Test: `test_allow_fill_anchor.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+from goldenmatch.core.golden import GroupProvenance
+from goldenmatch.core.lineage import render_group_provenance_line
+
+
+def test_render_group_line_includes_backfill():
+    gp = GroupProvenance(name="mailing_address", columns=["street", "city", "zip"], strategy="most_complete",
+                         winner_row_id=7, winner_source=None, values={}, tie=False, confidence=1.0,
+                         filled={"zip": 12})
+    out = render_group_provenance_line(gp)
+    assert "promoted together from record 7" in out
+    assert "mailing_address: zip back-filled from record 12" in out
+
+
+def test_render_group_line_no_fill_unchanged():
+    gp = GroupProvenance(name="addr", columns=["a", "b"], strategy="most_complete",
+                         winner_row_id=7, winner_source=None, values={}, tie=False, confidence=1.0)
+    out = render_group_provenance_line(gp)
+    assert "back-filled" not in out
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** — widen the renderer to append fill lines (it already returns a string; `render_cluster_provenance_nl` joins per-group output with newlines, so a multi-line return is fine):
+```python
+def render_group_provenance_line(gp) -> str:
+    cols = ", ".join(gp.columns)
+    line = (f"{cols} promoted together from record {gp.winner_row_id} "
+            f"via {gp.strategy} (group '{gp.name}')")
+    fills = [f"{gp.name}: {col} back-filled from record {rid}"
+             for col, rid in (getattr(gp, "filled", {}) or {}).items()]
+    return "\n".join([line, *fills]) if fills else line
+```
+
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** `feat(lineage): back-fill NL audit line for allow_fill`.
+
+### Task D3: omit empty `filled` in `golden_records` serialization
+
+**Files:** Modify `core/lineage.py` (`_serialize_golden_records`); Test: `test_allow_fill_anchor.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+import json
+from goldenmatch.core.golden import ClusterProvenance, GroupProvenance
+from goldenmatch.core.lineage import save_lineage
+
+
+def _cp(filled):
+    g = GroupProvenance(name="addr", columns=["street", "zip"], strategy="most_complete",
+                        winner_row_id=7, winner_source=None, values={}, tie=False, confidence=1.0, filled=filled)
+    return [ClusterProvenance(cluster_id=5, cluster_quality="strong", cluster_confidence=0.9, fields={}, groups=[g])]
+
+
+def test_filled_omitted_when_empty(tmp_path):
+    path = save_lineage([], tmp_path, "run", golden_provenance=_cp({}))
+    grp = json.loads(path.read_text(encoding="utf-8"))["golden_records"][0]["groups"][0]
+    assert "filled" not in grp
+
+
+def test_filled_present_when_nonempty(tmp_path):
+    path = save_lineage([], tmp_path, "run", golden_provenance=_cp({"zip": 12}))
+    grp = json.loads(path.read_text(encoding="utf-8"))["golden_records"][0]["groups"][0]
+    assert grp["filled"] == {"zip": 12}
+```
+
+- [ ] **Step 2: Run to verify it fails** (empty `filled: {}` present).
+- [ ] **Step 3: Implement** — in `_serialize_golden_records`, after building `records`, drop empty `filled` from each serialized group dict:
+```python
+def _serialize_golden_records(provenance: list) -> list[dict]:
+    records = _serialize_provenance(provenance)
+    for cp, rec in zip(provenance, records):
+        audit = _safe_cluster_audit(cp)
+        if audit:
+            rec["audit"] = audit
+        for grp in rec.get("groups", []):
+            if not grp.get("filled"):
+                grp.pop("filled", None)
+    return records
+```
+
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** `fix(lineage): omit empty filled in golden_records (parity)`.
+
+---
+
+## Phase E — combined + docs + parity
+
+### Task E1: allow_fill + anchor together + parity gate
+
+**Files:** Test: `tests/survivorship/test_allow_fill_anchor.py`
+
+- [ ] **Step 1: Write the tests**
+```python
+def test_anchor_plus_allow_fill():
+    rows = _rows([
+        {"plan_id": "P1", "plan_name": "Gold", "plan_tier": None},  # anchor winner (2/3)
+        {"plan_id": None, "plan_name": "Gold", "plan_tier": "G"},   # has tier
+    ])
+    res = group_winner(rows, ["plan_id", "plan_name", "plan_tier"],
+                       strategy="anchor", anchor="plan_id", allow_fill=True)
+    assert res.winner_pos == 0
+    assert res.values["plan_tier"] == "G" and res.filled == {"plan_tier": 1}
+
+
+def test_no_levers_byte_identical():
+    # strict lock-step (no allow_fill, default strategy) pins winner's null + empty filled
+    rows = _rows([{"a": "x", "b": None}, {"a": "p", "b": "q"}])
+    res = group_winner(rows, ["a", "b"], strategy="most_complete")
+    assert res.values["b"] is None and res.filled == {}
+```
+
+- [ ] **Step 2: Run to verify pass.**
+- [ ] **Step 3: Commit** `test(survivorship): anchor+allow_fill combined + parity`.
+
+### Task E2: docs
+
+**Files:** `docs-site/goldenmatch/configuration.mdx`
+
+- [ ] **Step 1:** In the "Lock-step field groups" section, document `strategy: anchor` (with `anchor: <column>`) and `allow_fill: true` (per-cell back-fill of the winner's nulls; the back-fill is recorded in the lineage audit and `filled`). Match the existing voice; ASCII only.
+- [ ] **Step 2: Commit** `docs: anchor strategy + allow_fill in configuration`.
+
+---
+
+## Open items carried from the spec (resolve during execution)
+
+- **Refactor parity (B1) is the highest-risk step.** Keep ALL existing `test_winner.py` cases green throughout; the new TIE-cluster tests pin the lowest-index winner. `sorted(reverse=True)` is stable in Python (ties keep ascending index) -> safe; the tests are the guard.
+- **`source_priority`/`most_recent` fill order:** the fill walks the SAME strategy ranking (`ranking[1:]`), so fills come from the strategy-best other row -- intended per spec.
+- **Non-provenance path untouched:** the `source_row_id`/`filled` writes are inside `if provenance:`; `provenance=False` stays byte-identical.

--- a/docs/superpowers/specs/2026-06-17-allow-fill-anchor-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-17-allow-fill-anchor-strategy-design.md
@@ -1,0 +1,307 @@
+---
+title: allow_fill + anchor group-winner strategy
+date: 2026-06-17
+status: design (approved in brainstorming; pre-spec-review)
+owner: Ben Severn
+related:
+  - docs/superpowers/specs/2026-06-17-correlated-survivorship-and-conditional-golden-rules-design.md
+  - docs/superpowers/specs/2026-06-17-groupprovenance-surfacing-design.md
+---
+
+# allow_fill + anchor group-winner strategy
+
+> v2 workstreams 3 + 4 of the correlated-survivorship program, bundled.
+> Stacks on workstream 1 (GroupProvenance surfacing, PR #1053) which stacks
+> on v1 (merged). Design-only until #1053 lands.
+
+## 1. Problem
+
+v1 lock-step `field_groups` promote a set of columns together from ONE
+winning source record (`core/survivorship/winner.py::group_winner`). Two
+real survivorship needs the v1 spec deferred:
+
+**allow_fill.** Strict lock-step pins the winner's values **including its
+nulls** (`winner.py`: `values = {c: rows[best].get(c) for c in columns}`).
+If the winning record is missing a group cell, the golden record is null
+there even when a sibling record in the cluster has the value. Users want
+to optionally back-fill those gaps.
+
+**anchor strategy.** The three group strategies (`most_complete`,
+`source_priority`, `most_recent`) pick the winner by a property of the
+*whole group*. Sometimes the right winner is "whoever has the key column":
+for `{plan_id, plan_name, plan_tier}` you want the record that HAS a
+`plan_id`, then bring `plan_name`/`plan_tier` along. There is no strategy
+that selects on one designated member column.
+
+Confirmed against current code: `group_winner` has the three strategies
+and the strict-lock-step pin; `GoldenGroupRule` (`config/schemas.py`)
+validates `strategy in _GROUP_STRATEGIES = {most_complete, source_priority,
+most_recent}`; `GroupResult` (`winner.py`) is
+`(winner_pos, values, confidence, tie)`; `GroupProvenance` (`core/golden.py`)
+is `(name, columns, strategy, winner_row_id, winner_source, values, tie,
+confidence)`; the surfacing (workstream 1) renders
+`render_group_provenance_line(gp)` into lineage/explain/MCP.
+
+## 2. Goals / non-goals
+
+**Goals**
+- `allow_fill` (per-group, opt-in): when the winner's group cell is null,
+  back-fill it **per-cell** from the best *other* row by the group's own
+  strategy. Maximizes completeness.
+- `anchor` (new group strategy): pick the winner among rows whose anchor
+  column is non-null (most-complete tiebreak); fall back to plain
+  `most_complete` if no row has the anchor.
+- Both record their provenance (which cells were filled, from which
+  record) and surface it through the workstream-1 audit trail.
+- **Byte-identical output when neither lever is used** (`allow_fill=False`
+  and no `anchor` strategy). Parity gate.
+- Fail-safe: the features are pure group-winner logic; no new external
+  deps, no distributed-path change (survivorship already refuses Ray/Sail).
+
+**Non-goals**
+- Single-runner-up / ranked-fill policies (the brainstorm chose per-cell
+  from any row).
+- Cross-group fill or filling from outside the cluster.
+- A configurable anchor sub-strategy (anchor uses most_complete tiebreak;
+  a sub-strategy knob is deferred — YAGNI until asked).
+- Changing strict-lock-step semantics when `allow_fill=False`.
+
+## 3. Design overview
+
+One unifying refactor in `winner.py`: compute a **strategy-ordered ranking
+of row indices** once; the winner is `ranking[0]`, and `allow_fill` walks
+the rest of the ranking per null cell. `anchor` is a new ranking. Both new
+behaviors are additive and gated; `GroupResult` and `GroupProvenance` each
+gain a `filled` map. The config gains two fields. `resolve.py` threads the
+new inputs/outputs. The NL renderer gains one fill line.
+
+---
+
+## Section 1 — Config surface (`config/schemas.py`)
+
+`GoldenGroupRule` gains two fields:
+
+```python
+class GoldenGroupRule(BaseModel):
+    name: str
+    columns: list[str]
+    category: str | None = None
+    strategy: str = "most_complete"
+    date_column: str | None = None
+    source_priority: list[str] | None = None
+    anchor: str | None = None        # NEW: required iff strategy == "anchor"
+    allow_fill: bool = False         # NEW: per-cell back-fill of winner nulls
+```
+
+`_GROUP_STRATEGIES` gains `"anchor"`. `_validate_group` adds:
+- `strategy == "anchor"` requires `anchor` set, and `anchor in columns`.
+- `anchor` set with a non-anchor strategy is allowed-but-ignored? No —
+  reject (`anchor` only meaningful for `strategy == "anchor"`) to avoid
+  silent misconfig. (Decision recorded; flag for spec review if the
+  reviewer prefers ignore-with-warning.)
+
+`allow_fill` is orthogonal to strategy: valid with any strategy including
+`anchor`. Default `False` everywhere → strict lock-step unchanged.
+
+---
+
+## Section 2 — `winner.py`
+
+### 2.1 Ranking refactor
+
+Introduce an internal `_ranking(rows, columns, strategy, *, source_priority,
+dates, anchor) -> list[int]` returning row indices best-to-worst:
+- `most_complete`: by `_populated(row, columns)` desc (stable).
+- `source_priority`: by source rank asc (then stable).
+- `most_recent`: by date desc, nulls last (then stable).
+- `anchor`: rows with non-null `anchor` first (most-complete among them),
+  then the rest by most_complete. If NO row has the anchor, the ranking is
+  exactly the `most_complete` ranking (the documented fallback).
+
+Winner = `ranking[0]`. `tie` is computed as today per strategy
+(`most_complete`/`anchor`: more than one row tied on the top key →
+`tie=True`, 0.7 confidence penalty; `source_priority`/`most_recent`:
+index-stable, no tie penalty).
+
+**Stable-sort hazard (load-bearing for refactor parity).** Today's winner
+is the LOWEST index among ties (`min`/`max` keep the first maximal element;
+`most_complete` uses `winners[0]`). A naive `sorted(range(n), key=...,
+reverse=True)` would INVERT tie order and pick a different winner, silently
+breaking parity. Build the descending ranking WITHOUT reversing tie order
+(e.g. sort an ascending key already oriented best-first, or negate the
+numeric key and sort ascending so equal keys keep input order). The
+refactor-parity test MUST include crafted *tie* clusters — that is the one
+place "same winner as today" can quietly fail.
+
+### 2.2 `allow_fill`
+
+`group_winner(..., allow_fill=False)`. When `allow_fill` is True, after
+pinning the winner's values, for each column `c` where the winner is null,
+walk `ranking[1:]` and take the first row whose `c` is non-null:
+
+```python
+filled: dict[str, int] = {}
+if allow_fill:
+    for c in columns:
+        if values[c] is None:
+            for j in ranking[1:]:
+                if rows[j].get(c) is not None:
+                    values[c] = rows[j].get(c)
+                    filled[c] = rows[j].get("__pos__", j)   # positional id
+                    break
+```
+
+`filled` is `{column: source positional index}` (resolve maps to row id).
+Empty when `allow_fill` is False or nothing was filled.
+
+### 2.3 `GroupResult`
+
+```python
+@dataclass
+class GroupResult:
+    winner_pos: int
+    values: dict[str, Any]
+    confidence: float
+    tie: bool
+    filled: dict[str, int] = field(default_factory=dict)   # NEW: {col: source pos}
+```
+
+(defaulted so existing construction in tests/code is unaffected.)
+
+### 2.4 Confidence
+
+- `allow_fill`: completeness counts filled cells.
+  `conf = (winner_populated + len(filled)) / len(columns)`, then `* 0.7`
+  if `tie`. A fully back-filled group → 1.0 (×0.7 on a winner tie). When
+  `allow_fill` is False, `filled` is empty → formula reduces to today's
+  `winner_populated / len(columns)`. **This preserves parity exactly.**
+- `anchor`: most_complete-style confidence on the winner
+  (`winner_populated / len`, ×0.7 on tie). An all-null-anchor cluster uses
+  the most_complete fallback confidence.
+
+---
+
+## Section 3 — `resolve.py`
+
+The group branch (currently builds `rows`, calls `group_winner`, pins
+`field_dicts`/`resolved`, builds `GroupProvenance`) changes minimally:
+- Pass `allow_fill=g.allow_fill` and `anchor=g.anchor` to `group_winner`.
+- Map `res.filled` (positional) to row ids:
+  `filled_ids = {c: row_id_array[p] for c, p in res.filled.items()}` when
+  `row_id_array` is present, else `{c: p ...}`.
+- Pass `filled=filled_ids` into the `GroupProvenance(...)` it builds.
+The pinned `res.values` (now possibly containing fills) flow to
+`field_dicts`/`resolved` exactly as today — the golden record automatically
+gets the filled values.
+
+The per-column `source_row_id` recorded on the group's `field_dicts`
+(used for the field-level provenance) should reflect the fill source for a
+filled cell: for a filled column use `filled_ids[c]`, else the winner row
+id. (Small consistency fix so a filled cell's `source_row_id` points at the
+record the value actually came from.) **Scope strictly to the
+`if provenance:` branch** in `resolve.py` (where `source_row_id` is set);
+the non-provenance path (`row_id_array is None` / `provenance=False`) stays
+untouched so its byte-parity holds.
+
+---
+
+## Section 4 — Provenance + NL (surfaces via workstream 1)
+
+### 4.1 `GroupProvenance` (`core/golden.py`)
+
+```python
+@dataclass
+class GroupProvenance:
+    name: str
+    columns: list[str]
+    strategy: str
+    winner_row_id: int
+    winner_source: str | None
+    values: dict[str, Any]
+    tie: bool
+    confidence: float
+    filled: dict[str, int] = field(default_factory=dict)   # NEW: {col: source row id}
+```
+
+`winner_row_id`/`winner_source` stay the PRIMARY winner. `filled` records
+which cells came from elsewhere. Defaulted → existing construction is
+unaffected and the `asdict` serialization (workstream 1) round-trips it for
+free. **Decided (was open):** the serializer omits `filled` when empty
+(mirroring the workstream-1 `audit`-key parity fix), so group records for
+strict-lock-step groups are unchanged — a small filter in the
+`golden_records` serialization (`_serialize_golden_records` /
+`_serialize_provenance` consumer) drops an empty `filled` key.
+
+### 4.2 NL audit line (`core/lineage.py::render_group_provenance_line`)
+
+Keep the existing "promoted together" line. When `filled` is non-empty,
+append one line per filled cell:
+`"{name}: {col} back-filled from record {row_id}"`
+e.g. `"mailing_address: zip back-filled from record 12"`.
+(Exact string, so the implementer doesn't invent it.) These render in the
+lineage `audit`, `explain --cluster`, and the MCP `lineage` tool via the
+workstream-1 wiring with no surface change.
+
+Note: `render_group_provenance_line` currently returns a single string;
+it widens to return the promotion line plus the fill lines (joined), and
+`render_cluster_provenance_nl` already joins per-group output with
+newlines, so the change is local.
+
+---
+
+## Section 5 — Parity, testing, module layout
+
+**Load-bearing parity:** `allow_fill=False` + no `anchor` strategy →
+byte-identical. Mechanisms: `allow_fill` defaults False (the fill loop is
+skipped, `filled` empty, confidence formula reduces to today's); `anchor`
+is opt-in (a config that doesn't use it never hits the new ranking branch);
+the ranking refactor must produce the SAME winner as today for the three
+existing strategies (a refactor-parity test pins this). A parity gate
+asserts identical `GroupResult` for the existing strategies before/after.
+
+**Tests** (extend `tests/survivorship/test_winner.py` + a new
+`test_allow_fill_anchor.py`):
+- **Refactor parity:** `_ranking` + `group_winner` produce the SAME
+  winner/values/confidence/tie as the pre-refactor function for
+  most_complete/source_priority/most_recent on crafted clusters.
+- **anchor:** picks the anchor-bearing most-complete row; most-complete
+  tiebreak among anchor-bearers; fallback to most_complete when no row has
+  the anchor; tie penalty; config validation (anchor required + in columns;
+  anchor with non-anchor strategy rejected).
+- **allow_fill:** a winner with a null cell gets it filled from the
+  strategy-best other row; `filled` records the right source id; multiple
+  null cells each filled independently; nothing to fill → `filled` empty;
+  `allow_fill=False` still pins the winner's null (strict); confidence
+  counts filled cells.
+- **allow_fill + anchor together:** anchor picks the winner, allow_fill
+  fills its nulls.
+- **Provenance/NL:** `GroupProvenance.filled` populated; the back-fill NL
+  line appears in `render_group_provenance_line` and round-trips in the
+  lineage `golden_records` audit; a filled cell's `source_row_id` points at
+  the fill record.
+- **Parity gate:** a no-levers config (no allow_fill, no anchor) →
+  byte-identical golden output + provenance vs a baseline.
+
+**Module layout:** all logic stays in `winner.py` (ranking + fill),
+`config/schemas.py` (two fields + validation), `resolve.py` (threading),
+`core/golden.py` (`GroupProvenance.filled`), `core/lineage.py` (NL line).
+No new files. Docs sweep at the end (configuration.mdx field-groups
+section: `anchor` + `allow_fill`; the surfacing note already covers the
+audit line).
+
+## Section 6 — Rollout / flags
+
+No env flags. Both features are per-`GoldenGroupRule` opt-ins
+(`strategy: anchor` / `allow_fill: true`). A config using neither is
+byte-identical to today. Auto-detection (workstream 1's heuristic /
+infermap path) does NOT propose `anchor`/`allow_fill` — they require
+explicit user intent.
+
+## Section 7 — Open questions for spec review
+
+- **anchor + non-anchor-strategy config:** reject (chosen) vs.
+  ignore-with-warning. Leaning reject (no silent misconfig).
+- **Per-cell fill ranking for `source_priority`/`most_recent` groups:**
+  confirm "best other row by the group's own strategy" is the intended
+  fill order for non-most_complete strategies (vs. always most_complete
+  for fills). Leaning strategy-consistent (use the same ranking).

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -451,7 +451,7 @@ class GoldenFieldRule(BaseModel):
         return self
 
 
-_GROUP_STRATEGIES = frozenset({"most_complete", "source_priority", "most_recent"})
+_GROUP_STRATEGIES = frozenset({"most_complete", "source_priority", "most_recent", "anchor"})
 
 
 class GoldenGroupRule(BaseModel):
@@ -461,6 +461,8 @@ class GoldenGroupRule(BaseModel):
     strategy: str = "most_complete"
     date_column: str | None = None
     source_priority: list[str] | None = None
+    anchor: str | None = None
+    allow_fill: bool = False
 
     @model_validator(mode="after")
     def _validate_group(self) -> GoldenGroupRule:
@@ -479,6 +481,16 @@ class GoldenGroupRule(BaseModel):
             raise ValueError(f"Group '{self.name}' strategy 'most_recent' requires 'date_column'.")
         if self.strategy == "source_priority" and not self.source_priority:
             raise ValueError(f"Group '{self.name}' strategy 'source_priority' requires 'source_priority'.")
+        if self.strategy == "anchor":
+            if not self.anchor:
+                raise ValueError(f"Group '{self.name}' strategy 'anchor' requires 'anchor'.")
+            if self.anchor not in self.columns:
+                raise ValueError(f"Group '{self.name}' anchor '{self.anchor}' must be one of its columns.")
+        elif self.anchor is not None:
+            raise ValueError(
+                f"Group '{self.name}' sets 'anchor' but strategy is '{self.strategy}' "
+                "(anchor only valid with strategy 'anchor')."
+            )
         return self
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -34,6 +34,7 @@ class GroupProvenance:
     values: dict[str, Any]
     tie: bool
     confidence: float
+    filled: dict[str, int] = dataclass_field(default_factory=dict)
 
 
 @dataclass

--- a/packages/python/goldenmatch/goldenmatch/core/lineage.py
+++ b/packages/python/goldenmatch/goldenmatch/core/lineage.py
@@ -370,10 +370,19 @@ def load_lineage(path: str | Path) -> dict:
 
 
 def render_group_provenance_line(gp) -> str:
-    """One audit line for a lock-step field group. Spec 4.1."""
+    """One audit line for a lock-step field group. Spec 4.1.
+
+    When allow_fill back-filled any columns, appends one line per filled column:
+    "{group_name}: {col} back-filled from record {rid}"
+    """
     cols = ", ".join(gp.columns)
-    return (f"{cols} promoted together from record {gp.winner_row_id} "
+    line = (f"{cols} promoted together from record {gp.winner_row_id} "
             f"via {gp.strategy} (group '{gp.name}')")
+    fills = [
+        f"{gp.name}: {col} back-filled from record {rid}"
+        for col, rid in (getattr(gp, "filled", {}) or {}).items()
+    ]
+    return "\n".join([line, *fills]) if fills else line
 
 
 def render_field_condition_line(field: str, fp) -> str | None:

--- a/packages/python/goldenmatch/goldenmatch/core/lineage.py
+++ b/packages/python/goldenmatch/goldenmatch/core/lineage.py
@@ -184,6 +184,9 @@ def _serialize_golden_records(provenance: list) -> list[dict]:
         audit = _safe_cluster_audit(cp)
         if audit:
             rec["audit"] = audit
+        for grp in rec.get("groups", []):
+            if not grp.get("filled"):
+                grp.pop("filled", None)
     return records
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/survivorship/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/core/survivorship/resolve.py
@@ -77,18 +77,24 @@ def resolve_cluster(cluster_df, rules, resolution_order, *,
                     row["__source__"] = source_array[i]
                 rows.append(row)
             res = group_winner(rows, list(g.columns), strategy=g.strategy,
-                               source_priority=g.source_priority, dates=dates)
+                               source_priority=g.source_priority, dates=dates,
+                               anchor=g.anchor, allow_fill=g.allow_fill)
             wid = (row_id_array[res.winner_pos]
                    if (row_id_array is not None and res.winner_pos is not None and res.winner_pos >= 0)
                    else None)
             wsrc = (source_array[res.winner_pos]
                     if (source_array is not None and res.winner_pos is not None and res.winner_pos >= 0)
                     else None)
+            filled_ids = (
+                {c: row_id_array[p] for c, p in res.filled.items()}
+                if row_id_array is not None
+                else dict(res.filled)
+            )
             for c in g.columns:
                 v = res.values.get(c)
                 fd = {"value": v, "confidence": res.confidence}
                 if provenance:
-                    fd["source_row_id"] = wid
+                    fd["source_row_id"] = filled_ids.get(c, wid)
                 field_dicts[c] = fd
                 resolved[c] = v
             confidences.append(res.confidence)
@@ -97,6 +103,7 @@ def resolve_cluster(cluster_df, rules, resolution_order, *,
                     name=g.name, columns=list(g.columns), strategy=g.strategy,
                     winner_row_id=wid, winner_source=wsrc,
                     values=dict(res.values), tie=res.tie, confidence=res.confidence,
+                    filled=filled_ids,
                 ))
         else:
             col = unit

--- a/packages/python/goldenmatch/goldenmatch/core/survivorship/winner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/survivorship/winner.py
@@ -1,7 +1,7 @@
 """Group-winner selection for lock-step field-group survivorship. Spec section 3.2/4.2."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -11,41 +11,67 @@ class GroupResult:
     values: dict[str, Any]  # {column: pinned value (may be None)}
     confidence: float
     tie: bool
+    filled: dict[str, int] = field(default_factory=dict)
 
 
 def _populated(row, cols) -> int:
     return sum(1 for c in cols if row.get(c) is not None)
 
 
+def _ranking(rows, columns, strategy, *, source_priority=None, dates=None, anchor=None):
+    """Return (order, tie) where order is a list of row indices from best to worst."""
+    n = len(rows)
+    if strategy == "source_priority":
+        rank = {s: i for i, s in enumerate(source_priority or [])}
+        order = sorted(range(n), key=lambda i: rank.get(rows[i].get("__source__"), len(rank)))
+        return order, False
+    if strategy == "most_recent":
+        def keyf(i):
+            d = dates[i] if dates and i < len(dates) else None
+            return (d is not None, d)
+        order = sorted(range(n), key=keyf, reverse=True)
+        return order, False
+    if strategy == "anchor":
+        counts = [_populated(rows[i], columns) for i in range(n)]
+        present = [rows[i].get(anchor) is not None for i in range(n)]
+        order = sorted(range(n), key=lambda i: (present[i], counts[i]), reverse=True)
+        w = order[0]
+        top_key = (present[w], counts[w])
+        tie = sum(1 for i in range(n) if (present[i], counts[i]) == top_key) > 1
+        return order, tie
+    # most_complete
+    counts = [_populated(rows[i], columns) for i in range(n)]
+    order = sorted(range(n), key=lambda i: counts[i], reverse=True)
+    top = counts[order[0]]
+    tie = sum(1 for c in counts if c == top) > 1
+    return order, tie
+
+
 def group_winner(rows, columns, strategy="most_complete", *,
-                 source_priority=None, dates=None) -> GroupResult:
+                 source_priority=None, dates=None, anchor=None, allow_fill=False) -> GroupResult:
     """Pick ONE winning row; pin every group column to that row (strict lock-step,
-    nulls included). `rows` is a list of dicts carrying the group columns.
-    `dates`/source come from the parallel arrays the caller slices per cluster."""
+    nulls included unless allow_fill=True). `rows` is a list of dicts carrying
+    the group columns. `dates`/source come from the parallel arrays the caller
+    slices per cluster."""
     n = len(rows)
     if n == 0:
         return GroupResult(-1, {c: None for c in columns}, 0.0, False)
 
-    if strategy == "source_priority":
-        rank = {s: i for i, s in enumerate(source_priority or [])}
-        best = min(range(n), key=lambda i: rank.get(rows[i].get("__source__"), len(rank)))
-        tie = False
-    elif strategy == "most_recent":
-        def keyf(i):
-            d = dates[i] if dates and i < len(dates) else None
-            return (d is not None, d)
-        best = max(range(n), key=keyf)
-        # ties on equal dates are index-stable; no tie penalty (unlike most_complete).
-        tie = False
-    else:  # most_complete
-        counts = [_populated(rows[i], columns) for i in range(n)]
-        top = max(counts)
-        winners = [i for i in range(n) if counts[i] == top]
-        best = winners[0]
-        tie = len(winners) > 1
-
-    populated = _populated(rows[best], columns)
-    base_conf = populated / len(columns) if columns else 0.0
-    conf = base_conf * 0.7 if tie else base_conf
+    ranking, tie = _ranking(rows, columns, strategy,
+                            source_priority=source_priority, dates=dates, anchor=anchor)
+    best = ranking[0]
     values = {c: rows[best].get(c) for c in columns}
-    return GroupResult(rows[best].get("__pos__", best), values, conf, tie)
+    filled: dict[str, int] = {}
+    if allow_fill:
+        for c in columns:
+            if values[c] is None:
+                for j in ranking[1:]:
+                    if rows[j].get(c) is not None:
+                        values[c] = rows[j].get(c)
+                        filled[c] = rows[j].get("__pos__", j)
+                        break
+
+    winner_populated = _populated(rows[best], columns)
+    base_conf = (winner_populated + len(filled)) / len(columns) if columns else 0.0
+    conf = base_conf * 0.7 if tie else base_conf
+    return GroupResult(rows[best].get("__pos__", best), values, conf, tie, filled)

--- a/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
+++ b/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
@@ -1,6 +1,10 @@
+import json
+
 import polars as pl
 import pytest
 from goldenmatch.config.schemas import GoldenGroupRule, GoldenRulesConfig
+from goldenmatch.core.golden import ClusterProvenance, GroupProvenance
+from goldenmatch.core.lineage import render_group_provenance_line, save_lineage
 from goldenmatch.core.survivorship.conditions import build_resolution_order
 from goldenmatch.core.survivorship.resolve import resolve_cluster
 from goldenmatch.core.survivorship.winner import group_winner
@@ -106,3 +110,42 @@ def test_resolve_allow_fill_records_filled_row_id():
     assert gp.filled == {"zip": 11}
     assert rec["zip"]["value"] == "90001"
     assert rec["zip"]["source_row_id"] == 11
+
+
+# D2 back-fill NL line --------------------------------------------------------
+
+
+def test_render_group_line_includes_backfill():
+    gp = GroupProvenance(name="mailing_address", columns=["street", "city", "zip"], strategy="most_complete",
+                         winner_row_id=7, winner_source=None, values={}, tie=False, confidence=1.0, filled={"zip": 12})
+    out = render_group_provenance_line(gp)
+    assert "promoted together from record 7" in out
+    assert "mailing_address: zip back-filled from record 12" in out
+
+
+def test_render_group_line_no_fill_unchanged():
+    gp = GroupProvenance(name="addr", columns=["a", "b"], strategy="most_complete",
+                         winner_row_id=7, winner_source=None, values={}, tie=False, confidence=1.0)
+    out = render_group_provenance_line(gp)
+    assert "back-filled" not in out
+
+
+# D3 omit empty filled in serialization ---------------------------------------
+
+
+def _cp_filled(filled):
+    g = GroupProvenance(name="addr", columns=["street", "zip"], strategy="most_complete",
+                        winner_row_id=7, winner_source=None, values={}, tie=False, confidence=1.0, filled=filled)
+    return [ClusterProvenance(cluster_id=5, cluster_quality="strong", cluster_confidence=0.9, fields={}, groups=[g])]
+
+
+def test_filled_omitted_when_empty(tmp_path):
+    path = save_lineage([], tmp_path, "run", golden_provenance=_cp_filled({}))
+    grp = json.loads(path.read_text(encoding="utf-8"))["golden_records"][0]["groups"][0]
+    assert "filled" not in grp
+
+
+def test_filled_present_when_nonempty(tmp_path):
+    path = save_lineage([], tmp_path, "run", golden_provenance=_cp_filled({"zip": 12}))
+    grp = json.loads(path.read_text(encoding="utf-8"))["golden_records"][0]["groups"][0]
+    assert grp["filled"] == {"zip": 12}

--- a/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
+++ b/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
@@ -1,5 +1,9 @@
+import polars as pl
 import pytest
-from goldenmatch.config.schemas import GoldenGroupRule
+from goldenmatch.config.schemas import GoldenGroupRule, GoldenRulesConfig
+from goldenmatch.core.survivorship.conditions import build_resolution_order
+from goldenmatch.core.survivorship.resolve import resolve_cluster
+from goldenmatch.core.survivorship.winner import group_winner
 from pydantic import ValidationError
 
 
@@ -34,8 +38,6 @@ def test_anchor_with_non_anchor_strategy_rejected():
 
 
 # B2 anchor group-winner strategy ---------------------------------------------
-
-from goldenmatch.core.survivorship.winner import group_winner  # noqa: E402
 
 
 def _rows(spec):
@@ -84,3 +86,23 @@ def test_allow_fill_nothing_to_fill():
     rows = _rows([{"a": "x", "b": "y"}, {"a": "p", "b": None}])
     res = group_winner(rows, ["a", "b"], strategy="most_complete", allow_fill=True)
     assert res.filled == {}
+
+
+# C1 resolve.py threading + filled remap --------------------------------------
+
+
+def test_resolve_allow_fill_records_filled_row_id():
+    df = pl.DataFrame({
+        "__cluster_id__": [5, 5], "__row_id__": [10, 11],
+        "street": ["1 Main St", "1 Main"], "city": ["LA", None], "zip": [None, "90001"],
+    })
+    rules = GoldenRulesConfig(default_strategy="most_complete", field_groups=[
+        GoldenGroupRule(name="addr", columns=["street", "city", "zip"], allow_fill=True)])
+    order = build_resolution_order(rules.field_rules, rules.field_groups, ["street", "city", "zip"])
+    rec, prov = resolve_cluster(df, rules, order, provenance=True, cluster_id=5)
+    gp = prov.groups[0]
+    # row 0 is most-complete (street+city, 2/3); zip filled from row 1 (row_id 11)
+    assert gp.values["zip"] == "90001"
+    assert gp.filled == {"zip": 11}
+    assert rec["zip"]["value"] == "90001"
+    assert rec["zip"]["source_row_id"] == 11

--- a/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
+++ b/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
@@ -149,3 +149,24 @@ def test_filled_present_when_nonempty(tmp_path):
     path = save_lineage([], tmp_path, "run", golden_provenance=_cp_filled({"zip": 12}))
     grp = json.loads(path.read_text(encoding="utf-8"))["golden_records"][0]["groups"][0]
     assert grp["filled"] == {"zip": 12}
+
+
+# E1 combined anchor + allow_fill + parity ------------------------------------
+
+
+def test_anchor_plus_allow_fill():
+    rows = _rows([
+        {"plan_id": "P1", "plan_name": "Gold", "plan_tier": None},   # anchor present, 2/3 -> winner
+        {"plan_id": None, "plan_name": "Gold", "plan_tier": "G"},     # has tier
+    ])
+    res = group_winner(rows, ["plan_id", "plan_name", "plan_tier"],
+                       strategy="anchor", anchor="plan_id", allow_fill=True)
+    assert res.winner_pos == 0
+    assert res.values["plan_tier"] == "G" and res.filled == {"plan_tier": 1}
+
+
+def test_no_levers_byte_identical():
+    # strict lock-step (no allow_fill, default strategy) pins the winner's null + empty filled
+    rows = _rows([{"a": "x", "b": None}, {"a": "p", "b": "q"}])
+    res = group_winner(rows, ["a", "b"], strategy="most_complete")
+    assert res.values["b"] is None and res.filled == {}

--- a/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
+++ b/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
@@ -1,0 +1,33 @@
+import pytest
+from goldenmatch.config.schemas import GoldenGroupRule
+from pydantic import ValidationError
+
+
+def test_defaults():
+    g = GoldenGroupRule(name="g", columns=["a", "b"])
+    assert g.anchor is None and g.allow_fill is False
+
+
+def test_allow_fill_orthogonal():
+    g = GoldenGroupRule(name="g", columns=["a", "b"], allow_fill=True)
+    assert g.allow_fill is True
+
+
+def test_anchor_strategy_valid():
+    g = GoldenGroupRule(name="g", columns=["plan_id", "plan_name"], strategy="anchor", anchor="plan_id")
+    assert g.strategy == "anchor" and g.anchor == "plan_id"
+
+
+def test_anchor_requires_anchor_column():
+    with pytest.raises(ValidationError):
+        GoldenGroupRule(name="g", columns=["a", "b"], strategy="anchor")
+
+
+def test_anchor_must_be_in_columns():
+    with pytest.raises(ValidationError):
+        GoldenGroupRule(name="g", columns=["a", "b"], strategy="anchor", anchor="c")
+
+
+def test_anchor_with_non_anchor_strategy_rejected():
+    with pytest.raises(ValidationError):
+        GoldenGroupRule(name="g", columns=["a", "b"], strategy="most_complete", anchor="a")

--- a/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
+++ b/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
@@ -31,3 +31,56 @@ def test_anchor_must_be_in_columns():
 def test_anchor_with_non_anchor_strategy_rejected():
     with pytest.raises(ValidationError):
         GoldenGroupRule(name="g", columns=["a", "b"], strategy="most_complete", anchor="a")
+
+
+# B2 anchor group-winner strategy ---------------------------------------------
+
+from goldenmatch.core.survivorship.winner import group_winner  # noqa: E402
+
+
+def _rows(spec):
+    return [{"__pos__": i, **r} for i, r in enumerate(spec)]
+
+
+def test_anchor_picks_anchor_bearing_most_complete():
+    rows = _rows([
+        {"plan_id": None, "plan_name": "Gold", "plan_tier": "G"},
+        {"plan_id": "P1", "plan_name": "Gold", "plan_tier": None},
+        {"plan_id": "P1", "plan_name": "Gold", "plan_tier": "G"},
+    ])
+    res = group_winner(rows, ["plan_id", "plan_name", "plan_tier"], strategy="anchor", anchor="plan_id")
+    assert res.winner_pos == 2 and res.values["plan_tier"] == "G"
+
+
+def test_anchor_fallback_to_most_complete_when_none_have_anchor():
+    rows = _rows([{"plan_id": None, "plan_name": "A", "plan_tier": "X"},
+                  {"plan_id": None, "plan_name": "B", "plan_tier": None}])
+    res = group_winner(rows, ["plan_id", "plan_name", "plan_tier"], strategy="anchor", anchor="plan_id")
+    assert res.winner_pos == 0
+
+
+# B3 allow_fill per-cell back-fill --------------------------------------------
+
+def test_allow_fill_fills_winner_nulls_from_strategy_best_other_row():
+    # Row 0 wins most_complete (3/4 populated); zip=None filled from row 1.
+    rows = _rows([
+        {"street": "1 Main St", "city": "LA", "state": "CA", "zip": None},
+        {"street": "1 Main", "city": None, "state": None, "zip": "90001"},
+    ])
+    res = group_winner(rows, ["street", "city", "state", "zip"], strategy="most_complete", allow_fill=True)
+    assert res.winner_pos == 0 and res.values["zip"] == "90001"
+    assert res.filled == {"zip": 1} and res.confidence == 1.0
+
+
+def test_allow_fill_off_keeps_winner_null():
+    # Row 0 wins most_complete (3/4 populated); without allow_fill, zip stays None.
+    rows = _rows([{"street": "1 Main St", "city": "LA", "state": "CA", "zip": None},
+                  {"street": "1 Main", "city": None, "state": None, "zip": "90001"}])
+    res = group_winner(rows, ["street", "city", "state", "zip"], strategy="most_complete")
+    assert res.values["zip"] is None and res.filled == {}
+
+
+def test_allow_fill_nothing_to_fill():
+    rows = _rows([{"a": "x", "b": "y"}, {"a": "p", "b": None}])
+    res = group_winner(rows, ["a", "b"], strategy="most_complete", allow_fill=True)
+    assert res.filled == {}

--- a/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
+++ b/packages/python/goldenmatch/tests/survivorship/test_allow_fill_anchor.py
@@ -166,7 +166,10 @@ def test_anchor_plus_allow_fill():
 
 
 def test_no_levers_byte_identical():
-    # strict lock-step (no allow_fill, default strategy) pins the winner's null + empty filled
-    rows = _rows([{"a": "x", "b": None}, {"a": "p", "b": "q"}])
-    res = group_winner(rows, ["a", "b"], strategy="most_complete")
-    assert res.values["b"] is None and res.filled == {}
+    # strict lock-step (allow_fill off): the winner is most-complete but still has a
+    # null cell; that null is PINNED, not back-filled from the other row.
+    rows = _rows([{"a": "x", "b": "y", "c": None},    # winner: 2/3 most-complete
+                  {"a": None, "b": None, "c": "z"}])   # has c, but allow_fill is off
+    res = group_winner(rows, ["a", "b", "c"], strategy="most_complete")
+    assert res.winner_pos == 0
+    assert res.values["c"] is None and res.filled == {}

--- a/packages/python/goldenmatch/tests/survivorship/test_winner.py
+++ b/packages/python/goldenmatch/tests/survivorship/test_winner.py
@@ -73,3 +73,28 @@ def test_lockstep_winner_null_not_backfilled_from_nonwinner():
     )
     assert res.winner_pos == 0
     assert res.values["zip"] is None   # winner's null pinned; no back-fill
+
+
+# B1 ranking-refactor parity guards ------------------------------------------
+
+
+def _rows_pb1(spec):
+    return [{"__pos__": i, **r} for i, r in enumerate(spec)]
+
+
+def test_most_complete_tiebreak_lowest_index():
+    rows = _rows_pb1([{"a": "x", "b": "y"}, {"a": "p", "b": "q"}])
+    res = group_winner(rows, ["a", "b"], strategy="most_complete")
+    assert res.winner_pos == 0 and res.tie is True and res.confidence == 0.7
+
+
+def test_source_priority_winner_and_no_tie():
+    rows = _rows_pb1([{"a": "x", "__source__": "billing"}, {"a": "p", "__source__": "crm"}])
+    res = group_winner(rows, ["a"], strategy="source_priority", source_priority=["crm", "billing"])
+    assert res.winner_pos == 1 and res.tie is False
+
+
+def test_most_recent_tie_lowest_index():
+    rows = _rows_pb1([{"a": "x"}, {"a": "p"}])
+    res = group_winner(rows, ["a"], strategy="most_recent", dates=["2024-01-01", "2024-01-01"])
+    assert res.winner_pos == 0


### PR DESCRIPTION
## Summary

Two opt-in group-winner extensions for lock-step `field_groups` survivorship (v2 workstreams 3+4, stacks on #1053):

- **`anchor` strategy** (`strategy: anchor` + `anchor: <column>`): the winner is the record whose anchor column is present (most-complete among those; falls back to plain `most_complete` if none have it), and the rest of the group is promoted from that record. For an identity/key column anchoring related fields (e.g. `plan_id` anchoring `{plan_id, plan_name, plan_tier}`).
- **`allow_fill: true`**: when the winning record is missing a group cell, back-fill it per-cell from the best other record (by the group's strategy) that has the value. Maximizes completeness; off by default (strict lock-step).

Both record provenance: `GroupProvenance.filled` (`{column: source row id}`) and a `"<group>: <col> back-filled from record N"` line that surfaces in the lineage `golden_records` audit, `explain --cluster`, and the MCP lineage tool (workstream-1 wiring).

## Implementation

One ranking refactor in `winner.py` (strategy-ordered row indices, winner = `ranking[0]`) shared by both features; `anchor` is a new ranking, `allow_fill` walks `ranking[1:]` per null cell. The refactor is parity-preserving: `sorted(reverse=True)` is stable in CPython, so it reproduces today's lowest-index-on-tie winner for the three existing strategies (pinned by tie-cluster parity tests + the unchanged `test_winner.py`).

## Parity

Byte-identical when neither lever is used: `allow_fill=False` leaves `filled` empty (confidence reduces exactly, `source_row_id` stays the winner, the serializer omits empty `filled`); `anchor` is opt-in. Guarded by `test_no_levers_byte_identical` + the refactor-parity tests.

## Decisions (resolved from spec open questions)

- `anchor` set with a non-anchor strategy is REJECTED at config-validate (no silent misconfig).
- Per-cell fill for `source_priority`/`most_recent` groups uses the SAME strategy ranking (`ranking[1:]`), not a separate most_complete pass.

## Test Plan

- [ ] CI green (full cross-package suite)
- [x] 197 local tests pass: survivorship suite (incl. refactor-parity + anchor + allow_fill + combined/parity) + golden/lineage/explain/review_queue regressions
- [x] `ruff check packages/python/goldenmatch` clean
- [x] pyright: only `config/schemas.py` is in the include slice; its two new fields are properly typed

Spec + plan: `docs/superpowers/{specs,plans}/2026-06-17-allow-fill-anchor-strategy*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)