### PR TITLE
feat: opt-in semantic blocking (recall lever) — abbreviation +5.3pp at zero precision cost

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/RECALL-LEVER.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/RECALL-LEVER.md
@@ -88,7 +88,7 @@ recall. **Gate on a measurement:** `auto+fields` + semantic blocking must clear
 regardless and should be scoped out (or addressed separately via a domain/knowledge
 source). This is a real product change and gets its own spec + plan before any code.
 
-## Semantic blocking shipped (in-product) -- now with per-source confirming scorers
+## Semantic blocking shipped (in-product) -- recall lever working (abbreviation +5.3pp)
 
 Semantic blocking is a real, opt-in capability: `dedupe_df(df,
 semantic_blocking=True)` unions three FREE deterministic candidate sources onto
@@ -112,126 +112,83 @@ flag (`adapters/goldenmatch_adapter.py`, mode `auto_fields_semantic`).
 
 ### Measured: auto+fields vs auto+fields+semantic (206 records, offline)
 
-Re-measured with the confirming scorers wired (`GOLDENMATCH_NATIVE=0`, in-house
+Measured with the full lever wired -- per-source confirming scorers, noise-tolerant
++ acronym-aware initialism, AND raw-name keying (`GOLDENMATCH_NATIVE=0`, in-house
 embedder, numpy ANN fallback -- reproducible by anyone, no key):
 
 | metric | auto+fields | auto+fields+semantic | delta |
 |---|---|---|---|
-| **overall F1** | 0.6018 | 0.6018 | +0.000 |
-| overall P | 0.7857 | 0.7857 | +0.000 |
-| overall R | 0.4877 | 0.4877 | +0.000 |
-| abbreviation F1 | 0.7727 | 0.7727 | +0.000 |
-| nickname_alias F1 | 0.8539 | 0.8539 | +0.000 |
-| synonym_brand F1 | 0.1667 | 0.1667 | +0.000 |
-| cross_lingual F1 | 0.7692 | 0.7692 | +0.000 |
-| typo F1 | 1.0000 | 1.0000 | +0.000 |
-| org_suffix F1 | 1.0000 | 1.0000 | +0.000 |
-| temporal_version F1 | 0.5714 | 0.5714 | +0.000 |
-| cross_document_exact F1 | 1.0000 | 1.0000 | +0.000 |
-| same_name_collision F1 | 0.3556 | 0.3556 | +0.000 |
+| **overall F1** | 0.602 | **0.612** | **+0.010** |
+| overall P | 0.786 | 0.790 | +0.004 |
+| overall R | 0.488 | 0.500 | +0.012 |
+| **abbreviation F1** | 0.773 | **0.826** | **+0.053** |
+| abbreviation R | 0.630 | 0.704 | **+0.074** |
+| abbreviation P | 1.000 | 1.000 | +0.000 |
 
-The two rows are still **byte-identical** (both `tp=198 fp=54 fn=208`). No class
-moved. Wiring the confirming scorers (the prior diagnosis' proposed fix) did
-**not** unstick the headline on this corpus.
+All other classes unchanged. The headline moves on the back of abbreviation recall,
+at **zero precision cost** (abbreviation precision stays 1.000; overall `fp` does
+not rise).
 
 ### Acceptance verdict vs 0.602
 
-**NOT MET (headline did not move).** `auto+fields+semantic` F1 = `auto+fields`
-F1 = **0.6018** (rounds to the documented 0.602; fractionally below 0.602 as a
-raw float). The capability still ships opt-in at **zero precision cost** (`fp`
-unchanged at 54 -- the additive union never adds a false merge here), but it is
-not a headline mover on ER-KG-Bench.
+**MET.** `auto+fields+semantic` = **0.612 > 0.602**, a real recall-positive move
+driven by the abbreviation class (+5.3pp F1, +7.4pp recall). A/B confirms it's
+load-bearing: with the semantic sources keyed off the *standardized* (title-cased)
+name the row is byte-identical to `auto+fields` (the old wall); keyed off the *raw*
+name it adds abbreviation pairs the ANN source alone did not catch.
 
 ### Precision cost (measured, not pre-guarded)
 
-**Zero, measured.** The approved stance was "measure the precision cost, don't
-pre-guard it." On this corpus the cost is nil: `fp` is identical (54) between the
-two rows, and **no** class's precision regressed -- no initialism collision, no
-alias-table error materialized, because the confirming pairs that survive to
-clustering are all pairs the baseline already merged. There is no precision
-finding to report and no scoped follow-up needed on the precision side.
+**Zero, measured.** The approved stance was "measure, don't pre-guard." abbreviation
+precision stays **1.000** and overall `fp` does not rise -- the confirmed initialism
+pairs are true matches on this corpus (no initialism collision materialized). No
+precision guard (block-size cap, secondary signal) is warranted: it would solve a
+problem the data does not show.
 
-### Why it's STILL a no-op: two distinct walls, both now isolated
+### How it was unstuck: four walls, the last was upstream title-casing
 
-Per-source confirming scorers are the right design, but two corpus-specific
-mechanisms keep the headline pinned. Both were isolated by instrumenting the
-pipeline at the `_semantic_blocking_pairs` return, the post-`_apply_postflight`
-pair set, and the `build_cluster_frames` call site:
+Moving the headline took clearing four walls in sequence, each isolated by
+instrumenting `_semantic_blocking_pairs`, the post-`_apply_postflight` pair set,
+and the `build_cluster_frames` call site:
 
-1. **The confirming scorers can't confirm the corpus's NOISY surface forms.**
-   `initialism_match` / `alias_match` are correct on clean expansions --
-   measured `initialism_match("IBM", "International Business Machines") = 1.0`,
-   `("NATO", "North Atlantic Treaty Organisation") = 1.0`,
-   `("WHO", "World Health Organization") = 1.0`. But ER-KG-Bench mentions carry
-   real-world suffix/parenthetical noise, and the strict check collapses the
-   moment it appears: `initialism_match("IBM", "International Business Machines
-   Corporation (Armonk, NY)") = 0.0`, `("IBM", "IBM Corp.") = 0.0`. So for the
-   actual gold abbreviation pairs the confirming scorer returns **0.0**, and the
-   only score those pairs carry into `all_pairs` is the **ANN char-ngram cosine**
-   (e.g. `IBM` <-> `International Business Machines Corporation (Armonk, NY)`
-   lands at **0.863**, not 1.0). `alias` adds nothing here (0 non-singleton
-   blocks on this corpus -- the `given_names`/`business` seed doesn't cover
-   these orgs).
+1. **Per-source confirming scorers.** The union first scored its acronym/alias
+   candidates with the multi-field *name* ensemble, which scores `IBM` <->
+   `International Business Machines` ~0. Fixed by scoring each source with its own
+   confirming scorer (`initialism_match` / `alias_match` at 1.0; ANN keeps cosine).
+2. **Noise-tolerant + acronym-aware initialism.** A 1-token acronym (`IBM`) has no
+   multi-word initialism, and real expansions carry suffix/parenthetical noise
+   (`...Corporation (Armonk, NY)`). Fixed in `derive_initialism`: strip
+   parentheticals + legal-form tokens anywhere, and treat a short all-caps token
+   as its own initialism key -- so `IBM` and its noisy expansion both derive `IBM`.
+3. **(superseded theory)** an earlier postflight-threshold guess (0.8 -> 0.895
+   dropping the 0.83-0.89 ANN-cosine band) -- real on an all-sources run, but NOT
+   the blocker once the initialism confirmer returns 1.0 (a 1.0 pair clears any
+   threshold).
+4. **Upstream standardize title-casing (the actual last wall).** auto-config's
+   standardize step title-cases the name *before* semantic blocking runs, so by
+   the time `derive_initialism` sees it, `IBM` is `Ibm` and the all-caps acronym
+   signal is gone -> no block key -> never co-locates with the expansion. **Fixed
+   by keying the semantic-blocking sources off the RAW, pre-standardize name**
+   (captured into an internal `__raw__<col>` before standardize, gated behind
+   `semantic_blocking`, stripped from output; ANN keeps the standardized column).
+   This is the change that moved abbreviation 0.773 -> 0.826.
 
-2. **Auto-config's postflight raises the threshold to 0.895 and drops exactly
-   those candidates.** The committed config is RED on this corpus
-   (`stop_reason=BUDGET_ITERATIONS`, `failing_subprofile=blocking`: with `name`
-   at cardinality 0.95 most blocks are singletons), and `_apply_postflight`
-   applies a `threshold` adjustment **0.8 -> 0.895**. Measured pre-postflight,
-   `all_pairs` holds 2871 pairs; postflight drops 1873 of them, with the dropped
-   mass concentrated in the **0.8 band (1638 pairs)** and **0.9 band (214)** --
-   i.e. precisely the 0.83-0.89 char-ngram-cosine scores the abbreviation pairs
-   land at. `IBM` <-> `International Business Machines...` (0.863) and three of
-   the four `NATO` variants (0.836, 0.844, 0.835) are dropped here. The few
-   confirmed/near-exact pairs that DO survive postflight (score >= 0.99, e.g.
-   `IBM` <-> `IBM Corp.` at 1.0) are pairs **string blocking already generated
-   and the baseline already merged**, so after `dedup_pairs_max_score` the
-   canonical cluster-input pair set is **219 in both runs, 0 new** -- which is
-   why the clustering output is byte-identical.
+### What still does NOT move (honest scope)
 
-Per-class, which sources *can* move what, and why they didn't here:
+- **synonym_brand (e.g. `Coumadin`/`warfarin`): walled, F1 0.167.** Bounded by the
+  small `given_names`/`business` alias seed (0 non-singleton alias blocks on these
+  orgs). Same class the embedder sweep found walled for *every* embedder (max
+  ~0.18) -- a knowledge-base problem, not a scorer/embedder one. Extending the seed
+  table or wiring a domain KB is the lever; out of scope here.
+- **cross_lingual: unchanged.** The free in-house char-ngram ANN can't generate
+  cross-lingual candidates (no shared characters); the multilingual gains the
+  embedder sweep showed (0.35 -> 0.91) need a *semantic* embedder -- the documented
+  opt-in upgrade (`ann_model="local:<st-model>"`), not the free offline default.
+- **typo / org_suffix: already F1 1.000** under `auto+fields` -- no recall left.
 
-- **initialism -> abbreviation:** fires at 1.0 on clean expansions, **0.0** on
-  the noisy ones this corpus actually contains; the surviving signal for those
-  pairs is ANN cosine ~0.83-0.86, which postflight's 0.895 threshold rejects.
-- **alias -> known synonyms in the seed table only:** bounded by the small
-  `given_names` / `business` refdata seed; 0 non-singleton blocks here. The
-  `synonym_brand` class (e.g. `Coumadin`/`warfarin`) is the same class the
-  embedder sweep found walled for *every* embedder (max 0.18) -- a knowledge-base
-  problem, not an embedder/scorer problem.
-- **ANN -> typo / suffix / transliteration:** these classes are *already* at
-  F1 1.0 (`typo`, `org_suffix`) under `auto+fields`, so there's no recall left to
-  add; the cross-lingual gains the multilingual model showed need a *semantic*
-  embedder, not the char-ngram one this offline path uses.
+### Scoped follow-ups (optional, recall side -- precision side needs nothing)
 
-**Bottom line:** the recall-lever capability is real, shipped opt-in, and now
-scores each candidate source with its own confirming scorer at zero precision
-cost. But on ER-KG-Bench the headline does not move, for two independent reasons:
-(a) the strict initialism/alias confirmers return 0.0 on the corpus's noisy
-real-world surface forms, leaving only the char-ngram ANN cosine (~0.83-0.86) for
-the genuine abbreviation pairs; and (b) auto-config's postflight raises the match
-threshold to **0.895** on this RED config and drops exactly that 0.83-0.89 band.
-Moving the headline here needs *both* (i) a noise-tolerant confirmer (strip
-`Corp./Inc./(City, ST)` suffixes + organisation/-zation spelling normalization
-before the initialism/alias check) **so the confirmer returns 1.0 on the noisy
-mentions and the pair clears any threshold**, and (ii) a world-knowledge semantic
-embedder for the candidates the char-ngram path can't generate at all.
-synonym/brand stays walled regardless.
-
-### Scoped follow-ups (recall side -- precision side has none)
-
-1. **Noise-tolerant initialism/alias confirmers.** Normalize the expansion
-   before the initialism check: drop trailing legal suffixes (`Corp.`, `Inc.`,
-   `Corporation`), parentheticals (`(Armonk, NY)`, `(WHO)`), and reconcile
-   `-ization`/`-isation`. This is what turns the measured 0.0 back into 1.0 on
-   the noisy mentions, so the confirmed pair clears the threshold regardless of
-   postflight. (Highest-leverage fix: it is the difference between the
-   abbreviation pairs scoring ~0.86 and scoring 1.0.)
-2. **A world-knowledge semantic embedder for the ANN source** (free multilingual
-   model, or the two-model ensemble) for the candidates the char-ngram cosine
-   cannot generate at all -- the lever the earlier embedder sweep proved
-   (abbreviation 0.21 -> 0.80-0.85, cross-lingual 0.35 -> 0.91).
-
-Neither needs an initialism-block-size cap or any precision guard: the measured
-precision cost on this corpus is zero, so capping is solving a problem the data
-does not show.
+1. **Extend the alias seed / wire a domain KB** to crack synonym_brand.
+2. **Semantic embedder for the ANN source** (free local multilingual model) for the
+   cross-lingual candidates the char-ngram path can't generate -- already a
+   documented opt-in (`ann_model`), just not the offline default.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/RECALL-LEVER.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/RECALL-LEVER.md
@@ -88,15 +88,21 @@ recall. **Gate on a measurement:** `auto+fields` + semantic blocking must clear
 regardless and should be scoped out (or addressed separately via a domain/knowledge
 source). This is a real product change and gets its own spec + plan before any code.
 
-## Semantic blocking shipped (in-product)
+## Semantic blocking shipped (in-product) -- now with per-source confirming scorers
 
-Semantic blocking is now a real, opt-in capability: `dedupe_df(df,
+Semantic blocking is a real, opt-in capability: `dedupe_df(df,
 semantic_blocking=True)` unions three FREE deterministic candidate sources onto
-the normal candidate set, all offline / no key / no faiss (numpy ANN fallback):
+the normal candidate set, all offline / no key / no faiss (numpy ANN fallback),
+and -- as of the per-source-confirm change -- scores **each source with its OWN
+confirming scorer** instead of the multi-field name scorer:
 
-- **in-house char-ngram ANN** (the `emb-ann` embedder, as a candidate-gen pass);
-- **initialism** (acronym block: `IBM` <- `International Business Machines`);
-- **refdata alias** (canonicalization on `given_names` / `business` seed tables).
+- **in-house char-ngram ANN** (the `emb-ann` embedder, as a candidate-gen pass)
+  -> kept at its cosine score, gated by `ann_threshold` (default 0.5);
+- **initialism** (acronym block: `IBM` <- `International Business Machines`)
+  -> confirmed by `initialism_match` (1.0 when one name is the other's
+  initialism; raw string similarity is ~0);
+- **refdata alias** (canonicalization on `given_names` / `business` seed tables)
+  -> confirmed by `alias_match` (1.0 when both canonicalize to the same alias).
 
 The union is **additive by construction** -- new pairs are appended before the
 `dedup_pairs_max_score` seam, which keeps the max score per canonical pair, so it
@@ -106,79 +112,126 @@ flag (`adapters/goldenmatch_adapter.py`, mode `auto_fields_semantic`).
 
 ### Measured: auto+fields vs auto+fields+semantic (206 records, offline)
 
-Run with the two goldenmatch rows over `dataset/records.csv`
-(`GOLDENMATCH_NATIVE=0`, in-house embedder, numpy ANN fallback -- reproducible by
-anyone, no key):
+Re-measured with the confirming scorers wired (`GOLDENMATCH_NATIVE=0`, in-house
+embedder, numpy ANN fallback -- reproducible by anyone, no key):
 
 | metric | auto+fields | auto+fields+semantic | delta |
 |---|---|---|---|
 | **overall F1** | 0.6018 | 0.6018 | +0.000 |
-| overall P | 0.786 | 0.786 | +0.000 |
-| overall R | 0.488 | 0.488 | +0.000 |
-| abbreviation F1 | 0.773 | 0.773 | +0.000 |
-| nickname_alias F1 | 0.854 | 0.854 | +0.000 |
-| synonym_brand F1 | 0.167 | 0.167 | +0.000 |
-| cross_lingual F1 | 0.769 | 0.769 | +0.000 |
-| typo F1 | 1.000 | 1.000 | +0.000 |
-| org_suffix F1 | 1.000 | 1.000 | +0.000 |
-| temporal_version F1 | 0.571 | 0.571 | +0.000 |
-| cross_document_exact F1 | 1.000 | 1.000 | +0.000 |
-| same_name_collision F1 | 0.356 | 0.356 | +0.000 |
+| overall P | 0.7857 | 0.7857 | +0.000 |
+| overall R | 0.4877 | 0.4877 | +0.000 |
+| abbreviation F1 | 0.7727 | 0.7727 | +0.000 |
+| nickname_alias F1 | 0.8539 | 0.8539 | +0.000 |
+| synonym_brand F1 | 0.1667 | 0.1667 | +0.000 |
+| cross_lingual F1 | 0.7692 | 0.7692 | +0.000 |
+| typo F1 | 1.0000 | 1.0000 | +0.000 |
+| org_suffix F1 | 1.0000 | 1.0000 | +0.000 |
+| temporal_version F1 | 0.5714 | 0.5714 | +0.000 |
+| cross_document_exact F1 | 1.0000 | 1.0000 | +0.000 |
+| same_name_collision F1 | 0.3556 | 0.3556 | +0.000 |
 
-The two rows are **byte-identical** (both `tp=198 fp=54 fn=208`). No class moved.
+The two rows are still **byte-identical** (both `tp=198 fp=54 fn=208`). No class
+moved. Wiring the confirming scorers (the prior diagnosis' proposed fix) did
+**not** unstick the headline on this corpus.
 
 ### Acceptance verdict vs 0.602
 
-**Tied, not cleared.** `auto+fields+semantic` F1 = `auto+fields` F1 = **0.6018**
-(rounds to the documented 0.602 baseline, fractionally below 0.602 as a raw
-float). So:
+**NOT MET (headline did not move).** `auto+fields+semantic` F1 = `auto+fields`
+F1 = **0.6018** (rounds to the documented 0.602; fractionally below 0.602 as a
+raw float). The capability still ships opt-in at **zero precision cost** (`fp`
+unchanged at 54 -- the additive union never adds a false merge here), but it is
+not a headline mover on ER-KG-Bench.
 
-- **>= baseline: MET (exactly tied)** -- the additive union guarantees recall
-  can't fall, and precision held (`fp` unchanged at 54), so it never regresses.
-- **>= 0.602 (headline move): NOT MET** -- it does not *raise* the headline on
-  this corpus. The capability ships (opt-in, zero precision cost), but it is not
-  a headline mover here.
+### Precision cost (measured, not pre-guarded)
 
-### Why it's a no-op here: the wall moved from blocking to scoring
+**Zero, measured.** The approved stance was "measure the precision cost, don't
+pre-guard it." On this corpus the cost is nil: `fp` is identical (54) between the
+two rows, and **no** class's precision regressed -- no initialism collision, no
+alias-table error materialized, because the confirming pairs that survive to
+clustering are all pairs the baseline already merged. There is no precision
+finding to report and no scoped follow-up needed on the precision side.
 
-Semantic blocking is working -- it generates **3,466 extra candidate pairs**. But
-the committed auto-config matchkey scores them on `name`+`entity_type`+`context`
-(weighted `ensemble`, threshold **0.8**), and only **1,108** of the new pairs
-clear 0.8. Every one of those 1,108 is a pair the **baseline blocking already
-generated and already merged** -- exact duplicates (`IBM`/`IBM`) or word-reordered
-forms (`FIFA World Cup 2018`/`2018 FIFA World Cup`) that string blocking catches
-anyway. The genuinely *new* recall-lever pairs (the abbreviation / synonym /
-cross-lingual cases where the strings do **not** look alike) score well below 0.8
-on the name field and are rejected at scoring. So the candidate set grew, but the
-final clustering didn't change.
+### Why it's STILL a no-op: two distinct walls, both now isolated
 
-This is exactly the wall the earlier embedder sweep predicted for the **offline
-char-ngram** tier: its cosine approximates *character* overlap, not world
-knowledge (`IBM` <-> `International Business Machines` ~0.05). The free in-house
-ANN bridges typo / org-suffix / transliteration (shared characters), but cannot
-generate the abbreviation/synonym pairs at all, and even when initialism/alias
-*do* surface a pair, the name scorer still demands string similarity to confirm
-it. Which classes the sources *can* move, and why they didn't here:
+Per-source confirming scorers are the right design, but two corpus-specific
+mechanisms keep the headline pinned. Both were isolated by instrumenting the
+pipeline at the `_semantic_blocking_pairs` return, the post-`_apply_postflight`
+pair set, and the `build_cluster_frames` call site:
 
-- **initialism -> abbreviation:** surfaces `IBM`/`International Business Machines`
-  as a candidate, but `ensemble`(name) scores it ~0, < 0.8 -> rejected at scoring.
+1. **The confirming scorers can't confirm the corpus's NOISY surface forms.**
+   `initialism_match` / `alias_match` are correct on clean expansions --
+   measured `initialism_match("IBM", "International Business Machines") = 1.0`,
+   `("NATO", "North Atlantic Treaty Organisation") = 1.0`,
+   `("WHO", "World Health Organization") = 1.0`. But ER-KG-Bench mentions carry
+   real-world suffix/parenthetical noise, and the strict check collapses the
+   moment it appears: `initialism_match("IBM", "International Business Machines
+   Corporation (Armonk, NY)") = 0.0`, `("IBM", "IBM Corp.") = 0.0`. So for the
+   actual gold abbreviation pairs the confirming scorer returns **0.0**, and the
+   only score those pairs carry into `all_pairs` is the **ANN char-ngram cosine**
+   (e.g. `IBM` <-> `International Business Machines Corporation (Armonk, NY)`
+   lands at **0.863**, not 1.0). `alias` adds nothing here (0 non-singleton
+   blocks on this corpus -- the `given_names`/`business` seed doesn't cover
+   these orgs).
+
+2. **Auto-config's postflight raises the threshold to 0.895 and drops exactly
+   those candidates.** The committed config is RED on this corpus
+   (`stop_reason=BUDGET_ITERATIONS`, `failing_subprofile=blocking`: with `name`
+   at cardinality 0.95 most blocks are singletons), and `_apply_postflight`
+   applies a `threshold` adjustment **0.8 -> 0.895**. Measured pre-postflight,
+   `all_pairs` holds 2871 pairs; postflight drops 1873 of them, with the dropped
+   mass concentrated in the **0.8 band (1638 pairs)** and **0.9 band (214)** --
+   i.e. precisely the 0.83-0.89 char-ngram-cosine scores the abbreviation pairs
+   land at. `IBM` <-> `International Business Machines...` (0.863) and three of
+   the four `NATO` variants (0.836, 0.844, 0.835) are dropped here. The few
+   confirmed/near-exact pairs that DO survive postflight (score >= 0.99, e.g.
+   `IBM` <-> `IBM Corp.` at 1.0) are pairs **string blocking already generated
+   and the baseline already merged**, so after `dedup_pairs_max_score` the
+   canonical cluster-input pair set is **219 in both runs, 0 new** -- which is
+   why the clustering output is byte-identical.
+
+Per-class, which sources *can* move what, and why they didn't here:
+
+- **initialism -> abbreviation:** fires at 1.0 on clean expansions, **0.0** on
+  the noisy ones this corpus actually contains; the surviving signal for those
+  pairs is ANN cosine ~0.83-0.86, which postflight's 0.895 threshold rejects.
 - **alias -> known synonyms in the seed table only:** bounded by the small
-  `given_names` / `business` refdata seed; a synonym not in the seed (most of the
-  `synonym_brand` class, e.g. `Coumadin`/`warfarin`) is never generated. This is
-  the same class the embedder sweep found walled for *every* embedder (max 0.18).
+  `given_names` / `business` refdata seed; 0 non-singleton blocks here. The
+  `synonym_brand` class (e.g. `Coumadin`/`warfarin`) is the same class the
+  embedder sweep found walled for *every* embedder (max 0.18) -- a knowledge-base
+  problem, not an embedder/scorer problem.
 - **ANN -> typo / suffix / transliteration:** these classes are *already* at
   F1 1.0 (`typo`, `org_suffix`) under `auto+fields`, so there's no recall left to
-  add there; the cross-lingual gains the multilingual model showed need a
-  *semantic* embedder, not the char-ngram one this offline path uses.
+  add; the cross-lingual gains the multilingual model showed need a *semantic*
+  embedder, not the char-ngram one this offline path uses.
 
-**Bottom line:** the recall-lever capability is real and now shipped opt-in and
-zero-cost (additive, no precision hit), but on ER-KG-Bench the headline does not
-move because (a) the free offline embedder lacks the world knowledge to *generate*
-the abbreviation/synonym pairs, and (b) the auto-config name scorer's 0.8
-threshold *rejects* the few semantic candidates that do get surfaced. To actually
-move the headline you need both a world-knowledge (semantic) embedder for
-candidate generation **and** a scorer that doesn't require string similarity to
-confirm a semantically-blocked pair (e.g. the LLM scorer, or a semantic
-similarity scoring field) -- the embedder swap alone is necessary but not
-sufficient. synonym/brand stays walled regardless (knowledge-base problem, not an
-embedder problem).
+**Bottom line:** the recall-lever capability is real, shipped opt-in, and now
+scores each candidate source with its own confirming scorer at zero precision
+cost. But on ER-KG-Bench the headline does not move, for two independent reasons:
+(a) the strict initialism/alias confirmers return 0.0 on the corpus's noisy
+real-world surface forms, leaving only the char-ngram ANN cosine (~0.83-0.86) for
+the genuine abbreviation pairs; and (b) auto-config's postflight raises the match
+threshold to **0.895** on this RED config and drops exactly that 0.83-0.89 band.
+Moving the headline here needs *both* (i) a noise-tolerant confirmer (strip
+`Corp./Inc./(City, ST)` suffixes + organisation/-zation spelling normalization
+before the initialism/alias check) **so the confirmer returns 1.0 on the noisy
+mentions and the pair clears any threshold**, and (ii) a world-knowledge semantic
+embedder for the candidates the char-ngram path can't generate at all.
+synonym/brand stays walled regardless.
+
+### Scoped follow-ups (recall side -- precision side has none)
+
+1. **Noise-tolerant initialism/alias confirmers.** Normalize the expansion
+   before the initialism check: drop trailing legal suffixes (`Corp.`, `Inc.`,
+   `Corporation`), parentheticals (`(Armonk, NY)`, `(WHO)`), and reconcile
+   `-ization`/`-isation`. This is what turns the measured 0.0 back into 1.0 on
+   the noisy mentions, so the confirmed pair clears the threshold regardless of
+   postflight. (Highest-leverage fix: it is the difference between the
+   abbreviation pairs scoring ~0.86 and scoring 1.0.)
+2. **A world-knowledge semantic embedder for the ANN source** (free multilingual
+   model, or the two-model ensemble) for the candidates the char-ngram cosine
+   cannot generate at all -- the lever the earlier embedder sweep proved
+   (abbreviation 0.21 -> 0.80-0.85, cross-lingual 0.35 -> 0.91).
+
+Neither needs an initialism-block-size cap or any precision guard: the measured
+precision cost on this corpus is zero, so capping is solving a problem the data
+does not show.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/RECALL-LEVER.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/RECALL-LEVER.md
@@ -87,3 +87,98 @@ recall. **Gate on a measurement:** `auto+fields` + semantic blocking must clear
 0.602 to count as a headline move. The synonym/brand class will remain walled
 regardless and should be scoped out (or addressed separately via a domain/knowledge
 source). This is a real product change and gets its own spec + plan before any code.
+
+## Semantic blocking shipped (in-product)
+
+Semantic blocking is now a real, opt-in capability: `dedupe_df(df,
+semantic_blocking=True)` unions three FREE deterministic candidate sources onto
+the normal candidate set, all offline / no key / no faiss (numpy ANN fallback):
+
+- **in-house char-ngram ANN** (the `emb-ann` embedder, as a candidate-gen pass);
+- **initialism** (acronym block: `IBM` <- `International Business Machines`);
+- **refdata alias** (canonicalization on `given_names` / `business` seed tables).
+
+The union is **additive by construction** -- new pairs are appended before the
+`dedup_pairs_max_score` seam, which keeps the max score per canonical pair, so it
+can never drop an existing pair. The bench exercises it as a new row,
+`goldenmatch(auto+fields+semantic)`, identical to `auto+fields` except for the
+flag (`adapters/goldenmatch_adapter.py`, mode `auto_fields_semantic`).
+
+### Measured: auto+fields vs auto+fields+semantic (206 records, offline)
+
+Run with the two goldenmatch rows over `dataset/records.csv`
+(`GOLDENMATCH_NATIVE=0`, in-house embedder, numpy ANN fallback -- reproducible by
+anyone, no key):
+
+| metric | auto+fields | auto+fields+semantic | delta |
+|---|---|---|---|
+| **overall F1** | 0.6018 | 0.6018 | +0.000 |
+| overall P | 0.786 | 0.786 | +0.000 |
+| overall R | 0.488 | 0.488 | +0.000 |
+| abbreviation F1 | 0.773 | 0.773 | +0.000 |
+| nickname_alias F1 | 0.854 | 0.854 | +0.000 |
+| synonym_brand F1 | 0.167 | 0.167 | +0.000 |
+| cross_lingual F1 | 0.769 | 0.769 | +0.000 |
+| typo F1 | 1.000 | 1.000 | +0.000 |
+| org_suffix F1 | 1.000 | 1.000 | +0.000 |
+| temporal_version F1 | 0.571 | 0.571 | +0.000 |
+| cross_document_exact F1 | 1.000 | 1.000 | +0.000 |
+| same_name_collision F1 | 0.356 | 0.356 | +0.000 |
+
+The two rows are **byte-identical** (both `tp=198 fp=54 fn=208`). No class moved.
+
+### Acceptance verdict vs 0.602
+
+**Tied, not cleared.** `auto+fields+semantic` F1 = `auto+fields` F1 = **0.6018**
+(rounds to the documented 0.602 baseline, fractionally below 0.602 as a raw
+float). So:
+
+- **>= baseline: MET (exactly tied)** -- the additive union guarantees recall
+  can't fall, and precision held (`fp` unchanged at 54), so it never regresses.
+- **>= 0.602 (headline move): NOT MET** -- it does not *raise* the headline on
+  this corpus. The capability ships (opt-in, zero precision cost), but it is not
+  a headline mover here.
+
+### Why it's a no-op here: the wall moved from blocking to scoring
+
+Semantic blocking is working -- it generates **3,466 extra candidate pairs**. But
+the committed auto-config matchkey scores them on `name`+`entity_type`+`context`
+(weighted `ensemble`, threshold **0.8**), and only **1,108** of the new pairs
+clear 0.8. Every one of those 1,108 is a pair the **baseline blocking already
+generated and already merged** -- exact duplicates (`IBM`/`IBM`) or word-reordered
+forms (`FIFA World Cup 2018`/`2018 FIFA World Cup`) that string blocking catches
+anyway. The genuinely *new* recall-lever pairs (the abbreviation / synonym /
+cross-lingual cases where the strings do **not** look alike) score well below 0.8
+on the name field and are rejected at scoring. So the candidate set grew, but the
+final clustering didn't change.
+
+This is exactly the wall the earlier embedder sweep predicted for the **offline
+char-ngram** tier: its cosine approximates *character* overlap, not world
+knowledge (`IBM` <-> `International Business Machines` ~0.05). The free in-house
+ANN bridges typo / org-suffix / transliteration (shared characters), but cannot
+generate the abbreviation/synonym pairs at all, and even when initialism/alias
+*do* surface a pair, the name scorer still demands string similarity to confirm
+it. Which classes the sources *can* move, and why they didn't here:
+
+- **initialism -> abbreviation:** surfaces `IBM`/`International Business Machines`
+  as a candidate, but `ensemble`(name) scores it ~0, < 0.8 -> rejected at scoring.
+- **alias -> known synonyms in the seed table only:** bounded by the small
+  `given_names` / `business` refdata seed; a synonym not in the seed (most of the
+  `synonym_brand` class, e.g. `Coumadin`/`warfarin`) is never generated. This is
+  the same class the embedder sweep found walled for *every* embedder (max 0.18).
+- **ANN -> typo / suffix / transliteration:** these classes are *already* at
+  F1 1.0 (`typo`, `org_suffix`) under `auto+fields`, so there's no recall left to
+  add there; the cross-lingual gains the multilingual model showed need a
+  *semantic* embedder, not the char-ngram one this offline path uses.
+
+**Bottom line:** the recall-lever capability is real and now shipped opt-in and
+zero-cost (additive, no precision hit), but on ER-KG-Bench the headline does not
+move because (a) the free offline embedder lacks the world knowledge to *generate*
+the abbreviation/synonym pairs, and (b) the auto-config name scorer's 0.8
+threshold *rejects* the few semantic candidates that do get surfaced. To actually
+move the headline you need both a world-knowledge (semantic) embedder for
+candidate generation **and** a scorer that doesn't require string similarity to
+confirm a semantically-blocked pair (e.g. the LLM scorer, or a semantic
+similarity scoring field) -- the embedder swap alone is necessary but not
+sufficient. synonym/brand stays walled regardless (knowledge-base problem, not an
+embedder problem).

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldenmatch_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldenmatch_adapter.py
@@ -39,6 +39,11 @@ _MODES = {
         "goldenmatch(auto+fields)",
         "zero-config dedupe_df(name+type+context) -- auto-config, multi-field",
     ),
+    "auto_fields_semantic": (
+        "goldenmatch(auto+fields+semantic)",
+        "zero-config dedupe_df(name+type+context) + semantic blocking "
+        "(in-house ANN + initialism + alias) -- additive candidate union, no key",
+    ),
     "auto_llm": (
         "goldenmatch(auto+llm)",
         "zero-config dedupe_df(name+type+context) + llm_scorer -- needs OPENAI_API_KEY",
@@ -62,13 +67,21 @@ class GoldenMatchAdapter:
         # Resolve the full set in index order so __row_id__ == record index.
         ordered = sorted(records, key=lambda r: r.index)
         data: dict[str, list[str]] = {"name": [r.mention for r in ordered]}
-        if self.mode in ("auto_fields", "auto_llm"):
+        if self.mode in ("auto_fields", "auto_fields_semantic", "auto_llm"):
             data["entity_type"] = [r.entity_type for r in ordered]
             data["context"] = [r.context for r in ordered]
         df = pl.DataFrame(data)
 
         # Zero-config: no exact/fuzzy kwargs -> dedupe_df calls auto_configure_df.
-        kwargs = {"llm_scorer": True} if self.mode == "auto_llm" else {}
+        # auto_fields_semantic is identical to auto_fields except it turns on the
+        # opt-in semantic-blocking candidate union (in-house char-ngram ANN +
+        # initialism + refdata alias); deterministic, offline, no key, no faiss
+        # (numpy fallback).
+        kwargs: dict[str, object] = {}
+        if self.mode == "auto_llm":
+            kwargs["llm_scorer"] = True
+        elif self.mode == "auto_fields_semantic":
+            kwargs["semantic_blocking"] = True
         result = gm.dedupe_df(df, **kwargs)
 
         return [

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -401,6 +401,7 @@ def dedupe_df(
     planning_effort: str | None = None,
     fs_model_path: str | None = None,
     certify: bool = False,
+    semantic_blocking: bool = False,
 ) -> DedupeResult:
     """Deduplicate a Polars DataFrame directly (no file I/O).
 
@@ -421,6 +422,11 @@ def dedupe_df(
             probabilistic matchkey without its own ``model_path`` loads the
             model from here (skipping EM) if it exists, or trains and saves it
             there on first run (Splink-style train-once -> reuse).
+        semantic_blocking: When True, attach a default ``SemanticBlockingConfig``
+            to the resolved config (opt-in semantic candidate generation /
+            recall lever). An explicit ``config`` that already sets
+            ``semantic_blocking`` wins. Config plumbing only today -- the config
+            is carried but not yet consumed, so the run behaves like ``False``.
         certify: When True, also compute an unsupervised recall estimate
             (capture-recapture over the config's decorrelated matchkey/pass
             systems) and attach it to ``DedupeResult.recall_certificate``.
@@ -500,6 +506,15 @@ def dedupe_df(
             config.llm_scorer = LLMScorerConfig(enabled=True)
         if llm_auto:
             config.llm_auto = llm_auto
+        # Opt-in semantic candidate generation (recall lever). Attach a default
+        # SemanticBlockingConfig when the caller asks for it and the resolved
+        # config doesn't already carry one (an explicit config wins). This is
+        # config plumbing only -- the config is carried into the pipeline but
+        # NOT consumed yet (Task 6 wires the actual candidate union), so
+        # semantic_blocking=True behaves identically to today.
+        if semantic_blocking and getattr(config, "semantic_blocking", None) is None:
+            from goldenmatch.config.schemas import SemanticBlockingConfig
+            config.semantic_blocking = SemanticBlockingConfig()
         # Splink-style train-once: point probabilistic matchkeys at a persisted
         # model file (load-or-train-and-save). Only fills matchkeys that don't
         # already carry their own model_path. No-op when there are none.

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -806,6 +806,40 @@ class DistributedRoutingConfig(BaseModel):
     golden: Literal["auto", "distributed", "in_process"] = "auto"
 
 
+class SemanticBlockingConfig(BaseModel):
+    """Opt-in semantic candidate-generation (recall-lever) config. Carries the
+    knobs for the additional blocking keys that union extra candidate pairs into
+    the blocking stage: ANN nearest-neighbors, initialism expansion, and alias
+    table lookups. This is config plumbing only -- it is attached to
+    ``GoldenMatchConfig.semantic_blocking`` and CONSUMED downstream; constructing
+    it does not change behavior on its own."""
+
+    keys: list[Literal["ann", "initialism", "alias"]] = Field(
+        default_factory=lambda: ["ann", "initialism", "alias"],
+        description=(
+            "Which semantic blocking keys to union into candidate generation: "
+            "'ann' (embedding nearest-neighbors), 'initialism' (initialism "
+            "expansion), 'alias' (alias-table lookups)."
+        ),
+    )
+    ann_model: str = Field(
+        default="inhouse",
+        description="Embedding model id for the ANN key (e.g. 'inhouse').",
+    )
+    ann_top_k: int = Field(
+        default=20,
+        description="Number of ANN neighbors retrieved per record for candidate generation.",
+    )
+    ann_threshold: float = Field(
+        default=0.5,
+        description="Minimum ANN similarity for a neighbor to become a candidate pair.",
+    )
+    alias_tables: list[Literal["given_names", "business"]] = Field(
+        default_factory=lambda: ["given_names", "business"],
+        description="Which alias tables the 'alias' key consults.",
+    )
+
+
 class GoldenMatchConfig(BaseModel):
     input: InputConfig | None = None
     output: OutputConfig = Field(default_factory=lambda: OutputConfig())
@@ -823,6 +857,7 @@ class GoldenMatchConfig(BaseModel):
     domain: DomainConfig | None = None
     backend: str | None = None  # None (default Polars), "ray", "duckdb"
     distributed_routing: DistributedRoutingConfig | None = None
+    semantic_blocking: SemanticBlockingConfig | None = None
     allow_slow_path: bool = False
     # Execution mode. "standard" (default) = the in-memory/Ray pipeline,
     # bit-identical artifacts. "scale" = the DataFusion spine (out-of-core,

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -22,6 +22,10 @@ VALID_SCORERS = frozenset({
     "exact", "jaro_winkler", "levenshtein", "token_sort", "soundex_match",
     "embedding", "record_embedding", "ensemble",
     "dice", "jaccard", "qgram",
+    # Free deterministic equality scorers (1.0/0.0): initialism collapse
+    # ("IBM" <-> "International Business Machines") and alias canonicalization
+    # ("Acme Inc" <-> "Acme Incorporated", "Bob" <-> "Robert").
+    "initialism_match", "alias_match",
 })
 
 VALID_STRATEGIES = frozenset({

--- a/packages/python/goldenmatch/goldenmatch/core/acronym.py
+++ b/packages/python/goldenmatch/goldenmatch/core/acronym.py
@@ -1,0 +1,104 @@
+"""Initialism blocking transform — abbreviation candidate generation.
+
+Turns a multi-token name into the initials of its tokens
+("International Business Machines" -> "IBM") so an initials-keyed blocking
+pass proposes the abbreviation as a match candidate ("IBM" <-> the full
+form). This closes a recall gap: an exact/soundex block on the raw name
+would never co-locate "IBM" with "International Business Machines".
+
+Exposed as a ``TransformPlugin`` named ``initialism`` (resolved by
+``goldenmatch.utils.transforms.apply_transform`` via the ``PluginRegistry``),
+mirroring ``goldenmatch.refdata.business.LegalFormStripTransform``. It is NOT
+a member of ``VALID_SIMPLE_TRANSFORMS`` — that frozenset is the native-Polars
+fast path; this is a Python-callable plugin transform.
+"""
+from __future__ import annotations
+
+import re
+
+from goldenmatch.plugins.base import TransformPlugin
+
+# First alphabetic character of a token (skips leading digits / punctuation).
+_FIRST_ALPHA = re.compile(r"[A-Za-z]")
+
+
+def _strip_trailing_legal_form(text: str) -> str:
+    """Drop a SINGLE trailing corporate-entity suffix (LLC, Inc, GmbH, ...).
+
+    Deliberately NOT ``goldenmatch.refdata.business.strip_legal_form`` — that
+    helper iterates up to 4 passes, so on "Acme Industries LLC" it strips
+    "LLC" *and then* "Industries" (a descriptive token also present in the
+    legal-form variant list), collapsing to "Acme". For an initialism block
+    key we want only the entity-type suffix gone ("Acme Industries"), keeping
+    the descriptive token so the abbreviation stays meaningful ("AI"). One
+    application of the shared compiled pattern does exactly that. Falls back
+    to whitespace-collapse when the refdata pack is unavailable.
+    """
+    cleaned = re.sub(r"\s+", " ", text).strip()
+    if not cleaned:
+        return cleaned
+    try:
+        from goldenmatch.refdata import business
+
+        business._load()
+        state = business._state
+    except Exception:  # noqa: BLE001 — never let an unhealthy pack break blocking
+        state = None
+    if state is None:
+        return cleaned
+    return state.pattern.sub("", cleaned).strip() or cleaned
+
+
+def derive_initialism(text: str | None) -> str | None:
+    """Return the upper-cased initials of a multi-token name.
+
+    "International Business Machines" -> "IBM". A single trailing legal-form
+    token is dropped first, so "Acme Industries LLC" -> "AI". A single
+    resulting token yields ``""`` (one letter is too coarse a block key — it
+    would over-merge), as does empty / whitespace-only input.
+
+    ``None`` -> ``None``.
+    """
+    if text is None:
+        return None
+
+    stripped = _strip_trailing_legal_form(text)
+
+    initials: list[str] = []
+    for token in stripped.split():
+        m = _FIRST_ALPHA.search(token)
+        if m is not None:
+            initials.append(m.group(0).upper())
+
+    # Fewer than 2 tokens contributes no useful abbreviation block key.
+    if len(initials) < 2:
+        return ""
+    return "".join(initials)
+
+
+class InitialismTransform(TransformPlugin):
+    """Adapter exposing ``derive_initialism`` through the
+    ``goldenmatch.plugins.base.TransformPlugin`` protocol."""
+
+    name = "initialism"
+
+    def transform(self, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return derive_initialism(value)
+
+
+def register_transforms() -> None:
+    """Idempotent. Registers the ``initialism`` transform plugin.
+
+    Called at module import (bottom of this file) and re-exported through
+    ``goldenmatch.refdata.__init__`` so it is live before blocking runs.
+    """
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    reg = PluginRegistry.instance()
+    if not reg.has_transform(InitialismTransform.name):
+        reg.register_transform(InitialismTransform.name, InitialismTransform())
+
+
+register_transforms()

--- a/packages/python/goldenmatch/goldenmatch/core/acronym.py
+++ b/packages/python/goldenmatch/goldenmatch/core/acronym.py
@@ -20,57 +20,99 @@ from goldenmatch.plugins.base import TransformPlugin
 
 # First alphabetic character of a token (skips leading digits / punctuation).
 _FIRST_ALPHA = re.compile(r"[A-Za-z]")
+# Any alphabetic character (used for the punctuation-only-token drop).
+_ANY_ALPHA = re.compile(r"[A-Za-z]")
+# A trailing/leading parenthetical group: "(Armonk, NY)", "(WHO)", etc.
+_PARENTHETICAL = re.compile(r"\s*\([^)]*\)")
 
 
-def _strip_trailing_legal_form(text: str) -> str:
-    """Drop a SINGLE trailing corporate-entity suffix (LLC, Inc, GmbH, ...).
+def _legal_form_variants() -> frozenset[str]:
+    """Normalized (lower-case) set of entity-TYPE legal-form variants, e.g.
+    ``{"inc", "incorporated", "corp", "corporation", "llc", ...}`` — EXCLUDING
+    descriptive tokens like "Industries" / "Group" / "Holdings".
 
-    Deliberately NOT ``goldenmatch.refdata.business.strip_legal_form`` — that
-    helper iterates up to 4 passes, so on "Acme Industries LLC" it strips
-    "LLC" *and then* "Industries" (a descriptive token also present in the
-    legal-form variant list), collapsing to "Acme". For an initialism block
-    key we want only the entity-type suffix gone ("Acme Industries"), keeping
-    the descriptive token so the abbreviation stays meaningful ("AI"). One
-    application of the shared compiled pattern does exactly that. Falls back
-    to whitespace-collapse when the refdata pack is unavailable.
+    Sourced from the same refdata pack ``strip_legal_form`` uses, so the
+    per-token drop here stays in lockstep with the trailing-suffix stripper but
+    keeps the descriptive token that makes the abbreviation meaningful
+    ("Acme Industries LLC" -> drop "LLC", keep "Industries" -> "AI"). Empty
+    frozenset when the pack is unavailable (initialism blocking then just keeps
+    the legal-form token, which is harmless — it only changes the key).
     """
-    cleaned = re.sub(r"\s+", " ", text).strip()
-    if not cleaned:
-        return cleaned
     try:
         from goldenmatch.refdata import business
 
-        business._load()
-        state = business._state
+        return business.entity_form_variants()
     except Exception:  # noqa: BLE001 — never let an unhealthy pack break blocking
-        state = None
-    if state is None:
-        return cleaned
-    return state.pattern.sub("", cleaned).strip() or cleaned
+        return frozenset()
+
+
+def _normalize_token_for_legal_check(token: str) -> str:
+    """Lower-case + strip trailing punctuation, matching the refdata pack's
+    ``_normalize_token`` so a token like ``"Corp."`` compares equal to the
+    bundled variant ``"corp"``."""
+    return token.strip().rstrip(".,").lower()
 
 
 def derive_initialism(text: str | None) -> str | None:
-    """Return the upper-cased initials of a multi-token name.
+    """Return an abbreviation block key for a name, noise-tolerant + acronym-aware.
 
-    "International Business Machines" -> "IBM". A single trailing legal-form
-    token is dropped first, so "Acme Industries LLC" -> "AI". A single
-    resulting token yields ``""`` (one letter is too coarse a block key — it
-    would over-merge), as does empty / whitespace-only input.
+    Steps:
+
+    1. Strip parentheticals: ``"... (Armonk, NY)"`` -> ``"..."``.
+    2. Tokenize on whitespace; drop legal-form tokens ANYWHERE (not just
+       trailing) and punctuation-only tokens.
+    3. **Acronym-as-own-key:** if exactly ONE token survives AND it looks like
+       an acronym (all-uppercase in the ORIGINAL, all alphabetic, length 2-6),
+       return it uppercased — so ``"IBM"`` blocks under its own letters and
+       co-locates with its expansion.
+    4. If >= 2 cleaned tokens: return the first-alpha-letter-of-each-token
+       initialism, uppercased (``"International Business Machines"`` -> ``"IBM"``).
+    5. Otherwise (1 non-acronym token like ``"Apple"``, or empty) -> ``""``.
+
+    Examples:
+        ``"IBM"`` -> ``"IBM"``; ``"Apple"`` -> ``""``;
+        ``"International Business Machines Corporation (Armonk, NY)"`` -> ``"IBM"``;
+        ``"International Business Machines"`` -> ``"IBM"``.
 
     ``None`` -> ``None``.
     """
     if text is None:
         return None
 
-    stripped = _strip_trailing_legal_form(text)
+    # 1. Strip parentheticals before tokenizing.
+    stripped = _PARENTHETICAL.sub("", text)
 
-    initials: list[str] = []
+    legal_variants = _legal_form_variants()
+
+    # 2. Tokenize, dropping legal-form tokens (anywhere) and punctuation-only tokens.
+    cleaned_tokens: list[str] = []
     for token in stripped.split():
+        if _ANY_ALPHA.search(token) is None:
+            continue  # punctuation-only / digits-only token
+        if _normalize_token_for_legal_check(token) in legal_variants:
+            continue  # drop legal-form token wherever it appears
+        cleaned_tokens.append(token)
+
+    # 3. Acronym-as-own-key: a lone all-caps alphabetic 2-6 char token blocks
+    #    under its own letters (so the acronym co-locates with its expansion).
+    if len(cleaned_tokens) == 1:
+        tok = cleaned_tokens[0]
+        if tok.isupper() and tok.isalpha() and 2 <= len(tok) <= 6:
+            return tok.upper()
+        # Non-acronym single token (e.g. "Apple") -> too coarse a key.
+        return ""
+
+    # 5. Empty after cleaning.
+    if not cleaned_tokens:
+        return ""
+
+    # 4. Multi-token initialism: first alpha letter of each token, uppercased.
+    initials: list[str] = []
+    for token in cleaned_tokens:
         m = _FIRST_ALPHA.search(token)
         if m is not None:
             initials.append(m.group(0).upper())
 
-    # Fewer than 2 tokens contributes no useful abbreviation block key.
     if len(initials) < 2:
         return ""
     return "".join(initials)

--- a/packages/python/goldenmatch/goldenmatch/core/ann_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/ann_blocker.py
@@ -1,38 +1,113 @@
-"""ANN (Approximate Nearest Neighbor) blocker for GoldenMatch using FAISS."""
+"""ANN (Approximate Nearest Neighbor) blocker for GoldenMatch.
+
+Uses FAISS when available (the ``goldenmatch[embeddings]`` extra). When faiss is
+absent -- or when explicitly forced off via the module-level ``_HAS_FAISS`` flag
+-- a pure-numpy all-pairs inner-product fallback runs instead. The fallback
+produces the SAME neighbor set as faiss for small N (parity), so in-house ANN
+blocking works with zero new dependencies at bench / medium scale; faiss stays
+the path for scale.
+"""
 
 from __future__ import annotations
 
+import importlib.util
+
 import numpy as np
+
+# Detected once at import; tests flip it to exercise the numpy fallback.
+_HAS_FAISS = importlib.util.find_spec("faiss") is not None
 
 
 class ANNBlocker:
-    """Build a FAISS inner-product index and query for top-K neighbors."""
+    """Build an inner-product index and query for top-K neighbors.
+
+    Backed by FAISS (`IndexFlatIP`) when available; otherwise a numpy all-pairs
+    inner-product fallback with byte-compatible top-K / self-exclusion /
+    canonicalization semantics.
+    """
 
     def __init__(self, top_k: int = 20):
         self.top_k = top_k
         self._index = None
+        # numpy-fallback corpus (stored on build_index so query_* can use it)
+        self._corpus: np.ndarray | None = None
 
     def build_index(self, embeddings: np.ndarray):
-        """Build FAISS index from L2-normalized embeddings."""
-        try:
-            import faiss
-        except ImportError:
-            raise ImportError(
-                "ANN blocking requires faiss-cpu. "
-                "Install with: pip install goldenmatch[embeddings]"
-            )
-        dim = embeddings.shape[1]
+        """Build the inner-product index from (ideally L2-normalized) embeddings.
+
+        FAISS path uses `IndexFlatIP`; numpy fallback stores the corpus for
+        all-pairs scoring at query time.
+        """
+        corpus = embeddings.astype(np.float32)
+        if not _HAS_FAISS:
+            # numpy fallback: keep the corpus; scoring happens at query time.
+            self._corpus = corpus
+            self._index = None
+            return
+        import faiss
+
+        dim = corpus.shape[1]
         self._index = faiss.IndexFlatIP(dim)  # inner product = cosine on normalized vectors
-        self._index.add(embeddings.astype(np.float32))
+        self._index.add(corpus)
+        self._corpus = corpus
+
+    def _np_search(self, query_embeddings: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """numpy replacement for ``faiss.IndexFlatIP.search``.
+
+        Returns ``(scores, indices)`` of shape ``(n_query, k)`` where
+        ``k = min(top_k, n_corpus)``.
+
+        Ranking matches faiss's `IndexFlatIP`: top-k by descending RAW inner
+        product against the stored corpus (faiss does NOT normalize internally,
+        so the neighbor SET is identical to faiss given the same input). The
+        emitted SCORE is the true cosine similarity (raw IP divided by the
+        vector norms) so it stays in ``[-1, 1]`` even when the caller passes
+        un-normalized vectors -- on the normal path the inputs are already
+        normalized, so cosine == the raw IP faiss would return. Self is NOT
+        excluded here (mirrors faiss); callers drop it, exactly as on the faiss
+        path.
+        """
+        if self._corpus is None:
+            raise RuntimeError("Index not built. Call build_index first.")
+        q = query_embeddings.astype(np.float32)
+        corpus = self._corpus
+        ip = q @ corpus.T  # (n_query, n_corpus) raw inner-product matrix
+        n_corpus = ip.shape[1]
+        k = min(self.top_k, n_corpus)
+        # Top-k per row by descending raw IP (argpartition for the cut, then
+        # sort the k survivors so order matches faiss's sorted output).
+        part = np.argpartition(-ip, k - 1, axis=1)[:, :k]
+        part_ip = np.take_along_axis(ip, part, axis=1)
+        order = np.argsort(-part_ip, axis=1)
+        indices = np.take_along_axis(part, order, axis=1)
+        # Cosine score for the emitted neighbors (range-safe, ranking-neutral).
+        q_norm = np.linalg.norm(q, axis=1, keepdims=True)
+        c_norm = np.linalg.norm(corpus, axis=1)
+        q_norm = np.where(q_norm == 0.0, 1.0, q_norm)
+        c_norm = np.where(c_norm == 0.0, 1.0, c_norm)
+        cos = (q @ corpus.T) / q_norm / c_norm[np.newaxis, :]
+        scores = np.take_along_axis(cos, indices, axis=1)
+        return scores, indices
+
+    def _search(self, query_embeddings: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Dispatch to faiss `IndexFlatIP.search` or the numpy fallback.
+
+        Returns ``(scores, indices)`` of shape ``(n_query, k)`` with identical
+        ranking semantics on both paths.
+        """
+        if not _HAS_FAISS:
+            return self._np_search(query_embeddings)
+        if self._index is None:
+            raise RuntimeError("Index not built. Call build_index first.")
+        return self._index.search(query_embeddings.astype(np.float32), self.top_k)
 
     def query(self, query_embeddings: np.ndarray) -> list[tuple[int, int]]:
         """Find top-K neighbors for each query. Returns (query_idx, neighbor_idx) pairs."""
-        scores, indices = self._index.search(
-            query_embeddings.astype(np.float32), self.top_k,
-        )
+        scores, indices = self._search(query_embeddings)
+        n_neighbors = indices.shape[1]
         pairs: set[tuple[int, int]] = set()
         for i in range(len(query_embeddings)):
-            for j_idx in range(self.top_k):
+            for j_idx in range(n_neighbors):
                 neighbor = int(indices[i][j_idx])
                 if neighbor != i and neighbor >= 0:
                     pairs.add((min(i, neighbor), max(i, neighbor)))
@@ -70,14 +145,17 @@ class ANNBlocker:
         Returns:
             List of (neighbor_index, similarity_score) tuples.
         """
-        if self._index is None:
-            raise RuntimeError("Index not built. Call build_index first.")
         vec = embedding.astype(np.float32)
         if vec.ndim == 1:
             vec = vec.reshape(1, -1)
-        scores, indices = self._index.search(vec, self.top_k)
+        if not _HAS_FAISS:
+            scores, indices = self._np_search(vec)
+        else:
+            if self._index is None:
+                raise RuntimeError("Index not built. Call build_index first.")
+            scores, indices = self._index.search(vec, self.top_k)
         results = []
-        for j in range(self.top_k):
+        for j in range(indices.shape[1]):
             neighbor = int(indices[0][j])
             if neighbor >= 0:
                 results.append((neighbor, float(scores[0][j])))
@@ -88,12 +166,11 @@ class ANNBlocker:
 
         Returns (idx_a, idx_b, cosine_similarity) tuples, ordered so idx_a < idx_b.
         """
-        scores_matrix, indices = self._index.search(
-            query_embeddings.astype(np.float32), self.top_k,
-        )
+        scores_matrix, indices = self._search(query_embeddings)
+        n_neighbors = indices.shape[1]
         pairs: dict[tuple[int, int], float] = {}
         for i in range(len(query_embeddings)):
-            for j_idx in range(self.top_k):
+            for j_idx in range(n_neighbors):
                 neighbor = int(indices[i][j_idx])
                 if neighbor != i and neighbor >= 0:
                     pair = (min(i, neighbor), max(i, neighbor))

--- a/packages/python/goldenmatch/goldenmatch/core/embedder.py
+++ b/packages/python/goldenmatch/goldenmatch/core/embedder.py
@@ -96,6 +96,10 @@ class _ProviderEmbedder:
         self._cache: dict[str, np.ndarray] = {}
         self.model_name = getattr(provider, "model_id", "provider")
 
+    def embed(self, values: list[str]) -> np.ndarray:
+        """Embed a list of strings (uncached passthrough to the wrapped provider)."""
+        return np.asarray(self._provider.embed(values), dtype=np.float32)  # type: ignore[attr-defined]
+
     def embed_column(self, values: list[str], cache_key: str) -> np.ndarray:
         if cache_key in self._cache:
             return self._cache[cache_key]
@@ -115,8 +119,12 @@ class _ProviderEmbedder:
 def _make_inhouse_embedder(model_name: str) -> _ProviderEmbedder:
     """Build a `_ProviderEmbedder` for the in-house model.
 
-    ``model_name`` is ``"inhouse:<path>"`` (path to a saved GoldenEmbedModel) or
-    bare ``"inhouse"`` (path from ``GOLDENMATCH_INHOUSE_MODEL``).
+    ``model_name`` is ``"inhouse:<path>"`` (path to a saved GoldenEmbedModel),
+    bare ``"inhouse"`` with ``GOLDENMATCH_INHOUSE_MODEL`` set (path to a saved
+    model), or bare ``"inhouse"`` with neither set — the zero-config default,
+    which builds an untrained ``GoldenEmbedModel`` (fixed-seed random projection
+    whose embeddings already approximate char-n-gram overlap; no path, no env,
+    no cloud, no torch).
     """
     from goldenmatch.embeddings.providers import InHouseProvider
 
@@ -124,11 +132,11 @@ def _make_inhouse_embedder(model_name: str) -> _ProviderEmbedder:
         "GOLDENMATCH_INHOUSE_MODEL"
     )
     if not path:
-        raise ValueError(
-            "in-house embedder requires a model path: set the matchkey field "
-            "`model` to 'inhouse:/path/to/model', or set GOLDENMATCH_INHOUSE_MODEL. "
-            "Train one with goldenmatch.embeddings.inhouse.train_embedder(...)."
-        )
+        # Zero-config: a freshly-constructed GoldenEmbedModel is already a usable
+        # embedder (untrained random projection). Provider accepts the instance.
+        from goldenmatch.embeddings.inhouse.model import GoldenEmbedModel
+
+        return _ProviderEmbedder(InHouseProvider(GoldenEmbedModel()))
     return _ProviderEmbedder(InHouseProvider(path))
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -869,6 +869,190 @@ def _prep_cache_clear() -> None:  # pyright: ignore[reportUnusedFunction]
     _PREP_CACHE_LRU.clear()
 
 
+# ── Semantic blocking (recall-lever) candidate-source union ──────────────────
+# When ``config.semantic_blocking`` is set, three additional candidate sources
+# are unioned onto the normal candidate set:
+#   - acronym  -> a multi_pass block on the ``initialism`` transform
+#   - alias    -> multi_pass blocks on the refdata canonicalization transforms
+#                 (refdata_given_name_canonical / refdata_business_canonical)
+#   - ann      -> embedding nearest-neighbor pairs via the ``ann_pairs`` strategy
+# The acronym/alias blocks are scored with the SAME block scorer the main fuzzy
+# loop uses; the ANN strategy returns pre-scored (a, b, cosine) pairs directly.
+# All sources are appended to ``all_pairs`` BEFORE the ``dedup_pairs_max_score``
+# seam, which canonicalizes (min, max) and keeps the max score -> purely
+# additive (never drops an existing pair). Gated entirely behind
+# ``config.semantic_blocking``; None (the default) does nothing.
+_SEMANTIC_ALIAS_TRANSFORMS: dict[str, str] = {
+    "given_names": "refdata_given_name_canonical",
+    "business": "refdata_business_canonical",
+}
+
+
+def _semantic_name_column(
+    config: GoldenMatchConfig, matchkeys: list, columns: list[str],
+) -> str | None:
+    """Pick the ``name``-like column the semantic-blocking sources operate on.
+
+    Preference order:
+      1. A weighted/probabilistic matchkey field whose column name looks
+         name-like (``name``/``company``/``business``/``org``/``title``).
+      2. Any weighted/probabilistic matchkey field (first one).
+      3. A blocking field that looks name-like, then the first blocking field.
+      4. The first user (non-``__``) column.
+
+    Returns None only when there is no user column at all.
+    """
+    name_like = ("name", "company", "business", "org", "title")
+
+    def _looks_name_like(col: str) -> bool:
+        low = col.lower()
+        return any(tok in low for tok in name_like)
+
+    # 1 + 2: matchkey fields (these are the columns the user is matching on).
+    mk_fields: list[str] = []
+    for mk in matchkeys:
+        if getattr(mk, "type", None) in ("weighted", "probabilistic"):
+            for f in getattr(mk, "fields", None) or []:
+                col = getattr(f, "field", None)
+                if col and not col.startswith("__") and col in columns:
+                    mk_fields.append(col)
+    for col in mk_fields:
+        if _looks_name_like(col):
+            return col
+    if mk_fields:
+        return mk_fields[0]
+
+    # 3: blocking fields.
+    block_fields: list[str] = []
+    if config.blocking is not None:
+        from goldenmatch.core.blocker import collect_blocking_fields
+        block_fields = [
+            c for c in collect_blocking_fields(config.blocking)
+            if not c.startswith("__") and c in columns
+        ]
+    for col in block_fields:
+        if _looks_name_like(col):
+            return col
+    if block_fields:
+        return block_fields[0]
+
+    # 4: first user column.
+    user_cols = [c for c in columns if not c.startswith("__")]
+    return user_cols[0] if user_cols else None
+
+
+def _semantic_blocking_pairs(
+    config: GoldenMatchConfig,
+    combined_lf: pl.LazyFrame,
+    collected_df: pl.DataFrame,
+    matchkeys: list,
+    matched_pairs: set[tuple[int, int]],
+    across_files_only: bool,
+    source_lookup: dict[int, str] | None,
+) -> list[tuple[int, int, float]]:
+    """Build + score the three semantic-blocking candidate sources.
+
+    Returns the union of ``(a, b, score)`` pairs to extend ``all_pairs`` with.
+    Reuses the pipeline's existing block scorer (``_get_block_scorer``) for the
+    acronym/alias blocks; the ANN strategy emits pre-scored pairs directly.
+    Best-effort per source: a failing source logs + is skipped (semantic
+    blocking is purely additive, so a missing source only loses recall, never
+    correctness).
+    """
+    sb = config.semantic_blocking
+    if sb is None:
+        return []
+
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+    )
+    from goldenmatch.core.blocker import build_blocks
+
+    name_col = _semantic_name_column(config, matchkeys, list(collected_df.columns))
+    if name_col is None:
+        logger.warning("semantic_blocking: no usable name column found; skipping")
+        return []
+
+    out: list[tuple[int, int, float]] = []
+
+    # The block scorer needs a weighted matchkey to score on. Reuse the first
+    # weighted matchkey verbatim when present (same scoring the main loop uses);
+    # otherwise synthesize a single-field jaro_winkler matchkey on the name
+    # column at the pipeline's effective threshold so the acronym/alias
+    # candidates are scored by the SAME comparison machinery.
+    score_mk = next(
+        (m for m in matchkeys if getattr(m, "type", None) == "weighted"), None
+    )
+    if score_mk is None:
+        from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+        score_mk = MatchkeyConfig(
+            name="__semantic_blocking__",
+            type="weighted",
+            fields=[MatchkeyField(field=name_col, scorer="jaro_winkler", weight=1.0)],
+            threshold=0.5,
+        )
+
+    block_scorer = _get_block_scorer(config)
+
+    # ── acronym + alias: one multi_pass blocking pass per requested transform ──
+    passes: list[BlockingKeyConfig] = []
+    if "initialism" in sb.keys:
+        passes.append(BlockingKeyConfig(fields=[name_col], transforms=["initialism"]))
+    if "alias" in sb.keys:
+        for table in sb.alias_tables:
+            transform = _SEMANTIC_ALIAS_TRANSFORMS.get(table)
+            if transform is not None:
+                passes.append(
+                    BlockingKeyConfig(fields=[name_col], transforms=[transform])
+                )
+    if passes:
+        try:
+            mp_config = BlockingConfig(strategy="multi_pass", passes=passes)
+            blocks = build_blocks(combined_lf, mp_config)
+            pairs = block_scorer(
+                blocks, score_mk, matched_pairs,
+                across_files_only=across_files_only,
+                source_lookup=source_lookup if across_files_only else None,
+            )
+            out.extend(pairs)
+        except Exception:
+            logger.warning(
+                "semantic_blocking acronym/alias source failed; skipping",
+                exc_info=True,
+            )
+
+    # ── ann: direct-pair ANN blocking returns pre-scored (a, b, cosine) pairs ──
+    if "ann" in sb.keys:
+        try:
+            ann_config = BlockingConfig(
+                strategy="ann_pairs",
+                ann_column=name_col,
+                ann_model=sb.ann_model,
+                ann_top_k=sb.ann_top_k,
+            )
+            ann_blocks = build_blocks(combined_lf, ann_config)
+            for blk in ann_blocks:
+                if blk.pre_scored_pairs:
+                    if across_files_only and source_lookup is not None:
+                        out.extend(
+                            (a, b, s) for a, b, s in blk.pre_scored_pairs
+                            if source_lookup.get(a) != source_lookup.get(b)
+                        )
+                    else:
+                        out.extend(blk.pre_scored_pairs)
+        except Exception:
+            logger.warning(
+                "semantic_blocking ann source failed; skipping", exc_info=True,
+            )
+
+    logger.info(
+        "semantic_blocking: unioned %d candidate pairs on column %r",
+        len(out), name_col,
+    )
+    return out
+
+
 def _run_dedupe_pipeline(
     combined_lf: pl.LazyFrame,
     config: GoldenMatchConfig,
@@ -1574,6 +1758,28 @@ def _run_dedupe_pipeline(
         _dump_bench_pairs(
             _bench_dump_dir, _bench_candidate_pairs, _bench_emitted_pairs
         )
+
+    # ── Step 3.2b: SEMANTIC BLOCKING (recall-lever, opt-in) ──
+    # Union three additional candidate sources (acronym/initialism, alias,
+    # ANN nearest-neighbor) onto the candidate set, scored by the SAME block
+    # scorer the fuzzy loop uses. Purely additive (dedup_pairs_max_score keeps
+    # the max score per canonical pair). Gated entirely behind
+    # config.semantic_blocking; None (the default) does nothing -> byte-identical.
+    if config.semantic_blocking is not None:
+        if _use_columnar:
+            # The columnar fast-path consumes the pair stream as a DataFrame
+            # (_columnar_pairs_df) and never touches all_pairs, so a union into
+            # all_pairs would silently no-op. Refuse rather than drop candidates.
+            raise NotImplementedError(
+                "semantic_blocking is incompatible with COLUMNAR_PIPELINE"
+            )
+        with stage("semantic_blocking"):
+            _semantic_pairs = _semantic_blocking_pairs(
+                config, combined_lf, collected_df, matchkeys,
+                matched_pairs, across_files_only,
+                source_lookup if across_files_only else None,
+            )
+        all_pairs.extend(_semantic_pairs)
 
     # ── Step 3.3: CROSS-ENCODER RERANKING (optional) ──
     for mk in matchkeys:

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -953,11 +953,28 @@ def _semantic_blocking_pairs(
     """Build + score the three semantic-blocking candidate sources.
 
     Returns the union of ``(a, b, score)`` pairs to extend ``all_pairs`` with.
-    Reuses the pipeline's existing block scorer (``_get_block_scorer``) for the
-    acronym/alias blocks; the ANN strategy emits pre-scored pairs directly.
-    Best-effort per source: a failing source logs + is skipped (semantic
-    blocking is purely additive, so a missing source only loses recall, never
-    correctness).
+
+    Each source is scored by its OWN CONFIRMING scorer, so a confirmed pair
+    comes out at score 1.0 and merges at clustering regardless of how low its
+    string similarity is:
+
+    - acronym/initialism candidates -> ``initialism_match`` (1.0 when one name
+      is the other's initialism, e.g. ``IBM`` <-> ``International Business
+      Machines``; raw string similarity is ~0).
+    - alias candidates -> ``alias_match`` (1.0 when both canonicalize to the
+      same business/given-name alias, e.g. ``Acme Inc`` <-> ``Acme
+      Incorporated``).
+    - ANN candidates -> cosine, kept as the pre-scored value the index emits
+      (gated by ``sb.ann_threshold`` so sub-threshold neighbors don't union in
+      a low-score pair that over-merges at clustering).
+
+    Reuses the pipeline's existing block scorer (``_get_block_scorer``). For
+    each acronym/alias source we synthesize a single-field weighted matchkey on
+    the name column whose field scorer IS the confirming scorer, at a 0.5
+    threshold so a 1.0 confirmed pair is emitted (and a 0.0 non-confirmation is
+    dropped). Best-effort per source: a failing source logs + is skipped
+    (semantic blocking is purely additive, so a missing source only loses
+    recall, never correctness).
     """
     sb = config.semantic_blocking
     if sb is None:
@@ -966,6 +983,8 @@ def _semantic_blocking_pairs(
     from goldenmatch.config.schemas import (
         BlockingConfig,
         BlockingKeyConfig,
+        MatchkeyConfig,
+        MatchkeyField,
     )
     from goldenmatch.core.blocker import build_blocks
 
@@ -975,54 +994,58 @@ def _semantic_blocking_pairs(
         return []
 
     out: list[tuple[int, int, float]] = []
+    block_scorer = _get_block_scorer(config)
 
-    # The block scorer needs a weighted matchkey to score on. Reuse the first
-    # weighted matchkey verbatim when present (same scoring the main loop uses);
-    # otherwise synthesize a single-field jaro_winkler matchkey on the name
-    # column at the pipeline's effective threshold so the acronym/alias
-    # candidates are scored by the SAME comparison machinery.
-    score_mk = next(
-        (m for m in matchkeys if getattr(m, "type", None) == "weighted"), None
-    )
-    if score_mk is None:
-        from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
-        score_mk = MatchkeyConfig(
-            name="__semantic_blocking__",
+    def _confirming_mk(name: str, scorer: str) -> MatchkeyConfig:
+        # Single-field weighted matchkey on the name column whose ONLY field
+        # uses the confirming scorer. threshold=0.5 emits a confirmed (1.0)
+        # pair and drops a non-confirmation (0.0); <=1.0 is required so the
+        # confirmed pair is emitted at all.
+        return MatchkeyConfig(
+            name=name,
             type="weighted",
-            fields=[MatchkeyField(field=name_col, scorer="jaro_winkler", weight=1.0)],
+            fields=[MatchkeyField(field=name_col, scorer=scorer, weight=1.0)],
             threshold=0.5,
         )
 
-    block_scorer = _get_block_scorer(config)
-
-    # ── acronym + alias: one multi_pass blocking pass per requested transform ──
-    passes: list[BlockingKeyConfig] = []
-    if "initialism" in sb.keys:
-        passes.append(BlockingKeyConfig(fields=[name_col], transforms=["initialism"]))
-    if "alias" in sb.keys:
-        for table in sb.alias_tables:
-            transform = _SEMANTIC_ALIAS_TRANSFORMS.get(table)
-            if transform is not None:
-                passes.append(
-                    BlockingKeyConfig(fields=[name_col], transforms=[transform])
-                )
-    if passes:
+    def _score_source(passes: list[BlockingKeyConfig], mk: MatchkeyConfig, label: str) -> None:
+        if not passes:
+            return
         try:
-            mp_config = BlockingConfig(strategy="multi_pass", passes=passes)
-            blocks = build_blocks(combined_lf, mp_config)
-            pairs = block_scorer(
-                blocks, score_mk, matched_pairs,
-                across_files_only=across_files_only,
-                source_lookup=source_lookup if across_files_only else None,
+            cfg = BlockingConfig(strategy="multi_pass", passes=passes)
+            blocks = build_blocks(combined_lf, cfg)
+            out.extend(
+                block_scorer(
+                    blocks, mk, matched_pairs,
+                    across_files_only=across_files_only,
+                    source_lookup=source_lookup if across_files_only else None,
+                )
             )
-            out.extend(pairs)
         except Exception:
             logger.warning(
-                "semantic_blocking acronym/alias source failed; skipping",
-                exc_info=True,
+                "semantic_blocking %s source failed; skipping", label, exc_info=True,
             )
 
+    # ── acronym/initialism: scored by initialism_match ──
+    if "initialism" in sb.keys:
+        _score_source(
+            [BlockingKeyConfig(fields=[name_col], transforms=["initialism"])],
+            _confirming_mk("__sem_initialism", "initialism_match"),
+            "initialism",
+        )
+
+    # ── alias: scored by alias_match (one pass per requested alias table) ──
+    if "alias" in sb.keys:
+        alias_passes = [
+            BlockingKeyConfig(fields=[name_col], transforms=[transform])
+            for table in sb.alias_tables
+            if (transform := _SEMANTIC_ALIAS_TRANSFORMS.get(table)) is not None
+        ]
+        _score_source(alias_passes, _confirming_mk("__sem_alias", "alias_match"), "alias")
+
     # ── ann: direct-pair ANN blocking returns pre-scored (a, b, cosine) pairs ──
+    # Kept as cosine; gated by sb.ann_threshold so a low-similarity neighbor
+    # doesn't union in a sub-threshold pair that over-merges at clustering.
     if "ann" in sb.keys:
         try:
             ann_config = BlockingConfig(
@@ -1033,14 +1056,16 @@ def _semantic_blocking_pairs(
             )
             ann_blocks = build_blocks(combined_lf, ann_config)
             for blk in ann_blocks:
-                if blk.pre_scored_pairs:
-                    if across_files_only and source_lookup is not None:
-                        out.extend(
-                            (a, b, s) for a, b, s in blk.pre_scored_pairs
-                            if source_lookup.get(a) != source_lookup.get(b)
-                        )
-                    else:
-                        out.extend(blk.pre_scored_pairs)
+                for a, b, s in blk.pre_scored_pairs or []:
+                    if s < sb.ann_threshold:
+                        continue
+                    if (
+                        across_files_only
+                        and source_lookup is not None
+                        and source_lookup.get(a) == source_lookup.get(b)
+                    ):
+                        continue
+                    out.append((a, b, s))
         except Exception:
             logger.warning(
                 "semantic_blocking ann source failed; skipping", exc_info=True,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -887,6 +887,12 @@ _SEMANTIC_ALIAS_TRANSFORMS: dict[str, str] = {
     "business": "refdata_business_canonical",
 }
 
+# Internal column prefix for the pre-standardize snapshot of the name column the
+# semantic-blocking sources key + score off of (see the capture in
+# ``_run_dedupe_pipeline`` just before standardize). ``__``-prefixed so it never
+# leaks into user-facing golden output.
+_SEMANTIC_RAW_COL_PREFIX = "__raw__"
+
 
 def _semantic_name_column(
     config: GoldenMatchConfig, matchkeys: list, columns: list[str],
@@ -993,18 +999,29 @@ def _semantic_blocking_pairs(
         logger.warning("semantic_blocking: no usable name column found; skipping")
         return []
 
+    # The initialism/alias sources must key + score off the RAW (pre-standardize)
+    # name so an all-caps acronym ("IBM") survives the `name_proper` title-casing
+    # (which would otherwise leave "Ibm", killing `derive_initialism`'s
+    # acronym-as-own-key step). `_run_dedupe_pipeline` snapshots it into
+    # `__raw__<name_col>` before standardize; fall back to `name_col` if absent
+    # (e.g. no standardization configured, or an upstream path that didn't
+    # capture it) -- the fall back is the prior behavior, never worse.
+    key_name_col = f"{_SEMANTIC_RAW_COL_PREFIX}{name_col}"
+    if key_name_col not in collected_df.columns:
+        key_name_col = name_col
+
     out: list[tuple[int, int, float]] = []
     block_scorer = _get_block_scorer(config)
 
-    def _confirming_mk(name: str, scorer: str) -> MatchkeyConfig:
-        # Single-field weighted matchkey on the name column whose ONLY field
-        # uses the confirming scorer. threshold=0.5 emits a confirmed (1.0)
-        # pair and drops a non-confirmation (0.0); <=1.0 is required so the
-        # confirmed pair is emitted at all.
+    def _confirming_mk(name: str, scorer: str, field_col: str) -> MatchkeyConfig:
+        # Single-field weighted matchkey on the given name column whose ONLY
+        # field uses the confirming scorer. threshold=0.5 emits a confirmed
+        # (1.0) pair and drops a non-confirmation (0.0); <=1.0 is required so
+        # the confirmed pair is emitted at all.
         return MatchkeyConfig(
             name=name,
             type="weighted",
-            fields=[MatchkeyField(field=name_col, scorer=scorer, weight=1.0)],
+            fields=[MatchkeyField(field=field_col, scorer=scorer, weight=1.0)],
             threshold=0.5,
         )
 
@@ -1026,22 +1043,26 @@ def _semantic_blocking_pairs(
                 "semantic_blocking %s source failed; skipping", label, exc_info=True,
             )
 
-    # ── acronym/initialism: scored by initialism_match ──
+    # ── acronym/initialism: scored by initialism_match (off the RAW name) ──
     if "initialism" in sb.keys:
         _score_source(
-            [BlockingKeyConfig(fields=[name_col], transforms=["initialism"])],
-            _confirming_mk("__sem_initialism", "initialism_match"),
+            [BlockingKeyConfig(fields=[key_name_col], transforms=["initialism"])],
+            _confirming_mk("__sem_initialism", "initialism_match", key_name_col),
             "initialism",
         )
 
-    # ── alias: scored by alias_match (one pass per requested alias table) ──
+    # ── alias: scored by alias_match (off the RAW name; one pass per table) ──
     if "alias" in sb.keys:
         alias_passes = [
-            BlockingKeyConfig(fields=[name_col], transforms=[transform])
+            BlockingKeyConfig(fields=[key_name_col], transforms=[transform])
             for table in sb.alias_tables
             if (transform := _SEMANTIC_ALIAS_TRANSFORMS.get(table)) is not None
         ]
-        _score_source(alias_passes, _confirming_mk("__sem_alias", "alias_match"), "alias")
+        _score_source(
+            alias_passes,
+            _confirming_mk("__sem_alias", "alias_match", key_name_col),
+            "alias",
+        )
 
     # ── ann: direct-pair ANN blocking returns pre-scored (a, b, cosine) pairs ──
     # Kept as cosine; gated by sb.ann_threshold so a low-similarity neighbor
@@ -1296,6 +1317,24 @@ def _run_dedupe_pipeline(
             return lf
         with stage(f"prep_force_collect_{label}"):
             return lf.collect().lazy()
+
+    # ── Semantic-blocking raw-name capture (recall lever) ──
+    # The semantic-blocking sources (initialism / alias) derive their block keys
+    # and confirming scores from the name column. Standardize (below) title-cases
+    # that column (`name_proper` -> "IBM" becomes "Ibm"), which destroys the
+    # all-caps acronym signal `derive_initialism` keys off of. Snapshot the RAW
+    # (pre-standardize) name value into an internal `__raw__<col>` column so
+    # `_semantic_blocking_pairs` can key + score off the un-standardized text.
+    # Gated entirely behind `config.semantic_blocking`; byte-identical when None.
+    if config.semantic_blocking is not None:
+        _sem_name_col = _semantic_name_column(
+            config, matchkeys, list(combined_lf.collect_schema().names()),
+        )
+        if _sem_name_col is not None:
+            _raw_col = f"{_SEMANTIC_RAW_COL_PREFIX}{_sem_name_col}"
+            combined_lf = combined_lf.with_columns(
+                pl.col(_sem_name_col).alias(_raw_col)
+            )
 
     if config.standardization and config.standardization.rules:
         with stage("standardize"):

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -98,6 +98,54 @@ def _emit_scoring_profile(
     current_emitter().set_scoring(profile)
 
 
+def _initialism_match_single(val_a: str, val_b: str) -> float:
+    """1.0 if either string is the other's initialism, or their initialisms
+    are equal; else 0.0.
+
+    "IBM" <-> "International Business Machines" matches because
+    ``derive_initialism("International Business Machines") == "IBM" == val_a``.
+    Empty-guarded: a derived ``""`` (single-token / empty input) never
+    matches, so two distinct single-token names ("Apple"/"Apricot") score 0.0.
+    Symmetric. The initialism collision ("IBM" <-> "Indian Banana Market") is
+    a known false positive — it scores 1.0 by design.
+    """
+    from goldenmatch.core.acronym import derive_initialism
+
+    ia = derive_initialism(val_a) or ""
+    ib = derive_initialism(val_b) or ""
+    if (
+        (ia and ia == val_b)
+        or (ib and val_a == ib)
+        or (ia and ib and ia == ib)
+    ):
+        return 1.0
+    return 0.0
+
+
+def _alias_match_single(val_a: str, val_b: str) -> float:
+    """1.0 if both values canonicalize to the same NON-EMPTY business alias
+    OR the same given-name canonical; else 0.0.
+
+    "Acme Inc" <-> "Acme Incorporated" both map to the business canonical
+    "acme"; "Bob" <-> "Robert" both map to the given-name canonical "robert".
+    Empty-guarded: an empty canonical never matches (both ``""`` -> 0.0).
+    Note canonicalization is an idempotent passthrough for OOV names, so two
+    *different* OOV names ("Acme"/"Globex") yield different canonicals -> 0.0.
+    """
+    from goldenmatch.refdata.business_aliases import canonical_company_form
+    from goldenmatch.refdata.given_names import canonical_form
+
+    cb_a = canonical_company_form(val_a) or ""
+    cb_b = canonical_company_form(val_b) or ""
+    if cb_a and cb_a == cb_b:
+        return 1.0
+    cg_a = canonical_form(val_a) or ""
+    cg_b = canonical_form(val_b) or ""
+    if cg_a and cg_a == cg_b:
+        return 1.0
+    return 0.0
+
+
 def score_field(val_a: str | None, val_b: str | None, scorer: str) -> float | None:
     """Score two field values using the specified scorer.
 
@@ -135,6 +183,10 @@ def score_field(val_a: str | None, val_b: str | None, scorer: str) -> float | No
         except Exception:
             sx = 0.0
         return max(jw, ts, sx)
+    elif scorer == "initialism_match":
+        return _initialism_match_single(val_a, val_b)
+    elif scorer == "alias_match":
+        return _alias_match_single(val_a, val_b)
     elif scorer == "dice":
         return _dice_score_single(val_a, val_b)
     elif scorer == "jaccard":
@@ -485,6 +537,10 @@ def _fuzzy_score_matrix(
             matrix = np.asarray(cdist(clean, clean, scorer=Levenshtein.normalized_similarity), dtype=np.float32)
         else:
             matrix = np.asarray(cdist(clean, clean, scorer=token_sort_ratio), dtype=np.float32) / 100.0
+    elif scorer_name == "initialism_match":
+        return _initialism_score_matrix(values)
+    elif scorer_name == "alias_match":
+        return _alias_score_matrix(values)
     elif scorer_name == "dice":
         return _dice_score_matrix(values)
     elif scorer_name == "jaccard":
@@ -583,6 +639,54 @@ def _soundex_score_matrix(values: list) -> np.ndarray:
         return m
     codes = [jellyfish.soundex(v) if v is not None else None for v in values]
     return _exact_score_matrix(codes)
+
+
+def _initialism_score_matrix(values: list) -> np.ndarray:
+    """NxN initialism-match matrix (no native kernel).
+
+    The match is a CROSS comparison of raw-string vs derived-initialism, not a
+    single canonical key per row, so this can't reduce to a hash-group like
+    ``_soundex_score_matrix``. Blocks reaching this path are small, so a direct
+    double-loop over the pairwise scorer is the safest correct impl — and it is
+    parity-checked against the pairwise ``score_field`` in
+    ``tests/test_semantic_scorers.py``.
+    """
+    n = len(values)
+    scores = np.zeros((n, n))
+    for i in range(n):
+        vi = values[i]
+        if vi is None:
+            continue
+        for j in range(i, n):
+            vj = values[j]
+            if vj is None:
+                continue
+            s = _initialism_match_single(vi, vj)
+            scores[i, j] = scores[j, i] = s
+    return scores
+
+
+def _alias_score_matrix(values: list) -> np.ndarray:
+    """NxN alias-match matrix (no native kernel).
+
+    Each row HAS a single canonical key per alias space, so this groups like
+    ``_soundex_score_matrix``: a pair matches iff it shares a NON-EMPTY
+    business canonical OR a non-empty given-name canonical. Two independent
+    hash-groupings (one per space) unioned together reproduce the pairwise
+    OR — and stay byte-identical to the pairwise ``score_field`` (parity-
+    checked in ``tests/test_semantic_scorers.py``).
+    """
+    from goldenmatch.refdata.business_aliases import canonical_company_form
+    from goldenmatch.refdata.given_names import canonical_form
+
+    # Empty canonicals are dropped (never group) so the empty guard holds.
+    biz = [
+        (canonical_company_form(v) or "") if v is not None else "" for v in values
+    ]
+    given = [(canonical_form(v) or "") if v is not None else "" for v in values]
+    scores = _exact_score_matrix([k or None for k in biz])
+    given_scores = _exact_score_matrix([k or None for k in given])
+    return np.maximum(scores, given_scores)
 
 
 # ---------------------------------------------------------------------------
@@ -847,10 +951,18 @@ def find_fuzzy_matches(
 
     row_ids = block_df["__row_id__"].to_list()
 
-    # Separate exact (cheap), record_embedding, and fuzzy (expensive) fields
-    exact_fields = [f for f in mk.fields if f.scorer == "exact" or f.scorer == "soundex_match"]
+    # Separate exact (cheap), record_embedding, and fuzzy (expensive) fields.
+    # initialism_match / alias_match are equality-style (1.0/0.0) scorers with
+    # no NxN compute cost beyond a key derivation, so they ride the cheap path
+    # alongside exact/soundex (and are excluded from the fuzzy partition for
+    # the early-termination short-circuit).
+    _EQUALITY_SCORERS = ("exact", "soundex_match", "initialism_match", "alias_match")
+    exact_fields = [f for f in mk.fields if f.scorer in _EQUALITY_SCORERS]
     record_emb_fields = [f for f in mk.fields if f.scorer == "record_embedding"]
-    fuzzy_fields = [f for f in mk.fields if f.scorer not in ("exact", "soundex_match", "record_embedding")]
+    fuzzy_fields = [
+        f for f in mk.fields
+        if f.scorer not in _EQUALITY_SCORERS and f.scorer != "record_embedding"
+    ]
 
     # All scoring-path MatchkeyFields are upstream-validated to have weight set;
     # narrow with cast helper so the schema-level Optional doesn't poison every
@@ -887,8 +999,12 @@ def find_fuzzy_matches(
 
         if f.scorer == "exact":
             scores = _exact_score_matrix(values)
-        else:  # soundex_match
+        elif f.scorer == "soundex_match":
             scores = _soundex_score_matrix(values)
+        elif f.scorer == "initialism_match":
+            scores = _initialism_score_matrix(values)
+        else:  # alias_match
+            scores = _alias_score_matrix(values)
 
         cheap_numerator += scores * _w(f) * valid
         cheap_denominator += _w(f) * valid

--- a/packages/python/goldenmatch/goldenmatch/refdata/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/__init__.py
@@ -69,6 +69,11 @@ from goldenmatch.refdata.business import (
 )
 from goldenmatch.refdata.business import register_transforms as _register_business_transforms
 from goldenmatch.refdata.business import strip_legal_form
+from goldenmatch.refdata.business_aliases import canonical_company_form
+from goldenmatch.refdata.business_aliases import is_available as business_aliases_available
+from goldenmatch.refdata.business_aliases import (
+    register_transforms as _register_business_alias_transforms,
+)
 from goldenmatch.refdata.given_names import (
     aliases_of,
     are_equivalent,
@@ -90,6 +95,7 @@ from goldenmatch.refdata.surnames import (
 # Register the bundled scorers + transforms on import. Idempotent.
 register_scorers()
 _register_business_transforms()
+_register_business_alias_transforms()
 _register_address_transforms()
 _register_industry_transforms()
 _register_acronym_transforms()
@@ -99,7 +105,9 @@ __all__ = [
     "addresses_available",
     "aliases_of",
     "are_equivalent",
+    "business_aliases_available",
     "business_available",
+    "canonical_company_form",
     "canonical_form",
     "code_for_title",
     "given_names_available",

--- a/packages/python/goldenmatch/goldenmatch/refdata/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/__init__.py
@@ -56,6 +56,7 @@ Provenance + license for every bundled dataset:
 """
 from __future__ import annotations
 
+from goldenmatch.core.acronym import register_transforms as _register_acronym_transforms
 from goldenmatch.refdata.addresses import is_available as addresses_available
 from goldenmatch.refdata.addresses import (
     known_tokens as address_tokens,
@@ -91,6 +92,7 @@ register_scorers()
 _register_business_transforms()
 _register_address_transforms()
 _register_industry_transforms()
+_register_acronym_transforms()
 
 __all__ = [
     "address_tokens",

--- a/packages/python/goldenmatch/goldenmatch/refdata/business.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/business.py
@@ -28,6 +28,13 @@ logger = logging.getLogger(__name__)
 _DATA_FILE = "legal_forms.json"
 
 
+# Categories in legal_forms.json that are DESCRIPTIVE tokens, not entity-type
+# suffixes. "Acme Industries LLC" keeps "Industries" (it makes the name
+# meaningful) but drops "LLC". Per-token strippers that want only the
+# entity-type forms exclude this category — see ``entity_form_variants``.
+_DESCRIPTOR_CATEGORIES = frozenset({"holding_descriptors"})
+
+
 @dataclass(frozen=True)
 class _BusinessState:
     """Loaded state: the compiled regex matching every known trailing
@@ -38,6 +45,7 @@ class _BusinessState:
 
     pattern: re.Pattern[str]
     variants_normalized: frozenset[str]
+    entity_variants_normalized: frozenset[str]
 
 
 _lock = Lock()
@@ -62,11 +70,14 @@ def _build_state_from_file() -> _BusinessState | None:
         payload = json.load(f)
     forms_block = payload.get("legal_forms", {})
     variants: set[str] = set()
-    for variant_list in forms_block.values():
+    entity_variants: set[str] = set()
+    for category, variant_list in forms_block.items():
         for v in variant_list:
             n = _normalize_token(v)
             if n:
                 variants.add(n)
+                if category not in _DESCRIPTOR_CATEGORIES:
+                    entity_variants.add(n)
     if not variants:
         return None
     # Descending length so "Limited Liability Company" beats "Limited" or
@@ -78,7 +89,11 @@ def _build_state_from_file() -> _BusinessState | None:
         r"[\s,\-.]+(?:" + "|".join(escaped) + r")[\s.,]*$",
         re.IGNORECASE,
     )
-    return _BusinessState(pattern=pattern, variants_normalized=frozenset(variants))
+    return _BusinessState(
+        pattern=pattern,
+        variants_normalized=frozenset(variants),
+        entity_variants_normalized=frozenset(entity_variants),
+    )
 
 
 def _load() -> None:
@@ -121,6 +136,21 @@ def known_variants() -> frozenset[str]:
     if _state is None:
         return frozenset()
     return _state.variants_normalized
+
+
+def entity_form_variants() -> frozenset[str]:
+    """Normalized variants of the entity-TYPE legal forms only (Inc, LLC, Corp,
+    Corporation, Ltd, GmbH, ...), EXCLUDING descriptive tokens like "Industries"
+    / "Group" / "Holdings".
+
+    Per-token strippers (e.g. the initialism block-key deriver) use this so they
+    drop "Corporation" from "International Business Machines Corporation" but keep
+    "Industries" in "Acme Industries LLC". Empty frozenset when the pack is
+    unavailable."""
+    _load()
+    if _state is None:
+        return frozenset()
+    return _state.entity_variants_normalized
 
 
 def strip_legal_form(value: str | None) -> str | None:

--- a/packages/python/goldenmatch/goldenmatch/refdata/business_aliases.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/business_aliases.py
@@ -1,0 +1,205 @@
+"""Business / brand alias canonicalization for candidate-generation blocking.
+
+Maps known brand / synonym / abbreviation surface forms of a company to a
+single canonical key, so records that name the same company differently
+("Google" vs "Alphabet Inc.", "IBM" vs "International Business Machines")
+collapse to the same value when used as a blocking transform — landing them
+in the same candidate set before scoring.
+
+Public API:
+
+- ``canonical_company_form(name)`` — the canonical key for ``name``. The
+  input is normalized (lower-case; trailing legal-form stripped via
+  ``business.strip_legal_form``; whitespace collapsed) and then mapped
+  through the bundled alias table. An OOV name maps to its own normalized
+  form (stable, idempotent passthrough). ``None`` → ``None``.
+- ``is_available()`` — True iff the bundled alias file loaded.
+- ``known_canonicals()`` — frozen set of canonical keys, for diagnostics.
+
+Two ``TransformPlugin`` adapters live here:
+
+- ``BusinessCanonicalTransform`` (``refdata_business_canonical``) wraps
+  ``canonical_company_form``.
+- ``GivenNameCanonicalTransform`` (``refdata_given_name_canonical``) wraps
+  ``given_names.canonical_form`` so first-name nickname variants
+  ("Bob" / "Robert") share a blocking key.
+
+Loading is lazy: parsed on first call and cached. A missing data file
+degrades to legal-form-stripped passthrough rather than raising.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from importlib import resources
+from threading import Lock
+
+from goldenmatch.plugins.base import TransformPlugin
+from goldenmatch.refdata.business import strip_legal_form
+
+logger = logging.getLogger(__name__)
+
+_DATA_FILE = "business_aliases.json"
+
+
+@dataclass(frozen=True)
+class _BusinessAliasState:
+    """Loaded state. Frozen for atomic-swap semantics on ``_reload`` —
+    readers don't take the lock, so an in-place dict mutation would race.
+
+    ``surface_to_canonical`` maps each normalized surface form (canonical
+    keys included, so they map to themselves) to its canonical key.
+    """
+
+    surface_to_canonical: Mapping[str, str]
+    canonicals: frozenset[str]
+
+
+_lock = Lock()
+_state: _BusinessAliasState | None = None
+
+
+def _normalize(name: str) -> str:
+    """Lower-case, strip a trailing legal-form suffix, collapse whitespace.
+
+    Mirrors the normalization the alias table keys/values were authored in,
+    so lookups hit. ``strip_legal_form`` already collapses whitespace, but
+    we collapse again defensively for the data-file-missing path.
+    """
+    stripped = strip_legal_form(name) or ""
+    return re.sub(r"\s+", " ", stripped).strip().lower()
+
+
+def _build_state_from_file() -> _BusinessAliasState | None:
+    surface_to_canonical: dict[str, str] = {}
+    canonicals: set[str] = set()
+    with resources.files("goldenmatch.refdata.data").joinpath(_DATA_FILE).open(
+        "r", encoding="utf-8"
+    ) as f:
+        payload = json.load(f)
+    aliases_block = payload.get("aliases", {})
+    for raw_canonical, raw_aliases in aliases_block.items():
+        c = _normalize(raw_canonical)
+        if not c:
+            continue
+        canonicals.add(c)
+        # The canonical key maps to itself so a record already in canonical
+        # form is recognized.
+        surface_to_canonical.setdefault(c, c)
+        for raw_alias in raw_aliases:
+            a = _normalize(raw_alias)
+            if not a:
+                continue
+            # First canonical wins on a collision; log so the bundled file
+            # can be deconflicted rather than silently last-winning.
+            existing = surface_to_canonical.get(a)
+            if existing is not None and existing != c:
+                logger.warning(
+                    "goldenmatch.refdata.business_aliases: surface form %r maps "
+                    "to both %r and %r in %s; keeping %r.",
+                    a, existing, c, _DATA_FILE, existing,
+                )
+                continue
+            surface_to_canonical[a] = c
+    if not surface_to_canonical:
+        return None
+    return _BusinessAliasState(
+        surface_to_canonical=dict(surface_to_canonical),
+        canonicals=frozenset(canonicals),
+    )
+
+
+def _load() -> None:
+    global _state
+    if _state is not None:
+        return
+    with _lock:
+        if _state is not None:
+            return
+        try:
+            _state = _build_state_from_file()
+        except (FileNotFoundError, json.JSONDecodeError, KeyError) as exc:
+            logger.warning(
+                "goldenmatch.refdata.business_aliases: data file unavailable "
+                "(%s); canonical_company_form falls back to normalized "
+                "passthrough.",
+                exc,
+            )
+            _state = None
+
+
+def _reload() -> None:
+    """Test-only: drop the cached state; next access re-parses."""
+    global _state
+    with _lock:
+        _state = None
+
+
+def is_available() -> bool:
+    _load()
+    return _state is not None
+
+
+def known_canonicals() -> frozenset[str]:
+    _load()
+    if _state is None:
+        return frozenset()
+    return _state.canonicals
+
+
+def canonical_company_form(name: str | None) -> str | None:
+    """Canonical company key for ``name``.
+
+    Normalizes (lower-case, legal-form-stripped, whitespace-collapsed) then
+    maps through the alias table. An OOV name returns its own normalized
+    form — stable and idempotent. ``None`` → ``None``; empty / whitespace-
+    only → ``""``. Data file missing → normalized passthrough.
+    """
+    if name is None:
+        return None
+    norm = _normalize(name)
+    if not norm:
+        return ""
+    _load()
+    if _state is None:
+        return norm
+    return _state.surface_to_canonical.get(norm, norm)
+
+
+class BusinessCanonicalTransform(TransformPlugin):
+    """Adapter exposing ``canonical_company_form`` through the
+    ``TransformPlugin`` protocol. Use the ``refdata_business_canonical``
+    transform name in a matchkey's ``transforms:`` list to block on the
+    canonical company form."""
+
+    name = "refdata_business_canonical"
+
+    def transform(self, value: str | None) -> str | None:
+        return canonical_company_form(value)
+
+
+class GivenNameCanonicalTransform(TransformPlugin):
+    """Adapter exposing ``given_names.canonical_form`` through the
+    ``TransformPlugin`` protocol. Use the ``refdata_given_name_canonical``
+    transform name to block on the canonical given-name form so nickname
+    variants (Bob/Robert) share a blocking key."""
+
+    name = "refdata_given_name_canonical"
+
+    def transform(self, value: str | None) -> str | None:
+        from goldenmatch.refdata.given_names import canonical_form
+
+        return canonical_form(value)
+
+
+def register_transforms() -> None:
+    """Idempotent. Called from ``goldenmatch.refdata.__init__`` on import."""
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    reg = PluginRegistry.instance()
+    for plugin_cls in (BusinessCanonicalTransform, GivenNameCanonicalTransform):
+        if not reg.has_transform(plugin_cls.name):
+            reg.register_transform(plugin_cls.name, plugin_cls())

--- a/packages/python/goldenmatch/goldenmatch/refdata/data/business_aliases.json
+++ b/packages/python/goldenmatch/goldenmatch/refdata/data/business_aliases.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "SEED business alias table. Maps a canonical company key (lowercase, legal-form-stripped) to its known brand/synonym surface variants. NOT a comprehensive KB -- a starter set so canonical-form blocking can land synonym/brand variants in the same candidate set. Keys and values are lowercase; legal-form suffixes (Inc, LLC, Corp, ...) are stripped at lookup time via business.strip_legal_form, so they need not be enumerated here. Extend per deployment.",
+  "aliases": {
+    "acme": ["acme inc", "acme incorporated", "acme corp", "acme corporation", "acme co"],
+    "alphabet": ["google", "google llc", "alphabet inc"],
+    "meta": ["facebook", "meta platforms", "facebook inc"],
+    "international business machines": ["ibm", "ibm corp", "big blue"],
+    "kentucky fried chicken": ["kfc", "kfc corporation"],
+    "minnesota mining and manufacturing": ["3m", "3m company"],
+    "federal express": ["fedex", "fedex corporation"],
+    "general electric": ["ge", "ge company"],
+    "philip morris international": ["pmi", "philip morris"]
+  }
+}

--- a/packages/python/goldenmatch/tests/test_acronym.py
+++ b/packages/python/goldenmatch/tests/test_acronym.py
@@ -31,7 +31,13 @@ def test_initialism_strips_parenthetical_and_legal_noise():
 
 
 def test_initialism_registered_as_plugin():
+    # Self-contained: call register_transforms() (idempotent) so the test does not
+    # depend on import-time registration surviving another xdist-shard test that may
+    # have cleared the PluginRegistry singleton (CLAUDE.md xdist worker-isolation rule).
+    from goldenmatch.core.acronym import register_transforms
     from goldenmatch.plugins.registry import PluginRegistry
+
+    register_transforms()
     reg = PluginRegistry.instance()
     assert reg.has_transform("initialism")
     assert reg.get_transform("initialism").transform("International Business Machines") == "IBM"

--- a/packages/python/goldenmatch/tests/test_acronym.py
+++ b/packages/python/goldenmatch/tests/test_acronym.py
@@ -1,0 +1,21 @@
+from goldenmatch.core.acronym import derive_initialism
+
+
+def test_initialism_basic():
+    assert derive_initialism("International Business Machines") == "IBM"
+
+
+def test_initialism_drops_legal_form():
+    assert derive_initialism("Acme Industries LLC") == "AI"
+
+
+def test_initialism_single_token_is_empty():
+    assert derive_initialism("IBM") == ""      # 1 token -> no block
+    assert derive_initialism("") == ""
+
+
+def test_initialism_registered_as_plugin():
+    from goldenmatch.plugins.registry import PluginRegistry
+    reg = PluginRegistry.instance()
+    assert reg.has_transform("initialism")
+    assert reg.get_transform("initialism").transform("International Business Machines") == "IBM"

--- a/packages/python/goldenmatch/tests/test_acronym.py
+++ b/packages/python/goldenmatch/tests/test_acronym.py
@@ -9,9 +9,25 @@ def test_initialism_drops_legal_form():
     assert derive_initialism("Acme Industries LLC") == "AI"
 
 
-def test_initialism_single_token_is_empty():
-    assert derive_initialism("IBM") == ""      # 1 token -> no block
+def test_initialism_single_token_acronym_is_own_key():
+    # Contract change: a 1-token ALL-CAPS acronym (len 2-6, alphabetic) is its
+    # OWN block key, uppercased, so "IBM" co-locates with its expansion.
+    assert derive_initialism("IBM") == "IBM"
+    # A 1-token NON-acronym word ("Apple": not all-caps) is still no-block: one
+    # initial letter is too coarse a key and would over-merge.
+    assert derive_initialism("Apple") == ""
+    # Lowercase 1-token (not all-caps in the original) is NOT acronym-like.
+    assert derive_initialism("apple") == ""
     assert derive_initialism("") == ""
+
+
+def test_initialism_strips_parenthetical_and_legal_noise():
+    # Noisy real-world mention: parenthetical + trailing legal form. The
+    # cleaned token stream is "International Business Machines" -> "IBM".
+    assert (
+        derive_initialism("International Business Machines Corporation (Armonk, NY)")
+        == "IBM"
+    )
 
 
 def test_initialism_registered_as_plugin():

--- a/packages/python/goldenmatch/tests/test_ann_fallback.py
+++ b/packages/python/goldenmatch/tests/test_ann_fallback.py
@@ -1,0 +1,47 @@
+"""Tests for the numpy all-pairs cosine fallback in the ANN blocker.
+
+The fallback path runs when faiss is absent (or explicitly forced off via the
+module-level ``_HAS_FAISS`` flag). It must produce the SAME neighbor set as
+faiss for small N (parity) with zero new dependencies.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from goldenmatch.core.ann_blocker import ANNBlocker
+
+
+def _vecs():
+    rng = np.random.default_rng(0)
+    return rng.standard_normal((20, 8)).astype(np.float32)
+
+
+def test_numpy_fallback_runs_without_faiss(monkeypatch):
+    monkeypatch.setattr("goldenmatch.core.ann_blocker._HAS_FAISS", False, raising=False)
+    b = ANNBlocker(top_k=5)
+    b.build_index(_vecs())
+    pairs = b.query_with_scores(_vecs())
+    assert pairs, "fallback should produce candidate pairs"
+    assert all(a < c for a, c, _ in pairs)                 # canonical (a<b)
+    assert all(-1.0001 <= s <= 1.0001 for *_, s in pairs)  # cosine range
+
+
+def test_fallback_parity_with_faiss_small_n():
+    import importlib.util
+
+    import pytest
+    if importlib.util.find_spec("faiss") is None:
+        pytest.skip("faiss not installed")
+    v = _vecs()
+    faiss_b = ANNBlocker(top_k=5); faiss_b.build_index(v)
+    faiss_pairs = {(a, c) for a, c, _ in faiss_b.query_with_scores(v)}
+    # force numpy on a fresh blocker
+    import goldenmatch.core.ann_blocker as m
+    orig = m._HAS_FAISS
+    try:
+        m._HAS_FAISS = False
+        np_b = ANNBlocker(top_k=5); np_b.build_index(v)
+        np_pairs = {(a, c) for a, c, _ in np_b.query_with_scores(v)}
+    finally:
+        m._HAS_FAISS = orig
+    assert faiss_pairs == np_pairs                          # same neighbor SET

--- a/packages/python/goldenmatch/tests/test_business_aliases.py
+++ b/packages/python/goldenmatch/tests/test_business_aliases.py
@@ -1,0 +1,21 @@
+from goldenmatch.plugins.registry import PluginRegistry
+from goldenmatch.refdata.business_aliases import canonical_company_form
+
+
+def test_business_canonical_collapses_seed_aliases():
+    assert canonical_company_form("Acme Inc") == canonical_company_form("Acme Incorporated")
+
+
+def test_business_canonical_unknown_passthrough_is_stable():
+    a = canonical_company_form("Globex Pharma")
+    assert a == canonical_company_form("Globex Pharma")   # idempotent
+
+
+def test_alias_transforms_registered():
+    from goldenmatch.refdata.given_names import are_equivalent
+    reg = PluginRegistry.instance()
+    assert reg.has_transform("refdata_business_canonical")
+    assert reg.has_transform("refdata_given_name_canonical")
+    gn = reg.get_transform("refdata_given_name_canonical")
+    assert are_equivalent("Bob", "Robert")                 # precondition from the data
+    assert gn.transform("Bob") == gn.transform("Robert")   # same set -> same canonical

--- a/packages/python/goldenmatch/tests/test_embedder_inhouse_default.py
+++ b/packages/python/goldenmatch/tests/test_embedder_inhouse_default.py
@@ -1,0 +1,15 @@
+import numpy as np
+from goldenmatch.core.embedder import get_embedder
+
+
+def test_bare_inhouse_is_zero_config():
+    emb = get_embedder("inhouse")          # no path, no env -> must NOT raise
+    vecs = emb.embed(["International Business Machines", "Margaret Chen"])
+    assert isinstance(vecs, np.ndarray) and vecs.shape[0] == 2
+
+
+def test_inhouse_lexical_signal():
+    emb = get_embedder("inhouse")
+    v = emb.embed(["Robert Jones", "Bob Jones", "Margaret Chen"])
+    n = v / (np.linalg.norm(v, axis=1, keepdims=True) + 1e-9)
+    assert (n[0] @ n[1]) > (n[0] @ n[2])   # char-overlap signal present untrained

--- a/packages/python/goldenmatch/tests/test_inhouse_pipeline_integration.py
+++ b/packages/python/goldenmatch/tests/test_inhouse_pipeline_integration.py
@@ -63,10 +63,13 @@ def test_embedding_scorer_uses_inhouse_model(inhouse_model_path):
     assert matrix[0, 1] > matrix[0, 2]
 
 
-def test_inhouse_embedder_requires_a_model_path(monkeypatch):
+def test_inhouse_embedder_zero_config_default(monkeypatch):
+    # Contract change: bare get_embedder("inhouse") (no path, no env) now returns the
+    # untrained fixed-seed default GoldenEmbedModel (zero-config) instead of raising
+    # ValueError. A trained model is still used when "inhouse:<path>"/the env is given.
     from goldenmatch.core.embedder import _embedders, get_embedder
 
     monkeypatch.delenv("GOLDENMATCH_INHOUSE_MODEL", raising=False)
     _embedders.pop("inhouse", None)
-    with pytest.raises(ValueError):
-        get_embedder("inhouse")
+    emb = get_embedder("inhouse")
+    assert emb is not None

--- a/packages/python/goldenmatch/tests/test_semantic_blocking_config.py
+++ b/packages/python/goldenmatch/tests/test_semantic_blocking_config.py
@@ -1,0 +1,14 @@
+from goldenmatch.config.schemas import GoldenMatchConfig, SemanticBlockingConfig
+
+
+def test_defaults_all_three_keys():
+    c = SemanticBlockingConfig()
+    assert set(c.keys) == {"ann", "initialism", "alias"}
+    assert c.ann_model == "inhouse"
+    assert c.ann_top_k == 20
+
+
+def test_config_attaches_to_goldenmatch_config():
+    gm = GoldenMatchConfig(semantic_blocking=SemanticBlockingConfig())
+    assert gm.semantic_blocking is not None
+    assert gm.semantic_blocking.keys

--- a/packages/python/goldenmatch/tests/test_semantic_blocking_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_semantic_blocking_pipeline.py
@@ -52,6 +52,83 @@ def test_semantic_blocking_only_adds_candidates():
     assert cluster_of(0) == cluster_of(1)  # IBM <-> Intl Business Machines merged
 
 
+def test_acronym_merges_through_standardize():
+    """The title-case wall: auto-config's standardize step title-cases the name
+    column (``name_proper`` -> ``"IBM"`` becomes ``"Ibm"``) BEFORE semantic
+    blocking runs. ``derive_initialism`` requires an all-caps token to treat a
+    lone acronym as its own block key, so a standardized ``"Ibm"`` derives ``""``
+    and never co-locates with its expansion.
+
+    This test isolates the initialism source ONLY (no ann/alias) so the merge
+    can ONLY come from initialism keying off the RAW name. With ann/alias on,
+    the ANN embedding similarity masks the wall (it merges IBM<->expansion on
+    its own), so a "semantic_blocking=True" test passes regardless of this bug.
+
+    The semantic-blocking path must derive its block keys + confirming scores
+    from the RAW (un-standardized) name so the acronym signal survives.
+    """
+    from goldenmatch.config.schemas import SemanticBlockingConfig
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    df = pl.DataFrame(
+        {"name": ["International Business Machines", "IBM", "Globex"]}
+    )
+    # auto-config carries the name_proper standardization rule that title-cases
+    # the column; isolate the initialism source so the ANN source can't mask it.
+    cfg = auto_configure_df(df)
+    cfg.semantic_blocking = SemanticBlockingConfig(keys=["initialism"], alias_tables=[])
+    for mk in cfg.get_matchkeys():
+        if mk.type == "weighted":
+            mk.rerank = False  # avoid HF cross-encoder download in CI
+
+    on = gm.dedupe_df(df, config=cfg)
+
+    def cluster_of(rid):
+        return next(c for c, i in on.clusters.items() if rid in i["members"])
+
+    # IBM <-> International Business Machines despite title-casing upstream.
+    assert cluster_of(0) == cluster_of(1)
+    # Globex (no initialism link) is NOT swept in.
+    assert cluster_of(2) != cluster_of(0)
+
+
+def test_acronym_merges_through_standardize_extra_columns():
+    """The prompt's scenario shape (entity_type/context columns present), but
+    isolated to the initialism source so the extra equal-valued columns can't
+    carry the (0,1) merge on their own.
+    """
+    from goldenmatch.config.schemas import SemanticBlockingConfig
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    df = pl.DataFrame(
+        {
+            "name": [
+                "IBM",
+                "International Business Machines Corporation",
+                "Globex Pharmaceuticals",
+                "Globex Pharma",
+            ],
+            "entity_type": ["org", "org", "org", "org"],
+            "context": ["tech", "tech", "chem", "chem"],
+        }
+    )
+    cfg = auto_configure_df(df)
+    # Initialism source only, and drop the non-name columns from the weighted
+    # matchkey so the equal-valued entity_type/context can't mask the wall.
+    cfg.semantic_blocking = SemanticBlockingConfig(keys=["initialism"], alias_tables=[])
+    for mk in cfg.get_matchkeys():
+        if mk.type == "weighted":
+            mk.rerank = False
+            mk.fields = [f for f in mk.fields if f.field == "name"]
+
+    on = gm.dedupe_df(df, config=cfg)
+
+    def cluster_of(rid):
+        return next(c for c, i in on.clusters.items() if rid in i["members"])
+
+    assert cluster_of(0) == cluster_of(1)  # IBM <-> expansion despite title-casing
+
+
 def test_initialism_confirmed_merges_at_auto_threshold():
     # Name is the ONLY signal: string similarity scores
     # "International Business Machines" <-> "IBM" ~0.58, BELOW the zero-config

--- a/packages/python/goldenmatch/tests/test_semantic_blocking_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_semantic_blocking_pipeline.py
@@ -1,0 +1,52 @@
+"""Pipeline-level tests for ``semantic_blocking`` candidate-source union.
+
+Task 6 of the recall-lever plan: when ``config.semantic_blocking`` is set,
+THREE additional candidate sources (acronym/initialism, alias, ANN) are unioned
+onto the normal candidate set, scored by the same scoring the pipeline already
+uses, and fed through clustering. The change must be:
+
+- purely ADDITIVE (never drops an existing pair), and
+- BYTE-IDENTICAL when ``semantic_blocking`` is None (the default).
+"""
+
+import goldenmatch as gm
+import polars as pl
+
+
+# row ids == row order
+def _df():
+    return pl.DataFrame(
+        {
+            "name": [
+                "International Business Machines",
+                "IBM",
+                "Acme Inc",
+                "Acme Incorporated",
+                "Globex",
+            ]
+        }
+    )
+
+
+def test_off_is_default_and_changes_nothing():
+    base = gm.dedupe_df(_df(), fuzzy={"name": 0.6})
+    base2 = gm.dedupe_df(_df(), fuzzy={"name": 0.6}, semantic_blocking=False)
+    bp = {(min(a, b), max(a, b)) for a, b, _ in base.scored_pairs}
+    bp2 = {(min(a, b), max(a, b)) for a, b, _ in base2.scored_pairs}
+    assert bp == bp2
+
+
+def test_semantic_blocking_only_adds_candidates():
+    df = _df()
+    off = gm.dedupe_df(df, fuzzy={"name": 0.6})
+    on = gm.dedupe_df(df, fuzzy={"name": 0.6}, semantic_blocking=True)
+    off_pairs = {(min(a, b), max(a, b)) for a, b, _ in off.scored_pairs}
+    on_pairs = {(min(a, b), max(a, b)) for a, b, _ in on.scored_pairs}
+    assert off_pairs <= on_pairs  # purely additive
+
+    def cluster_of(rid):
+        return next(
+            cid for cid, info in on.clusters.items() if rid in info["members"]
+        )
+
+    assert cluster_of(0) == cluster_of(1)  # IBM <-> Intl Business Machines merged

--- a/packages/python/goldenmatch/tests/test_semantic_blocking_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_semantic_blocking_pipeline.py
@@ -50,3 +50,23 @@ def test_semantic_blocking_only_adds_candidates():
         )
 
     assert cluster_of(0) == cluster_of(1)  # IBM <-> Intl Business Machines merged
+
+
+def test_initialism_confirmed_merges_at_auto_threshold():
+    # Name is the ONLY signal: string similarity scores
+    # "International Business Machines" <-> "IBM" ~0.58, BELOW the zero-config
+    # ensemble@0.8 threshold. Only the confirming `initialism_match` scorer
+    # (=1.0) can carry the pair over. (Adding identical helper columns would
+    # let the normal fuzzy path merge it on its own and mask the no-op.)
+    df = pl.DataFrame(
+        {"name": ["International Business Machines", "IBM", "Globex"]}
+    )
+    on = gm.dedupe_df(df, semantic_blocking=True)  # zero-config -> auto picks ensemble@0.8
+
+    def cluster_of(rid):
+        return next(c for c, i in on.clusters.items() if rid in i["members"])
+
+    assert cluster_of(0) == cluster_of(1)  # confirmed by initialism_match=1.0, NOT string sim
+    # ...and Globex (no initialism/alias/string link) is NOT swept in. Guards
+    # against a source emitting raw sub-threshold scores that over-merge.
+    assert cluster_of(2) != cluster_of(0)

--- a/packages/python/goldenmatch/tests/test_semantic_scorers.py
+++ b/packages/python/goldenmatch/tests/test_semantic_scorers.py
@@ -1,0 +1,63 @@
+"""Tests for the two free deterministic equality scorers:
+
+- ``initialism_match`` — 1.0 if one string's initialism equals the other
+  string, or their initialisms are equal (empty-guarded).
+- ``alias_match`` — 1.0 if both canonicalize to the same (non-empty) business
+  alias OR the same given-name canonical.
+
+Both are equality-style (1.0/0.0) scorers, mirroring ``soundex_match``. The
+matrix-parity tests assert the block path (``_fuzzy_score_matrix``) agrees
+cell-for-cell with the pairwise ``score_field`` path.
+"""
+from __future__ import annotations
+
+import numpy as np
+from goldenmatch.core.scorer import _fuzzy_score_matrix, score_field
+
+
+def test_initialism_match():
+    assert score_field("IBM", "International Business Machines", "initialism_match") == 1.0
+    assert score_field("International Business Machines", "IBM", "initialism_match") == 1.0
+    # Initialism collision — the documented false-positive risk. Assert it holds.
+    assert score_field("IBM", "Indian Banana Market", "initialism_match") == 1.0
+    assert score_field("IBM", "Apple", "initialism_match") == 0.0
+    assert score_field("", "", "initialism_match") == 0.0
+    # Both single-token -> derive_initialism returns "" -> empty-guarded to 0.0.
+    assert score_field("Apple", "Apricot", "initialism_match") == 0.0
+
+
+def test_alias_match():
+    # Business alias seed table: "Acme Inc" and "Acme Incorporated" both
+    # canonicalize to "acme" (confirmed against the bundled data).
+    assert score_field("Acme Inc", "Acme Incorporated", "alias_match") == 1.0
+    # Given-name table: "Bob" and "Robert" both canonicalize to "robert".
+    assert score_field("Bob", "Robert", "alias_match") == 1.0
+    assert score_field("Acme", "Globex", "alias_match") == 0.0
+    assert score_field("", "", "alias_match") == 0.0
+
+
+def _pairwise_matrix(values: list[str], scorer: str) -> np.ndarray:
+    """Reference NxN matrix built straight from the pairwise score_field."""
+    n = len(values)
+    out = np.zeros((n, n), dtype=np.float64)
+    for i in range(n):
+        for j in range(n):
+            s = score_field(values[i], values[j], scorer)
+            out[i, j] = 0.0 if s is None else float(s)
+    return out
+
+
+def test_initialism_match_matrix_parity():
+    values = ["IBM", "International Business Machines", "Indian Banana Market", "Apple"]
+    matrix = _fuzzy_score_matrix(values, "initialism_match")
+    expected = _pairwise_matrix(values, "initialism_match")
+    assert matrix.shape == (len(values), len(values))
+    np.testing.assert_array_equal(matrix, expected)
+
+
+def test_alias_match_matrix_parity():
+    values = ["Acme Inc", "Acme Incorporated", "Bob", "Robert"]
+    matrix = _fuzzy_score_matrix(values, "alias_match")
+    expected = _pairwise_matrix(values, "alias_match")
+    assert matrix.shape == (len(values), len(values))
+    np.testing.assert_array_equal(matrix, expected)

--- a/packages/python/goldenmatch/tests/test_semantic_scorers.py
+++ b/packages/python/goldenmatch/tests/test_semantic_scorers.py
@@ -18,11 +18,21 @@ from goldenmatch.core.scorer import _fuzzy_score_matrix, score_field
 def test_initialism_match():
     assert score_field("IBM", "International Business Machines", "initialism_match") == 1.0
     assert score_field("International Business Machines", "IBM", "initialism_match") == 1.0
+    # Noise-tolerant: a NOISY real-world expansion (legal form + parenthetical)
+    # still derives "IBM", so the acronym ("IBM" also now derives "IBM") confirms.
+    assert (
+        score_field(
+            "IBM",
+            "International Business Machines Corporation (Armonk, NY)",
+            "initialism_match",
+        )
+        == 1.0
+    )
     # Initialism collision — the documented false-positive risk. Assert it holds.
     assert score_field("IBM", "Indian Banana Market", "initialism_match") == 1.0
     assert score_field("IBM", "Apple", "initialism_match") == 0.0
     assert score_field("", "", "initialism_match") == 0.0
-    # Both single-token -> derive_initialism returns "" -> empty-guarded to 0.0.
+    # Both single-token non-acronym -> derive_initialism returns "" -> 0.0.
     assert score_field("Apple", "Apricot", "initialism_match") == 0.0
 
 


### PR DESCRIPTION
Adds **opt-in semantic blocking** to goldenmatch: `dedupe_df(df, semantic_blocking=True)` unions three FREE deterministic candidate sources onto the normal candidate set, each confirmed by its own scorer. On ER-KG-Bench this moves the headline `auto+fields` F1 **0.602 -> 0.612** (abbreviation **+5.3pp F1 / +7.4pp recall**) at **zero precision cost**. Default OFF, byte-identical when off, no torch / no LLM / no faiss (numpy ANN fallback).

**Candidate sources (all $0, deterministic):**
- **char-ngram ANN** — the in-house `GoldenEmbedModel` as a candidate-gen pass (zero-config `get_embedder("inhouse")` default; numpy all-pairs fallback when faiss absent), gated by `ann_threshold`.
- **initialism** — acronym block (`IBM` <- `International Business Machines`), confirmed by a new `initialism_match` scorer (noise-tolerant + acronym-aware: strips legal-form/parenthetical noise, treats a short all-caps token as its own key).
- **refdata alias** — canonicalization on `given_names` + a new seed `business` alias table, confirmed by a new `alias_match` scorer.

**How it works:** each source is scored by its OWN confirming scorer (not the string ensemble that scored these ~0), emitted pre-scored into `all_pairs`, deduped additively (`dedup_pairs_max_score`) so it can never drop an existing pair. The semantic sources key off the **raw, pre-standardize** name (`__raw__<col>`, internal, stripped from output) so auto-config's title-casing doesn't erase the acronym signal — the change that actually unstuck the abbreviation class.

**Honest scope (documented in `RECALL-LEVER.md`):** synonym_brand stays walled (knowledge-base problem, not a scorer one); cross_lingual needs a semantic embedder (the documented `ann_model` opt-in upgrade), which the free char-ngram path can't generate. typo/org_suffix were already at F1 1.0.

**Surface:** new `SemanticBlockingConfig` + `dedupe_df(semantic_blocking=)`; two new scorers in `VALID_SCORERS`; `initialism` + `refdata_*_canonical` plugin transforms; bench row `goldenmatch(auto+fields+semantic)`. Touches only the semantic-blocking path — auto-config's general scorer selection is unchanged, so other benchmarks are unaffected.

Tests: scorer unit + matrix-parity, plugin-registration, ANN numpy-fallback parity, pipeline additive/byte-identical-off + IBM-merges-through-standardize. `test_scorer`/`test_api`/`test_pipeline` regression-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)