### PR TITLE
autoconfig E3: route TS planner + classifier through the wasm core (opt-in, pure-TS default)

### DIFF
--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -22,11 +22,27 @@ exposed as the **opt-in subpath** `goldenmatch/core/autoconfig-wasm`.
   vectors into `tests/parity/fixtures/autoconfig/`.
 - **Cross-surface parity gate:** `tests/parity/autoconfig-core.parity.test.ts` runs the
   same golden vectors as Rust (`tests/golden.rs`) + Python — 92 tests, byte-identical.
-- **Still divergent (E3, not yet done):** the existing `profiler.ts` (`ColumnType` uses
-  `id`/`text`, lacks `address`/`description`) and `autoconfigPlannerRules.ts` (6 rules vs
-  the core's 8) are NOT yet rerouted through the wasm core. The loader is in place and
-  parity-proven; rerouting the existing planner/classifier internals to call it (and
-  reconciling those vocabularies) is the next step.
+- **Opt-in backend, pure-TS default + fallback (the E3 posture, mirrors Python's default-OFF
+  native gate).** The always-on planner/classifier reach the wasm through a tiny LEAN
+  registry `src/core/autoconfigWasmBackend.ts` (`get/setAutoconfigWasmBackend`,
+  `isAutoconfigWasmEnabled`) that `import type`s from the heavy loader (erased — zero bundle
+  cost). Importing the heavy `goldenmatch/core/autoconfig-wasm` subpath and calling
+  **`enableAutoconfigWasm()`** registers the backend; until then `applyPlannerRules` runs the
+  pure-TS rules. **Why opt-in, not a hard reroute:** statically importing the loader into the
+  main `core` graph bloats `core/index` 734KB → 2.4MB (the inlined wasm). The registry keeps
+  default bundles lean (no wasm); only subpath importers pay the ~1.7MB. `disableAutoconfigWasm()`
+  reverts (test isolation).
+- **Planner reroute DONE (E3, planner half).** `autoconfigPlanner.ts::applyPlannerRules`
+  prefers the registered wasm backend, else the TS rule table (kept as the faithful-port
+  fallback — NOT deleted). Equivalence proven in
+  `tests/parity/autoconfig-wasm-planner-equivalence.test.ts` (wasm plan ≡ pure-TS plan on
+  every Python fixture ⇒ TS rules ≡ wasm ≡ Python).
+- **Classifier reroute STILL pending (E3, classifier half).** `profiler.ts` still uses its
+  hand-written heuristics with the `ColumnType` vocab (`id`/`text`, lacks `address`/`description`).
+  Rerouting it through `backend.classifyColumns` needs a core-13 ↔ TS-11 vocab adapter
+  (`identifier`↔`id`, `string`↔`text`, and a home for `address`/`description`) and updates to
+  every `inferredType` consumer (`autoconfig.ts`, `node/a2a|mcp/server.ts`). Tracked as the
+  next step; the loader + backend registry are the seam it will use.
 
 ## Wave history
 | npm | Python parity | Headline |

--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -37,12 +37,21 @@ exposed as the **opt-in subpath** `goldenmatch/core/autoconfig-wasm`.
   fallback — NOT deleted). Equivalence proven in
   `tests/parity/autoconfig-wasm-planner-equivalence.test.ts` (wasm plan ≡ pure-TS plan on
   every Python fixture ⇒ TS rules ≡ wasm ≡ Python).
