### PR TITLE
ci(qa-e2e): source GraphRAG QA lane OpenAI key from GOLDENGRAPH_OPENAI_API_KEY

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run goldengraph end-to-end (real LLM, budget-capped)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
           POLARS_SKIP_CPU_CHECK: "1"
         run: |
           python -m erkgbench.qa_e2e.run_qa_e2e \
@@ -71,7 +71,7 @@ jobs:
       - name: Run LightRAG end-to-end (real LLM, budget-capped)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
           POLARS_SKIP_CPU_CHECK: "1"
         run: |
           python -m erkgbench.qa_e2e.run_qa_e2e \
@@ -102,8 +102,8 @@ jobs:
       - name: Run MS-GraphRAG end-to-end (real LLM, budget-capped)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GRAPHRAG_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          GRAPHRAG_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
           POLARS_SKIP_CPU_CHECK: "1"
         run: |
           python -m erkgbench.qa_e2e.run_qa_e2e \
@@ -139,7 +139,7 @@ jobs:
       - name: Run Graphiti end-to-end (real LLM + FalkorDB, budget-capped)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
           FALKORDB_HOST: localhost
           FALKORDB_PORT: "6379"
           POLARS_SKIP_CPU_CHECK: "1"


### PR DESCRIPTION
Points all four jobs in `bench-graphrag-qa.yml` (`goldengraph` / `lightrag` / `ms_graphrag` / `graphiti`) at a **GoldenGraph-scoped** repo secret, `secrets.GOLDENGRAPH_OPENAI_API_KEY`, instead of the generic `OPENAI_API_KEY`. The env var names the engines actually read (`OPENAI_API_KEY`, `GRAPHRAG_API_KEY`) are unchanged — only the secret *source* moves.

Why: the OpenAI key for the goldengraph evidence head-to-head is now stored under the `GOLDENGRAPH_OPENAI_API_KEY` name (set as a repo secret), so the lane should consume that name.

Now rebased onto main (post-#1161 merge) — the diff is just the 5-line secret-source change. Opt-in `workflow_dispatch` lane, so no required-CI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb