### PR TITLE
feat(qa-e2e): containment answer-match metric + echo scores to log

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -49,6 +49,7 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
     tracker.record_usage(build.input_tokens, build.output_tokens, model)
 
     ems: list[float] = []
+    matches: list[float] = []
     f1s: list[float] = []
     recalls: list[float] = []
     decay_rows: list[tuple[int, float]] = []
@@ -58,13 +59,16 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
             break
         ans = engine.answer(build.handle, q.question)
         tracker.record_usage(ans.input_tokens, ans.output_tokens, model)
-        em = metrics.exact_match(ans.text, q.gold_answer)
-        ems.append(em)
+        am = metrics.answer_match(ans.text, q.gold_answer)
+        matches.append(am)
+        ems.append(metrics.exact_match(ans.text, q.gold_answer))
         f1s.append(metrics.token_f1(ans.text, q.gold_answer))
         recalls.append(
             metrics.supporting_fact_recall(ans.retrieved_fact_ids, q.gold_supporting_fact_ids)
         )
-        decay_rows.append((q.hop_count, em))
+        # Decay = correctness by hop count. answer_match (containment) is the
+        # meaningful correctness signal for free-text answers; exact_match reads ~0.
+        decay_rows.append((q.hop_count, am))
         answered += 1
 
     return {
@@ -74,6 +78,7 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
         "model": model,
         "n_questions": len(corpus.questions),
         "n_answered": answered,
+        "answer_match": _mean(matches),
         "exact_match": _mean(ems),
         "token_f1": _mean(f1s),
         "support_recall": _mean(recalls),
@@ -96,17 +101,19 @@ def write_results(results: list[dict], *, md_path: str | Path, json_path: str | 
     Path(json_path).write_text(json.dumps(results, indent=2, sort_keys=True), encoding="utf-8")
     lines = ["# ER-KG-Bench -- end-to-end multi-hop QA (evidence program #1)", ""]
     lines.append(
-        "| engine | corpus | EM | token-F1 | support-recall | cost (USD) | answered | budget hit |"
+        "| engine | corpus | answer-match | EM | token-F1 | support-recall | "
+        "cost (USD) | answered | budget hit |"
     )
-    lines.append("|---|---|---|---|---|---|---|---|")
+    lines.append("|---|---|---|---|---|---|---|---|---|")
     for r in results:
         lines.append(
-            f"| {r['engine']} | {r['corpus']} | {r['exact_match']} | {r['token_f1']} | "
-            f"{r['support_recall']} | {r['cost_usd']} | {r['n_answered']}/{r['n_questions']} | "
+            f"| {r['engine']} | {r['corpus']} | {r['answer_match']} | {r['exact_match']} | "
+            f"{r['token_f1']} | {r['support_recall']} | {r['cost_usd']} | "
+            f"{r['n_answered']}/{r['n_questions']} | "
             f"{'yes' if r['budget_exhausted'] else 'no'} |"
         )
     lines.append("")
-    lines.append("## Decay curve (engineered corpus: mean EM by hop count)")
+    lines.append("## Decay curve (engineered corpus: mean answer-match by hop count)")
     for r in results:
         if r["corpus"] == "engineered":
             curve = ", ".join(f"{h}:{v}" for h, v in r["decay_curve"].items())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
@@ -22,6 +22,27 @@ def exact_match(pred: str, gold: str) -> float:
     return 1.0 if _normalize(pred) == _normalize(gold) else 0.0
 
 
+def answer_match(pred: str, gold: str) -> float:
+    """Containment correctness for free-text / generative answers: 1.0 if the
+    normalized gold answer appears as a contiguous token run inside the normalized
+    prediction, else 0.0.
+
+    Generative engines return a sentence ("the final entity is Acme Corp"), so
+    whole-string `exact_match` reads ~0 even when the answer is right; containment
+    captures "the answer names the correct entity" without an LLM judge. Token-level
+    (not raw substring) so a gold "acme" can't spuriously match inside "acmecorp"."""
+    g = _normalize(gold).split()
+    p = _normalize(pred).split()
+    if not g:
+        return 1.0 if not p else 0.0
+    if len(g) > len(p):
+        return 0.0
+    for i in range(len(p) - len(g) + 1):
+        if p[i : i + len(g)] == g:
+            return 1.0
+    return 0.0
+
+
 def token_f1(pred: str, gold: str) -> float:
     p = _normalize(pred).split()
     g = _normalize(gold).split()

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -103,6 +103,14 @@ def main(argv: list[str] | None = None) -> int:
         f"wrote {out_md} ({result['n_answered']}/{result['n_questions']} answered, "
         f"${result['cost_usd']})"
     )
+    # Echo the head-to-head scores so the CI job log carries them without an
+    # artifact download (answer_match is the correctness signal; EM reads ~0 on
+    # free-text generative answers).
+    print(
+        f"  scores[{result['engine']}]: answer_match={result['answer_match']} "
+        f"token_f1={result['token_f1']} exact_match={result['exact_match']} "
+        f"support_recall={result['support_recall']}"
+    )
     return 0
 
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_harness.py
@@ -57,10 +57,23 @@ def test_run_engine_scores_and_records_cost():
     res = run_engine(_MockEngine(), _toy_corpus(), model="gpt-4o-mini", budget_usd=25.0)
     assert res["engine"] == "mock"
     assert res["n_answered"] == 1
+    assert res["answer_match"] == 1.0
     assert res["exact_match"] == 1.0
     assert res["support_recall"] == 1.0
     assert res["cost_usd"] > 0.0
     assert res["budget_exhausted"] is False
+
+
+def test_run_engine_answer_match_scores_free_text_when_em_misses():
+    # a generative answer that NAMES the gold but isn't string-equal: answer_match
+    # credits it (1.0), exact_match does not (0.0) -- the wiring this PR adds.
+    engine = _MockEngine(answer_text="Following the chain, the answer is Ada.")
+    res = run_engine(engine, _toy_corpus(), model="gpt-4o-mini", budget_usd=25.0)
+    assert res["answer_match"] == 1.0
+    assert res["exact_match"] == 0.0
+    # decay curve is driven by answer_match (correctness by hop), so the 1-hop
+    # question registers as correct.
+    assert res["decay_curve"] == {1: 1.0}
 
 
 def test_run_engine_stops_at_budget_cap():

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_metrics.py
@@ -6,6 +6,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from erkgbench.qa_e2e.metrics import (  # noqa: E402
+    answer_match,
     decay_curve,
     exact_match,
     supporting_fact_recall,
@@ -16,6 +17,22 @@ from erkgbench.qa_e2e.metrics import (  # noqa: E402
 def test_exact_match_normalizes_articles_punct_case():
     assert exact_match("The Acme Corp.", "acme corp") == 1.0
     assert exact_match("Ada Lovelace", "Charles Babbage") == 0.0
+
+
+def test_answer_match_containment_on_free_text():
+    # gold appears as a token run inside a generative sentence -> 1.0, where
+    # exact_match (whole-string) reads 0.0 on the same pair.
+    assert answer_match("The final entity is Acme Corp.", "Acme Corp") == 1.0
+    assert exact_match("The final entity is Acme Corp.", "Acme Corp") == 0.0
+    # normalization (case / articles / punctuation) still applies
+    assert answer_match("...the answer: the ACME corp!", "Acme Corp") == 1.0
+    # wrong answer -> 0.0
+    assert answer_match("The final entity is Globex.", "Acme Corp") == 0.0
+    # token-level, not raw substring: 'acme' must not match inside 'acmecorp'
+    assert answer_match("acmecorp wins", "acme") == 0.0
+    # empty gold is vacuously matched only by an empty prediction
+    assert answer_match("anything", "") == 0.0
+    assert answer_match("", "") == 1.0
 
 
 def test_token_f1_partial_overlap():


### PR DESCRIPTION
## Context

Follow-up to #1167 (which unbroke the four real-LLM GraphRAG-QA engines). With all engines running, the next question was *who's better* — but the head-to-head scores weren't visible.

**Correction to an earlier read:** the QA-e2e harness was **already** computing `exact_match` / `token_f1` / `support_recall` per question (`harness.run_engine` → `qa_e2e/metrics.py`) and writing them to the results MD/JSON. The two real gaps were:

1. **Not surfaced** — the scores never hit stdout, so the head-to-head required downloading the per-engine artifacts.
2. **Degenerate on free-text** — `gold_answer` is a canonical entity *name* (e.g. `Acme Corp`), but the engines return generative sentences (*"…the final entity is Acme Corp."*). SQuAD-style `exact_match` needs whole-string equality, so it reads ~0 for every engine; `token_f1` is low and noisy; `support_recall` is structurally 0 for goldengraph (`retrieved_fact_ids=()`).

## Change

Add a deterministic containment metric **`answer_match`**: `1.0` when the normalized gold answer appears as a **contiguous token run** inside the normalized prediction, else `0.0`. Token-level (not raw substring) so a gold `acme` can't spuriously match inside `acmecorp`. This is the meaningful correctness signal for generative QA, at **zero extra LLM cost**.

- `harness.run_engine` computes `answer_match` per question, aggregates it into the result dict, and drives the **decay curve** off it (correctness by hop count — the old `exact_match`-based decay was uninformative at ~0).
- `write_results` leads the markdown table with the `answer-match` column and relabels the decay section.
- `run_qa_e2e.main` echoes a `scores[<engine>]: answer_match=… token_f1=… exact_match=… support_recall=…` line so the **CI job log carries the head-to-head** without an artifact download.

Existing `exact_match` / `token_f1` / `support_recall` are unchanged and still reported alongside.

## Tests

- `test_qa_metrics.py`: containment / normalization (case, articles, punctuation) / token-boundary / empty-gold cases for `answer_match`.
- `test_qa_harness.py`: a free-text `run_engine` case asserting `answer_match==1.0` while `exact_match==0.0` on a naming sentence, and that the decay curve follows correctness.

Verified end-to-end via the `--self-test` CLI (scores echo to stdout; `answer-match` column present in the written MD). `ruff` clean; 9/9 metrics+harness tests pass.

This is benchmark-harness-only (no shipped-package or CI-workflow change); the `bench-graphrag-qa` lane will print the head-to-head on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_