### PR TITLE
ci(publish-goldenmatch): make workflow_dispatch self-sufficient (create tag on publish)

### DIFF
--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -14,8 +14,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to build + release (e.g. v2.1.0)"
+        description: "Release tag to build + publish (e.g. v2.2.0). Created at `ref` if it does not exist yet."
         required: true
+      ref:
+        description: "Branch/commit to build from when the tag does not exist yet (default: this branch). The release is still named from `tag`."
+        required: false
+        default: ""
 
 permissions:
   id-token: write       # PyPI OIDC + cosign keyless signing
@@ -36,7 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          # On dispatch, build from `ref` (default: the dispatched branch) so a
+          # not-yet-created tag still works; the release step creates the tag at
+          # this commit when it publishes. On a tag push, build from the tag.
+          ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.ref || github.ref) || github.ref }}
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
@@ -103,6 +110,7 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v2
         with:
           tag_name: ${{ env.TAG }}
+          target_commitish: ${{ inputs.ref || github.sha }}
           name: goldenmatch ${{ env.TAG }}
           body_path: ${{ env.NOTES_FILE }}
           draft: true


### PR DESCRIPTION
## Why

Cutting v2.2.0 needs the `v2.2.0` tag created, but the remote sandbox **cannot push git tags** (the git proxy 403s tag refs), and a tag pushed by `GITHUB_TOKEN` wouldn't chain-trigger the `push: tags` path anyway. The existing `workflow_dispatch` checked out `inputs.tag`, which fails when the tag doesn't exist yet — so there was no token-only path to cut a release.

## What

Make `workflow_dispatch` self-sufficient so a single dispatch can build **and** create the tag:

- **New optional `ref` input** (default: the dispatched branch). On dispatch, checkout builds from `ref || github.ref` instead of the (possibly missing) tag.
- **Pin `target_commitish`** on the release step to `inputs.ref || github.sha`, so the tag the release step creates lands on the built commit.

`softprops/action-gh-release` creates the git tag when the **draft release is published** (the final `gh release edit --draft=false`), so one dispatch now does: build → PyPI → cosign sign + attest → draft release with signed assets → publish (which creates + seals `vX.Y.Z`).

**The `push: tags: v*` path is unchanged** — pushing a tag still cuts a release exactly as before. This only makes the manual dispatch work without a pre-existing tag.

## Plan

Once this merges, I'll dispatch `publish-goldenmatch.yml` with `tag=v2.2.0` (ref defaults to `main`) to ship goldenmatch 2.2.0 (version + CHANGELOG already on `main` from #1070).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkcJhg84jhMuPBGEsTgY6y

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkcJhg84jhMuPBGEsTgY6y)_