### PR TITLE
docs(goldengraph): SP6 head-to-head eval spec (review-approved)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-goldengraph-sp6-headtohead-eval.md
+++ b/docs/superpowers/plans/2026-06-20-goldengraph-sp6-headtohead-eval.md
@@ -1,0 +1,112 @@
+# goldengraph SP6 — head-to-head eval implementation plan
+
+> **For agentic workers:** use superpowers:subagent-driven-development or
+> executing-plans. Steps use `- [ ]` checkboxes. TDD: failing test → minimal impl →
+> run → commit.
+
+**Goal:** Add goldengraph to ER-KG-Bench (engine row) and a deterministic
+fact-completeness eval that measures resolution's downstream win, per
+`docs/superpowers/specs/2026-06-20-goldengraph-sp6-headtohead-eval-design.md`.
+
+**Architecture:** Reuse ER-KG-Bench (`packages/python/goldenmatch/benchmarks/er-kg-bench/`).
+Half 1 = a new adapter mirroring `goldenmatch_adapter.py`. Half 2 = extend the
+demo KG model with facts + a `qa_eval.py` that scores fact co-location (resolved
+vs exact-match floor) via the `demo/narrative.under_merge_answer` reachability
+model. New informational `bench-er-kg.yml` lane (deterministic gate; LLM +
+real-framework opt-in).
+
+**Tech stack:** Python (polars, goldenmatch, goldengraph), the existing
+`erkgbench` harness, pytest, GitHub Actions.
+
+**Paths** (all under `packages/python/goldenmatch/benchmarks/er-kg-bench/` unless noted):
+`erkgbench/adapters/base.py` (Record/AdapterBase — read-only), `erkgbench/adapters/goldenmatch_adapter.py`
+(mirror), `erkgbench/run.py` (adapter list ~line 120), `demo/kg.py` (Node/build_kg),
+`demo/narrative.py` (under_merge_answer), `demo/test_demo.py` (must stay green),
+`erkgbench/metrics.py` (read-only), goldengraph pkg `packages/python/goldengraph/goldengraph/`
+(resolve API).
+
+---
+
+### Task 1: `Node.facts` + `build_kg` unions facts
+**Files:** Modify `demo/kg.py`; Test `demo/test_demo.py` (add case).
+
+- [ ] **Step 1 — failing test.** In `demo/test_demo.py`, add `test_build_kg_unions_facts`: build a 2-record cluster whose records carry facts `["f1"]` and `["f2"]`; assert the resulting `Node.facts == ("f1","f2")` (sorted, deduped) and that an empty-facts build yields `Node.facts == ()`.
+- [ ] **Step 2 — run, expect fail** (`Node` has no `facts`): `cd packages/python/goldenmatch/benchmarks/er-kg-bench && python -m pytest demo/test_demo.py -q`.
+- [ ] **Step 3 — implement.** Add `facts: tuple[str, ...] = ()` to the `Node` dataclass (frozen; default keeps existing constructions valid). Add a `facts: dict[int, list[str]] | None = None` param to `build_kg`; when present, set each node's `facts = tuple(sorted({f for i in idxs for f in facts.get(i, [])}))`. Default `None` → `()` (existing callers + `demo/test_demo.py` unchanged).
+- [ ] **Step 4 — run, expect pass** (new test + all existing demo tests green).
+- [ ] **Step 5 — commit:** `feat(er-kg-bench): Node.facts + build_kg fact union`.
+
+### Task 2 (Half 1): goldengraph adapter + parity lock
+**Files:** Create `erkgbench/adapters/goldengraph_adapter.py`; Modify `erkgbench/run.py`; Test `erkgbench/tests/test_goldengraph_adapter.py`.
+
+- [ ] **Step 1 — failing test.** `test_goldengraph_partition_parity`: build ~6 `Record`s (two clear dup groups), run `GoldenGraphAdapter().resolve(records)` AND `goldenmatch.dedupe_df` on the **same fields goldengraph.resolve uses** — `{name, typ}` (NOT context: `goldengraph/resolve.py::resolve` builds a `{name, typ}` frame and calls `gm.dedupe_df`). Assert the two partitions (frozensets of frozensets over indices) are EQUAL. Parity holds BY CONSTRUCTION because goldengraph.resolve wraps `gm.dedupe_df` — the test locks that the engine wiring doesn't drift.
+- [ ] **Step 2 — run, expect fail** (adapter missing).
+- [ ] **Step 3 — implement.** `GoldenGraphAdapter(AdapterBase)` with `name="goldengraph"`, `fidelity="real"`, `deterministic=True`, `defaults="goldengraph engine: resolve (Provided mode) -> store; wraps goldenmatch dedupe_df on name+type"`. In `resolve(records)`: order by `.index`; build `goldengraph.Mention`s from `(mention, entity_type)`; call `goldengraph.resolve(mentions) -> list[ResolvedEntity]`; group record indices by the resolved entity (each `ResolvedEntity` carries its member mention indices) → return clusters in record-index space. If goldengraph isn't importable, raise a clear ImportError (the runner records it as an error row, never fatal). **NOTE:** this is the Provided-mode path (= goldenmatch resolver). The goldengraph-core NATIVE resolver (`ResolutionMode::Native`, score-core/graph-core) is a DIFFERENT algorithm whose quality is NOT parity-locked to gm.dedupe_df — add it as a separate `goldengraph(native-kernel)` row only as a follow-up with its own (non-parity) measurement, not in this task.
+- [ ] **Step 4 — register.** In `run.py`, import `GoldenGraphAdapter` and append `GoldenGraphAdapter()` to the `adapters = [...]` list (~line 120), after the goldenmatch rows.
+- [ ] **Step 5 — run, expect pass:** `python -m pytest erkgbench/tests/test_goldengraph_adapter.py -q`.
+- [ ] **Step 6 — commit:** `feat(er-kg-bench): goldengraph engine adapter + parity lock`.
+
+### Task 3 (Half 2): authored QA corpus + loader
+**Files:** Create `dataset/qa.jsonl`; Create `erkgbench/qa_loader.py`; Test `erkgbench/tests/test_qa_loader.py`.
+
+- [ ] **Step 1 — failing test.** `test_qa_loader`: load `qa.jsonl`; assert ≥8 items; each has `qa_id, entity_id, question, seed_surface, gold_facts (non-empty list), gold_answer`; every `entity_id` exists in `dataset/records.csv`; every `seed_surface` matches a `mention` of that entity_id in records.csv.
+- [ ] **Step 2 — run, expect fail** (no qa.jsonl / loader).
+- [ ] **Step 3 — author the corpus.** Write `dataset/qa.jsonl`: pick ≥8 entities from `records.csv` with multi-surface / cross-document structure (abbreviation, xling, xdoc, suffix classes). For each, attach 2-4 distinct `gold_facts` to DIFFERENT surface forms (record indices) of that entity, a `question` whose answer needs all of them, a `seed_surface` (one of the surface forms), and a `gold_answer`. Add `dataset/qa_facts.csv` (or inline in qa.jsonl) mapping `record_id -> fact` so a fact is attached to a specific surface-form record. Implement `qa_loader.py::load_qa() -> list[QAItem]` + `load_qa_facts() -> dict[int, list[str]]`.
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit:** `feat(er-kg-bench): authored QA fact corpus + loader`.
+
+### Task 4 (Half 2): fact-completeness eval (the deterministic gate)
+**Files:** Create `erkgbench/qa_eval.py`; Test `erkgbench/tests/test_qa_eval.py`.
+
+- [ ] **Step 1 — failing test.** `test_completeness_resolved_vs_split` on a tiny in-memory fixture: one entity, 2 surface forms, facts `["a"]` on form-1 and `["b"]` on form-2, a QA item with `gold_facts=["a","b"]`, `seed_surface=form-1`. RESOLVED partition `[[0,1]]` → completeness == 1.0. SPLIT partition `[[0],[1]]` → completeness == 0.5 (seed lands on form-1's node only). Assert both.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement `qa_eval.py`.**
+  - `engine_completeness(partition, qa_items, facts_by_record) -> dict` : for each QA item, `build_kg(partition, mentions, types, contexts, facts=facts_by_record)`; select the **landed cluster** using the SAME selection `under_merge_answer` uses — `landed = next(c for c in partition if any(mentions[i] == seed_surface for i in c), [])` — then `retrieved = set(union of facts over landed's records)` (note: `under_merge_answer` returns *name*-reachability; SP6 applies its landed-cluster selection to *facts*, so factor the selection into a shared helper or replicate the one-liner — do NOT expect under_merge_answer to return facts). `completeness = |gold ∩ retrieved| / |gold|`. Return mean + per-failure-class breakdown.
+  - `run_qa_eval(adapters, records, qa_items, facts_by_record) -> rows` : run each adapter's `resolve` → partition → `engine_completeness`. Use the landed-cluster selection above (do NOT use `kg.retrieve` — see spec).
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit:** `feat(er-kg-bench): deterministic fact-completeness eval`.
+
+### Task 5 (Half 2): opt-in LLM-judged correctness
+**Files:** Modify `erkgbench/qa_eval.py`; Test `erkgbench/tests/test_qa_eval.py` (stub).
+
+- [ ] **Step 1 — failing test.** `test_llm_judge_plumbing`: inject a stub `answer_fn` (returns a fixed string) + stub `judge_fn` (returns 1 if gold_facts substring-present else 0); assert `run_qa_eval(..., judge=stub)` adds a `correctness` field per row and the stub was called once per QA item. Assert plumbing, NOT accuracy (goldenmatch-kg posture).
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement.** Optional `judge` arg; when set, build an answer from the retrieved facts via `demo/agent.py::answer` (inject `llm_fn`) and score via `judge`. Default `None` → skip (deterministic path unchanged). Real OpenAI judge/answerer wired only when `OPENAI_API_KEY` present (lazy).
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit:** `feat(er-kg-bench): opt-in LLM-judged answer correctness`.
+
+### Task 6 (Half 2): RESULTS_QA.md + a CLI entrypoint
+**Files:** Modify `erkgbench/qa_eval.py` (add `main`/render); Create `results/RESULTS_QA.md` (generated); Test `erkgbench/tests/test_qa_eval.py` (render).
+
+- [ ] **Step 1 — failing test.** `test_render_results_qa`: given rows, `render_results_qa(rows)` returns markdown with a per-engine completeness column, a per-failure-class breakdown, and the authored/synthetic honesty disclaimer line.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** `render_results_qa` + a `python -m erkgbench.qa_eval` entrypoint (loads corpus + qa, runs goldengraph + exact-match-floor adapters, writes `results/RESULTS_QA.md`). Include the disclaimer ("authored synthetic QA layer; measures fact co-location, not real-world QA accuracy; the (ER_accuracy)^hops exponent is not measured").
+- [ ] **Step 4 — run, expect pass;** then run the entrypoint to generate `results/RESULTS_QA.md` and commit it.
+- [ ] **Step 5 — commit:** `feat(er-kg-bench): RESULTS_QA.md + qa_eval entrypoint`.
+
+### Task 7 (Half 2, opt-in): real-framework baseline (best-effort)
+**Files:** Modify `erkgbench/qa_eval.py`; reuse `erkgbench/adapters/real/`.
+
+- [ ] **Step 1 — failing test.** `test_framework_baseline_skips_when_absent`: with the framework deps absent, `run_qa_eval(..., with_frameworks=True)` records a `skipped` row, never raises.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement.** Behind `with_frameworks`, build a real neo4j-graphrag and/or LlamaIndex KG (prefer the `goldenmatch-kg` shims if importable; else stand the framework up directly per the spec) and score completeness. Import-guarded → `skipped` if deps missing. NOT on the gate.
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit:** `feat(er-kg-bench): opt-in real-framework completeness baseline`.
+
+### Task 8: CI lane `bench-er-kg.yml`
+**Files:** Create `.github/workflows/bench-er-kg.yml` (repo root).
+
+- [ ] **Step 1 — write the workflow.** `workflow_dispatch` (inputs `with_llm`, `with_frameworks`), `permissions: contents: read`, informational (NOT in `ci-required`). **gate job** (always, `ubuntu-latest`): checkout → setup-python 3.12 → build goldengraph native (`maturin develop` in the goldengraph-native crate into a venv) → install goldenmatch + goldengraph → run Half-1 scoring (goldengraph adapter via `erkgbench/run.py` or a targeted invocation) + Half-2 `python -m erkgbench.qa_eval` (deterministic) → **assert** goldengraph mean completeness − exact-match-floor mean completeness ≥ a concrete margin (e.g. 0.25) and the parity test passes. **opt-in steps** gated on inputs: `with_llm` (needs `OPENAI_API_KEY` secret), `with_frameworks` (isolated venv, best-effort).
+- [ ] **Step 2 — validate YAML** locally (`python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/bench-er-kg.yml'))"`).
+- [ ] **Step 3 — commit:** `ci(er-kg-bench): bench-er-kg lane (deterministic gate + opt-in llm/frameworks)`.
+
+### Finish
+- [ ] Run the full er-kg-bench test set locally: `python -m pytest demo/ erkgbench/tests/ -q`.
+- [ ] Push; dispatch `bench-er-kg.yml` on the branch; confirm the gate job green (it builds native + runs the deterministic eval — the surface's validator).
+- [ ] PR; arm auto-merge after the lane is green; use superpowers:finishing-a-development-branch.
+
+## Notes / risks
+- **Determinism:** the gate is deterministic (fixed corpus + authored facts + exact set membership + deterministic resolver). goldenmatch auto-config has mild EM-order non-determinism — the parity test compares partitions on a small frame where the result is stable; if it flakes, pin via an explicit small config or assert cluster-equivalence with a tolerance, and note it (the goldenmatch_adapter already documents this).
+- **goldengraph resolve entrypoint:** confirm the exact call at implementation time (`goldengraph` pkg `resolve` vs `goldengraph-native` build_graph Provided/native mode); the adapter just needs records→partition.
+- **Don't fork the KG model** — extend `demo/kg.py::Node`; keep `demo/test_demo.py` green.
+- **Local Windows:** native build flakiness is documented; the CI gate is the validator of record. Run the pure-Python tests (Tasks 1,3,4,5,6,7 logic) locally; Task 2 parity + the gate run in CI.

--- a/docs/superpowers/specs/2026-06-20-goldengraph-sp6-headtohead-eval-design.md
+++ b/docs/superpowers/specs/2026-06-20-goldengraph-sp6-headtohead-eval-design.md
@@ -1,0 +1,172 @@
+# goldengraph SP6 — head-to-head eval design
+
+The capstone: prove goldengraph's thesis with measurement, not assertion. Builds
+on the investigation (`2026-06-20-goldengraph-sp6-benchmark-infra-investigation.md`)
+and reuses ER-KG-Bench (`packages/python/goldenmatch/benchmarks/er-kg-bench/`)
+rather than rebuilding a benchmark.
+
+## Goal
+Two questions, two halves:
+1. **Resolution quality** — does goldengraph's resolution-backed KG resolve entities
+   at least as well as goldenmatch (and beat the KG frameworks) on the existing
+   ER-KG-Bench corpus?
+2. **Downstream win** — does resolution actually buy better retrieval? **Measure the
+   fact-co-location property that CAUSES the README's `(ER_accuracy)^hops` decay**: a
+   resolved KG puts all of an entity's facts on one node, so retrieving that entity
+   returns them all; an unresolved/exact-match KG splits the entity across duplicate
+   surface-form nodes, so retrieving "the entity" returns only the queried node's
+   facts and misses the rest. We measure the *fact co-location / completeness* (the
+   base cause), NOT a hop-exponent — the KG model carries no edges to traverse (see
+   Metrics). Today this is demonstrated once in `demo/`; SP6 measures it across a
+   corpus and across engines.
+
+## Corpus facts (what we build on)
+`dataset/records.csv` rows are `record_id, mention, entity_type, context,
+entity_id, failure_class, source` — surface forms grouped by `entity_id`
+(Wikidata QID / RxCUI), 206 records / 48 entities / 9 failure classes. There is a
+shared `context` per entity but **no distinct per-mention facts** — so the corpus
+alone can't show fact loss under under-merge. The `demo/` (kg.py `build_kg`/
+`retrieve`, agent.py `answer`, run_demo.py before/after KG + COUNT question) crafts
+that fact structure for one protagonist. SP6 generalizes it into a small authored
+QA layer.
+
+## Half 1 — goldengraph as an ER-KG-Bench engine (reuse)
+Add `erkgbench/adapters/goldengraph_adapter.py`: feed the corpus mentions through
+goldengraph's resolve step (the native engine via `goldengraph` / `goldengraph-native`,
+or goldenmatch-Provided mode), emit the partition in the harness's existing shape,
+score via the unchanged `erkgbench/metrics.py` (per-class pair P/R/F1). Wire it into
+`erkgbench/run.py` as a new engine row → it appears in `results/RESULTS.md`'s
+headline + per-class tables next to the 11 framework configs.
+
+- **Expectation (honest):** goldengraph resolves via the same goldenmatch resolver,
+  so it should land at/near `goldenmatch(auto+fields)` F1 0.602 — the value is
+  showing the **native engine** carries the +13pp ER lead end-to-end, and locking it
+  with a parity check (goldengraph partition == goldenmatch `dedupe_df` partition on
+  this corpus), not a new accuracy claim.
+
+## Half 2 — QA / retrieval-completeness eval (the new measurement)
+
+### QA corpus (authored)
+A new `qa/` artifact (e.g. `dataset/qa.jsonl`) keyed to existing `entity_id`s.
+Each item:
+```
+{ "qa_id", "entity_id", "question",
+  "seed_surface": "<one surface form to query by>",
+  "gold_facts": ["fact-1", "fact-2", ...],   # facts attached to DIFFERENT surface
+                                             # forms / source docs of this entity
+  "gold_answer": "<NL answer requiring all gold_facts>" }
+```
+Facts are attached to specific `(entity_id, surface_form, source)` rows (simulating
+facts learned from different documents). The point: an entity with N surface forms
+carries facts spread across them, so an unresolved KG that keeps N separate nodes
+can only retrieve the queried node's facts. Pick entities with rich multi-surface /
+cross-document structure (the abbreviation, xling, xdoc, suffix classes are ideal).
+**Honesty:** this is an authored, synthetic QA layer (we write the facts +
+questions), not a standard QA benchmark. It proves a *structural* property
+(resolution co-locates facts) deterministically; it is not a claim about real-world
+QA accuracy. State this in `RESULTS_QA.md`.
+
+### KG construction per engine (the baselines — "Both")
+Add a `facts: tuple[str, ...]` field to the EXISTING `demo/kg.py::Node` (additive,
+default empty — keeps `demo/test_demo.py` green) and have `build_kg` union an
+entity's authored facts across the cluster's `record_indices` exactly as it already
+unions `names`. (Do NOT fork a parallel KG model — extend the demo's.) Build a KG
+under each resolution strategy:
+- **goldengraph** — resolved partition → one node per entity, all its facts co-located.
+- **exact-match floor** — the harness's `validated` exact-match resolver → one node
+  per distinct surface string, facts split. The controlled, self-contained baseline
+  (no heavy deps); always runs, gates CI.
+- **real framework KG** — a real neo4j-graphrag and/or LlamaIndex KG (with and
+  without goldenmatch resolution) for a credible "vs the competition" head-to-head.
+  Prefer the `goldenmatch-kg` shims **if/when they land**; they are spec'd but NOT
+  yet in main, so the implementer may stand the frameworks up directly instead — do
+  not block on a nonexistent import. **Opt-in / best-effort**: heavy framework deps
+  in an isolated venv (mirrors the `goldenmatch-kg.yml` per-framework matrix); skip
+  (status `skipped`, never fatal) if deps unavailable. NOT part of the CI gate, and
+  NOT a blocker for SP6's gate.
+
+### Metrics ("Both") — NO hop axis
+The KG model carries no edges (`Node` = names/type/context/facts/record_indices; `KG`
+= nodes) so there is nothing to traverse and **no `k-hops` sweep**. The win is
+structural fact co-location, measured by a single resolved-vs-unresolved comparison.
+Reuse the reachability model `demo/narrative.py::under_merge_answer` already uses
+(`distinct_nodes` / `names_reachable` / `complete`), NOT `demo/kg.py::retrieve(query)`
+— `demo/run_demo.py` (~lines 244-251) explicitly rejects query-only retrieval because
+it surfaces only the one literally-queried node and HIDES the fragmentation (making
+before == after); it presents the entity's whole reachable slice instead.
+
+For each QA item × engine:
+- **fact completeness (deterministic — the gated metric):** identify the node(s) the
+  engine treats as "this entity" — resolved: the single merged node; exact-match
+  floor: only the node matching `seed_surface` (the other surface forms are stranded
+  on separate nodes the floor never connects). `retrieved_facts` = union of `facts`
+  over those reachable node(s), per the `under_merge_answer` model. Score
+  `completeness = |gold_facts ∩ retrieved_facts| / |gold_facts|`. No LLM →
+  reproducible, free, CI-gateable. Resolved ≈ 1.0 (all facts on one node); floor < 1.0
+  (facts stranded on the other surface-form nodes). Report mean completeness per
+  engine, broken out by failure class. This measures the fact co-location that is the
+  *cause* of the `(ER_accuracy)^hops` decay — we do NOT claim to measure the
+  hop-exponent itself (no graph topology exists to traverse).
+- **LLM-judged answer correctness (opt-in — color):** generate an NL answer from the
+  retrieved facts (`agent.answer`), LLM-judge vs `gold_answer` (0/1 or graded).
+  Non-deterministic, costs API → off by default (needs `OPENAI_API_KEY`), runs only
+  in the report lane, never gates. The richer end-to-end signal on top of the
+  deterministic structural metric.
+
+### Output
+`results/RESULTS_QA.md`: (1) **fact-completeness table** (engine × mean completeness,
+broken out by failure class) — goldengraph high/≈1.0 vs the exact-match floor (and any
+real framework) lower; (2) the framing (resolution co-locates facts → complete
+retrieval; under-merge strands them); (3) the opt-in LLM-judged correctness column
+when run.
+
+## CI lane
+New informational `bench-er-kg.yml` (`workflow_dispatch`; not `ci-required`, like the
+other binding lanes):
+- **gate job** (always): builds goldengraph native, runs Half-1 engine scoring +
+  Half-2 **deterministic fact-completeness** for goldengraph vs exact-match floor.
+  Asserts goldengraph's mean completeness exceeds the floor's by a concrete margin
+  (the thesis), and the Half-1 parity check. Self-contained, no LLM, no framework deps.
+- **opt-in inputs:** `with_llm` (LLM-judged correctness; needs the OpenAI secret),
+  `with_frameworks` (real neo4j-graphrag / LlamaIndex KGs via the shims, isolated
+  venv, best-effort).
+Confirm green before arming auto-merge.
+
+## Determinism & honesty (the bar this program has held)
+- The CI gate is deterministic: fixed corpus, fixed authored facts, exact fact-set
+  membership, resolver output is deterministic. LLM answer + LLM judge + real
+  frameworks are all opt-in / non-gated.
+- The QA corpus is authored/synthetic — `RESULTS_QA.md` says so plainly. SP6 proves a
+  structural property (resolution co-locates an entity's facts on one node → complete
+  retrieval; under-merge strands them), not a real-world QA-accuracy number.
+- Half 1 adds a real engine row to a committed table; it's a parity-locked
+  demonstration that the native engine carries goldenmatch's measured ER lead, not a
+  fresh accuracy claim.
+
+## Testing
+- Half 1: parity unit test (goldengraph partition == goldenmatch `dedupe_df`
+  partition on the corpus); adapter emits the harness shape; `metrics.py` unchanged.
+- Half 2: deterministic fact-completeness on a tiny fixture (resolved vs split) with a
+  known gold-fact set → asserts resolved≈1.0, split<1.0; the `Node.facts` addition +
+  `build_kg` keep the existing `demo/test_demo.py` green; LLM paths use a stub
+  judge/answerer (assert plumbing, not LLM accuracy — the goldenmatch-kg posture).
+
+## File structure
+```
+benchmarks/er-kg-bench/
+  erkgbench/adapters/goldengraph_adapter.py   # Half 1: new engine row
+  erkgbench/run.py                            # +goldengraph engine wiring
+  dataset/qa.jsonl                            # Half 2: authored fact/QA layer (keyed to entity_id)
+  demo/kg.py                                  # +Node.facts field + build_kg unions facts (extend, don't fork)
+  erkgbench/qa_eval.py                        # build per-engine KG, fact-completeness, (opt) LLM-judge
+  results/RESULTS_QA.md                       # fact-completeness output
+  tests/test_qa_eval.py                       # deterministic fact-completeness fixture + stubs
+.github/workflows/bench-er-kg.yml             # informational lane (gate + opt-in llm/frameworks)
+```
+
+## Out of scope / follow-ups
+- A real-world QA benchmark (this is an authored structural eval).
+- Multi-hop reasoning beyond fact co-location (we measure fact-completeness, not inference).
+- Publishing the eval as a standalone leaderboard.
+- Wiring the real-framework head-to-head into the gate (stays opt-in until the
+  framework deps prove stable in CI).


### PR DESCRIPTION
## goldengraph SP6 — head-to-head eval spec

The capstone design. Reuses ER-KG-Bench (not a rebuild). Two halves, per your Both/Both calls.

Builds on the merged investigation (#1143). Spec-reviewed twice (the first pass caught a real flaw — see below).

### Half 1 — goldengraph as an ER-KG-Bench engine (reuse)
Add a `goldengraph` adapter; score via the unchanged `metrics.py`; it joins the committed headline table next to the 11 framework configs. Parity-locked to goldenmatch `dedupe_df` — a demonstration that the **native engine** carries goldenmatch's measured **+13pp ER lead** (0.602 vs 0.471), not a fresh accuracy claim.

### Half 2 — fact-completeness eval (the new measurement)
The corpus has no per-mention facts, so SP6 authors a small `qa.jsonl` layer (facts attached to different surface forms of an entity). Then, per engine:
- **fact-completeness (deterministic, gated):** fraction of an entity's gold facts co-located where retrieval lands. Resolved (goldengraph) ≈ 1.0 — all facts on one node; exact-match floor < 1.0 — facts stranded on separate surface-form nodes. Reuses the demo's `under_merge_answer` reachability model.
- **LLM-judged answer correctness (opt-in):** richer end-to-end color; non-deterministic, never gates.
- **baselines (Both):** exact-match floor (controlled, gates) + real neo4j-graphrag/LlamaIndex KGs (opt-in, best-effort).

### The flaw the review caught
The first draft framed the metric as `fact-recall@k-hops` — but the KG model has **no edges** and the demo's `retrieve` does no hop traversal, so the hop sweep was fictional (and `run_demo.py` documents that query-only retrieval hides fragmentation). Fixed: measure fact **co-location** directly (single resolved-vs-unresolved comparison via `under_merge_answer`), and explicitly disclaim that the `(ER_accuracy)^hops` *exponent* is not measured — only its structural cause.

### Honesty
The QA corpus is authored/synthetic — `RESULTS_QA.md` will say so. SP6 proves a structural property (resolution co-locates facts → complete retrieval), not a real-world QA-accuracy number. CI gate is fully deterministic; LLM + real frameworks are opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)