-- **Classifier reroute STILL pending (E3, classifier half).** `profiler.ts` still uses its
-  hand-written heuristics with the `ColumnType` vocab (`id`/`text`, lacks `address`/`description`).
-  Rerouting it through `backend.classifyColumns` needs a core-13 ↔ TS-11 vocab adapter
-  (`identifier`↔`id`, `string`↔`text`, and a home for `address`/`description`) and updates to
-  every `inferredType` consumer (`autoconfig.ts`, `node/a2a|mcp/server.ts`). Tracked as the
-  next step; the loader + backend registry are the seam it will use.
+- **Classifier reroute DONE (E3, classifier half).** `profiler.ts::profileColumn` routes
+  through `backend.classifyColumns` when the wasm backend is enabled, else the hand-written
+  heuristic (kept as the fallback). `coreColTypeToTs` maps the core's 13-value vocab onto the
+  profiler's 11-value `ColumnType`: `identifier`→`id`, `string`→`text`, and `address`/
+  `description`→`text` (collapsed into the existing free-text bucket so every `inferredType`
+  consumer — `autoconfig.ts`, `node/a2a|mcp/server.ts` — keeps working WITHOUT widening
+  `ColumnType` or touching those consumers). Unlike the planner, wasm ≠ pure-TS here (different
+  classifiers), so there's no equivalence test — the core's correctness is the golden-vector
+  parity; `tests/parity/autoconfig-wasm-classifier.test.ts` guards the wiring + remap (email
+  survives 1:1, `identifier`→`id`, no core-only label leaks, disable reverts). `profiler.ts`
+  `import type`s the loader (erased), value-imports only the lean registry, so `core/index`
+  stays lean (no wasm).
+- **Remaining (optional follow-up):** adopt the full core-13 vocab in `ColumnType` (surface
+  `address`/`description` instead of collapsing to `text`) + the corresponding consumer
+  switches. Not required to route through the core; it's a fidelity upgrade.
 
 ## Wave history
 | npm | Python parity | Headline |

--- a/packages/typescript/goldenmatch/src/core/autoconfigPlanner.ts
+++ b/packages/typescript/goldenmatch/src/core/autoconfigPlanner.ts
@@ -2,20 +2,46 @@
  * autoconfigPlanner.ts — planner-rule dispatcher for controller v3.
  * Edge-safe: no `node:` imports.
  *
- * Ports goldenmatch/core/autoconfig_planner.py. Rules are evaluated in
- * registry order; the first predicate to return true fires and its action
- * returns an ExecutionPlan. A default plan is returned when no rule matches
- * (rule_name='no_rules_registered' for empty registry, 'no_rule_matched'
- * otherwise).
+ * Ports goldenmatch/core/autoconfig_planner.py. By DEFAULT the pure-TS rules
+ * are evaluated in registry order (first matching predicate fires). When the
+ * opt-in `goldenmatch/core/autoconfig-wasm` backend has been enabled, planning
+ * instead routes through the shared `goldenmatch-autoconfig-core` wasm — the
+ * SAME core the Python `goldenmatch-native` wheel calls — for byte-parity across
+ * Python / Rust / TS (the TS rules are a faithful port, so the two agree; the
+ * parity test guards it). This mirrors Python's default-OFF native gate.
  */
 
 import type { ComplexityProfile } from "./complexityProfile.js";
 import type { RuntimeProfile } from "./runtimeProfile.js";
-import type { ExecutionPlan } from "./executionPlan.js";
+import type { BackendName, ExecutionPlan } from "./executionPlan.js";
 import { makeExecutionPlan } from "./executionPlan.js";
