### PR TITLE
fix(qa-e2e): unbreak goldengraph/ms_graphrag/graphiti real-LLM bench jobs

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install graphiti-core + goldenmatch + datasets + openai (isolated)
-        run: python -m pip install --upgrade pip pytest numpy graphiti-core goldenmatch datasets openai
+        run: python -m pip install --upgrade pip pytest numpy "graphiti-core[falkordb]" goldenmatch datasets openai
       - name: Run Graphiti end-to-end (real LLM + FalkorDB, budget-capped)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:

--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -16,12 +16,16 @@ on:
       budget_usd:
         description: "hard cost cap per run"
         default: "25"
+      engine:
+        description: "all | goldengraph | lightrag | ms_graphrag | graphiti"
+        default: "all"
 
 permissions:
   contents: read
 
 jobs:
   goldengraph:
+    if: ${{ inputs.engine == 'all' || inputs.engine == 'goldengraph' }}
     runs-on: large-new-64GB
     timeout-minutes: 60
     steps:
@@ -59,6 +63,7 @@ jobs:
           if-no-files-found: ignore
 
   lightrag:
+    if: ${{ inputs.engine == 'all' || inputs.engine == 'lightrag' }}
     runs-on: large-new-64GB
     timeout-minutes: 60
     steps:
@@ -90,6 +95,7 @@ jobs:
           if-no-files-found: ignore
 
   ms_graphrag:
+    if: ${{ inputs.engine == 'all' || inputs.engine == 'ms_graphrag' }}
     runs-on: large-new-64GB
     timeout-minutes: 90  # MS-GraphRAG indexing is the long pole
     steps:
@@ -122,6 +128,7 @@ jobs:
           if-no-files-found: ignore
 
   graphiti:
+    if: ${{ inputs.engine == 'all' || inputs.engine == 'graphiti' }}
     runs-on: large-new-64GB
     timeout-minutes: 60
     services:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/graphiti.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/graphiti.py
@@ -46,6 +46,28 @@ async def _default_openai_complete(prompt: str) -> str:
     return resp.choices[0].message.content or ""
 
 
+def _new_graphiti(host: str, port: int):
+    """A fresh Graphiti client over FalkorDB. Created INSIDE the asyncio.run loop that
+    uses it -- Graphiti's FalkorDB connection is bound to the running loop, so a client
+    shared across the build loop and the per-answer loops raises 'Event loop is
+    closed'. Each call gets its own client; the graph persists in FalkorDB."""
+    from graphiti_core import Graphiti
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+    return Graphiti(graph_driver=FalkorDriver(host=host, port=port))
+
+
+async def _close_quietly(graphiti) -> None:
+    """Close the client's connections within the current loop (best-effort), so they
+    aren't torn down later against a closed loop."""
+    close = getattr(graphiti, "close", None)
+    if callable(close):
+        try:
+            await close()
+        except Exception:  # noqa: BLE001 - teardown must never fail the run
+            pass
+
+
 class GraphitiQAEngine:
     name = "graphiti"
     fidelity = "real-e2e"
@@ -64,42 +86,49 @@ class GraphitiQAEngine:
         self._synth = llm_callable or _default_openai_complete
 
     def build_kg(self, corpus) -> BuildResult:
-        from graphiti_core import Graphiti
-        from graphiti_core.driver.falkordb_driver import FalkorDriver
         from graphiti_core.nodes import EpisodeType
 
         t0 = time.perf_counter()
-        driver = FalkorDriver(host=self._host, port=self._port)
-        graphiti = Graphiti(graph_driver=driver)  # default OpenAI llm/embedder via OPENAI_API_KEY
 
         async def _build():
-            await graphiti.build_indices_and_constraints()
-            now = _dt.datetime.now(_dt.UTC)
-            for doc in corpus.documents:
-                await graphiti.add_episode(
-                    name=doc.id,
-                    episode_body=doc.text,
-                    source=EpisodeType.text,
-                    reference_time=now,
-                    source_description="qa-e2e",
-                )
+            # default OpenAI llm/embedder via OPENAI_API_KEY
+            graphiti = _new_graphiti(self._host, self._port)
+            try:
+                await graphiti.build_indices_and_constraints()
+                now = _dt.datetime.now(_dt.UTC)
+                for doc in corpus.documents:
+                    await graphiti.add_episode(
+                        name=doc.id,
+                        episode_body=doc.text,
+                        source=EpisodeType.text,
+                        reference_time=now,
+                        source_description="qa-e2e",
+                    )
+            finally:
+                await _close_quietly(graphiti)
 
         asyncio.run(_build())
