### PR TITLE
feat(qa-e2e): persist per-question records so near-zero results are debuggable

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -53,6 +53,7 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
     f1s: list[float] = []
     recalls: list[float] = []
     decay_rows: list[tuple[int, float]] = []
+    records: list[dict] = []
     answered = 0
     for q in corpus.questions:
         if tracker.budget_exhausted or not tracker.can_send(_estimate_tokens(q.question)):
@@ -60,15 +61,32 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
         ans = engine.answer(build.handle, q.question)
         tracker.record_usage(ans.input_tokens, ans.output_tokens, model)
         am = metrics.answer_match(ans.text, q.gold_answer)
+        em = metrics.exact_match(ans.text, q.gold_answer)
+        f1 = metrics.token_f1(ans.text, q.gold_answer)
+        rec = metrics.supporting_fact_recall(ans.retrieved_fact_ids, q.gold_supporting_fact_ids)
         matches.append(am)
-        ems.append(metrics.exact_match(ans.text, q.gold_answer))
-        f1s.append(metrics.token_f1(ans.text, q.gold_answer))
-        recalls.append(
-            metrics.supporting_fact_recall(ans.retrieved_fact_ids, q.gold_supporting_fact_ids)
-        )
+        ems.append(em)
+        f1s.append(f1)
+        recalls.append(rec)
         # Decay = correctness by hop count. answer_match (containment) is the
         # meaningful correctness signal for free-text answers; exact_match reads ~0.
         decay_rows.append((q.hop_count, am))
+        # Persist the per-question record so a near-zero aggregate is debuggable
+        # post-hoc (wrong reasoning vs. async-corrupted output vs. phrasing the
+        # matcher misses) -- the aggregate alone made the bench a black box. The
+        # prediction is truncated so a verbose engine can't bloat the artifact.
+        records.append(
+            {
+                "id": q.id,
+                "question": q.question,
+                "gold_answer": q.gold_answer,
+                "prediction": _truncate(ans.text),
+                "hop_count": q.hop_count,
+                "answer_match": am,
+                "exact_match": em,
+                "token_f1": round(f1, 4),
+            }
+        )
         answered += 1
 
     return {
@@ -85,7 +103,16 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
         "decay_curve": metrics.decay_curve(decay_rows),
         "cost_usd": round(tracker.total_cost_usd, 6),
         "budget_exhausted": tracker.budget_exhausted,
+        "per_question": records,
     }
+
+
+def _truncate(text: str, limit: int = 2000) -> str:
+    """Cap a stored prediction so a verbose engine (LightRAG essays) can't bloat
+    the results artifact; the head is what the answer_match check reads anyway."""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + " ...[truncated]"
 
 
 def _estimate_tokens(text: str) -> int:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -111,6 +111,16 @@ def main(argv: list[str] | None = None) -> int:
         f"token_f1={result['token_f1']} exact_match={result['exact_match']} "
         f"support_recall={result['support_recall']}"
     )
+    # A few example Q->A records so the log shows WHAT the engine answered (wrong
+    # vs. async-corrupted vs. phrasing) -- the full set rides in the JSON artifact.
+    for rec in result.get("per_question", [])[:3]:
+        pred = " ".join(rec["prediction"].split())
+        if len(pred) > 160:
+            pred = pred[:160] + "..."
+        print(
+            f"    {rec['id']} hop{rec['hop_count']} am={rec['answer_match']} "
+            f"gold={rec['gold_answer']!r} pred={pred!r}"
+        )
     return 0
 
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_harness.py
@@ -76,6 +76,34 @@ def test_run_engine_answer_match_scores_free_text_when_em_misses():
     assert res["decay_curve"] == {1: 1.0}
 
 
