### PR TITLE
feat(goldenmatch): config_weaknesses — deterministic config-critique tool

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -422,6 +422,7 @@ Every `GOLDENMATCH_*` variable the package reads, grouped by who should care. De
 | `GOLDENMATCH_GPU_MODE` / `_GPU_ENDPOINT` / `_GPU_API_KEY` | auto | GPU embedding mode / remote endpoint / key. |
 | `GOLDENMATCH_LLAMA_GGUF` | unset | Path to a local GGUF embedding model for the `model="llama"` / `"llama:/path.gguf"` backend — offline embeddings, no cloud/torch (`pip install goldenmatch[llama]`). Benchmarks: `scripts/bench_llama_embedder.py`, `scripts/bench_llama_product_matching.py`. |
 | `GOLDENMATCH_LLM_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible base URL for the LLM scorer — point at a local llama.cpp / llamafile server for offline, free LLM judging (also honors `OPENAI_BASE_URL`). |
+| `GOLDENMATCH_WEAKNESS_LLM` | `0` (off) | Opt-in: let the `config_weaknesses` tool phrase its one-paragraph `summary_plain` with an LLM (needs `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`). Only a compact structured digest of the findings (ids/severities/short labels) is sent — never raw rows or data. The structured findings themselves are always deterministic and never depend on the LLM; off = deterministic template summary. |
 | `GOLDENMATCH_UDF_IMPORTS` | unset | Snowflake UDF import asset directory. |
 | `GOLDENMATCH_SYNC_STREAMING_THRESHOLD` / `_STREAMING_BLOCK_WORKERS` | `500000` / auto | Postgres streaming-store thresholds. |
 | `GOLDENMATCH_ANALYTICS` | `0` (off) | Opt-in anonymous, PII-free usage analytics to PostHog (needs `POSTHOG_API_KEY`). Off = nothing collected. |

--- a/packages/python/goldenmatch/LAUNCHGUIDE.md
+++ b/packages/python/goldenmatch/LAUNCHGUIDE.md
@@ -4,7 +4,7 @@
 Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.
 
 ## Description
-GoldenMatch finds duplicate records with zero configuration. No rules to write, no models to train — point it at a CSV and get deduplicated results in 30 seconds. Achieves 97.2% F1 on DBLP-ACM out of the box. Supports single-source deduplication, cross-source matching, golden record creation, and privacy-preserving record linkage (PPRL) with bloom filters. 58 MCP tools give AI assistants full control over the entity resolution workflow — from analysis and configuration through matching, review, and export. DQBench ER score: 95.30.
+GoldenMatch finds duplicate records with zero configuration. No rules to write, no models to train — point it at a CSV and get deduplicated results in 30 seconds. Achieves 97.2% F1 on DBLP-ACM out of the box. Supports single-source deduplication, cross-source matching, golden record creation, and privacy-preserving record linkage (PPRL) with bloom filters. 59 MCP tools give AI assistants full control over the entity resolution workflow — from analysis and configuration through matching, review, and export. DQBench ER score: 95.30.
 
 ## Setup Requirements
 No environment variables required. Works out of the box with local CSV files.
@@ -27,7 +27,7 @@ Record deduplication, Entity resolution, Customer matching, Data merging, Golden
 - Domain-specific matching rules (people, companies, products)
 - Cluster management — inspect, shatter, unmerge, suggest config improvements
 - Real-time single-record matching against loaded datasets
-- 58 MCP tools covering the full ER workflow
+- 59 MCP tools covering the full ER workflow
 - 4 MCP Resources: dataset stats, cluster summary, current config, dataset schema
 - 5 MCP Prompts: deduplicate-walkthrough, investigate-cluster, compare-records, data-quality-audit, pprl-setup
 - Integrates with GoldenCheck (scan quality) and GoldenFlow (transform)

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -70,7 +70,7 @@ npm install goldenmatch
 - **96.4% F1 zero-config** on DBLP-ACM (hand-tuned ceiling: 91.8%). [DQBench ER score: 62.87 no-LLM](https://github.com/benseverndev-oss/dqbench)
 - **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
-- **58 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
+- **59 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
 
 ### What's new in v1.17

--- a/packages/python/goldenmatch/goldenmatch/core/config_critique.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_critique.py
@@ -1,0 +1,634 @@
+"""Deterministic config-weakness generator (``diagnose_config``).
+
+After auto-config builds a config and a first run produces a result, this
+module explains — in plain English — what the auto-built rules *did* and where
+they are risky. It is the read-only, deterministic core; MCP wiring lives in a
+separate task and imports ``diagnose_config`` from here.
+
+Design (spec 2026-06-?? §5):
+
+- One pure entry point, ``diagnose_config(df, config, result)``, returns
+  ``{"findings": [...], "summary_plain": str}``.
+- Each *detector* maps engine signals (the resolved ``GoldenMatchConfig``, the
+  column profile from ``profile_columns``, and the postflight signals on
+  ``result.postflight_report``) to at most one finding.
+- Detectors are **defensive**: any signal can be absent (no postflight report,
+  empty profile, weird config). A missing signal means "skip this detector,"
+  never raise. Each detector body is wrapped so one failure can't kill the
+  rest — ``diagnose_config`` never raises on a valid ``(df, config, result)``.
+- Findings are ranked high→low by severity, then truncated to ``max_findings``.
+- Wording is template-driven and deterministic. ``phrasing="plain"`` (default)
+  is non-technical; ``phrasing="technical"`` may name columns/metrics directly.
+  Neither requires an LLM.
+- An OPTIONAL one-paragraph LLM summary is gated behind
+  ``GOLDENMATCH_WEAKNESS_LLM=1`` AND a detected provider, and is sent ONLY a
+  compact structured digest (ids + severities + short labels — tens of tokens,
+  never raw data). Any failure falls back to the deterministic template
+  summary, so the function is fully usable offline.
+
+The deterministic detectors reuse existing engine signals rather than
+recomputing: ``_collect_referenced_columns`` from ``autoconfig_verify`` for the
+column walk, ``profile_columns`` for null-rate / cardinality / col_type, and
+``PostflightReport.signals`` (``block_size_percentiles`` / ``oversized_clusters``
+/ ``preliminary_cluster_sizes``) for the live-run block + cluster shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import TYPE_CHECKING, Any
+
+from goldenmatch.core.autoconfig_verify import _collect_referenced_columns
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.core.autoconfig import ColumnProfile
+
+# ── Tunables (deterministic thresholds) ──────────────────────────────────────
+
+# A column with more than this fraction of nulls is mostly empty: matching on
+# it is rarely doing useful work. Mirrors the spec's null_rate > 0.2 cutoff.
+_NULL_SINK_RATE = 0.2
+# A matchkey column whose distinct-value ratio is below this discriminates
+# almost nothing (e.g. a near-constant "country" column).
+_LOW_SIGNAL_CARD = 0.01
+# An id-like column has a near-unique distinct ratio.
+_ID_CARD = 0.98
+# Profiled column types that are legitimate identity attributes — high
+# cardinality is EXPECTED and GOOD for these, so cardinality alone must not
+# mark them as an admitted identifier. (``profile_columns`` col_type vocab.)
+_IDENTITY_COL_TYPES = frozenset(
+    {"email", "name", "phone", "address", "zip", "geo"}
+)
+# Block-size sanity ceilings. The engine's own preflight (Check 4) warns when a
+# block P99 exceeds 5000 ("mega-blocks dominate runtime"); we reuse the same
+# ceiling and escalate to HIGH when it's an order of magnitude past it.
+_BLOCK_P99_WARN = 5000
+_BLOCK_P99_HIGH = 50_000
+
+# severity → rank for stable high→low ordering.
+_SEVERITY_RANK = {"high": 0, "medium": 1, "low": 2}
+
+# A column named exactly this (case-insensitive), or clearly a source-system /
+# provenance label, just records WHERE a row came from. Matching on it merges
+# rows that happen to share an origin and splits the same person across feeds.
+_SOURCE_NAME_RE = re.compile(
+    r"^(source|source_system|src|origin|feed|dataset|system|provider|channel)$",
+    re.IGNORECASE,
+)
+
+# A per-row identifier column. These are unique by construction, so as an exact
+# key they never agree and as a fuzzy signal they inject noise. Pattern mirrors
+# the foreign-id / pk family the quality-exclusion detectors already recognise.
+_ID_NAME_RE = re.compile(
+    r"(^|_)(id|uuid|guid|pk)$"
+    r"|^(record_id|row_id|external_id|legacy_id|source_id|source_pk)$",
+    re.IGNORECASE,
+)
+
+
+# ── Finding construction ──────────────────────────────────────────────────────
+
+
+def _finding(
+    *,
+    id: str,
+    severity: str,
+    evidence: dict,
+    fix_config_hint: dict,
+    title_plain: str,
+    detail_plain: str,
+    fix_plain: str,
+) -> dict:
+    """Assemble one finding dict in the public contract shape.
+
+    ``phrasing`` selection happens in the detector by choosing which strings to
+    pass here, so this helper stays phrasing-agnostic.
+    """
+    return {
+        "id": id,
+        "severity": severity,
+        "title_plain": title_plain,
+        "detail_plain": detail_plain,
+        "evidence": evidence,
+        "fix_plain": fix_plain,
+        "fix_config_hint": fix_config_hint,
+    }
+
+
+# ── Detectors ──────────────────────────────────────────────────────────────────
+#
+# Each detector returns ``list[dict]`` (0+ findings). They take only the
+# already-computed context (config, referenced columns, profiles-by-name,
+# signals) so they're cheap and independently testable.
+
+
+def _detect_source_admitted(
+    referenced: set[str], excluded: set[str], phrasing: str
+) -> list[dict]:
+    out: list[dict] = []
+    for col in sorted(referenced):
+        if col in excluded:
+            continue
+        if not _SOURCE_NAME_RE.match(col):
+            continue
+        if phrasing == "technical":
+            title = f"Provenance column '{col}' is used as a matching signal"
+            detail = (
+                f"'{col}' looks like a source/provenance label, not an "
+                f"identity attribute. Using it in a matchkey or blocking pass "
+                f"makes records from the same feed look more alike and splits "
+                f"one entity across feeds."
+            )
+        else:
+            title = "Two different companies may be merged"
+            detail = (
+                f"The matcher is using the '{col}' label as a matching signal, "
+                f"but that label only records where a row came from. Records "
+                f"from the same system get treated as more similar, and the "
+                f"same person split across systems looks less similar."
+            )
+        out.append(
+            _finding(
+                id="source_admitted",
+                severity="high",
+                evidence={"column": col, "reason": "source/provenance label"},
+                fix_config_hint={"action": "exclude_column", "column": col},
+                title_plain=title,
+                detail_plain=detail,
+                fix_plain=(
+                    f"Stop matching on '{col}'; it just records where a row "
+                    f"came from."
+                ),
+            )
+        )
+    return out
+
+
+def _detect_id_admitted(
+    referenced: set[str],
+    excluded: set[str],
+    profiles_by_name: dict[str, ColumnProfile],
+    phrasing: str,
+) -> list[dict]:
+    out: list[dict] = []
+    for col in sorted(referenced):
+        if col in excluded:
+            continue
+        prof = profiles_by_name.get(col)
+        by_name = bool(_ID_NAME_RE.search(col))
+        by_type = prof is not None and prof.col_type == "identifier"
+        # Near-unique cardinality alone is NOT enough: email / name / phone /
+        # address are legitimately high-cardinality and ARE the columns you
+        # want to match on. Only infer "id by cardinality" for columns the
+        # profiler did NOT recognise as an identity-bearing attribute.
+        by_card = (
+            prof is not None
+            and prof.cardinality_ratio >= _ID_CARD
+            and prof.col_type not in _IDENTITY_COL_TYPES
+        )
+        if not (by_name or by_type or by_card):
+            continue
+        # Don't double-fire with source_admitted on the same column.
+        if _SOURCE_NAME_RE.match(col):
+            continue
+        why = (
+            "name looks like a per-row id"
+            if by_name
+            else "profiled as an identifier"
+            if by_type
+            else "nearly every value is unique"
+        )
+        evidence: dict = {"column": col, "reason": why}
+        if prof is not None:
+            evidence["cardinality_ratio"] = round(prof.cardinality_ratio, 4)
+        if phrasing == "technical":
+            title = f"Identifier column '{col}' is used as a matching signal"
+            detail = (
+                f"'{col}' is a per-row id ({why}). Identifiers don't repeat "
+                f"across true duplicates, so as an exact key it never agrees, "
+                f"and as a fuzzy signal it only adds noise."
+            )
+        else:
+            title = "An ID number is being used to decide who matches"
+            detail = (
+                f"The matcher is using '{col}' to compare records, but that "
+                f"column is a unique ID (every row has a different value). It "
+                f"can't tell you which records are the same person."
+            )
+        out.append(
+            _finding(
+                id="id_admitted",
+                severity="high",
+                evidence=evidence,
+                fix_config_hint={"action": "exclude_column", "column": col},
+                title_plain=title,
+                detail_plain=detail,
+                fix_plain=(
+                    f"Stop matching on '{col}'; it's a unique ID, not a shared "
+                    f"trait."
+                ),
+            )
+        )
+    return out
+
+
+def _detect_null_sink(
+    matchkey_cols: set[str],
+    profiles_by_name: dict[str, ColumnProfile],
+    phrasing: str,
+) -> list[dict]:
+    out: list[dict] = []
+    for col in sorted(matchkey_cols):
+        prof = profiles_by_name.get(col)
+        if prof is None or prof.null_rate <= _NULL_SINK_RATE:
+            continue
+        pct = round(prof.null_rate * 100)
+        if phrasing == "technical":
+            title = f"Matchkey column '{col}' is {pct}% null"
+            detail = (
+                f"'{col}' has null_rate {prof.null_rate:.2f} (> "
+                f"{_NULL_SINK_RATE:.2f}). Most pairs have nothing to compare "
+                f"on this field, so it contributes little to the score."
+            )
+        else:
+            title = f"The matcher relies on a mostly-empty column ('{col}')"
+            detail = (
+                f"About {pct}% of rows have no value in '{col}', so for most "
+                f"records there's nothing to compare. Matching leans on it "
+                f"anyway, which weakens the result."
+            )
+        out.append(
+            _finding(
+                id="null_sink",
+                severity="medium",
+                evidence={"column": col, "null_rate": round(prof.null_rate, 4)},
+                fix_config_hint={"action": "demote_to_blocking", "column": col},
+                title_plain=title,
+                detail_plain=detail,
+                fix_plain=(
+                    f"Stop matching on '{col}'; it's empty for most rows."
+                ),
+            )
+        )
+    return out
+
+
+def _detect_low_signal_key(
+    matchkey_cols: set[str],
+    profiles_by_name: dict[str, ColumnProfile],
+    phrasing: str,
+) -> list[dict]:
+    out: list[dict] = []
+    for col in sorted(matchkey_cols):
+        prof = profiles_by_name.get(col)
+        if prof is None:
+            continue
+        # An id-like / near-unique column is handled by id_admitted; here we
+        # only flag the OPPOSITE extreme — almost no distinct values.
+        if prof.cardinality_ratio >= _LOW_SIGNAL_CARD:
+            continue
+        if phrasing == "technical":
+            title = f"Matchkey column '{col}' has near-zero cardinality"
+            detail = (
+                f"'{col}' has cardinality_ratio {prof.cardinality_ratio:.4f} "
+                f"(< {_LOW_SIGNAL_CARD}). Almost every row shares the same "
+                f"value, so the field barely separates matches from non-matches."
+            )
+        else:
+            title = f"A column ('{col}') is almost the same for every row"
+            detail = (
+                f"Nearly all rows share the same '{col}' value, so it does "
+                f"little to tell records apart. It's mostly along for the ride."
+            )
+        out.append(
+            _finding(
+                id="low_signal_key",
+                severity="low",
+                evidence={
+                    "column": col,
+                    "cardinality_ratio": round(prof.cardinality_ratio, 4),
+                },
+                fix_config_hint={"action": "demote_to_blocking", "column": col},
+                title_plain=title,
+                detail_plain=detail,
+                fix_plain=(
+                    f"Drop '{col}' from matching; it barely varies."
+                ),
+            )
+        )
+    return out
+
+
+def _detect_oversized_block(signals: dict | None, phrasing: str) -> list[dict]:
+    if not signals:
+        return []
+    pct = signals.get("block_size_percentiles") or {}
+    p99 = pct.get("p99")
+    max_size = pct.get("max")
+    if not isinstance(p99, (int, float)):
+        return []
+    if p99 <= _BLOCK_P99_WARN:
+        return []
+    severity = "high" if p99 >= _BLOCK_P99_HIGH else "medium"
+    evidence: dict = {"p99": int(p99)}
+    if isinstance(max_size, (int, float)):
+        evidence["max"] = int(max_size)
+    action = "compound_blocking" if severity == "high" else "tighten_blocking"
+    if phrasing == "technical":
+        title = f"A blocking key produces oversized blocks (P99={int(p99)})"
+        detail = (
+            f"Block-size P99 is {int(p99)} (ceiling {_BLOCK_P99_WARN}); a "
+            f"shared value is grouping too many rows into one block, which "
+            f"both slows scoring and risks over-merging within the block."
+        )
+    else:
+        title = "A common value is lumping too many records together"
+        detail = (
+            f"One blocking value groups thousands of records at once (the "
+            f"biggest group is around {int(p99)} rows). That makes the run "
+            f"slow and risks merging records that only share that one value."
+        )
+    return [
+        _finding(
+            id="shared_value_block",
+            severity=severity,
+            evidence=evidence,
+            fix_config_hint={"action": action},
+            title_plain=title,
+            detail_plain=detail,
+            fix_plain=(
+                "Block on a more specific combination of fields so each group "
+                "stays small."
+            ),
+        )
+    ]
+
+
+def _detect_over_merge(
+    signals: dict | None, clusters: dict | None, phrasing: str
+) -> list[dict]:
+    max_size = 0
+    n_oversized = 0
+    if signals:
+        oversized = signals.get("oversized_clusters") or []
+        n_oversized = len(oversized)
+        sizes = [
+            c.get("size", 0)
+            for c in oversized
+            if isinstance(c, dict) and isinstance(c.get("size"), (int, float))
+        ]
+        if sizes:
+            max_size = max(int(s) for s in sizes)
+        prelim = signals.get("preliminary_cluster_sizes") or {}
+        pmax = prelim.get("max")
+        if isinstance(pmax, (int, float)):
+            max_size = max(max_size, int(pmax))
+    # Fallback when postflight is absent but raw clusters are present.
+    if max_size == 0 and clusters:
+        try:
+            for cid, info in clusters.items():
+                members = info.get("members") if isinstance(info, dict) else None
+                size = len(members) if members is not None else 0
+                if size > max_size:
+                    max_size = size
+        except Exception:
+            return []
+    # Only flag genuine mega-clusters — mirrors postflight's >100 oversized cut.
+    if n_oversized == 0 and max_size <= 100:
+        return []
+    if phrasing == "technical":
+        title = f"Cluster sizes show over-merging (max={max_size})"
+        detail = (
+            f"The largest cluster has {max_size} records "
+            f"({n_oversized} oversized cluster(s) flagged). A few mega-clusters "
+            f"usually mean the threshold is too loose or a weak signal is "
+            f"chaining records together."
+        )
+    else:
+        title = "Too many records got merged into one giant group"
+        detail = (
+            f"The biggest merged group has about {max_size} records, which is "
+            f"far larger than a real duplicate set. The rules are probably "
+            f"merging records that aren't actually the same."
+        )
+    return [
+        _finding(
+            id="over_merge",
+            severity="high",
+            evidence={"max_cluster_size": max_size, "oversized_clusters": n_oversized},
+            fix_config_hint={"action": "raise_threshold"},
+            title_plain=title,
+            detail_plain=detail,
+            fix_plain=(
+                "Raise the match threshold (or tighten the rules) so only "
+                "strong evidence merges records."
+            ),
+        )
+    ]
+
+
+# ── Orchestration ──────────────────────────────────────────────────────────────
+
+
+def _matchkey_columns(config: GoldenMatchConfig) -> set[str]:
+    """Columns referenced specifically by matchkey fields (not blocking).
+
+    null_sink / low_signal_key only care about columns that feed the score, so
+    they look here rather than at the full referenced set (which includes
+    blocking-only columns).
+    """
+    cols: set[str] = set()
+    try:
+        for mk in config.get_matchkeys():
+            for f in mk.fields:
+                if f.field is not None and f.field != "__record__":
+                    cols.add(f.field)
+                if f.column is not None:
+                    cols.add(f.column)
+                if f.columns:
+                    cols.update(f.columns)
+    except Exception:
+        return set()
+    return cols
+
+
+def _safe(fn, *args) -> list[dict]:
+    """Run one detector, swallowing any error so a single bad detector can't
+    take down the whole diagnosis. Returns ``[]`` on failure."""
+    try:
+        result = fn(*args)
+        return result if isinstance(result, list) else []
+    except Exception:
+        return []
+
+
+def _signals_of(result: Any) -> dict | None:
+    """Extract the postflight signals dict from a result, defensively."""
+    report = getattr(result, "postflight_report", None)
+    if report is None:
+        return None
+    signals = getattr(report, "signals", None)
+    return signals if isinstance(signals, dict) else None
+
+
+def _clusters_of(result: Any) -> dict | None:
+    clusters = getattr(result, "clusters", None)
+    return clusters if isinstance(clusters, dict) else None
+
+
+def _profiles_by_name(df: pl.DataFrame) -> dict[str, ColumnProfile]:
+    """Profile the frame once (no LLM) and key by column name. Empty on error."""
+    try:
+        from goldenmatch.core.autoconfig import profile_columns
+
+        profiles = profile_columns(df, llm_provider=None)
+        return {p.name: p for p in profiles}
+    except Exception:
+        return {}
+
+
+def _template_summary(findings: list[dict]) -> str:
+    """Deterministic one-paragraph summary of the auto-built rules' risk."""
+    if not findings:
+        return (
+            "The auto-built matching rules look solid for this data; no "
+            "risky signals stood out. Zero-config nailed this one. Review the "
+            "matches and adjust only if something looks off."
+        )
+    n = len(findings)
+    highs = sum(1 for f in findings if f["severity"] == "high")
+    titles = "; ".join(f["title_plain"] for f in findings[:3])
+    lead = (
+        f"The auto-built rules ran, but {n} thing(s) look risky"
+        + (f" ({highs} serious)" if highs else "")
+        + ". "
+    )
+    tail = (
+        f"Top issues: {titles}. Each finding below says what to change in "
+        f"plain terms."
+    )
+    return lead + tail
+
+
+def _maybe_llm_summary(findings: list[dict], fallback: str) -> str:
+    """Optional compact LLM summary, gated + fail-closed.
+
+    Returns ``fallback`` unless ``GOLDENMATCH_WEAKNESS_LLM=1`` AND a provider is
+    detected AND the call succeeds. The payload is a tiny structured digest
+    (id + severity + title only) — never raw data — so this can't leak rows.
+    Any error returns the deterministic template summary.
+    """
+    if os.environ.get("GOLDENMATCH_WEAKNESS_LLM") != "1":
+        return fallback
+    if not findings:
+        return fallback
+    try:
+        from goldenmatch.core.llm_scorer import (
+            _call_anthropic,
+            _call_openai,
+            _detect_provider,
+        )
+
+        provider, key = _detect_provider()
+        if not provider or not key:
+            return fallback
+
+        digest = [
+            {"id": f["id"], "severity": f["severity"], "label": f["title_plain"]}
+            for f in findings
+        ]
+        prompt = (
+            "You summarize data-matching config weaknesses for a non-technical "
+            "reader. Given this JSON list of findings (id, severity, label), "
+            "write ONE short plain-English paragraph (no jargon, no bullet "
+            "points) describing what the auto-built rules did and where they "
+            "are risky. Do not invent findings beyond the list.\n\n"
+            + json.dumps(digest)
+        )
+        if provider == "openai":
+            model = os.environ.get("GOLDENMATCH_WEAKNESS_LLM_MODEL", "gpt-4o-mini")
+            text, _, _ = _call_openai(prompt, key, model, max_tokens=200)
+        elif provider == "anthropic":
+            model = os.environ.get(
+                "GOLDENMATCH_WEAKNESS_LLM_MODEL", "claude-3-5-haiku-latest"
+            )
+            text, _, _ = _call_anthropic(prompt, key, model, max_tokens=200)
+        else:
+            return fallback
+        text = (text or "").strip()
+        return text or fallback
+    except Exception:
+        return fallback
+
+
+def diagnose_config(
+    df: pl.DataFrame,
+    config: GoldenMatchConfig,
+    result: Any,
+    *,
+    max_findings: int = 6,
+    phrasing: str = "plain",
+) -> dict:
+    """Explain where an auto-built matching config is risky, in plain English.
+
+    Args:
+        df: the input frame the config was built from (used for profiling).
+        config: the resolved ``GoldenMatchConfig``.
+        result: a ``DedupeResult``-like object; ``.postflight_report`` and
+            ``.clusters`` are read defensively (either may be absent/None).
+        max_findings: cap on returned findings AFTER severity ranking.
+        phrasing: ``"plain"`` (default, non-technical) or ``"technical"``.
+
+    Returns:
+        ``{"findings": list[dict], "summary_plain": str}``. ``findings`` is
+        ranked high→low by severity and truncated to ``max_findings``. When no
+        weakness fires, ``findings`` is empty and ``summary_plain`` says the
+        rules look solid.
+
+    Never raises on a valid ``(df, config, result)``: every detector runs
+    inside ``_safe`` and missing signals are skipped, not treated as errors.
+    """
+    if phrasing not in ("plain", "technical"):
+        phrasing = "plain"
+
+    try:
+        referenced = _collect_referenced_columns(config)
+    except Exception:
+        referenced = set()
+    try:
+        excluded = set(getattr(config, "exclude_columns", None) or [])
+    except Exception:
+        excluded = set()
+    matchkey_cols = _matchkey_columns(config) - excluded
+
+    profiles_by_name = _profiles_by_name(df)
+    signals = _signals_of(result)
+    clusters = _clusters_of(result)
+
+    findings: list[dict] = []
+    findings += _safe(_detect_source_admitted, referenced, excluded, phrasing)
+    findings += _safe(
+        _detect_id_admitted, referenced, excluded, profiles_by_name, phrasing
+    )
+    findings += _safe(_detect_oversized_block, signals, phrasing)
+    findings += _safe(_detect_over_merge, signals, clusters, phrasing)
+    findings += _safe(_detect_null_sink, matchkey_cols, profiles_by_name, phrasing)
+    findings += _safe(
+        _detect_low_signal_key, matchkey_cols, profiles_by_name, phrasing
+    )
+
+    # Rank high→low by severity (stable: preserves detector order within a tier
+    # so output is fully deterministic), then truncate.
+    findings.sort(key=lambda f: _SEVERITY_RANK.get(f.get("severity"), 99))
+    if max_findings is not None and max_findings >= 0:
+        findings = findings[:max_findings]
+
+    summary = _template_summary(findings)
+    summary = _maybe_llm_summary(findings, summary)
+
+    return {"findings": findings, "summary_plain": summary}

--- a/packages/python/goldenmatch/goldenmatch/core/config_critique.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_critique.py
@@ -391,7 +391,7 @@ def _detect_over_merge(
     # Fallback when postflight is absent but raw clusters are present.
     if max_size == 0 and clusters:
         try:
-            for cid, info in clusters.items():
+            for info in clusters.values():
                 members = info.get("members") if isinstance(info, dict) else None
                 size = len(members) if members is not None else 0
                 if size > max_size:
@@ -624,7 +624,7 @@ def diagnose_config(
 
     # Rank high→low by severity (stable: preserves detector order within a tier
     # so output is fully deterministic), then truncate.
-    findings.sort(key=lambda f: _SEVERITY_RANK.get(f.get("severity"), 99))
+    findings.sort(key=lambda f: _SEVERITY_RANK.get(str(f.get("severity", "")), 99))
     if max_findings is not None and max_findings >= 0:
         findings = findings[:max_findings]
 

--- a/packages/python/goldenmatch/goldenmatch/core/config_critique.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_critique.py
@@ -622,6 +622,30 @@ def diagnose_config(
         _detect_low_signal_key, matchkey_cols, profiles_by_name, phrasing
     )
 
+    # A mostly-empty column also reads as "low cardinality" (few distinct
+    # non-null values), so null_sink and low_signal_key can both fire on the
+    # same column. The emptiness is the root cause, so when both fire we keep
+    # null_sink and drop the redundant low_signal_key — one clear finding per
+    # column instead of two slightly-contradictory ones on the "what to watch"
+    # panel.
+    _null_sink_cols = {
+        f["evidence"]["column"]
+        for f in findings
+        if f.get("id") == "null_sink"
+        and isinstance(f.get("evidence"), dict)
+        and "column" in f["evidence"]
+    }
+    if _null_sink_cols:
+        findings = [
+            f
+            for f in findings
+            if not (
+                f.get("id") == "low_signal_key"
+                and isinstance(f.get("evidence"), dict)
+                and f["evidence"].get("column") in _null_sink_cols
+            )
+        ]
+
     # Rank high→low by severity (stable: preserves detector order within a tier
     # so output is fully deterministic), then truncate.
     findings.sort(key=lambda f: _SEVERITY_RANK.get(str(f.get("severity", "")), 99))

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1667,7 +1667,7 @@ async def run_server_http(
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenMatch",
-            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 58 MCP tools for matching, explaining, reviewing, evaluating, blocking analysis, lineage, data quality, transforms, identity graph, distributed-routing config, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
+            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 59 MCP tools for matching, explaining, reviewing, evaluating, blocking analysis, config critique, lineage, data quality, transforms, identity graph, distributed-routing config, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
             "homepage": "https://github.com/benseverndev-oss/goldenmatch",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -541,6 +541,32 @@ _BASE_TOOLS = [
             "required": ["run_id"],
         },
     ),
+    Tool(
+        name="config_weaknesses",
+        description=(
+            "Diagnose weaknesses in the loaded run's auto-config: columns admitted "
+            "that shouldn't be (source/provenance labels, per-row IDs), oversized or "
+            "shared-value blocks, null sinks, low-signal matchkeys, and over-merging. "
+            "Returns ranked findings, each with a plain-English explanation + a concrete "
+            "fix, plus a one-paragraph summary."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "max_findings": {
+                    "type": "integer",
+                    "description": "Max findings to return, ranked by severity (default 6).",
+                    "default": 6,
+                },
+                "phrasing": {
+                    "type": "string",
+                    "enum": ["plain", "technical"],
+                    "description": "Wording style for the findings (default plain).",
+                    "default": "plain",
+                },
+            },
+        },
+    ),
 ]
 
 # TOOLS is the union of agent tools + memory tools + base tools, in the same order list_tools returns.
@@ -910,6 +936,10 @@ def _handle_tool(name: str, args: dict) -> dict:
         return _tool_list_runs(args.get("output_dir", "."))
     elif name == "rollback":
         return _tool_rollback(args["run_id"], args.get("output_dir", "."))
+    elif name == "config_weaknesses":
+        return _tool_config_weaknesses(
+            args.get("max_findings", 6), args.get("phrasing", "plain")
+        )
     else:
         return {"error": f"Unknown tool: {name}"}
 
@@ -1555,6 +1585,15 @@ def _tool_rollback(run_id: str, output_dir: str = ".") -> dict:
     if isinstance(vdir, dict):
         return vdir
     return rollback_run(run_id, str(vdir))
+
+
+def _tool_config_weaknesses(max_findings: int = 6, phrasing: str = "plain") -> dict:
+    """Diagnose weaknesses in the loaded run's auto-config (see core.config_critique)."""
+    from goldenmatch.core.config_critique import diagnose_config
+    return diagnose_config(
+        _engine.data, _config, _result,
+        max_findings=max_findings, phrasing=phrasing,
+    )
 
 
 def resolve_http_auth_token(host: str) -> str | None:

--- a/packages/python/goldenmatch/tests/test_config_critique.py
+++ b/packages/python/goldenmatch/tests/test_config_critique.py
@@ -1,0 +1,348 @@
+"""Unit tests for the deterministic config-weakness generator.
+
+`diagnose_config(df, config, result)` maps engine signals (the resolved
+config + profile + postflight signals) to plain-English findings. These tests
+construct the inputs DIRECTLY (small DataFrame, hand-built GoldenMatchConfig,
+minimal DedupeResult carrying a populated postflight_report) so each detector
+is exercised at unit level with no engine run — fast and deterministic.
+
+Covered: the three named findings (source_admitted, shared_value_block,
+null_sink), plus id_admitted / low_signal_key / over_merge; the no-LLM
+phrasing="plain" rendering; severity ranking + max_findings truncation; and
+the clean-data "no findings" path.
+"""
+from __future__ import annotations
+
+import polars as pl
+
+from goldenmatch._api import DedupeResult
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_verify import PostflightReport
+from goldenmatch.core.config_critique import diagnose_config
+
+
+# ── Builders ────────────────────────────────────────────────────────────────
+
+
+def _exact_config(*, fields, blocking_fields=None, exclude=None):
+    """A minimal exact-matchkey config.
+
+    An exact matchkey needs no threshold/scorer/weight and (unlike
+    weighted/probabilistic) does NOT require a blocking config, so this builds
+    a valid GoldenMatchConfig from just a field list. ``blocking_fields``, when
+    given, attaches a static blocking key over those columns.
+    """
+    blocking = None
+    if blocking_fields is not None:
+        blocking = BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=list(blocking_fields))],
+        )
+    return GoldenMatchConfig(
+        blocking=blocking,
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk",
+                type="exact",
+                fields=[MatchkeyField(field=f) for f in fields],
+            )
+        ],
+        exclude_columns=list(exclude or []),
+    )
+
+
+def _weighted_config(*, fields_weights, blocking_fields, threshold=0.7):
+    """A weighted-matchkey config (requires blocking + per-field scorer/weight)."""
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=list(blocking_fields))],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk",
+                type="weighted",
+                threshold=threshold,
+                fields=[
+                    MatchkeyField(field=f, scorer="jaro_winkler", weight=w)
+                    for f, w in fields_weights
+                ],
+            )
+        ],
+    )
+
+
+def _result(*, signals=None, clusters=None):
+    """A minimal DedupeResult carrying an optional postflight_report."""
+    report = None
+    if signals is not None:
+        report = PostflightReport(signals=signals)
+    return DedupeResult(
+        clusters=clusters or {},
+        postflight_report=report,
+    )
+
+
+# ── source_admitted ───────────────────────────────────────────────────────────
+
+
+def test_source_admitted_fires_high():
+    df = pl.DataFrame({
+        "name": ["a", "b", "c"],
+        "source": ["crm", "events", "crm"],
+    })
+    cfg = _exact_config(fields=["name", "source"])
+    out = diagnose_config(df, cfg, _result())
+
+    ids = [f["id"] for f in out["findings"]]
+    assert "source_admitted" in ids
+    finding = next(f for f in out["findings"] if f["id"] == "source_admitted")
+    assert finding["severity"] == "high"
+    assert finding["evidence"]["column"] == "source"
+    assert finding["fix_config_hint"] == {
+        "action": "exclude_column",
+        "column": "source",
+    }
+
+
+def test_source_admitted_skipped_when_already_excluded():
+    df = pl.DataFrame({
+        "name": ["a", "b", "c"],
+        "source": ["crm", "events", "crm"],
+    })
+    # 'source' referenced by config but also in exclude_columns -> not a weakness.
+    cfg = _exact_config(fields=["name"], exclude=["source"])
+    out = diagnose_config(df, cfg, _result())
+    assert all(f["id"] != "source_admitted" for f in out["findings"])
+
+
+# ── id_admitted ────────────────────────────────────────────────────────────────
+
+
+def test_id_admitted_fires_on_id_suffix():
+    df = pl.DataFrame({
+        "name": ["a", "b", "c"],
+        "customer_id": ["1", "2", "3"],
+    })
+    cfg = _exact_config(fields=["name", "customer_id"])
+    out = diagnose_config(df, cfg, _result())
+
+    ids = [f["id"] for f in out["findings"]]
+    assert "id_admitted" in ids
+    finding = next(f for f in out["findings"] if f["id"] == "id_admitted")
+    assert finding["severity"] == "high"
+    assert finding["fix_config_hint"]["action"] == "exclude_column"
+    assert finding["fix_config_hint"]["column"] == "customer_id"
+
+
+# ── shared_value_block / oversized_block ───────────────────────────────────────
+
+
+def test_shared_value_block_fires_from_postflight_percentiles():
+    df = pl.DataFrame({
+        "name": ["a", "b", "c"],
+        "state": ["NY", "NY", "CA"],
+    })
+    cfg = _exact_config(fields=["name"], blocking_fields=["state"])
+    # Oversized block: p99 way over the 5000 sanity ceiling.
+    signals = {"block_size_percentiles": {"p50": 4, "p95": 900, "p99": 12000, "max": 30000}}
+    out = diagnose_config(df, cfg, _result(signals=signals))
+
+    ids = [f["id"] for f in out["findings"]]
+    assert "shared_value_block" in ids
+    finding = next(f for f in out["findings"] if f["id"] == "shared_value_block")
+    assert finding["severity"] in ("high", "medium")
+    assert finding["evidence"]["p99"] == 12000
+    assert finding["evidence"]["max"] == 30000
+    assert finding["fix_config_hint"]["action"] in (
+        "tighten_blocking",
+        "compound_blocking",
+    )
+
+
+def test_shared_value_block_silent_when_blocks_healthy():
+    df = pl.DataFrame({"name": ["a", "b", "c"]})
+    cfg = _exact_config(fields=["name"], blocking_fields=["name"])
+    signals = {"block_size_percentiles": {"p50": 2, "p95": 10, "p99": 40, "max": 60}}
+    out = diagnose_config(df, cfg, _result(signals=signals))
+    assert all(f["id"] != "shared_value_block" for f in out["findings"])
+
+
+# ── null_sink ──────────────────────────────────────────────────────────────────
+
+
+def test_null_sink_fires_above_threshold():
+    # 'phone' is 60% null among a matching column -> null_sink.
+    df = pl.DataFrame({
+        "name": ["a", "b", "c", "d", "e"],
+        "phone": ["555", None, None, None, "777"],
+    })
+    cfg = _exact_config(fields=["name", "phone"])
+    out = diagnose_config(df, cfg, _result())
+
+    ids = [f["id"] for f in out["findings"]]
+    assert "null_sink" in ids
+    finding = next(f for f in out["findings"] if f["id"] == "null_sink")
+    assert finding["severity"] == "medium"
+    assert finding["evidence"]["column"] == "phone"
+    assert finding["evidence"]["null_rate"] > 0.2
+
+
+def test_null_sink_silent_when_column_dense():
+    df = pl.DataFrame({
+        "name": ["a", "b", "c", "d", "e"],
+        "phone": ["1", "2", "3", "4", "5"],
+    })
+    cfg = _exact_config(fields=["name", "phone"])
+    out = diagnose_config(df, cfg, _result())
+    assert all(f["id"] != "null_sink" for f in out["findings"])
+
+
+# ── low_signal_key ─────────────────────────────────────────────────────────────
+
+
+def test_low_signal_key_fires_on_constant_column():
+    # 'country' is constant (cardinality_ratio ~ 0.005 << 0.01) over 200 rows.
+    df = pl.DataFrame({
+        "name": [f"n{i}" for i in range(200)],
+        "country": ["US"] * 200,
+    })
+    cfg = _exact_config(fields=["name", "country"])
+    out = diagnose_config(df, cfg, _result())
+
+    ids = [f["id"] for f in out["findings"]]
+    assert "low_signal_key" in ids
+    finding = next(f for f in out["findings"] if f["id"] == "low_signal_key")
+    assert finding["severity"] == "low"
+    assert finding["evidence"]["column"] == "country"
+
+
+# ── over_merge ─────────────────────────────────────────────────────────────────
+
+
+def test_over_merge_fires_on_oversized_clusters():
+    df = pl.DataFrame({"name": ["a", "b", "c"]})
+    cfg = _exact_config(fields=["name"])
+    signals = {
+        "oversized_clusters": [{"cluster_id": 7, "size": 4200, "bottleneck_pair": [1, 2]}],
+        "preliminary_cluster_sizes": {"p50": 2, "p95": 9, "p99": 50, "max": 4200, "count": 100},
+    }
+    out = diagnose_config(df, cfg, _result(signals=signals))
+
+    ids = [f["id"] for f in out["findings"]]
+    assert "over_merge" in ids
+    finding = next(f for f in out["findings"] if f["id"] == "over_merge")
+    assert finding["severity"] == "high"
+    assert finding["fix_config_hint"]["action"] == "raise_threshold"
+    assert finding["evidence"]["max_cluster_size"] == 4200
+
+
+# ── phrasing="plain" renders the plain fields, no LLM ──────────────────────────
+
+
+def test_plain_phrasing_renders_plain_fields_no_llm(monkeypatch):
+    # Hard-guarantee no LLM path: even if a key is present, the gate env is off.
+    monkeypatch.delenv("GOLDENMATCH_WEAKNESS_LLM", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+
+    df = pl.DataFrame({
+        "name": ["a", "b", "c"],
+        "source": ["crm", "events", "crm"],
+    })
+    cfg = _exact_config(fields=["name", "source"])
+    out = diagnose_config(df, cfg, _result(), phrasing="plain")
+
+    assert out["findings"], "expected at least the source_admitted finding"
+    for f in out["findings"]:
+        for key in ("title_plain", "detail_plain", "fix_plain"):
+            assert isinstance(f[key], str) and f[key], f"{key} must be non-empty"
+        # plain wording must not leak the raw metric/key jargon that the
+        # technical phrasing would use.
+        assert "cardinality_ratio" not in f["detail_plain"]
+    assert isinstance(out["summary_plain"], str) and out["summary_plain"]
+
+
+def test_technical_phrasing_is_deterministic_and_distinct():
+    df = pl.DataFrame({
+        "name": ["a", "b", "c"],
+        "source": ["crm", "events", "crm"],
+    })
+    cfg = _exact_config(fields=["name", "source"])
+    plain = diagnose_config(df, cfg, _result(), phrasing="plain")
+    tech = diagnose_config(df, cfg, _result(), phrasing="technical")
+    # Same finding set, both deterministic.
+    assert [f["id"] for f in plain["findings"]] == [f["id"] for f in tech["findings"]]
+    # Re-running technical twice is byte-identical (no LLM, no randomness).
+    tech2 = diagnose_config(df, cfg, _result(), phrasing="technical")
+    assert tech == tech2
+
+
+# ── ranking + max_findings truncation ──────────────────────────────────────────
+
+
+def test_findings_ranked_high_to_low_and_truncated():
+    # Build a config that fires several detectors of mixed severity:
+    #  - source (high), customer_id (high)  -> high
+    #  - phone null_sink (medium)
+    #  - country low_signal_key (low)
+    df = pl.DataFrame({
+        "name": [f"n{i}" for i in range(200)],
+        "source": (["crm", "events"] * 100),
+        "customer_id": [str(i) for i in range(200)],
+        "phone": (["555"] + [None] * 199),
+        "country": ["US"] * 200,
+    })
+    cfg = _exact_config(fields=["name", "source", "customer_id", "phone", "country"])
+    out = diagnose_config(df, cfg, _result())
+
+    sevs = [f["severity"] for f in out["findings"]]
+    rank = {"high": 0, "medium": 1, "low": 2}
+    assert sevs == sorted(sevs, key=lambda s: rank[s]), "findings must be high->low"
+
+    # max_findings truncates AFTER ranking — keep the most severe.
+    capped = diagnose_config(df, cfg, _result(), max_findings=2)
+    assert len(capped["findings"]) == 2
+    assert all(f["severity"] == "high" for f in capped["findings"])
+
+
+# ── clean data: no findings ─────────────────────────────────────────────────────
+
+
+def test_clean_single_source_no_findings():
+    df = pl.DataFrame({
+        "name": ["alice", "bob", "carol", "dave"],
+        "email": ["a@x.com", "b@x.com", "c@x.com", "d@x.com"],
+    })
+    cfg = _exact_config(fields=["name", "email"], blocking_fields=["email"])
+    signals = {
+        "block_size_percentiles": {"p50": 1, "p95": 2, "p99": 3, "max": 3},
+        "oversized_clusters": [],
+        "preliminary_cluster_sizes": {"p50": 1, "p95": 2, "p99": 2, "max": 2, "count": 4},
+    }
+    out = diagnose_config(df, cfg, _result(signals=signals))
+    assert out["findings"] == []
+    assert isinstance(out["summary_plain"], str) and out["summary_plain"]
+
+
+# ── robustness: missing signals never raise ─────────────────────────────────────
+
+
+def test_no_postflight_report_does_not_raise():
+    df = pl.DataFrame({"name": ["a", "b", "c"]})
+    cfg = _exact_config(fields=["name"], blocking_fields=["name"])
+    # result with postflight_report=None — block/over_merge detectors must skip.
+    out = diagnose_config(df, cfg, DedupeResult())
+    assert "findings" in out and "summary_plain" in out
+
+
+def test_empty_dataframe_does_not_raise():
+    df = pl.DataFrame({"name": []}, schema={"name": pl.Utf8})
+    cfg = _exact_config(fields=["name"])
+    out = diagnose_config(df, cfg, _result())
+    assert isinstance(out["findings"], list)

--- a/packages/python/goldenmatch/tests/test_config_critique.py
+++ b/packages/python/goldenmatch/tests/test_config_critique.py
@@ -15,7 +15,6 @@ the clean-data "no findings" path.
 from __future__ import annotations
 
 import polars as pl
-
 from goldenmatch._api import DedupeResult
 from goldenmatch.config.schemas import (
     BlockingConfig,
@@ -26,7 +25,6 @@ from goldenmatch.config.schemas import (
 )
 from goldenmatch.core.autoconfig_verify import PostflightReport
 from goldenmatch.core.config_critique import diagnose_config
-
 
 # ── Builders ────────────────────────────────────────────────────────────────
 

--- a/packages/python/goldenmatch/tests/test_config_critique.py
+++ b/packages/python/goldenmatch/tests/test_config_critique.py
@@ -11,6 +11,7 @@ null_sink), plus id_admitted / low_signal_key / over_merge; the no-LLM
 phrasing="plain" rendering; severity ranking + max_findings truncation; and
 the clean-data "no findings" path.
 """
+
 from __future__ import annotations
 
 import polars as pl
@@ -221,6 +222,29 @@ def test_low_signal_key_fires_on_constant_column():
     finding = next(f for f in out["findings"] if f["id"] == "low_signal_key")
     assert finding["severity"] == "low"
     assert finding["evidence"]["column"] == "country"
+
+
+def test_null_sink_wins_over_low_signal_key_on_same_column():
+    # A mostly-null column also reads as low-cardinality (few distinct non-null
+    # values). The emptiness is the root cause, so a single column must never
+    # produce BOTH null_sink and low_signal_key — null_sink wins.
+    df = pl.DataFrame({
+        "name": [f"n{i}" for i in range(200)],
+        "phone": (["555"] + [None] * 199),  # 99.5% null + 1 distinct value
+    })
+    cfg = _exact_config(fields=["name", "phone"])
+    out = diagnose_config(df, cfg, _result())
+
+    by_col: dict[str, set[str]] = {}
+    for f in out["findings"]:
+        col = f.get("evidence", {}).get("column")
+        if col is not None:
+            by_col.setdefault(col, set()).add(f["id"])
+    for col, ids in by_col.items():
+        assert not ({"null_sink", "low_signal_key"} <= ids), (
+            f"column {col!r} fired both null_sink and low_signal_key"
+        )
+    assert any(f["id"] == "null_sink" for f in out["findings"])
 
 
 # ── over_merge ─────────────────────────────────────────────────────────────────

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -16,7 +16,7 @@ import pytest
 # ── Registration ──────────────────────────────────────────────────────────────
 
 
-def test_total_tool_count_is_58():
+def test_total_tool_count_is_59():
     from goldenmatch.mcp.agent_tools import AGENT_TOOLS
     from goldenmatch.mcp.identity_tools import IDENTITY_TOOLS
     from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
@@ -26,9 +26,9 @@ def test_total_tool_count_is_58():
     assert len(AGENT_TOOLS) == 17   # +1 certify_recall
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 7
-    assert len(_BASE_TOOLS) == 24
+    assert len(_BASE_TOOLS) == 25   # +1 config_weaknesses
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 58
+    assert len(TOOLS) == 59
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))
@@ -41,7 +41,7 @@ def test_new_tool_names_registered():
     for new in (
         "evaluate", "analyze_blocking", "compare_clusters", "schema_match",
         "lineage", "list_runs", "rollback", "sensitivity", "incremental",
-        "identity_show", "memory_import",
+        "identity_show", "memory_import", "config_weaknesses",
     ):
         assert new in names, f"{new} missing from TOOLS"
 
@@ -123,6 +123,17 @@ def test_lineage_to_dir(demo_file, simple_config, tmp_path):
     out.mkdir()
     result = _handle_tool("lineage", {"max_pairs": 10, "output_dir": str(out)})
     assert "saved_to" in result
+
+
+def test_config_weaknesses(demo_file, simple_config):
+    from goldenmatch.mcp.server import TOOLS, _handle_tool, create_server
+
+    create_server([demo_file], simple_config)
+    result = _handle_tool("config_weaknesses", {})
+    # Shape only — demo data may legitimately produce zero findings.
+    assert isinstance(result["findings"], list)
+    assert isinstance(result["summary_plain"], str)
+    assert "config_weaknesses" in {t.name for t in TOOLS}
 
 
 # ── Base tools that are file/store based (no loaded dataset needed) ────────────

--- a/packages/python/goldenmatch/tests/test_memory_tools.py
+++ b/packages/python/goldenmatch/tests/test_memory_tools.py
@@ -157,11 +157,11 @@ def test_memory_tools_op_error_returns_structured_error(tmp_path, monkeypatch):
 
 
 def test_server_card_description_count():
-    """server.py description string advertises 58 MCP tools."""
+    """server.py description string advertises 59 MCP tools."""
     server_path = (
         Path(__file__).resolve().parent.parent / "goldenmatch" / "mcp" / "server.py"
     )
     text = server_path.read_text(encoding="utf-8")
     match = re.search(r"(\d+) MCP tools", text)
     assert match is not None
-    assert int(match.group(1)) == 58
+    assert int(match.group(1)) == 59


### PR DESCRIPTION
**Draft / founder-gated.** Build is complete and CI is green (`ci-required` ✅). This ships the `config_weaknesses` capability for the bensevern.dev `/dedupe` page's "What to watch" critique panel — the **2.2.0 fast-follow** to the perf half that shipped on 2.1.0 (showcase ADR-0018 Phase 3, Track A; the panel currently ships dark / fail-to-off). **Do not merge until the founder cuts goldenmatch 2.2.0** — that's the gated step where the showcase bumps its pin, un-stubs the critique client, and lights up the panel.

## What this adds

A deterministic config/run weakness generator: after auto-config builds a config and a first run produces a result, explain in plain English what the auto-built rules *did* and where they're risky.

**Task A1 — pure core** (`goldenmatch/core/config_critique.py` + `tests/test_config_critique.py`):
- `diagnose_config(df, config, result, *, max_findings=6, phrasing="plain") -> {findings, summary_plain}`. Six deterministic detectors — `source_admitted`, `id_admitted`, `shared_value_block`/oversized-block, `null_sink`, `low_signal_key`, `over_merge` — reusing `autoconfig_verify._collect_referenced_columns`, `profile_columns`, and `PostflightReport.signals`. Findings ranked high→low, truncated to `max_findings`. When a column fires both `null_sink` and `low_signal_key`, `null_sink` wins (emptiness is the root cause). Optional one-paragraph LLM summary gated on `GOLDENMATCH_WEAKNESS_LLM=1` + a detected provider — sends only a compact id/severity/label digest (never raw data), fails closed to the deterministic template.

**Task A2 — MCP tool** (`goldenmatch/mcp/server.py` + `tests/test_mcp_new_tools.py`):
- Registered `config_weaknesses` in `_BASE_TOOLS` (+ dispatch + handler) reading the server's loaded `_engine.data` / `_config` / `_result`. Tool count 58 → 59 (server-card prose, its `test_server_card_description_count` guard, README/LAUNCHGUIDE, and the `_BASE_TOOLS`/`TOOLS` count assertions all synced).
- New `GOLDENMATCH_WEAKNESS_LLM` flag documented in `docs-site/goldenmatch/tuning.mdx` (canonical flag reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
