### PR TITLE
feat(goldengraph): SP3 — community detection (label-propagation)

### DIFF
--- a/docs/superpowers/specs/2026-06-20-goldengraph-sp3-communities-design.md
+++ b/docs/superpowers/specs/2026-06-20-goldengraph-sp3-communities-design.md
@@ -1,0 +1,87 @@
+# goldengraph SP3 — community detection — design
+
+**Status:** Design draft 2026-06-20. SP3 of the program roadmap (`2026-06-20-goldengraph-program-roadmap.md`). Awaiting approval → plan.
+
+**Builds on:** SP1 (resolved `Graph`), graph-core (`connected_components` WCC kernel). **Surface:** Rust core (graph-core kernel + goldengraph-core query), pyo3-free. **Independent of SP2** (runs over the in-memory resolved graph, like SP1's `neighborhood`).
+
+---
+
+## Motivation
+
+GraphRAG's "global" queries (themes spanning the whole corpus) need community structure: groups of densely-connected entities, each summarizable into a report the LLM map-reduces over. SP1 gives local (neighborhood) retrieval; SP3 adds the community partition that global search rides on. The popular frameworks lean on Leiden (Microsoft GraphRAG) for this; we add a deterministic, portable, pyo3-free kernel.
+
+## Scope
+
+1. **A community-detection kernel in `graph-core`** (the shared pyo3-free kernel crate, alongside `connected_components`), reusing its graph-traversal idiom. Suite-wide: native/pgrx/datafusion can expose it later, exactly as they do WCC.
+2. **A `communities(&Graph)` query in `goldengraph-core`** that runs the kernel over the resolved entity-space edges and returns entity-id communities.
+
+## Resolved decision (the roadmap's deferred item)
+
+- **Algorithm: deterministic label propagation** (not Leiden, for SP3). Rationale: (a) **determinism** — the core forbids RNG/wall-clock (golden vectors); standard LP randomizes node order, so we fix it to an **asynchronous in-place sweep in ascending id order** with a smallest-label tie-break — fully deterministic, no RNG, no oscillation (async, unlike synchronous LP); (b) it mirrors the existing `connected_components` shape (edge list + id universe → `Vec<Vec<i64>>`), minimal new surface; (c) it's O(iters × edges), fast. **Leiden (modularity-optimal, hierarchical) is a future quality upgrade** behind the same return shape — noted, not built. Communities are **flat** in SP3; hierarchical is the Leiden follow-up.
+- **Honest limitation:** on small or densely-connected graphs, label propagation tends to merge across sparse bridges, so it often returns **community ≈ connected-component** granularity (a bridged two-cluster graph usually collapses to ONE community). Its sub-component granularity only emerges on larger graphs with clear density contrast. In the extreme — one large, densely-connected corpus graph (exactly the shape GraphRAG global search targets) — LP can return a *single* community, degenerating "themes across the corpus" to one report. So SP3 delivers a *working but coarse* community layer (enough to get global search off the ground — each community gets a summary); **Leiden is the granularity upgrade**. The golden vectors pin the kernel's *actual, descriptive* behavior, not an optimality claim.
+
+## The kernel (`graph-core/src/lib.rs`)
+
+```
+/// Deterministic label-propagation communities over `all_ids` ∪ edge endpoints.
+/// Each id starts in its own community. Repeatedly, in ASCENDING id order, each
+/// id adopts the most frequent label among its neighbors (ties → smallest
+/// label); a node with no neighbors keeps its own. Iterate until a full sweep
+/// makes no change or `max_iters` is hit. Returns communities (each a sorted
+/// Vec of ids); singletons included (parity with `connected_components`).
+pub fn label_propagation_communities(
+    edges: &[(i64, i64, f64)], all_ids: &[i64], max_iters: u32,
+) -> Vec<Vec<i64>>;
+```
+
+- **Determinism:** fixed ascending-id sweep order + smallest-label tie-break → identical output regardless of edge/id input order. No RNG. **Termination** is guaranteed by the `max_iters` cap (LP converges fast in practice; async reduces but doesn't eliminate oscillation on all topologies, so the cap is the hard backstop). At the cap the kernel returns the current — deterministic, well-formed (every id assigned) — partition, not necessarily a fixed point.
+- **Undirected, set adjacency:** an edge `(a,b,_)` makes `a` and `b` neighbors both ways (matching `neighborhood`'s undirected expansion). Adjacency is a **set** — duplicate edges collapse (no double-counting) and **self-loops `(a,a)` are ignored** (a node never votes for its own label; "most frequent among neighbors" excludes self). Edge weight is ignored (LP is unweighted in SP3; weighted LP is a future option).
+- **Output order:** communities sorted by their minimum id; members sorted ascending (deterministic, like the snapshot canonical form).
+
+## The query (`goldengraph-core/src/community.rs`)
+
+```
+/// `id` = positional index after sorting communities by their minimum member.
+pub struct Community { pub id: u32, pub members: Vec<EntityId> }   // members sorted ascending
+
+/// Fixed iteration cap for the query path — part of the deterministic contract
+/// (it co-determines the frozen golden partition; never an ad-hoc value).
+pub const COMMUNITY_MAX_ITERS: u32 = 100;
+
+/// Partition a resolved Graph's entities into communities via the graph-core
+/// kernel over its entity-space edges. Entities with no edges are singletons.
+pub fn communities(graph: &Graph) -> Vec<Community>;   // passes COMMUNITY_MAX_ITERS
+```
+
+- Maps the `Graph`'s `Edge`s to `(subj as i64, obj as i64, 1.0)` pairs + the entity-id universe, calls the kernel with `COMMUNITY_MAX_ITERS`, maps the `Vec<Vec<i64>>` back to `Community` (members as `EntityId`, communities sorted by min member, `id` = that positional index).
+- Deterministic; reuses SP1 `Graph` so it composes with `neighborhood` (a global query = communities → per-community subgraph via `neighborhood` on community members).
+
+## Determinism + parity
+
+Golden vectors extend the SP1/SP2 pattern: a fixture `(Graph) -> communities` checked byte-for-byte (canonical JSON: communities by min member, members sorted). SP5's WASM/C reuse it.
+
+## Testing (TDD)
+
+Tests pin determinism + mechanics + the kernel's *actual* behavior (not optimality):
+- **Disconnected components** (two separate triangles, no bridge) → 2 communities (LP = WCC here).
+- **Connected graph** (one triangle) → 1 community.
+- **Singletons** (ids with no edges) → each its own community (parity with `connected_components`).
+- **Determinism / order-independence:** shuffling edge and id input order → byte-identical output (the headline guard — the fixed ascending-id sweep + smallest-label tie-break is the sole order source).
+- **Convergence:** a chain (0-1-2-3-4) terminates within `max_iters` and returns a deterministic, well-formed partition; pin whatever partition LP actually yields.
+- **`max_iters` cutoff:** with `max_iters=1` on a graph needing more sweeps, assert a well-formed partition (every id assigned) is returned — proves the cap backstops termination, not just the convergence path.
+- **Set adjacency / self-loop:** a duplicate edge and a self-loop `(a,a)` don't change the partition vs the deduped, self-loop-free graph.
+- **Query:** the SP1 differentiator graph (Apple/Jobs/iPhone resolved) → connected entities share a community; an isolated entity is its own.
+- **Golden-vector byte-equality** (descriptive: whatever the deterministic kernel produces, frozen).
+
+## CI
+
+graph-core changes run under ci.yml's `rust` job (`cargo test/clippy --manifest-path graph-core/Cargo.toml`) — **ci-required**. goldengraph-core changes also run the informational `goldengraph` lane. No workflow change.
+
+## Non-goals (SP3)
+
+Leiden / modularity optimization (future quality upgrade). Hierarchical communities (future). Weighted LP (future). **LLM community summaries + global-search map-reduce** (host-side — SP4). **Persisting communities in the SP2 store + as-of-community queries** (a follow-up once both land; SP3 is in-memory over a resolved `Graph`). Distributed community detection.
+
+## Risks / open questions (resolve in the plan)
+
+- **LP quality vs Leiden:** label propagation can under-merge or produce unbalanced communities on some topologies. Acceptable for SP3 (gets global-search off the ground); Leiden is the quality follow-up. The golden vectors pin behavior, not optimality.
+- **Determinism of the sweep:** the fixed ascending-id, smallest-label-tie rule must be the sole source of order — the order-independence test is the guard.

--- a/packages/rust/extensions/goldengraph-core/src/community.rs
+++ b/packages/rust/extensions/goldengraph-core/src/community.rs
@@ -1,0 +1,106 @@
+//! SP3 — community detection over the resolved graph.
+//!
+//! Partitions a resolved `Graph`'s entities into communities via graph-core's
+//! deterministic label-propagation kernel, run over the entity-space edges.
+//! A "global" query composes this with SP1 retrieval: communities → per-community
+//! subgraph via `neighborhood` over each community's members.
+//!
+//! Honest scope (carried from the spec): label propagation is a modest first
+//! kernel — on small/dense graphs it yields community ≈ connected-component
+//! granularity; Leiden is the future granularity upgrade. In-memory over a
+//! resolved `Graph`; persisting communities in the SP2 store is a follow-up.
+
+use goldenmatch_graph_core::label_propagation_communities;
+
+use crate::model::{EntityId, Graph};
+
+/// Fixed iteration cap for the query path — part of the deterministic contract
+/// (it co-determines the partition the golden vectors freeze; never ad-hoc).
+pub const COMMUNITY_MAX_ITERS: u32 = 100;
+
+/// A detected community: a stable positional `id` plus its member entity ids.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Community {
+    /// Positional index after sorting communities by their minimum member.
+    pub id: u32,
+    /// Member entity ids, sorted ascending.
+    pub members: Vec<EntityId>,
+}
+
+/// Partition a resolved `Graph`'s entities into communities. Entities with no
+/// edges are singleton communities. Deterministic and independent of edge order
+/// (the kernel sorts by min member; `id` is that positional index).
+pub fn communities(graph: &Graph) -> Vec<Community> {
+    let all_ids: Vec<i64> = graph.entities.iter().map(|e| e.entity_id as i64).collect();
+    let edges: Vec<(i64, i64, f64)> = graph
+        .edges
+        .iter()
+        .map(|e| (e.subj as i64, e.obj as i64, 1.0))
+        .collect();
+    let raw = label_propagation_communities(&edges, &all_ids, COMMUNITY_MAX_ITERS);
+    raw.into_iter()
+        .enumerate()
+        .map(|(i, members)| Community {
+            id: i as u32,
+            members: members.into_iter().map(|x| x as EntityId).collect(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Edge, EntityNode};
+
+    fn node(id: EntityId) -> EntityNode {
+        EntityNode {
+            entity_id: id,
+            canonical_name: format!("E{id}"),
+            typ: "t".into(),
+            members: vec![],
+            surface_names: vec![format!("E{id}")],
+        }
+    }
+    fn edge(s: EntityId, o: EntityId) -> Edge {
+        Edge {
+            subj: s,
+            predicate: "r".into(),
+            obj: o,
+            source_refs: vec![],
+        }
+    }
+
+    #[test]
+    fn connected_entities_share_a_community_isolated_is_singleton() {
+        // 0-1, 0-2 connected; 3 isolated
+        let g = Graph {
+            entities: vec![node(0), node(1), node(2), node(3)],
+            edges: vec![edge(0, 1), edge(0, 2)],
+        };
+        let c = communities(&g);
+        assert_eq!(
+            c,
+            vec![
+                Community {
+                    id: 0,
+                    members: vec![0, 1, 2]
+                },
+                Community {
+                    id: 1,
+                    members: vec![3]
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn communities_order_independent_of_edge_order() {
+        let mk = |edges: Vec<Edge>| Graph {
+            entities: vec![node(0), node(1), node(2), node(3), node(4)],
+            edges,
+        };
+        let a = communities(&mk(vec![edge(0, 1), edge(1, 2), edge(3, 4)]));
+        let b = communities(&mk(vec![edge(3, 4), edge(2, 1), edge(1, 0)]));
+        assert_eq!(a, b);
+    }
+}

--- a/packages/rust/extensions/goldengraph-core/src/lib.rs
+++ b/packages/rust/extensions/goldengraph-core/src/lib.rs
@@ -10,6 +10,7 @@
 //! Intentionally pyo3-free: the Python binding is the sibling
 //! `goldengraph-native` crate. No LLM, no embeddings, no persistence (SP2+).
 
+pub mod community;
 pub mod model;
 pub mod resolve;
 pub mod retrieve;

--- a/packages/rust/extensions/goldengraph-core/tests/community_integration.rs
+++ b/packages/rust/extensions/goldengraph-core/tests/community_integration.rs
@@ -1,0 +1,69 @@
+//! SP3 community-detection golden vectors — the cross-binding contract.
+//!
+//! Builds a resolved `Graph` from the fixture, runs `communities`, and asserts
+//! the partition byte-equals the fixture (canonical JSON). Descriptive: freezes
+//! the deterministic label-propagation output. SP5's WASM/C reuse this fixture.
+
+use goldengraph_core::community::communities;
+use goldengraph_core::model::{Edge, EntityNode, Graph};
+use serde_json::{json, Value};
+
+fn load() -> Value {
+    let raw = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/community_golden.json"
+    ))
+    .expect("read community fixture");
+    serde_json::from_str(&raw).expect("parse community fixture")
+}
+
+fn build_graph(v: &Value) -> Graph {
+    let entities = v["graph"]["entities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| EntityNode {
+            entity_id: e["entity_id"].as_u64().unwrap() as u32,
+            canonical_name: e["canonical_name"].as_str().unwrap().to_string(),
+            typ: e["typ"].as_str().unwrap().to_string(),
+            members: vec![],
+            surface_names: e["surface_names"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|s| s.as_str().unwrap().to_string())
+                .collect(),
+        })
+        .collect();
+    let edges = v["graph"]["edges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| Edge {
+            subj: e["subj"].as_u64().unwrap() as u32,
+            predicate: e["predicate"].as_str().unwrap().to_string(),
+            obj: e["obj"].as_u64().unwrap() as u32,
+            source_refs: e["source_refs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|s| s.as_str().unwrap().to_string())
+                .collect(),
+        })
+        .collect();
+    Graph { entities, edges }
+}
+
+#[test]
+fn community_golden_vectors_match() {
+    let v = load();
+    let g = build_graph(&v);
+    let computed: Vec<Value> = communities(&g)
+        .into_iter()
+        .map(|c| json!({ "id": c.id, "members": c.members }))
+        .collect();
+    assert_eq!(
+        serde_json::to_string(&Value::Array(computed)).unwrap(),
+        serde_json::to_string(&v["expected_communities"]).unwrap(),
+    );
+}

--- a/packages/rust/extensions/goldengraph-core/tests/fixtures/community_golden.json
+++ b/packages/rust/extensions/goldengraph-core/tests/fixtures/community_golden.json
@@ -1,0 +1,27 @@
+{
+  "_doc": "SP3 community-detection golden vectors (cross-binding contract; SP5 WASM/C reuse). Build the resolved `graph`, run communities(), assert it byte-equals `expected_communities` (communities by ascending min member, members sorted, id = positional index). DESCRIPTIVE: freezes the deterministic label-propagation partition, not an optimality claim. Two disconnected triangles + an isolated node -> three communities (here LP == connected components, the documented small-graph behavior).",
+  "graph": {
+    "entities": [
+      { "entity_id": 0, "canonical_name": "Acme", "typ": "org", "surface_names": ["Acme"] },
+      { "entity_id": 1, "canonical_name": "Beta", "typ": "org", "surface_names": ["Beta"] },
+      { "entity_id": 2, "canonical_name": "Gamma", "typ": "org", "surface_names": ["Gamma"] },
+      { "entity_id": 3, "canonical_name": "Delta", "typ": "person", "surface_names": ["Delta"] },
+      { "entity_id": 4, "canonical_name": "Eps", "typ": "person", "surface_names": ["Eps"] },
+      { "entity_id": 5, "canonical_name": "Zeta", "typ": "person", "surface_names": ["Zeta"] },
+      { "entity_id": 6, "canonical_name": "Lone", "typ": "product", "surface_names": ["Lone"] }
+    ],
+    "edges": [
+      { "subj": 0, "predicate": "r", "obj": 1, "source_refs": ["d1"] },
+      { "subj": 1, "predicate": "r", "obj": 2, "source_refs": ["d2"] },
+      { "subj": 0, "predicate": "r", "obj": 2, "source_refs": ["d3"] },
+      { "subj": 3, "predicate": "r", "obj": 4, "source_refs": ["d4"] },
+      { "subj": 4, "predicate": "r", "obj": 5, "source_refs": ["d5"] },
+      { "subj": 3, "predicate": "r", "obj": 5, "source_refs": ["d6"] }
+    ]
+  },
+  "expected_communities": [
+    { "id": 0, "members": [0, 1, 2] },
+    { "id": 1, "members": [3, 4, 5] },
+    { "id": 2, "members": [6] }
+  ]
+}

--- a/packages/rust/extensions/graph-core/src/lib.rs
+++ b/packages/rust/extensions/graph-core/src/lib.rs
@@ -77,6 +77,91 @@ pub fn connected_components(edges: &[(i64, i64, f64)], all_ids: &[i64]) -> Vec<V
     groups.into_values().collect()
 }
 
+/// Deterministic label-propagation communities over `all_ids` ∪ edge endpoints.
+///
+/// Each id starts in its own community. Repeatedly, in ASCENDING id order, each
+/// id adopts the most frequent label among its (set) neighbors — ties broken by
+/// the smallest label; a node with no neighbors keeps its own. Updates are
+/// applied in place (asynchronous), so the processed/unprocessed split is fixed
+/// by ascending id, making the result independent of input edge/id order. The
+/// sweep repeats until a full pass makes no change or `max_iters` is hit (the
+/// hard termination backstop). Adjacency is a SET — duplicate edges collapse and
+/// self-loops `(a,a)` are ignored (a node never votes for its own label). Edge
+/// weight is ignored (unweighted LP). Returns communities sorted by minimum id,
+/// each member list sorted ascending; singletons included (parity with
+/// `connected_components`).
+///
+/// Label propagation is intentionally a modest first kernel: on small or densely
+/// connected graphs it tends to merge across bridges (community ≈ connected
+/// component). A modularity-optimal method (Leiden) behind the same return shape
+/// is the future quality upgrade.
+pub fn label_propagation_communities(
+    edges: &[(i64, i64, f64)],
+    all_ids: &[i64],
+    max_iters: u32,
+) -> Vec<Vec<i64>> {
+    use std::collections::BTreeSet;
+
+    // Set adjacency over the id universe ∪ edge endpoints; drop self-loops.
+    let mut adj: BTreeMap<i64, BTreeSet<i64>> = BTreeMap::new();
+    for &id in all_ids {
+        adj.entry(id).or_default();
+    }
+    for &(a, b, _s) in edges {
+        adj.entry(a).or_default();
+        adj.entry(b).or_default();
+        if a != b {
+            adj.get_mut(&a).unwrap().insert(b);
+            adj.get_mut(&b).unwrap().insert(a);
+        }
+    }
+
+    // Each node starts as its own label. BTreeMap keys are ascending.
+    let nodes: Vec<i64> = adj.keys().copied().collect();
+    let mut label: BTreeMap<i64, i64> = nodes.iter().map(|&id| (id, id)).collect();
+
+    for _ in 0..max_iters {
+        let mut changed = false;
+        for &v in &nodes {
+            let neighbors = &adj[&v];
+            if neighbors.is_empty() {
+                continue; // no neighbors → keep own label
+            }
+            // Tally neighbor labels (current/in-place values).
+            let mut freq: BTreeMap<i64, usize> = BTreeMap::new();
+            for &u in neighbors {
+                *freq.entry(label[&u]).or_insert(0) += 1;
+            }
+            // Most frequent; ascending-label iteration + strict `>` keeps the
+            // SMALLEST label among those tied for the max count.
+            let mut best_label = v;
+            let mut best_count = 0usize;
+            for (&lab, &cnt) in &freq {
+                if cnt > best_count {
+                    best_count = cnt;
+                    best_label = lab;
+                }
+            }
+            if best_label != label[&v] {
+                label.insert(v, best_label);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // Group by final label; members ascending (nodes iterated ascending).
+    let mut groups: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
+    for &v in &nodes {
+        groups.entry(label[&v]).or_default().push(v);
+    }
+    let mut out: Vec<Vec<i64>> = groups.into_values().collect();
+    out.sort_by_key(|c| c[0]); // c[0] is the min member (ascending push order)
+    out
+}
+
 /// Arrow columnar dedup over int64 id columns + float64 score. Validates types,
 /// reads the columns, runs `dedup_pairs_max_score`, returns three Arrow arrays.
 pub fn dedup_pairs_arrow_data(
@@ -376,6 +461,53 @@ mod tests {
         let mut sorted: Vec<Vec<i64>> = comps.iter().map(|c| { let mut v = c.clone(); v.sort(); v }).collect();
         sorted.sort();
         assert_eq!(sorted, vec![vec![1, 2, 3], vec![4]]);
+    }
+
+    #[test]
+    fn lp_disconnected_components_and_singletons() {
+        // two separate triangles + an isolated node 6
+        let edges = [
+            (0, 1, 1.0), (1, 2, 1.0), (0, 2, 1.0),
+            (3, 4, 1.0), (4, 5, 1.0), (3, 5, 1.0),
+        ];
+        let got = label_propagation_communities(&edges, &[0, 1, 2, 3, 4, 5, 6], 100);
+        assert_eq!(got, vec![vec![0, 1, 2], vec![3, 4, 5], vec![6]]);
+    }
+
+    #[test]
+    fn lp_connected_graph_one_community() {
+        let got = label_propagation_communities(&[(0, 1, 1.0), (1, 2, 1.0)], &[0, 1, 2], 100);
+        assert_eq!(got, vec![vec![0, 1, 2]]);
+    }
+
+    #[test]
+    fn lp_deterministic_under_input_permutation() {
+        let edges_a = [(0, 1, 1.0), (1, 2, 1.0), (3, 4, 1.0)];
+        let edges_b = [(4, 3, 1.0), (2, 1, 1.0), (1, 0, 1.0)]; // shuffled + reversed
+        let a = label_propagation_communities(&edges_a, &[0, 1, 2, 3, 4], 100);
+        let b = label_propagation_communities(&edges_b, &[4, 3, 2, 1, 0], 100);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn lp_dup_edges_and_self_loops_ignored() {
+        let plain = label_propagation_communities(&[(0, 1, 1.0), (1, 2, 1.0)], &[0, 1, 2], 100);
+        let noisy = label_propagation_communities(
+            &[(0, 1, 1.0), (1, 0, 1.0), (1, 2, 1.0), (2, 2, 1.0), (0, 0, 1.0)],
+            &[0, 1, 2],
+            100,
+        );
+        assert_eq!(plain, noisy);
+    }
+
+    #[test]
+    fn lp_max_iters_cutoff_returns_well_formed_partition() {
+        // chain that may need several sweeps; cap at 1 -> still a valid partition
+        let got = label_propagation_communities(&[(0, 1, 1.0), (1, 2, 1.0), (2, 3, 1.0)], &[0, 1, 2, 3], 1);
+        // every id assigned exactly once
+        let mut all: Vec<i64> = got.iter().flatten().copied().collect();
+        all.sort();
+        assert_eq!(all, vec![0, 1, 2, 3]);
     }
 
     use arrow::array::{Array, Float64Array, Int64Array, ListArray, StringArray};


### PR DESCRIPTION
## goldengraph SP3 — community detection

Third phase: a deterministic, portable community-detection kernel + a `communities(&Graph)` query, enabling GraphRAG-style "global" structure over the resolved graph. Runs in-memory over the resolved `Graph` (like SP1's `neighborhood`), so it's independent of SP2's store.

Spec: `docs/superpowers/specs/2026-06-20-goldengraph-sp3-communities-design.md` (review-approved). Roadmap: `docs/superpowers/specs/2026-06-20-goldengraph-program-roadmap.md`.

### What's in
- **`graph-core::label_propagation_communities(edges, all_ids, max_iters)`** — deterministic label propagation: async in-place sweep in ascending-id order, most-frequent-neighbor-label with smallest-label tie-break, **set adjacency** (dup edges collapse, self-loops ignored), `max_iters` termination backstop. Order-independent; mirrors `connected_components`. Suite-wide kernel (native/pgrx/datafusion can expose it later, like WCC).
- **`goldengraph-core::community::communities(&Graph) -> Vec<Community>`** + `COMMUNITY_MAX_ITERS`. Composes with SP1 retrieval (global query = communities → per-community `neighborhood`).
- Golden vectors (cross-binding contract for SP5).

### Honest scope
Label propagation is a **modest first kernel**: on small/dense graphs it merges across bridges, so community ≈ connected-component granularity (a single dense corpus can collapse to one community). It's a working but coarse layer — enough for global search; **Leiden is the granularity upgrade**, behind the same return shape.

### Tests (8 new)
5 kernel (disconnected/connected/singleton, order-independence, dup+self-loop, max_iters cutoff) + 2 query + 1 golden-vector. graph-core 12 + goldengraph-core 24 unit + integration all green; clippy/fmt clean.

### Out (deferred by design)
LLM community summaries + global-search map-reduce (host-side, **SP4**). Persisting communities in the SP2 store + as-of-community queries (**follow-up** once SP2+SP3 land). Leiden / hierarchical / weighted LP (future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)