### PR TITLE
Demote shared-attribute fields from the multi-source weighted matchkey (#858)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -685,6 +685,40 @@ def _adaptive_threshold(fields: list[MatchkeyField]) -> float:
     return 0.80
 
 
+# #858: distinguish real person-name columns from "name"-typed SHARED ATTRIBUTE
+# columns (company, job_title, department, ...). The profiler's name heuristic
+# classifies an organization/role column as col_type="name", which then enters
+# the weighted matchkey as a full-weight person-name fuzzy field. Under
+# multi-source that collapses distinct people who share an employer / title (the
+# crm_multisource_realistic over-merge: bare F1 0.13 -> 0.77 once company +
+# job_title are demoted). The org/attribute check runs FIRST so a name-bearing
+# org column (e.g. "company_name") is still recognized as a shared attribute.
+_ORG_ATTR_COLUMN_RE = re.compile(
+    r"(?i)(?:^|[^a-z])("
+    r"company|employer|organi[sz]ation|org|firm|business|corp|"
+    r"job|title|role|position|occupation|department|dept|division|team|group|"
+    r"category|segment|industry|sector|brand|product"
+    r")(?:[^a-z]|$)"
+)
+_PERSON_NAME_COLUMN_RE = re.compile(
+    r"(?i)(?:^|[^a-z])("
+    r"first|last|given|family|sur|surname|middle|maiden|forename|fore|"
+    r"nick|nickname|preferred|legal|full|display|fname|lname|mname|name|"
+    r"person|contact|individual|party|customer|client|member|patient|applicant"
+    r")(?:[^a-z]|$)"
+)
+
+
+def _is_person_name_column(column: str) -> bool:
+    """True when a ``col_type='name'`` column is plausibly a PERSON name (so it
+    earns a positive weighted-matchkey feature), False when it's a shared
+    organization/role attribute (company, job_title, department). The org check
+    wins, so ``company_name`` reads as a shared attribute, not a person name."""
+    if _ORG_ATTR_COLUMN_RE.search(column):
+        return False
+    return bool(_PERSON_NAME_COLUMN_RE.search(column))
+
+
 def build_matchkeys(
     profiles: list[ColumnProfile], df: pl.DataFrame | None = None,
     *, multi_source: bool = False,
@@ -833,6 +867,32 @@ def build_matchkeys(
                 "Skipping exact matchkey for '%s' (%s).", p.name, reason,
             )
             skipped_exact.append((p.name, reason))
+            continue
+
+        # #858: under multi-source, a low-cardinality "name"-typed field whose
+        # column is NOT a person name (company, job_title, department, ...) is a
+        # shared workplace/categorical attribute, NOT an identity claim. As a
+        # full-weight positive feature in the weighted matchkey it collapses
+        # distinct people who share an employer / title -- the dominant driver of
+        # the multi-source over-merge (crm_multisource_realistic: bare F1 0.13;
+        # demoting company + job_title -> 0.77). Demote to blocking-only, exactly
+        # like the phone demotion above (real person-name fields and
+        # high-cardinality fields are kept). Gated on the multi_source detection,
+        # so single-source autoconfig is byte-identical.
+        if (
+            multi_source
+            and scorer != "exact"
+            and p.col_type == "name"
+            and 0 < p.cardinality_ratio < 0.5
+            and not _is_person_name_column(p.name)
+        ):
+            logger.info(
+                "Demoting weighted field '%s' to blocking-only "
+                "(multi-source: low-cardinality non-person-name shared attribute, "
+                "cardinality_ratio=%.4f). Avoids collapsing distinct people who "
+                "share this value; column remains a blocking candidate.",
+                p.name, p.cardinality_ratio,
+            )
             continue
 
         mf = MatchkeyField(

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -275,3 +275,64 @@ def test_overlap_default_partition_is_dunder_source():
     assert _check_source_overlap(df, "rid") == 0.0          # disjoint
     # absent partition -> 1.0 (fail-open)
     assert _check_source_overlap(pl.DataFrame({"rid": ["1"]}), "rid") == 1.0
+
+
+# ── Shared-attribute demotion (company / job_title over-merge driver) ─────────
+
+def test_is_person_name_column():
+    # Real person-name fields -> positive identity feature.
+    for c in ("first_name", "last_name", "surname", "given_name", "maiden_name",
+              "full_name", "nickname", "fname", "lname", "contact_name"):
+        assert ac._is_person_name_column(c), c
+    # Shared workplace / categorical attributes -> NOT a person name.
+    for c in ("company", "job_title", "employer", "department", "organization",
+              "role", "industry", "company_name"):  # org check beats "name"
+        assert not ac._is_person_name_column(c), c
+
+
+def _weighted_fields(mks):
+    return [f.field for mk in mks if mk.type == "weighted" for f in (mk.fields or [])]
+
+
+def test_multisource_demotes_low_card_shared_attributes():
+    """#858 root cause: company + job_title are profiled as col_type='name' and
+    admitted as full-weight weighted-matchkey fields, collapsing distinct people
+    who share an employer / title. Under multi_source they must be demoted to
+    blocking-only; single-source keeps the legacy behavior byte-identical."""
+    df = pl.DataFrame({
+        "source": ["hubspot", "salesforce"] * 10,
+        "crm_id": [f"id{i}" for i in range(20)],
+        "first_name": [f"First{i}" for i in range(20)],
+        "last_name": [f"Last{i}" for i in range(20)],
+        "company": ["Lighthouse Imaging LLC", "Brightline Therapeutics Inc",
+                    "Vertex Oncology Group", "Acme Co"] * 5,
+        "job_title": ["Principal Scientist", "Chief Medical Officer"] * 10,
+    })
+    profs = profile_columns(df)
+    by = {p.name: p for p in profs}
+    # Precondition: the profiler classifies these as low-cardinality "name".
+    assert by["company"].col_type == "name" and by["company"].cardinality_ratio < 0.5
+    assert by["job_title"].col_type == "name" and by["job_title"].cardinality_ratio < 0.5
+
+    ms = _weighted_fields(build_matchkeys(profs, df, multi_source=True))
+    ss = _weighted_fields(build_matchkeys(profs, df, multi_source=False))
+
+    # multi-source: shared attributes demoted, real person names kept.
+    assert "company" not in ms and "job_title" not in ms
+    assert "first_name" in ms and "last_name" in ms
+    # single-source: unchanged legacy behavior (both still admitted).
+    assert "company" in ss and "job_title" in ss
+
+
+def test_multisource_keeps_high_card_name_field():
+    """A high-cardinality name-typed field (e.g. a real surname column) is NOT
+    demoted even under multi_source -- only low-card shared attributes are."""
+    df = pl.DataFrame({
+        "source": ["a", "b"] * 10,
+        "rid": [f"r{i}" for i in range(20)],
+        "first_name": [f"First{i}" for i in range(20)],   # card 1.0
+        "last_name": [f"Last{i}" for i in range(20)],      # card 1.0
+    })
+    profs = profile_columns(df)
+    ms = _weighted_fields(build_matchkeys(profs, df, multi_source=True))
+    assert "first_name" in ms and "last_name" in ms


### PR DESCRIPTION
Closes #858.

## #858 — zero-config over-merges multi-source CRM

Reproduced the reporter's `crm_multisource_realistic` over-merge **exactly** from the issue gist: bare `dedupe_df(df)` → **F1 0.1296, P 0.0695, R 0.9579**, 95 clusters with a single 89-member blob.

### Root cause (corrects the issue's hypothesis)
The issue comment attributed it to *"bare autoconfig admits the `source` label + an exact-`phone` matchkey."* Instrumenting the real fixture shows that's **not** what happens — the 2.0.0 machinery fires correctly:
- `_detect_source_partition → 'source'`, and `_source_correlated_exclusions → ['record_id', 'source']` — both excluded.
- `phone` **is** demoted (committed config has `exact_email`, never `exact_phone`).

The actual driver: the profiler classifies **`company`** (cardinality 0.079) and **`job_title`** (0.036) as `col_type="name"`, so they enter the weighted matchkey as **full-weight person-name fuzzy fields**. With blocking on `(city, first_name)`, distinct people sharing an employer/title collapse. Ablation:

| config | P | R | F1 |
|---|---|---|---|
| bare (committed) | 0.069 | 0.958 | **0.130** |
| − `job_title` | 0.343 | 0.876 | 0.493 |
| − `company` | 0.205 | 0.785 | 0.325 |
| **− `company` − `job_title`** | 0.753 | 0.778 | **0.766** |

### Fix
Under `multi_source`, a low-cardinality (< 0.5) `name`-typed field whose column is **not** a person name (`company`, `job_title`, `department`, `company_name`, …) is a shared workplace/categorical attribute, not an identity claim — **demote it to blocking-only**, exactly like the existing phone demotion. Person-name columns (`first/last/surname/…`) and high-cardinality fields are kept; `_is_person_name_column` runs the org/attribute check first so a name-bearing org column (`company_name`) is still recognized as a shared attribute.

**Gated entirely on the `multi_source` source-partition detection**, so single-source autoconfig is byte-identical (the clean febrl-shape path is untouched).

### Measured on the fixture
**Bare F1 0.13 → 0.77** (P 0.07 → 0.75), largest cluster 89 → 10. The reporter's curated config reaches 0.84 (the remaining gap is surname/email up-weighting + soundex-on-surname blocking — config tuning beyond zero-config's remit); this resolves the *catastrophic* over-merge that's the subject of the issue.

### Test plan
- `tests/test_autoconfig_multisource.py` — `_is_person_name_column` unit cases (person names vs org/attribute, incl. `company_name`); `build_matchkeys` demotes `company`/`job_title` under `multi_source` but keeps them single-source (legacy byte-identical); high-cardinality name fields are never demoted.
- Full autoconfig suites green: `test_autoconfig.py` + `test_autoconfig_multisource.py` + `test_autoconfig_regressions.py` → **152 + 3 new passed, 3 skipped**.

### Notes
- Independent of the other audit PRs (#1052 merged, #1054 in queue) — separate branch.
- Follow-up (not in scope): closing the last 0.77→0.84 gap would need surname/email re-weighting + soundex blocking under multi-source, a larger autoconfig-tuning change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)