### PR TITLE
docs(goldensynonym): trained domain-aware synonym scorer framework (spec)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-goldensynonym-gs1-framework.md
+++ b/docs/superpowers/plans/2026-06-20-goldensynonym-gs1-framework.md
@@ -1,0 +1,101 @@
+# GoldenSynonym GS1 — framework + table-backed scorer (implementation plan)
+
+> **For agentic workers:** use superpowers:executing-plans / subagent-driven-development.
+> Steps use `- [ ]`. TDD: failing test → minimal impl → run → commit.
+
+**Goal:** Ship the reusable `synonym` scorer surface (GS1 of the GoldenSynonym spec,
+`docs/superpowers/specs/2026-06-20-goldensynonym-trained-synonym-scorer-design.md`) —
+a `ScorerPlugin` resolving a per-domain `SynonymModel`, with a table-lookup fast-path
++ Jaro-Winkler fallback. **No training, no RxNorm** (those are GS2). GS1 is useful
+today: drop in a per-domain synonym JSON table and `scorer: synonym` resolves it.
+
+**Architecture:** mirrors `goldenmatch/refdata/` (the `given_name_aliased_jw`
+precedent) + the embedder provider registry. New package `goldenmatch/synonym/`.
+Pure Python → covered by the standard `ci.yml` python suite (no new lane).
+
+**Paths** (under `packages/python/goldenmatch/goldenmatch/`):
+`synonym/__init__.py`, `synonym/providers.py`, `synonym/table.py`, `synonym/scorer.py`,
+`synonym/data/`, tests under `goldenmatch/synonym/tests/` or the package `tests/`.
+Verified contracts (read-only): `plugins/base.py::ScorerPlugin` (`name`,
+`score_pair(a,b)->float|None`, optional `score_matrix(values)->np.ndarray`);
+`plugins/registry.py::PluginRegistry.instance().register_scorer(name, plugin)`;
+`refdata/given_names.py` (alias-table load + `are_equivalent`) + `refdata/__init__.py`
+(registration at import); `core/scorer.py` dispatch falls through to the registry for
+non-`VALID_SCORERS` names (so `synonym` needs NO `VALID_SCORERS` entry).
+
+---
+
+### Task 1: `SynonymModel` protocol + provider registry + stub
+**Files:** Create `synonym/providers.py`, `synonym/model.py`; Test `synonym/tests/test_providers.py`.
+
+- [ ] **Step 1 — failing test.** `test_resolve_default_is_stub_and_scores_zeroish`: `resolve_synonym_model("drug")` returns an object with `score(a, b) -> float | None`; the default `StubSynonymModel` returns `None` (no learned signal) so the scorer falls back to JW. `test_register_and_resolve`: `register_synonym_model("drug", m)` then `resolve_synonym_model("drug") is m`; unknown domain → the default stub (never raises).
+- [ ] **Step 2 — run, expect fail** (module missing): `pytest packages/python/goldenmatch/goldenmatch/synonym/tests/test_providers.py -q`.
+- [ ] **Step 3 — implement.** `model.py`: `SynonymModel` Protocol (`score(self, a: str, b: str) -> float | None`) + `StubSynonymModel` (returns `None`). `providers.py`: module-level `_REGISTRY: dict[str, SynonymModel]`, `register_synonym_model(domain, model)`, `resolve_synonym_model(domain) -> SynonymModel` (registry hit, else `StubSynonymModel()`). Thread-safe lazy default.
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit:** `feat(synonym): SynonymModel protocol + provider registry + stub (GS1 T1)`.
+
+### Task 2: per-domain synonym alias table (the table fast-path data)
+**Files:** Create `synonym/table.py`, `synonym/data/.gitkeep`; Test `synonym/tests/test_table.py`.
+
+- [ ] **Step 1 — failing test.** Using a tmp/fixture JSON `{"aliases": {"ibuprofen": ["advil","motrin"]}}`: `SynonymTable.from_json(path)`; `are_equivalent("Advil","ibuprofen") is True` (case/space-normalized, symmetric); `are_equivalent("Advil","Tylenol") is False`; a MISSING table file → `SynonymTable.empty()` whose `are_equivalent` is always False + `is_available() is False` (graceful, like `refdata/given_names.py`).
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement.** `table.py`: `SynonymTable` with `_normalize` (lower/strip non-alnum, mirror refdata), a canonical→set(aliases) map expanded to a symmetric equivalence lookup, `are_equivalent(a,b)`, `is_available()`, `from_json(path)`, `empty()`. Per-domain tables load lazily from `synonym/data/<domain>_synonyms.json` (none committed in GS1 — GS2 adds the drug table off RxNorm; GS1 ships the loader + an `empty()` default).
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit:** `feat(synonym): per-domain synonym alias table loader (GS1 T2)`.
+
+### Task 3: `SynonymScorer(ScorerPlugin)` — score_pair + score_matrix
+**Files:** Create `synonym/scorer.py`; Test `synonym/tests/test_scorer.py`.
+
+- [ ] **Step 1 — failing test.** `SynonymScorer(domain="drug", table=<fixture>, model=<stub>)`:
+  - table hit → `score_pair("Advil","ibuprofen") == 1.0`;
+  - no table hit, stub model returns None → falls back to Jaro-Winkler (assert == `rapidfuzz` JW of the two, e.g. "Advil" vs "Advel");
+  - injected model returning 0.9 (no table hit) → `score_pair == 0.9` (model-primary when present);
+  - `score_pair(None, x) is None`;
+  - `score_matrix(["Advil","ibuprofen","Tylenol"])` is a symmetric float32 NxN, diagonal 1.0, [Advil,ibuprofen]==1.0 via table.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement.** `SynonymScorer`: `name="synonym"`. `score_pair`: None-guard → table `are_equivalent` →1.0 → model.score (if not None) → else JW. `score_matrix`: vectorized JW base (`rapidfuzz.process.cdist`, like `refdata/scorer.py`), then overwrite table-equivalent + model-scored cells; diagonal 1.0; float32 symmetric. Domain/table/model are constructor args (defaults: domain="generic", `SynonymTable.empty()`, `resolve_synonym_model(domain)`).
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit:** `feat(synonym): SynonymScorer plugin (table -> model -> JW) (GS1 T3)`.
+
+### Task 4: register at import + registry-resolution test
+**Files:** Create `synonym/__init__.py`; Modify `goldenmatch/__init__.py`; Test `synonym/tests/test_registration.py`.
+
+**Registration mechanism (verified, NOT "mirror refdata"):** `goldenmatch/__init__.py`
+does NOT import refdata; `PluginRegistry.get_scorer` is a plain dict lookup (no
+auto-`discover()`); refdata scorers only register incidentally because auto-config
+imports refdata when it *selects* them. `synonym` is OPT-IN (never auto-selected in
+GS1), so that lazy trigger never fires — a user's `scorer: synonym` would miss the
+registry. So GS1 registers `synonym` at **goldenmatch package import** by importing
+`goldenmatch.synonym` from `goldenmatch/__init__.py`. This is cheap + safe because GS1
+`synonym` has **no heavy import-time cost** (lazy/empty table, stub model) and does JW
+via `rapidfuzz` DIRECTLY — it must NOT import `core.scorer` at module level (that
+would risk a circular import, since `core.scorer` reaches the registry).
+
+- [ ] **Step 1 — failing test.** `test_synonym_registered_on_package_import`: in a
+  subprocess (clean import), `import goldenmatch` then
+  `PluginRegistry.instance().get_scorer("synonym")` is a `SynonymScorer` (NOT None) —
+  proves package-init registration, not just `import goldenmatch.synonym`.
+  `test_score_field_dispatches_synonym`: `core.scorer.score_field("Advil","ibuprofen","synonym")`
+  returns a float (no "unknown scorer"). `test_valid_scorers_unchanged`:
+  `"synonym" not in VALID_SCORERS`.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement.** `synonym/__init__.py`: `register_synonym_scorer()` →
+  `PluginRegistry.instance().register_scorer("synonym", SynonymScorer())`, called at
+  module init; export it. Add `from goldenmatch import synonym as _synonym  # noqa: F401`
+  (or `import goldenmatch.synonym`) near the end of `goldenmatch/__init__.py` (after
+  core imports, to avoid circulars). Confirm no circular import by running the package
+  import smoke. Do NOT touch `VALID_SCORERS`. Verify `synonym/scorer.py` imports only
+  `rapidfuzz` + `plugins.base` + the local table/providers (no `core.scorer`).
+- [ ] **Step 4 — run, expect pass:** `pytest packages/python/goldenmatch/goldenmatch/synonym/tests/ -q`.
+- [ ] **Step 5 — commit:** `feat(synonym): register synonym scorer at package import (GS1 T4)`.
+
+### Finish
+- [ ] Full GS1 suite: `pytest packages/python/goldenmatch/goldenmatch/synonym/tests/ -q` (all green).
+- [ ] Quick import smoke: `python -c "import goldenmatch; from goldenmatch.plugins.registry import PluginRegistry; assert PluginRegistry.instance().get_scorer('synonym')"`.
+- [ ] PR; GS1 runs in the standard `ci.yml` python lane (no new workflow). superpowers:finishing-a-development-branch.
+
+## Notes / risks
+- **Local test env:** goldenmatch import pulls polars → set `POLARS_SKIP_CPU_CHECK=1` (+ `GOLDENMATCH_ANALYTICS=0`); avoid the full xdist suite locally (OOM) — run only `synonym/tests/`.
+- **score_matrix parity:** float32 JW base matches `_fuzzy_score_matrix`; table/model overwrites are exact — no float drift concern (table=1.0, model=its own value).
+- **GS2 dependency:** the drug `synonym_synonyms.json` table + the trained `SynonymModel` are GS2 (need the off-CI RxNorm derivation + a UMLS license). GS1 ships with `empty()` table + `StubSynonymModel` → `synonym` degrades to JW until GS2 lands. That's intended (GS1 = surface).
+- **Don't reuse the refdata `alias_match` builtin:** `synonym` is the new pluggable, model-capable path; the existing `given_name_aliased_jw`/`alias_match` stay as-is (additive).

