### PR TITLE
feat(goldengraph): context-aware resolution — recovers the ER lead (0.415→0.602)

### DIFF
--- a/packages/python/goldengraph/goldengraph/extract.py
+++ b/packages/python/goldengraph/goldengraph/extract.py
@@ -16,9 +16,12 @@ from .llm import LLMClient
 
 _PROMPT = """You extract a knowledge graph from text. Return STRICT JSON only, \
 no prose, in exactly this shape:
-{{"entities": [{{"name": "<surface name>", "type": "<coarse type>"}}], \
+{{"entities": [{{"name": "<surface name>", "type": "<coarse type>", \
+"description": "<one short factual phrase describing the entity>"}}], \
 "relationships": [{{"subj": <entity index>, "predicate": "<verb phrase>", \
 "obj": <entity index>}}]}}
+The `description` is a brief, source-grounded characterization (e.g. "American \
+technology corporation") that disambiguates the entity for resolution. \
 `subj`/`obj` are 0-based indices into `entities`. Text:
 {text}"""
 
@@ -27,6 +30,7 @@ no prose, in exactly this shape:
 class Mention:
     name: str
     typ: str
+    context: str = ""  # short description; sharpens resolution (optional, default "")
 
 
 @dataclass
@@ -55,7 +59,11 @@ def _strip_fence(raw: str) -> str:
 def parse_extraction(raw: str) -> Extraction:
     data = json.loads(_strip_fence(raw))
     mentions = [
-        Mention(name=str(e["name"]), typ=str(e.get("type", e.get("typ", ""))))
+        Mention(
+            name=str(e["name"]),
+            typ=str(e.get("type", e.get("typ", ""))),
+            context=str(e.get("description", e.get("context", ""))),
+        )
         for e in data.get("entities", [])
     ]
     n = len(mentions)

--- a/packages/python/goldengraph/goldengraph/resolve.py
+++ b/packages/python/goldengraph/goldengraph/resolve.py
@@ -43,9 +43,14 @@ def resolve(mentions: list[Mention]) -> list[ResolvedEntity]:
     import goldenmatch as gm
     import polars as pl
 
-    df = pl.DataFrame(
-        {"name": [m.name for m in mentions], "type": [m.typ for m in mentions]}
-    )
+    # Resolve on name+type, and on `context` (the per-mention description) when
+    # any mention carries one -- the extra evidence sharpens resolution (the field
+    # that takes goldenmatch from name-only to its best on ER-KG-Bench). Falls back
+    # to name+type when extraction produced no descriptions (backward compatible).
+    cols = {"name": [m.name for m in mentions], "type": [m.typ for m in mentions]}
+    if any(m.context for m in mentions):
+        cols["context"] = [m.context for m in mentions]
+    df = pl.DataFrame(cols)
     result = gm.dedupe_df(df)
 
     n = len(mentions)

--- a/packages/python/goldengraph/tests/test_extract_description.py
+++ b/packages/python/goldengraph/tests/test_extract_description.py
@@ -1,0 +1,28 @@
+"""Extraction captures a per-entity `description` -> Mention.context (the field
+that sharpens resolution). Pure parse test -- no goldenmatch, no LLM."""
+
+from __future__ import annotations
+
+import json
+
+from goldengraph.extract import Mention, parse_extraction
+
+
+def test_parse_extraction_populates_context_from_description():
+    raw = json.dumps(
+        {
+            "entities": [
+                {"name": "IBM", "type": "org", "description": "American technology corporation"},
+                {"name": "Apple", "type": "org"},  # no description -> context ""
+            ],
+            "relationships": [],
+        }
+    )
+    ex = parse_extraction(raw)
+    assert ex.mentions[0].context == "American technology corporation"
+    assert ex.mentions[1].context == ""  # default when the model omits it
+
+
+def test_mention_context_defaults_empty():
+    m = Mention(name="X", typ="org")
+    assert m.context == ""

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldengraph_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldengraph_adapter.py
@@ -34,7 +34,11 @@ class GoldenGraphAdapter(AdapterBase):
         from goldengraph.resolve import resolve as gg_resolve
 
         ordered = sorted(records, key=lambda r: r.index)
