### PR TITLE
feat(goldengraph): GraphRAG evidence #1 / PR D — Graphiti competitor adapter

### DIFF
--- a/.github/workflows/bench-graphiti-smoke.yml
+++ b/.github/workflows/bench-graphiti-smoke.yml
@@ -1,0 +1,33 @@
+# Graphiti adapter smoke (GraphRAG evidence #1 / PR D). Isolated graphiti-core
+# venv, DB-free + key-free: validates QAEngine protocol conformance + the
+# fact-synthesis cost seam. Graphiti needs a graph DB for the real e2e (that runs
+# in bench-graphrag-qa with a FalkorDB service). Informational lane.
+name: bench-graphiti-smoke
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/graphiti.py"
+      - "packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_graphiti_smoke.py"
+      - ".github/workflows/bench-graphiti-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  graphiti-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install graphiti-core + goldenmatch (isolated)
+        run: python -m pip install --upgrade pip pytest numpy graphiti-core goldenmatch
+      - name: Graphiti adapter smoke (protocol + synthesis cost seam, DB-free)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: python -m pytest tests/test_qa_graphiti_smoke.py -v

--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -88,3 +88,41 @@ jobs:
           name: graphrag-qa-results-lightrag
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_lightrag*.*
           if-no-files-found: ignore
