### PR TITLE
feat(goldengraph): SP4c — retrieval + synthesis + query (Python)

### DIFF
--- a/docs/superpowers/specs/2026-06-20-goldengraph-sp4c-retrieval-design.md
+++ b/docs/superpowers/specs/2026-06-20-goldengraph-sp4c-retrieval-design.md
@@ -1,0 +1,65 @@
+# goldengraph SP4c — retrieval + synthesis + query (Python) — design
+
+**Status:** Design draft 2026-06-20. SP4c slice of SP4 (`2026-06-20-goldengraph-sp4-host-pipeline-design.md`). Awaiting approval → plan. **Depends on SP4b** (the `goldengraph` Python package + `ingest`) **and SP4a** (`PyStore`/`PyGraph.communities`), both merged/queued.
+
+**Surface:** extends the standalone `goldengraph` Python package. **The "ask the KG" path** — the second half of the standalone milestone (SP4b builds the graph; SP4c queries it).
+
+---
+
+## Motivation
+
+SP4b turns text into a durable graph. SP4c answers questions against it: find the relevant entities (embedding-seeded), pull their neighborhood (SP1 retrieval over an SP2 `as_of` slice), and synthesize an answer (LLM) — local (a subgraph) or global (map-reduce over SP3 community summaries, GraphRAG's two query modes). Plus a text-to-Cypher export for users who persist to Neo4j. Resolution-merged entities mean a query about "Apple Inc." finds facts attached to "Apple"/"Apple Computer" too — the differentiator, now end-to-end.
+
+## Prerequisite — a `PyGraph.entities()` accessor (small SP4a-binding change)
+
+Embedding-seeded retrieval must read **every** entity's `canonical_name`, but the SP4a binding exposes no entity enumeration — `PyGraph` has only `query(seeds, hops)` (needs seeds you don't have yet), `seeds_by_name`, and `communities()`. So SP4c first adds **`PyGraph.entities() -> list[dict]`** to `goldengraph-native` (a ~10-line accessor mirroring the existing `graph_view_to_dict` entity projection: `[{entity_id, canonical_name, typ, surface_names, members}]`). This is an explicit SP4c prerequisite (like SP5a's serde-derive prereq) — without it `seed_by_query` has nothing to embed. (Reconstructing the entity set via `communities()` → `query(members, hops)` was rejected: it drops isolated/edgeless entities.)
+
+## Modules (extend the `goldengraph` package)
+
+### `embed.py` — embedder boundary + embedding-seeded retrieval
+```
+import numpy as np
+class Embedder(Protocol):
+    def embed(self, texts: list[str]) -> np.ndarray: ...   # shape (len(texts), dim)
+
+def seed_by_query(slice_graph, query, embedder, *, k=5) -> list[int]   # top-k entity ids
+```
+- Provider-agnostic `Embedder` protocol (mirrors SP4b's `LLMClient`), returning `np.ndarray` to match goldenmatch (cosine is numpy anyway — no per-call `.tolist()`). The default adapter wraps a goldenmatch embedding **provider** (`goldenmatch.embeddings.providers` / `_ProviderEmbedder.embed(texts) -> np.ndarray`, imported lazily — NOT the bare `goldenmatch.core.embedder.Embedder` class, whose surface is `embed_column`/`cosine_similarity_matrix`, not `.embed(texts)`). Tests inject a deterministic stub.
+- `seed_by_query` takes the **`PyGraph` returned by `as_of(v,t)`** (resolves the circular ordering: entity ids are slice-specific, so seeds must be valid on the same slice they query). It reads `slice_graph.entities()`, embeds the query + each `canonical_name`, cosine-ranks, and returns the top-`k` entity ids. **Tie-break: deterministic secondary sort by `entity_id`** (one-hot/zero stub vectors tie often — without this the top-k flakes). **Decision — recompute per query** (embed all entities each call): correctness-first and simple; a **persisted embedding sidecar** (keyed by entity id, alongside the snapshot — the SP2 store deliberately holds no vectors) + an ANN index is the scale optimization, noted not built. Cosine in numpy.
+
+### `synthesize.py` — LLM answer assembly (reuse `LLMClient` + `BudgetTracker`)
+```
+def synthesize_local(query, subgraph, llm) -> str          # subgraph -> answer
+def synthesize_global(query, community_views, llm) -> str  # map-reduce over community summaries
+```
+- **Local:** seed → `store.as_of(v,t).query(seeds, hops)` subgraph → LLM prompt (the subgraph's entities + edges) → answer.
+- **Global:** the `as_of` slice's `.communities()` → per-community subgraph (`slice.query(members, hops)`) → LLM summary each (map) → LLM combine summaries to answer the query (reduce). The GraphRAG global mode, on SP3's communities. **Cost:** this is N+1 LLM calls; `BudgetTracker` is reactive (it enforces `max_cost_usd`/`max_calls` via `record_usage` AFTER each call), so the plan must both `record_usage` per map call AND pre-emptively cap the community count — the tracker alone can't stop the fan-out before the calls fire.
+
+### `answer.py` — NL query orchestration + text-to-Cypher
+```
+def ask(query, store, *, valid_t, tx_t, llm, embedder, mode="local", k=5, hops=1) -> str
+def to_cypher(query, llm, *, schema_hint=None) -> str       # emit Cypher string (NOT executed)
+```
+- `ask(mode="local")` flow (ordering pinned): `slice = store.as_of(v,t)` → `seeds = seed_by_query(slice, query, embedder, k)` → `sub = slice.query(seeds, hops)` → `synthesize_local(query, sub, llm)`. `mode="global"` = `slice.communities()` → per-community `slice.query(members, hops)` → map-reduce. The native-store path is primary; seeds are always taken on the same `as_of` slice they query.
+- `to_cypher`: a thin LLM adapter emitting a Cypher string for Neo4j users; **returns the string, does not execute** (no Neo4j dep — the caller runs it). The native NL query is primary; Cypher is an export convenience.
+
+## Determinism + testing
+
+- **Stub embedder + stub LLM (deterministic):** a stub `Embedder` returns fixed vectors (e.g. one-hot per known name) so `seed_by_query` is deterministic; a stub `LLMClient` echoes a canned answer. Build a small graph via SP4b `ingest` (injected resolver) → `ask(...)` → assert the right seeds were chosen + the synthesis prompt saw the expected subgraph (assert on a recording stub's captured prompt, not on free-form LLM text). Verifies the **retrieval + assembly wiring**, not embedding/LLM accuracy.
+- **`to_cypher`** test: stub LLM returns a fixed Cypher string; assert it's returned verbatim (no execution).
+- **Real embedder/LLM:** opt-in lane (skipped without creds), as in SP4b. Accuracy is SP6's eval.
+
+## CI
+
+Extends the existing **`goldengraph-pipeline.yml`** lane (no new lane): the new `embed`/`synthesize`/`answer` tests run with the same install (goldenmatch + the native engine wheel). Informational; confirm green before arming.
+
+## Non-goals (SP4c)
+
+Persisted embedding sidecar / ANN index (the recompute-per-query optimization — measure first). Reranking / cross-encoder boosting. Neo4j execution (caller's). Real embedder/LLM accuracy guarantees (SP6). Streaming answers. The WASM/C surfaces (SP5). Multi-hop reasoning beyond `hops` neighborhoods.
+
+## Risks / open questions (resolve in the plan)
+
+- **Recompute-per-query embedding cost** is O(entities) embeds per query — fine for moderate KGs / SP4c correctness; the persisted sidecar is the escape hatch (same "measure first" discipline as the core's perf-audit lesson).
+- **Embedder availability:** goldenmatch's embedder may need a model/provider; the stub keeps tests hermetic, and the default adapter imports it lazily so the package loads without it.
+- **Global-search LLM cost:** map-reduce over communities is N+1 LLM calls; gate with `BudgetTracker` and cap community count in the plan.
+- **`as_of` defaults:** `ask` takes explicit `valid_t`/`tx_t`; pick sensible defaults (latest known tx, open valid) in the plan so the common case is one arg.

--- a/packages/python/goldengraph/goldengraph/__init__.py
+++ b/packages/python/goldengraph/goldengraph/__init__.py
@@ -5,10 +5,13 @@ store (the goldengraph-native engine). Entity resolution is the differentiator:
 duplicate surface forms across documents collapse into one durable entity.
 """
 
+from .answer import ask, to_cypher
+from .embed import Embedder, GoldenmatchEmbedder, seed_by_query
 from .extract import Extraction, Mention, Relationship, extract, parse_extraction
 from .ingest import build_batch, ingest
 from .llm import LLMClient, OpenAIClient
 from .resolve import ResolvedEntity, resolve
+from .synthesize import synthesize_global, synthesize_local
 
 __all__ = [
     "LLMClient",
@@ -22,4 +25,12 @@ __all__ = [
     "resolve",
     "build_batch",
     "ingest",
+    # SP4c — retrieval + synthesis + query
+    "Embedder",
+    "GoldenmatchEmbedder",
+    "seed_by_query",
+    "synthesize_local",
+    "synthesize_global",
+    "ask",
+    "to_cypher",
 ]

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -1,0 +1,58 @@
+"""NL query orchestration over the durable store + text-to-Cypher export.
+
+`ask` is the "ask the KG" entry point: take an `as_of` slice, seed it (local) or
+walk its communities (global), and synthesize. `to_cypher` emits a Cypher string
+for Neo4j users (it does NOT execute — no Neo4j dependency; the caller runs it).
+"""
+
+from __future__ import annotations
+
+from .embed import Embedder, seed_by_query
+from .llm import LLMClient
+from .synthesize import synthesize_global, synthesize_local
+
+
+def ask(
+    query: str,
+    store,
+    *,
+    llm: LLMClient,
+    embedder: Embedder,
+    valid_t: int,
+    tx_t: int,
+    mode: str = "local",
+    k: int = 5,
+    hops: int = 1,
+    max_communities: int = 10,
+) -> str:
+    """Answer `query` against `store` as-of `(valid_t, tx_t)`.
+
+    `mode="local"`: embedding-seeded neighborhood → synthesize. `mode="global"`:
+    community map-reduce (capped at `max_communities` — the pre-emptive guard on
+    the N+1 LLM fan-out; per-call budget is the `LLMClient`'s job).
+    """
+    slice_graph = store.as_of(valid_t, tx_t)
+    if mode == "global":
+        communities = slice_graph.communities()[:max_communities]
+        views = [slice_graph.query(c["members"], hops) for c in communities]
+        return synthesize_global(query, views, llm)
+    if mode != "local":
+        raise ValueError(f"mode must be 'local' or 'global', got {mode!r}")
+    seeds = seed_by_query(slice_graph, query, embedder, k=k)
+    subgraph = slice_graph.query(seeds, hops)
+    return synthesize_local(query, subgraph, llm)
+
+
+_CYPHER_PROMPT = (
+    "Translate the question into a SINGLE Cypher query for a Neo4j knowledge "
+    "graph (nodes are entities with a `name`; edges carry a `predicate`). Output "
+    "only the Cypher.\nQuestion: {q}\n{schema}"
+)
+
+
+def to_cypher(query: str, llm: LLMClient, *, schema_hint: str | None = None) -> str:
+    """Emit a Cypher query string for `query` (NOT executed — the caller runs it
+    against their own Neo4j; goldengraph has no Neo4j dependency)."""
+    return llm.complete(
+        _CYPHER_PROMPT.format(q=query, schema=schema_hint or "")
+    ).strip()

--- a/packages/python/goldengraph/goldengraph/embed.py
+++ b/packages/python/goldengraph/goldengraph/embed.py
@@ -1,0 +1,65 @@
+"""Embedding-seeded retrieval: turn a query into entity seeds.
+
+Provider-agnostic `Embedder` protocol (mirrors `LLMClient`); the default
+`GoldenmatchEmbedder` lazily wraps a goldenmatch embedding provider. Tests inject
+a deterministic stub. `seed_by_query` operates on the `PyGraph` returned by
+`as_of(v,t)` — entity ids are slice-specific, so seeds must be valid on the same
+slice they query.
+
+Recompute-per-query (embed every entity each call): correctness-first; a
+persisted embedding sidecar + ANN index is the scale optimization, not built.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import numpy as np
+
+
+class Embedder(Protocol):
+    """Embed texts → an array of shape (len(texts), dim)."""
+
+    def embed(self, texts: list[str]) -> np.ndarray: ...
+
+
+class GoldenmatchEmbedder:
+    """Default embedder — wraps a goldenmatch embedding provider (lazy import).
+
+    `provider` is a goldenmatch provider name ('local', 'inhouse', 'vertex',
+    'openai', ...) or any object with `.embed(texts) -> np.ndarray`.
+    """
+
+    def __init__(self, provider: str = "local", *, model: str | None = None):
+        self._provider_name = provider
+        self._model = model
+        self._provider = None
+
+    def _ensure(self):
+        if self._provider is None:
+            from goldenmatch.embeddings.providers import resolve_provider
+
+            self._provider = resolve_provider(self._provider_name, model=self._model)
+        return self._provider
+
+    def embed(self, texts: list[str]) -> np.ndarray:
+        return np.asarray(self._ensure().embed(texts), dtype=float)
+
+
+def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5) -> list[int]:
+    """Top-`k` entity ids in `slice_graph` (a `PyGraph` from `as_of`) nearest the
+    query by cosine over canonical-name embeddings. Tie-break: ascending
+    `entity_id` (deterministic — stub/zero vectors tie often)."""
+    ents = slice_graph.entities()
+    if not ents:
+        return []
+    ids = [int(e["entity_id"]) for e in ents]
+    names = [str(e["canonical_name"]) for e in ents]
+    vecs = np.asarray(embedder.embed([query] + names), dtype=float)
+    q = vecs[0]
+    mat = vecs[1:]
+    qn = q / (np.linalg.norm(q) + 1e-12)
+    mn = mat / (np.linalg.norm(mat, axis=1, keepdims=True) + 1e-12)
+    sims = mn @ qn
+    order = sorted(range(len(ids)), key=lambda i: (-float(sims[i]), ids[i]))
+    return [ids[i] for i in order[:k]]

--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -1,0 +1,46 @@
+"""LLM answer synthesis over a retrieved subgraph — local + global (map-reduce).
+
+Local: one subgraph → one answer. Global: per-community summaries (map) combined
+into one answer (reduce) — the GraphRAG global mode over SP3 communities. Budget
+enforcement lives in the `LLMClient` impl (the protocol returns text, not usage);
+the caller (`ask`) pre-emptively caps community count.
+"""
+
+from __future__ import annotations
+
+from .llm import LLMClient
+
+
+def _format_subgraph(view: dict) -> str:
+    ents = "; ".join(
+        f"{e['entity_id']}:{e['canonical_name']}({e['typ']})" for e in view["entities"]
+    )
+    edges = "; ".join(
+        f"{e['subj']} -{e['predicate']}-> {e['obj']}" for e in view["edges"]
+    )
+    return f"Entities: {ents}\nRelationships: {edges}"
+
+
+_LOCAL_PROMPT = (
+    "Answer the question using ONLY this knowledge subgraph; if it is "
+    "insufficient, say so.\nQuestion: {q}\n{sub}"
+)
+_MAP_PROMPT = "Summarize this community as it bears on the question.\nQuestion: {q}\n{sub}"
+_REDUCE_PROMPT = (
+    "Answer the question by combining these community summaries.\n"
+    "Question: {q}\nSummaries:\n{summaries}"
+)
+
+
+def synthesize_local(query: str, subgraph: dict, llm: LLMClient) -> str:
+    return llm.complete(_LOCAL_PROMPT.format(q=query, sub=_format_subgraph(subgraph)))
+
+
+def synthesize_global(query: str, community_views: list[dict], llm: LLMClient) -> str:
+    summaries = [
+        llm.complete(_MAP_PROMPT.format(q=query, sub=_format_subgraph(v)))
+        for v in community_views
+    ]
+    return llm.complete(
+        _REDUCE_PROMPT.format(q=query, summaries="\n".join(summaries))
+    )

--- a/packages/python/goldengraph/tests/conftest.py
+++ b/packages/python/goldengraph/tests/conftest.py
@@ -20,6 +20,37 @@ class StubLLM:
         return self.response
 
 
+class RecordingLLM:
+    """Records every prompt it sees and returns a canned answer — lets a test
+    assert WHAT the synthesizer was given (the subgraph), not free-form text."""
+
+    def __init__(self, response: str = "ANSWER"):
+        self.response = response
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self.response
+
+
+class StubEmbedder:
+    """Deterministic one-hot embedder: each known string maps to a basis vector;
+    unknown strings → the zero vector. Makes cosine ranking reproducible."""
+
+    def __init__(self, vocab: dict[str, int]):
+        self.vocab = vocab
+        self.dim = max(vocab.values()) + 1 if vocab else 1
+
+    def embed(self, texts: list[str]):
+        import numpy as np
+
+        m = np.zeros((len(texts), self.dim), dtype=float)
+        for i, t in enumerate(texts):
+            if t in self.vocab:
+                m[i, self.vocab[t]] = 1.0
+        return m
+
+
 @pytest.fixture
 def store():
     from goldengraph_native import _native as gg

--- a/packages/python/goldengraph/tests/test_retrieval.py
+++ b/packages/python/goldengraph/tests/test_retrieval.py
@@ -1,0 +1,105 @@
+"""SP4c retrieval + synthesis + query tests.
+
+Deterministic via a one-hot StubEmbedder + a RecordingLLM (asserts WHAT the
+synthesizer saw, not free-form text). Builds a graph through SP4b `ingest` with
+an injected resolver, then queries it through the real `PyStore` engine — no
+goldenmatch, no real embedder/LLM.
+"""
+
+from __future__ import annotations
+
+import json
+
+from goldengraph import ResolvedEntity, ask, seed_by_query, to_cypher
+from goldengraph.extract import Mention
+from conftest import RecordingLLM, StubEmbedder, StubLLM
+
+# Acme --made--> Rocket ; Coyote isolated-ish
+_EXTRACTION = json.dumps(
+    {
+        "entities": [
+            {"name": "Acme", "type": "org"},
+            {"name": "Rocket", "type": "product"},
+            {"name": "Coyote", "type": "person"},
+        ],
+        "relationships": [{"subj": 0, "predicate": "made", "obj": 1}],
+    }
+)
+
+
+def _identity_resolver(mentions: list[Mention]) -> list[ResolvedEntity]:
+    return [
+        ResolvedEntity(i, m.name, m.typ, [m.name], [f"k{i}"], [i])
+        for i, m in enumerate(mentions)
+    ]
+
+
+def _seed_store(store):
+    from goldengraph import ingest
+
+    ingest("doc", store, at=100, llm=StubLLM(_EXTRACTION), resolver=_identity_resolver)
+
+
+# vocab: the query word + entity canonical names, each its own basis vector
+_VOCAB = {"Acme": 0, "Rocket": 1, "Coyote": 2}
+
+
+def test_seed_by_query_picks_nearest_entity(store):
+    _seed_store(store)
+    g = store.as_of(150, 150)
+    seeds = seed_by_query(g, "Acme", StubEmbedder(_VOCAB), k=1)
+    # the "Acme" entity is the cosine-nearest to the query "Acme"
+    acme_id = g.seeds_by_name("Acme")[0]
+    assert seeds == [acme_id]
+
+
+def test_ask_local_synthesizes_over_the_seeded_subgraph(store):
+    _seed_store(store)
+    llm = RecordingLLM()
+    out = ask(
+        "Acme",
+        store,
+        llm=llm,
+        embedder=StubEmbedder(_VOCAB),
+        valid_t=150,
+        tx_t=150,
+        mode="local",
+        hops=1,
+    )
+    assert out == "ANSWER"
+    # the synthesis prompt saw the Acme->Rocket fact (seeded + 1-hop)
+    prompt = llm.prompts[-1]
+    assert "Acme" in prompt and "Rocket" in prompt and "made" in prompt
+
+
+def test_ask_global_maps_then_reduces(store):
+    _seed_store(store)
+    llm = RecordingLLM()
+    out = ask(
+        "what happened",
+        store,
+        llm=llm,
+        embedder=StubEmbedder(_VOCAB),
+        valid_t=150,
+        tx_t=150,
+        mode="global",
+    )
+    assert out == "ANSWER"
+    # >=1 map prompt + 1 reduce prompt; the reduce prompt combines summaries
+    assert len(llm.prompts) >= 2
+    assert "Summaries:" in llm.prompts[-1]
+
+
+def test_ask_rejects_bad_mode(store):
+    import pytest
+
+    _seed_store(store)
+    with pytest.raises(ValueError):
+        ask("q", store, llm=RecordingLLM(), embedder=StubEmbedder(_VOCAB),
+            valid_t=1, tx_t=1, mode="sideways")
+
+
+def test_to_cypher_returns_string_only():
+    llm = StubLLM("MATCH (a)-[:MADE]->(b) RETURN a, b")
+    cy = to_cypher("what did Acme make?", llm)
+    assert cy.startswith("MATCH")  # emitted, not executed

--- a/packages/rust/extensions/goldengraph-native/src/lib.rs
+++ b/packages/rust/extensions/goldengraph-native/src/lib.rs
@@ -61,6 +61,25 @@ impl PyGraph {
         }
         Ok(out)
     }
+
+    /// All entities in the graph as `[{entity_id, canonical_name, typ, members,
+    /// surface_names}]` (SP4c needs to enumerate entities to embed their names;
+    /// `query`/`seeds_by_name` can't enumerate). Same projection as `query`'s
+    /// entity dicts, over the full entity set.
+    fn entities<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let out = PyList::empty(py);
+        for e in &self.inner.entities {
+            let d = PyDict::new(py);
+            d.set_item("entity_id", e.entity_id)?;
+            d.set_item("canonical_name", e.canonical_name.as_str())?;
+            d.set_item("typ", e.typ.as_str())?;
+            d.set_item("members", PyList::new(py, &e.members)?)?;
+            let names: Vec<&str> = e.surface_names.iter().map(String::as_str).collect();
+            d.set_item("surface_names", PyList::new(py, names)?)?;
+            out.append(d)?;
+        }
+        Ok(out)
+    }
 }
 
 /// A durable, bi-temporal knowledge-graph store (SP2). Wraps the pyo3-free


### PR DESCRIPTION
## goldengraph SP4c — the "ask the KG" path

Final SP4 slice: query the durable graph. **embedding-seeded retrieval → local/global synthesis → answer**, plus a text-to-Cypher export. Completes the standalone milestone (SP4b builds the KG; SP4c queries it).

Spec: `docs/superpowers/specs/2026-06-20-goldengraph-sp4c-retrieval-design.md` (review-approved). Depends on SP4a/SP4b (merged).

### What's in
- **Binding prereq:** `PyGraph.entities()` — enumerate entities to embed their names (the binding had no enumeration; `query` needs seeds you don't have yet).
- **`embed.py`** — `Embedder` protocol + `GoldenmatchEmbedder` (lazy goldenmatch provider) + `seed_by_query` over the `as_of` slice (entity ids are slice-specific), cosine with deterministic `entity_id` tie-break.
- **`synthesize.py`** — local (subgraph→answer) + global (per-community map-reduce over SP3 communities).
- **`answer.py`** — `ask(mode="local"|"global")` (community count capped) + `to_cypher` (emits a Cypher string, does NOT execute — no Neo4j dep).

### Tests (5)
One-hot `StubEmbedder` + a `RecordingLLM` (asserts the synthesizer saw the right subgraph, not free-form text), driven through the real `PyStore` engine. Recompute-per-query retrieval (sidecar/ANN is the noted scale optimization).

### Validation note (honest)
The Python modules are **import-validated locally** (compile + import + the 18-symbol surface). The Rust `entities()` accessor + the live `PyStore` integration tests are validated by the **`goldengraph-pipeline` CI lane** (clean Linux runner) — the local Rust build is currently blocked by a corrupted toolchain sysroot on the dev box (intermittent; not the SP4c code). CI is the validator of record here.

### Out
SP5b (C ABI), SP6 (eval). Persisted embedding sidecar / ANN. Real embedder/LLM accuracy (SP6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)