### PR TITLE
bench(autoconfig): Stage D measure-first — full-frame blocking measure is already cheap

### DIFF
--- a/docs/superpowers/specs/2026-06-21-autoconfig-sample-quality-finding.md
+++ b/docs/superpowers/specs/2026-06-21-autoconfig-sample-quality-finding.md
@@ -74,3 +74,44 @@ by ~500x.** This is the same family of failure as the at-scale blocking blow-ups
    `measure_blocking_profile` vs the Python path at 1M/10M rows; if affordable,
    propose flipping full-measurement on at lower planning-effort tiers. Gate any
    default change on that measured wall (measure-first; `feedback_verify_perf_not_just_ship`).
+
+## Stage D bench UPDATE (2026-06-21, MEASURED — partly refutes the native premise)
+
+Bench: `scripts/bench_stage_d_full_frame_measure.py` (native ext present). Person
+frame, single exact `last_name` pass (fixed-cardinality — the regime where
+extrapolation breaks). Wall of `measure_blocking_profile` (the current production
+full-frame path) vs a restructured "fast" path (one `group_by().len()` →
+pair-count aggregate):
+
+| N (rows) | `measure_blocking_profile` | fast (1 groupby + native agg) | fast (pure-py agg) |
+|---|---|---|---|
+| 100k | 120 ms | 20 ms | 6 ms |
+| 1M   | 272 ms | 19 ms | 19 ms |
+
+High block-cardinality probe (native vs pure `candidate_pair_count` over the
+block-sizes list, the only step the native kernel touches):
+
+| N | n_blocks | native agg | pure-py agg | speedup |
+|---|---|---|---|---|
+| 1M | 317k | 5.1 ms | 16.2 ms | 3.2× |
+| 5M | 1.58M | 91.4 ms | 79.2 ms | **0.9× (native slower)** |
+
+**Conclusions (honest, measure-first):**
+1. **Full-frame measurement is ALREADY affordable** — 272 ms at 1M with the
+   current implementation. It can be defaulted-on at lower planning-effort tiers
+   TODAY, with NO native acceleration. The finding's framing ("native-fast
+   profiling is what makes full-frame measurement cheap enough to be the default")
+   is **not borne out** — full-frame is already cheap with pure polars.
+2. **The real win is a POLARS refactor, not native.** `measure_blocking_profile`'s
+   per-block `collect()` loop dominates (272 ms@1M); a single `group_by().len()`
+   gets the block-size distribution in ~19 ms (**≈14×**). This restructure applies
+   verbatim to the TS port's profiler too (all surfaces benefit).
+3. **The native `candidate_pair_count` kernel is NOT the lever here.** The
+   size→pairs sum is trivial: 3× at moderate block counts, and a wash-to-LOSS at
+   1.5M+ blocks (marshaling a million-element list to the kernel beats the Python
+   `sum`). Keep it off this path.
+
+**Revised actionable conclusion:** the config-quality fix is *doing full-frame
+measurement at all* (cheap; flip it on at lower tiers) + the ~14× polars
+restructure of `measure_blocking_profile` — NOT native-accelerating it. The native
+core's payoff stays cross-surface parity + planner/classifier correctness.