+
+  graphiti:
+    runs-on: large-new-64GB
+    timeout-minutes: 60
+    services:
+      falkordb:
+        image: falkordb/falkordb:latest
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install graphiti-core + goldenmatch + datasets + openai (isolated)
+        run: python -m pip install --upgrade pip pytest numpy graphiti-core goldenmatch datasets openai
+      - name: Run Graphiti end-to-end (real LLM + FalkorDB, budget-capped)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          FALKORDB_HOST: localhost
+          FALKORDB_PORT: "6379"
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: |
+          python -m erkgbench.qa_e2e.run_qa_e2e \
+            --engine graphiti \
+            --corpus "${{ inputs.corpus }}" \
+            --max-questions "${{ inputs.max_questions }}" \
+            --budget-usd "${{ inputs.budget_usd }}" \
+            --out-md results/RESULTS_QA_E2E_graphiti.md \
+            --out-json results/results_qa_e2e_graphiti.json
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-qa-results-graphiti
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_graphiti*.*
+          if-no-files-found: ignore

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/graphiti.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/graphiti.py
@@ -1,0 +1,111 @@
+"""Graphiti QA engine adapter. Graphiti is a retrieval layer over a graph DB
+(Neo4j/FalkorDB) with LLM-driven extraction; it returns FACTS, not answers, so the
+adapter adds a small LLM synthesis step over the retrieved facts.
+
+Cost seam (pragmatic + honest): the adapter counts its OWN synthesis call (len//4,
+consistent with the goldengraph/lightrag engines). Graphiti's INTERNAL extraction
+LLM calls (during add_episode) run through Graphiti's own OpenAI client and are NOT
+counted by the harness -- so build cost is reported as 0/approximate. This avoids
+wrapping Graphiti's version-fragile LLMClient internals; the engineered corpus is
+small, and the results note Graphiti's cost as synthesis-only. Graphiti is also
+nondeterministic by construction.
+
+Graphiti + the FalkorDB driver are imported lazily so importing this module for the
+registry never requires a DB or the heavy dep."""
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import time
+from typing import Any
+
+from ..harness import AnswerResult, BuildResult
+
+
+async def synthesize_from_facts(question: str, facts, llm_callable, counter: dict) -> str:
+    """One LLM call turning retrieved facts into a concise answer; counts tokens
+    (len//4) into `counter`. `llm_callable` is an async `(prompt) -> str`."""
+    prompt = (
+        "Answer the question concisely using ONLY these facts.\nFacts:\n"
+        + "\n".join(f"- {f}" for f in facts)
+        + f"\n\nQuestion: {question}\nAnswer:"
+    )
+    counter["in"] += max(1, len(prompt) // 4)
+    out = await llm_callable(prompt)
+    counter["out"] += max(1, len(out) // 4)
+    return out or ""
+
+
+async def _default_openai_complete(prompt: str) -> str:
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI()  # reads OPENAI_API_KEY
+    resp = await client.chat.completions.create(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": prompt}]
+    )
+    return resp.choices[0].message.content or ""
+
+
+class GraphitiQAEngine:
+    name = "graphiti"
+    fidelity = "real-e2e"
+
+    def __init__(
+        self,
+        *,
+        falkordb_host: str = "localhost",
+        falkordb_port: int = 6379,
+        llm_callable: Any | None = None,
+    ):
+        self._host = falkordb_host
+        self._port = falkordb_port
+        self._counter = {"in": 0, "out": 0}
+        # synthesis LLM (the only call the adapter makes directly); injectable for tests
+        self._synth = llm_callable or _default_openai_complete
+
+    def build_kg(self, corpus) -> BuildResult:
+        from graphiti_core import Graphiti
+        from graphiti_core.driver.falkordb_driver import FalkorDriver
+        from graphiti_core.nodes import EpisodeType
+
+        t0 = time.perf_counter()
+        driver = FalkorDriver(host=self._host, port=self._port)
+        graphiti = Graphiti(graph_driver=driver)  # default OpenAI llm/embedder via OPENAI_API_KEY
+
+        async def _build():
+            await graphiti.build_indices_and_constraints()
+            now = _dt.datetime.now(_dt.UTC)
+            for doc in corpus.documents:
+                await graphiti.add_episode(
+                    name=doc.id,
+                    episode_body=doc.text,
+                    source=EpisodeType.text,
+                    reference_time=now,
+                    source_description="qa-e2e",
+                )
+
+        asyncio.run(_build())
+        handle = {"graphiti": graphiti}
+        # Graphiti-internal extraction cost is not counted (see module docstring).
+        return BuildResult(
+            handle=handle, input_tokens=0, output_tokens=0, latency_s=time.perf_counter() - t0
+        )
+
+    def answer(self, handle, question: str) -> AnswerResult:
+        t0 = time.perf_counter()
+        before = dict(self._counter)
+        graphiti = handle["graphiti"]
+
+        async def _answer():
+            edges = await graphiti.search(question, num_results=5)
+            facts = [getattr(e, "fact", str(e)) for e in edges]
+            return await synthesize_from_facts(question, facts, self._synth, self._counter)
+
+        text = asyncio.run(_answer())
+        return AnswerResult(
+            text=text,
+            retrieved_fact_ids=(),  # fact uuids exist but don't align to corpus ids
+            input_tokens=self._counter["in"] - before["in"],
+            output_tokens=self._counter["out"] - before["out"],
+            latency_s=time.perf_counter() - t0,
+        )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -4,6 +4,7 @@ goldengraph run is selected with `--engine goldengraph` in the opt-in lane."""
 from __future__ import annotations
 
 import argparse
+import os
 
 from . import engineered
 from .corpora import load_musique
@@ -48,6 +49,13 @@ def _build_engine(name: str):
 
         return LightRAGQAEngine(
             llm_model_func=gpt_4o_mini_complete, embedding_func=openai_embed
+        )
+    if name == "graphiti":
+        from .engines.graphiti import GraphitiQAEngine
+
+        return GraphitiQAEngine(
+            falkordb_host=os.environ.get("FALKORDB_HOST", "localhost"),
+            falkordb_port=int(os.environ.get("FALKORDB_PORT", "6379")),
         )
     raise SystemExit(f"unknown engine: {name}")
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_graphiti_smoke.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_graphiti_smoke.py
@@ -1,0 +1,40 @@
+"""Protocol conformance + the fact-synthesis cost seam, DB-free and LLM-free. The
+real e2e (add_episode -> search against a live FalkorDB) is the opt-in
+bench-graphrag-qa lane (it needs a graph DB). Runs in the graphiti-core venv lane."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+pytest.importorskip("graphiti_core")
+
+from erkgbench.qa_e2e.engines.graphiti import (  # noqa: E402
+    GraphitiQAEngine,
+    synthesize_from_facts,
+)
+from erkgbench.qa_e2e.harness import QAEngine  # noqa: E402
+
+
+def test_graphiti_engine_conforms_to_protocol():
+    eng = GraphitiQAEngine(falkordb_host="localhost", falkordb_port=6379)
+    assert isinstance(eng, QAEngine)
+    assert eng.name == "graphiti"
+    assert eng.fidelity == "real-e2e"
+
+
+def test_synthesize_from_facts_calls_llm_and_counts():
+    counter = {"in": 0, "out": 0}
+
+    async def _stub(prompt):
+        return "Ada"
+
+    text = asyncio.run(
+        synthesize_from_facts("Who founded Acme?", ["Acme founded by Ada"], _stub, counter)
+    )
+    assert text == "Ada"
+    assert counter["in"] > 0 and counter["out"] > 0


### PR DESCRIPTION
**PR D** — adds Graphiti to the qa-e2e head-to-head (off the plan in #1158). Builds on PRs A/B.

- `engines/graphiti.py` — `GraphitiQAEngine` over Graphiti's async API (`add_episode`→`search`), driven via `asyncio.run`. Graphiti returns facts (not answers), so the adapter adds a small LLM synthesis step (`synthesize_from_facts`).
- **Graph DB:** the real lane uses a **FalkorDB service container** (Graphiti has no embedded backend); the smoke is DB-free.
- **Cost seam (pragmatic deviation from the plan):** counts the adapter's own synthesis call; Graphiti's internal extraction LLM is **not** wrapped (version-fragile internals I can't verify locally) → build cost reported approximate/0, noted in the module + results. Honest over fake-precise.
- `tests/test_qa_graphiti_smoke.py` — protocol + synthesis cost-seam (DB-free, no LLM); `bench-graphiti-smoke.yml` (isolated `graphiti-core` venv).
- `bench-graphrag-qa.yml` — adds a `graphiti` job (FalkorDB service + real LLM + openai), per-engine result file.

**CONFIRM-in-CI items** (flagged in the plan; my best-guess from Context7 `/getzep/graphiti`): the index-setup method `build_indices_and_constraints`, `EpisodeType.text`, and `search(...).fact`. The isolated smoke + real lane validate these; nondeterminism + `retrieved_fact_ids=()` (support-recall 0.0 by construction) noted.

**Verified locally:** py_compile + ruff clean, both YAMLs valid, smoke skips without `graphiti_core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)