### PR TITLE
feat(goldengraph): SP4a — pyo3 binding for the store + communities

### DIFF
--- a/docs/superpowers/specs/2026-06-20-goldengraph-sp4-host-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-20-goldengraph-sp4-host-pipeline-design.md
@@ -1,0 +1,83 @@
+# goldengraph SP4 — host LLM pipeline (Python) — design
+
+**Status:** Design draft 2026-06-20. SP4 of the program roadmap (`2026-06-20-goldengraph-program-roadmap.md`) — the standalone milestone. Decomposed into slices (SP4 is too large for one PR); **this doc fully specs SP4a** (the binding) and outlines SP4b/SP4c.
+
+**Builds on:** SP1 (engine), SP2 (store), SP3 (communities). **Surface:** the pyo3 binding (`goldengraph-native`) + a new Python `goldengraph` package.
+
+---
+
+## Motivation
+
+SP1–SP3 are a portable Rust engine (resolve → store → query → communities) with a *thin* SP1 pyo3 binding (`build_graph`/`query`/`seeds_by_name`). SP4 makes goldengraph a **standalone own-your-KG tool**: feed it text, get back a queryable, durable, bi-temporal knowledge graph with LLM-extracted entities/relationships and LLM-synthesized answers — entity resolution as the differentiator. This is the phase that lets goldengraph stand alone rather than only as a drop-in ER stage.
+
+## Why decompose
+
+SP4 spans six concerns that don't belong in one PR: (1) expose the store + communities to Python, (2) LLM extraction, (3) resolution + store-write, (4) embedding-seeded retrieval, (5) LLM synthesis, (6) NL-query + text-to-Cypher. (1) is LLM-free Rust+pyo3 (CI-validatable now); (2)–(6) are LLM-dependent Python needing mocked-LLM tests + API-key lanes. Slices:
+
+- **SP4a — binding extension** (this spec, full): expose SP2's `GraphStore` + SP3's `communities` through `goldengraph-native`, so Python can build/persist/query a durable graph. No LLM. The unblocker for everything below.
+- **SP4b — extraction → resolve → store pipeline** (own spec): text → triples (LLM) → zero-config resolution (reuse goldenmatch's Python auto-config controller) → `record_key` assignment (reuse `fingerprint-core` via goldenmatch) → `StoreBatch.append`. The "build a KG from text" path.
+- **SP4c — retrieval + synthesis + query** (own spec): embedding-seeded retrieval (reuse `goldenembed-rs`), local + global (community map-reduce) answering (LLM synthesis), NL query over the store + a text-to-Cypher export adapter. The "ask the KG" path.
+
+Each is its own spec → plan → implement → PR. The Python `goldengraph` package is created in SP4b (SP4a only touches the Rust binding + its Python test surface).
+
+---
+
+## SP4a — binding extension (fully specified)
+
+**Goal:** the Python surface for SP2 store + SP3 communities, so SP4b/SP4c (and any host) can persist + query a durable bi-temporal graph from Python.
+
+**Files:** `packages/rust/extensions/goldengraph-native/src/lib.rs` (extend), `tests/test_goldengraph.py` (extend). The `goldengraph` lane already builds + pytests this.
+
+**Dependency note:** the `PyStore` surface (store) depends only on SP2 and is **implementable now** (SP2 store is on main). `PyGraph.communities()` calls `goldengraph_core::community::communities`, which lands on main only when **SP3 (#1135) merges** — so implement `PyStore` first and add `communities()` once SP3 is on main (refetch before starting).
+
+### New surface
+
+- **`PyGraph.communities() -> list[dict]`** — `[{ "id": int, "members": [int] }]` via `goldengraph_core::community::communities` over the wrapped `Graph`. (A "global" query = `communities()` then `query(members, hops)` per community.)
+- **`PyStore`** (`#[pyclass]` wrapping `goldengraph_core::store::GraphStore`):
+  - `PyStore(snapshot: str | None = None)` — constructor; `open(snapshot)` mapping `StoreError` → `ValueError`.
+  - `append(batch_json: str)` — `batch_json` is a `StoreBatch` serialized to JSON (entities with `record_keys`, edges with `valid_from`/`valid_to`/`source_refs`, `ingested_at`). Parsed via `serde_json` (the SP2 types already derive `Deserialize`). **JSON-string boundary** chosen over positional tuples: it reuses the serde model, is robust to field growth, and matches the snapshot theme; the SP4b Python layer builds the JSON from typed args.
+  - `as_of(valid_t: int, tx_t: int) -> PyGraph` — returns a `PyGraph` (not a dict) so the temporal slice composes with `query`/`seeds_by_name`/`communities`.
+  - `snapshot() -> str`, `history(id: int) -> list[dict]`.
+
+### Marshaling
+
+Reuse the existing `graph_view_to_dict`. `append` does `serde_json::from_str::<StoreBatch>(batch_json).map_err(PyValueError)`. `history` maps `HistoryEvent` → `{"kind":"merge"|"split", ...}` dicts. Keep conversions explicit + small (mirrors SP1's binding style).
+
+### Tests (in `test_goldengraph.py`, run by the `goldengraph` CI lane)
+
+- **Store round-trip:** `append` two batches (JSON) → `snapshot()` → reopen → snapshot byte-identical.
+- **Bi-temporal `as_of`:** append + correction → `as_of(v, before)` vs `as_of(v, after)` differ (reusing the SP2 scenario through Python); the returned `PyGraph.query(...)` works.
+- **Merge time-travel:** `as_of(_, before_merge).query(...)` shows entities separate; after, merged (the SP2 headline through Python).
+- **Communities:** build the SP1 differentiator graph → `PyGraph.communities()` groups the connected entities; isolated entity is its own.
+- **Error path:** malformed `batch_json` → `ValueError`; malformed constructor `snapshot` → `ValueError` (both are `serde_json::from_str` sites).
+
+### SP4a non-goals
+No LLM, no Python `goldengraph` package yet (SP4b), no embedding (SP4c), no compact binary. Pure binding + tests.
+
+---
+
+## SP4b — extraction → resolve → store (outline; own spec later)
+
+- New Python package `packages/python/goldengraph/` (standalone, **excluded from the uv workspace** like `goldenmatch-kg` — its LLM/embedding extras are heavy/fast-moving; its own CI lane). Depends on `goldenmatch` (controller, fingerprint, LLM client, `BudgetTracker`) + `goldengraph-native` (the engine).
+- `extract(text, llm) -> (mentions, relationships)` — LLM prompt → typed triples. Mocked-LLM deterministic stub for tests (à la goldenmatch-kg conftest); real-LLM = opt-in lane.
+- `resolve(mentions) -> (resolved entities, record_keys)` — **reuse goldenmatch's zero-config auto-config controller** (the moat, Python side) + `fingerprint-core` `:h1:` keys.
+- `ingest(text, store, at)` — extract → resolve → build `StoreBatch` JSON → `store.append`. The end-to-end "KG from text."
+- **Key decisions for its spec:** extraction prompt/output schema; how relationships map to `BatchEdge` valid-times (default `valid_from = ingest time`?); controller config caching across batches.
+
+## SP4c — retrieval + synthesis + query (outline; own spec later)
+
+- **Embedding-seeded retrieval:** `goldenembed-rs` embeds the query + entity canonical names; nearest entities seed `as_of(...).query(seeds, hops)`. **Decision for its spec:** where entity embeddings live (recompute per query vs a sidecar index; the SP2 store deliberately doesn't hold vectors).
+- **Synthesis:** local (subgraph → answer) + global (per-community summary → map-reduce, using SP3 `communities`) — LLM, reusing `BudgetTracker`.
+- **Query surface:** NL query over the store + a **text-to-Cypher export adapter** (thin LLM adapter for Neo4j users; the native-store NL query is primary).
+
+---
+
+## Cross-slice non-goals (SP4)
+
+WASM/C bindings of any of this (SP5). The head-to-head eval (SP6). Compact binary store format. Persisting communities/embeddings in the store (community persistence is the SP2+SP3 follow-up; embedding storage is an SP4c decision). Native zero-config controller (Future — SP4 reuses the Python one).
+
+## Risks / open questions
+
+- **SP4a `append` JSON boundary:** ergonomic enough for SP4b (which builds the JSON) but a raw Python caller passes a JSON string. Acceptable — the SP4b Python layer is the real user-facing API; the binding is plumbing.
+- **SP4b/SP4c are LLM-bound:** correctness tests must use a deterministic mocked LLM; real-LLM behavior is an opt-in lane (needs `OPENAI_API_KEY`). Accuracy is covered by SP6's eval, not SP4 unit tests.
+- **Package weight:** `goldengraph` Python pulls goldenmatch + native + (optionally) embed/LLM extras — keep it out of the uv workspace (the `goldenmatch[native]` footgun) with its own lane, mirroring `goldenmatch-kg`.

--- a/packages/rust/extensions/goldengraph-native/Cargo.lock
+++ b/packages/rust/extensions/goldengraph-native/Cargo.lock
@@ -344,6 +344,8 @@ version = "0.1.0"
 dependencies = [
  "goldenmatch-graph-core",
  "goldenmatch-score-core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -352,6 +354,7 @@ version = "0.1.0"
 dependencies = [
  "goldengraph-core",
  "pyo3",
+ "serde_json",
 ]
 
 [[package]]
@@ -415,6 +418,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -694,6 +703,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,3 +939,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/packages/rust/extensions/goldengraph-native/Cargo.toml
+++ b/packages/rust/extensions/goldengraph-native/Cargo.toml
@@ -30,8 +30,11 @@ crate-type = ["cdylib"]
 # extension-module: don't link libpython (this .so is imported BY CPython).
 pyo3 = { version = ">=0.28, <0.29", features = ["extension-module", "abi3-py311"] }
 # The pyo3-free knowledge-graph engine. The shims below marshal Python <-> these
-# types and call its `build_graph` / `neighborhood` entry points.
+# types and call its `build_graph` / `neighborhood` / store entry points.
 goldengraph-core = { path = "../goldengraph-core" }
+# Parse the `StoreBatch` JSON boundary for `PyStore.append` (the SP2 store types
+# derive serde Deserialize; the JSON string is the marshaling boundary).
+serde_json = "1"
 
 [profile.release]
 opt-level = 3

--- a/packages/rust/extensions/goldengraph-native/src/lib.rs
+++ b/packages/rust/extensions/goldengraph-native/src/lib.rs
@@ -18,6 +18,7 @@ use goldengraph_core::build_graph as core_build_graph;
 use goldengraph_core::model::{Edge, EntityId, EntityNode, Graph, Mention, MentionEdge, MentionId};
 use goldengraph_core::resolve::{NativeConfig, ResolutionMode};
 use goldengraph_core::retrieve::{neighborhood, seeds_by_name as core_seeds_by_name};
+use goldengraph_core::store::{GraphStore, HistoryEvent, StableId, StoreBatch};
 
 /// A resolution-merged knowledge graph, queryable by neighborhood.
 #[pyclass]
@@ -44,6 +45,70 @@ impl PyGraph {
     /// not just the canonical the resolver happened to pick).
     fn seeds_by_name(&self, name: &str) -> Vec<EntityId> {
         core_seeds_by_name(&self.inner, name)
+    }
+}
+
+/// A durable, bi-temporal knowledge-graph store (SP2). Wraps the pyo3-free
+/// `goldengraph_core::store::GraphStore`. Identity is keyed on host-supplied
+/// `record_key`s; `as_of` answers two-axis time-travel queries.
+#[pyclass]
+struct PyStore {
+    inner: GraphStore,
+}
+
+#[pymethods]
+impl PyStore {
+    /// Open from a canonical JSON `snapshot` (or empty when `None`).
+    #[new]
+    #[pyo3(signature = (snapshot=None))]
+    fn new(snapshot: Option<&str>) -> PyResult<Self> {
+        GraphStore::open(snapshot)
+            .map(|inner| PyStore { inner })
+            .map_err(|e| PyValueError::new_err(format!("invalid snapshot: {e:?}")))
+    }
+
+    /// Reconcile + append a batch. `batch_json` is a `StoreBatch` serialized to
+    /// JSON (entities with `record_keys`, edges with `valid_from`/`valid_to`/
+    /// `source_refs`, `ingested_at`). The SP4b Python layer builds this JSON.
+    fn append(&mut self, batch_json: &str) -> PyResult<()> {
+        let batch: StoreBatch = serde_json::from_str(batch_json)
+            .map_err(|e| PyValueError::new_err(format!("invalid StoreBatch JSON: {e}")))?;
+        self.inner.append(batch);
+        Ok(())
+    }
+
+    /// Bi-temporal slice as a queryable `PyGraph` (valid time × transaction time).
+    fn as_of(&self, valid_t: i64, tx_t: i64) -> PyGraph {
+        PyGraph { inner: self.inner.as_of(valid_t, tx_t) }
+    }
+
+    /// Canonical JSON snapshot (round-trips via the constructor).
+    fn snapshot(&self) -> String {
+        self.inner.snapshot()
+    }
+
+    /// History events literally naming `id`, as plain dicts.
+    fn history<'py>(&self, py: Python<'py>, id: StableId) -> PyResult<Bound<'py, PyList>> {
+        let out = PyList::empty(py);
+        for ev in self.inner.history(id) {
+            let d = PyDict::new(py);
+            match ev {
+                HistoryEvent::Merge { kept, absorbed, at } => {
+                    d.set_item("kind", "merge")?;
+                    d.set_item("kept", kept)?;
+                    d.set_item("absorbed", PyList::new(py, absorbed)?)?;
+                    d.set_item("at", at)?;
+                }
+                HistoryEvent::Split { from, into, at } => {
+                    d.set_item("kind", "split")?;
+                    d.set_item("from", from)?;
+                    d.set_item("into", PyList::new(py, into)?)?;
+                    d.set_item("at", at)?;
+                }
+            }
+            out.append(d)?;
+        }
+        Ok(out)
     }
 }
 
@@ -134,6 +199,7 @@ fn build_graph(
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<PyGraph>()?;
+    m.add_class::<PyStore>()?;
     m.add_function(wrap_pyfunction!(build_graph, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/goldengraph-native/src/lib.rs
+++ b/packages/rust/extensions/goldengraph-native/src/lib.rs
@@ -15,6 +15,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
 use goldengraph_core::build_graph as core_build_graph;
+use goldengraph_core::community::communities as core_communities;
 use goldengraph_core::model::{Edge, EntityId, EntityNode, Graph, Mention, MentionEdge, MentionId};
 use goldengraph_core::resolve::{NativeConfig, ResolutionMode};
 use goldengraph_core::retrieve::{neighborhood, seeds_by_name as core_seeds_by_name};
@@ -45,6 +46,20 @@ impl PyGraph {
     /// not just the canonical the resolver happened to pick).
     fn seeds_by_name(&self, name: &str) -> Vec<EntityId> {
         core_seeds_by_name(&self.inner, name)
+    }
+
+    /// Community partition of this graph (SP3 label propagation), as
+    /// `[{ "id": int, "members": [int] }]`. A "global" query = `communities()`
+    /// then `query(members, hops)` per community.
+    fn communities<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let out = PyList::empty(py);
+        for c in core_communities(&self.inner) {
+            let d = PyDict::new(py);
+            d.set_item("id", c.id)?;
+            d.set_item("members", PyList::new(py, &c.members)?)?;
+            out.append(d)?;
+        }
+        Ok(out)
     }
 }
 
@@ -79,7 +94,9 @@ impl PyStore {
 
     /// Bi-temporal slice as a queryable `PyGraph` (valid time × transaction time).
     fn as_of(&self, valid_t: i64, tx_t: i64) -> PyGraph {
-        PyGraph { inner: self.inner.as_of(valid_t, tx_t) }
+        PyGraph {
+            inner: self.inner.as_of(valid_t, tx_t),
+        }
     }
 
     /// Canonical JSON snapshot (round-trips via the constructor).

--- a/packages/rust/extensions/goldengraph-native/tests/test_goldengraph.py
+++ b/packages/rust/extensions/goldengraph-native/tests/test_goldengraph.py
@@ -83,6 +83,14 @@ def test_bad_resolution_raises():
         gg.build_graph(MENTIONS, EDGES, "not-a-valid-resolution")
 
 
+def test_communities_group_connected_entities():
+    # resolved differentiator graph: 0(Apple)->1(Jobs), 0->2(iPhone) all connected
+    g = gg.build_graph(MENTIONS, EDGES, {0: 0, 1: 0, 2: 1, 3: 2})
+    comms = g.communities()
+    assert len(comms) == 1
+    assert sorted(comms[0]["members"]) == [0, 1, 2]
+
+
 # ---- SP4a: PyStore (durable bi-temporal store) ----------------------------
 
 import json

--- a/packages/rust/extensions/goldengraph-native/tests/test_goldengraph.py
+++ b/packages/rust/extensions/goldengraph-native/tests/test_goldengraph.py
@@ -81,3 +81,93 @@ def test_bad_resolution_raises():
 
     with pytest.raises(ValueError):
         gg.build_graph(MENTIONS, EDGES, "not-a-valid-resolution")
+
+
+# ---- SP4a: PyStore (durable bi-temporal store) ----------------------------
+
+import json
+
+
+def _ent(local, name, keys, typ="org"):
+    return {
+        "local_id": local,
+        "canonical_name": name,
+        "typ": typ,
+        "surface_names": [name],
+        "record_keys": keys,
+    }
+
+
+def _edge(s, o, valid_from, valid_to, refs, predicate="made"):
+    return {
+        "subj_local": s,
+        "predicate": predicate,
+        "obj_local": o,
+        "valid_from": valid_from,
+        "valid_to": valid_to,
+        "source_refs": refs,
+    }
+
+
+def _batch(entities, edges, at):
+    return json.dumps({"entities": entities, "edges": edges, "ingested_at": at})
+
+
+def test_store_round_trip_snapshot_byte_identical():
+    s = gg.PyStore()
+    s.append(_batch([_ent(0, "Acme", ["a"]), _ent(1, "Beta", ["b"])],
+                     [_edge(0, 1, 10, None, ["d1"])], 100))
+    s.append(_batch([_ent(0, "Acme", ["a"])], [], 200))
+    snap = s.snapshot()
+    assert snap == gg.PyStore(snap).snapshot()
+
+
+def test_store_bitemporal_correction():
+    # learn an open edge, then correct it to end at 20 (later tx-time)
+    s = gg.PyStore()
+    s.append(_batch([_ent(0, "X", ["x"]), _ent(1, "Y", ["y"])],
+                    [_edge(0, 1, 10, None, ["d"])], 100))
+    s.append(_batch([_ent(0, "X", ["x"]), _ent(1, "Y", ["y"])],
+                    [_edge(0, 1, 10, 20, ["d"])], 200))
+
+    before = s.as_of(25, 150)  # only the open version known -> edge present
+    assert len(before.query(before.seeds_by_name("X"), 1)["edges"]) == 1
+    after = s.as_of(25, 250)   # correction known -> window ended at 20
+    assert len(after.query(after.seeds_by_name("X"), 1)["edges"]) == 0
+
+
+def test_store_merge_time_travel():
+    # A,B both -> C; later A and B resolve together (share keys a,b) at tx 200
+    s = gg.PyStore()
+    s.append(_batch(
+        [_ent(0, "Acme", ["a"]), _ent(1, "Beta", ["b"]), _ent(2, "Cee", ["c"], "product")],
+        [_edge(0, 2, 0, None, ["e1"]), _edge(1, 2, 0, None, ["e2"])],
+        100,
+    ))
+    s.append(_batch([_ent(0, "Acme", ["a", "b"]), _ent(1, "Cee", ["c"], "product")], [], 200))
+
+    # before the merge: C neighbors A and B -> 2 edges
+    before = s.as_of(50, 150)
+    assert len(before.query(before.seeds_by_name("Cee"), 1)["edges"]) == 2
+    # after: B's edge remaps onto merged A -> collapses to 1 edge
+    after = s.as_of(50, 250)
+    assert len(after.query(after.seeds_by_name("Cee"), 1)["edges"]) == 1
+
+
+def test_store_history_names_both_sides_of_merge():
+    s = gg.PyStore()
+    s.append(_batch([_ent(0, "A", ["a"]), _ent(1, "B", ["b"])], [], 10))
+    s.append(_batch([_ent(0, "AB", ["a", "b"])], [], 20))
+    ev = s.history(0)
+    assert len(ev) == 1 and ev[0]["kind"] == "merge" and ev[0]["kept"] == 0
+    assert s.history(1)[0]["absorbed"] == [1]
+
+
+def test_store_bad_json_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        gg.PyStore("{ not valid json")
+    s = gg.PyStore()
+    with pytest.raises(ValueError):
+        s.append("{ also not valid")


### PR DESCRIPTION
## goldengraph SP4a — binding extension

First slice of SP4 (the standalone-pipeline phase). Exposes SP2's durable bi-temporal **store** and SP3's **communities** through the `goldengraph-native` pyo3 binding, so a Python host (SP4b/SP4c, or any caller) can build, persist, time-travel, and query a knowledge graph. LLM-free; CI-validated by the `goldengraph` lane.

Spec: `docs/superpowers/specs/2026-06-20-goldengraph-sp4-host-pipeline-design.md` (review-approved; SP4 decomposed into SP4a binding / SP4b extraction→resolve→store / SP4c retrieval+synthesis+query — this PR is SP4a).

### What's in
- **`PyStore`** wrapping `GraphStore`: `PyStore(snapshot=None)`, `append(batch_json)`, `as_of(valid_t, tx_t) -> PyGraph`, `snapshot() -> str`, `history(id) -> list[dict]`. `append` takes a `StoreBatch` JSON string (the SP2 types derive serde `Deserialize`); `as_of` returns a queryable `PyGraph` so the temporal slice composes with `query`/`seeds_by_name`/`communities`.
- **`PyGraph.communities()`** → `[{id, members}]` via SP3's label-propagation kernel.

### Tests (6 new Python, 11 total)
Store round-trip (snapshot byte-identical across reopen), bi-temporal correction (`as_of` before/after a later-tx correction), merge time-travel (entity count/edge collapse across a resolution change), `history` dicts, error paths (bad snapshot + bad batch JSON), and communities grouping. All green via `maturin develop` + pytest locally; the `goldengraph` lane runs them in CI.

### Scope (deferred to later SP4 slices)
- **SP4b** — LLM extraction → zero-config resolution (reuse goldenmatch controller + fingerprint) → store-write; new standalone Python `goldengraph` package.
- **SP4c** — embedding-seeded retrieval (goldenembed) + synthesis (local + global community map-reduce) + NL query + text-to-Cypher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)