-        mentions = [Mention(name=r.mention, typ=r.entity_type) for r in ordered]
+        # Pass `context` (the entity description) so resolution uses name+type+context
+        # -- the field that lifts goldenmatch from name-only to its best on this corpus.
+        mentions = [
+            Mention(name=r.mention, typ=r.entity_type, context=r.context) for r in ordered
+        ]
         entities = gg_resolve(mentions)
         # ResolvedEntity.member_idx are positions in `ordered`; map back to the
         # caller's record indices (identity when records are 0..n-1 in order).

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS_QA.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS_QA.md
@@ -8,7 +8,7 @@ one node; an exact-match KG strands them across surface forms.
 
 | Engine | status | mean fact-completeness | mean correctness (LLM) |
 |---|---|---|---|
-| goldengraph | ok | **0.533** | - |
+| goldengraph | ok | **0.733** | - |
 | exact-match-floor | ok | **0.333** | - |
 
 ## Per-failure-class fact-completeness
@@ -16,4 +16,4 @@ one node; an exact-match KG strands them across surface forms.
 | Engine | abbreviation | nickname_alias | synonym_brand |
 |---|---|---|---|
 | exact-match-floor | 0.33 | 0.33 | 0.33 |
-| goldengraph | 0.58 | 0.67 | 0.33 |
+| goldengraph | 0.92 | 0.89 | 0.33 |

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_goldengraph_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_goldengraph_adapter.py
@@ -48,9 +48,15 @@ def test_goldengraph_partition_parity(monkeypatch):
     ]
     adapter_part = _multi(GoldenGraphAdapter().resolve(recs))
 
-    # Direct dedupe_df on the SAME fields goldengraph.resolve feeds it (name+type).
+    # Direct dedupe_df on the SAME fields goldengraph.resolve feeds it now:
+    # name+type+context (the adapter passes Record.context, and resolve adds the
+    # context column whenever any mention carries one).
     df = pl.DataFrame(
-        {"name": [r.mention for r in recs], "type": [r.entity_type for r in recs]}
+        {
+            "name": [r.mention for r in recs],
+            "type": [r.entity_type for r in recs],
+            "context": [r.context for r in recs],
+        }
     )
     res = gm.dedupe_df(df)
     gm_part = _multi(


### PR DESCRIPTION
## Context-aware resolution — the fix SP6 surfaced

SP6 (#1146) measured goldengraph's resolver at **F1 0.415**, *below* the top KG frameworks (~0.47), because `goldengraph.resolve` deduped on **name+type only — it dropped `context`** (the field that takes goldenmatch from 0.52 → 0.602). This fixes that.

### Change
- **Extraction** now asks the LLM for a per-entity `description` → `Mention.context` (a real pipeline improvement, not benchmark-only — GraphRAG-style extractors produce entity descriptions too).
- **`resolve()`** feeds name+type+`context` to `dedupe_df` when any mention carries one; falls back to name+type otherwise (backward compatible).
- **SP6 adapter** passes `Record.context`.

### Measured (ER-KG-Bench)
| Metric | before (name+type) | after (name+type+context) |
|---|---|---|
| **ER F1** | 0.415 | **0.602** (P 0.786 / R 0.488) |
| vs best framework (0.471) | −5.6pp (behind) | **+13pp (leads)** |
| **Fact-completeness** | 0.533 | **0.733** (vs floor 0.333) |
| — abbreviation / nickname | 0.58 / 0.67 | 0.92 / 0.89 |
| — synonym_brand | 0.33 | 0.33 (semantic limit) |

goldengraph's ER F1 now equals goldenmatch(auto+fields) exactly (parity by construction) and leads every framework row.

### Honesty caveat
The ER-KG-Bench `context` column is a clean, per-entity description. Production descriptions (extracted per-document) are noisier, so 0.602 is an **upper bound**, not a production guarantee. The `synonym_brand` class still ties the floor (0.33) — brand-name synonyms ("ibuprofen"/"Advil") need real semantics, which name+type+context dedupe doesn't provide.

### Tests
2 engine tests (description→context parse) + the updated adapter parity (now name+type+context) + 23 SP6 tests, all green locally.

### Stacking
Branches off #1146 (SP6 impl). The diff includes #1146's commits until it merges; after #1146 lands I'll rebase `--onto origin/main` so this shows only the context-fix changes. Not arming auto-merge until #1146 is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)