### PR TITLE
fix(core): register semantic-blocking transforms at point of use (fixes shard-3 queue flake)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -999,6 +999,24 @@ def _semantic_blocking_pairs(
         logger.warning("semantic_blocking: no usable name column found; skipping")
         return []
 
+    # Register the semantic-blocking transforms at the POINT OF USE. `initialism`
+    # (core.acronym) and the alias `refdata_*` transforms are registered only as an
+    # import side-effect of their modules; the normal dedupe_df flow imports neither,
+    # so without this a fresh process / xdist worker hits "Unknown transform" and the
+    # source either silently fail-opens (no merge) or errors on lazy collect. Register
+    # here so semantic_blocking is order-independent. acronym's register is idempotent
+    # and core (always available); the refdata import (alias only) is guarded.
+    from goldenmatch.core.acronym import register_transforms as _register_initialism
+
+    _register_initialism()
+    if "alias" in sb.keys:
+        try:
+            import goldenmatch.refdata  # noqa: F401  registers the refdata_* alias transforms
+        except Exception:
+            logger.debug(
+                "semantic_blocking: refdata pack unavailable; alias source will be skipped",
+            )
+
     # The initialism/alias sources must key + score off the RAW (pre-standardize)
     # name so an all-caps acronym ("IBM") survives the `name_proper` title-casing
     # (which would otherwise leave "Ibm", killing `derive_initialism`'s

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1011,7 +1011,12 @@ def _semantic_blocking_pairs(
     _register_initialism()
     if "alias" in sb.keys:
         try:
-            import goldenmatch.refdata  # noqa: F401  registers the refdata_* alias transforms
+            # Side-effect import (registers the refdata_* alias transforms). Use
+            # importlib so neither ruff (F401) nor pyright (reportUnusedImport) flags
+            # an "unused" import -- the value is intentionally discarded.
+            import importlib
+
+            importlib.import_module("goldenmatch.refdata")
         except Exception:
             logger.debug(
                 "semantic_blocking: refdata pack unavailable; alias source will be skipped",

--- a/packages/python/goldenmatch/tests/test_semantic_blocking_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_semantic_blocking_pipeline.py
@@ -147,3 +147,44 @@ def test_initialism_confirmed_merges_at_auto_threshold():
     # ...and Globex (no initialism/alias/string link) is NOT swept in. Guards
     # against a source emitting raw sub-threshold scores that over-merge.
     assert cluster_of(2) != cluster_of(0)
+
+
+def test_semantic_blocking_registers_initialism_at_point_of_use():
+    """Regression: the initialism source must register its transform at the POINT
+    OF USE. ``initialism`` is registered only as an import side-effect of
+    ``core.acronym``, which the normal ``dedupe_df`` flow never imports -- so on a
+    fresh process / xdist worker that has not imported it, the source raises
+    ``ValueError: Unknown transform: 'initialism'``, fail-opens, and the merge
+    silently never happens (a no-op for users; the cause of the shard-3 xdist
+    flake). Simulate that worker by removing ``initialism`` from the registry
+    before the run, then assert the pipeline re-registers it and the merge fires.
+    """
+    from goldenmatch.config.schemas import SemanticBlockingConfig
+    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    reg = PluginRegistry.instance()
+    saved = reg.get_transform("initialism")
+    reg._transforms.pop("initialism", None)
+    try:
+        assert not reg.has_transform("initialism")  # precondition: unregistered worker
+
+        df = _df()  # row 0 "International Business Machines", row 1 "IBM"
+        cfg = auto_configure_df(df)
+        # Initialism source only (no ann/alias) so the merge can ONLY come from
+        # the initialism transform that the cleared registry is missing.
+        cfg.semantic_blocking = SemanticBlockingConfig(keys=["initialism"], alias_tables=[])
+        for mk in cfg.get_matchkeys():
+            if mk.type == "weighted":
+                mk.rerank = False  # avoid HF cross-encoder download in CI
+
+        on = gm.dedupe_df(df, config=cfg)
+
+        def cluster_of(rid):
+            return next(c for c, i in on.clusters.items() if rid in i["members"])
+
+        assert cluster_of(0) == cluster_of(1)  # IBM <-> expansion, despite cleared registry
+        assert reg.has_transform("initialism")  # pipeline re-registered at point of use
+    finally:
+        if saved is not None and not reg.has_transform("initialism"):
+            reg.register_transform("initialism", saved)


### PR DESCRIPTION
**Fixes the flaky `test_semantic_blocking_pipeline.py` shard-3 failures that were poisoning the merge queue** (every PR's `force_all` run had a chance of being kicked by it).

**Root cause** (confirmed from a kicked run's CI log, not hypothesized): the semantic-blocking sources key + score off the `initialism` transform (`core.acronym`) and the alias `refdata_*` transforms, which are registered **only as an import side-effect** of their modules. The normal `dedupe_df` flow imports neither — so on a fresh process, or a `pytest -n auto` worker that didn't happen to import `core.acronym` first, the source raises `ValueError: Unknown transform: 'initialism'`. In the default config it's swallowed by a fail-open `try/except` (silent no-op — the merge never happens); in others it propagates on lazy `collect` and crashes the dedupe. The deterministic acronym merge dropping out by worker assignment is exactly the shard-3 flake.

This is also a **real user-facing bug**, not just a test issue: anyone calling `dedupe_df(..., semantic_blocking=True)` after only `import goldenmatch` hits the same silent no-op.

**Fix:** register the transforms at the **point of use** in `_semantic_blocking_pairs` — idempotent `acronym.register_transforms()` for the core `initialism`, and a guarded `import goldenmatch.refdata` for the alias `refdata_*` transforms (only when `'alias'` is requested). Order-independent. Isolated to the semantic-blocking path; non-semantic-blocking dedupe is untouched.

**Test:** new regression test clears `initialism` from the registry to simulate the unregistered worker, then asserts `dedupe_df(semantic_blocking)` still merges + re-registers. Red before (Unknown transform), green after. The 4 formerly-flaky tests now pass deterministically (6/6 in the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)