+def test_run_engine_persists_per_question_records():
+    # the harness keeps a per-question record so a near-zero aggregate is
+    # debuggable post-hoc -- this is what was missing (artifacts were aggregate-only).
+    engine = _MockEngine(answer_text="the final entity is Ada")
+    res = run_engine(engine, _toy_corpus(), model="gpt-4o-mini", budget_usd=25.0)
+    recs = res["per_question"]
+    assert len(recs) == res["n_answered"] == 1
+    r = recs[0]
+    assert r["id"] == "q1"
+    assert r["question"] == "Who founded Acme?"
+    assert r["gold_answer"] == "Ada"
+    assert r["prediction"] == "the final entity is Ada"  # the actual answer is kept
+    assert r["hop_count"] == 1
+    assert r["answer_match"] == 1.0  # containment credits the naming sentence
+    assert r["exact_match"] == 0.0
+
+
+def test_run_engine_truncates_long_prediction():
+    from erkgbench.qa_e2e.harness import _truncate
+
+    engine = _MockEngine(answer_text="x" * 5000)
+    res = run_engine(engine, _toy_corpus(), model="gpt-4o-mini", budget_usd=25.0)
+    pred = res["per_question"][0]["prediction"]
+    assert pred.endswith("...[truncated]")
+    assert len(pred) < 5000
+    assert _truncate("short") == "short"
+
+
 def test_run_engine_stops_at_budget_cap():
     # a tiny cap so the FIRST answer call is refused after build cost
     big = _MockEngine(in_tokens=10_000_000, out_tokens=10_000_000)


### PR DESCRIPTION
## Context

The first real `answer_match` head-to-head ([run 27917960960](https://github.com/benseverndev-oss/goldenmatch/actions/runs/27917960960), all four engines, `engine=all`) came back **~0 for everyone** — best was ms_graphrag at 0.05 (1/20), the other three at zero, `token_f1` ≈ 0.017 across the board.

When I went to diagnose *why*, I hit a wall: **the result artifacts are ~400 bytes — aggregate scores + decay curve only.** `run_engine` computed `answer_match` per question and then **discarded the answer text**, so there was no record *anywhere* (not the JSON, not the MD, not the job log) of what each engine actually answered. That makes a near-zero aggregate impossible to triage — genuinely wrong reasoning, async-corrupted output (lightrag/graphiti both threw event-loop errors in their query phase), and a right entity phrased so the containment matcher misses all read identically as `0.0`. A benchmark whose whole point is a credible head-to-head was a **black box past the scalar** — which cuts directly against the never-black-box principle.

## Change

`run_engine` now appends a per-question record to the result dict under **`per_question`**:

```json
{ "id", "question", "gold_answer", "prediction", "hop_count",
  "answer_match", "exact_match", "token_f1" }
```

- It rides into the JSON artifact via the existing `write_results` dump — no new file, no upload change.
- The stored **prediction is truncated to 2000 chars** so a verbose engine (LightRAG essays) can't bloat the artifact; the head is what `answer_match` reads anyway.
- `run_qa_e2e.main` **echoes the first 3 Q→A records** to the log, so the failure mode is visible inline without downloading the artifact:
  ```
  eng-q0 hop1 am=0.0 gold='approximate string matching' pred='...'
  ```

Aggregates, decay curve, and the markdown table are unchanged.

## Why this is the right next step

With this, one re-run tells us — per engine, per question — exactly *what was said*, separating "wrong reasoning" from "async-broken" (the lightrag/graphiti event-loop suspicion) from "right entity, matcher missed it." It turns the QA bench from a scalar black box into something introspectable, and unblocks the actual diagnosis of the near-zero scores.

## Tests

`test_qa_harness.py`: the per-question record keeps the actual answer text and the right per-question scores (containment credits a naming sentence `exact_match` misses); long predictions are truncated with a marker; `_truncate` is a no-op under the limit. Self-test CLI verified end-to-end (echo + `per_question` present in JSON). `ruff` clean; 11/11 metrics+harness tests pass.

Benchmark-harness-only — no shipped-package or CI-workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_