### PR TITLE
docs: document lsh blocking strategy (#1081)

### DIFF
--- a/docs-site/goldenmatch/blocking.mdx
+++ b/docs-site/goldenmatch/blocking.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Blocking Strategies"
-description: "Reduce the O(N²) comparison space with GoldenMatch's 8 blocking strategies: static, adaptive, sorted neighborhood, multi-pass, ANN hybrid, ANN, canopy, and learned."
-keywords: ["blocking", "entity resolution", "deduplication", "ann", "adaptive", "multi-pass", "learned blocking", "sorted neighborhood"]
+description: "Reduce the O(N²) comparison space with GoldenMatch's 9 blocking strategies: static, adaptive, sorted neighborhood, multi-pass, ANN hybrid, ANN, canopy, learned, and MinHash/LSH."
+keywords: ["blocking", "entity resolution", "deduplication", "ann", "adaptive", "multi-pass", "learned blocking", "sorted neighborhood", "minhash", "lsh", "near-duplicate"]
 ---
 
-Blocking reduces the comparison space from O(N^2) to O(N*B) by grouping records that share a key. GoldenMatch supports 8 strategies.
+Blocking reduces the comparison space from O(N^2) to O(N*B) by grouping records that share a key. GoldenMatch supports 9 strategies.
 
 ## Strategy overview
 
@@ -18,6 +18,7 @@ Blocking reduces the comparison space from O(N^2) to O(N*B) by grouping records 
 | `ann_pairs` | Direct-pair ANN scoring | 50--100x faster than `ann` |
 | `canopy` | TF-IDF canopy clustering | Text-heavy data |
 | `learned` | Data-driven predicate selection | Auto-discovers rules |
+| `lsh` | MinHash/LSH sketching on a text column | Near-duplicate text / corpus dedup |
 
 ## Static blocking
 
@@ -161,6 +162,35 @@ blocks = gm.apply_learned_blocks(df, rules)
 ```
 
 Cache the learned rules to skip re-training on subsequent runs.
+
+## MinHash/LSH blocking
+
+*New in #1081.* Probabilistic sketching for near-duplicate text. Each record's
+text column is shingled (char- or word-grams), MinHashed into a signature, and
+the signature is split into LSH bands; records that share at least one band
+bucket become candidates. This is the set-similarity (Jaccard) path — the right
+tool for document/corpus-scale near-duplicate detection, where the other
+strategies (keyed predicates, embeddings) are a poor fit.
+
+```yaml
+blocking:
+  strategy: lsh
+  lsh:
+    column: description   # the text column to shingle
+    mode: word            # word- or char-grams
+    k: 2                  # shingle size
+    num_perms: 128        # MinHash signature length
+    threshold: 0.5        # similarity threshold; picks the band/row split via
+                          # optimal_bands. Or set num_bands explicitly (must
+                          # divide num_perms).
+```
+
+A lower `threshold` yields more bands (higher recall, more candidate pairs); a
+higher one yields fewer (more precision, fewer pairs). Empty / whitespace-only
+text rows have nothing to sketch and are skipped. The underlying kernel
+(`goldenmatch.core.sketch`) is shared byte-for-byte across Python, the optional
+native extension, and the TypeScript port. Recall is measured by an always-on
+synthetic gate plus a Quora Question Pairs benchmark (`bench-lsh-recall.yml`).
 
 ## Auto-select
 

--- a/docs-site/goldenmatch/blocking.mdx
+++ b/docs-site/goldenmatch/blocking.mdx
@@ -169,8 +169,8 @@ Cache the learned rules to skip re-training on subsequent runs.
 text column is shingled (char- or word-grams), MinHashed into a signature, and
 the signature is split into LSH bands; records that share at least one band
 bucket become candidates. This is the set-similarity (Jaccard) path — the right
-tool for document/corpus-scale near-duplicate detection, where the other
-strategies (keyed predicates, embeddings) are a poor fit.
+tool for document/corpus-scale near-duplicate detection, where keyed-predicate
+strategies (static/multi-pass) are a poor fit.
 
 ```yaml
 blocking:
@@ -186,9 +186,21 @@ blocking:
 ```
 
 A lower `threshold` yields more bands (higher recall, more candidate pairs); a
-higher one yields fewer (more precision, fewer pairs). Empty / whitespace-only
-text rows have nothing to sketch and are skipped. The underlying kernel
-(`goldenmatch.core.sketch`) is shared byte-for-byte across Python, the optional
+higher one yields fewer (more precision, fewer pairs).
+
+<Note>
+  **LSH measures *lexical* overlap, not *semantic* similarity.** It excels at
+  near-duplicates that share words/characters (boilerplate, reposts, lightly
+  edited copies). It does **not** catch paraphrases that mean the same thing in
+  different words — on the Quora Question Pairs benchmark (semantic duplicates)
+  it recovers only ~21% of labeled pairs at `threshold: 0.5`, versus ~98% on a
+  lexical-near-duplicate set. For semantic matching, use the `ann` strategy
+  (embedding nearest-neighbor).
+</Note>
+
+Empty / whitespace-only text rows have nothing to sketch and are skipped. The
+underlying kernel (`goldenmatch.core.sketch`) is shared byte-for-byte across
+Python, the optional
 native extension, and the TypeScript port. Recall is measured by an always-on
 synthetic gate plus a Quora Question Pairs benchmark (`bench-lsh-recall.yml`).
 


### PR DESCRIPTION
Doc-only follow-up to the #1081 MinHash/LSH rollout (PR #1116).

The canonical **Blocking Strategies** page (`docs-site/goldenmatch/blocking.mdx`) still advertised "8 strategies" and didn't mention MinHash/LSH. This adds:
- the `lsh` row to the strategy-overview table,
- a **MinHash/LSH blocking** section (YAML example + threshold/recall notes),
- the 8 → 9 count bump in the frontmatter description, intro line, and keywords.

Validated locally: `docs.json` parses, README callout-sync `--check` clean, `mint validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)