### PR TITLE
autoconfig E3 follow-up: adopt full core-13 column vocabulary in profiler ColumnType

### DIFF
--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -39,19 +39,23 @@ exposed as the **opt-in subpath** `goldenmatch/core/autoconfig-wasm`.
   every Python fixture ⇒ TS rules ≡ wasm ≡ Python).
 - **Classifier reroute DONE (E3, classifier half).** `profiler.ts::profileColumn` routes
   through `backend.classifyColumns` when the wasm backend is enabled, else the hand-written
-  heuristic (kept as the fallback). `coreColTypeToTs` maps the core's 13-value vocab onto the
-  profiler's 11-value `ColumnType`: `identifier`→`id`, `string`→`text`, and `address`/
-  `description`→`text` (collapsed into the existing free-text bucket so every `inferredType`
-  consumer — `autoconfig.ts`, `node/a2a|mcp/server.ts` — keeps working WITHOUT widening
-  `ColumnType` or touching those consumers). Unlike the planner, wasm ≠ pure-TS here (different
+  heuristic (kept as the fallback). Unlike the planner, wasm ≠ pure-TS here (different
   classifiers), so there's no equivalence test — the core's correctness is the golden-vector
-  parity; `tests/parity/autoconfig-wasm-classifier.test.ts` guards the wiring + remap (email
-  survives 1:1, `identifier`→`id`, no core-only label leaks, disable reverts). `profiler.ts`
-  `import type`s the loader (erased), value-imports only the lean registry, so `core/index`
-  stays lean (no wasm).
-- **Remaining (optional follow-up):** adopt the full core-13 vocab in `ColumnType` (surface
-  `address`/`description` instead of collapsing to `text`) + the corresponding consumer
-  switches. Not required to route through the core; it's a fidelity upgrade.
+  parity; `tests/parity/autoconfig-wasm-classifier.test.ts` guards the wiring (email survives
+  1:1, `identifier` flows through verbatim, no value outside `ColumnType` leaks, disable
+  reverts). `profiler.ts` `import type`s the loader (erased), value-imports only the lean
+  registry, so `core/index` stays lean (no wasm).
+- **Classifier-vocab lever DONE (E3 follow-up).** `profiler.ts`'s `ColumnType` is now the
+  core's FULL 13-value vocabulary (`email | name | phone | zip | address | geo | identifier |
+  description | numeric | date | string | year | multi_name`) — no `coreColTypeToTs` remap;
+  the wasm path assigns `inferredType = profile.colType` directly. The pure-TS heuristic
+  (`guessTypeByName`/`guessTypeAndConfidence`) gained `address`/`description` name patterns and
+  renamed `id`→`identifier`, `text`→`string` to match. Consumers updated for the new vocab:
+  `autoconfig.ts::classifyColumn` reads `=== "identifier"` and surfaces `address` to its own
+  `token_sort @ 0.8` kind (vs the free-text `@ 0.5`); `node/a2a|mcp/server.ts` fuzzy-suggest
+  matches `string`/`address`/`description` (was `text`). NOTE: `complexityProfile.ts` has a
+  SEPARATE coarser `ColumnType` (`text`/`id-like`/`unknown`, populated from JS `typeof`, used
+  by `autoconfigRules.ts`) — that one is a different layer, untouched by this lever.
 
 ## Wave history
 | npm | Python parity | Headline |

--- a/packages/typescript/goldenmatch/src/core/autoconfig.ts
+++ b/packages/typescript/goldenmatch/src/core/autoconfig.ts
@@ -155,6 +155,7 @@ type ClassifiedKind =
   | "name"
   | "multi_name"
   | "id"
+  | "address"
   | "numeric"
   | "text";
 
@@ -212,9 +213,12 @@ function classifyColumn(profile: ColumnProfile): ClassifiedKind {
   if (nameMatches(name, NAME_NAME_PATTERNS) || profile.inferredType === "name") {
     return "name";
   }
-  if (nameMatches(name, ID_NAME_PATTERNS) || profile.inferredType === "id") {
+  if (nameMatches(name, ID_NAME_PATTERNS) || profile.inferredType === "identifier") {
     return "id";
   }
+  // Address routes to its own kind (token_sort @ 0.8) rather than collapsing
+  // into the free-text bucket (token_sort @ 0.5). Description stays free-text.
+  if (profile.inferredType === "address") return "address";
   if (profile.inferredType === "numeric") return "numeric";
   return "text";
 }
@@ -246,6 +250,7 @@ function colTypeFor(kind: ClassifiedKind): string {
   if (kind === "multi_name") return "multi_name"; // handled outside map
   if (kind === "geo") return "geo";
   if (kind === "id") return "identifier";
+  if (kind === "address") return "address";
   if (kind === "text") return "string";
   return "skip"; // numeric, date, year, etc.
 }

--- a/packages/typescript/goldenmatch/src/core/profiler.ts
+++ b/packages/typescript/goldenmatch/src/core/profiler.ts
@@ -10,24 +10,32 @@ import { getAutoconfigWasmBackend } from "./autoconfigWasmBackend.js";
 // Type-only (erased — no wasm bytes pulled into the bundle). The value path goes
 // through the lean registry above; the heavy loader is only reached when a caller
 // has imported `goldenmatch/core/autoconfig-wasm` and called enableAutoconfigWasm().
-import type { CoreColumnStats, CoreColumnType } from "./autoconfigWasm.js";
+import type { CoreColumnStats } from "./autoconfigWasm.js";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * The column vocabulary — now the SAME 13 values as the shared autoconfig core
+ * (`CoreColumnType` in autoconfigWasm.ts), so the wasm classifier path needs no
+ * remap. Renamed from the legacy port (`id`→`identifier`, `text`→`string`) and
+ * widened with `address`/`description` (free-text shapes the core distinguishes).
+ */
 export type ColumnType =
   | "email"
+  | "name"
   | "phone"
   | "zip"
-  | "date"
-  | "year"
-  | "name"
-  | "multi_name"
+  | "address"
   | "geo"
-  | "id"
+  | "identifier"
+  | "description"
   | "numeric"
-  | "text";
+  | "date"
+  | "string"
+  | "year"
+  | "multi_name";
 
 export interface ColumnProfile {
   readonly name: string;
@@ -108,7 +116,10 @@ function guessTypeByName(columnName: string): ColumnType | null {
   if (/date|created|modified|updated|_at$|birth|dob/i.test(lname)) return "date";
   if (/^(city|state|county|country|region|province)/i.test(lname)) return "geo";
   if (/city_desc|state_cd|country_code|state_code/i.test(lname)) return "geo";
-  if (/^id$|_id$|uuid|guid/i.test(lname)) return "id";
+  if (/address|street|^addr|_addr/i.test(lname)) return "address";
+  if (/description|^desc|_desc|notes?|comment|summary|remarks?|bio|about/i.test(lname))
+    return "description";
+  if (/^id$|_id$|uuid|guid/i.test(lname)) return "identifier";
   if (/name|first|last|full_name|surname/i.test(lname)) return "name";
   return null;
 }
@@ -210,7 +221,7 @@ function guessTypeAndConfidence(
   values: readonly string[],
   columnName: string,
 ): { type: ColumnType; confidence: number } {
-  if (values.length === 0) return { type: "text", confidence: 0.3 };
+  if (values.length === 0) return { type: "string", confidence: 0.3 };
 
   const nameType = guessTypeByName(columnName);
   const dataType = guessTypeByData(values);
@@ -219,16 +230,18 @@ function guessTypeAndConfidence(
     if (nameType === dataType) {
       return { type: nameType, confidence: 0.9 };
     }
-    // Disagreement: name heuristics are authoritative for geo/date/id/zip/email/name;
+    // Disagreement: name heuristics are authoritative for the name-derived types;
     // data heuristic wins otherwise. Confidence 0.7 either way (only one "source of truth").
     const nameAuthoritative =
       nameType === "date" ||
       nameType === "year" ||
       nameType === "geo" ||
-      nameType === "id" ||
+      nameType === "identifier" ||
       nameType === "email" ||
       nameType === "zip" ||
-      nameType === "name";
+      nameType === "name" ||
+      nameType === "address" ||
+      nameType === "description";
     return {
       type: nameAuthoritative ? nameType : dataType,
       confidence: 0.7,
@@ -236,31 +249,7 @@ function guessTypeAndConfidence(
   }
   if (nameType !== null) return { type: nameType, confidence: 0.7 };
   if (dataType !== null) return { type: dataType, confidence: 0.7 };
-  return { type: "text", confidence: 0.3 };
-}
-
-/**
- * Map the shared core's 13-value column vocabulary back onto this profiler's
- * 11-value `ColumnType`. The core adds `address`/`description` (free-text shapes
- * the hand-written TS heuristic never emitted) and renames `id`→`identifier` /
- * `text`→`string`. We collapse `address`/`description` to `text` (the existing
- * free-text bucket) so every downstream `inferredType` consumer keeps working
- * unchanged — adopting the full core vocab (and the address/description
- * distinction) is a follow-up, not required to route through the core.
- */
-function coreColTypeToTs(core: CoreColumnType): ColumnType {
-  switch (core) {
-    case "identifier":
-      return "id";
-    case "string":
-    case "address":
-    case "description":
-      return "text";
-    default:
-      // email / name / phone / zip / geo / numeric / date / year / multi_name
-      // are shared verbatim between the two vocabularies.
-      return core;
-  }
+  return { type: "string", confidence: 0.3 };
 }
 
 function profileColumn(name: string, rawValues: readonly unknown[]): ColumnProfile {
@@ -315,7 +304,8 @@ function profileColumn(name: string, rawValues: readonly unknown[]): ColumnProfi
     };
     const profile = wasm.classifyColumns([stats])[0];
     if (profile !== undefined) {
-      inferredType = coreColTypeToTs(profile.colType);
+      // ColumnType is now the SAME 13-value vocab as CoreColumnType — assign directly.
+      inferredType = profile.colType;
       confidence = profile.confidence;
     } else {
       ({ type: inferredType, confidence } = guessTypeAndConfidence(

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -357,7 +357,13 @@ async function dispatchSkill(
         else if (col.inferredType === "phone" && col.cardinalityRatio >= 0.5) exact.push(col.name);
         else if (col.inferredType === "zip" || col.inferredType === "geo") blocking.push(col.name);
         else if (col.inferredType === "name") fuzzy[col.name] = 0.85;
-        else if (col.inferredType === "text" && col.avgLength > 4) fuzzy[col.name] = 0.8;
+        else if (
+          (col.inferredType === "string" ||
+            col.inferredType === "address" ||
+            col.inferredType === "description") &&
+          col.avgLength > 4
+        )
+          fuzzy[col.name] = 0.8;
       }
       return { suggested: { exact, fuzzy, blocking, threshold: 0.85 } };
     }

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -704,7 +704,12 @@ export async function handleTool(
             if (col.cardinalityRatio >= 0.5) exact.push(col.name);
           } else if (col.inferredType === "geo") {
             blocking.push(col.name);
-          } else if (col.inferredType === "text" && col.avgLength > 4) {
+          } else if (
+            (col.inferredType === "string" ||
+              col.inferredType === "address" ||
+              col.inferredType === "description") &&
+            col.avgLength > 4
+          ) {
             fuzzy[col.name] = 0.8;
           }
         }

--- a/packages/typescript/goldenmatch/tests/parity/autoconfig-wasm-classifier.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/autoconfig-wasm-classifier.test.ts
@@ -5,12 +5,11 @@
  * when the opt-in backend is enabled. Unlike the planner, the wasm and pure-TS
  * classifiers are DIFFERENT implementations, so there's no byte-equivalence to
  * assert — the core's correctness is covered by the golden vectors
- * (`autoconfig-core.parity.test.ts`). This test guards the WIRING + the
- * core-13 → TS-11 `ColumnType` remap:
+ * (`autoconfig-core.parity.test.ts`). This test guards the WIRING now that
+ * `ColumnType` is the core's full 13-value vocabulary (no remap):
  *   - a shared type (email) survives 1:1,
- *   - `identifier` is remapped to `id`,
- *   - the profiler never leaks a core-only label (`identifier`/`string`/
- *     `address`/`description`) into its 11-value vocabulary,
+ *   - `identifier` flows through verbatim (was remapped to `id` pre-vocab-lever),
+ *   - the profiler never emits a value outside the 13-value `ColumnType`,
  *   - disabling restores the pure-TS path.
  */
 import { describe, it, expect, afterEach } from "vitest";
@@ -24,16 +23,18 @@ import { isAutoconfigWasmEnabled } from "../../src/core/autoconfigWasmBackend.js
 
 const TS_COLUMN_TYPES: ReadonlySet<ColumnType> = new Set<ColumnType>([
   "email",
+  "name",
   "phone",
   "zip",
-  "date",
-  "year",
-  "name",
-  "multi_name",
+  "address",
   "geo",
-  "id",
+  "identifier",
+  "description",
   "numeric",
-  "text",
+  "date",
+  "string",
+  "year",
+  "multi_name",
 ]);
 
 function rows(n: number): Record<string, string>[] {
@@ -63,8 +64,8 @@ describe("autoconfig classifier: wasm path", () => {
 
     // Shared type survives 1:1.
     expect(byName.email!.inferredType).toBe("email");
-    // core `identifier` (from the `_id` name pattern) → TS `id`.
-    expect(byName.customer_id!.inferredType).toBe("id");
+    // core `identifier` (from the `_id` name pattern) flows through verbatim.
+    expect(byName.customer_id!.inferredType).toBe("identifier");
 
     // No core-only label ever leaks into the TS vocabulary.
     for (const col of profile.columns) {

--- a/packages/typescript/goldenmatch/tests/unit/autoconfigVerify-preflight.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/autoconfigVerify-preflight.test.ts
@@ -359,7 +359,7 @@ describe("preflight Check 6: weight_confidence", () => {
           totalCount: 1,
           distinctCount: 1,
           cardinalityRatio: 1,
-          inferredType: "text",
+          inferredType: "string",
           avgLength: 1,
           maxLength: 1,
           sampleValues: ["x"],


### PR DESCRIPTION
**Supersedes #1173** — recreated against `main` now that **#1174** (E3, ⤳#1169) has merged (`17d8038`). The original was stacked on #1169's branch, which collapsed when the foundation squash-merged; this is #1173's own commit (`cac620d`) rebased cleanly onto `main` — no content change.

## E3 follow-up — the classifier-vocab lever

#1174 routed the TS classifier through the shared wasm core but kept the profiler's 11-value `ColumnType` and bridged with a `coreColTypeToTs` remap (`identifier`→`id`, `string`→`text`, `address`/`description`→`text`). That collapse threw away the core's `address`/`description` distinctions. This PR adopts the core's **full 13-value vocabulary** so the wasm path needs no remap and the richer labels surface.

### What changed
- **`profiler.ts`**: `ColumnType` widened to the core's 13 values (`email | name | phone | zip | address | geo | identifier | description | numeric | date | string | year | multi_name`). The wasm path now assigns `inferredType = profile.colType` directly (`coreColTypeToTs` deleted — was identity). The pure-TS heuristic gained `address`/`description` patterns; `id`→`identifier`, `text`→`string`.
- **`autoconfig.ts`**: `classifyColumn` reads `inferredType === "identifier"`; surfaces `address` to its own `token_sort @ 0.8` kind instead of the free-text `@ 0.5` bucket.
- **`node/a2a/server.ts` + `node/mcp/server.ts`**: fuzzy-suggest now matches `string`/`address`/`description` (was `text`).
- **tests**: classifier-wiring + preflight fixtures updated to the new vocab.

`complexityProfile.ts` keeps its **separate** coarse `ColumnType` (`text`/`id-like`/`unknown`) — a different layer, deliberately untouched.

### Verified locally (original #1173)
`tsc --noEmit` clean; full vitest suite **2085 passed** / 1 expected-fail / 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_