### PR TITLE
fix(deps): bump undici 7.25.0 -> 7.28.0 to clear the stuck security update

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2290,8 +2290,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
@@ -3671,7 +3671,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4244,7 +4244,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:


### PR DESCRIPTION
## What was red

`main` had a recurring red **`npm_and_yarn ... undici - Update`** Dependabot job (`security_update_not_possible`):

```
The latest possible version of undici that can be installed is 7.25.0
The earliest fixed version is 7.28.0.
```

The actual CI gate (`ci`, CodeQL, publish-containers, Scorecard, ast-grep) is green on `main` HEAD, and the old `bench-lsh-recall` red was a stale pre-fix run (already re-run green). This Dependabot failure was the one persistent red.

## Root cause

`undici@7.25.0` is a transitive dep of `jsdom@29.1.1` (a test-only devDependency). jsdom already declares `undici: ^7.25.0`, which **permits 7.28.0** — but `pnpm-lock.yaml` was resolved back when 7.25.0 was the newest 7.x, so it pinned the vulnerable build. Dependabot's `npm_and_yarn` updater has limited pnpm-lock support and couldn't refresh that transitive pin, so it gave up with `security_update_not_possible` and the job stayed red.

## Fix

`pnpm up undici -r` refreshes the lockfile to `undici@7.28.0` (the patched release; `engines: node >=20.18.1`, satisfied by the repo's `node >=22`). Once `main`'s lockfile no longer carries 7.25.0, the advisory and its red job clear.

Diff is 4 lines in `pnpm-lock.yaml` only (resolution + jsdom reference). Verified `pnpm install --frozen-lockfile` reports the lockfile up to date, so CI's frozen install will accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_