### PR TITLE
fix(throughput): early text-column gate must share the blocking predicate (#1086 follow-up 3)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1970,6 +1970,38 @@ def _text_corpus_blocking(
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+# Column-DATA types that are structured (not free text) and can't be sketched.
+_NON_SKETCHABLE_COL_TYPES = frozenset({"numeric", "date", "year", "zip", "phone", "geo"})
+
+
+def sketchable_text_cols(profiles: list[ColumnProfile]) -> list[ColumnProfile]:
+    """Columns the throughput tier can sketch on.
+
+    Prefers the semantic text types (description / string / name / multi_name).
+    But heterogeneous corpus text (web crawl) is routinely MIS-classified by the
+    semantic col_type heuristics -- a long FineWeb/C4 document that embeds street
+    names / emails / unique ids lands as "address" / "email" / "identifier", not
+    "description" (measured on real FineWeb: a ~3k-char doc column classified
+    "address"). So when no semantic text column exists, fall back to any column
+    holding substantial free text -- keyed on ``avg_len``, NOT the semantic label
+    -- excluding only columns whose DATA is structured. A short identifier
+    (``doc_id``) is filtered by the length floor; a long mis-labelled text column
+    is not.
+
+    Shared by ``_throughput_blocking`` and ``auto_configure_df``'s early
+    validation so the two cannot diverge.
+    """
+    semantic = [
+        p for p in profiles
+        if p.col_type in ("description", "string", "name", "multi_name")
+    ]
+    if semantic:
+        return semantic
+    return [
+        p for p in profiles
+        if p.col_type not in _NON_SKETCHABLE_COL_TYPES and p.avg_len >= 50
+    ]
+
 
 def _throughput_blocking(
     profiles: list[ColumnProfile], config: GoldenMatchConfig | None = None
@@ -1984,22 +2016,7 @@ def _throughput_blocking(
     the throughput tier cannot operate without a sketch target.
     """
     from goldenmatch.core.throughput_verify import ThroughputNotApplicableError
-    text_cols = [p for p in profiles if p.col_type in ("description", "string", "name", "multi_name")]
-    if not text_cols:
-        # Heterogeneous corpus text (web crawl) is routinely MIS-classified by the
-        # semantic col_type heuristics: a long FineWeb/C4 document that embeds
-        # street names / emails / unique ids lands as "address" / "email" /
-        # "identifier", not "description" (measured on real FineWeb: a ~3k-char doc
-        # column classified "address"). The throughput tier only needs the longest
-        # column holding substantial free text, so fall back to that — keyed on
-        # avg_len, NOT the semantic label — excluding only columns whose DATA is
-        # structured (numeric/date/year/zip/phone/geo). A short identifier (doc_id)
-        # is filtered by the length floor; a long mis-labelled text column is not.
-        _STRUCTURED = {"numeric", "date", "year", "zip", "phone", "geo"}
-        text_cols = [
-            p for p in profiles
-            if p.col_type not in _STRUCTURED and p.avg_len >= 50
-        ]
+    text_cols = sketchable_text_cols(profiles)
     if not text_cols:
         raise ThroughputNotApplicableError(
             "throughput tier requires a text column to sketch on; none found "
@@ -2955,10 +2972,13 @@ def auto_configure_df(
         from goldenmatch.core.throughput_verify import ThroughputNotApplicableError
         if isinstance(df, _pl_tp.DataFrame):
             _early_profiles = profile_columns(df)
-            _text_types = ("description", "string", "name", "multi_name")
-            if not any(p.col_type in _text_types for p in _early_profiles):
+            # Same predicate as _throughput_blocking (shared helper) so the early
+            # gate and the blocking builder cannot diverge — heterogeneous corpus
+            # text mis-classified as "address"/"identifier" must pass here too.
+            if not sketchable_text_cols(_early_profiles):
                 raise ThroughputNotApplicableError(
-                    "throughput tier requires a text column to sketch on; none found"
+                    "throughput tier requires a text column to sketch on; none found "
+                    f"(columns: {[(p.name, p.col_type, round(p.avg_len)) for p in _early_profiles]})"
                 )
 
     # Coerce + validate input types.

--- a/packages/python/goldenmatch/tests/test_throughput_blocking_fallback.py
+++ b/packages/python/goldenmatch/tests/test_throughput_blocking_fallback.py
@@ -6,7 +6,11 @@ as "address", not "description". The throughput tier must still sketch on the
 longest text-bearing column rather than raise ThroughputNotApplicableError.
 """
 import pytest
-from goldenmatch.core.autoconfig import ColumnProfile, _throughput_blocking
+from goldenmatch.core.autoconfig import (
+    ColumnProfile,
+    _throughput_blocking,
+    sketchable_text_cols,
+)
 from goldenmatch.core.throughput_verify import ThroughputNotApplicableError
 
 
@@ -49,3 +53,17 @@ def test_refuses_when_only_structured_columns():
     profiles = [_p("id", "identifier", 8), _p("age", "numeric", 2), _p("z", "zip", 5)]
     with pytest.raises(ThroughputNotApplicableError):
         _throughput_blocking(profiles)
+
+
+def test_sketchable_text_cols_shared_predicate():
+    # The shared helper backs BOTH _throughput_blocking and auto_configure_df's
+    # early gate, so they cannot diverge (the early gate was the missed site).
+    assert [p.name for p in sketchable_text_cols(
+        [_p("doc_id", "identifier", 10), _p("text", "address", 2916)])] == ["text"]
+    assert [p.name for p in sketchable_text_cols(
+        [_p("doc_id", "identifier", 11), _p("text", "identifier", 3018)])] == ["text"]
+    # semantic text wins outright
+    assert [p.name for p in sketchable_text_cols(
+        [_p("body", "description", 400)])] == ["body"]
+    # structured-only -> empty (early gate refuses)
+    assert sketchable_text_cols([_p("age", "numeric", 2), _p("z", "zip", 5)]) == []


### PR DESCRIPTION
Third (and root) follow-up to #1086. The headline bench *still* `ThroughputNotApplicable`'d on FineWeb after #1142 — the giveaway was the error message lacked the `(columns: ...)` suffix #1142 added.

Root cause: `auto_configure_df` has a **second** throughput text-column check — an *early validation* (~line 2960) that runs **before** the controller — and it used the restrictive `col_type in (description/string/name/multi_name)` test, refusing on FineWeb's `address`-typed text before `_throughput_blocking`'s avg_len fallback was ever reached. The two checks had diverged (twice).

Fix: extract the predicate into a shared `sketchable_text_cols(profiles)` helper (semantic text types, else longest non-structured column with `avg_len >= 50`) and use it in **both** the early gate and the blocking builder, so they cannot drift again. The early-gate error now also lists `(name, col_type, avg_len)`. + helper unit test.

Verified directly: `sketchable_text_cols` picks the text column for `address`- and `identifier`-typed long text, keeps the semantic path, and returns empty (refuse) for structured-only. pyright + ruff clean.

(datatrove now runs after #1142's spacy fix but found 0 dups on the last run — separate cluster-output-parsing bug I'll address next; goldenmatch is the headline.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)