+import { getAutoconfigWasmBackend } from "./autoconfigWasmBackend.js";
 
 export interface PlannerContext {
   readonly userBackend?: string | null;
+}
+
+const KNOWN_BACKENDS: ReadonlySet<string> = new Set<BackendName>([
+  "polars-direct",
+  "bucket",
+  "chunked",
+  "duckdb",
+  "ray",
+]);
+
+/**
+ * Normalize a user backend override into the wasm core's `user_backend`. Empty/
+ * absent → null (auto); an unrecognized backend is also coerced to null, since
+ * the core only accepts the known BackendName enum (passing garbage would throw
+ * on deserialize) — a bad override falls through to auto-planning, never crashes.
+ */
+function normalizeUserBackend(
+  userBackend: string | null | undefined,
+): BackendName | null {
+  if (userBackend === undefined || userBackend === null || userBackend === "") {
+    return null;
+  }
+  return KNOWN_BACKENDS.has(userBackend) ? (userBackend as BackendName) : null;
 }
 
 export type PlannerPredicate = (
@@ -49,6 +75,28 @@ export function applyPlannerRules(
   rules: readonly PlannerRule[],
   context: PlannerContext = {},
 ): ExecutionPlan {
+  // Opt-in fast path: route through the shared wasm decision core when enabled.
+  const wasm = getAutoconfigWasmBackend();
+  if (wasm !== null) {
+    return wasm.decidePlan({
+      nRowsFull,
+      estimatedPairCount: profile.blocking.totalComparisons,
+      runtime: {
+        availableRamGb: runtime.availableRamGb,
+        cpuCount: runtime.cpuCount,
+        diskFreeGb: runtime.diskFreeGb,
+      },
+      caps: {
+        // The edge-safe TS core never has a native bucket kernel or ray binding.
+        bucketAvailable: false,
+        rayAvailable: false,
+        rayAutoSelect: false,
+        userBackend: normalizeUserBackend(context.userBackend),
+      },
+    });
+  }
+
+  // Default: the pure-TS rule table (faithful port of the Python planner).
   if (rules.length === 0) {
     return makeExecutionPlan({ ruleName: "no_rules_registered" });
   }

--- a/packages/typescript/goldenmatch/src/core/autoconfigWasm.ts
+++ b/packages/typescript/goldenmatch/src/core/autoconfigWasm.ts
@@ -26,6 +26,10 @@ import type {
   ExecutionPlan,
   SpillThreshold,
 } from "./executionPlan.js";
+import {
+  setAutoconfigWasmBackend,
+  disableAutoconfigWasm,
+} from "./autoconfigWasmBackend.js";
 
 // ---------------------------------------------------------------------------
 // Public types (camelCase mirror of the core's serde shapes)
@@ -259,3 +263,25 @@ export function classifyColumnsRawJson(colsJson: string): string {
   ensureInit();
   return autoconfig_classify_columns(colsJson);
 }
+
+// ---------------------------------------------------------------------------
+// Opt-in enable: register this wasm core as the backend for the always-on
+// planner/classifier. Importing THIS module is what pays the ~1.7 MB wasm cost
+// (it statically embeds the base64); the main `goldenmatch/core` graph only
+// touches the lean registry, so default bundles carry no wasm. Sync because the
+// bytes are inlined + `initSync` is synchronous (no async enable needed, unlike
+// the runtime-loaded score-wasm backend).
+// ---------------------------------------------------------------------------
+
+/**
+ * Enable the shared wasm decision core for `applyPlannerRules` (and, once it's
+ * rerouted, the column classifier). After this call, auto-config planning is
+ * byte-parity with Python/Rust. Pure-TS stays the default until this is called;
+ * `disableAutoconfigWasm()` reverts.
+ */
+export function enableAutoconfigWasm(): void {
+  ensureInit();
+  setAutoconfigWasmBackend({ decidePlan, classifyColumns });
+}
+
+export { disableAutoconfigWasm };

--- a/packages/typescript/goldenmatch/src/core/autoconfigWasmBackend.ts
+++ b/packages/typescript/goldenmatch/src/core/autoconfigWasmBackend.ts
@@ -1,0 +1,47 @@
+/**
+ * autoconfigWasmBackend.ts — lean runtime registry for the OPT-IN autoconfig
+ * wasm backend. Edge-safe: no `node:` imports, and (critically) NO value import
+ * of the heavy `autoconfigWasm` module — only `import type`, which tsc/esbuild
+ * fully erase. So importing this registry (which the always-on planner/classifier
+ * do) pulls ZERO wasm bytes into the bundle.
+ *
+ * The heavy `goldenmatch/core/autoconfig-wasm` subpath registers a backend here
+ * via `enableAutoconfigWasm()`; until then `get*` returns null and callers use
+ * their pure-TS path. This mirrors the score-wasm `goldenmatch-wasm-runtime`
+ * split (shared lean registry + consumer-owned heavy enable) and Python's
+ * default-OFF native gate (`native_enabled("autoconfig")`).
+ */
+import type { ExecutionPlan } from "./executionPlan.js";
+import type {
+  PlannerInput,
+  CoreColumnStats,
+  CoreColumnProfile,
+} from "./autoconfigWasm.js";
+
+/** The shared decision surface the wasm core implements. */
+export interface AutoconfigWasmBackend {
+  decidePlan(input: PlannerInput): ExecutionPlan;
+  classifyColumns(cols: readonly CoreColumnStats[]): CoreColumnProfile[];
+}
+
+let _backend: AutoconfigWasmBackend | null = null;
+
+/** Register the wasm backend (called by the opt-in subpath's enable fn). */
+export function setAutoconfigWasmBackend(backend: AutoconfigWasmBackend): void {
+  _backend = backend;
+}
+
+/** The registered backend, or null when wasm is not enabled (the default). */
+export function getAutoconfigWasmBackend(): AutoconfigWasmBackend | null {
+  return _backend;
+}
+
+/** Clear the backend — restores the pure-TS path (test isolation / opt-out). */
+export function disableAutoconfigWasm(): void {
+  _backend = null;
+}
+
+/** True when the opt-in wasm backend is currently registered. */
+export function isAutoconfigWasmEnabled(): boolean {
+  return _backend !== null;
+}

--- a/packages/typescript/goldenmatch/src/core/profiler.ts
+++ b/packages/typescript/goldenmatch/src/core/profiler.ts
@@ -6,6 +6,11 @@
  */
 
 import type { Row } from "./types.js";
+import { getAutoconfigWasmBackend } from "./autoconfigWasmBackend.js";
+// Type-only (erased — no wasm bytes pulled into the bundle). The value path goes
+// through the lean registry above; the heavy loader is only reached when a caller
+// has imported `goldenmatch/core/autoconfig-wasm` and called enableAutoconfigWasm().
+import type { CoreColumnStats, CoreColumnType } from "./autoconfigWasm.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -234,6 +239,30 @@ function guessTypeAndConfidence(
   return { type: "text", confidence: 0.3 };
 }
 
+/**
+ * Map the shared core's 13-value column vocabulary back onto this profiler's
+ * 11-value `ColumnType`. The core adds `address`/`description` (free-text shapes
+ * the hand-written TS heuristic never emitted) and renames `id`→`identifier` /
+ * `text`→`string`. We collapse `address`/`description` to `text` (the existing
+ * free-text bucket) so every downstream `inferredType` consumer keeps working
+ * unchanged — adopting the full core vocab (and the address/description
+ * distinction) is a follow-up, not required to route through the core.
+ */
+function coreColTypeToTs(core: CoreColumnType): ColumnType {
+  switch (core) {
+    case "identifier":
+      return "id";
+    case "string":
+    case "address":
+    case "description":
+      return "text";
+    default:
+      // email / name / phone / zip / geo / numeric / date / year / multi_name
+      // are shared verbatim between the two vocabularies.
+      return core;
+  }
+}
+
 function profileColumn(name: string, rawValues: readonly unknown[]): ColumnProfile {
   const totalCount = rawValues.length;
   let nullCount = 0;
@@ -266,10 +295,40 @@ function profileColumn(name: string, rawValues: readonly unknown[]): ColumnProfi
 
   // Subsample for type guessing for performance
   const sampleForType = nonNull.length > 500 ? nonNull.slice(0, 500) : nonNull;
-  const { type: inferredType, confidence } = guessTypeAndConfidence(
-    sampleForType,
-    name,
-  );
+
+  // Opt-in: classify via the shared wasm core (= Python's classifier) when the
+  // backend is enabled; otherwise fall back to the pure-TS heuristic. The two
+  // are DIFFERENT implementations (the core adds address/description + slightly
+  // different thresholds), so this can change a column's inferredType when wasm
+  // is on — by design, the wasm path follows Python, the source of truth.
+  let inferredType: ColumnType;
+  let confidence: number;
+  const wasm = getAutoconfigWasmBackend();
+  if (wasm !== null) {
+    const stats: CoreColumnStats = {
+      name,
+      dtype: "String",
+      sampleValues: sampleForType,
+      nullRate,
+      cardinalityRatio,
+      avgLen: avgLength,
+    };
+    const profile = wasm.classifyColumns([stats])[0];
+    if (profile !== undefined) {
+      inferredType = coreColTypeToTs(profile.colType);
+      confidence = profile.confidence;
+    } else {
+      ({ type: inferredType, confidence } = guessTypeAndConfidence(
+        sampleForType,
+        name,
+      ));
+    }
+  } else {
+    ({ type: inferredType, confidence } = guessTypeAndConfidence(
+      sampleForType,
+      name,
+    ));
+  }
 
   return {
     name,

--- a/packages/typescript/goldenmatch/tests/parity/autoconfig-wasm-classifier.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/autoconfig-wasm-classifier.test.ts
@@ -1,0 +1,85 @@
+/**
+ * autoconfig-wasm-classifier.test.ts
+ *
+ * The column classifier in `profiler.ts` routes through the shared wasm core
+ * when the opt-in backend is enabled. Unlike the planner, the wasm and pure-TS
+ * classifiers are DIFFERENT implementations, so there's no byte-equivalence to
+ * assert — the core's correctness is covered by the golden vectors
+ * (`autoconfig-core.parity.test.ts`). This test guards the WIRING + the
+ * core-13 → TS-11 `ColumnType` remap:
+ *   - a shared type (email) survives 1:1,
+ *   - `identifier` is remapped to `id`,
+ *   - the profiler never leaks a core-only label (`identifier`/`string`/
+ *     `address`/`description`) into its 11-value vocabulary,
+ *   - disabling restores the pure-TS path.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { profileRows } from "../../src/core/profiler.js";
+import type { ColumnType } from "../../src/core/profiler.js";
+import {
+  enableAutoconfigWasm,
+  disableAutoconfigWasm,
+} from "../../src/core/autoconfigWasm.js";
+import { isAutoconfigWasmEnabled } from "../../src/core/autoconfigWasmBackend.js";
+
+const TS_COLUMN_TYPES: ReadonlySet<ColumnType> = new Set<ColumnType>([
+  "email",
+  "phone",
+  "zip",
+  "date",
+  "year",
+  "name",
+  "multi_name",
+  "geo",
+  "id",
+  "numeric",
+  "text",
+]);
+
+function rows(n: number): Record<string, string>[] {
+  return Array.from({ length: n }, (_, i) => ({
+    email: `user${i}@example.com`,
+    customer_id: `ID${String(i).padStart(4, "0")}`,
+    first_name: ["Alice", "Bob", "Carol", "Dave", "Eve"][i % 5]!,
+    amount: String(100 + i),
+  }));
+}
+
+afterEach(() => {
+  disableAutoconfigWasm();
+});
+
+describe("autoconfig classifier: wasm path", () => {
+  it("defaults to pure-TS (wasm not enabled)", () => {
+    expect(isAutoconfigWasmEnabled()).toBe(false);
+  });
+
+  it("routes through the wasm core and remaps the vocabulary", () => {
+    enableAutoconfigWasm();
+    expect(isAutoconfigWasmEnabled()).toBe(true);
+
+    const profile = profileRows(rows(20));
+    const byName = profile.byName;
+
+    // Shared type survives 1:1.
+    expect(byName.email!.inferredType).toBe("email");
+    // core `identifier` (from the `_id` name pattern) → TS `id`.
+    expect(byName.customer_id!.inferredType).toBe("id");
+
+    // No core-only label ever leaks into the TS vocabulary.
+    for (const col of profile.columns) {
+      expect(TS_COLUMN_TYPES.has(col.inferredType)).toBe(true);
+      expect(col.confidence).toBeGreaterThanOrEqual(0);
+      expect(col.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("reverts to the pure-TS classifier when disabled", () => {
+    enableAutoconfigWasm();
+    disableAutoconfigWasm();
+    expect(isAutoconfigWasmEnabled()).toBe(false);
+    // Still classifies (pure-TS path) without throwing.
+    const profile = profileRows(rows(10));
+    expect(TS_COLUMN_TYPES.has(profile.byName.email!.inferredType)).toBe(true);
+  });
+});

--- a/packages/typescript/goldenmatch/tests/parity/autoconfig-wasm-planner-equivalence.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/autoconfig-wasm-planner-equivalence.test.ts
@@ -1,0 +1,85 @@
+/**
+ * autoconfig-wasm-planner-equivalence.test.ts
+ *
+ * Proves the OPT-IN wasm planner path is byte-identical to the default pure-TS
+ * path: for every Python-generated planner fixture, `applyPlannerRules` returns
+ * the same ExecutionPlan whether the wasm backend is enabled or not. Combined
+ * with `planner.parity.test.ts` (TS rules == Python) and
+ * `autoconfig-core.parity.test.ts` (wasm == Python golden vectors), this closes
+ * the loop: pure-TS rules ≡ wasm core ≡ Python, so enabling the wasm core is a
+ * safe, behavior-preserving swap (it just makes the agreement load-bearing).
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import fixturesRaw from "./v2-fixtures.json" with { type: "json" };
+import { applyPlannerRules } from "../../src/core/autoconfigPlanner.js";
+import { DEFAULT_PLANNER_RULES } from "../../src/core/autoconfigPlannerRules.js";
+import {
+  makeComplexityProfile,
+  makeBlockingProfile,
+} from "../../src/core/complexityProfile.js";
+import { makeRuntimeProfile } from "../../src/core/runtimeProfile.js";
+import {
+  enableAutoconfigWasm,
+  disableAutoconfigWasm,
+} from "../../src/core/autoconfigWasm.js";
+import { isAutoconfigWasmEnabled } from "../../src/core/autoconfigWasmBackend.js";
+
+interface PlannerCase {
+  name: string;
+  input: {
+    n_rows: number;
+    pair_count: number;
+    ram_gb: number;
+    cpu_count: number;
+    disk_gb: number;
+    user_backend: string | null;
+  };
+}
+
+const cases = (fixturesRaw as { planner: PlannerCase[] }).planner;
+
+afterEach(() => {
+  // Always restore the pure-TS default so no other test sees the wasm backend.
+  disableAutoconfigWasm();
+});
+
+describe("autoconfig planner: wasm path ≡ pure-TS path", () => {
+  it("defaults to pure-TS (wasm not enabled)", () => {
+    expect(isAutoconfigWasmEnabled()).toBe(false);
+  });
+
+  for (const c of cases) {
+    it(`equivalent: ${c.name}`, () => {
+      const profile = makeComplexityProfile({
+        blocking: makeBlockingProfile({ totalComparisons: c.input.pair_count }),
+      });
+      const runtime = makeRuntimeProfile({
+        availableRamGb: c.input.ram_gb,
+        cpuCount: c.input.cpu_count,
+        diskFreeGb: c.input.disk_gb,
+      });
+      const ctx = { userBackend: c.input.user_backend };
+
+      disableAutoconfigWasm();
+      const tsPlan = applyPlannerRules(
+        profile,
+        runtime,
+        c.input.n_rows,
+        DEFAULT_PLANNER_RULES,
+        ctx,
+      );
+
+      enableAutoconfigWasm();
+      expect(isAutoconfigWasmEnabled()).toBe(true);
+      const wasmPlan = applyPlannerRules(
+        profile,
+        runtime,
+        c.input.n_rows,
+        DEFAULT_PLANNER_RULES,
+        ctx,
+      );
+
+      expect(wasmPlan).toEqual(tsPlan);
+    });
+  }
+});


### PR DESCRIPTION
**Supersedes #1169** — recreated against `main` now that #1166 (the native-core foundation) has merged (`3cca3d7`). Squash-merging #1166 deleted its branch and auto-closed the stack; this is #1169's own two commits (`19bc61c` planner half, `e40c65d` classifier half) rebased cleanly onto `main` — no content change.

## E3 — reroute the TS planner **and** classifier through the shared wasm core

Both autoconfig decision layers now route through `goldenmatch-autoconfig-core` (the SAME core the Python `goldenmatch-native` wheel calls) — as an **opt-in backend**, not a hard dependency, so default bundles stay lean and the pure-TS implementations remain the fallback. Mirrors Python's default-OFF native gate.

**Why opt-in:** statically importing the inlined-wasm loader into the always-on `core` graph bloats `core/index` 734KB → 2.4MB. Instead a tiny lean registry (`autoconfigWasmBackend.ts`) only `import type`s the heavy loader (erased → zero bundle cost); the planner + classifier import that. `core/index` stays ~779KB with no wasm bytes. Importing `goldenmatch/core/autoconfig-wasm` + calling `enableAutoconfigWasm()` registers the backend; `disableAutoconfigWasm()` reverts.

- **Planner** (`applyPlannerRules`): prefers the wasm backend, else the pure-TS rule table. `autoconfig-wasm-planner-equivalence.test.ts` asserts wasm plan `==` pure-TS plan on every Python fixture ⇒ TS rules ≡ wasm ≡ Python.
- **Classifier** (`profiler.ts::profileColumn`): prefers `backend.classifyColumns`, else the heuristic. `coreColTypeToTs` maps the core's 13-value vocab onto the profiler's 11-value `ColumnType` so no widening / consumer changes. `autoconfig-wasm-classifier.test.ts` guards wiring + remap.

### Verified locally (original #1169)
tsc clean; full suite 2085 passed / 1 expected-fail; `core/index.cjs` carries no wasm base64 (779KB lean); the 1.64MB `core/autoconfig-wasm` subpath is the only heavy entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_