### PR TITLE
docs(goldengraph): PR-C (MS-GraphRAG) + PR-D (Graphiti) competitor plans

### DIFF
--- a/docs/superpowers/plans/2026-06-21-goldengraph-evidence-pr-c-msgraphrag.md
+++ b/docs/superpowers/plans/2026-06-21-goldengraph-evidence-pr-c-msgraphrag.md
@@ -1,0 +1,113 @@
+# GoldenGraph Evidence #1 / PR C — MS-GraphRAG competitor adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add Microsoft GraphRAG to the qa-e2e harness — the headline GraphRAG name. This is the program's **long pole**: it has a Python API, but indexing is a multi-workflow pipeline with config + dataframe IO, and its LLM is config-driven (awkward cost seam).
+
+**Architecture:** A `MSGraphRAGQAEngine` over GraphRAG's **async Python API** (`graphrag.api.build_index` → `graphrag.api.local_search`), driven via `asyncio.run`. `build_index` writes parquet artifacts to a working dir; `answer` loads those artifacts and calls `local_search`. The LLM is driven by a programmatic `GraphRagConfig` (model + `OPENAI_API_KEY`); cost is read from GraphRAG's pipeline result if exposed, else estimated (flagged approximate).
+
+**Tech Stack:** `graphrag` (Microsoft, pinned), `pandas`/`pyarrow`, `asyncio`, the `erkgbench/qa_e2e` harness, OpenAI via config.
+
+**Prerequisite:** PR A (#1156, merged). Independent of PRs B/D.
+
+**Confirmed API (Context7 `/microsoft/graphrag`):**
+- `import graphrag.api as api`
+- `index_result = await api.build_index(config=<GraphRagConfig>, input_documents=<pandas.DataFrame>)` — input is a documents dataframe; outputs are written under the config's output dir.
+- Query via `await api.local_search(...)` / `api.global_search(...)` — these take the **loaded index artifacts** (entities/relationships/communities/community_reports/text_units dataframes) + the query.
+- `GraphRagConfig` from `graphrag.config.load_config(root_dir)` (settings.yaml) OR constructed programmatically. The CLI is built on this API.
+- **CONFIRM during impl (read graphrag source / the api_overview notebook):** the minimal programmatic `GraphRagConfig` (output/storage dir, the default chat + embedding models block), `build_index`'s exact `input_documents` column contract, and `local_search`'s exact parameter list + which parquet files to load.
+
+**Design obstacles (load-bearing):**
+1. **Config + dataframe IO, not a one-liner.** `build_index` needs a `GraphRagConfig` (a temp root dir, an output dir, LLM/embedding model config) and a documents dataframe; `local_search` needs the resulting parquet artifacts loaded back. Encapsulate all of this in the adapter; this is the bulk of the work.
+2. **Config-driven LLM → awkward cost seam.** GraphRAG owns its LLM calls via config; there's no inject-a-counting-func hook like LightRAG. Read token usage from `build_index`'s `PipelineRunResult` if exposed; otherwise estimate (corpus size × model) and **mark `cost_usd` approximate** in the results. Do NOT fake precision.
+3. **Indexing is expensive** (many LLM calls per chunk — the spec's "long pole"). Keep `--max-questions` small and the corpus small for the headline; the budget cap still applies.
+4. **Version churn.** GraphRAG's API moves fast; pin the version and record it. If the programmatic `build_index`/`local_search` API differs from the pinned docs, the CONFIRM step catches it before coding.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `erkgbench/qa_e2e/engines/ms_graphrag.py` | `MSGraphRAGQAEngine` + `_build_config` + `_load_artifacts`. |
+| `tests/test_qa_ms_graphrag_smoke.py` | Protocol conformance + config-builder unit test (no index, no LLM). |
+| `erkgbench/qa_e2e/run_qa_e2e.py` | Add `ms_graphrag` to `_build_engine`. |
+| `.github/workflows/bench-msgraphrag-smoke.yml` | Isolated `graphrag` venv; protocol/config smoke (no LLM). |
+| `.github/workflows/bench-graphrag-qa.yml` | Add an `ms_graphrag` job (real LLM, budget-capped). |
+
+---
+
+## Task 1: Adapter + config builder (testable seam)
+
+**Files:** Create `erkgbench/qa_e2e/engines/ms_graphrag.py`; Test `tests/test_qa_ms_graphrag_smoke.py`.
+
+- [ ] **Step 1: Failing test** — protocol conformance + that `_build_config(workdir, model)` returns a usable `GraphRagConfig` with the output dir set (NO index, NO LLM):
+
+```python
+# tests/test_qa_ms_graphrag_smoke.py
+"""Protocol conformance + config builder. Does NOT run build_index/local_search
+(those need real LLM + are expensive) -- that's the opt-in bench-graphrag-qa lane."""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+pytest.importorskip("graphrag")
+
+from erkgbench.qa_e2e.engines.ms_graphrag import MSGraphRAGQAEngine  # noqa: E402
+from erkgbench.qa_e2e.harness import QAEngine  # noqa: E402
+
+
+def test_ms_graphrag_engine_conforms_to_protocol():
+    eng = MSGraphRAGQAEngine(model="gpt-4o-mini")
+    assert isinstance(eng, QAEngine)
+    assert eng.name == "ms_graphrag"
+    assert eng.fidelity == "real-e2e"
+
+
+def test_build_config_sets_output_dir(tmp_path):
+    eng = MSGraphRAGQAEngine(model="gpt-4o-mini")
+    cfg = eng._build_config(str(tmp_path))
+    # the config points indexing output under the given working dir
+    assert str(tmp_path) in repr(cfg)
+```
+
+- [ ] **Step 2: run -> fail** (graphrag venv). **Step 3: Implement** `engines/ms_graphrag.py`:
+  - `_build_config(workdir, model) -> GraphRagConfig` — programmatic config: root/output/storage dir under `workdir`, default chat model `model` + an embedding model, `api_key` from `OPENAI_API_KEY`. (CONFIRM the minimal config shape from graphrag source.)
+  - `_load_artifacts(output_dir) -> dict[str, pandas.DataFrame]` — read the parquet outputs (`entities`, `relationships`, `communities`, `community_reports`, `text_units`) `local_search` needs. (CONFIRM file names.)
+  - `MSGraphRAGQAEngine(*, model="gpt-4o-mini")`:
+    - `build_kg(corpus)`: `workdir = mkdtemp`; `cfg = _build_config(workdir)`; `df = pandas.DataFrame({"id":[d.id...], "text":[d.text...]})`; `result = asyncio.run(api.build_index(config=cfg, input_documents=df))`; handle = `{cfg, output_dir}`; tokens from `result` stats if exposed else 0 (flag approximate).
+    - `answer(handle, question)`: `arts = _load_artifacts(output_dir)`; `resp, _ctx = asyncio.run(api.local_search(config=cfg, query=question, **arts, community_level=2, response_type="single sentence"))`; `text = resp`; `retrieved_fact_ids=()`.
+  - `asyncio.run` drives the async calls.
+
+- [ ] **Step 4: run -> pass** (2 tests, no index). **Step 5: commit** `feat(qa-e2e): MS-GraphRAG engine adapter + config-builder smoke`.
+
+---
+
+## Task 2: Wire `ms_graphrag` into the CLI
+
+- [ ] Add to `_build_engine`: `if name == "ms_graphrag": from .engines.ms_graphrag import MSGraphRAGQAEngine; return MSGraphRAGQAEngine(model="gpt-4o-mini")`. py_compile + ruff. Commit.
+
+---
+
+## Task 3: CI — protocol smoke lane + real lane job
+
+- [ ] **`bench-msgraphrag-smoke.yml`** (`push` on the adapter path; `ubuntu-latest`, no LLM): `pip install graphrag goldenmatch pytest pandas pyarrow numpy`; run `tests/test_qa_ms_graphrag_smoke.py`.
+- [ ] **`bench-graphrag-qa.yml`** — add an `ms_graphrag` job mirroring the others: `pip install graphrag goldenmatch datasets pandas pyarrow`, run `--engine ms_graphrag` with the budget cap, write `results_qa_e2e_ms_graphrag.json`. Same `OPENAI_API_KEY` secret. `timeout-minutes: 90` (indexing is slow).
+- [ ] Validate YAML; commit `ci(qa-e2e): MS-GraphRAG smoke lane + real job`.
+
+---
+
+## Done criteria
+- `MSGraphRAGQAEngine` conforms; the config-builder smoke passes in the `graphrag` venv.
+- `bench-graphrag-qa` `ms_graphrag` job runs `build_index` → `local_search` end-to-end (real LLM, budget-capped).
+- Results mark MS-GraphRAG's `cost_usd` **approximate** (config-driven LLM) + `retrieved_fact_ids=()`.
+
+## Open questions
+- The three CONFIRM items (minimal `GraphRagConfig`, `build_index` input columns, `local_search` params + artifact filenames) — resolve FIRST during impl from graphrag source / the `api_overview` + `input_documents` notebooks. If the programmatic config is too heavy to build by hand, fall back to writing a minimal `settings.yaml` into the workdir and `graphrag.config.load_config(workdir)`.
+- Token accounting: prefer real usage from `PipelineRunResult`; document the fallback estimate if it isn't exposed.

--- a/docs/superpowers/plans/2026-06-21-goldengraph-evidence-pr-d-graphiti.md
+++ b/docs/superpowers/plans/2026-06-21-goldengraph-evidence-pr-d-graphiti.md
@@ -1,0 +1,156 @@
+# GoldenGraph Evidence #1 / PR D — Graphiti competitor adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a real Graphiti engine to the qa-e2e harness — the temporally-aware, LLM-extraction competitor (nondeterministic, needs a graph DB), so the head-to-head includes it.
+
+**Architecture:** A `GraphitiQAEngine` implementing the `QAEngine` protocol over Graphiti's real async API (`add_episode` → `search`), driven via `asyncio.run`. **Graphiti has no embedded backend — it requires Neo4j or FalkorDB.** We use **FalkorDB** (Redis-based, a single lightweight container) as a CI **service container**. Graphiti `search` returns retrieved facts/edges, not a synthesized answer, so the adapter adds a small **LLM synthesis step** over the retrieved facts (the cost seam wraps both Graphiti's internal extraction LLM and the adapter's synthesis LLM).
+
+**Tech Stack:** `graphiti-core` (pinned), FalkorDB service container, `asyncio`, the existing `erkgbench/qa_e2e` harness, OpenAI (via Graphiti's `LLMClient` + the synthesis call).
+
+**Prerequisite:** PR A (#1156, merged). Independent of PRs B/C.
+
+**Confirmed API (Context7 `/getzep/graphiti`):**
+- `from graphiti_core import Graphiti`; `Graphiti(graph_driver=FalkorDriver(host, port))` (from `graphiti_core.driver.falkordb_driver`) OR `Graphiti(neo4j_uri, user, password)`.
+- `await client.add_episode(name=, episode_body=, source_description=, reference_time=<datetime>, source=EpisodeType.text)` — ingest one document.
+- `await client.search(query) -> list[EntityEdge]` — retrieve facts.
+- LLM/embedder are configured on the client (OpenAI by default via `OPENAI_API_KEY`); a custom `LLMClient` is injectable for the cost seam.
+- **CONFIRM during impl:** the index-setup method name (`build_indices_and_constraints`), the exact `search` return shape (`.fact`/`.episodes`), and the `LLMClient` injection point + signature.
+
+**Design obstacles (load-bearing — surfaced from research):**
+1. **Graph DB required.** Real e2e cannot run without a Neo4j/FalkorDB server. → FalkorDB service container in the opt-in lane; no DB means no e2e (the CI smoke is DB-free, see below).
+2. **Search ≠ answer.** Graphiti returns facts; the adapter synthesizes an answer from the top facts via one LLM call. Keep the synthesis prompt minimal + shared across engines for fairness (a tiny `synthesize_from_facts(question, facts, llm)` helper).
+3. **Nondeterministic.** Graphiti's extraction is LLM-driven; runs vary. This is expected (it's the determinism gap goldengraph exploits in slice #2). Record it; don't chase flakiness.
+4. **Cost seam spans two places** — Graphiti-internal extraction calls + the adapter's synthesis call. Wrap Graphiti's `LLMClient` with a counting decorator AND count the synthesis call into the same counter.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `erkgbench/qa_e2e/engines/graphiti.py` | `GraphitiQAEngine` + counting LLMClient wrapper + `synthesize_from_facts`. |
+| `tests/test_qa_graphiti_smoke.py` | Protocol conformance + cost-seam test (DB-free, no LLM). |
+| `erkgbench/qa_e2e/run_qa_e2e.py` | Add `graphiti` to `_build_engine` (reads `FALKORDB_HOST`/`PORT` env). |
+| `.github/workflows/bench-graphiti-smoke.yml` | Isolated `graphiti-core` venv; DB-free protocol/cost smoke. |
+| `.github/workflows/bench-graphrag-qa.yml` | Add a `graphiti` job WITH a `falkordb` service container. |
+
+---
+
+## Task 1: Graphiti adapter (DB-free testable seam + real path)
+
+**Files:** Create `erkgbench/qa_e2e/engines/graphiti.py`; Test `tests/test_qa_graphiti_smoke.py`.
+
+- [ ] **Step 1: Failing test** (protocol + cost seam + the synthesis helper — NO DB, NO real LLM)
+
+```python
+# tests/test_qa_graphiti_smoke.py
+"""Protocol conformance + cost-seam + fact-synthesis helper, all DB-free and
+LLM-free. The real e2e (add_episode -> search against a live FalkorDB) is the
+opt-in bench-graphrag-qa lane (it needs a graph DB)."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+pytest.importorskip("graphiti_core")
+
+from erkgbench.qa_e2e.engines.graphiti import (  # noqa: E402
+    GraphitiQAEngine,
+    make_counting_llm_client,
+    synthesize_from_facts,
+)
+from erkgbench.qa_e2e.harness import QAEngine  # noqa: E402
+
+
+def test_graphiti_engine_conforms_to_protocol():
+    eng = GraphitiQAEngine(falkordb_host="localhost", falkordb_port=6379)
+    assert isinstance(eng, QAEngine)
+    assert eng.name == "graphiti"
+    assert eng.fidelity == "real-e2e"
+
+
+def test_synthesize_from_facts_calls_llm_and_counts():
+    counter = {"in": 0, "out": 0}
+
+    async def _stub(prompt, **kwargs):
+        return "Ada"
+
+    text = asyncio.run(
+        synthesize_from_facts("Who founded Acme?", ["Acme founded by Ada"], _stub, counter)
+    )
+    assert text == "Ada"
+    assert counter["in"] > 0 and counter["out"] > 0
+```
+
+- [ ] **Step 2: run -> fail** (`pytest tests/test_qa_graphiti_smoke.py` in the graphiti venv).
+
+- [ ] **Step 3: Implement** `engines/graphiti.py`:
+  - `make_counting_llm_client(inner_llm_client, counter)` — a thin `LLMClient` subclass/wrapper that counts tokens on each generate call and delegates (CONFIRM the `LLMClient` abstract method name, likely `generate_response`).
+  - `synthesize_from_facts(question, facts, llm_callable, counter) -> str` — one LLM call combining the question + top facts into an answer; counts tokens.
+  - `GraphitiQAEngine(*, falkordb_host, falkordb_port, llm_client=None)`:
+    - `build_kg(corpus)`: construct `Graphiti(graph_driver=FalkorDriver(host, port))` with the counting LLM client; `await build_indices_and_constraints()`; `await add_episode(...)` per doc; handle = `{client}`.
+    - `answer(handle, question)`: `facts = await client.search(question)`; `text = await synthesize_from_facts(question, [f.fact for f in facts[:5]], ...)`; `retrieved_fact_ids=()` (fact uuids available but not aligned to corpus ids); count tokens.
+  - All async bodies driven via `asyncio.run`.
+
+- [ ] **Step 4: run -> pass** (2 tests, DB-free). **Step 5: commit** `feat(qa-e2e): Graphiti engine adapter + DB-free smoke`.
+
+---
+
+## Task 2: Wire `graphiti` into the CLI
+
+- [ ] Add to `run_qa_e2e._build_engine`: `if name == "graphiti": from .engines.graphiti import GraphitiQAEngine; return GraphitiQAEngine(falkordb_host=os.environ.get("FALKORDB_HOST","localhost"), falkordb_port=int(os.environ.get("FALKORDB_PORT","6379")))`. py_compile + ruff. Commit.
+
+---
+
+## Task 3: CI — DB-free smoke lane + real lane with a FalkorDB service
+
+- [ ] **`bench-graphiti-smoke.yml`** (`push` on the adapter path; `ubuntu-latest`, no DB): `pip install graphiti-core goldenmatch pytest numpy`; run `tests/test_qa_graphiti_smoke.py`.
+- [ ] **`bench-graphrag-qa.yml`** — add a `graphiti` job WITH a service container:
+
+```yaml
+  graphiti:
+    runs-on: large-new-64GB
+    timeout-minutes: 60
+    services:
+      falkordb:
+        image: falkordb/falkordb:latest
+        ports: ["6379:6379"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with: { python-version: "3.12" }
+      - run: python -m pip install --upgrade pip pytest numpy graphiti-core goldenmatch datasets
+      - name: Run Graphiti end-to-end (real LLM + FalkorDB, budget-capped)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          FALKORDB_HOST: localhost
+          FALKORDB_PORT: "6379"
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: |
+          python -m erkgbench.qa_e2e.run_qa_e2e --engine graphiti \
+            --corpus "${{ inputs.corpus }}" --max-questions "${{ inputs.max_questions }}" \
+            --budget-usd "${{ inputs.budget_usd }}" \
+            --out-md results/RESULTS_QA_E2E_graphiti.md --out-json results/results_qa_e2e_graphiti.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with: { name: graphrag-qa-results-graphiti, path: "packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_graphiti*.*", if-no-files-found: ignore }
+```
+
+- [ ] Validate YAML; commit `ci(qa-e2e): Graphiti smoke lane + FalkorDB-backed real job`.
+
+---
+
+## Done criteria
+- `GraphitiQAEngine` conforms; DB-free smoke (protocol + cost seam + synthesis helper) passes in the `graphiti-core` venv.
+- `bench-graphrag-qa` `graphiti` job runs end-to-end against a FalkorDB service.
+- Results note Graphiti's **nondeterminism** + `retrieved_fact_ids=()` (support-recall 0.0 by construction).
+
+## Open questions
+- Confirm Graphiti's index-setup method + `search` return shape + `LLMClient` method to wrap (the three CONFIRM items above) — do this first during impl by reading `graphiti_core`.
+- FalkorDB vs Neo4j: FalkorDB is the lighter CI service; if `graphiti-core` pins a Neo4j-only feature, fall back to a `neo4j` service container.


### PR DESCRIPTION
The two remaining competitor-adapter plans for the GraphRAG evidence head-to-head (after PR B / LightRAG, #1157). Both researched via Context7 and written obstacle-aware with explicit CONFIRM-during-impl notes for the API specifics.

- **PR D (Graphiti)** — `add_episode`→`search`, async. Requires a graph DB (no embedded backend), so the real-e2e lane uses a **FalkorDB service container**. `search` returns facts, so the adapter adds a small LLM synthesis step; nondeterministic by design. DB-free CI smoke = protocol + cost seam + synth helper.
- **PR C (MS-GraphRAG, the long pole)** — Python `api.build_index`→`api.local_search`, async. Config + dataframe IO writing parquet artifacts the query side loads back; config-driven LLM so `cost_usd` is **approximate** (flagged, not faked). Smoke = protocol + config builder.

Each follows the established adapter shape (PR A goldengraph, PR B LightRAG): `QAEngine` protocol, isolated venv lane, `real-e2e` fidelity, per-engine result files. After C+D land, PR "E"/the board merges the per-engine JSONs into the headline table (item 4).

Docs-only; the implementations follow (they need DB-container / config plumbing + an impl-time API-confirmation pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)