### PR TITLE
feat(goldengraph): SP4b — text -> KG pipeline (Python)

### DIFF
--- a/.github/workflows/goldengraph-pipeline.yml
+++ b/.github/workflows/goldengraph-pipeline.yml
@@ -1,0 +1,44 @@
+# goldengraph (Python pipeline) build signal — SP4b. The `goldengraph` package
+# is STANDALONE (excluded from the uv workspace, like goldenmatch-kg): it pulls
+# goldenmatch + the goldengraph-native engine wheel (built here via maturin), so
+# it is installed + tested on its own lane, NOT in the ci.yml matrix.
+#
+# Informational lane (NOT ci-required). It is the only real-execution signal for
+# the pipeline, so confirm it green before arming auto-merge. Resolution accuracy
+# is goldenmatch's concern (+ SP6 eval); these tests verify extraction parsing,
+# the resolve->store marshaling (injected resolver), and the goldenmatch-backed
+# resolve on exact duplicates.
+name: goldengraph-pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "packages/python/goldengraph/**"
+      - "packages/rust/extensions/goldengraph-native/**"
+      - "packages/rust/extensions/goldengraph-core/**"
+      - ".github/workflows/goldengraph-pipeline.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  pipeline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install goldenmatch + build/install the goldengraph-native engine wheel
+        run: |
+          python -m pip install --upgrade pip maturin pytest goldenmatch
+          maturin build --release \
+            -m packages/rust/extensions/goldengraph-native/Cargo.toml --out dist
+          python -m pip install dist/*.whl
+      - name: Install goldengraph (standalone) + run the pipeline tests
+        run: |
+          python -m pip install --no-deps -e packages/python/goldengraph
+          python -m pytest packages/python/goldengraph/tests -q

--- a/docs/superpowers/specs/2026-06-20-goldengraph-sp4b-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-20-goldengraph-sp4b-pipeline-design.md
@@ -1,0 +1,75 @@
+# goldengraph SP4b — extraction → resolve → store (Python pipeline) — design
+
+**Status:** Design draft 2026-06-20. SP4b slice of SP4 (`2026-06-20-goldengraph-sp4-host-pipeline-design.md`). Awaiting approval → plan. **Depends on SP4a** (PyStore + communities in `goldengraph-native`, PR #1136, in queue).
+
+**Surface:** a new standalone Python package `packages/python/goldengraph/`. **The "build a KG from text" path** — the first half of the standalone milestone.
+
+---
+
+## Motivation
+
+SP4a gave Python a durable, queryable, bi-temporal store. SP4b feeds it: **text → LLM-extracted entities + relationships → zero-config resolution → durable store**. This is what makes goldengraph a standalone own-your-KG tool rather than a Rust engine. Entity resolution — the moat — runs via goldenmatch's existing zero-config controller, so duplicate surface forms across documents collapse into one durable entity (the thing the popular frameworks do badly).
+
+## Package shape
+
+`packages/python/goldengraph/` (PyPI `goldengraph`), mirroring the `goldenmatch-kg` precedent:
+- **Excluded from the uv workspace** (`[tool.uv.workspace].exclude` in root `pyproject.toml`) — its LLM/native extras are heavy and shouldn't enter the main `uv.lock` (the `goldenmatch[native]` footgun). Its own CI lane; not in the `ci.yml` matrix; not (yet) a published-suite roster package.
+- **Deps:** `goldenmatch` (zero-config `dedupe_df`, `record_fingerprint`, `BudgetTracker`) + `goldengraph-native` (the engine: `PyStore`, `build_graph`). LLM access via a minimal in-package protocol (below), real providers behind an optional extra.
+
+## Modules
+
+### `llm.py` — provider-agnostic LLM boundary
+```
+class LLMClient(Protocol):
+    def complete(self, prompt: str) -> str: ...
+```
+- Tests inject a deterministic stub (à la goldenmatch-kg's conftest). A thin OpenAI adapter ships behind a `[openai]` extra (uses the key from the env; reuses goldenmatch's `BudgetTracker` to cap spend). **Decision:** goldengraph owns this minimal protocol rather than coupling to goldenmatch's internal LLM client — it keeps extraction testable + provider-swappable. (Accuracy of real extraction is an SP6 concern, not an SP4b unit test.)
+
+### `extract.py` — text → triples (NEW logic)
+```
+@dataclass
+class Mention: name: str; typ: str
+@dataclass
+class Relationship: subj: int; predicate: str; obj: int   # subj/obj index into mentions
+@dataclass
+class Extraction: mentions: list[Mention]; relationships: list[Relationship]
+
+def extract(text: str, llm: LLMClient) -> Extraction
+```
+- A prompt template instructs the LLM to return strict JSON (`{"entities":[{"name","type"}], "relationships":[{"subj","predicate","obj"}]}` with subj/obj as entity indices). `extract` parses + validates that JSON into the typed result; malformed/out-of-range indices are dropped (defensive — LLMs drift). goldenmatch has no text→triples extractor (`llm_extract_features` is ER *feature* extraction), so this is genuinely new; only the LLM transport + budget are reused.
+
+### `resolve.py` — mentions → entities + record keys (REUSE the controller)
+```
+@dataclass
+class ResolvedEntity: local_id: int; canonical_name: str; typ: str
+                      surface_names: list[str]; record_keys: list[str]; member_idx: list[int]
+def resolve(mentions: list[Mention]) -> list[ResolvedEntity]
+```
+- Builds a Polars frame of mention `(name, typ)` and calls **`goldenmatch.dedupe_df`** (the zero-config auto-config controller — the moat), exactly as goldenmatch-kg's `resolve_entities` does (mirror its ~40-line group-extraction, including singletons; do NOT depend on the goldenmatch-kg package — depend on `goldenmatch` directly). Each group → a `ResolvedEntity`: `canonical_name` = longest member name; `surface_names` = distinct member names; `record_keys` = `goldenmatch.record_fingerprint` (the `:h1:` key) per member mention. `member_idx` maps back to extraction indices (for edge remap).
+
+### `ingest.py` — the end-to-end path
+```
+def ingest(text: str, store: PyStore, *, at: int, llm: LLMClient,
+           valid_from: int | None = None) -> None
+```
+- `extract` → `resolve` → build a `StoreBatch` dict → `json.dumps` → `store.append(json)`. Entities map 1:1 to `ResolvedEntity` (`local_id`); build a `mention_idx → local_id` lookup from `ResolvedEntity.member_idx`, then remap each extracted `Relationship`'s `subj`/`obj` into a `BatchEdge` (`valid_from = valid_from or at`, `valid_to = None`, `source_refs = []` or a caller-supplied doc id; `ingested_at = at`). **Edge cases (specify in the plan):** a relationship whose endpoints resolve to the SAME entity (self-loop after dedup) → drop it (SP1/SP2 retrieval treats self-loops as noise); a relationship index with no owning entity → can't happen (singletons are included in `resolve`), but guard defensively. Reuses SP4a's JSON `append` boundary.
+
+## Determinism + testing
+
+- **Mocked-LLM tests (deterministic):** a stub `LLMClient` returns fixed JSON for a fixed input → `ingest` into a `PyStore` → `store.as_of(...).query(...)` asserts the expected entities/edges. To assert "duplicates collapse" WITHOUT a flaky fuzzy merge, use **exact-duplicate mentions** (identical `name`+`typ`, which dedup version-stably) OR inject a deterministic `resolve` stub — NOT a fuzzy toy-merge (see the caveat below). This verifies the **binding/marshaling + the resolve→store wiring**, not LLM or fuzzy-resolution accuracy.
+- **Resolution caveat (carried from goldenmatch-kg):** zero-config `dedupe_df` on a tiny toy frame commits a degenerate config whose fuzzy merges vary by goldenmatch version/process — so assert on the *plumbing* (a hand-curated mention set with an unambiguous duplicate, or inject resolution), NOT on a flaky toy-merge. The moat's accuracy is covered by SP6's eval + goldenmatch's own parity suite.
+- **Real-LLM lane:** an opt-in test (skipped without `OPENAI_API_KEY`) runs the OpenAI adapter end-to-end on a short passage. Never required.
+
+## CI
+
+A new informational lane `goldengraph-pipeline.yml` (mirrors `goldenmatch-kg.yml`): install `goldenmatch` + build/install `goldengraph-native` (maturin) + install `goldengraph`, run pytest with the mocked LLM. Triggers on `packages/python/goldengraph/**` + the native crate. Informational (not `ci-required`) — confirm green before arming auto-merge (the only real-execution signal for the pipeline).
+
+## Non-goals (SP4b)
+
+Retrieval / synthesis / NL query / text-to-Cypher (**SP4c**). Embedding (SP4c). Community summaries (SP4c — uses SP4a `communities()`). WASM/C (SP5). The eval (SP6). Real-LLM accuracy guarantees (SP6). Publishing `goldengraph` to PyPI / MCP roster (a later rollout once the pipeline is real).
+
+## Risks / open questions (resolve in the plan)
+
+- **`record_key` granularity + the limit of store-side reconciliation (honest):** key on `record_fingerprint({"name": ..., "typ": ...})` — `record_fingerprint` takes a **dict**, and the dict keys must be constructed identically on every call or the fingerprint drifts and cross-document reconciliation silently breaks (pin the exact dict keys in the plan + assert in a test). Identical surface forms across documents share a key → reconcile to the same entity (desired). BUT a distinct-but-resolved pair only stays linked **while each batch's resolution keeps emitting both keys on one entity**: SP4a's store treats a batch's `record_keys` as AUTHORITATIVE (it does not union prior survivor keys, and emits a Split when a stored entity's keys land across batch entities). So **the store does NOT persist a fuzzy link across batches** — reconciliation is per-batch-resolution-driven. If document N+1 mentions only one surface form, the store sees only that key; it won't back-stop resolution drift. This is acceptable for SP4b (it matches the "each batch is a full resolution pass" contract), but the implementer must not assume the store remembers fuzzy links the resolver didn't re-emit.
+- **`dedupe_df` output shape:** `resolve_entities` reads `result.clusters[*].{members,size}`; mirror exactly (members are row indices). Pin in the plan against the installed goldenmatch.
+- **Package not in uv workspace** → its own lockfile/lane; the local dev loop needs `goldenmatch` + the `goldengraph-native` wheel installed (maturin) in a dedicated venv (the SP4a exFAT `CARGO_TARGET_DIR=C:` + explicit `VIRTUAL_ENV` gotchas apply).

--- a/packages/python/goldengraph/README.md
+++ b/packages/python/goldengraph/README.md
@@ -1,0 +1,33 @@
+# goldengraph
+
+Build an own-your-KG knowledge graph from text:
+
+**text → LLM extraction → goldenmatch entity resolution → a durable, bi-temporal store.**
+
+Entity resolution is the differentiator — duplicate surface forms across
+documents collapse into one durable entity, the thing most GraphRAG frameworks
+do badly.
+
+```python
+from goldengraph import ingest, OpenAIClient
+from goldengraph_native import _native as gg
+
+store = gg.PyStore()                 # durable bi-temporal store (SP2 engine)
+llm = OpenAIClient()                 # or any object with .complete(prompt) -> str
+ingest("Acme Inc, founded by ...", store, at=1, llm=llm)
+
+snapshot = store.snapshot()          # canonical JSON; persist + reopen later
+view = store.as_of(valid_t=1, tx_t=1)   # bi-temporal slice -> queryable graph
+```
+
+- **`extract(text, llm)`** — text → typed entities + relationships (LLM).
+- **`resolve(mentions)`** — goldenmatch's zero-config `dedupe_df` → merged entities + `:h1:` record keys.
+- **`ingest(text, store, *, at, llm)`** — the end-to-end path into the store.
+
+Part of the [goldengraph](https://github.com/benseverndev-oss/goldenmatch) program.
+The engine (`goldengraph-native`: store / query / communities) is pyo3-free Rust;
+this package is the Python host pipeline. LLM access is provider-agnostic
+(`LLMClient` protocol); an `OpenAIClient` ships behind the `[openai]` extra.
+
+**Scope:** SP4b (this package) is the *build* path. Retrieval + synthesis +
+NL query (SP4c) and WASM/C surfaces (SP5) are separate slices.

--- a/packages/python/goldengraph/goldengraph/__init__.py
+++ b/packages/python/goldengraph/goldengraph/__init__.py
@@ -1,0 +1,25 @@
+"""goldengraph — build an own-your-KG knowledge graph from text.
+
+text -> LLM extraction -> goldenmatch entity resolution -> a durable, bi-temporal
+store (the goldengraph-native engine). Entity resolution is the differentiator:
+duplicate surface forms across documents collapse into one durable entity.
+"""
+
+from .extract import Extraction, Mention, Relationship, extract, parse_extraction
+from .ingest import build_batch, ingest
+from .llm import LLMClient, OpenAIClient
+from .resolve import ResolvedEntity, resolve
+
+__all__ = [
+    "LLMClient",
+    "OpenAIClient",
+    "Mention",
+    "Relationship",
+    "Extraction",
+    "extract",
+    "parse_extraction",
+    "ResolvedEntity",
+    "resolve",
+    "build_batch",
+    "ingest",
+]

--- a/packages/python/goldengraph/goldengraph/extract.py
+++ b/packages/python/goldengraph/goldengraph/extract.py
@@ -1,0 +1,73 @@
+"""LLM extraction: text -> entities + relationships (typed triples).
+
+This is genuinely new logic — goldenmatch has `llm_extract_features` (ER feature
+extraction), not a text->triples extractor. Only the LLM transport (`LLMClient`)
+and (optionally) `BudgetTracker` are reused. The extractor is defensive about LLM
+drift: malformed JSON raises; out-of-range / non-int relationship endpoints are
+dropped rather than poisoning the graph.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from .llm import LLMClient
+
+_PROMPT = """You extract a knowledge graph from text. Return STRICT JSON only, \
+no prose, in exactly this shape:
+{{"entities": [{{"name": "<surface name>", "type": "<coarse type>"}}], \
+"relationships": [{{"subj": <entity index>, "predicate": "<verb phrase>", \
+"obj": <entity index>}}]}}
+`subj`/`obj` are 0-based indices into `entities`. Text:
+{text}"""
+
+
+@dataclass
+class Mention:
+    name: str
+    typ: str
+
+
+@dataclass
+class Relationship:
+    subj: int  # index into the Extraction.mentions list
+    predicate: str
+    obj: int
+
+
+@dataclass
+class Extraction:
+    mentions: list[Mention]
+    relationships: list[Relationship]
+
+
+def _strip_fence(raw: str) -> str:
+    """Strip a leading ```json / ``` fence if the model wrapped its output."""
+    s = raw.strip()
+    if s.startswith("```"):
+        s = s.split("\n", 1)[1] if "\n" in s else s[3:]
+        if s.rstrip().endswith("```"):
+            s = s.rstrip()[:-3]
+    return s.strip()
+
+
+def parse_extraction(raw: str) -> Extraction:
+    data = json.loads(_strip_fence(raw))
+    mentions = [
+        Mention(name=str(e["name"]), typ=str(e.get("type", e.get("typ", ""))))
+        for e in data.get("entities", [])
+    ]
+    n = len(mentions)
+    rels: list[Relationship] = []
+    for r in data.get("relationships", []):
+        s, o = r.get("subj"), r.get("obj")
+        # defensive: drop endpoints that aren't valid entity indices
+        if isinstance(s, int) and isinstance(o, int) and 0 <= s < n and 0 <= o < n:
+            rels.append(Relationship(subj=s, predicate=str(r.get("predicate", "")), obj=o))
+    return Extraction(mentions=mentions, relationships=rels)
+
+
+def extract(text: str, llm: LLMClient) -> Extraction:
+    """Extract entities + relationships from `text` via `llm`."""
+    return parse_extraction(llm.complete(_PROMPT.format(text=text)))

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -1,0 +1,84 @@
+"""The end-to-end path: text -> extract -> resolve -> durable store.
+
+`ingest` wires the pipeline into SP4a's `PyStore` over the JSON `append`
+boundary. `resolver` is injectable (defaults to goldenmatch-backed `resolve`) so
+tests can supply a deterministic resolution without goldenmatch installed.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from .extract import Extraction, Mention, extract as _extract
+from .llm import LLMClient
+from .resolve import ResolvedEntity, resolve as _resolve
+
+Resolver = Callable[[list[Mention]], list[ResolvedEntity]]
+
+
+def build_batch(
+    extraction: Extraction,
+    entities: list[ResolvedEntity],
+    *,
+    at: int,
+    valid_from: int | None = None,
+) -> dict:
+    """Build a `StoreBatch` dict (SP4a JSON shape) from a resolved extraction.
+
+    Remaps each relationship's mention indices to the owning entity `local_id`;
+    drops self-loops (endpoints in the same entity after dedup) and orphans.
+    """
+    mention_to_local: dict[int, int] = {}
+    for e in entities:
+        for mi in e.member_idx:
+            mention_to_local[mi] = e.local_id
+
+    vf = at if valid_from is None else valid_from
+    edges = []
+    for r in extraction.relationships:
+        s = mention_to_local.get(r.subj)
+        o = mention_to_local.get(r.obj)
+        if s is None or o is None or s == o:  # orphan or self-loop -> drop
+            continue
+        edges.append(
+            {
+                "subj_local": s,
+                "predicate": r.predicate,
+                "obj_local": o,
+                "valid_from": vf,
+                "valid_to": None,
+                "source_refs": [],
+            }
+        )
+
+    return {
+        "entities": [
+            {
+                "local_id": e.local_id,
+                "canonical_name": e.canonical_name,
+                "typ": e.typ,
+                "surface_names": e.surface_names,
+                "record_keys": e.record_keys,
+            }
+            for e in entities
+        ],
+        "edges": edges,
+        "ingested_at": at,
+    }
+
+
+def ingest(
+    text: str,
+    store,
+    *,
+    at: int,
+    llm: LLMClient,
+    valid_from: int | None = None,
+    resolver: Resolver | None = None,
+) -> None:
+    """Extract a KG from `text` and append it to `store` (a `PyStore`)."""
+    extraction = _extract(text, llm)
+    entities = (resolver or _resolve)(extraction.mentions)
+    batch = build_batch(extraction, entities, at=at, valid_from=valid_from)
+    store.append(json.dumps(batch))

--- a/packages/python/goldengraph/goldengraph/llm.py
+++ b/packages/python/goldengraph/goldengraph/llm.py
@@ -1,0 +1,52 @@
+"""Provider-agnostic LLM boundary for goldengraph extraction.
+
+Tests inject a deterministic stub; the optional `OpenAIClient` (behind the
+`[openai]` extra) is the only real provider shipped. goldengraph owns this
+minimal protocol rather than coupling to goldenmatch's internal LLM client, so
+extraction stays testable + provider-swappable.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class LLMClient(Protocol):
+    """A single-shot text completion: prompt in, raw model text out."""
+
+    def complete(self, prompt: str) -> str: ...
+
+
+class OpenAIClient:
+    """Minimal OpenAI adapter (optional `[openai]` extra). Reuses goldenmatch's
+    `BudgetTracker` to cap spend when one is supplied."""
+
+    def __init__(self, model: str = "gpt-4o-mini", *, budget=None, client=None):
+        self.model = model
+        self.budget = budget
+        self._client = client  # injectable for tests; else lazily built
+
+    def _ensure_client(self):
+        if self._client is None:
+            import openai  # lazy: only needed for the real provider
+
+            self._client = openai.OpenAI()
+        return self._client
+
+    def complete(self, prompt: str) -> str:
+        client = self._ensure_client()
+        resp = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+        )
+        text = resp.choices[0].message.content or ""
+        if self.budget is not None:
+            # Best-effort spend accounting; BudgetTracker raises if over cap.
+            usage = getattr(resp, "usage", None)
+            if usage is not None:
+                self.budget.record_call(
+                    getattr(usage, "prompt_tokens", 0),
+                    getattr(usage, "completion_tokens", 0),
+                )
+        return text

--- a/packages/python/goldengraph/goldengraph/resolve.py
+++ b/packages/python/goldengraph/goldengraph/resolve.py
@@ -1,0 +1,74 @@
+"""Entity resolution over extracted mentions, reusing goldenmatch.
+
+Mirrors goldenmatch-kg's `resolve_entities` (~40 lines): build a Polars frame of
+(name, type), call goldenmatch's zero-config `dedupe_df` (the auto-config
+controller — the moat), extract groups + singletons. Each group's members get a
+`record_key` (goldenmatch's `:h1:` `record_fingerprint`) so the durable store can
+reconcile the same surface form across documents.
+
+goldenmatch + polars are imported LAZILY (inside `resolve`) so the package
+imports without them — tests that inject a resolver need neither.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .extract import Mention
+
+
+@dataclass
+class ResolvedEntity:
+    local_id: int
+    canonical_name: str
+    typ: str
+    surface_names: list[str]
+    record_keys: list[str]
+    member_idx: list[int]  # indices into the extraction's mentions list
+
+
+def _record_key(name: str, typ: str) -> str:
+    import goldenmatch as gm
+
+    # dict arg, fixed keys — the fingerprint must be constructed identically on
+    # every call or cross-document reconciliation drifts.
+    return gm.record_fingerprint({"name": name, "typ": typ})
+
+
+def resolve(mentions: list[Mention]) -> list[ResolvedEntity]:
+    """Resolve mentions into entities via goldenmatch's zero-config dedupe."""
+    if not mentions:
+        return []
+
+    import goldenmatch as gm
+    import polars as pl
+
+    df = pl.DataFrame(
+        {"name": [m.name for m in mentions], "type": [m.typ for m in mentions]}
+    )
+    result = gm.dedupe_df(df)
+
+    n = len(mentions)
+    groups_idx: list[list[int]] = []
+    seen: set[int] = set()
+    for info in result.clusters.values():
+        members = [int(x) for x in info["members"]]
+        if info.get("size", len(members)) > 1:
+            groups_idx.append(members)
+            seen.update(members)
+    groups_idx.extend([i] for i in range(n) if i not in seen)  # singletons
+
+    out: list[ResolvedEntity] = []
+    for local_id, grp in enumerate(sorted(groups_idx, key=min)):
+        rep = min(grp, key=lambda i: (-len(mentions[i].name), i))  # longest name
+        out.append(
+            ResolvedEntity(
+                local_id=local_id,
+                canonical_name=mentions[rep].name,
+                typ=mentions[rep].typ,
+                surface_names=sorted({mentions[i].name for i in grp}),
+                record_keys=sorted({_record_key(mentions[i].name, mentions[i].typ) for i in grp}),
+                member_idx=sorted(grp),
+            )
+        )
+    return out

--- a/packages/python/goldengraph/pyproject.toml
+++ b/packages/python/goldengraph/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "goldengraph"
+version = "0.1.0"
+description = "Build an own-your-KG knowledge graph from text: LLM extraction -> goldenmatch entity resolution -> a durable bi-temporal store (goldengraph engine)."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Ben Severn", email = "benzsevern@gmail.com" }]
+# goldenmatch provides the zero-config resolution controller (dedupe_df), the
+# :h1: record fingerprint, and the LLM budget tracker. goldengraph-native (the
+# engine: PyStore/build_graph) is installed alongside via maturin (it is not a
+# PyPI dep yet), mirroring how the native binding is provided in CI.
+dependencies = ["goldenmatch>=2.0"]
+
+[project.optional-dependencies]
+openai = ["openai>=1.0"]
+dev = ["pytest", "maturin"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["goldengraph"]

--- a/packages/python/goldengraph/tests/conftest.py
+++ b/packages/python/goldengraph/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Test fixtures: a deterministic stub LLM + a fresh store.
+
+The stub returns canned extraction JSON regardless of prompt, so the pipeline is
+deterministic without a real model (the goldenmatch-kg posture). goldenmatch's
+resolution accuracy is covered by its own parity suite + SP6's eval, not here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class StubLLM:
+    """Returns a fixed completion for every prompt."""
+
+    def __init__(self, response: str):
+        self.response = response
+
+    def complete(self, prompt: str) -> str:  # noqa: ARG002 - prompt ignored by design
+        return self.response
+
+
+@pytest.fixture
+def store():
+    from goldengraph_native import _native as gg
+
+    return gg.PyStore()

--- a/packages/python/goldengraph/tests/test_pipeline.py
+++ b/packages/python/goldengraph/tests/test_pipeline.py
@@ -1,0 +1,116 @@
+"""SP4b pipeline tests.
+
+The marshaling/wiring tests INJECT a deterministic resolver, so they need no
+goldenmatch (resolution accuracy is goldenmatch's + SP6's concern). One test
+exercises the real goldenmatch-backed `resolve` and is skipped when goldenmatch
+isn't importable (it runs in the CI lane, which installs goldenmatch).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from goldengraph import ResolvedEntity, build_batch, extract, ingest, parse_extraction
+from goldengraph.extract import Mention
+from conftest import StubLLM
+
+# canned extraction: 3 entities, one relationship (Acme -> Rocket)
+_EXTRACTION_JSON = json.dumps(
+    {
+        "entities": [
+            {"name": "Acme", "type": "org"},
+            {"name": "Coyote", "type": "person"},
+            {"name": "Rocket", "type": "product"},
+        ],
+        "relationships": [
+            {"subj": 0, "predicate": "made", "obj": 2},
+            {"subj": 99, "predicate": "bad_index", "obj": 0},  # dropped (out of range)
+        ],
+    }
+)
+
+
+def _identity_resolver(mentions: list[Mention]) -> list[ResolvedEntity]:
+    """1:1 mention->entity (no merge); deterministic, no goldenmatch."""
+    return [
+        ResolvedEntity(
+            local_id=i,
+            canonical_name=m.name,
+            typ=m.typ,
+            surface_names=[m.name],
+            record_keys=[f"k{i}"],
+            member_idx=[i],
+        )
+        for i, m in enumerate(mentions)
+    ]
+
+
+def test_extract_parses_and_drops_bad_indices():
+    ex = parse_extraction(_EXTRACTION_JSON)
+    assert [m.name for m in ex.mentions] == ["Acme", "Coyote", "Rocket"]
+    assert len(ex.relationships) == 1  # the out-of-range relationship was dropped
+    assert (ex.relationships[0].subj, ex.relationships[0].obj) == (0, 2)
+
+
+def test_extract_strips_code_fence():
+    fenced = "```json\n" + _EXTRACTION_JSON + "\n```"
+    assert len(parse_extraction(fenced).mentions) == 3
+
+
+def test_ingest_marshals_to_store(store):
+    ingest(
+        "irrelevant (stub)",
+        store,
+        at=100,
+        llm=StubLLM(_EXTRACTION_JSON),
+        resolver=_identity_resolver,
+    )
+    view = store.as_of(150, 150)
+    seeds = view.seeds_by_name("Acme")
+    assert seeds  # Acme entity present
+    edges = view.query(seeds, 1)["edges"]
+    assert len(edges) == 1 and edges[0]["predicate"] == "made"
+
+
+def test_ingest_drops_self_loops(store):
+    # a relationship whose endpoints resolve to the SAME entity is dropped
+    one = json.dumps(
+        {
+            "entities": [{"name": "X", "type": "t"}],
+            "relationships": [{"subj": 0, "predicate": "self", "obj": 0}],
+        }
+    )
+    ingest("x", store, at=10, llm=StubLLM(one), resolver=_identity_resolver)
+    view = store.as_of(20, 20)
+    assert view.query(view.seeds_by_name("X"), 1)["edges"] == []
+
+
+def test_build_batch_remaps_to_entity_local_ids():
+    ex = parse_extraction(_EXTRACTION_JSON)
+    # a resolver that MERGES mentions 0 and 1 into entity 0, mention 2 -> entity 1
+    merged = [
+        ResolvedEntity(0, "Acme", "org", ["Acme", "Coyote"], ["k0", "k1"], [0, 1]),
+        ResolvedEntity(1, "Rocket", "product", ["Rocket"], ["k2"], [2]),
+    ]
+    batch = build_batch(ex, merged, at=5)
+    # rel was mention 0 -> mention 2; remaps to entity 0 -> entity 1
+    assert batch["edges"] == [
+        {"subj_local": 0, "predicate": "made", "obj_local": 1,
+         "valid_from": 5, "valid_to": None, "source_refs": []}
+    ]
+
+
+def test_resolve_groups_exact_duplicates():
+    pytest.importorskip("goldenmatch")
+    from goldengraph import resolve
+
+    # exact-duplicate surface forms dedup version-stably (no fuzzy toy-merge)
+    mentions = [Mention("Acme Inc", "org"), Mention("Acme Inc", "org"), Mention("Beta", "org")]
+    entities = resolve(mentions)
+    # the two identical "Acme Inc" mentions collapse into one entity
+    names = sorted(e.canonical_name for e in entities)
+    assert names == ["Acme Inc", "Beta"]
+    acme = next(e for e in entities if e.canonical_name == "Acme Inc")
+    assert sorted(acme.member_idx) == [0, 1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,10 @@ members = ["packages/python/*"]
 # trees that would enter the main uv.lock and risk breaking `uv sync --all-packages`
 # repo-wide (the documented goldenmatch[native] footgun). It is a standalone package
 # built + tested by its own lane (.github/workflows/goldenmatch-kg.yml).
-exclude = ["packages/python/goldenmatch-kg"]
+# goldengraph (SP4b) is EXCLUDED for the same reasons: it depends on the
+# goldengraph-native engine wheel (maturin-built) + optional LLM extras, so it is
+# standalone, built + tested by .github/workflows/goldengraph-pipeline.yml.
+exclude = ["packages/python/goldenmatch-kg", "packages/python/goldengraph"]
 
 [tool.uv.sources]
 goldenmatch = { workspace = true }


### PR DESCRIPTION
## goldengraph SP4b — the "build a KG from text" path

Second slice of SP4. A new standalone Python `goldengraph` package that turns text into a durable knowledge graph: **LLM extraction → goldenmatch zero-config resolution → SP4a `PyStore`**. Entity resolution is the differentiator (duplicate surface forms across documents collapse into one durable entity).

Spec: `docs/superpowers/specs/2026-06-20-goldengraph-sp4b-pipeline-design.md` (review-approved). Depends on SP4a (merged — `PyStore` is on main).

### What's in
- **`extract(text, llm)`** — text → typed entities + relationships. NEW logic (goldenmatch has no text→triples extractor); defensive JSON parse (drops out-of-range relationship endpoints, strips code fences).
- **`resolve(mentions)`** — reuses goldenmatch's zero-config `dedupe_df` (the moat) + `record_fingerprint` (`:h1:` keys); mirrors goldenmatch-kg's `resolve_entities` (lazy goldenmatch import).
- **`ingest(text, store, *, at, llm)`** — extract → resolve → build `StoreBatch` JSON → `PyStore.append`; remaps mention indices → entity `local_id`, drops self-loops/orphans. `resolver=` injectable.
- **`LLMClient`** protocol + optional `OpenAIClient` (`[openai]` extra, reuses `BudgetTracker`).

### Standalone package
Excluded from the uv workspace (the goldenmatch-kg precedent — heavy/optional deps); own informational lane `goldengraph-pipeline.yml` (installs goldenmatch + builds the native engine wheel via maturin + pytest).

### Tests (6; honest about LLM/resolution nondeterminism)
Marshaling/wiring tests inject a deterministic resolver (no goldenmatch needed) and run through the **real `PyStore` engine** — verified locally (5 passed). The goldenmatch-backed `resolve` test uses **exact-duplicate** mentions (version-stable, not a flaky fuzzy toy-merge) and runs in the CI lane. LLM accuracy is deferred to SP6's eval.

### Out (later)
SP4c (embedding-seeded retrieval + synthesis + NL query + text-to-Cypher). Real-LLM accuracy (SP6). PyPI/MCP publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)