--- a/packages/python/goldenmatch/scripts/bench_stage_d_full_frame_measure.py
+++ b/packages/python/goldenmatch/scripts/bench_stage_d_full_frame_measure.py
@@ -1,0 +1,110 @@
+"""Stage D measure-first bench: full-frame blocking measurement wall.
+
+The Stage D finding (docs/superpowers/specs/2026-06-21-autoconfig-sample-quality-
+finding.md) showed linear sample extrapolation under-counts candidate pairs by
+~the sampling fraction (up to ~500x at 10M), so the planner under-provisions the
+backend. The only accurate fix is FULL-FRAME measurement. This bench answers the
+finding's open question: is full-frame `measure_blocking_profile` affordable
+enough to default-on, and where does the wall go (native kernel vs polars)?
+
+Run: python scripts/bench_stage_d_full_frame_measure.py
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import polars as pl
+
+from goldenmatch.core.blocker import build_blocks, measure_blocking_profile
+from goldenmatch.core._native_loader import native_module
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, GoldenMatchConfig
+
+_SURNAMES = [
+    "smith", "jones", "brown", "davis", "wilson", "taylor", "thomas", "moore",
+    "jackson", "white", "harris", "martin", "thompson", "garcia", "martinez",
+    "robinson", "clark", "rodriguez", "lewis", "lee", "walker", "hall", "allen",
+    "young", "king", "wright", "scott", "green", "baker", "adams",
+]
+_FIRST = ["james", "mary", "john", "patricia", "robert", "jennifer", "michael", "linda"]
+
+
+def make_person_df(n: int, seed: int = 0) -> pl.DataFrame:
+    """Person-shaped frame: surname blocking key with realistic skew (fixed
+    cardinality => block size grows with N, the regime where extrapolation breaks)."""
+    import random
+
+    rng = random.Random(seed)
+    last = [rng.choice(_SURNAMES) for _ in range(n)]
+    first = [rng.choice(_FIRST) for _ in range(n)]
+    zip_ = [f"{rng.randint(10000, 99999)}" for _ in range(n)]
+    return pl.DataFrame({"first_name": first, "last_name": last, "zip": zip_})
+
+
+def _config() -> GoldenMatchConfig:
+    """Single exact pass on last_name -- the canonical fixed-cardinality scheme."""
+    cfg = GoldenMatchConfig()
+    cfg.blocking = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["last_name"], transforms=[])],
+        max_block_size=100_000,
+        skip_oversized=False,
+    )
+    return cfg
+
+
+def _fast_full_frame_pairs(df: pl.DataFrame, native: bool) -> tuple[int, float]:
+    """The 'fast' full-frame path: ONE polars group_by().len() to get block sizes
+    in a single query (no per-block collect loop), then the pair-count aggregate
+    (native candidate_pair_count when available, else the Python sum)."""
+    t = time.perf_counter()
+    sizes = (
+        df.lazy()
+        .group_by("last_name")
+        .agg(pl.len().alias("__sz__"))
+        .select("__sz__")
+        .collect()["__sz__"]
+        .to_list()
+    )
+    if native:
+        nm = native_module()
+        pairs = nm.candidate_pair_count(sizes)
+    else:
+        pairs = sum(s * (s - 1) // 2 for s in sizes)
+    return pairs, time.perf_counter() - t
+
+
+def main() -> None:
+    sizes = [100_000, 1_000_000]
+    # 5M only if there's headroom (string-heavy frame ~ a few hundred MB).
+    if os.environ.get("BENCH_5M") == "1":
+        sizes.append(5_000_000)
+
+    nm = native_module()
+    print(f"native ext: {'present' if nm else 'ABSENT'}  "
+          f"candidate_pair_count: {hasattr(nm, 'candidate_pair_count') if nm else False}\n")
+    cfg = _config()
+
+    hdr = f"{'N':>10} | {'measure_blocking_profile':>26} | {'fast(polars+native)':>20} | {'fast(pure py)':>14} | {'true_pairs':>14}"
+    print(hdr)
+    print("-" * len(hdr))
+    for n in sizes:
+        df = make_person_df(n)
+
+        # (1) the current production full-frame path
+        t = time.perf_counter()
+        prof = measure_blocking_profile(df, cfg)
+        wall_measure = time.perf_counter() - t
+        true_pairs = prof.total_comparisons if prof else -1
+
+        # (2) the fast restructured path, native + pure
+        p_nat, wall_fast_nat = _fast_full_frame_pairs(df, native=bool(nm))
+        p_py, wall_fast_py = _fast_full_frame_pairs(df, native=False)
+        assert p_nat == p_py == true_pairs, f"pair-count mismatch: {p_nat}/{p_py}/{true_pairs}"
+
+        print(f"{n:>10,} | {wall_measure*1e3:>23.1f}ms | {wall_fast_nat*1e3:>17.1f}ms | "
+              f"{wall_fast_py*1e3:>11.1f}ms | {true_pairs:>14,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldenmatch/scripts/bench_stage_d_full_frame_measure.py
+++ b/packages/python/goldenmatch/scripts/bench_stage_d_full_frame_measure.py
@@ -15,10 +15,9 @@ import os
 import time
 
 import polars as pl
-
-from goldenmatch.core.blocker import build_blocks, measure_blocking_profile
-from goldenmatch.core._native_loader import native_module
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, GoldenMatchConfig
+from goldenmatch.core._native_loader import native_module
+from goldenmatch.core.blocker import measure_blocking_profile
 
 _SURNAMES = [
     "smith", "jones", "brown", "davis", "wilson", "taylor", "thomas", "moore",


### PR DESCRIPTION
**Supersedes #1172** — recreated against `main` now that #1166 has merged (`3cca3d7`); the squash auto-closed the stack. This is #1172's own two commits (`94907ed` bench, `8e9baa1` ruff) rebased cleanly onto `main` — no content change. Measure-first artifact (a bench + finding-doc update; **no production code change**).

## What this measures
The Stage D finding showed linear sample-extrapolation under-counts candidate pairs by ~the sampling fraction (up to ~500× at 10M), so the planner under-provisions the backend. Open question: **is native-fast profiling needed to make full-frame `measure_blocking_profile` affordable as a default?**

## Answer (partly refutes the native premise)
| N (rows) | `measure_blocking_profile` | fast (1 groupby + native agg) | fast (pure-py agg) |
|---|---|---|---|
| 100k | 120 ms | 20 ms | 6 ms |
| 1M | **272 ms** | 19 ms | 19 ms |

- **Full-frame measurement is already affordable** — 272ms @ 1M; can be defaulted-on at lower planning-effort tiers today, no native acceleration needed.
- **The real win is a polars refactor, not native** — per-block `collect()` loop (272ms) vs one `group_by().len()` (~19ms) ≈ **14×**.
- **The native `candidate_pair_count` kernel is *not* the lever** — 3× at moderate block counts, wash-to-loss at 1.5M+ blocks.

**Revised conclusion (in the finding doc):** the config-quality fix is *doing full-frame measurement at all* + the polars restructure — the native core's payoff stays cross-surface parity + planner/classifier correctness, not accelerating the profiler. Honest application of `feedback_verify_perf_not_just_ship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_