### PR TITLE
bench: measure-first survivorship columnar scale investigation

### DIFF
--- a/.github/workflows/bench-survivorship-columnar.yml
+++ b/.github/workflows/bench-survivorship-columnar.yml
@@ -1,0 +1,46 @@
+name: bench-survivorship-columnar
+
+# Measure-first bench: survivorship slow path vs vectorized floor.
+# Dispatched manually; no native build (this bench exercises the Python
+# survivorship path and the polars-native floor, not the Rust kernel).
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Comma-separated row counts (e.g. '1000000,5000000')"
+        default: "1000000,5000000"
+      runs:
+        description: "Repetitions per measurement (median)"
+        default: "3"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: large-new-64GB
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Run survivorship-columnar bench
+        env:
+          GOLDENMATCH_NATIVE: "0"
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: |
+          set -euo pipefail
+          uv run python packages/python/goldenmatch/scripts/bench_survivorship_columnar.py \
+            --rows "${{ inputs.rows }}" --runs "${{ inputs.runs }}" \
+            --output bench_survivorship_columnar.json | tee -a "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
+        with:
+          name: survivorship-columnar
+          path: bench_survivorship_columnar.json
+          retention-days: 30

--- a/docs/superpowers/plans/2026-06-17-survivorship-columnar-measure-first.md
+++ b/docs/superpowers/plans/2026-06-17-survivorship-columnar-measure-first.md
@@ -1,0 +1,342 @@
+# Columnar Survivorship Measure-First Bench Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a benchmark (`scripts/bench_survivorship_columnar.py`) + a CI workflow + a smoke test that measure the survivorship slow path's wall + RSS against the vectorized fast-path floor at scale, with a per-phase breakdown, then produce a measured GO/NO-GO verdict on a Phase-2 vectorized rewrite. NO production code changes.
+
+**Architecture:** The bench synthesizes a `__cluster_id__`-tagged multi-member frame directly (skip blocking/dedupe), then measures two variants in separate subprocesses (clean peak RSS each, mirroring `bench_scorer_columnar.py`): (1) the SLOW path, reconstructed by calling the same functions `build_golden_records_batch`'s survivorship branch calls (`sort` -> `build_resolution_order` -> `partition_by` -> per-cluster `resolve_cluster`) with per-phase timers; (2) the FLOOR, a plain `most_complete` config routed through the vectorized `_build_golden_records_polars_native` path (asserted eligible). The verdict computes the vectorizable tax and applies the distributed-plan-style kill criterion.
+
+**Tech Stack:** Python 3.11+, Polars, `argparse`/`subprocess`/`resource`/`statistics`/`time`, pytest (smoke only), GitHub Actions. Spec: `docs/superpowers/specs/2026-06-17-survivorship-columnar-measure-first-design.md`.
+
+**Dependency:** Stacks on the merged/landing survivorship work (v1 + #1053 + #1055). Branch off `origin/main` once #1055 lands (the bench imports `resolve_cluster`, `build_resolution_order`, `GoldenGroupRule`, `_polars_native_eligible`). The bench only READS these; no survivorship-feature code is modified.
+
+---
+
+## Conventions for every task
+
+- **Run tests / the smoke** (targeted local runs only; the SCALE bench runs in CI, never locally):
+  `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 <repo>/.venv/Scripts/python.exe -m pytest <path> -v`
+  (`GOLDENMATCH_NATIVE=0` if a stale native wheel interferes).
+- A 1k-row bench run is fine locally; 1M/5M runs are CI-only (`large-new-64GB`).
+- **Commit** after each green step. Squash-merge via PR at the end.
+- **No em dashes / ASCII only** in committed strings.
+- This workstream adds ONLY: one script, one workflow, one smoke test. It changes NO production code -> production behavior is trivially byte-identical.
+
+---
+
+## File Structure
+
+**New files**
+- `packages/python/goldenmatch/scripts/bench_survivorship_columnar.py` — the bench (workload synth, configs, per-phase slow timer, floor timer, verdict, table, argparse + subprocess child).
+- `.github/workflows/bench-survivorship-columnar.yml` — `workflow_dispatch` on `large-new-64GB`.
+- `packages/python/goldenmatch/tests/test_bench_survivorship_columnar_smoke.py` — 1k smoke (harness bit-rot guard, NOT a perf assertion).
+
+**Modified files**: none (no production code touched).
+
+---
+
+## Task 0: Branch setup
+
+- [ ] **Step 1:** Confirm #1055 merged; branch off fresh `origin/main`.
+```bash
+git fetch origin
+git switch -c feat/survivorship-columnar-bench origin/main
+# sanity: the imports the bench needs exist
+grep -n "def resolve_cluster" packages/python/goldenmatch/goldenmatch/core/survivorship/resolve.py
+grep -n "def _polars_native_eligible\|def _build_golden_records_polars_native\|def build_golden_records_batch" packages/python/goldenmatch/goldenmatch/core/golden.py
+ls packages/python/goldenmatch/scripts/bench_scorer_columnar.py   # the model
+```
+
+---
+
+## Task 1: clustered workload synthesizer
+
+**Files:**
+- Create: `scripts/bench_survivorship_columnar.py`
+- Test: `tests/test_bench_survivorship_columnar_smoke.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/test_bench_survivorship_columnar_smoke.py
+import importlib.util
+from pathlib import Path
+
+_BENCH = Path(__file__).parent.parent / "scripts" / "bench_survivorship_columnar.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("bench_surv_col", _BENCH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_make_clustered_workload_shape():
+    mod = _load()
+    df = mod.make_clustered_workload(rows=1000, avg_cluster_size=3, seed=7)
+    # tagged multi-member frame
+    assert "__cluster_id__" in df.columns and "__row_id__" in df.columns
+    assert "__source__" in df.columns       # source metadata for source_priority
+    assert {"first_name", "last_name", "street", "city", "state", "zip", "phone", "updated_at"} <= set(df.columns)
+    assert df.height == 1000
+    # multiple clusters, all multi-member (size >= 2), some nulls to give the resolver work
+    n_clusters = df["__cluster_id__"].n_unique()
+    assert 100 < n_clusters < 500          # ~333 clusters at avg size 3
+    assert df["zip"].null_count() > 0       # nulls -> group-winner / fill has work
+```
+
+- [ ] **Step 2: Run to verify it fails** (module/function missing).
+
+- [ ] **Step 3: Implement** `make_clustered_workload` in the bench (model the deterministic-seed style of `bench_scorer_columnar.py::make_workload`). Synthesize `rows` records partitioned into clusters of ~`avg_cluster_size`, each cluster a near-duplicate person/address with intra-cluster nulls/variation:
+```python
+from __future__ import annotations
+import argparse, json, os, statistics, subprocess, sys, time
+import polars as pl
+
+_STATES = ["CA", "NY", "TX", "FL", "IL", "WA", "MA", "OH"]
+_SOURCES = ["crm", "billing", "events"]
+
+
+def make_clustered_workload(rows: int, avg_cluster_size: int = 3, seed: int = 7) -> pl.DataFrame:
+    import random
+    rnd = random.Random(seed)
+    recs = []
+    rid = 0
+    cid = 0
+    while len(recs) < rows:
+        size = max(2, avg_cluster_size)        # all multi-member (survivorship only sees multi-member)
+        cid += 1
+        base_zip = f"{10000 + cid % 89999:05d}"
+        for k in range(size):
+            if len(recs) >= rows:
+                break
+            recs.append({
+                "__cluster_id__": cid,
+                "__row_id__": rid,
+                "first_name": rnd.choice(["Jon", "John", "Jonathan"]),
+                "last_name": f"Sev{cid % 997}",
+                "street": None if k == 0 else f"{cid % 9999} Main St",   # winner-null on some cells
+                "city": "Springfield" if k != 1 else None,
+                "state": _STATES[cid % len(_STATES)],
+                "zip": None if k == 1 else base_zip,
+                "phone": None if k == 2 else f"212555{cid % 9999:04d}",
+                "updated_at": f"2024-{1 + (k % 12):02d}-01",
+                "__source__": _SOURCES[(cid + k) % len(_SOURCES)],   # metadata col resolve_cluster reads for source_priority
+            })
+            rid += 1
+    return pl.DataFrame(recs[:rows])
+```
+
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** `bench(survivorship): clustered workload synthesizer`.
+
+## Task 2: configs + eligibility assert
+
+**Files:** Modify the bench; Test: append to the smoke.
+
+- [ ] **Step 1: Write the failing test**
+```python
+def test_configs_and_floor_eligibility():
+    mod = _load()
+    surv = mod.make_survivorship_config()
+    floor = mod.make_floor_config()
+    from goldenmatch.core.golden import _survivorship_active, _polars_native_eligible
+    assert _survivorship_active(surv.golden_rules) is True
+    assert _survivorship_active(floor.golden_rules) is False
+    # the floor MUST land on the vectorized native path (else the tax is corrupted)
+    assert _polars_native_eligible(floor.golden_rules, None) is True
+    mod.assert_floor_eligible(floor)        # raises if not eligible
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** `make_survivorship_config`, `make_floor_config`, `assert_floor_eligible`. The survivorship config is the realistic mixed one from the spec (a `mailing_address` field group + a conditional/validated `phone` rule). The floor is plain `most_complete`, empty `field_rules`. Return objects exposing `.golden_rules` (a `MatchConfig`-like holder, or just return the `GoldenRulesConfig` and adapt the test — match whatever `build_golden_records_batch` consumes; it takes `rules: GoldenRulesConfig`, so these helpers can return `GoldenRulesConfig` directly and the test reads them directly rather than via `.golden_rules`. Adjust the test accordingly during impl.):
+```python
+from goldenmatch.config.schemas import (
+    GoldenRulesConfig, GoldenGroupRule, GoldenFieldRule,
+)
+
+
+def make_survivorship_config() -> GoldenRulesConfig:
+    return GoldenRulesConfig(
+        default_strategy="most_complete",
+        field_groups=[GoldenGroupRule(name="mailing_address",
+                                      columns=["street", "city", "state", "zip"],
+                                      strategy="most_complete")],
+        field_rules={"phone": [
+            GoldenFieldRule(when="state in ['CA','NY']", strategy="most_recent",
+                            date_column="updated_at", validate="nanp"),
+            GoldenFieldRule(strategy="source_priority", source_priority=["crm", "billing"]),
+        ]},
+    )
+
+
+def make_floor_config() -> GoldenRulesConfig:
+    return GoldenRulesConfig(default_strategy="most_complete")   # no levers -> native eligible
+
+
+def assert_floor_eligible(floor_rules) -> None:
+    from goldenmatch.core.golden import _polars_native_eligible, _survivorship_active
+    assert not _survivorship_active(floor_rules), "floor config must be non-survivorship"
+    assert _polars_native_eligible(floor_rules, None), "floor config must hit the vectorized native path"
+```
+(NB: `make_*_config` return `GoldenRulesConfig`; update the Task-2 test to call `_survivorship_active(surv)` / `assert_floor_eligible(floor)` on the rules object directly. Also confirm at plan-execution time that `validate="nanp"` resolves in `goldenflow_filter`; if `nanp` is not wired in the bench env, swap to a validator that is, or drop `validate:` and note it in the report -- an unknown validator silently no-ops, understating the conditional path's work.)
+
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** `bench(survivorship): mixed + floor configs with native-eligibility guard`.
+
+## Task 3: measurement core (slow per-phase + floor + parity)
+
+**Files:** Modify the bench; Test: append to the smoke.
+
+- [ ] **Step 1: Write the failing test**
+```python
+def test_measure_returns_phase_split_and_parity():
+    mod = _load()
+    df = mod.make_clustered_workload(rows=1000, avg_cluster_size=3, seed=7)
+    slow = mod.run_slow(df, mod.make_survivorship_config(), runs=1)
+    floor = mod.run_floor(df, mod.make_floor_config(), runs=1)
+    # phase split keys present
+    for k in ("total_wall_s", "sort_wall_s", "partition_wall_s", "loop_wall_s", "n_clusters", "rows_out"):
+        assert k in slow
+    assert "total_wall_s" in floor and "rows_out" in floor
+    # one golden record per cluster on BOTH paths -> same row count (guards a broken workload)
+    assert slow["rows_out"] == floor["rows_out"] == df["__cluster_id__"].n_unique()
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** `run_slow` (reconstruct the survivorship branch's phases with timers, calling the SAME functions `build_golden_records_batch` calls) and `run_floor` (the native path), each returning median wall over `runs`:
+```python
+def run_slow(multi_df, rules, runs: int) -> dict:
+    from goldenmatch.core.golden import _is_internal
+    from goldenmatch.core.survivorship.conditions import build_resolution_order
+    from goldenmatch.core.survivorship.resolve import resolve_cluster
+    totals, sorts, parts, loops = [], [], [], []
+    rows_out = 0
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        s_sorted = multi_df.sort("__cluster_id__")
+        t_sort = time.perf_counter()
+        user_cols = [c for c in s_sorted.columns if not _is_internal(c) and c != "__cluster_id__"]
+        order = build_resolution_order(rules.field_rules, rules.field_groups, user_cols)
+        partitions = s_sorted.partition_by("__cluster_id__", maintain_order=True)
+        t_part = time.perf_counter()
+        out = []
+        for cdf in partitions:
+            cid = cdf["__cluster_id__"][0]
+            rec, _ = resolve_cluster(cdf, rules, order, cluster_id=int(cid))
+            out.append(rec)
+        t_loop = time.perf_counter()
+        rows_out = len(out)
+        totals.append(t_loop - t0); sorts.append(t_sort - t0)
+        parts.append(t_part - t_sort); loops.append(t_loop - t_part)
+    return {
+        "total_wall_s": round(statistics.median(totals), 4),
+        "sort_wall_s": round(statistics.median(sorts), 4),
+        "partition_wall_s": round(statistics.median(parts), 4),
+        "loop_wall_s": round(statistics.median(loops), 4),
+        "n_clusters": multi_df["__cluster_id__"].n_unique(),
+        "rows_out": rows_out,
+    }
+
+
+def run_floor(multi_df, floor_rules, runs: int) -> dict:
+    from goldenmatch.core.golden import build_golden_records_batch
+    assert_floor_eligible(floor_rules)
+    walls = []
+    rows_out = 0
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        out = build_golden_records_batch(multi_df, floor_rules)   # native vectorized path
+        walls.append(time.perf_counter() - t0)
+        rows_out = len(out)
+    return {"total_wall_s": round(statistics.median(walls), 4), "rows_out": rows_out}
+```
+(Implementation notes for the executor: the slow reconstruction mirrors `core/golden.py`'s survivorship branch (`sort` -> `build_resolution_order` -> `partition_by(..., maintain_order=True)` -> `resolve_cluster(..., cluster_id=int(cid))`), `provenance=False` for the common case. `build_golden_records_batch` returns a list (one dict per cluster); `rows_out = len(out)`. Confirm `build_golden_records_batch(multi_df, floor_rules)` actually routes to `_build_golden_records_polars_native` for the floor config -- if the native gate lives in a wrapper rather than `build_golden_records_batch`, call that wrapper for the floor instead, keeping the `assert_floor_eligible` guard. The intra-loop split (materialize vs group_winner vs eval_predicate) is NOT computed here; it comes from a `py-spy` profile captured in the verdict report, per the spec.)
+
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** `bench(survivorship): slow per-phase + floor measurement + row-count parity`.
+
+## Task 4: verdict + table + main (subprocess per variant)
+
+**Files:** Modify the bench; Test: append to the smoke.
+
+- [ ] **Step 1: Write the failing test**
+```python
+def test_main_runs_1k_and_emits_table(capsys):
+    mod = _load()
+    rc = mod.main(["--rows", "1000", "--runs", "1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "survivorship-columnar" in out.lower()
+    assert "tax" in out.lower() and "verdict" in out.lower()
+
+
+def test_verdict_no_go_when_tax_small():
+    mod = _load()
+    # slow barely above floor -> tax < bar -> NO-GO
+    v = mod.verdict(slow={"total_wall_s": 1.05, "sort_wall_s": 0.1, "partition_wall_s": 0.1,
+                          "loop_wall_s": 0.85, "peak_rss_mb": 100},
+                    floor={"total_wall_s": 1.0, "peak_rss_mb": 95})
+    assert "NO-GO" in v
+
+
+def test_verdict_go_when_vectorizable_tax_large():
+    mod = _load()
+    # slow 3x floor, dominated by partition+loop (vectorizable) -> GO
+    v = mod.verdict(slow={"total_wall_s": 3.0, "sort_wall_s": 0.1, "partition_wall_s": 0.4,
+                          "loop_wall_s": 2.5, "peak_rss_mb": 100},
+                    floor={"total_wall_s": 1.0, "peak_rss_mb": 95})
+    assert "GO" in v and "NO-GO" not in v
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** `_peak_rss_mb` (copy from `bench_scorer_columnar.py`, Unix-only, returns None off-Unix), `verdict`, `_table`, and `main` with `argparse` + subprocess-per-variant for clean RSS (mirror `bench_scorer_columnar.py`'s `--child` pattern: parent spawns a child per variant per scale, child prints a JSON dict, parent aggregates). The `verdict`:
+```python
+def verdict(slow: dict, floor: dict) -> str:
+    total = slow["total_wall_s"]
+    tax = max(0.0, total - floor["total_wall_s"])
+    # vectorizable phases: sort is shared/cheap; partition + loop-overhead + materialization +
+    # group_winner are the rewrite-recoverable bucket. Coarse proxy = partition + loop walls.
+    # (loop_wall includes the inherently-Python conditional eval; the report's py-spy split
+    # refines this. For the coarse GO/NO-GO, treat partition+loop as the recoverable ceiling
+    # and require it to dominate the tax.)
+    recoverable = slow["partition_wall_s"] + slow["loop_wall_s"]
+    frac = recoverable / total if total else 0.0
+    rss_ok = (floor.get("peak_rss_mb") is None or slow.get("peak_rss_mb") is None
+              or slow["peak_rss_mb"] <= floor["peak_rss_mb"] * 1.15)
+    go = (tax / total >= 0.25 if total else False) and frac >= 0.25 and rss_ok
+    return (f"VERDICT: {'GO' if go else 'NO-GO'} "
+            f"(tax={tax:.3f}s {100*tax/total:.0f}% of slow, recoverable~{100*frac:.0f}%, "
+            f"rss_ok={rss_ok}). "
+            + ("Vectorizable cost dominates and clears the 25-30% bar -> pursue Phase-2 rewrite."
+               if go else
+               "Tax below bar or not localized to a vectorizable phase, or RSS regressed -> keep the slow path."))
+```
+(The `_table` prints the per-scale slow/floor/tax/per-phase/RSS rows. `main` parses `--rows "1000000,5000000"`, `--runs`, `--seed` (default 7), `--avg-cluster-size` (default 3), `--child`; for each scale, runs slow + floor variants (each in its own subprocess for clean peak RSS), prints the table + the verdict. Title line contains "survivorship-columnar". **Seed alignment:** the df is NOT pickled across the process boundary -- each child re-synthesizes the workload from `--rows`/`--seed`/`--avg-cluster-size` (mirroring `bench_scorer_columnar.py`), so the parent MUST thread the SAME `--seed`/`--avg-cluster-size` to both the slow-child and the floor-child, else they measure different frames and the tax is invalid.)
+
+- [ ] **Step 4: Run to verify pass** (the 1k `main` smoke + the two synthetic-verdict unit tests).
+- [ ] **Step 5: Commit** `bench(survivorship): verdict + table + main (subprocess per variant)`.
+
+## Task 5: CI workflow
+
+**Files:** Create `.github/workflows/bench-survivorship-columnar.yml`
+
+- [ ] **Step 1: Implement** a `workflow_dispatch` workflow modeled on `.github/workflows/bench-scorer-columnar.yml` (the closest analog -- same script shape, runner, and setup): inputs `rows` (default `1000000,5000000`) and `runs` (default 3); `runs-on: large-new-64GB`; checkout, `setup-uv` + `uv sync --all-packages`; run `uv run python packages/python/goldenmatch/scripts/bench_survivorship_columnar.py --rows ${{ inputs.rows }} --runs ${{ inputs.runs }} | tee -a $GITHUB_STEP_SUMMARY`; `upload-artifact` the output. Set `env: { GOLDENMATCH_NATIVE: "0", POLARS_SKIP_CPU_CHECK: "1" }` (per the scorer-columnar workflow) to dodge stale-wheel / CPU-check footguns. (Read `bench-scorer-columnar.yml` for the exact runner label + setup steps and match them.)
+- [ ] **Step 2: Commit** `ci(bench): survivorship columnar workflow_dispatch on large-new-64GB`.
+
+## Task 6 (execution-time, NOT code): run at scale + write the verdict report
+
+> This task runs AFTER the PR merges (or via `workflow_dispatch` on the branch). It is a measurement + writeup step, not a code change.
+
+- [ ] **Step 1:** Trigger `bench-survivorship-columnar.yml` at `rows=1000000,5000000`, `runs=3` on `large-new-64GB`. Capture the table + verdict.
+- [ ] **Step 2:** Capture an intra-`resolve_cluster` `py-spy` profile (materialize vs group_winner vs eval_predicate) from one scale run for the report appendix.
+- [ ] **Step 3:** Write `docs/superpowers/reports/2026-06-XX-survivorship-columnar-verdict.md`: the 1M+5M wall/RSS/per-phase table, the recoverable computation, the py-spy split, and the GO/NO-GO. If NO-GO, record "keep the slow path" with the evidence so it is not re-litigated; if GO, name the follow-on Phase-2 rewrite spec.
+
+---
+
+## Open items carried from the spec (resolve during execution)
+
+- **`validate="nanp"` reachability:** confirm at impl time `nanp` resolves in `goldenflow_filter` in the bench env; else swap/drop and note in the report (an unknown validator silently no-ops, understating the conditional cost).
+- **Floor entry point:** confirm `build_golden_records_batch(multi_df, floor_rules)` reaches `_build_golden_records_polars_native`; if the native gate is in a wrapper, call that for the floor (keep `assert_floor_eligible`).
+- **RSS off-Unix:** `_peak_rss_mb()` returns None off-Unix; the smoke asserts table keys only, never an RSS value; `verdict`'s `rss_ok` treats None as pass.
+- **Coarse vs fine attribution:** the bench's `loop_wall` lumps materialization + group_winner + the per-cluster conditional eval; the report's py-spy appendix splits them. The coarse verdict treats partition+loop as the recoverable ceiling. This OVER-counts the truly-vectorizable portion (loop_wall includes the non-vectorizable conditional eval), which is **OPTIMISTIC for GO**: a coarse GO MUST be de-risked by the py-spy split before any Phase-2 commitment, while a coarse NO-GO is robust (even the inflated recoverable did not clear the bar). The methodology is conservative *overall* because the only automatic conclusion it can stand on alone is NO-GO.

--- a/docs/superpowers/specs/2026-06-17-survivorship-columnar-measure-first-design.md
+++ b/docs/superpowers/specs/2026-06-17-survivorship-columnar-measure-first-design.md
@@ -1,0 +1,219 @@
+---
+title: Columnar survivorship scale path (measure-first verdict)
+date: 2026-06-17
+status: design (approved in brainstorming; pre-spec-review)
+owner: Ben Severn
+related:
+  - docs/superpowers/specs/2026-06-17-correlated-survivorship-and-conditional-golden-rules-design.md
+  - docs/superpowers/specs/2026-06-17-groupprovenance-surfacing-design.md
+  - docs/superpowers/specs/2026-06-17-allow-fill-anchor-strategy-design.md
+---
+
+# Columnar survivorship scale path (measure-first verdict)
+
+> v2 workstream 2 of the correlated-survivorship program. A MEASURE-FIRST
+> investigation: the deliverable is a bench + a measured verdict, NOT a
+> rewrite. A Phase-2 vectorized rewrite is a separate, conditional spec
+> that only happens if the verdict clears the bar.
+
+## 1. Problem
+
+Survivorship resolution does not use the fast columnar path. When
+`_survivorship_active(rules)` is true, `_polars_native_eligible` returns
+False and `build_golden_records_batch` takes the slow branch
+(`core/golden.py` ~L884):
+
+```python
+s_sorted = multi_df.sort("__cluster_id__")
+order = build_resolution_order(...)
+for cdf in s_sorted.partition_by("__cluster_id__", maintain_order=True):
+    rec, prov = resolve_cluster(cdf, rules, order, ...)   # per-cluster Python
+```
+
+`resolve_cluster` (`core/survivorship/resolve.py`) materializes one frame +
+per-column Python lists PER CLUSTER (`col_arrays = {c: cluster_df[c].to_list()}`,
+plus `source_array`/`row_id_array`), then resolves each unit (group via
+`group_winner`, scalar via `merge_field`, conditional via the safe-`ast`
+`eval_predicate`). At scale this is one Python iteration + materialization
+per cluster: at ~1.67M clusters (5M rows, avg size 3) that is ~1.67M
+iterations. The resolver's own docstring flags it: "materializes one frame +
+per-column lists PER CLUSTER by design ... A columnar/array-slice
+survivorship path that avoids per-cluster materialization is a tracked scale
+follow-up."
+
+**But the project's history says be skeptical.** Every prior columnar
+rewrite in this codebase came in flat-or-negative: the scorer columnar A/B
+was ~1-2% SLOWER with +13-16% RSS (`bench_scorer_columnar.py`); the Phase-2
+Arrow columnar kernels stayed gated OFF (1.05-1.07x, +30% RSS). So a columnar
+survivorship rewrite is a real risk of being a no-op. **This workstream
+refuses to design the rewrite before measuring whether it would win.**
+
+## 2. Goals / non-goals
+
+**Goals**
+- A bench (`scripts/bench_survivorship_columnar.py`) that measures the
+  survivorship slow path's wall + RSS at scale on a realistic config, with a
+  **per-phase breakdown** that attributes the cost.
+- A measured **verdict** (committed report) with a go/no-go on a Phase-2
+  vectorized rewrite, against an explicit kill criterion.
+- The methodology is **floor + attribution, no prototype**: compare the slow
+  path to the non-survivorship fast path (the floor / lower bound) and use
+  the per-phase split to size the *recoverable* (vectorizable) portion of the
+  tax. No vectorized prototype is built in this workstream (that would be
+  half the rewrite, defeating measure-first).
+
+**Non-goals**
+- The vectorized rewrite itself (conditional Phase 2, separate spec).
+- Any change to the production survivorship path. This workstream adds ONLY
+  a bench script + a report. The slow path is untouched -> trivially
+  byte-identical.
+- Per-lever isolation benches. The brainstorm chose ONE realistic mixed
+  config; the per-phase breakdown does the attribution.
+- Distributed/Sail scale (survivorship already refuses those paths).
+
+## 3. The bench
+
+`scripts/bench_survivorship_columnar.py`, modeled on
+`scripts/bench_scorer_columnar.py` (same shape: `argparse`, a
+`make_workload(...)`, 5-run median wall, peak RSS).
+
+### 3.1 Workload (realistic mixed config)
+
+A person/address dataset generated with a dupe-rate knob driving cluster
+count/size (reuse the `make_workload` pattern; synthetic surnames MUST
+distribute across soundex codes per the project fixture lesson, else
+blocking/clustering hangs -- but this bench operates on an
+already-`__cluster_id__`-tagged multi-member frame, so it can synthesize
+clusters directly and skip blocking entirely). Columns: `first_name`,
+`last_name`, `street`, `city`, `state`, `zip`, `phone`, `updated_at`,
+`source`. One realistic mixed `GoldenRulesConfig`:
+- a `mailing_address` field_group over `{street, city, state, zip}`
+  (`most_complete`),
+- a conditional `phone` rule: `[{when: "state in ['CA','NY']", strategy:
+  most_recent, date_column: updated_at, validate: nanp}, {strategy:
+  source_priority, source_priority: [crm, billing]}]`,
+- plain fields otherwise.
+
+**Scales:** 1M and 5M rows. The per-cluster-loop cost tracks cluster COUNT,
+so the bench reports cluster count and uses a dupe-rate giving many small
+clusters (the worst case for the Python loop). A 50M extrapolation note is
+derived, not run (cost ceiling).
+
+### 3.2 What it measures (5-run median wall + per-phase peak RSS)
+
+1. **Slow path** (`build_golden_records_batch` with the survivorship config),
+   with a per-phase wall breakdown via lightweight timers around:
+   `sort`, `partition_by`, the per-cluster loop, and -- inside a
+   representative `resolve_cluster` sampling or an instrumented run --
+   per-cluster **materialization** (`to_list`), **`group_winner`**, and the
+   **conditional `eval_predicate`**. (Implementation note: prefer a coarse
+   wall split via `GOLDENMATCH_BUCKET_DEBUG`-style env-gated timers added
+   only to the bench's call path, NOT new production instrumentation, to keep
+   the production path byte-identical. If per-`resolve_cluster` attribution
+   needs finer detail, a sampling profiler (`py-spy`-style) over the bench
+   process is acceptable and is captured in the report rather than as code.)
+2. **Fast-path floor**: the SAME workload through the non-survivorship path
+   (a plain `most_complete` `GoldenRulesConfig` with empty `field_rules`,
+   which makes `_survivorship_active` False AND `_polars_native_eligible`
+   True, routing to `_build_golden_records_polars_native` -- a genuinely
+   vectorized `group_by`-per-column path, NOT the L904 col-arrays-once middle
+   loop). This is the absolute lower bound on achievable wall -- a rewrite
+   cannot beat it and realistically will not reach it (it still does
+   group-winner work). **The bench MUST assert the floor lands on the
+   vectorized path** (`_polars_native_eligible(floor_rules, None) is True`,
+   mirroring `bench_scorer_columnar.py`'s eligibility guard) -- else a future
+   eligibility-gate change could silently make the "floor" the slower middle
+   loop and corrupt the tax.
+
+Both report wall (5-run median, per the perf-audit "measure wall not cumtime"
+lesson) and peak RSS markers (per the RSS-as-tracked-constraint discipline).
+
+### 3.3 Where it runs
+
+A `bench-survivorship-columnar.yml` `workflow_dispatch` workflow on
+`large-new-64GB` (16c/64GB). The box is memory-starved; this bench does NOT
+run on the laptop. Inputs: `rows` (1000000 / 5000000), `dupe_rate`. A 1k-row
+smoke runs in the normal CI lane (Section 5).
+
+## 4. Verdict methodology + kill criterion
+
+`tax = slow_wall - floor_wall` is the TOTAL headroom. Split the slow wall by
+the per-phase breakdown into:
+- **Vectorizable phases** a rewrite could eliminate/vectorize: the per-cluster
+  loop overhead (Python iteration), per-cluster materialization (`to_list`),
+  and `group_winner` (expressible as a polars `group_by` + agg).
+- **Inherently-Python phase**: the conditional `eval_predicate` -- a
+  **per-conditional-field, per-cluster** `ast` walk (`select_conditional_strategy`
+  calls it once per conditional field per cluster, against the cluster's
+  already-resolved scalar dict; NOT per-row). It is far cheaper than a
+  per-row walk would be, so a "dominated by the conditional eval -> NO-GO"
+  outcome is correspondingly LESS likely; not vectorizable, stays on the slow
+  path regardless.
+
+**Recoverable = sum of the vectorizable-phase wall.** The floor bounds it
+(recoverable cannot exceed `slow - floor`).
+
+**Kill criterion (the distributed-plan-style bar):** pursue a Phase-2
+vectorized rewrite ONLY if **recoverable >= ~25-30% of slow wall AND it
+localizes** to the vectorizable phases (i.e. the cost is genuinely in the
+loop/materialization/group_winner, not dominated by the conditional eval or
+the unavoidable `merge_field` work). RSS must not regress (a vectorized path
+that recovers wall but blows up RSS is also a no-go, matching the prior
+columnar A/B failure mode). Otherwise the verdict is **"keep the slow path"**
+with the numbers as proof (mirroring the columnar-pipeline-verdict and
+quality-bridges-inert outcomes).
+
+## 5. Deliverable + testing
+
+**Deliverable:**
+- `scripts/bench_survivorship_columnar.py` (the bench).
+- `.github/workflows/bench-survivorship-columnar.yml` (`workflow_dispatch`,
+  `large-new-64GB`).
+- A committed verdict report (`docs/superpowers/reports/2026-06-XX-
+  survivorship-columnar-verdict.md`) with the wall/RSS/per-phase table at
+  1M + 5M, the recoverable computation, and the go/no-go. If GO, it names the
+  follow-on Phase-2 rewrite spec; if NO-GO, it records "keep the slow path"
+  with the evidence so this isn't re-litigated.
+
+**No production code changes.** The slow path, `resolve_cluster`, and the
+config schema are untouched. So there is no parity gate to write -- the
+"parity" is trivially that production behavior is unchanged (the bench is a
+read-only measurement harness).
+
+**Testing:**
+- A 1k-row smoke test (`tests/.../test_bench_survivorship_columnar_smoke.py`
+  or a tiny CI step) that imports the bench, runs it at `rows=1000`, and
+  asserts it completes and emits the expected table keys (slow wall, floor
+  wall, per-phase split). This guards the harness from bit-rot; it is NOT a
+  perf assertion (perf numbers are environment-specific and live in the
+  report). The smoke must tolerate a `None` RSS (the model bench's
+  `_peak_rss_mb()` uses `resource.getrusage`, Unix-only; on a non-Unix CI
+  runner RSS may be `None` -- the smoke asserts the table keys, never an RSS
+  value).
+- **Plan-time check:** confirm `nanp` is a registered `validate_with`
+  validator name reachable by `goldenflow_filter` before using it in the
+  bench config; an unknown name silently no-ops the candidate drop (fail-open
+  by design), which would understate the conditional path's work. If `nanp`
+  is not wired in the bench's env, use a validator that is, or drop
+  `validate:` from the bench config and note it.
+- The bench's own correctness is bounded: it asserts the slow path and the
+  floor path produce the same ROW COUNT (one golden record per cluster) so a
+  silently-broken workload can't produce a misleading tax.
+
+## 6. Open questions for spec review
+
+- **Per-phase attribution mechanism:** env-gated bench-only timers vs a
+  sampling profiler captured in the report. Leaning bench-only coarse timers
+  for the phase split (deterministic, in the table) + an optional `py-spy`
+  appendix for the intra-`resolve_cluster` detail. Confirm no production
+  instrumentation is added.
+- **Floor fidelity:** the non-survivorship fast path does strictly LESS work
+  (no groups/conditionals), so the floor is a loose lower bound. Is "floor +
+  per-phase recoverable" a defensible go/no-go basis, or does the verdict
+  need a thin vectorized `group_winner` micro-prototype to tighten the
+  recoverable estimate? Leaning no-prototype (measure-first); the per-phase
+  vectorizable-wall is the primary signal and the floor is the bound.
+- **Scale ceiling:** 1M + 5M measured, 50M extrapolated. Is a measured 50M
+  run worth the runner cost, or is the extrapolation sufficient for a go/no-go?
+  Leaning extrapolate (the cost is linear in cluster count; 5M is enough to
+  establish the per-cluster constant).

--- a/packages/python/goldenmatch/scripts/bench_survivorship_columnar.py
+++ b/packages/python/goldenmatch/scripts/bench_survivorship_columnar.py
@@ -1,0 +1,422 @@
+"""Measure-first bench: survivorship slow path vs vectorized floor.
+
+Synthesizes a __cluster_id__-tagged multi-member frame directly (no
+blocking/dedupe), then measures two variants in separate subprocesses for
+clean peak RSS:
+
+  slow  -- the real survivorship branch: sort -> build_resolution_order ->
+            partition_by -> per-cluster resolve_cluster. Per-phase timers
+            isolate sort / partition / loop costs.
+  floor -- plain most_complete config routed through the vectorized
+           _build_golden_records_polars_native path (asserted eligible before
+           the run; the bench is meaningless if this assertion fails).
+
+The verdict applies the distributed-plan-style kill criterion:
+  - tax (slow_total - floor_total) >= 25% of slow_total, AND
+  - recoverable fraction (partition_wall + loop_wall) >= 25% of slow_total,
+    AND RSS delta <= 15%.
+GO -> pursue Phase-2 columnar survivorship rewrite.
+NO-GO -> keep the slow path (no evidence the rewrite pays).
+
+Local smoke:  python scripts/bench_survivorship_columnar.py --rows 1000 --runs 1
+CI workflow:  bench-survivorship-columnar.yml (large-new-64GB)
+              passes --rows 1000000,5000000 --runs 3
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+
+_STATES = ["CA", "NY", "TX", "FL", "IL", "WA", "MA", "OH"]
+_SOURCES = ["crm", "billing", "events"]
+
+
+# ---------------------------------------------------------------------------
+# Workload synthesis
+# ---------------------------------------------------------------------------
+
+def make_clustered_workload(rows: int, avg_cluster_size: int = 3, seed: int = 7):
+    """Return a polars DataFrame of `rows` tagged multi-member records.
+
+    Every cluster has at least 2 members (survivorship only fires on
+    multi-member clusters). Intra-cluster nulls give the resolver real work
+    across all levers (group_winner, most_recent, source_priority, validate).
+    The frame includes `__source__` so source_priority has data to read.
+    """
+    import random
+
+    import polars as pl
+
+    rnd = random.Random(seed)
+    recs = []
+    rid = 0
+    cid = 0
+    while len(recs) < rows:
+        size = max(2, avg_cluster_size)  # all multi-member
+        cid += 1
+        base_zip = f"{10000 + cid % 89999:05d}"
+        for k in range(size):
+            if len(recs) >= rows:
+                break
+            recs.append({
+                "__cluster_id__": cid,
+                "__row_id__": rid,
+                "first_name": rnd.choice(["Jon", "John", "Jonathan"]),
+                "last_name": f"Sev{cid % 997}",
+                "street": None if k == 0 else f"{cid % 9999} Main St",
+                "city": "Springfield" if k != 1 else None,
+                "state": _STATES[cid % len(_STATES)],
+                "zip": None if k == 1 else base_zip,
+                "phone": None if k == 2 else f"212555{cid % 9999:04d}",
+                "updated_at": f"2024-{1 + (k % 12):02d}-01",
+                "__source__": _SOURCES[(cid + k) % len(_SOURCES)],
+            })
+            rid += 1
+    return pl.DataFrame(recs[:rows])
+
+
+# ---------------------------------------------------------------------------
+# Config builders
+# ---------------------------------------------------------------------------
+
+def make_survivorship_config():
+    """A realistic mixed survivorship config: field group + conditional rule."""
+    from goldenmatch.config.schemas import (
+        GoldenFieldRule,
+        GoldenGroupRule,
+        GoldenRulesConfig,
+    )
+
+    return GoldenRulesConfig(
+        default_strategy="most_complete",
+        field_groups=[
+            GoldenGroupRule(
+                name="mailing_address",
+                columns=["street", "city", "state", "zip"],
+                strategy="most_complete",
+            ),
+        ],
+        field_rules={
+            "phone": [
+                GoldenFieldRule(
+                    when="state in ['CA','NY']",
+                    strategy="most_recent",
+                    date_column="updated_at",
+                    validate="nanp",
+                ),
+                GoldenFieldRule(
+                    strategy="source_priority",
+                    source_priority=["crm", "billing"],
+                ),
+            ],
+        },
+    )
+
+
+def make_floor_config():
+    """Plain most_complete -- no levers -> native-eligible."""
+    from goldenmatch.config.schemas import GoldenRulesConfig
+
+    return GoldenRulesConfig(default_strategy="most_complete")
+
+
+def assert_floor_eligible(floor_rules) -> None:
+    """Raise if the floor config would NOT route to the vectorized native path.
+
+    A failed assertion means the 'floor' variant is not actually the fast path,
+    so the measured tax is garbage. Abort rather than silently produce a wrong
+    verdict.
+    """
+    from goldenmatch.core.golden import _polars_native_eligible, _survivorship_active
+
+    assert not _survivorship_active(floor_rules), \
+        "floor config must be non-survivorship"
+    assert _polars_native_eligible(floor_rules, None), \
+        "floor config must hit the vectorized native path"
+
+
+# ---------------------------------------------------------------------------
+# Measurement core
+# ---------------------------------------------------------------------------
+
+def run_slow(multi_df, rules, runs: int) -> dict:
+    """Reconstruct the survivorship branch with per-phase timers.
+
+    Mirrors build_golden_records_batch's survivorship branch exactly:
+      1. sort by __cluster_id__
+      2. build_resolution_order
+      3. partition_by(__cluster_id__, maintain_order=True)
+      4. per-cluster resolve_cluster(provenance=False)
+
+    Returns median wall over `runs` with a phase breakdown.
+    """
+    from goldenmatch.core.golden import _is_internal
+    from goldenmatch.core.survivorship.conditions import build_resolution_order
+    from goldenmatch.core.survivorship.resolve import resolve_cluster
+
+    totals, sorts, parts, loops = [], [], [], []
+    rows_out = 0
+    for _ in range(runs):
+        t0 = time.perf_counter()
+
+        # Phase 1: sort (same as production branch)
+        s_sorted = multi_df.sort("__cluster_id__")
+        t_sort = time.perf_counter()
+
+        # Phase 2: build resolution order + partition (combined as "partition" phase)
+        user_cols = [
+            c for c in s_sorted.columns
+            if not _is_internal(c) and c != "__cluster_id__"
+        ]
+        order = build_resolution_order(rules.field_rules, rules.field_groups, user_cols)
+        partitions = s_sorted.partition_by("__cluster_id__", maintain_order=True)
+        t_part = time.perf_counter()
+
+        # Phase 3: per-cluster loop (the O(clusters) Python loop)
+        out = []
+        for cdf in partitions:
+            cid = cdf["__cluster_id__"][0]
+            rec, _ = resolve_cluster(cdf, rules, order, cluster_id=int(cid))
+            out.append(rec)
+        t_loop = time.perf_counter()
+
+        rows_out = len(out)
+        totals.append(t_loop - t0)
+        sorts.append(t_sort - t0)
+        parts.append(t_part - t_sort)
+        loops.append(t_loop - t_part)
+
+    return {
+        "total_wall_s": round(statistics.median(totals), 4),
+        "sort_wall_s": round(statistics.median(sorts), 4),
+        "partition_wall_s": round(statistics.median(parts), 4),
+        "loop_wall_s": round(statistics.median(loops), 4),
+        "n_clusters": multi_df["__cluster_id__"].n_unique(),
+        "rows_out": rows_out,
+    }
+
+
+def run_floor(multi_df, floor_rules, runs: int) -> dict:
+    """Time the vectorized native path (asserts eligibility first)."""
+    from goldenmatch.core.golden import build_golden_records_batch
+
+    assert_floor_eligible(floor_rules)
+    walls = []
+    rows_out = 0
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        out = build_golden_records_batch(multi_df, floor_rules)
+        walls.append(time.perf_counter() - t0)
+        rows_out = len(out)
+    return {
+        "total_wall_s": round(statistics.median(walls), 4),
+        "rows_out": rows_out,
+    }
+
+
+# ---------------------------------------------------------------------------
+# RSS
+# ---------------------------------------------------------------------------
+
+def _peak_rss_mb():
+    """Return peak RSS in MB for this process, or None on non-Unix."""
+    try:
+        import resource
+        return round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0, 1)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+def verdict(slow: dict, floor: dict) -> str:
+    """Compute the GO/NO-GO verdict from slow + floor timing dicts.
+
+    Criterion (all must hold for GO):
+      - tax (slow_total - floor_total) >= 25% of slow_total
+      - recoverable (partition_wall + loop_wall) >= 25% of slow_total
+        (coarse proxy; over-counts the truly-vectorizable portion because
+        loop_wall includes the non-vectorizable conditional eval -- makes
+        NO-GO robust and GO optimistic; de-risk a coarse GO with py-spy)
+      - RSS delta <= 15% (or either side is None -> treat as pass)
+    """
+    total = slow["total_wall_s"]
+    tax = max(0.0, total - floor["total_wall_s"])
+    recoverable = slow.get("partition_wall_s", 0.0) + slow.get("loop_wall_s", 0.0)
+    frac = recoverable / total if total else 0.0
+    rss_ok = (
+        floor.get("peak_rss_mb") is None
+        or slow.get("peak_rss_mb") is None
+        or slow["peak_rss_mb"] <= floor["peak_rss_mb"] * 1.15
+    )
+    go = (
+        (tax / total >= 0.25 if total else False)
+        and frac >= 0.25
+        and rss_ok
+    )
+    label = "GO" if go else "NO-GO"
+    detail = (
+        "Vectorizable cost dominates and clears the 25-30% bar -> pursue Phase-2 rewrite."
+        if go else
+        "Tax below bar or not localized to a vectorizable phase, or RSS regressed -> keep the slow path."
+    )
+    return (
+        f"VERDICT: {label} "
+        f"(tax={tax:.3f}s {100 * tax / total:.0f}% of slow, "
+        f"recoverable~{100 * frac:.0f}%, rss_ok={rss_ok}). "
+        + detail
+    )
+
+
+# ---------------------------------------------------------------------------
+# Table
+# ---------------------------------------------------------------------------
+
+def _table(results: list) -> str:
+    rows = [
+        "",
+        "## survivorship-columnar bench",
+        "",
+        "| rows | variant | total s | sort s | partition s | loop s | peak RSS MB | row count |",
+        "|---|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for r in results:
+        n = r["rows"]
+        for variant, d in (("slow", r["slow"]), ("floor", r["floor"])):
+            if d.get("oom"):
+                rows.append(f"| {n:,} | {variant} | OOM | - | - | - | - | - |")
+            else:
+                rows.append(
+                    f"| {n:,} | {variant}"
+                    f" | {d.get('total_wall_s', '-')}"
+                    f" | {d.get('sort_wall_s', '-')}"
+                    f" | {d.get('partition_wall_s', '-')}"
+                    f" | {d.get('loop_wall_s', '-')}"
+                    f" | {d.get('peak_rss_mb', 'N/A')}"
+                    f" | {d.get('rows_out', '-')} |"
+                )
+        rows.append(f"| {n:,} | verdict | {r['verdict']} | | | | | |")
+    return "\n".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# Child entrypoint (subprocess per variant for clean peak RSS)
+# ---------------------------------------------------------------------------
+
+def _child_slow(rows: int, runs: int, seed: int, avg_cluster_size: int) -> int:
+    df = make_clustered_workload(rows=rows, avg_cluster_size=avg_cluster_size, seed=seed)
+    rules = make_survivorship_config()
+    result = run_slow(df, rules, runs)
+    result["peak_rss_mb"] = _peak_rss_mb()
+    print(json.dumps(result), flush=True)
+    return 0
+
+
+def _child_floor(rows: int, runs: int, seed: int, avg_cluster_size: int) -> int:
+    df = make_clustered_workload(rows=rows, avg_cluster_size=avg_cluster_size, seed=seed)
+    floor_rules = make_floor_config()
+    result = run_floor(df, floor_rules, runs)
+    result["peak_rss_mb"] = _peak_rss_mb()
+    print(json.dumps(result), flush=True)
+    return 0
+
+
+def _bench_variant(variant: str, rows: int, runs: int, seed: int,
+                   avg_cluster_size: int) -> dict:
+    """Spawn a child subprocess for the given variant; return the parsed JSON dict."""
+    cmd = [
+        sys.executable,
+        os.path.abspath(__file__),
+        "--child", variant,
+        "--rows", str(rows),
+        "--runs", str(runs),
+        "--seed", str(seed),
+        "--avg-cluster-size", str(avg_cluster_size),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    last = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            last = line
+    if proc.returncode != 0 or last is None:
+        return {
+            "variant": variant,
+            "rows": rows,
+            "oom": True,
+            "returncode": proc.returncode,
+            "stderr_tail": proc.stderr[-400:],
+        }
+    return json.loads(last)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Survivorship slow-path vs floor vectorized bench."
+    )
+    ap.add_argument("--rows", default="1000000,5000000",
+                    help="Comma-separated row counts")
+    ap.add_argument("--runs", type=int, default=3,
+                    help="Repetitions per measurement (median)")
+    ap.add_argument("--seed", type=int, default=7,
+                    help="RNG seed for workload synthesis (same across both variants)")
+    ap.add_argument("--avg-cluster-size", type=int, default=3,
+                    dest="avg_cluster_size",
+                    help="Average members per cluster (same across both variants)")
+    ap.add_argument("--child", choices=["slow", "floor"], default=None,
+                    help="Internal: run as a child subprocess for a single variant")
+    ap.add_argument("--output", default=None,
+                    help="Write JSON results to this path")
+    args = ap.parse_args(argv)
+
+    # Child mode: run one variant and print JSON to stdout.
+    if args.child == "slow":
+        return _child_slow(
+            rows=int(args.rows),
+            runs=args.runs,
+            seed=args.seed,
+            avg_cluster_size=args.avg_cluster_size,
+        )
+    if args.child == "floor":
+        return _child_floor(
+            rows=int(args.rows),
+            runs=args.runs,
+            seed=args.seed,
+            avg_cluster_size=args.avg_cluster_size,
+        )
+
+    # Parent mode: spawn a child per variant per scale and aggregate.
+    rows_list = [int(x.strip()) for x in args.rows.split(",") if x.strip()]
+    results = []
+    for n in rows_list:
+        slow_d = _bench_variant("slow", n, args.runs, args.seed, args.avg_cluster_size)
+        floor_d = _bench_variant("floor", n, args.runs, args.seed, args.avg_cluster_size)
+        v = verdict(slow_d, floor_d) if not slow_d.get("oom") and not floor_d.get("oom") else "OOM"
+        results.append({"rows": n, "slow": slow_d, "floor": floor_d, "verdict": v})
+
+    text = _table(results)
+    for r in results:
+        if not r["slow"].get("oom") and not r["floor"].get("oom"):
+            print(r["verdict"])
+    print(text)
+
+    if args.output:
+        from pathlib import Path
+        Path(args.output).write_text(json.dumps(results, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_bench_survivorship_columnar_smoke.py
+++ b/packages/python/goldenmatch/tests/test_bench_survivorship_columnar_smoke.py
@@ -1,0 +1,167 @@
+"""Smoke + eligibility guards for the survivorship columnar measure-first bench.
+
+Loads the bench script by path (scripts/ is not a package) and runs a suite
+of fast micro-checks at 1k rows. These are harness bit-rot guards, NOT perf
+assertions -- they confirm the workload synthesizer, config builders,
+measurement functions, and verdict logic stay wired to the real production
+symbols. The at-scale runs (1M/5M) live in bench-survivorship-columnar.yml.
+"""
+from pathlib import Path
+
+import pytest
+
+_BENCH = Path(__file__).resolve().parent.parent / "scripts" / "bench_survivorship_columnar.py"
+_SCRIPTS = str(_BENCH.parent)
+
+# ---------------------------------------------------------------------------
+# Loader helper -- import the bench module from its file path.
+# ---------------------------------------------------------------------------
+
+def _load():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("bench_surv_col", _BENCH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Task 1: workload synthesizer
+# ---------------------------------------------------------------------------
+
+def test_make_clustered_workload_shape():
+    mod = _load()
+    df = mod.make_clustered_workload(rows=1000, avg_cluster_size=3, seed=7)
+    # tagged multi-member frame
+    assert "__cluster_id__" in df.columns
+    assert "__row_id__" in df.columns
+    assert "__source__" in df.columns       # source metadata for source_priority
+    assert {"first_name", "last_name", "street", "city", "state", "zip",
+            "phone", "updated_at"} <= set(df.columns)
+    assert df.height == 1000
+    # multiple clusters, all multi-member (size >= 2), some nulls to give the resolver work
+    n_clusters = df["__cluster_id__"].n_unique()
+    assert 100 < n_clusters < 500          # ~333 clusters at avg size 3
+    assert df["zip"].null_count() > 0       # nulls -> group-winner / fill has work
+
+
+def test_make_clustered_workload_deterministic():
+    """Same seed must produce identical frames."""
+    mod = _load()
+    df1 = mod.make_clustered_workload(rows=500, avg_cluster_size=3, seed=42)
+    df2 = mod.make_clustered_workload(rows=500, avg_cluster_size=3, seed=42)
+    assert df1.frame_equal(df2)
+
+
+# ---------------------------------------------------------------------------
+# Task 2: configs + eligibility guard
+# ---------------------------------------------------------------------------
+
+def test_configs_and_floor_eligibility():
+    mod = _load()
+    surv = mod.make_survivorship_config()
+    floor = mod.make_floor_config()
+    from goldenmatch.core.golden import _polars_native_eligible, _survivorship_active
+    # make_*_config return GoldenRulesConfig directly -- check on the returned object
+    assert _survivorship_active(surv) is True
+    assert _survivorship_active(floor) is False
+    # the floor MUST land on the vectorized native path
+    assert _polars_native_eligible(floor, None) is True
+    mod.assert_floor_eligible(floor)        # raises if not eligible
+
+
+def test_assert_floor_eligible_raises_on_survivorship_config():
+    """assert_floor_eligible must reject a survivorship config."""
+    mod = _load()
+    surv = mod.make_survivorship_config()
+    with pytest.raises(AssertionError):
+        mod.assert_floor_eligible(surv)
+
+
+# ---------------------------------------------------------------------------
+# Task 3: measurement core
+# ---------------------------------------------------------------------------
+
+def test_measure_returns_phase_split_and_parity():
+    mod = _load()
+    df = mod.make_clustered_workload(rows=1000, avg_cluster_size=3, seed=7)
+    slow = mod.run_slow(df, mod.make_survivorship_config(), runs=1)
+    floor = mod.run_floor(df, mod.make_floor_config(), runs=1)
+    # phase split keys present in slow result
+    for k in ("total_wall_s", "sort_wall_s", "partition_wall_s", "loop_wall_s",
+               "n_clusters", "rows_out"):
+        assert k in slow, f"key {k!r} missing from slow result"
+    assert "total_wall_s" in floor
+    assert "rows_out" in floor
+    # one golden record per cluster on BOTH paths -> same row count
+    n_clusters = df["__cluster_id__"].n_unique()
+    assert slow["rows_out"] == n_clusters, \
+        f"slow rows_out {slow['rows_out']} != n_clusters {n_clusters}"
+    assert floor["rows_out"] == n_clusters, \
+        f"floor rows_out {floor['rows_out']} != n_clusters {n_clusters}"
+
+
+def test_run_floor_rejects_survivorship_config():
+    """run_floor must abort if given a survivorship config (eligibility guard)."""
+    mod = _load()
+    df = mod.make_clustered_workload(rows=200, avg_cluster_size=3, seed=7)
+    with pytest.raises(AssertionError):
+        mod.run_floor(df, mod.make_survivorship_config(), runs=1)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: verdict + table + main (subprocess per variant)
+# ---------------------------------------------------------------------------
+
+def test_verdict_no_go_when_tax_small():
+    mod = _load()
+    # slow barely above floor -> tax < 25% bar -> NO-GO
+    v = mod.verdict(
+        slow={"total_wall_s": 1.05, "sort_wall_s": 0.1, "partition_wall_s": 0.1,
+              "loop_wall_s": 0.85, "peak_rss_mb": 100},
+        floor={"total_wall_s": 1.0, "peak_rss_mb": 95},
+    )
+    assert "NO-GO" in v
+
+
+def test_verdict_go_when_vectorizable_tax_large():
+    mod = _load()
+    # slow 3x floor, dominated by partition+loop (vectorizable) -> GO
+    v = mod.verdict(
+        slow={"total_wall_s": 3.0, "sort_wall_s": 0.1, "partition_wall_s": 0.4,
+              "loop_wall_s": 2.5, "peak_rss_mb": 100},
+        floor={"total_wall_s": 1.0, "peak_rss_mb": 95},
+    )
+    assert "GO" in v and "NO-GO" not in v
+
+
+def test_verdict_no_go_when_rss_regresses():
+    mod = _load()
+    # slow wall dominates (would be GO on wall alone) but RSS blows out
+    v = mod.verdict(
+        slow={"total_wall_s": 3.0, "sort_wall_s": 0.1, "partition_wall_s": 0.4,
+              "loop_wall_s": 2.5, "peak_rss_mb": 500},
+        floor={"total_wall_s": 1.0, "peak_rss_mb": 100},   # 5x RSS regression
+    )
+    assert "NO-GO" in v
+
+
+def test_verdict_rss_none_treated_as_pass():
+    mod = _load()
+    # RSS None on both -> rss_ok=True; if wall criterion also passes -> GO
+    v = mod.verdict(
+        slow={"total_wall_s": 3.0, "sort_wall_s": 0.1, "partition_wall_s": 0.4,
+              "loop_wall_s": 2.5, "peak_rss_mb": None},
+        floor={"total_wall_s": 1.0, "peak_rss_mb": None},
+    )
+    assert "GO" in v and "NO-GO" not in v
+
+
+def test_main_runs_1k_and_emits_table(capsys):
+    mod = _load()
+    rc = mod.main(["--rows", "1000", "--runs", "1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Title + key columns present
+    assert "survivorship-columnar" in out.lower()
+    assert "tax" in out.lower() or "verdict" in out.lower()

--- a/packages/python/goldenmatch/tests/test_bench_survivorship_columnar_smoke.py
+++ b/packages/python/goldenmatch/tests/test_bench_survivorship_columnar_smoke.py
@@ -50,7 +50,7 @@ def test_make_clustered_workload_deterministic():
     mod = _load()
     df1 = mod.make_clustered_workload(rows=500, avg_cluster_size=3, seed=42)
     df2 = mod.make_clustered_workload(rows=500, avg_cluster_size=3, seed=42)
-    assert df1.frame_equal(df2)
+    assert df1.equals(df2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A measure-first investigation harness for the survivorship columnar-scale question (v2 workstream 2). **No production code changes** — adds only a bench, a smoke test, and a CI workflow. Survivorship behavior is trivially byte-identical.

The bench compares the survivorship slow path (`partition_by` + per-cluster `resolve_cluster` Python loop) against the vectorized fast-path floor (`_build_golden_records_polars_native`, asserted eligible) on one realistic mixed config (address group + conditional/validated phone), with a per-phase wall breakdown (sort / partition / loop) and peak RSS, at 1M + 5M.

`run_slow` is a faithful reconstruction of the production survivorship branch (same calls, `maintain_order=True`, default non-provenance resolver args) so the measured tax is representative.

## Verdict gate (deferred to the post-merge run)

This PR ships the instrument, not the verdict. The actual GO/NO-GO comes from a post-merge `workflow_dispatch` run on `large-new-64GB` + a py-spy intra-loop split, written up as a committed report. The bar: pursue a Phase-2 vectorized rewrite only if the vectorizable tax (partition+loop, NOT the per-cluster conditional eval) is >= ~25-30% wall AND localizes AND no RSS regression. Given this codebase's prior columnar A/B no-ops, a "keep the slow path" verdict is the likely outcome — with the numbers to back it.

## Test Plan

- [ ] CI green
- [x] 11 local smoke tests pass (workload shape/determinism, both eligibility-guard directions, phase-split keys, row-count parity, all verdict branches, full --child subprocess end-to-end)
- [x] `ruff check` clean
- [x] pyright: bench script + smoke are outside the include slice; no production code touched

Spec + plan: `docs/superpowers/{specs,plans}/2026-06-17-survivorship-columnar-measure-first*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)