### PR TITLE
release(goldenmatch): v2.2.0

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-19
+
+### Added
+- **Semantic blocking: an opt-in recall lever for abbreviations and aliases (#1065).**
+  New `SemanticBlockingConfig` plus a `dedupe_df(semantic_blocking=...)` flag union
+  extra candidate sources into the pipeline: an initialism/abbreviation blocking
+  transform, a business-alias canonical-form table, and an embedding ANN pass with a
+  numpy all-pairs fallback (faiss optional, `get_embedder("inhouse")` works zero-config).
+  Off by default. On the abbreviation-heavy benchmark it adds +5.3pp recall at zero
+  precision cost.
+- **`config_weaknesses`: a deterministic config-critique tool (#1064).**
+  New `core/config_critique.py::diagnose_config(df, config, result)` is a pure, offline
+  generator that explains in plain English where an auto-built matching config is risky:
+  a source/provenance column admitted as a matching signal, a per-row identifier admitted
+  as a key, oversized shared-value blocks, null-sink and low-signal matchkeys, and
+  over-merge mega-clusters. Each finding maps to one concrete fix (exclude_column, tighten
+  blocking, demote, raise_threshold) and findings are ranked high-to-low. No engine run
+  required; `phrasing="plain"` (default) and `"technical"` are both deterministic.
+
+### Security
+- **Removed a ReDoS in the initialism parenthetical regex (#1067).**
+  A leading `\s*` in the acronym parser backtracked polynomially on long whitespace runs
+  not followed by `(` (CodeQL py/polynomial-redos, high severity, introduced with the
+  semantic-blocking work in #1065). The fix drops the `\s*`; the subsequent `.split()`
+  normalizes any leftover whitespace, so it is behavior-identical and linear.
+
 ## [2.1.0] - 2026-06-18
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "2.1.0"
+version = "2.2.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release prep: goldenmatch v2.2.0

Bumps the version `2.1.0 → 2.2.0` across all four spots and adds the dated `## [2.2.0]` CHANGELOG section (which `publish-goldenmatch.yml` extracts as the GitHub Release notes).

### Version bumped in
- `pyproject.toml`
- `goldenmatch/__init__.py` (`__version__`)
- `server.json` (top-level + the pypi package entry)
- `CHANGELOG.md` (new dated section)

### What's in 2.2.0 (since v2.1.0)
- **feat: opt-in semantic blocking** — recall lever for abbreviations/aliases, +5.3pp at zero precision cost (#1065)
- **feat: `config_weaknesses`** — deterministic, offline config-critique tool (#1064)
- **security: ReDoS removed** from the initialism parenthetical regex (CodeQL py/polynomial-redos, high) (#1067)

### How the release gets cut (post-#1063 SOP)
This PR only stages the bump. After it merges to `main`, the release is cut by **pushing the `v2.2.0` tag** — `publish-goldenmatch.yml` then owns the GitHub Release end-to-end (build → PyPI → cosign sign + provenance → draft release with signed assets → publish/seal), and `publish-mcp.yml` syncs the MCP Registry + Smithery description. **Do not `gh release create`** (immutable-releases setting seals assets at publish; the workflow uploads them while the release is still a draft).

I'll push the tag once this is on `main` (confirming with you first, since it triggers the production PyPI publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkcJhg84jhMuPBGEsTgY6y

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkcJhg84jhMuPBGEsTgY6y)_