### PR TITLE
autoconfig F: native core as source of truth (gate default-on) + goldenmatch-native 0.1.7

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -77,6 +77,26 @@ except Exception:  # noqa: BLE001 - any import/load failure falls back below
 #     dispatch telemetry, with no output change. Bench: kernel not-slower
 #     (1.44x faster per-pair) -- the measure-first gate in the spike.
 #
+# Signed off 2026-06-21 (autoconfig native core -- a SOURCE-OF-TRUTH/consistency
+# flip, NOT a perf one; the rest of this list is perf-motivated):
+#   - autoconfig: the Layer-1 planner (autoconfig_decide_plan) + Layer-2 column
+#     classifier (autoconfig_classify_columns) -- the deterministic auto-config
+#     decision logic, ported to the pyo3-free goldenmatch-autoconfig-core crate
+#     and shared verbatim by the Python wheel AND the TS port (via wasm). Output
+#     is BYTE-IDENTICAL to the pure-Python oracle: 88 golden vectors (49 planner
+#     + 39 classifier) generated from pure Python and asserted in
+#     tests/test_autoconfig_native_parity.py (+ the Rust tests/golden.rs and the
+#     TS tests/parity/autoconfig-core.parity.test.ts), so gating native on never
+#     changes a committed config. Distinct rationale from the perf entries above:
+#     autoconfig runs ONCE per auto_configure_df (not a per-row hot loop), so this
+#     is NOT a wall-clock-lift decision -- it makes the compiled core the single
+#     canonical implementation across Python/Rust/TS (repo direction: native is
+#     the source of truth wherever the kernel is byte-identical). Published-wheel
+#     skew is handled gracefully: both dispatch sites guard with
+#     `hasattr(_nm, "autoconfig_decide_plan"/"autoconfig_classify_columns")`, so a
+#     wheel that predates the symbols (PyPI 0.1.6) falls through to pure Python
+#     until goldenmatch-native 0.1.7 (this change bumps it) is published.
+#
 # NOT yet gated on (ships default-off; reachable via GOLDENMATCH_NATIVE=1):
 #   - pprl_bloom: the CLK bloom-filter hash loop (bloom_clk_batch). Python does
 #     all preprocessing (lower/strip/pad/balanced-salt) and the kernel only
@@ -95,7 +115,15 @@ except Exception:  # noqa: BLE001 - any import/load failure falls back below
 #     byte-identical (deterministic, golden-vector verified), so the flip is a
 #     perf/wheel-republish decision, not an accuracy one.
 _GATED_ON: frozenset[str] = frozenset(
-    {"clustering", "block_scoring", "pairs", "featurize", "hashing", "field_scoring"}
+    {
+        "clustering",
+        "block_scoring",
+        "pairs",
+        "featurize",
+        "hashing",
+        "field_scoring",
+        "autoconfig",
+    }
 )
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner.py
@@ -107,11 +107,13 @@ def apply_planner_rules(
         rule's name or a sentinel (``no_rules_registered``,
         ``no_rule_matched``).
     """
-    # Native fast path: only for the production DEFAULT_RULES registry and
-    # when the "autoconfig" component is enabled. Custom rule lists (used in
-    # unit tests) stay on the pure-Python path. "autoconfig" is intentionally
-    # NOT in _GATED_ON yet, so under GOLDENMATCH_NATIVE=auto/unset this block
-    # never fires -- pure Python runs unchanged. Cutover = Task F1.
+    # Native path: only for the production DEFAULT_RULES registry and when the
+    # "autoconfig" component is enabled. Custom rule lists (used in unit tests)
+    # stay on the pure-Python path. As of the source-of-truth cutover (Task F1,
+    # 2026-06-21) "autoconfig" IS in _GATED_ON, so under GOLDENMATCH_NATIVE=auto
+    # this runs whenever the ext carries the symbol -- output is byte-identical
+    # to pure Python (golden-vector parity), and the `hasattr` guard below falls
+    # back to pure Python on a wheel that predates the symbol.
     if native_enabled("autoconfig"):
         _nm = native_module()
         if hasattr(_nm, "autoconfig_decide_plan") and rules is _default_rules():

--- a/packages/python/goldenmatch/tests/test_autoconfig_backend_routing.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_backend_routing.py
@@ -32,7 +32,15 @@ def _native_off(monkeypatch):
     (bucket when the native block-scorer is enabled, else polars-direct). Pin it
     OFF so these routing assertions are deterministic regardless of whether the
     native ext is built in the test env. Bucket-branch coverage lives in
-    test_autoconfig_planner_rules.py."""
+    test_autoconfig_planner_rules.py.
+
+    ``GOLDENMATCH_NATIVE=0`` forces the pure-Python path globally -- this is the
+    load-bearing pin: it makes ``native_enabled(...)`` return False for EVERY
+    component, so both the pure-Python ``_scoring_backend()`` AND the native
+    ``autoconfig`` dispatch (gated-on since 2026-06-21) resolve to polars-direct.
+    The ``pr.native_enabled`` monkeypatch alone only covered the pure-Python rule
+    path, not the native planner dispatch's capability probe."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
     import goldenmatch.core.autoconfig_planner_rules as pr
     monkeypatch.setattr(pr, "native_enabled", lambda component: False)
 

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "arrow",
  "blake2",

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.6"
+version = "0.1.7"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -20,4 +20,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.6"
+    __version__ = "0.1.7"


### PR DESCRIPTION
**Supersedes #1170** — recreated against `main` now that #1166 has merged (`3cca3d7`); the squash auto-closed the stack. This is #1170's own two commits (`452a61a` gate-flip + 0.1.7 bump, `d6236e3` third version-file bump) rebased cleanly onto `main` — no content change.

## F — make the native autoconfig core the source of truth (gate default-on) + bump goldenmatch-native 0.1.7

Adds `"autoconfig"` to `_GATED_ON` so the shared `goldenmatch-autoconfig-core` kernels (`autoconfig_decide_plan` / `autoconfig_classify_columns`) run by default under `GOLDENMATCH_NATIVE=auto`.

**Honest framing:** unlike the other `_GATED_ON` entries, this is **not** a perf flip — autoconfig runs once per `auto_configure_df`, not a per-row hot loop. It's a consistency / source-of-truth flip. Safe because:
- **Byte-identical output.** 88 golden vectors assert native == pure-Python; 1248 autoconfig/planner/controller/classifier/pipeline tests pass native-on (only pre-existing TUI/MCP env failures, identical on baseline).
- **Graceful on a stale wheel.** Both dispatch sites guard with `hasattr(...)`, so a wheel predating the symbols (PyPI 0.1.6) falls through to pure-Python until **goldenmatch-native 0.1.7** (bumped here — Cargo.toml + pyproject.toml + Cargo.lock in lockstep) is published.

Also fixes a latent test-isolation gap the flip exposed (`_native_off` fixture now pins `GOLDENMATCH_NATIVE=0`).

### Release step intentionally NOT done here
The wheel publish (tag `goldenmatch-native-v0.1.7`) is a maintainer action — cut the tag when ready. Until then the gate is on and degrades gracefully to pure-Python for `[native]` users still on 0.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_