--- a/docs/superpowers/specs/2026-06-20-goldensynonym-trained-synonym-scorer-design.md
+++ b/docs/superpowers/specs/2026-06-20-goldensynonym-trained-synonym-scorer-design.md
@@ -1,0 +1,174 @@
+# GoldenSynonym — a trained, domain-aware synonym scorer framework
+
+A pluggable, **trained** synonym scorer for goldenmatch that resolves domain
+synonyms a string/embedding scorer can't — brand↔generic drug names first
+(ibuprofen↔Advil↔Duexis), extensible to other domains. Motivated by ER-KG-Bench:
+`synonym_brand` sits at the exact-match floor (0.33) because no scorer encodes
+drug-synonym knowledge; the rest of the table is strong.
+
+## The honest ceiling (this shapes the whole design)
+Brand↔generic synonymy is mostly **arbitrary domain knowledge**, not a signal in
+the text. "Advil"="ibuprofen", "Vybrique"="sildenafil" have no lexical or
+generic-semantic similarity (a generic embedder already scored 0.44 on this
+corpus). So a trained model can only win in two real ways, and we design + measure
+for exactly these:
+1. **Morphological / sub-lexical families** it CAN learn — salt/dosage variants,
+   transliterations, "-profen"/"-cillin" stems, partial-overlap brands.
+2. **Coverage** — it scores *every* pair, not just table hits.
+For *purely arbitrary* brand names, a trained model just **memorizes the mapping
+in its weights** — same information as a lookup table, worse reproducibility. So
+the framework's defensible value is **the general pluggable scorer + a measured
+held-out generalization number**, not "beating a table on arbitrary brands." The
+eval is built to expose precisely how much real generalization there is.
+
+## Architecture
+A general `synonym` scorer that resolves a per-domain **trained model**, mirroring
+two proven patterns already in the repo: the refdata scorer plugins
+(`given_name_aliased_jw`) and the embedder's provider registry.
+
+- **`SynonymScorer(ScorerPlugin)`** in `goldenmatch/synonym/scorer.py` — implements
+  `score_pair(a, b) -> float | None` and the vectorized `score_matrix(values) ->
+  np.ndarray` (the perf path the refdata scorers use). Registered via
+  `PluginRegistry.instance().register_scorer("synonym", ...)`, selected by
+  `scorer: synonym` in a matchkey. Late/graceful resolution: if no model is
+  available it degrades to Jaro-Winkler (never errors).
+- **`SynonymModel` provider registry** (`goldenmatch/synonym/providers.py`) —
+  `resolve_synonym_model(domain: str) -> SynonymModel`, mirroring
+  `goldenmatch.embeddings.providers.resolve_provider`. Each domain (`drug`, later
+  `chemical`/`product`/…) supplies a trained model. The active domain is set on the
+  scorer (config/env), defaulting to a domain-agnostic model.
+- **Scoring path (trained-primary):** the model embeds both names in its learned
+  space → cosine → a **calibrated threshold** maps to [0,1]. An optional refdata
+  table (the training source) provides a known-equivalence fast path (→1.0) and a
+  fallback when the model is absent; the table is also the **baseline** the eval
+  compares the trained layer against.
+
+## The trained model
+- **Method:** contrastive metric learning. Positives = known synonym pairs;
+  **hard negatives** = same-domain non-synonyms (e.g. two distinct drugs, similar
+  strings) so the model learns the *knowledge*, not just string distance. Output =
+  a fine-tuned sentence encoder; score = cosine in its space.
+- **Base model (default):** fine-tune a small generic sentence-transformer
+  (MiniLM-class) on the domain pairs — self-contained, and "the training is the
+  point" (vs. leaning on a domain-pretrained biomedical model that already
+  memorized drug synonymy during *its* pretraining, which would just relocate the
+  lookup). A domain-pretrained base stays an opt-in `base_model` knob.
+- **Drug training data:** synonym pairs derived from **RxNorm**. RxNorm RRF is NOT
+  an anonymous download — it sits behind a **free UMLS license + UTS API key**. So
+  the derivation is a **one-time, off-CI, by-a-licensed-human** step: run it locally,
+  commit the resulting small `drug_synonyms.train.jsonl`. **CI never touches
+  RXNCONSO/RXNREL.** Pin the exact filter for reviewability/reproducibility-in-
+  principle: brand↔generic pairs from RXNREL `RELA ∈ {has_tradename, tradename_of}`
+  joined to RXNCONSO atoms, restricted to the train RxCUI split with ALL surface
+  atoms of held-out RxCUIs excluded (not just train-split positives — see the honesty
+  section). The derivation script is committed but is dev tooling, not run by CI.
+- **Calibration:** pick the cosine threshold on a held-out *validation* split
+  (max-F1), store it with the model so `score_pair` returns a meaningful [0,1].
+
+## The honesty design (load-bearing — non-negotiable)
+The corpus's `synonym_brand` entities ARE RxNorm drugs, and the ground truth IS
+RxNorm grouping. A model trained on all of RxNorm would be reading the answer key.
+So:
+- **Disjoint split — by RxCUI AND by surface string (leak-proof):** the drug model
+  trains on RxNorm drugs with **zero entity overlap** with the ER-KG-Bench corpus
+  (split by RxCUI), AND **every surface atom (all RXNCONSO strings) of the held-out
+  RxCUIs is excluded from training entirely — positives AND negatives.** Excluding
+  only positive pairs is not enough: if a held-out brand like "Advil" appears even as
+  the negative half of a training pair, the model has seen the surface form and the
+  generalization number is contaminated. The corpus's 4 drug families
+  (ibuprofen/acetaminophen/sildenafil/warfarin + all their brands) are held out
+  whole.
+- The `synonym_brand` re-measure is then a **true generalization test**: does the
+  model resolve synonyms of drugs whose strings it never saw? Report THREE numbers —
+  in-domain (train RxCUIs), **held-out** (the corpus), and the **refdata-table
+  baseline** on the same held-out set — plus, for the production scorer, the
+  trained-model-only number (known-equivalence fast-path DISABLED) **separately** from
+  the production number (fast-path on), so "what did training actually buy" is never
+  masked by the table hits the model sits in front of.
+- **Directional prediction (stated up front, so a near-baseline result reads as
+  confirmation, not failure):** for arbitrary brand names the held-out number is
+  *expected to land near the table baseline* — that IS the ceiling. A meaningful
+  trained lift, if any, will show on the *morphological* subset (salt/dosage/stem
+  variants), which `RESULTS` breaks out.
+- `RESULTS` states the split + that arbitrary-brand resolution is memorization-bound
+  (the table is the production path; the trained model is the coverage/morphology
+  layer). No spin.
+
+## Reproducibility + artifacts
+Fine-tuned encoders are too large to commit. To stay reproducible without baking an
+answer-key model into the repo:
+- **Commit the derived training pairs** (the held-out-split RxNorm pair file, small).
+- **Train only in the OPT-IN eval lane** (seeded) → an ephemeral model artifact,
+  cached locally (gitignored), optionally uploaded to a GitHub release for reuse (the
+  `bench-dataset-v1` pattern). A few-thousand-pair MiniLM-class contrastive fine-tune
+  is expected ~5-15 min on a CI CPU runner — **this runs ONLY on the opt-in lane,
+  NEVER on the deterministic `bench-er-kg` gate or the blocking pytest suite** (CI
+  pytest is blocking — a real fine-tune there would be a timeout/flake bomb). GS2 must
+  measure + record the actual wall-clock; if it exceeds a lane budget, switch to
+  pre-train-once-and-upload.
+- **GS2 unit tests use a TINY toy-fixture model trained in-process** (a handful of
+  synthetic morphological pairs, ~seconds, seeded) to assert the trainer's contract +
+  held-out morphological lift — they do NOT run the real RxNorm fine-tune. The real
+  model + the corpus re-measure live in the opt-in lane only.
+- No pre-trained model file is committed; the model is always reproducible from the
+  committed pairs + a fixed seed.
+- **Calibration** (the cosine threshold) is **recomputed on each train** from the
+  validation split (not committed, so it can't drift from a re-derived model); GS2
+  asserts it lands in a stable band.
+
+## Where it plugs in
+- **goldenmatch:** a registered `synonym` scorer (opt-in via `scorer: synonym` in a
+  matchkey, or auto-config promotion later). Pure additive — no default change.
+- **goldengraph / ER-KG-Bench:** opt-in. The `synonym` scorer becomes a matchkey
+  field option in the goldengraph adapter's resolution config; the eval re-measure
+  is an **opt-in lane step** (like `--with-frameworks`), NOT the deterministic gate
+  (it needs a model + training, and is non-deterministic).
+
+## Scope + staging (multi-PR, like the goldengraph phases)
+1. **GS1 — framework:** `goldenmatch/synonym/` package — `SynonymScorer` plugin +
+   `SynonymModel` protocol + provider registry + refdata-table fallback + registration
+   (at module init, like `refdata/__init__.py::register_scorers()`). `synonym` needs
+   **no change to `VALID_SCORERS`** — schema validation falls through to the plugin
+   registry for unknown scorer names (state this explicitly so the implementer doesn't
+   add a dead entry). Unit tests with a stub model (assert plumbing + graceful JW
+   degradation). No training yet. Ships the reusable surface.
+2. **GS2 — drug provider + training:** RxNorm→pairs derivation (committed split),
+   the contrastive trainer (`scripts/train_synonym_model.py`), the drug `SynonymModel`,
+   calibration. Tests on a tiny fixture corpus (train/eval disjoint) asserting the
+   trained model beats JW on held-out *morphological* pairs.
+3. **GS3 — eval re-measure (opt-in lane only):** wire `synonym` into the ER-KG-Bench
+   drug rows; run the held-out generalization measurement; write the honest `RESULTS`
+   — in-domain vs held-out vs table-baseline, AND trained-model-only (fast-path off)
+   vs production (fast-path on), AND the morphological-subset breakout — plus the
+   synonym_brand delta. State the directional prediction was/wasn't borne out.
+
+## Determinism, honesty, testing
+- The framework + plumbing tests are deterministic (stub model). The trained model +
+  the eval re-measure are non-deterministic / model-bearing → opt-in, never on the
+  `bench-er-kg` deterministic gate.
+- Honesty: held-out split reported; table baseline reported; memorization ceiling
+  stated; "trained model is the coverage/morphology layer, table is production" is
+  the explicit framing if held-out generalization is weak (the likely outcome).
+- Tests: scorer protocol + registration + JW degradation (GS1); trainer + held-out
+  morphological win + calibration (GS2); eval wiring + RESULTS render (GS3).
+
+## Out of scope / follow-ups
+- Other domains (chemical/product/org) — the framework supports them; only `drug`
+  ships first.
+- Auto-config promotion of `synonym` (it stays opt-in until a sweep justifies it).
+- A large pre-trained domain model as the committed default (kept an opt-in knob).
+- Replacing the refdata tables (`given_name_aliased_jw` etc.) — GoldenSynonym is
+  additive; the name/business alias scorers stay as-is.
+
+## File structure
+```
+packages/python/goldenmatch/goldenmatch/synonym/
+  __init__.py            # register the synonym scorer (like refdata/__init__.py)
+  scorer.py              # SynonymScorer(ScorerPlugin): score_pair + score_matrix
+  providers.py           # SynonymModel protocol + resolve_synonym_model(domain)
+  model.py               # trained-model wrapper (embed + cosine + threshold) + stub
+  data/
+    drug_synonyms.train.jsonl   # RxNorm-derived pairs, eval-disjoint split (committed)
+  tests/...              # GS1 plumbing (stub), GS2 trainer/held-out, GS3 wiring
+scripts/train_synonym_model.py   # contrastive trainer (seeded, CPU-friendly)
+```


### PR DESCRIPTION
## GoldenSynonym — trained, pluggable synonym scorer (spec for review)

Closes (measures) the one class the goldengraph eval flagged as a real wall: `synonym_brand` sits at the exact-match floor (0.33) because nothing encodes drug-synonym knowledge. Per your call: **trained mechanism, general framework.**

Review-approved (twice — 3 blockers fixed). This is the spec gate; no code yet.

### Design
- A general **`synonym` ScorerPlugin** (mirrors the existing `given_name_aliased_jw` refdata precedent + the vectorized `score_matrix` path) resolving a **per-domain trained `SynonymModel`** from a provider registry (mirrors the embedder's providers). Drug domain first; chemical/product/… plug in later.
- **Trained:** contrastive fine-tune of a small encoder on synonym pairs (drugs ← RxNorm), hard negatives, calibrated threshold. The refdata table is the *training source + fallback + eval baseline*, not the primary scorer.

### The honest ceiling (up front, shapes everything)
Brand↔generic synonymy ("Advil"="ibuprofen") is **arbitrary domain knowledge, not a text signal** — a trained model either learns *morphological* families (real win) or *memorizes* the mapping (= a table, worse reproducibility). So the defensible value is the **general scorer + a measured held-out generalization number**, not beating a table on arbitrary brands. The eval is built to *expose* weak generalization, not hide it.

### Load-bearing honesty design
- Train on an RxNorm split **disjoint from the corpus by RxCUI AND by surface string** (every RXNCONSO atom of held-out drugs excluded — positives *and* negatives — so "Advil" never leaks in even as a negative). The corpus's 4 drug families are held out whole.
- Report **five numbers**: in-domain, held-out, table-baseline, trained-model-only (fast-path off), production (fast-path on) + a morphological-subset breakout. Directional prediction stated up front (held-out likely ≈ baseline for arbitrary brands).

### Feasibility pinned (the review's blockers)
- RxNorm RRF needs a UMLS license → derivation is **off-CI, one-time, licensed-human**; CI never touches RXNCONSO/RXNREL; exact filter pinned.
- Real training is **opt-in-lane only**, never the blocking pytest gate; GS2 tests use a toy in-process model; wall-clock budgeted.

### Staging (multi-PR)
GS1 framework + stub (ships the surface) → GS2 RxNorm pairs + trainer + drug model → GS3 opt-in eval re-measure + honest RESULTS.

**This is the brainstorming spec gate — please review.** If it looks right, I'll write the GS1 implementation plan next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)