### PR TITLE
fix(bench): allow_red_config + validated 10k/50k default scales (#1086)

### DIFF
--- a/.github/workflows/bench-corpus-dedup.yml
+++ b/.github/workflows/bench-corpus-dedup.yml
@@ -19,9 +19,13 @@ on:
         required: false
         default: "fineweb"
       scales:
+        # 10k/50k base (=14k/70k after injected dups) is the validated working
+        # range. 100k+ currently wedges the survivorship/golden stage (O(N)
+        # iter_rows) — push the ceiling up via a throughput-skips-golden follow-up
+        # before raising this default.
         description: "Space-separated doc counts to sweep"
         required: false
-        default: "100000 1000000"
+        default: "10000 50000"
       engines:
         description: "Engines (space-separated): goldenmatch datatrove"
         required: false

--- a/scripts/bench_corpus_dedup/run_goldenmatch.py
+++ b/scripts/bench_corpus_dedup/run_goldenmatch.py
@@ -85,7 +85,12 @@ def main() -> None:
         result.update(n_docs=n, bytes_in=bytes_in)
 
         t0 = time.perf_counter()
-        ded = dedupe_df(df, throughput=args.recall_target)
+        # allow_red_config: at >=100k rows the controller can commit a RED config
+        # (e.g. BUDGET_TIME on the blocking sub-profile) and would otherwise raise
+        # ControllerNotConfidentError. The throughput overlay REPLACES blocking +
+        # scoring with sketch-then-verify, so that RED verdict is moot here — we
+        # want the tier to run regardless.
+        ded = dedupe_df(df, throughput=args.recall_target, allow_red_config=True)
         dedupe_wall = time.perf_counter() - t0
 
         # --- tier-engaged proof + cost metrics from the posture ---


### PR DESCRIPTION
Unblocks the headline bench's goldenmatch datapoint and pins the default scales to the validated range.

- **`run_goldenmatch.py` passes `allow_red_config=True`.** At >=100k rows the controller can commit a RED config (`BUDGET_TIME` on blocking) and raise `ControllerNotConfidentError`. The throughput overlay *replaces* blocking + scoring with sketch-then-verify, so that verdict is moot — the tier should run. No-op below 100k (the perf-gate's offline corpus), so the gate baseline is unchanged.
- **Default scales -> `10000 50000`** (= 14k/70k after injected dups), the validated working range. Measured on real FineWeb: **275 / 1,192 docs/sec, ~0.43 recall**. 100k+ currently wedges the survivorship/golden stage (O(N) `iter_rows`) — a tracked follow-up.

Validated on the branch (`bench-corpus-dedup.yml --ref fix/1086-allow-red`, goldenmatch-only): both datapoints `ok`, real numbers, no hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)