### PR TITLE
fix(throughput): robust corpus-text column selection + datatrove deps (#1086 follow-up)

### DIFF
--- a/.github/workflows/bench-corpus-dedup.yml
+++ b/.github/workflows/bench-corpus-dedup.yml
@@ -70,7 +70,9 @@ jobs:
 
       - name: Install datatrove (competitor engine, not a repo dependency)
         if: contains(inputs.engines, 'datatrove')
-        run: uv pip install datatrove
+        # [processing] pulls the text-processing deps the MinHash pipeline needs
+        # (regex, nltk, tokenizers); bare `datatrove` ModuleNotFoundError'd on regex.
+        run: uv pip install 'datatrove[processing]'
 
       - name: Install duckdb (evaluator) + datasets (corpus streaming)
         run: uv pip install duckdb datasets

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1986,6 +1986,19 @@ def _throughput_blocking(
     from goldenmatch.core.throughput_verify import ThroughputNotApplicableError
     text_cols = [p for p in profiles if p.col_type in ("description", "string", "name", "multi_name")]
     if not text_cols:
+        # Heterogeneous corpus text (web crawl) is routinely MIS-classified by the
+        # semantic col_type heuristics: a long FineWeb/C4 document that embeds
+        # street names or emails lands as "address"/"email", not "description"
+        # (measured on real FineWeb: a 2.9k-char doc column classified "address").
+        # The throughput tier only needs the longest text-bearing column to sketch
+        # on, so fall back to the longest non-structured string column before
+        # refusing. Structured / short-token types can't be sketched usefully.
+        _NON_SKETCHABLE = {"numeric", "date", "year", "zip", "phone", "geo", "identifier"}
+        text_cols = [
+            p for p in profiles
+            if p.col_type not in _NON_SKETCHABLE and p.avg_len >= 20
+        ]
+    if not text_cols:
         raise ThroughputNotApplicableError(
             "throughput tier requires a text column to sketch on; none found"
         )

--- a/packages/python/goldenmatch/tests/test_throughput_blocking_fallback.py
+++ b/packages/python/goldenmatch/tests/test_throughput_blocking_fallback.py
@@ -1,0 +1,42 @@
+"""Throughput tier column-selection robustness (#1086).
+
+Real corpus text (FineWeb/C4 web crawl) is routinely mis-classified by the
+semantic col_type heuristics -- a long document that embeds street names lands
+as "address", not "description". The throughput tier must still sketch on the
+longest text-bearing column rather than raise ThroughputNotApplicableError.
+"""
+import pytest
+from goldenmatch.core.autoconfig import ColumnProfile, _throughput_blocking
+from goldenmatch.core.throughput_verify import ThroughputNotApplicableError
+
+
+def _p(name: str, col_type: str, avg_len: float, card: float = 1.0) -> ColumnProfile:
+    return ColumnProfile(
+        name=name, dtype="str", col_type=col_type, confidence=0.7,
+        avg_len=avg_len, cardinality_ratio=card,
+    )
+
+
+def _sketch_col(blk) -> str:
+    return blk.lsh.column if blk.lsh is not None else blk.simhash.column
+
+
+def test_falls_back_on_misclassified_corpus_text():
+    # Measured: real FineWeb doc text classifies as "address" (avg_len ~2.9k).
+    profiles = [_p("doc_id", "identifier", 10), _p("text", "address", 2916)]
+    blk = _throughput_blocking(profiles)
+    assert blk.strategy in ("lsh", "simhash")
+    assert _sketch_col(blk) == "text"
+
+
+def test_prefers_semantic_text_column_when_present():
+    profiles = [_p("doc_id", "identifier", 10), _p("body", "description", 400)]
+    blk = _throughput_blocking(profiles)
+    assert blk.strategy in ("lsh", "simhash")
+
+
+def test_refuses_when_only_structured_columns():
+    # No long string column -> genuinely no sketch target.
+    profiles = [_p("id", "identifier", 8), _p("age", "numeric", 2), _p("z", "zip", 5)]
+    with pytest.raises(ThroughputNotApplicableError):
+        _throughput_blocking(profiles)


### PR DESCRIPTION
Follow-up to #1086 (PR #1134). The headline `bench-corpus-dedup` run on real FineWeb errored on **both** engines:

1. **goldenmatch** — `ThroughputNotApplicableError: requires a text column to sketch on; none found`. Root cause: the semantic `col_type` heuristic classifies heterogeneous web documents as **`address`** (verified against real FineWeb: a 2.9k-char doc column → `address`; smaller samples → `multi_name`), and `_throughput_blocking` only accepted `description/string/name/multi_name`. Fix: when no semantic text column is found, **fall back to the longest non-structured string column** (`avg_len >= 20`, not `numeric/date/year/zip/phone/geo/identifier`) before refusing — a corpus's text column is whatever is longest, regardless of the semantic label. Refuses only when there's genuinely no long string column. + 3 unit tests.

2. **datatrove** — `ModuleNotFoundError: No module named 'regex'`. Fix: `bench-corpus-dedup.yml` installs `datatrove[processing]` (pulls regex/nltk/tokenizers).

Verified locally: `_throughput_blocking` falls back to the text column on the address-misclassified profile, keeps the description path, and still refuses on structured-only columns. pyright + ruff clean.

After merge I'll re-dispatch the headline bench for the docs/sec-vs-datatrove number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)