-        handle = {"graphiti": graphiti}
+        # No live client in the handle: it would be bound to the loop above and break
+        # the per-answer loops. The graph lives in FalkorDB; answer reconnects.
         # Graphiti-internal extraction cost is not counted (see module docstring).
         return BuildResult(
-            handle=handle, input_tokens=0, output_tokens=0, latency_s=time.perf_counter() - t0
+            handle={}, input_tokens=0, output_tokens=0, latency_s=time.perf_counter() - t0
         )
 
     def answer(self, handle, question: str) -> AnswerResult:
         t0 = time.perf_counter()
         before = dict(self._counter)
-        graphiti = handle["graphiti"]
 
         async def _answer():
-            edges = await graphiti.search(question, num_results=5)
-            facts = [getattr(e, "fact", str(e)) for e in edges]
-            return await synthesize_from_facts(question, facts, self._synth, self._counter)
+            graphiti = _new_graphiti(self._host, self._port)
+            try:
+                edges = await graphiti.search(question, num_results=5)
+                facts = [getattr(e, "fact", str(e)) for e in edges]
+                return await synthesize_from_facts(
+                    question, facts, self._synth, self._counter
+                )
+            finally:
+                await _close_quietly(graphiti)
 
         text = asyncio.run(_answer())
         return AnswerResult(

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/ms_graphrag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/ms_graphrag.py
@@ -40,8 +40,15 @@ class MSGraphRAGQAEngine:
     fidelity = "real-e2e"
 
     def __init__(
-        self, *, model: str = "gpt-4o-mini", embedding_model: str = "text-embedding-3-small"
+        self, *, model: str = "gpt-4o-mini", embedding_model: str = "text-embedding-3-large"
     ):
+        # text-embedding-3-large (3072-dim) matches graphrag's default
+        # vector_store.vector_size (3072). graphrag decouples the embedding model from
+        # the LanceDB column dimension, so a 1536-dim model (3-small) provisions a
+        # 3072-dim store at index time and then fails local_search at query time with
+        # "query dim(1536) doesn't match the column vector dim(3072)". Aligning the
+        # model to the default vector_size keeps index + query consistent with zero
+        # nested config overrides.
         self._model = model
         self._embedding_model = embedding_model
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/ms_graphrag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/ms_graphrag.py
@@ -55,6 +55,8 @@ class MSGraphRAGQAEngine:
     def _build_config(self, workdir: str):
         """Scaffold graphrag's own canonical config for the installed version, then
         load it. Self-heals across graphrag's fast-moving settings schema."""
+        import os
+
         from graphrag.cli.initialize import initialize_project_at
         from graphrag.config.load_config import load_config
 
@@ -63,7 +65,14 @@ class MSGraphRAGQAEngine:
         initialize_project_at(
             root, force=True, model=self._model, embedding_model=self._embedding_model
         )
-        return load_config(root)
+        # graphrag's load_config does os.chdir(project_dir) and never restores the CWD
+        # -- which would silently break the harness's later relative `results/` write
+        # (it would land in graphrag's tempdir). Save + restore the CWD ourselves.
+        cwd = os.getcwd()
+        try:
+            return load_config(root)
+        finally:
+            os.chdir(cwd)
 
     def build_kg(self, corpus) -> BuildResult:
         import graphrag.api as api

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/ms_graphrag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/ms_graphrag.py
@@ -54,9 +54,9 @@ class MSGraphRAGQAEngine:
 
     def _build_config(self, workdir: str):
         """Scaffold graphrag's own canonical config for the installed version, then
-        load it. Self-heals across graphrag's fast-moving settings schema."""
-        import os
-
+        load it. Self-heals across graphrag's fast-moving settings schema. NOTE: this
+        os.chdir()s into the project dir (graphrag's load_config does, and relies on
+        it); callers that need a stable CWD must save/restore it themselves."""
         from graphrag.cli.initialize import initialize_project_at
         from graphrag.config.load_config import load_config
 
@@ -65,14 +65,14 @@ class MSGraphRAGQAEngine:
         initialize_project_at(
             root, force=True, model=self._model, embedding_model=self._embedding_model
         )
-        # graphrag's load_config does os.chdir(project_dir) and never restores the CWD
-        # -- which would silently break the harness's later relative `results/` write
-        # (it would land in graphrag's tempdir). Save + restore the CWD ourselves.
-        cwd = os.getcwd()
-        try:
-            return load_config(root)
-        finally:
-            os.chdir(cwd)
+        # graphrag's load_config does os.chdir(project_dir) and does NOT restore the
+        # CWD -- and graphrag RELIES on that: its storage base_dirs are relative to the
+        # project dir, so build_index writes output/*.parquet under the chdir'd CWD. We
+        # deliberately let the chdir stand (restoring it makes build_index write the
+        # artifacts to the wrong dir). The harness's results write is made
+        # CWD-independent instead, by resolving --out paths to absolute in
+        # run_qa_e2e.main before the engine runs.
+        return load_config(root)
 
     def build_kg(self, corpus) -> BuildResult:
         import graphrag.api as api

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -40,7 +40,14 @@ def _build_engine(name: str):
         from .engines.goldengraph import GoldenGraphQAEngine
 
         return GoldenGraphQAEngine(
-            llm=OpenAIClient(model="gpt-4o-mini"), embedder=GoldenmatchEmbedder()
+            llm=OpenAIClient(model="gpt-4o-mini"),
+            # provider="openai" uses goldenmatch's stdlib-only OpenAI embedding
+            # provider (urllib + OPENAI_API_KEY) -- no torch/sentence-transformers
+            # install, and it matches the OpenAI embeddings the other engines use, so
+            # the head-to-head compares KG construction, not embedding backends. The
+            # default "local" provider needs goldenmatch[embeddings] (not installed in
+            # this lane) and raised ImportError at query time.
+            embedder=GoldenmatchEmbedder(provider="openai"),
         )
     if name == "lightrag":
         from lightrag.llm.openai import gpt_4o_mini_complete, openai_embed
@@ -54,7 +61,7 @@ def _build_engine(name: str):
         from .engines.ms_graphrag import MSGraphRAGQAEngine
 
         return MSGraphRAGQAEngine(
-            model="gpt-4o-mini", embedding_model="text-embedding-3-small"
+            model="gpt-4o-mini", embedding_model="text-embedding-3-large"
         )
     if name == "graphiti":
         from .engines.graphiti import GraphitiQAEngine

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+from pathlib import Path
 
 from . import engineered
 from .corpora import load_musique
@@ -86,12 +87,20 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--out-json", required=True)
     args = p.parse_args(argv)
 
+    # Resolve output paths to absolute up front: some engines (graphrag's load_config)
+    # os.chdir() during the run, so a relative results/ path would write to the wrong
+    # dir. Anchoring before the run -- and creating the parent -- makes the write
+    # CWD-independent.
+    out_md = Path(args.out_md).resolve()
+    out_json = Path(args.out_json).resolve()
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+
     corpus = _load_corpus(args.corpus, args.max_questions, args.musique_path)
     engine = _MockEngine() if args.self_test else _build_engine(args.engine)
     result = run_engine(engine, corpus, model=args.model, budget_usd=args.budget_usd)
-    write_results([result], md_path=args.out_md, json_path=args.out_json)
+    write_results([result], md_path=out_md, json_path=out_json)
     print(
-        f"wrote {args.out_md} ({result['n_answered']}/{result['n_questions']} answered, "
+        f"wrote {out_md} ({result['n_answered']}/{result['n_questions']} answered, "
         f"${result['cost_usd']})"
     )
     return 0

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_ms_graphrag_smoke.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_ms_graphrag_smoke.py
@@ -28,7 +28,7 @@ def test_ms_graphrag_config_is_valid_for_installed_version(tmp_path):
     """Scaffold + load the config and assert the chat/embedding models are actually
     populated. No LLM, no network. Guards the version-schema drift that silently
     blanked the models when a hand-written 2.x settings.yaml met graphrag 3.x."""
-    eng = MSGraphRAGQAEngine(model="gpt-4o-mini", embedding_model="text-embedding-3-small")
+    eng = MSGraphRAGQAEngine(model="gpt-4o-mini", embedding_model="text-embedding-3-large")
     cfg = eng._build_config(str(tmp_path))
 
     assert cfg.completion_models, "no completion model configured (schema drift?)"
@@ -36,4 +36,7 @@ def test_ms_graphrag_config_is_valid_for_installed_version(tmp_path):
     chat = next(iter(cfg.completion_models.values()))
     assert chat.model == "gpt-4o-mini"
     embed = next(iter(cfg.embedding_models.values()))
-    assert embed.model == "text-embedding-3-small"
+    assert embed.model == "text-embedding-3-large"
+    # The embedding model dim must match the vector store column dim, or local_search
+    # fails on a LanceDB dim mismatch (1536 vs 3072). 3-large == default 3072.
+    assert cfg.vector_store.vector_size == 3072

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_ms_graphrag_smoke.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_ms_graphrag_smoke.py
@@ -29,7 +29,15 @@ def test_ms_graphrag_config_is_valid_for_installed_version(tmp_path):
     populated. No LLM, no network. Guards the version-schema drift that silently
     blanked the models when a hand-written 2.x settings.yaml met graphrag 3.x."""
     eng = MSGraphRAGQAEngine(model="gpt-4o-mini", embedding_model="text-embedding-3-large")
-    cfg = eng._build_config(str(tmp_path))
+    # _build_config os.chdir()s into the project dir (graphrag's load_config does);
+    # restore CWD so the chdir doesn't leak into the rest of the test session.
+    import os
+
+    cwd = os.getcwd()
+    try:
+        cfg = eng._build_config(str(tmp_path))
+    finally:
+        os.chdir(cwd)
 
     assert cfg.completion_models, "no completion model configured (schema drift?)"
     assert cfg.embedding_models, "no embedding model configured (schema drift?)"


### PR DESCRIPTION
The first real `bench-graphrag-qa` run found **lightrag green, the other three engines failing**. Each root cause is fixed and every engine is now validated end-to-end under real LLM:

| Engine | Original failure | Fix | Validated |
|---|---|---|---|
| **ms_graphrag** | `local_search` → `lance error: query dim(1536) != column vector dim(3072)` | Embedding model → `text-embedding-3-large` (3072), matching graphrag's default `vector_store.vector_size` | ✅ run #6 (engine-only) |
| **goldengraph** | query-seed embedding `ImportError` (default `local` embedder needs `goldenmatch[embeddings]`) | Adapter → `GoldenmatchEmbedder(provider="openai")` (stdlib urllib, no torch; matches the other engines' OpenAI embeddings) | ✅ runs #4, #5 |
| **graphiti** | `build_kg` → `ImportError` for `FalkorDriver` | Install `graphiti-core[falkordb]` | ✅ run #5 |

Two secondary bugs surfaced once the originals were cleared, both fixed:
- **ms_graphrag** then failed the results write — graphrag's `load_config` does `os.chdir(project_dir)` and graphrag *relies* on that (relative storage base_dirs). Fix: let the chdir stand; make the harness CWD-independent by resolving `--out` paths to absolute in `run_qa_e2e.main`. (An interim attempt to restore the CWD backfired — it broke `build_index`'s input/output — and was reverted.)
- **graphiti** then hit `RuntimeError: Event loop is closed` — the client/connection was created in `build_kg`'s `asyncio.run` loop and reused in `answer`'s separate loop. Fix: each `asyncio.run` creates a fresh client (graph persists in FalkorDB).

Also added an optional `engine` workflow input (`all` | one engine) so a single adapter can be validated without re-running the others under real-LLM cost — used here to validate ms_graphrag in isolation (~1× instead of 4×).

**Engine status across runs:** goldengraph ✅✅ · lightrag ✅✅ · graphiti ✅ · ms_graphrag ✅. The bench lane is opt-in (not `ci-required`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb