### PR TITLE
feat: auto-enable lexical near-dup blocking for text corpora (#1082, Phase A)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-text-near-dup-blocking-path.md
+++ b/docs/superpowers/plans/2026-06-19-text-near-dup-blocking-path.md
@@ -149,7 +149,7 @@ if _is_text_corpus(profiles):
 
 (Delete the `_ann_eligible` / `ann_min_rows` auto-selection — ANN is no longer auto-picked for description columns; explicit `strategy="ann"` still works. Keep `_embedding_cols` only if used elsewhere; otherwise remove dead code.)
 
-- [ ] **Step 4: run, verify pass.** Also run `tests/test_autoconfig.py -q` to confirm no regression in existing classification/blocking tests.
+- [ ] **Step 4: run, verify pass.** Also run `tests/test_autoconfig.py -q` and `tests/test_autoconfig_regressions.py -q`. **Expected behavior change:** if any existing test asserts `strategy=="ann"` is *auto-selected* for a description-only / large-text df, UPDATE that assertion (to `lsh`, or `simhash` under an embedder) — dropping ANN auto-selection is the intended change per the spec, not a regression to "fix back". A genuine regression is the exact/name/structured paths changing; those must stay identical.
 - [ ] **Step 5: commit** `feat(autoconfig): route text corpora to lsh blocking (#1082)`.
 
 ## Task A3: controller guard — don't swap a near-dup strategy
@@ -169,10 +169,15 @@ def test_blocking_rules_skip_lsh_strategy():
     ctx, profile = _profile(candidates_compared=10, mass_above_threshold=0.0)
     for rule in (R.rule_blocking_key_swap, R.rule_blocking_singleton_trap,
                  R.rule_uniform_heavy_blocking):
-        assert rule(cfg, profile, ctx) is None  # guarded, no swap
+        assert rule(profile, cfg, history) is None  # guarded, no swap
 ```
 
-(Adapt `_config_with_blocking`/`_profile` to the real rule signature — read `autoconfig_rules.py` for the exact `(config, profile, ctx)` shape and `ComplexityProfile` fields.)
+(Adapt `_config_with_blocking`/`_profile` to the real rule signature — **read
+`autoconfig_rules.py` for the exact shape**: it is `(profile, current, history,
+ctx=None)`, NOT `(config, profile, ctx)`. Note `rule_cross_blocking_disagreement`
+also early-returns `None` when `ctx is None` for a separate reason, so to prove
+the *guard* specifically, either pass a non-None `ctx` or just assert the
+end-state "strategy survives" rather than per-rule `None`.)
 
 - [ ] **Step 2: run, verify fail** (rules currently return a swap proposal).
 - [ ] **Step 3: implement.** Add the shared helper and guard every blocking-strategy/key rule:

--- a/docs/superpowers/plans/2026-06-19-text-near-dup-blocking-path.md
+++ b/docs/superpowers/plans/2026-06-19-text-near-dup-blocking-path.md
@@ -1,0 +1,343 @@
+# Document/text near-dup blocking path Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `dedupe_df(text_corpus)` auto-block on near-dup shingles/LSH with no manual config (lexical, the done bar), and add a new pyo3-free SimHash kernel over embeddings as a semantic `strategy="simhash"` escalation.
+
+**Architecture:** Phase A (Python only) adds a text-corpus detector + routing to `build_blocking` that emits `strategy="lsh"` (reusing the shipped #1081 kernel), and guards the controller's blocking-refit rules from swapping it. Phase B adds a SimHash (Rademacher ±1 hyperplane) kernel to `sketch-core` — byte-identical across Rust/Python/TS via golden vectors — exposed as `strategy="simhash"` + `SimHashLSHBlocker`, auto-selected when an embedder is reachable.
+
+**Tech Stack:** Python (polars autoconfig + pytest), Rust (`sketch-core` pyo3-free + `native` pyo3, `rayon`), TypeScript (pure-TS), GitHub Actions bench.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-text-near-dup-blocking-path-design.md` — read it first. The SimHash parity contract ("Phase B — Kernel") is normative; code below matches it.
+
+**Golden constants** (precomputed from the verified reference; tests assert these exact values). `base_hash`/`splitmix64` are the #1081 kernel (already shipped, reused).
+
+- `V = [0.5, -0.3, 0.8, 0.1, -0.9, 0.4, -0.2, 0.7]` (a fixed dim-8 input vector).
+- `simhash_signature(V, num_planes=8, seed=42)` = `[1, 1, 1, 1, 1, 0, 1, 1]`
+- `simhash_band_hashes(that_sig, num_bands=4)` = `[8326405673782927272, 10087387020540333614, 407431194778926956, 13491348438230804516]`
+- `simhash_signature(V, num_planes=16, seed=7)` = `[1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1]`
+- `simhash_signature([0.0]*8, 8, 42)` = `[1]*8` (zero vector → all-ones; `dot==0` tie → 1).
+
+**Measured recall gate config** (semantic SimHash): `num_planes=256, num_bands=32` (r=8) → recall **1.000** / candidate-reduction **0.86** on Gaussian variants at cosine ≥ 0.89. `num_bands=64` (r=4) collapses reduction to ~0.03 — do not use.
+
+---
+
+## Environment notes (read once)
+
+- **Worktree:** `.worktrees/1082-text-near-dup` (branch `feat/1082-text-near-dup-path`, off fresh `origin/main` which has #1081). `docs/superpowers/**` is gitignored — `git add -f`.
+- **Python tests:** `cd packages/python/goldenmatch`; prefix `PYTHONPATH=<worktree pkg> POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 GOLDENMATCH_NATIVE=0 python -m pytest tests/test_<file>.py -q`. Target specific files (full collection is slow). Never run the whole suite locally (OOM).
+- **Rust:** `CG="C:/Users/bsevern/.cargo/bin/cargo.exe"`; set `CARGO_HOME=C:/Users/bsevern/.cargo RUSTUP_HOME=C:/Users/bsevern/.rustup RUSTUP_TOOLCHAIN=1.94.1`. Test the crate: `$CG test --manifest-path packages/rust/extensions/sketch-core/Cargo.toml`. Clippy: `$CG clippy --manifest-path .../Cargo.toml --all-targets -- -D warnings`. fmt only touches files you changed.
+- **native crate:** `cargo check --no-default-features` (set `PYO3_PYTHON=<venv python>`) to verify the shim compiles; the full wheel + parity test run in CI's `native` lane. After `cargo fmt` on native, REVERT any reformatting of files you didn't edit (CI doesn't fmt-check the `native` crate).
+- **TS:** do NOT run `tsc`/vitest locally (OOM) — CI gates it. Author against `src/core/` patterns; edge-safe (no `node:` imports).
+- **Native gate:** `simhash` is NOT added to `_GATED_ON` (same as `sketch`); reachable via `GOLDENMATCH_NATIVE=1`.
+- **Commit cadence:** one commit per task. Two PRs: **Phase A** (lexical auto-enable — the done bar, shippable on its own) then **Phase B** (SimHash). Arm `gh pr merge --auto --squash` on green; stop.
+
+---
+
+## File Structure
+
+**Phase A — new:** `tests/test_text_corpus_autoconfig.py`.
+**Phase A — modified:** `core/autoconfig.py` (detector + routing), `core/autoconfig_rules.py` (controller guard).
+
+**Phase B — new:** `packages/rust/extensions/sketch-core/src/simhash.rs`; `core/simhash_blocker.py`; `scripts/gen_simhash_golden.py`; `tests/fixtures/sketch_simhash_golden.json`; `tests/test_simhash_reference.py`, `tests/test_native_simhash_parity.py`, `tests/test_simhash_blocker.py`, `tests/test_simhash_recall.py`; `packages/typescript/goldenmatch/src/core/simhash.ts`, `tests/unit/simhash.test.ts`.
+**Phase B — modified:** `sketch-core/src/lib.rs`, `native/src/sketch.rs`, `native/src/lib.rs`; `core/sketch.py` (+ SimHash reference); `config/schemas.py` (`SimHashKeyConfig`); `core/blocker.py` (dispatch); `core/autoconfig.py` (semantic routing); `scripts/bench_lsh_recall_qqp.py` (`--method`).
+
+---
+
+# PHASE A — lexical auto-enable (the done bar; shippable PR on its own)
+
+## Task A1: `_is_text_corpus` detector
+
+**Files:** Modify `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`; Test `packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py`.
+
+- [ ] **Step 1: failing test.** Build `ColumnProfile` lists by hand and assert detection:
+
+```python
+from goldenmatch.core.autoconfig import ColumnProfile, _is_text_corpus
+
+def _p(name, col_type, card=0.9, avg_len=120.0):
+    return ColumnProfile(name=name, dtype="str", col_type=col_type, confidence=0.9,
+                         null_rate=0.0, cardinality_ratio=card, avg_len=avg_len)
+
+def test_single_text_column_is_corpus():
+    assert _is_text_corpus([_p("body", "description")]) is True
+
+def test_structured_with_name_is_not_corpus():
+    assert _is_text_corpus([_p("name", "name", card=0.8, avg_len=12.0),
+                            _p("bio", "description")]) is False
+
+def test_low_card_name_does_not_block_corpus():
+    # a low-cardinality (<0.1) name-classified column is not "blockable" -> still a corpus
+    assert _is_text_corpus([_p("category", "name", card=0.02, avg_len=8.0),
+                            _p("body", "description")]) is True
+
+def test_no_description_is_not_corpus():
+    assert _is_text_corpus([_p("name", "name", card=0.8, avg_len=12.0)]) is False
+```
+
+- [ ] **Step 2: run, verify fail.**
+- [ ] **Step 3: implement** in autoconfig.py:
+
+```python
+def _is_text_corpus(profiles: list[ColumnProfile]) -> bool:
+    """True when the data is a text corpus: a description column dominates and
+    there is no blockable name column (the text is the primary identity)."""
+    has_description = any(p.col_type == "description" for p in profiles)
+    if not has_description:
+        return False
+    has_blockable_name = any(
+        p.col_type in ("name", "multi_name") and p.cardinality_ratio >= 0.1
+        for p in profiles
+    )
+    return not has_blockable_name
+```
+
+- [ ] **Step 4: run, verify pass.** **Step 5: commit** `feat(autoconfig): _is_text_corpus detector (#1082)`.
+
+## Task A2: route text corpora to `strategy="lsh"`
+
+**Files:** Modify `core/autoconfig.py` (the `build_blocking` `_ann_eligible` block ~2224–2236, and add helpers); extend `test_text_corpus_autoconfig.py`.
+
+- [ ] **Step 1: failing test** — a text-corpus df gets `strategy="lsh"` on the longest description column:
+
+```python
+import polars as pl
+from goldenmatch.core.autoconfig import profile_columns, build_blocking
+
+def test_build_blocking_text_corpus_emits_lsh():
+    df = pl.DataFrame({"body": [
+        "the quick brown fox jumps over the lazy dog near the river bank today",
+        "the quick brown fox jumps over the lazy dog beside the river bank today",
+        "completely unrelated sentence about astrophysics and quantum mechanics here",
+    ] * 20})
+    profiles = profile_columns(df)
+    cfg = build_blocking(profiles, df)
+    assert cfg.strategy == "lsh"
+    assert cfg.lsh is not None and cfg.lsh.column == "body"
+    assert cfg.lsh.mode == "word" and cfg.lsh.num_perms == 128
+```
+
+- [ ] **Step 2: run, verify fail** (currently emits `ann`/name fallback).
+- [ ] **Step 3: implement.** Add helpers + replace the `_ann_eligible` return block:
+
+```python
+def _embedder_available(config=None) -> bool:
+    from goldenmatch.core.embedder import inhouse_embedding_available
+    if inhouse_embedding_available():
+        return True
+    # a configured embedding provider on the resolved config also counts
+    return bool(getattr(getattr(config, "embedding", None), "provider", None))
+
+def _auto_build_lsh_config(profiles: list[ColumnProfile]) -> "BlockingConfig":
+    from goldenmatch.config.schemas import BlockingConfig, LSHKeyConfig
+    descs = [p for p in profiles if p.col_type == "description"]
+    col = max(descs, key=lambda p: p.avg_len).name
+    return BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(
+        column=col, mode="word", k=2, num_perms=128, threshold=0.5, seed=0))
+
+def _text_corpus_blocking(profiles, df, config=None) -> "BlockingConfig":
+    # Phase B fills in the semantic branch; Phase A is lexical only.
+    return _auto_build_lsh_config(profiles)
+```
+
+Then, where the `_ann_eligible` block currently returns `BlockingConfig(strategy="ann", ...)`, replace it with:
+
+```python
+if _is_text_corpus(profiles):
+    return _text_corpus_blocking(profiles, df)
+```
+
+(Delete the `_ann_eligible` / `ann_min_rows` auto-selection — ANN is no longer auto-picked for description columns; explicit `strategy="ann"` still works. Keep `_embedding_cols` only if used elsewhere; otherwise remove dead code.)
+
+- [ ] **Step 4: run, verify pass.** Also run `tests/test_autoconfig.py -q` to confirm no regression in existing classification/blocking tests.
+- [ ] **Step 5: commit** `feat(autoconfig): route text corpora to lsh blocking (#1082)`.
+
+## Task A3: controller guard — don't swap a near-dup strategy
+
+**Files:** Modify `core/autoconfig_rules.py`; Test `tests/test_text_corpus_autoconfig.py`.
+
+- [ ] **Step 1: failing test** — drive the controller on a text-corpus shape; the committed `lsh` strategy must survive (point the profile at the singleton-trap + key-swap shapes). Use the existing controller test harness pattern (see `tests/test_autoconfig_regressions.py` for how `AutoConfigController` is driven). Minimal version:
+
+```python
+from goldenmatch.config.schemas import BlockingConfig, LSHKeyConfig
+from goldenmatch.core import autoconfig_rules as R
+
+def test_blocking_rules_skip_lsh_strategy():
+    cfg = _config_with_blocking(BlockingConfig(strategy="lsh",
+        lsh=LSHKeyConfig(column="body", threshold=0.5)))
+    # a profile that would normally trip key-swap (compared, nothing matched)
+    ctx, profile = _profile(candidates_compared=10, mass_above_threshold=0.0)
+    for rule in (R.rule_blocking_key_swap, R.rule_blocking_singleton_trap,
+                 R.rule_uniform_heavy_blocking):
+        assert rule(cfg, profile, ctx) is None  # guarded, no swap
+```
+
+(Adapt `_config_with_blocking`/`_profile` to the real rule signature — read `autoconfig_rules.py` for the exact `(config, profile, ctx)` shape and `ComplexityProfile` fields.)
+
+- [ ] **Step 2: run, verify fail** (rules currently return a swap proposal).
+- [ ] **Step 3: implement.** Add the shared helper and guard every blocking-strategy/key rule:
+
+```python
+def _near_dup_locked(config) -> bool:
+    b = getattr(config, "blocking", None)
+    return b is not None and b.strategy in ("lsh", "simhash")
+```
+
+Add `if _near_dup_locked(current): return None` as the FIRST line of each of these nine rules: `rule_blocking_singleton_trap`, `rule_blocking_too_coarse`, `rule_blocking_key_swap`, `rule_uniform_heavy_blocking`, `rule_blocking_field_null_heavy`, `rule_low_reduction_ratio`, `rule_recall_gap_suspected`, `rule_cross_blocking_disagreement`, `rule_blocking_adaptive_on_p99_outlier`. (Do NOT guard threshold/matchkey rules.)
+
+- [ ] **Step 4: run, verify pass.** **Step 5: commit** `fix(autoconfig): controller must not swap lsh/simhash blocking (#1082)`.
+
+## Task A4: end-to-end zero-config text dedupe
+
+**Files:** Test `tests/test_text_corpus_autoconfig.py`.
+
+- [ ] **Step 1: failing test** — `dedupe_df` on a tiny text corpus (near-dup pairs + distinct) clusters the near-dups together without any config. Build a ~30-row corpus (some near-dup paraphrase-free lexical variants), call `dedupe_df(df)`, assert the known near-dup rows land in the same cluster and distinct rows don't. Follow `tests/test_autoconfig_regressions.py` patterns (set `rerank=False`, `confidence_required=False` if needed for the offline/borderline path).
+- [ ] **Step 2–4: run → implement nothing new (exercises A1–A3) → pass.** If it fails because clustering/scoring needs tuning, adjust the corpus, not the pipeline.
+- [ ] **Step 5: commit** `test(autoconfig): zero-config text-corpus dedupe e2e (#1082)`.
+
+**→ PHASE A is a shippable milestone. Open PR "feat: auto-enable lexical near-dup blocking for text corpora (#1082)", land it, then continue to Phase B.**
+
+---
+
+# PHASE B — semantic SimHash
+
+## Task B1: Rust `simhash.rs` kernel
+
+**Files:** Create `packages/rust/extensions/sketch-core/src/simhash.rs`; modify `src/lib.rs`.
+
+- [ ] **Step 1: implement** `simhash.rs` (reuse `crate::hash::{base_hash, splitmix64}`):
+
+```rust
+//! SimHash (random ±1 hyperplane) LSH over f64 vectors. Mirrors the Python
+//! reference (core/sketch.py) and TS port byte-for-byte; see the #1082 spec.
+use crate::hash::{base_hash, splitmix64};
+
+/// LSB-first ±1 draw from a splitmix64 stream, refilling 64 bits at a time.
+struct BitStream { state: u64, buf: u64, left: u32 }
+impl BitStream {
+    fn new(seed: u64) -> Self { Self { state: seed, buf: 0, left: 0 } }
+    #[inline]
+    fn draw_pm1(&mut self) -> f64 {
+        if self.left == 0 { let (v, s) = splitmix64(self.state); self.buf = v; self.state = s; self.left = 64; }
+        let bit = self.buf & 1; self.buf >>= 1; self.left -= 1;
+        if bit == 1 { 1.0 } else { -1.0 }
+    }
+}
+
+/// Projection matrix (num_planes x dim), Rademacher ±1, row-major from the stream.
+fn projection_matrix(num_planes: usize, dim: usize, seed: u64) -> Vec<Vec<f64>> {
+    let mut bs = BitStream::new(seed);
+    (0..num_planes).map(|_| (0..dim).map(|_| bs.draw_pm1()).collect()).collect()
+}
+
+/// SimHash signature: one byte (0/1) per plane. Empty/zero vector -> all ones.
+pub fn simhash_signature(vector: &[f64], num_planes: usize, seed: u64) -> Vec<u8> {
+    let planes = projection_matrix(num_planes, vector.len(), seed);
+    planes.iter().map(|row| {
+        let mut dot = 0.0_f64;
+        for j in 0..vector.len() { dot += row[j] * vector[j]; }
+        if dot >= 0.0 { 1u8 } else { 0u8 }
+    }).collect()
+}
+
+/// Banded LSH over the 0/1 signature bytes. num_planes must be divisible by num_bands.
+pub fn simhash_band_hashes(sig: &[u8], num_bands: usize) -> Vec<u64> {
+    let n = sig.len();
+    assert!(num_bands > 0 && n.is_multiple_of(num_bands),
+        "num_planes {n} not divisible by num_bands {num_bands}");
+    let r = n / num_bands;
+    (0..num_bands).map(|b| {
+        let mut buf = Vec::with_capacity(8 + r);
+        buf.extend_from_slice(&(b as u64).to_le_bytes());
+        buf.extend_from_slice(&sig[b * r..(b + 1) * r]);
+        base_hash(&buf)
+    }).collect()
+}
+```
+
+`#[cfg(test)]`: assert the golden constants (sig for `V` at planes=8 seed=42 == `[1,1,1,1,1,0,1,1]`; band hashes == the 4 values; zero vector → all ones; non-divisible panics). Add a `simhash_band_hashes_batch(vectors: &[Vec<f64>], num_planes, num_bands, seed)` that builds the matrix ONCE and projects all rows (rayon-guarded like the MinHash batch). `lib.rs`: `pub mod simhash; pub use simhash::*;`.
+
+- [ ] **Step 2:** `$CG test --manifest-path packages/rust/extensions/sketch-core/Cargo.toml simhash` → PASS; `$CG clippy ... --all-targets -- -D warnings`; `$CG fmt`.
+- [ ] **Step 3: commit** `feat(sketch-core): SimHash kernel (#1082)`.
+
+## Task B2: Python SimHash reference + golden fixture
+
+**Files:** Modify `core/sketch.py`; create `scripts/gen_simhash_golden.py`, `tests/fixtures/sketch_simhash_golden.json`, `tests/test_simhash_reference.py`.
+
+- [ ] **Step 1: failing test** (`test_simhash_reference.py`) asserting the golden constants via `sketch.simhash_signature` / `sketch.simhash_band_hashes`.
+- [ ] **Step 2: run, verify fail.** **Step 3: implement** in `sketch.py` (mirror the Rust exactly: `_SimBitStream`, `simhash_signature(vector, num_planes, seed)`, `simhash_band_hashes(sig, num_bands)`, `simhash_band_hashes_batch(vectors, num_planes, num_bands, seed)` native-gated on `"simhash"`). Use floats; `dot >= 0.0 → 1`.
+- [ ] **Step 4: pass.** Write `gen_simhash_golden.py` (imports sketch.py; emits cases over fixed vectors incl. zero/negative/varied dims + params; u64 band hashes as decimal strings, sig as 0/1 int arrays). Run it → fixture. Add `test_simhash_golden.py` locking the reference to the fixture.
+- [ ] **Step 5: commit** `feat(sketch): SimHash Python reference + golden vectors (#1082)`.
+
+## Task B3: Rust golden-vector test
+
+**Files:** Create/extend `packages/rust/extensions/sketch-core/tests/` golden test to read `sketch_simhash_golden.json` and assert Rust reproduces every case (mirror the existing `tests/golden.rs` MinHash pattern; sig compares as `Vec<u8>`, band hashes as `u64`).
+
+- [ ] Run `$CG test --manifest-path .../sketch-core/Cargo.toml` → PASS. Commit `test(sketch-core): SimHash golden-vector parity (#1082)`.
+
+## Task B4: native pyo3 binding + parity
+
+**Files:** Modify `native/src/sketch.rs` (+ `simhash_band_hashes_batch` pyfunction taking `Vec<Vec<f64>>`), `native/src/lib.rs` (register); create `tests/test_native_simhash_parity.py`.
+
+- [ ] **Step 1:** add the shim (validate `num_planes % num_bands == 0`); register. `cargo check --no-default-features` (with `PYO3_PYTHON`) → compiles; clippy clean; REVERT any fmt changes to unrelated native files.
+- [ ] **Step 2:** parity test (skipif native unbuilt / missing symbol) sweeping random vectors, native vs `sketch._simhash_band_hashes_batch_python`. Commit `feat(native): SimHash pyo3 binding + parity (#1082)`.
+
+## Task B5: `SimHashKeyConfig` + `SimHashLSHBlocker` + dispatch
+
+**Files:** Modify `config/schemas.py` (`SimHashKeyConfig`, `strategy="simhash"` + validator, re-export), `core/blocker.py` (dispatch); create `core/simhash_blocker.py`, `tests/test_simhash_blocker.py`.
+
+- [ ] **Step 1: failing tests** — config validation (mirror `LSHKeyConfig`: `num_planes>=1`, `threshold` XOR `num_bands`, divisibility); `strategy="simhash"` requires `simhash` block; the blocker over a small synthetic embedding matrix clusters high-cosine rows (inject a fake embedder via a test seam or pass embeddings directly).
+- [ ] **Step 2–4:** implement `SimHashKeyConfig(column, num_planes=256, num_bands|threshold, seed=0, model=None)`; `SimHashLSHBlocker` (`from_config`; `blocks(df, embeddings)` over an `(n, dim)` float64 array → `simhash_band_hashes_batch` → `BlockResult` per non-singleton `(band, bucket)`, dropping all-zero rows; `build_simhash_blocks(lf, config)` embeds `config.simhash.column` via `get_embedder(model)`). Wire `strategy=="simhash"` into `build_blocks`. Run → pass.
+- [ ] **Step 5: commit** `feat(sketch): SimHashLSHBlocker + simhash strategy (#1082)`.
+
+## Task B6: auto-config semantic routing
+
+**Files:** Modify `core/autoconfig.py` (`_text_corpus_blocking` semantic branch); extend `test_text_corpus_autoconfig.py`.
+
+- [ ] **Step 1: failing test** — with `_embedder_available` monkeypatched True, a text-corpus df → `strategy=="simhash"` (column = longest description); patched False → `strategy=="lsh"` (regression of A2).
+- [ ] **Step 2–4:** fill the semantic branch:
+
+```python
+def _text_corpus_blocking(profiles, df, config=None):
+    if _embedder_available(config):
+        from goldenmatch.config.schemas import BlockingConfig, SimHashKeyConfig
+        col = max((p for p in profiles if p.col_type == "description"),
+                  key=lambda p: p.avg_len).name
+        return BlockingConfig(strategy="simhash",
+            simhash=SimHashKeyConfig(column=col, num_planes=256, num_bands=32, seed=0))
+    return _auto_build_lsh_config(profiles)
+```
+
+Run → pass. **Step 5: commit** `feat(autoconfig): semantic SimHash routing when embedder available (#1082)`.
+
+## Task B7: SimHash recall gate
+
+**Files:** Create `scripts/bench_simhash_recall.py` (importable `measure_simhash_recall`: synthetic Gaussian base vectors + noisy variants, known dup pairs, measure recall + reduction via `SimHashLSHBlocker` over the vectors); `tests/test_simhash_recall.py` pins `num_planes=256, num_bands=32, noise=0.3, seed=1` and asserts `recall >= 0.95` and `reduction >= 0.7` (measured 1.0 / 0.86). Commit `feat(bench): SimHash recall harness + gate (#1082)`.
+
+## Task B8: TS SimHash port
+
+**Files:** Create `packages/typescript/goldenmatch/src/core/simhash.ts` (+ barrel export), `tests/unit/simhash.test.ts` (copy the simhash golden fixture into the TS test tree; assert every case). Pure-TS, `number` math; NO TS blocker (no embedder). Do NOT run tsc/vitest locally — CI gates. Commit `feat(ts/sketch): SimHash kernel port + golden parity (#1082)`.
+
+## Task B9: QQP lexical-vs-semantic A/B
+
+**Files:** Modify `scripts/bench_lsh_recall_qqp.py` (add `--method {lexical,semantic}`; `semantic` embeds the unique questions via `get_embedder` and runs `SimHashLSHBlocker`), `.github/workflows/bench-lsh-recall.yml` (a `method` input or run both). The honest payoff: semantic recovers more QQP paraphrases than lexical's 0.21. Commit `feat(bench): QQP lexical-vs-semantic A/B (#1082)`.
+
+## Task B10: docs
+
+- [ ] rollout-docs-sweep: `blocking.mdx` (new `simhash` strategy + "auto-enabled for text corpora" on `lsh`), `configuration.mdx` (`simhash` config), `tuning.mdx` (`simhash` native component), CHANGELOGs (py + ts), context-network ADR + nav + log, a zero-config text-corpus example. Commit `docs: SimHash semantic near-dup rollout (#1082)`.
+
+**→ Open PR "feat: semantic SimHash near-dup blocking (#1082)", land it.**
+
+---
+
+## Finalization
+
+- [ ] Targeted local test pass (Phase A python; Phase B python + `cargo test sketch-core`). TS via CI.
+- [ ] Both PRs green + auto-merge armed; record any bench numbers on #1082.
+
+## Risks / watch-items
+
+- **Auto-config regression:** run `tests/test_autoconfig.py` after A2 (the `_ann_eligible` removal must not break the structured paths).
+- **Controller guard completeness:** all nine blocking rules guarded (grep `_near_dup_locked`); a tenth must adopt it.
+- **SimHash f64 parity:** golden vectors + native sweep; TS is kernel-parity-only.
+- **Embedder in tests:** B5/B6 must not require a real model download — inject embeddings / monkeypatch `_embedder_available`.

--- a/docs/superpowers/specs/2026-06-19-text-near-dup-blocking-path-design.md
+++ b/docs/superpowers/specs/2026-06-19-text-near-dup-blocking-path-design.md
@@ -1,0 +1,221 @@
+# Document/text near-dup blocking path — design
+
+- **Issue:** [#1082](https://github.com/benseverndev-oss/goldenmatch/issues/1082) — Document/text near-dup blocking path
+- **Epic:** [#1080](https://github.com/benseverndev-oss/goldenmatch/issues/1080) — Training-Data Dedup at Scale
+- **Builds on:** #1081 (the MinHash/LSH `sketch-core` kernel + `MinHashLSHBlocker` + `strategy="lsh"`)
+- **Date:** 2026-06-19
+- **Status:** Approved (brainstorming) — pending spec review + plan
+
+## Motivation
+
+#1081 shipped the MinHash/LSH kernel and a `MinHashLSHBlocker`, but using it
+requires a manual `BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(...))`. On a
+bare text corpus, `dedupe_df(corpus)` does NOT pick it: auto-config routes a
+long-text (`description`) column to `strategy="ann"` (FAISS embeddings, ≥100K
+rows) or falls through to name-based multi-pass blocking — neither is right for
+"a column of documents". #1082 makes the text path zero-config.
+
+It also adds the **semantic** counterpart. The #1081 Quora-QQP bench surfaced
+LSH's scope boundary honestly: lexical shingle/LSH recovers near-duplicates
+(~0.98 on lexical edits) but only ~0.21 of QQP's *paraphrase* duplicates,
+because MinHash measures lexical Jaccard, not meaning. A SimHash (random
+hyperplane) LSH over embedding vectors closes that gap with a true LSH path
+(cosine-similarity buckets) rather than FAISS.
+
+## Goals
+
+- Auto-config detects a text corpus and emits a near-dup blocking strategy with
+  **no manual matchkey/blocking config** (the issue's done bar).
+- **Lexical** path: reuse the #1081 shingle/MinHash/LSH kernel (`strategy="lsh"`).
+- **Semantic** path: a new pyo3-free SimHash kernel in `sketch-core` over
+  embedding vectors, exposed as `strategy="simhash"` + `SimHashLSHBlocker`.
+- Routing: **lexical is the zero-config default**; **semantic is the escalation**
+  when an embedder is already reachable.
+- Cross-language parity for the SimHash kernel function (Rust/Python/TS golden
+  vectors); the semantic *blocker* is Python-primary (embeddings live there).
+- Recall validated: extend the QQP bench with a lexical-vs-semantic A/B.
+
+## Non-goals (later epic phases)
+
+- Sketch-then-verify execution plan (#1083).
+- Distributed billion-scale (#1084).
+- Corpus-dedup product surface / CLI (#1085).
+- Numeric TS semantic blocking end-to-end (TS has no real embedder; the TS
+  SimHash kernel ships for parity/completeness only).
+- A new embedding provider — semantic routing uses the existing
+  `get_embedder` / `inhouse_embedding_available` machinery.
+
+## Architecture
+
+Two near-dup paths behind one auto-config decision:
+
+```
+                       ┌─ exact-key (email/phone/id/zip-compound)  [highest precedence, unchanged]
+auto-config build_blocking ─┤
+                       ├─ TEXT CORPUS?  (description col, no exact key, no blockable name)
+                       │     ├─ embedder reachable?  →  strategy="simhash"  (semantic, SimHash over embeddings)
+                       │     └─ else                 →  strategy="lsh"      (lexical, #1081 shingle/MinHash)
+                       └─ name / multi-pass fallback               [unchanged, for structured records]
+```
+
+Both strategies emit `BlockResult`s through the existing blocker contract; the
+controller keeps the chosen strategy across iterations (it never swaps blocking
+strategy), so no controller change is needed.
+
+## Phase A — lexical auto-enable
+
+### Detection: `_is_text_corpus(profiles)`
+
+Returns true when **all** of:
+- at least one `description` column exists (`col_type == "description"`), and
+- no scale-safe exact-key blocking fired earlier in `build_blocking` (no
+  email/phone/identifier/zip-compound key), and
+- there is **no blockable `name` column** — i.e. no `col_type == "name"` /
+  `"multi_name"` column with `cardinality_ratio >= 0.1` (the text is the primary
+  identity, not a description field on otherwise-structured records).
+
+This targets true corpora (a column of documents / a 1-column text CSV) while
+leaving structured-record routing untouched (a name column ⇒ name/multi-pass
+blocking, with the description still feeding the `record_embedding` matchkey for
+scoring). It supersedes the old `description → ann` fallback for corpora.
+
+### Config emission: `_auto_build_lsh_config(profiles)`
+
+Picks the longest description column (max `avg_len`); emits
+`LSHKeyConfig(column=<that>, mode="word", k=2, num_perms=128, threshold=0.5,
+seed=0)` — the #1081-validated config. Returns `BlockingConfig(strategy="lsh",
+lsh=...)`.
+
+### Routing hook
+
+In `build_blocking()` (autoconfig.py), replace the current `description → ann`
+fallback branch with: `if _is_text_corpus(profiles): return
+_text_corpus_blocking(profiles, df)`, where `_text_corpus_blocking` picks
+semantic (Phase B) when `_embedder_available()` else lexical. Place it after the
+exact-key + bounded-compound attempts, before the name/multi-pass fallback.
+`_embedder_available()` = `inhouse_embedding_available()` or a configured
+embedding provider on the resolved config.
+
+## Phase B — semantic SimHash
+
+### Kernel: `sketch-core/simhash.rs` (pyo3-free)
+
+Reuses the #1081 hash family (`base_hash`, `splitmix64`). All floating-point is
+`f64` (Rust `f64` / Python `float64` / TS `number`) so the function is
+byte-identical across languages on identical input vectors.
+
+`simhash_signature(vector: &[f64], num_planes: usize, seed: u64) -> Vec<u8>`
+(each element `0` or `1`):
+
+- The `num_planes × dim` projection matrix has **Rademacher ±1** entries drawn
+  row-major from a splitmix64 bitstream seeded at `seed`. Bit-drawing is pinned:
+  maintain `(state, bitbuf, bits_left)`; to draw one entry, if `bits_left == 0`
+  then `(v, state) = splitmix64(state); bitbuf = v; bits_left = 64`; the entry is
+  `+1.0 if (bitbuf & 1) == 1 else -1.0`; then `bitbuf >>= 1; bits_left -= 1`.
+  Entries are drawn in order plane 0 col 0..dim, plane 1 col 0..dim, … (row-major).
+- For plane `i`: `dot = Σ_j plane[i][j] * vector[j]` accumulated in `f64`, `j`
+  ascending; `sig[i] = 1 if dot >= 0.0 else 0` (the `dot == 0` tie → `1`, pinned).
+- Empty/all-zero vectors are allowed (every dot is `0.0` → all-ones signature);
+  the blocker drops them (no content).
+
+`simhash_band_hashes(sig: &[u8], num_bands: usize) -> Vec<u64>`:
+
+- `num_planes = sig.len()` must be divisible by `num_bands`; `r = num_planes /
+  num_bands`. For band `b`: `bucket = base_hash(le8(b) ++ sig[b*r .. (b+1)*r])`
+  (the 8 little-endian bytes of the band index `u64`, then the `r` `0/1` bytes).
+  Mixing `b` in keeps identical bit-runs in different bands separate. (One byte
+  per plane-bit — no cross-word bit-packing — to keep the contract unambiguous
+  across three languages; 256 bytes/record is negligible.)
+
+Batch entry point `simhash_band_hashes_batch(vectors, num_planes, num_bands,
+seed)` generates the projection matrix **once** (same seed/dim for the batch) and
+reuses it across rows; rayon fan-out guarded by
+`GOLDENMATCH_NATIVE_SKETCH_RAYON_MIN_ROWS` (shared with #1081).
+
+`optimal_planes_bands(num_planes, threshold)` — the same S-curve helper as MinHash
+(host-side, picks `num_bands`).
+
+### Python binding + blocker
+
+- pyo3 shims in `native` (`simhash_band_hashes_batch`), registered in `_native`;
+  pure-Python reference/fallback in `core/sketch.py` (extends the module). Native
+  gated like `"sketch"` (not default-on; reachable via `GOLDENMATCH_NATIVE=1`).
+- `SimHashKeyConfig` (`column`, `num_planes=256`, `num_bands | threshold`, `seed=0`,
+  `model: str | None`) + `strategy="simhash"` with a positive validator branch
+  (mirrors `LSHKeyConfig`).
+- `SimHashLSHBlocker` (`core/simhash_blocker.py`): embed the text column via
+  `get_embedder(model)` → `np.asarray(..., dtype=float64)` → `simhash_band_hashes_batch`
+  → group `(band, bucket)` into `BlockResult`s (same shape/contract as
+  `MinHashLSHBlocker`; drops all-zero/empty rows). Wire `strategy="simhash"` into
+  `build_blocks` dispatch.
+
+### TS
+
+`src/core/simhash.ts` (pure-TS, `number` math) for kernel parity (golden
+vectors). No TS semantic blocker (no real embedder) — documented.
+
+## Parity & correctness
+
+- A SimHash golden-vector fixture (`sketch_simhash_golden.json`) of fixed input
+  vectors + params → signature + band hashes, generated from the Python
+  reference; checked by Rust + Python (+ TS for the function). `GOLDENMATCH_NATIVE=0/1`
+  native↔python parity sweep.
+- f64 everywhere removes the f32/f64 sign-boundary divergence risk; the `dot == 0`
+  tie is pinned. Real near-zero dots over random planes are astronomically rare,
+  but the contract is still exact for golden inputs.
+
+## Tests
+
+- **Phase A:** `_is_text_corpus` / routing unit tests — a text-corpus df →
+  `strategy=="lsh"` on the right column; a structured df with a name + a
+  description → still name/multi-pass (guards the false-positive); zero-config
+  end-to-end `dedupe_df` on a tiny text corpus produces sensible clusters.
+- **Phase B:** SimHash kernel golden + Rust↔Python parity (`test_native_simhash_parity.py`);
+  `SimHashLSHBlocker` test with synthetic embeddings (known high-cosine pairs
+  cluster, orthogonal ones don't); routing test (`_embedder_available()` patched
+  true → `strategy=="simhash"`). SimHash recall vs cosine threshold on synthetic
+  vectors as an always-on gate.
+- **Recall A/B:** extend `scripts/bench_lsh_recall_qqp.py` with `--method
+  {lexical,semantic}`; the bench workflow runs both and reports the pair — the
+  honest payoff is semantic recovering materially more QQP paraphrases than
+  lexical's 0.21.
+
+## Docs / rollout
+
+`blocking.mdx` (new `simhash` strategy + "auto-enabled for text corpora" note on
+`lsh`), `configuration.mdx`, `tuning.mdx` (the `simhash` native component),
+CHANGELOGs (py + ts), a context-network ADR, and a zero-config text-corpus
+example. Swept via the rollout-docs-sweep skill.
+
+## File manifest (new / modified)
+
+**Phase A (new):** `tests/test_text_corpus_autoconfig.py`.
+**Phase A (modified):** `core/autoconfig.py` (`_is_text_corpus`, `_auto_build_lsh_config`,
+`_text_corpus_blocking`, `_embedder_available`, routing in `build_blocking`).
+
+**Phase B (new):** `packages/rust/extensions/sketch-core/src/simhash.rs`;
+`native/src/sketch.rs` (+ simhash fns) ; `core/simhash_blocker.py`;
+`core/sketch.py` (+ SimHash reference/fallback); `scripts/gen_simhash_golden.py`
++ `tests/fixtures/sketch_simhash_golden.json`; `tests/test_simhash_reference.py`,
+`tests/test_native_simhash_parity.py`, `tests/test_simhash_blocker.py`;
+`packages/typescript/goldenmatch/src/core/simhash.ts` + golden test.
+**Phase B (modified):** `sketch-core/src/lib.rs`, `native/src/lib.rs`,
+`native/Cargo.toml`; `config/schemas.py` (`SimHashKeyConfig`, `strategy="simhash"`);
+`core/blocker.py` (dispatch); `_native_loader.py` (note); `.github/workflows/ci.yml`
+(already covers sketch-core); `scripts/bench_lsh_recall_qqp.py` (`--method`).
+
+## Risks & mitigations
+
+- **False-positive routing** (structured-with-description → LSH) → the
+  no-blockable-name guard + the unit test that pins a name+description df to
+  name-blocking.
+- **SimHash f64 parity** → f64 everywhere + pinned tie + golden vectors; TS
+  semantic path is explicitly out (no embedder).
+- **Projection-matrix cost** → generated once per batch (not per row); rayon
+  guard reused.
+- **Embedder availability fl/flapping routing** → routing reads
+  `_embedder_available()` once at config time; the chosen strategy is frozen on
+  the committed config (controller never swaps it).
+- **Auto-config regression** → the text-corpus branch only fires on the narrow
+  detected shape; the existing exact/name paths are untouched; guard with the
+  structured-df test + the standard auto-config suite.

--- a/docs/superpowers/specs/2026-06-19-text-near-dup-blocking-path-design.md
+++ b/docs/superpowers/specs/2026-06-19-text-near-dup-blocking-path-design.md
@@ -61,18 +61,33 @@ auto-config build_blocking ─┤
 Both strategies emit `BlockResult`s through the existing blocker contract.
 
 **Controller guard (required).** The auto-config controller's refit rules CAN
-swap a committed blocking strategy mid-iteration —
-`autoconfig_rules.py::rule_blocking_key_swap` rewrites `blocking` to
-`strategy="static"` (`first_token` key) on a "candidates compared, nothing
-matched" profile, and `rule_cross_blocking_disagreement` (and the multi-pass
-promotions) rewrite to `strategy="multi_pass"`. A near-dup corpus at the default
-threshold can plausibly hit that "compared, nothing matched" state, so without a
-guard a committed `lsh`/`simhash` config would be silently swapped to
-`static`/`multi_pass`. **Each of those rules must early-return `None` when
-`current.blocking.strategy in {"lsh", "simhash"}`** (the near-dup strategies own
-their candidate generation and must not be re-routed by the structured-record
-refit heuristics). This is a required change, with a regression test that drives
-the controller on a text-corpus shape and asserts the committed strategy survives.
+swap a committed blocking strategy mid-iteration. `lsh`/`simhash` configs carry
+**empty `.keys`** (the validator forbids `keys`/`passes`), so the rules that
+early-return on `not current.blocking.keys` already self-skip them
+(`rule_no_matches`, `rule_low_reduction_ratio`, `rule_blocking_field_null_heavy`,
+`rule_cross_blocking_disagreement`). But several rules gate only on
+`current.blocking is None` and would actively rewrite an `lsh` config — notably
+`rule_blocking_singleton_trap` and `rule_uniform_heavy_blocking` (→ `static`) and
+`rule_blocking_key_swap` (→ `static`/`first_token`). A near-dup corpus plausibly
+hits both the "candidates compared, nothing matched" (`mass_above_threshold==0`)
+and the "nothing compared" (`candidates_compared==0`, the singleton-trap) shapes,
+so without a guard a committed `lsh`/`simhash` config gets silently swapped.
+
+**Required change:** introduce a shared helper `_near_dup_locked(config) -> bool`
+(true when `config.blocking.strategy in {"lsh","simhash"}`) and early-return
+`None` from **every refit rule that emits a `blocking`-strategy/key update** when
+it is true. The complete set in `DEFAULT_RULES` to guard:
+`rule_blocking_singleton_trap`, `rule_blocking_too_coarse`,
+`rule_blocking_key_swap`, `rule_uniform_heavy_blocking`,
+`rule_blocking_field_null_heavy`, `rule_low_reduction_ratio`,
+`rule_recall_gap_suspected`, `rule_cross_blocking_disagreement`,
+`rule_blocking_adaptive_on_p99_outlier`. (Threshold/matchkey rules are NOT
+guarded — the controller may still tune the score threshold on an `lsh` config.)
+Add the guard to each rule body (explicit + greppable; a tenth blocking rule must
+adopt the same first-line check). A **controller-survival** regression test drives
+the controller on a text-corpus shape that trips BOTH `rule_blocking_singleton_trap`
+(`candidates_compared==0`) and `rule_blocking_key_swap` (`mass_above_threshold==0`)
+and asserts the committed `lsh`/`simhash` strategy survives every iteration.
 
 ## Phase A — lexical auto-enable
 

--- a/docs/superpowers/specs/2026-06-19-text-near-dup-blocking-path-design.md
+++ b/docs/superpowers/specs/2026-06-19-text-near-dup-blocking-path-design.md
@@ -58,9 +58,21 @@ auto-config build_blocking ─┤
                        └─ name / multi-pass fallback               [unchanged, for structured records]
 ```
 
-Both strategies emit `BlockResult`s through the existing blocker contract; the
-controller keeps the chosen strategy across iterations (it never swaps blocking
-strategy), so no controller change is needed.
+Both strategies emit `BlockResult`s through the existing blocker contract.
+
+**Controller guard (required).** The auto-config controller's refit rules CAN
+swap a committed blocking strategy mid-iteration —
+`autoconfig_rules.py::rule_blocking_key_swap` rewrites `blocking` to
+`strategy="static"` (`first_token` key) on a "candidates compared, nothing
+matched" profile, and `rule_cross_blocking_disagreement` (and the multi-pass
+promotions) rewrite to `strategy="multi_pass"`. A near-dup corpus at the default
+threshold can plausibly hit that "compared, nothing matched" state, so without a
+guard a committed `lsh`/`simhash` config would be silently swapped to
+`static`/`multi_pass`. **Each of those rules must early-return `None` when
+`current.blocking.strategy in {"lsh", "simhash"}`** (the near-dup strategies own
+their candidate generation and must not be re-routed by the structured-record
+refit heuristics). This is a required change, with a regression test that drives
+the controller on a text-corpus shape and asserts the committed strategy survives.
 
 ## Phase A — lexical auto-enable
 
@@ -88,13 +100,23 @@ lsh=...)`.
 
 ### Routing hook
 
-In `build_blocking()` (autoconfig.py), replace the current `description → ann`
-fallback branch with: `if _is_text_corpus(profiles): return
-_text_corpus_blocking(profiles, df)`, where `_text_corpus_blocking` picks
-semantic (Phase B) when `_embedder_available()` else lexical. Place it after the
-exact-key + bounded-compound attempts, before the name/multi-pass fallback.
-`_embedder_available()` = `inhouse_embedding_available()` or a configured
-embedding provider on the resolved config.
+In `build_blocking()` (autoconfig.py), insert `if _is_text_corpus(profiles):
+return _text_corpus_blocking(profiles, df)` after the exact-key +
+bounded-compound attempts and **in place of the existing `_ann_eligible` block**
+(autoconfig.py ~2224–2236), before the name/multi-pass fallback.
+`_text_corpus_blocking` picks semantic (Phase B) when `_embedder_available()`,
+else lexical.
+
+**Interaction with the existing ANN auto-selection (pinned):** the current
+`_ann_eligible` branch auto-selects `strategy="ann"` for a `description` column at
+`rows >= GOLDENMATCH_ANN_MIN_ROWS` (default 100K). The text-corpus branch
+**replaces it entirely** — ANN is **no longer auto-selected** for description
+columns at any row count; semantic SimHash is the new auto embedding path
+(`strategy="ann"` remains available via explicit config). This removes the
+double-routing ambiguity (text-corpus and `_ann_eligible` would otherwise both be
+eligible above 100K) and the row-count gate (LSH/SimHash auto-enables for text
+corpora regardless of size). `_embedder_available()` = `inhouse_embedding_available()`
+or a configured embedding provider on the resolved config.
 
 ## Phase B — semantic SimHash
 
@@ -132,8 +154,8 @@ seed)` generates the projection matrix **once** (same seed/dim for the batch) an
 reuses it across rows; rayon fan-out guarded by
 `GOLDENMATCH_NATIVE_SKETCH_RAYON_MIN_ROWS` (shared with #1081).
 
-`optimal_planes_bands(num_planes, threshold)` — the same S-curve helper as MinHash
-(host-side, picks `num_bands`).
+Band selection reuses the existing `optimal_bands(num_planes, threshold)` helper
+(host-side; `num_planes` plays the role of `num_perms`) — no new helper.
 
 ### Python binding + blocker
 
@@ -168,7 +190,11 @@ vectors). No TS semantic blocker (no real embedder) — documented.
 
 - **Phase A:** `_is_text_corpus` / routing unit tests — a text-corpus df →
   `strategy=="lsh"` on the right column; a structured df with a name + a
-  description → still name/multi-pass (guards the false-positive); zero-config
+  description → still name/multi-pass (guards the false-positive); a corpus that
+  also has a low-cardinality (`< 0.1`) name-classified column → still `lsh` (pins
+  the guard threshold); a **controller-survival** test driving the
+  `AutoConfigController` on a text-corpus shape that asserts the committed
+  `lsh`/`simhash` strategy is not swapped to `static`/`multi_pass`; zero-config
   end-to-end `dedupe_df` on a tiny text corpus produces sensible clusters.
 - **Phase B:** SimHash kernel golden + Rust↔Python parity (`test_native_simhash_parity.py`);
   `SimHashLSHBlocker` test with synthetic embeddings (known high-cosine pairs
@@ -191,7 +217,10 @@ example. Swept via the rollout-docs-sweep skill.
 
 **Phase A (new):** `tests/test_text_corpus_autoconfig.py`.
 **Phase A (modified):** `core/autoconfig.py` (`_is_text_corpus`, `_auto_build_lsh_config`,
-`_text_corpus_blocking`, `_embedder_available`, routing in `build_blocking`).
+`_text_corpus_blocking`, `_embedder_available`, routing in `build_blocking` — replacing
+the `_ann_eligible` block); `core/autoconfig_rules.py` (guard `rule_blocking_key_swap`,
+`rule_cross_blocking_disagreement`, and the multi-pass promotion rules to early-return
+`None` when `blocking.strategy in {"lsh","simhash"}`).
 
 **Phase B (new):** `packages/rust/extensions/sketch-core/src/simhash.rs`;
 `native/src/sketch.rs` (+ simhash fns) ; `core/simhash_blocker.py`;
@@ -213,9 +242,12 @@ example. Swept via the rollout-docs-sweep skill.
   semantic path is explicitly out (no embedder).
 - **Projection-matrix cost** → generated once per batch (not per row); rayon
   guard reused.
-- **Embedder availability fl/flapping routing** → routing reads
-  `_embedder_available()` once at config time; the chosen strategy is frozen on
-  the committed config (controller never swaps it).
+- **Embedder availability flapping routing** → routing reads
+  `_embedder_available()` once at config time.
+- **Controller swapping the near-dup strategy** → the refit rules that rewrite
+  `blocking.strategy` (`rule_blocking_key_swap`, `rule_cross_blocking_disagreement`,
+  multi-pass promotions) are guarded to skip `lsh`/`simhash` configs; a
+  controller-survival regression test pins this.
 - **Auto-config regression** → the text-corpus branch only fires on the narrow
   detected shape; the existing exact/name paths are untouched; guard with the
   structured-df test + the standard auto-config suite.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1914,13 +1914,13 @@ def _is_text_corpus(profiles: list[ColumnProfile]) -> bool:
     return not has_blockable_name
 
 
-def _embedder_available(config=None) -> bool:
+def _embedder_available(config: GoldenMatchConfig | None = None) -> bool:
     """True when a semantic embedder is reachable for text-corpus blocking.
 
-    #1082 Phase A is lexical-only and does not consume this, but the helper is
-    in place for Phase B's semantic (SimHash/embedding) branch: it's True when
-    the in-house embedding model is importable OR the caller configured an
-    embedding provider.
+    Gates the semantic (SimHash/embedding) branch of ``_text_corpus_blocking``:
+    True when the in-house embedding model is importable OR the caller configured
+    an embedding provider. #1082 Phase A routes both the lexical and the
+    embedder-available case to lexical LSH; Phase B fills in the semantic branch.
     """
     from goldenmatch.core.embedder import inhouse_embedding_available
     if inhouse_embedding_available():
@@ -1943,13 +1943,16 @@ def _auto_build_lsh_config(profiles: list[ColumnProfile]) -> BlockingConfig:
 
 
 def _text_corpus_blocking(
-    profiles: list[ColumnProfile], df: pl.DataFrame, config=None
+    profiles: list[ColumnProfile], df: pl.DataFrame, config: GoldenMatchConfig | None = None
 ) -> BlockingConfig:
     """Pick the text-corpus blocking strategy.
 
-    #1082 Phase A is lexical only (MinHash/LSH). Phase B adds a semantic
-    (SimHash / embedding-ANN) branch here, gated on ``_embedder_available``.
+    #1082 Phase A is lexical only (MinHash/LSH). Phase B replaces the
+    embedder-available branch with semantic SimHash; for now both route to the
+    lexical path.
     """
+    if _embedder_available(config):
+        return _auto_build_lsh_config(profiles)
     return _auto_build_lsh_config(profiles)
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1892,6 +1892,28 @@ def _scale_safe_bounded_compound(
     return None
 
 
+def _is_text_corpus(profiles: list[ColumnProfile]) -> bool:
+    """True when the data reads as a free-text corpus, not structured records.
+
+    #1082 Phase A: a text corpus is a dataset whose identity signal lives in a
+    long free-text (``description``) column with NO usable structured blocking
+    key. A high-cardinality ``name``/``multi_name`` column (cardinality_ratio
+    >= 0.1) is a usable structured blocking key, so its presence means this is
+    structured data that happens to carry a free-text field — NOT a text
+    corpus — and the normal exact/name blocking paths handle it. A low-
+    cardinality name (a label, a category) can't block usefully, so a
+    description-bearing dataset still reads as a corpus.
+    """
+    has_description = any(p.col_type == "description" for p in profiles)
+    if not has_description:
+        return False
+    has_blockable_name = any(
+        p.col_type in ("name", "multi_name") and p.cardinality_ratio >= 0.1
+        for p in profiles
+    )
+    return not has_blockable_name
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1914,6 +1914,45 @@ def _is_text_corpus(profiles: list[ColumnProfile]) -> bool:
     return not has_blockable_name
 
 
+def _embedder_available(config=None) -> bool:
+    """True when a semantic embedder is reachable for text-corpus blocking.
+
+    #1082 Phase A is lexical-only and does not consume this, but the helper is
+    in place for Phase B's semantic (SimHash/embedding) branch: it's True when
+    the in-house embedding model is importable OR the caller configured an
+    embedding provider.
+    """
+    from goldenmatch.core.embedder import inhouse_embedding_available
+    if inhouse_embedding_available():
+        return True
+    return bool(getattr(getattr(config, "embedding", None), "provider", None))
+
+
+def _auto_build_lsh_config(profiles: list[ColumnProfile]) -> BlockingConfig:
+    """Build a MinHash/LSH blocking config over the longest description column.
+
+    #1082 Phase A: word-shingle MinHash/LSH (k=2, 128 perms, Jaccard
+    threshold 0.5) on the description column with the largest average length —
+    the field most likely to carry the near-duplicate lexical signal.
+    """
+    from goldenmatch.config.schemas import LSHKeyConfig
+    descs = [p for p in profiles if p.col_type == "description"]
+    col = max(descs, key=lambda p: p.avg_len).name
+    return BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(
+        column=col, mode="word", k=2, num_perms=128, threshold=0.5, seed=0))
+
+
+def _text_corpus_blocking(
+    profiles: list[ColumnProfile], df: pl.DataFrame, config=None
+) -> BlockingConfig:
+    """Pick the text-corpus blocking strategy.
+
+    #1082 Phase A is lexical only (MinHash/LSH). Phase B adds a semantic
+    (SimHash / embedding-ANN) branch here, gated on ``_embedder_available``.
+    """
+    return _auto_build_lsh_config(profiles)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -1968,39 +2007,13 @@ def build_blocking(
     effective_n_full = n_rows_full if n_rows_full is not None else df.height
     sample_n = max(df.height, 1)
 
-    # #491: ANN blocking is a FALLBACK, not a preempt. ANN is emitted ONLY
-    # when an embedding-bearing column exists, the dataset is at scale, AND no
-    # bounded exact blocking key is available. A strong exact identifier still
-    # wins over ANN when present — we evaluate the exact/safe-exact path first
-    # (below) and only fall through to ANN when that path produced no usable
-    # key, before the name/compound fallback.
-    #
-    # STRICT invariant preserved: ANN is never emitted without an embedding-
-    # bearing column. ANNBlocker needs a vector column (blocker.py raises
-    # ValueError if ``ann_column`` is unset). The embedding signal is a profile
-    # with ``col_type == "description"`` — those columns become
-    # ``record_embedding`` scorers in build_matchkeys (line ~852) and carry the
-    # vectors ANN embeds. No embedding column => never ann.
-    #
-    # ANN_MIN_ROWS default 100_000; env-overridable via
-    # GOLDENMATCH_ANN_MIN_ROWS (mirrors the env-threshold pattern used by
-    # GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD below).
-    _ANN_MIN_ROWS_DEFAULT = 100_000
-    _ann_raw = os.environ.get("GOLDENMATCH_ANN_MIN_ROWS")
-    if _ann_raw is not None:
-        try:
-            ann_min_rows = int(_ann_raw)
-        except ValueError:
-            logger.warning(
-                "GOLDENMATCH_ANN_MIN_ROWS=%r is not an int; ignoring and "
-                "using default %d.", _ann_raw, _ANN_MIN_ROWS_DEFAULT,
-            )
-            ann_min_rows = _ANN_MIN_ROWS_DEFAULT
-    else:
-        ann_min_rows = _ANN_MIN_ROWS_DEFAULT
-
-    _embedding_cols = [p for p in profiles if p.col_type == "description"]
-    _ann_eligible = bool(_embedding_cols) and effective_n_full >= ann_min_rows
+    # #1082: ANN is no longer AUTO-selected for description columns. A free-
+    # text corpus (description column, no blockable structured key) is routed
+    # to MinHash/LSH near-duplicate blocking via ``_is_text_corpus`` /
+    # ``_text_corpus_blocking`` below (after the exact-key path). Explicit
+    # ``ann``/``ann_pairs`` configs still work, and blocker.py's ANN sub-block
+    # fallback inside oversized blocks is unchanged. The old #491 auto-ANN
+    # path (ANN_MIN_ROWS gate + embedding-column detection here) was removed.
 
     def _projected_ratio(p: ColumnProfile) -> float:
         """Sample-corrected cardinality_ratio for the #408/#410 blocking gate.
@@ -2243,19 +2256,25 @@ def build_blocking(
             max_safe_block,
         )
 
-    # #491: ANN fallback. We only reach here when no bounded exact blocking
-    # key was found (the exact path above returns whenever it had a usable
-    # safe_exact key). If embeddings are present at scale, prefer ANN over the
-    # name/compound fallback below.
-    if _ann_eligible:
-        ann_col = _embedding_cols[0].name
+    # #1082: text-corpus fallback. We only reach here when no bounded exact
+    # blocking key was found (the exact path above returns whenever it had a
+    # usable safe_exact key). When the data reads as a free-text corpus (a
+    # description column and no blockable structured key), route to MinHash/LSH
+    # near-duplicate blocking rather than the name/compound fallback below.
+    #
+    # NOTE: this REPLACES the prior #491 ANN auto-selection for description
+    # columns. ANN is no longer auto-picked here -- a text corpus now gets
+    # lexical LSH blocking; explicit ann/ann_pairs configs still work, and the
+    # ANN sub-block fallback inside oversized blocks (blocker.py) is unchanged.
+    if _is_text_corpus(profiles):
+        text_blk = _text_corpus_blocking(profiles, df)
         logger.info(
-            "Auto-selecting ANN blocking (fallback): no bounded exact "
-            "blocking key available, embedding column %r present and "
-            "n_rows=%d >= ANN_MIN_ROWS=%d. See #491.",
-            ann_col, effective_n_full, ann_min_rows,
+            "Auto-selecting %s blocking (text corpus): no bounded exact "
+            "blocking key and no blockable structured column; routing the "
+            "description corpus to near-duplicate blocking. See #1082.",
+            text_blk.strategy,
         )
-        return BlockingConfig(strategy="ann", ann_column=ann_col)
+        return text_blk
 
     # ── Check if name-based fallback would also be oversized ──
     # #715: the name path picks ONE primary name column (pattern_names[0], else

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -132,6 +132,22 @@ def _orthogonal_key(cfg: GoldenMatchConfig, df_columns: list[str]) -> BlockingKe
     return BlockingKeyConfig(fields=[candidates[0]], transforms=["lowercase"])
 
 
+def _near_dup_locked(config: GoldenMatchConfig) -> bool:
+    """True when blocking is a near-duplicate strategy the controller must not
+    swap away (#1082).
+
+    The text-corpus auto-enable path (``_is_text_corpus`` →
+    ``strategy="lsh"``) and the Phase-B SimHash path both pick a blocking
+    strategy purpose-built for free-text near-duplicate detection. The generic
+    blocking-refit rules reason about structured keys (singleton traps,
+    oversized buckets, key swaps) and would wrongly rewrite these strategies
+    into a name/identifier compound. Every blocking-rewrite rule guards on this
+    first.
+    """
+    b = getattr(config, "blocking", None)
+    return b is not None and b.strategy in ("lsh", "simhash")
+
+
 def rule_blocking_singleton_trap(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -152,6 +168,8 @@ def rule_blocking_singleton_trap(
     first weighted matchkey, producing coarser blocks that are more likely
     to contain matching cross-source pairs.
     """
+    if _near_dup_locked(current):
+        return None
     bp = profile.blocking
     sp = profile.scoring
     # If candidates were actually compared, this is not the singleton trap.
@@ -206,6 +224,8 @@ def rule_blocking_singleton_trap(
 def rule_blocking_too_coarse(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
+    if _near_dup_locked(current):
+        return None
     bp = profile.blocking
     n_rows = profile.data.n_rows
     if bp.n_blocks == 0 or n_rows == 0:
@@ -282,6 +302,8 @@ def rule_unimodal_scoring(
 def rule_low_reduction_ratio(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
+    if _near_dup_locked(current):
+        return None
     bp = profile.blocking
     if bp.reduction_ratio >= 0.5:
         return None
@@ -405,6 +427,8 @@ def rule_blocking_key_swap(
 
     v1.10: vetoed when identity_score >= 0.8 AND full_pop_matchkey_hits > 0.
     """
+    if _near_dup_locked(current):
+        return None
     sp = profile.scoring
     # Only fire when fuzzy actually compared candidates AND nothing matched
     if sp.candidates_compared == 0:
@@ -522,6 +546,8 @@ def rule_uniform_heavy_blocking(
     (text or id-like, cardinality_ratio in [0.3, 0.95]) not currently
     in blocking — typically a name/email field.
     """
+    if _near_dup_locked(current):
+        return None
     bp = profile.blocking
     sp = profile.scoring
     dp = profile.data
@@ -600,6 +626,8 @@ def rule_blocking_field_null_heavy(
     Action: convert to multi-pass with a second key on a low-null
     high-cardinality field.
     """
+    if _near_dup_locked(current):
+        return None
     if current.blocking is None or not current.blocking.keys:
         return None
     # Only fire on single-pass, single-key blocking
@@ -759,6 +787,8 @@ def rule_recall_gap_suspected(
     second pass on the highest-cardinality non-null user column not already
     in blocking.
     """
+    if _near_dup_locked(current):
+        return None
     sp = profile.scoring
     if current.blocking is None:
         return None
@@ -965,6 +995,8 @@ def rule_cross_blocking_disagreement(
 
     Spec: §Components rule firing conditions.
     """
+    if _near_dup_locked(current):
+        return None
     if ctx is None:
         return None
     if len(history.entries) < 1:
@@ -1145,6 +1177,8 @@ def rule_blocking_adaptive_on_p99_outlier(
     cheap promotion lands first; the key-swap rule still fires on the
     next iteration if adaptive alone doesn't bound the tail.
     """
+    if _near_dup_locked(current):
+        return None
     if current.blocking is None or current.blocking.strategy != "static":
         return None
     if not current.blocking.keys:

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -384,13 +384,19 @@ class TestBuildBlocking:
         blocking = build_blocking(profiles, df)
         assert blocking.strategy == "multi_pass"
 
-    def test_description_only_uses_canopy(self):
+    def test_description_only_uses_lsh(self):
+        # #1082: a description-only df is a text corpus and now routes to
+        # MinHash/LSH near-duplicate blocking. (Pre-#1082 the description-only
+        # fallback was strategy="canopy"; ANN/canopy auto-selection for a text
+        # corpus was intentionally dropped.)
         profiles = [
             ColumnProfile("desc", "Utf8", "description", 0.7),
         ]
         df = pl.DataFrame({"desc": ["long text here"] * 3})
         blocking = build_blocking(profiles, df)
-        assert blocking.strategy == "canopy"
+        assert blocking.strategy == "lsh"
+        assert blocking.lsh is not None
+        assert blocking.lsh.column == "desc"
 
     def test_name_with_geo_compounds_blocking(self):
         """When geo columns exist, name-based blocking should compound with geo."""
@@ -415,9 +421,16 @@ class TestBuildBlocking:
         assert "facility_name" in primary_fields
 
     def test_name_without_geo_stays_name_only(self):
-        """Without geo columns, name-based blocking should remain name-only."""
+        """Without geo columns, name-based blocking should remain name-only.
+
+        #1082: the `name` column carries a realistic cardinality_ratio (0.8)
+        so it reads as a blockable structured key -- the data is NOT a text
+        corpus and the structured name path is unchanged. (A name column left
+        at the default cardinality_ratio=0.0 would look unblockable to the
+        #1082 text-corpus detector; real profiling never assigns a name 0.0.)
+        """
         profiles = [
-            ColumnProfile("name", "Utf8", "name", 0.9),
+            ColumnProfile("name", "Utf8", "name", 0.9, cardinality_ratio=0.8),
             ColumnProfile("description", "Utf8", "description", 0.7),
         ]
         df = pl.DataFrame({"name": ["John", "Jane", "Bob"], "description": ["a", "b", "c"]})

--- a/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
@@ -335,15 +335,18 @@ def _ann_df(cols: list[str]):
     return pl.DataFrame({c: ["a", "b", "c", "d"] for c in cols})
 
 
-def test_ann_blocking_when_embeddings_and_scale():
+def test_no_auto_ann_when_embeddings_and_blockable_name():
+    # #1082: ANN is no longer AUTO-selected for a description column. This
+    # profile set carries a blockable `last_name` (card 0.3 >= 0.1), so it is
+    # NOT a text corpus -- it falls through to the name-based blocking path,
+    # not ANN and not LSH. (Pre-#1082 this auto-selected strategy="ann".)
     from goldenmatch.core.autoconfig import build_blocking
 
     profiles = _profiles_with_embeddings()
     df = _ann_df(["bio", "last_name"])
     blk = build_blocking(profiles, df, n_rows_full=200_000)
-    assert blk.strategy == "ann"
-    assert blk.ann_column  # set to the embedding column name
-    assert blk.ann_column == "bio"
+    assert blk.strategy != "ann"
+    assert blk.strategy != "lsh"  # a blockable name => not a pure text corpus
 
 
 def test_no_ann_without_embeddings():

--- a/packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py
@@ -1,0 +1,234 @@
+"""Phase A of #1082: lexical text-corpus auto-enable.
+
+Covers the `_is_text_corpus` detector (A1), the build_blocking routing of a
+text corpus to `strategy="lsh"` (A2), the controller guard that keeps the
+auto-config refit rules from swapping an lsh/simhash strategy away (A3), and
+a zero-config end-to-end text dedupe (A4).
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.core.autoconfig import (
+    ColumnProfile,
+    _is_text_corpus,
+)
+
+# ───────────────────────── A1: _is_text_corpus detector ─────────────────────
+
+
+def _desc(name: str, *, card: float = 0.95, avg_len: float = 60.0) -> ColumnProfile:
+    return ColumnProfile(
+        name, "Utf8", "description", 0.9,
+        sample_values=["a long sentence about something", "another long sentence"],
+        null_rate=0.0, cardinality_ratio=card, avg_len=avg_len,
+    )
+
+
+def _name(name: str, *, card: float, col_type: str = "name") -> ColumnProfile:
+    return ColumnProfile(
+        name, "Utf8", col_type, 0.9,
+        sample_values=["smith", "jones", "garcia"],
+        null_rate=0.0, cardinality_ratio=card, avg_len=5.0,
+    )
+
+
+def test_single_description_column_is_text_corpus():
+    assert _is_text_corpus([_desc("body")]) is True
+
+
+def test_high_card_name_plus_description_is_not_text_corpus():
+    # A real blockable name column (card 0.8 >= 0.1) means this is structured
+    # data with a free-text field, NOT a pure text corpus.
+    assert _is_text_corpus([_name("last_name", card=0.8), _desc("notes")]) is False
+
+
+def test_low_card_name_plus_description_is_text_corpus():
+    # A low-cardinality "name" (card 0.02) can't block usefully, so a
+    # description-bearing dataset still reads as a text corpus.
+    assert _is_text_corpus([_name("label", card=0.02), _desc("body")]) is True
+
+
+def test_name_only_is_not_text_corpus():
+    assert _is_text_corpus([_name("last_name", card=0.8)]) is False
+
+
+def test_multi_name_high_card_blocks_text_corpus():
+    # multi_name is also a blockable name type.
+    assert _is_text_corpus([_name("authors", card=0.5, col_type="multi_name"), _desc("title")]) is False
+
+
+# ───────────────────────── A2: route text corpora to lsh ────────────────────
+
+
+def test_build_blocking_routes_text_corpus_to_lsh():
+    from goldenmatch.core.autoconfig import build_blocking, profile_columns
+
+    base = "the quick brown fox jumps over the lazy dog near the river bank"
+    variants = [
+        base,
+        base.replace("quick", "fast"),
+        base.replace("lazy", "sleepy"),
+        "a completely different statement about astronomy and distant galaxies far away",
+        "yet another unrelated remark concerning gardening tools and spring planting",
+        "an entirely separate note discussing maritime navigation and old sailing charts",
+    ]
+    df = pl.DataFrame({"body": variants * 5})
+    profiles = profile_columns(df)
+    blk = build_blocking(profiles, df)
+    assert blk.strategy == "lsh"
+    assert blk.lsh is not None
+    assert blk.lsh.column == "body"
+    assert blk.lsh.mode == "word"
+    assert blk.lsh.num_perms == 128
+
+
+# ───────────────────────── A3: controller guard ─────────────────────────────
+
+
+def _lsh_config():
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        GoldenMatchConfig,
+        LSHKeyConfig,
+    )
+
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="lsh",
+            lsh=LSHKeyConfig(column="body", threshold=0.5),
+        )
+    )
+
+
+def _swap_prone_profile():
+    """A ComplexityProfile shaped to trip the blocking-rewrite rules:
+    blocks formed, zero candidates compared, oversized p99, low reduction.
+
+    The controller guard short-circuits each rule before it reads the
+    profile, so the exact values here only matter as "would otherwise fire"
+    bait — they don't need to reflect a real run.
+    """
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile,
+        ComplexityProfile,
+        DataProfile,
+        ScoringProfile,
+    )
+
+    return ComplexityProfile(
+        data=DataProfile(
+            n_rows=10_000,
+            n_cols=1,
+            column_types={"body": "text"},
+            null_rate={"body": 0.0},
+        ),
+        blocking=BlockingProfile(
+            n_blocks=5,
+            block_sizes_p50=1,
+            block_sizes_p99=9_000,
+            block_sizes_max=9_000,
+            reduction_ratio=0.05,
+        ),
+        scoring=ScoringProfile(candidates_compared=0),
+    )
+
+
+def test_guarded_rules_return_none_when_lsh_locked():
+    from goldenmatch.core import autoconfig_rules as ar
+    from goldenmatch.core.autoconfig_history import RunHistory
+
+    cfg = _lsh_config()
+    profile = _swap_prone_profile()
+    history = RunHistory()
+
+    guarded = [
+        ar.rule_blocking_singleton_trap,
+        ar.rule_blocking_too_coarse,
+        ar.rule_blocking_key_swap,
+        ar.rule_uniform_heavy_blocking,
+        ar.rule_blocking_field_null_heavy,
+        ar.rule_low_reduction_ratio,
+        ar.rule_recall_gap_suspected,
+        ar.rule_cross_blocking_disagreement,
+        ar.rule_blocking_adaptive_on_p99_outlier,
+    ]
+    for rule in guarded:
+        assert rule(profile, cfg, history) is None, (
+            f"{rule.__name__} swapped blocking despite lsh lock"
+        )
+
+
+def test_near_dup_locked_helper():
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        GoldenMatchConfig,
+        LSHKeyConfig,
+    )
+    from goldenmatch.core.autoconfig_rules import _near_dup_locked
+
+    lsh = GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="lsh", lsh=LSHKeyConfig(column="body", threshold=0.5)
+        )
+    )
+    assert _near_dup_locked(lsh) is True
+
+    static = GoldenMatchConfig()
+    assert _near_dup_locked(static) is False
+
+    no_blocking = GoldenMatchConfig()
+    no_blocking.blocking = None
+    assert _near_dup_locked(no_blocking) is False
+
+
+# ───────────────────────── A4: zero-config text dedupe e2e ───────────────────
+
+
+def test_zero_config_text_corpus_dedupe_e2e():
+    import goldenmatch
+
+    base = "the annual budget report shows a significant increase in marketing spend"
+    near_dups = [
+        base,
+        base.replace("significant", "substantial"),
+        base.replace("marketing", "advertising"),
+    ]
+    distinct = [
+        "weather patterns over the pacific ocean shifted dramatically this winter season",
+        "the museum unveiled a new exhibit featuring ancient pottery from coastal villages",
+        "local farmers reported record yields after an unusually wet and mild growing year",
+        "the orchestra performed a moving rendition of a forgotten romantic era symphony",
+        "engineers completed the suspension bridge two months ahead of the planned schedule",
+    ]
+    rows = near_dups + distinct
+    # Repeat the distinct rows a couple times to give the corpus some bulk;
+    # each repeat is itself an exact near-dup group, but the assertions below
+    # only check the near_dups group and that distinct sentences don't merge
+    # with the near_dups group.
+    df = pl.DataFrame({"text": rows})
+
+    result = goldenmatch.dedupe_df(df, confidence_required=False)
+
+    # Recover the cluster id per row via the deduped frame, if exposed; else
+    # fall back to the clusters mapping on the result.
+    clusters = result.clusters  # dict[int, dict] keyed by cluster id
+    # Build row_id -> cluster_id.
+    member_to_cluster: dict[int, int] = {}
+    for cid, info in clusters.items():
+        for member in info["members"]:
+            member_to_cluster[member] = cid
+
+    # The three near-dup rows are row ids 0, 1, 2.
+    near_dup_clusters = {member_to_cluster.get(i) for i in (0, 1, 2)}
+    # They must all land together (one shared cluster id, not None).
+    assert len(near_dup_clusters) == 1, (
+        f"near-dup rows split across clusters: {near_dup_clusters}"
+    )
+    shared = next(iter(near_dup_clusters))
+    assert shared is not None
+
+    # No distinct sentence (row ids 3..7) should join the near-dup cluster.
+    for i in range(3, len(rows)):
+        assert member_to_cluster.get(i) != shared, (
+            f"distinct row {i} merged into the near-dup cluster"
+        )

--- a/packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py
@@ -185,7 +185,14 @@ def test_near_dup_locked_helper():
 
 
 def test_zero_config_text_corpus_dedupe_e2e():
+    """End-to-end: a single text column dedupes near-dups with NO config.
+
+    Exercises A1 (text-corpus detection) + A2 (lsh routing) + A3 (the
+    controller leaving lsh in place) through the public ``dedupe_df`` entry
+    point.
+    """
     import goldenmatch
+    from goldenmatch.core.autoconfig import auto_configure_df
 
     base = "the annual budget report shows a significant increase in marketing spend"
     near_dups = [
@@ -201,11 +208,12 @@ def test_zero_config_text_corpus_dedupe_e2e():
         "engineers completed the suspension bridge two months ahead of the planned schedule",
     ]
     rows = near_dups + distinct
-    # Repeat the distinct rows a couple times to give the corpus some bulk;
-    # each repeat is itself an exact near-dup group, but the assertions below
-    # only check the near_dups group and that distinct sentences don't merge
-    # with the near_dups group.
     df = pl.DataFrame({"text": rows})
+
+    # The zero-config path must pick lsh blocking for this corpus.
+    cfg = auto_configure_df(df, confidence_required=False)
+    assert cfg.blocking is not None
+    assert cfg.blocking.strategy == "lsh"
 
     result = goldenmatch.dedupe_df(df, confidence_required=False)
 

--- a/packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_text_corpus_autoconfig.py
@@ -85,7 +85,47 @@ def test_build_blocking_routes_text_corpus_to_lsh():
 # ───────────────────────── A3: controller guard ─────────────────────────────
 
 
+def _weighted_matchkey():
+    """A weighted matchkey carrying a text field the blocking-swap rules can
+    re-key onto (``rule_blocking_key_swap`` walks the first weighted matchkey
+    for a text/name field)."""
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    return MatchkeyConfig(
+        name="primary",
+        type="weighted",
+        threshold=0.85,
+        fields=[
+            MatchkeyField(
+                field="name", transforms=["lowercase"],
+                scorer="ensemble", weight=1.0,
+            ),
+        ],
+    )
+
+
+def _static_config():
+    """Normal static blocking on ``city`` (NOT the matchkey's ``name`` field,
+    so the swap rules propose a genuine change) with a weighted matchkey."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+    )
+
+    return GoldenMatchConfig(
+        matchkeys=[_weighted_matchkey()],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["city"], transforms=["lowercase"])],
+        ),
+    )
+
+
 def _lsh_config():
+    """Same matchkey, but lsh blocking (the near-dup-locked strategy). An lsh
+    BlockingConfig must NOT carry keys/passes, so blocking is the only
+    difference from ``_static_config``."""
     from goldenmatch.config.schemas import (
         BlockingConfig,
         GoldenMatchConfig,
@@ -93,20 +133,31 @@ def _lsh_config():
     )
 
     return GoldenMatchConfig(
+        matchkeys=[_weighted_matchkey()],
         blocking=BlockingConfig(
             strategy="lsh",
             lsh=LSHKeyConfig(column="body", threshold=0.5),
-        )
+        ),
     )
 
 
 def _swap_prone_profile():
-    """A ComplexityProfile shaped to trip the blocking-rewrite rules:
-    blocks formed, zero candidates compared, oversized p99, low reduction.
+    """A ComplexityProfile shaped to ACTUALLY trip both
+    ``rule_blocking_key_swap`` and ``rule_uniform_heavy_blocking``.
 
-    The controller guard short-circuits each rule before it reads the
-    profile, so the exact values here only matter as "would otherwise fire"
-    bait — they don't need to reflect a real run.
+    Trigger conditions matched precisely against the rule bodies:
+
+    - ``rule_blocking_key_swap``: ``candidates_compared > 0`` AND
+      ``mass_above_threshold == 0.0``; matchkey carries a text field
+      (``name`` typed "text" here). History supplies the prior decision the
+      rule requires (it's the iter-1+ fallback).
+    - ``rule_uniform_heavy_blocking``: ``avg_block = n_rows/n_blocks >= 30``
+      (10_000/100 = 100), ``candidates_compared >= n_rows``,
+      ``mass_above_threshold >= 0.5``, ``mass_in_borderline >= 0.5``, and a
+      high-cardinality identity-bearing column (``name``, type "name",
+      cardinality 0.8, not in blocking) to swap onto.
+
+    Both gates fire on these values, so static-vs-lsh isolates the guard.
     """
     from goldenmatch.core.complexity_profile import (
         BlockingProfile,
@@ -118,28 +169,132 @@ def _swap_prone_profile():
     return ComplexityProfile(
         data=DataProfile(
             n_rows=10_000,
-            n_cols=1,
-            column_types={"body": "text"},
-            null_rate={"body": 0.0},
+            n_cols=2,
+            column_types={"name": "name", "city": "geo"},
+            cardinality_ratio={"name": 0.8, "city": 0.05},
+            null_rate={"name": 0.0, "city": 0.0},
         ),
         blocking=BlockingProfile(
-            n_blocks=5,
-            block_sizes_p50=1,
-            block_sizes_p99=9_000,
-            block_sizes_max=9_000,
-            reduction_ratio=0.05,
+            n_blocks=100,
+            block_sizes_p50=100,
+            block_sizes_p99=120,
+            block_sizes_max=150,
+            reduction_ratio=0.5,
         ),
-        scoring=ScoringProfile(candidates_compared=0),
+        scoring=ScoringProfile(
+            n_pairs_scored=50_000,
+            # >= n_rows so uniform_heavy treats blocking as over-coarse
+            candidates_compared=50_000,
+            # 0.0 so blocking_key_swap fires; >= 0.5 satisfies uniform_heavy
+            mass_above_threshold=0.0,
+            mass_in_borderline=0.6,
+        ),
     )
 
 
-def test_guarded_rules_return_none_when_lsh_locked():
-    from goldenmatch.core import autoconfig_rules as ar
+def _swap_prone_profile_uniform():
+    """Variant for ``rule_uniform_heavy_blocking`` only: it needs
+    ``mass_above_threshold >= 0.5`` (the "everything matches" signature),
+    which is mutually exclusive with ``rule_blocking_key_swap``'s
+    ``mass_above_threshold == 0.0``. Same shape otherwise."""
+    import dataclasses
+
+    base = _swap_prone_profile()
+    return dataclasses.replace(
+        base,
+        scoring=dataclasses.replace(
+            base.scoring, mass_above_threshold=0.6, mass_in_borderline=0.6
+        ),
+    )
+
+
+def _history_with_prior_decision():
+    """A RunHistory with one prior decision — ``rule_blocking_key_swap`` is the
+    iter-1+ fallback and bails when ``history.decisions`` is empty."""
+    from goldenmatch.core.autoconfig_history import (
+        HistoryEntry,
+        PolicyDecision,
+        RunHistory,
+    )
+
+    h = RunHistory()
+    h.entries.append(
+        HistoryEntry(
+            iteration=0,
+            config=_static_config(),
+            profile=_swap_prone_profile(),
+            decision=PolicyDecision(
+                rule_name="rule_blocking_field_null_heavy",
+                rationale="prior",
+                config_diff={},
+            ),
+            error=None,
+            wall_clock_ms=10,
+        )
+    )
+    return h
+
+
+def test_blocking_key_swap_fires_static_but_guard_blocks_lsh():
+    """rule_blocking_key_swap proposes a swap on a static config that trips it,
+    and the near-dup guard suppresses the identical proposal under lsh.
+
+    This is the teeth: removing ``if _near_dup_locked(current): return None``
+    flips the lsh assertion from None to a proposal.
+    """
+    from goldenmatch.core.autoconfig_rules import rule_blocking_key_swap
+
+    profile = _swap_prone_profile()
+    history = _history_with_prior_decision()
+
+    # static: the profile genuinely trips the rule -> non-None proposal.
+    static_out = rule_blocking_key_swap(profile, _static_config(), history)
+    assert static_out is not None, "profile should trip rule_blocking_key_swap on static blocking"
+    new_cfg, _decision = static_out
+    assert new_cfg.blocking is not None
+    assert new_cfg.blocking.strategy == "static"
+    assert new_cfg.blocking.keys[0].fields == ["name"]
+
+    # lsh: same profile + history, only the guard differs -> None.
+    lsh_out = rule_blocking_key_swap(profile, _lsh_config(), history)
+    assert lsh_out is None, "near-dup guard must suppress rule_blocking_key_swap under lsh"
+
+
+def test_uniform_heavy_blocking_fires_static_but_guard_blocks_lsh():
+    """rule_uniform_heavy_blocking proposes a swap on a static config that trips
+    it, and the near-dup guard suppresses the identical proposal under lsh."""
     from goldenmatch.core.autoconfig_history import RunHistory
+    from goldenmatch.core.autoconfig_rules import rule_uniform_heavy_blocking
+
+    profile = _swap_prone_profile_uniform()
+    history = RunHistory()
+
+    # static: the profile genuinely trips the rule -> non-None proposal.
+    static_out = rule_uniform_heavy_blocking(profile, _static_config(), history)
+    assert static_out is not None, "profile should trip rule_uniform_heavy_blocking on static blocking"
+    new_cfg, _decision = static_out
+    assert new_cfg.blocking is not None
+    assert new_cfg.blocking.strategy == "static"
+    assert new_cfg.blocking.keys[0].fields == ["name"]
+
+    # lsh: same profile + history, only the guard differs -> None.
+    lsh_out = rule_uniform_heavy_blocking(profile, _lsh_config(), history)
+    assert lsh_out is None, "near-dup guard must suppress rule_uniform_heavy_blocking under lsh"
+
+
+def test_guarded_rules_return_none_when_lsh_locked():
+    """Breadth check: every guarded rule returns None on an lsh config.
+
+    Kept as a regression net across all nine guarded rules. The per-rule
+    teeth (static fires, lsh blocked) live in the two tests above —
+    several rules here return None for reasons unrelated to the guard on
+    this profile, so this test alone does NOT prove the guard works.
+    """
+    from goldenmatch.core import autoconfig_rules as ar
 
     cfg = _lsh_config()
     profile = _swap_prone_profile()
-    history = RunHistory()
+    history = _history_with_prior_decision()
 
     guarded = [
         ar.rule_blocking_singleton_trap,


### PR DESCRIPTION
Phase A of #1082 (Document/text near-dup blocking path) — the explicit "Done" bar: a text corpus now blocks on shingles/LSH with **no manual matchkey/blocking config**. Builds on #1081's MinHash/LSH kernel. Part of the dedup epic #1080.

## What this does
`dedupe_df(text_corpus)` now auto-detects a text corpus and emits `strategy="lsh"` zero-config, instead of routing a long-text column to FAISS `ann` (≥100K rows) or falling through to name-based blocking.

- **`_is_text_corpus(profiles)`** — fires when a `description` column exists and there's no blockable `name`/`multi_name` column (`cardinality_ratio >= 0.1`). The text is the primary identity, not a description field on otherwise-structured records.
- **Routing** — a text-corpus branch in `build_blocking` (in place of the old `_ann_eligible` block) emits `BlockingConfig(strategy="lsh", lsh=LSHKeyConfig(column=<longest description>, mode="word", k=2, num_perms=128, threshold=0.5))`. **ANN is no longer auto-selected for description columns** (intended — semantic SimHash becomes the auto embedding path in Phase B; explicit `strategy="ann"` still works).
- **Controller guard** — the nine auto-config refit rules that rewrite `blocking.strategy`/keys now early-return when the committed strategy is `lsh`/`simhash`, so the controller can't swap a near-dup strategy mid-iteration to `static`/`multi_pass`.

## Tests
New `tests/test_text_corpus_autoconfig.py` (11 tests incl. a controller-guard test with **proven teeth** — verified it fails if a guard is removed). The structured/exact/name paths are byte-identical (382 passing across every autoconfig + `build_blocking`-calling test file). Updated a few existing assertions where ANN/canopy auto-select was intentionally dropped for description columns (legit behavior change, not masking a regression).

## Follow-up
**Phase B (#1082)** — the new SimHash-over-embeddings kernel (`strategy="simhash"`, the semantic escalation when an embedder is reachable) lands in a separate PR. Spec + plan committed in this branch under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)