### PR TITLE
fix(core): remove ReDoS from initialism regex (CodeQL py/polynomial-redos)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/acronym.py
+++ b/packages/python/goldenmatch/goldenmatch/core/acronym.py
@@ -22,8 +22,12 @@ from goldenmatch.plugins.base import TransformPlugin
 _FIRST_ALPHA = re.compile(r"[A-Za-z]")
 # Any alphabetic character (used for the punctuation-only-token drop).
 _ANY_ALPHA = re.compile(r"[A-Za-z]")
-# A trailing/leading parenthetical group: "(Armonk, NY)", "(WHO)", etc.
-_PARENTHETICAL = re.compile(r"\s*\([^)]*\)")
+# A parenthetical group: "(Armonk, NY)", "(WHO)", etc. No leading ``\s*`` on
+# purpose: ``\s*\(`` backtracks polynomially (ReDoS, CodeQL py/polynomial-redos)
+# on long whitespace runs not followed by "(". Dropping it is behavior-identical
+# here because the subsequent ``.split()`` normalizes any leftover whitespace;
+# ``[^)]*`` is linear (no backtracking).
+_PARENTHETICAL = re.compile(r"\([^)]*\)")
 
 
 def _legal_form_variants() -> frozenset[str]:


### PR DESCRIPTION
Fix-forward for the 1 high-severity CodeQL alert (`py/polynomial-redos`, `acronym.py`) that shipped to main with the semantic-blocking feature (#1065 — the alert was non-required so the queue merged it).

`_PARENTHETICAL = re.compile(r"\s*\([^)]*\)")` — the leading `\s*` adjacent to the required `\(` backtracks polynomially on long whitespace runs not followed by `(`. Dropping it (`r"\([^)]*\)"`) is **behavior-identical** here: the subsequent `.split()` in `derive_initialism` normalizes any leftover whitespace, and `[^)]*` is linear. Tests `test_acronym.py` + `test_semantic_scorers.py` green (9 passed), incl. the noisy-mention case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)