### PR TITLE
fix(throughput): avg_len-keyed text-column fallback + datatrove spacy dep (#1086 follow-up 2)

### DIFF
--- a/.github/workflows/bench-corpus-dedup.yml
+++ b/.github/workflows/bench-corpus-dedup.yml
@@ -70,9 +70,11 @@ jobs:
 
       - name: Install datatrove (competitor engine, not a repo dependency)
         if: contains(inputs.engines, 'datatrove')
-        # [processing] pulls the text-processing deps the MinHash pipeline needs
-        # (regex, nltk, tokenizers); bare `datatrove` ModuleNotFoundError'd on regex.
-        run: uv pip install 'datatrove[processing]'
+        # [processing] pulls regex/nltk; datatrove's `en` word tokenizer (used to
+        # build MinHash word n-grams) also needs spacy + its small English model.
+        run: |
+          uv pip install 'datatrove[processing]' spacy
+          uv run python -m spacy download en_core_web_sm
 
       - name: Install duckdb (evaluator) + datasets (corpus streaming)
         run: uv pip install duckdb datasets

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1988,19 +1988,22 @@ def _throughput_blocking(
     if not text_cols:
         # Heterogeneous corpus text (web crawl) is routinely MIS-classified by the
         # semantic col_type heuristics: a long FineWeb/C4 document that embeds
-        # street names or emails lands as "address"/"email", not "description"
-        # (measured on real FineWeb: a 2.9k-char doc column classified "address").
-        # The throughput tier only needs the longest text-bearing column to sketch
-        # on, so fall back to the longest non-structured string column before
-        # refusing. Structured / short-token types can't be sketched usefully.
-        _NON_SKETCHABLE = {"numeric", "date", "year", "zip", "phone", "geo", "identifier"}
+        # street names / emails / unique ids lands as "address" / "email" /
+        # "identifier", not "description" (measured on real FineWeb: a ~3k-char doc
+        # column classified "address"). The throughput tier only needs the longest
+        # column holding substantial free text, so fall back to that — keyed on
+        # avg_len, NOT the semantic label — excluding only columns whose DATA is
+        # structured (numeric/date/year/zip/phone/geo). A short identifier (doc_id)
+        # is filtered by the length floor; a long mis-labelled text column is not.
+        _STRUCTURED = {"numeric", "date", "year", "zip", "phone", "geo"}
         text_cols = [
             p for p in profiles
-            if p.col_type not in _NON_SKETCHABLE and p.avg_len >= 20
+            if p.col_type not in _STRUCTURED and p.avg_len >= 50
         ]
     if not text_cols:
         raise ThroughputNotApplicableError(
-            "throughput tier requires a text column to sketch on; none found"
+            "throughput tier requires a text column to sketch on; none found "
+            f"(columns: {[(p.name, p.col_type, round(p.avg_len)) for p in profiles]})"
         )
     if any(p.col_type == "description" for p in profiles):
         return _text_corpus_blocking(profiles, None, config)

--- a/packages/python/goldenmatch/tests/test_throughput_blocking_fallback.py
+++ b/packages/python/goldenmatch/tests/test_throughput_blocking_fallback.py
@@ -29,6 +29,15 @@ def test_falls_back_on_misclassified_corpus_text():
     assert _sketch_col(blk) == "text"
 
 
+def test_falls_back_on_long_text_typed_as_identifier():
+    # At scale, a unique long-text column can be classified "identifier" — the
+    # fallback keys on avg_len, not the label, so a long doc column still sketches
+    # while the short doc_id identifier is filtered by the length floor.
+    profiles = [_p("doc_id", "identifier", 11), _p("text", "identifier", 3018)]
+    blk = _throughput_blocking(profiles)
+    assert _sketch_col(blk) == "text"
+
+
 def test_prefers_semantic_text_column_when_present():
     profiles = [_p("doc_id", "identifier", 10), _p("body", "description", 400)]
     blk = _throughput_blocking(profiles)


### PR DESCRIPTION
Second follow-up to #1086 — the headline `bench-corpus-dedup` run still errored on both engines after #1139:

1. **goldenmatch — still `ThroughputNotApplicable` at 140k.** #1139's fallback excluded `identifier`-typed columns. At ~1k docs FineWeb `text` classifies as `address` (fallback worked locally), but at 140k the long unique text column is evidently classified into an excluded type. Fix: the fallback now keys on **`avg_len`, not the semantic label** — when no semantic text column exists, sketch on the longest column with `avg_len >= 50` whose *data* isn't structured (`numeric/date/year/zip/phone/geo`). A short `doc_id` is filtered by the length floor; a long mis-labelled doc column (address/identifier/whatever) is picked. The error message now lists `(name, col_type, avg_len)` so any residual case self-diagnoses. + unit test for the long-`identifier` case.

2. **datatrove — `ImportError: spacy`.** The `en` word tokenizer (MinHash word n-grams) needs spacy + its small English model. Workflow now installs `spacy` + `en_core_web_sm` alongside `datatrove[processing]`.

Verified the 4 fallback cases directly (address-long → text, identifier-long → text, description → semantic, structured-only → refuse). pyright + ruff clean.

After merge I'll re-dispatch the headline bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)