### PR TITLE
feat(canonicalize): TypeScript port of the pure field canonicalizers (#1128)

### DIFF
--- a/packages/typescript/goldenflow/src/core/canonicalize.ts
+++ b/packages/typescript/goldenflow/src/core/canonicalize.ts
@@ -50,19 +50,36 @@ function asciiUpper(s: string): string {
 }
 
 // The ASCII whitespace set we collapse/trim on: " \t\n\r\f\v". Deliberately NOT
-// the Unicode-aware `\s`.
-const ASCII_WS = /[ \t\n\r\f\v]+/g;
-const ASCII_WS_LEADING = /^[ \t\n\r\f\v]+/;
-const ASCII_WS_TRAILING = /[ \t\n\r\f\v]+$/;
+// the Unicode-aware `\s` — and handled WITHOUT regex (a Set membership scan), so
+// there is no polynomial-backtracking (ReDoS) surface on long whitespace runs.
+// The token scan also mirrors Python's `_ascii_ws_split` one-for-one.
+const ASCII_WS_CHARS = new Set([" ", "\t", "\n", "\r", "\f", "\v"]);
 
-/** Trim runs of the ASCII whitespace set from both ends. */
+/** Trim runs of the ASCII whitespace set from both ends (linear, no regex). */
 function trimAsciiWs(s: string): string {
-  return s.replace(ASCII_WS_LEADING, "").replace(ASCII_WS_TRAILING, "");
+  let start = 0;
+  let end = s.length;
+  while (start < end && ASCII_WS_CHARS.has(s[start]!)) start++;
+  while (end > start && ASCII_WS_CHARS.has(s[end - 1]!)) end--;
+  return s.slice(start, end);
 }
 
 /** Collapse runs of ASCII whitespace to a single space and trim the ends. */
 function collapseWs(s: string): string {
-  return s.split(ASCII_WS).filter((t) => t.length > 0).join(" ");
+  const tokens: string[] = [];
+  let current = "";
+  for (const ch of s) {
+    if (ASCII_WS_CHARS.has(ch)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens.join(" ");
 }
 
 // ASCII punctuation == Python string.punctuation. A Set keeps deletion

--- a/packages/typescript/goldenflow/src/core/canonicalize.ts
+++ b/packages/typescript/goldenflow/src/core/canonicalize.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure, language-portable per-value field canonicalizers (#1128).
+ *
+ * Byte-identical TypeScript port of the Python reference at
+ * `packages/python/goldenflow/goldenflow/canonicalize.py`. `canonicalize(value,
+ * kind)` reduces a single field value to a deterministic canonical string for
+ * match keys (email / phone / name / postal).
+ *
+ * The point of the port is PPRL / clean rooms: in the true-clean-room tier each
+ * party hashes its own values client-side, so the browser-side TypeScript and
+ * the server-side Python MUST agree on the exact canonical string before
+ * hashing, or the CLKs never line up. Every rule below is therefore written to
+ * be byte-for-byte identical to the Python version — which means **ASCII-only**
+ * primitives, NOT the Unicode-aware `String.prototype.toLowerCase()` /
+ * `.trim()` / `\s` / `\d`, which would diverge from Python's ASCII-only choices.
+ *
+ * Contract (identical to Python):
+ * - scalar: one string in, one string out.
+ * - total: `null` / `undefined` map to `""`; never throws on string input.
+ * - idempotent: `f(f(x)) === f(x)`.
+ * - locale-independent: case folding only touches `A`–`Z` / `a`–`z`; non-ASCII
+ *   bytes pass through unchanged.
+ * - dependency-free.
+ *
+ * Per-`kind` rules:
+ * - `email`  : trim ASCII whitespace, then ASCII-lowercase.
+ * - `phone`  : keep ASCII digits only; if 11 digits starting `1` (NANP country
+ *   code), drop the leading `1` → 10 digits.
+ * - `name`   : ASCII-lowercase, delete ASCII punctuation, collapse ASCII
+ *   whitespace runs to one space, trim.
+ * - `postal` : if it contains an ASCII letter (alphanumeric postcode, e.g. UK
+ *   `"SW1A 1AA"` / CA `"K1A 0B1"`), keep ASCII alphanumerics and ASCII-uppercase;
+ *   otherwise keep ASCII digits and take the first 5.
+ */
+
+export type CanonicalizeKind = "email" | "phone" | "name" | "postal";
+
+// ── Portable ASCII primitives ────────────────────────────────────────────────
+// Each mirrors the Python helper one-for-one. The regexes carry NO `u`/Unicode
+// flag, so the character classes are strictly ASCII.
+
+/** Lowercase ONLY ASCII A–Z (mirrors Python str.maketrans ASCII table). */
+function asciiLower(s: string): string {
+  return s.replace(/[A-Z]/g, (c) => String.fromCharCode(c.charCodeAt(0) + 32));
+}
+
+/** Uppercase ONLY ASCII a–z. */
+function asciiUpper(s: string): string {
+  return s.replace(/[a-z]/g, (c) => String.fromCharCode(c.charCodeAt(0) - 32));
+}
+
+// The ASCII whitespace set we collapse/trim on: " \t\n\r\f\v". Deliberately NOT
+// the Unicode-aware `\s`.
+const ASCII_WS = /[ \t\n\r\f\v]+/g;
+const ASCII_WS_LEADING = /^[ \t\n\r\f\v]+/;
+const ASCII_WS_TRAILING = /[ \t\n\r\f\v]+$/;
+
+/** Trim runs of the ASCII whitespace set from both ends. */
+function trimAsciiWs(s: string): string {
+  return s.replace(ASCII_WS_LEADING, "").replace(ASCII_WS_TRAILING, "");
+}
+
+/** Collapse runs of ASCII whitespace to a single space and trim the ends. */
+function collapseWs(s: string): string {
+  return s.split(ASCII_WS).filter((t) => t.length > 0).join(" ");
+}
+
+// ASCII punctuation == Python string.punctuation. A Set keeps deletion
+// regex-metacharacter-safe and obviously ASCII-only.
+const ASCII_PUNCT = new Set("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+
+/** Delete every ASCII punctuation char. */
+function deletePunct(s: string): string {
+  let out = "";
+  for (const ch of s) {
+    if (!ASCII_PUNCT.has(ch)) out += ch;
+  }
+  return out;
+}
+
+// ── Per-kind canonicalizers ──────────────────────────────────────────────────
+
+function canonEmail(value: string): string {
+  return asciiLower(trimAsciiWs(value));
+}
+
+function canonPhone(value: string): string {
+  let digits = value.replace(/[^0-9]/g, "");
+  if (digits.length === 11 && digits[0] === "1") {
+    digits = digits.slice(1);
+  }
+  return digits;
+}
+
+function canonName(value: string): string {
+  return collapseWs(deletePunct(asciiLower(value)));
+}
+
+function canonPostal(value: string): string {
+  const hasLetter = /[A-Za-z]/.test(value);
+  if (hasLetter) {
+    return asciiUpper(value.replace(/[^A-Za-z0-9]/g, ""));
+  }
+  return value.replace(/[^0-9]/g, "").slice(0, 5);
+}
+
+const CANONICALIZERS: Record<CanonicalizeKind, (value: string) => string> = {
+  email: canonEmail,
+  phone: canonPhone,
+  name: canonName,
+  postal: canonPostal,
+};
+
+/**
+ * Reduce a single field value to its canonical match-key string.
+ *
+ * Pure, total, idempotent, locale-independent, dependency-free — see the
+ * module doc comment for the full spec. `null` / `undefined` map to `""`.
+ *
+ * @param value the raw field value (or `null` / `undefined`).
+ * @param kind which canonicalizer: `"email"`, `"phone"`, `"name"`, or `"postal"`.
+ * @returns the canonical string.
+ * @throws if `kind` is not one of the four supported values (a programming
+ *   error, surfaced loudly rather than silently no-op'd).
+ */
+export function canonicalize(
+  value: string | null | undefined,
+  kind: CanonicalizeKind,
+): string {
+  const fn = CANONICALIZERS[kind];
+  if (fn === undefined) {
+    throw new Error(
+      `Unknown canonicalize kind ${JSON.stringify(kind)}; ` +
+        `expected one of email, phone, name, postal.`,
+    );
+  }
+  if (value === null || value === undefined) return "";
+  return fn(value);
+}

--- a/packages/typescript/goldenflow/src/core/index.ts
+++ b/packages/typescript/goldenflow/src/core/index.ts
@@ -41,6 +41,10 @@ export {
 // Data layer
 export { TabularData, isNullish, toColumnValue } from "./data.js";
 
+// Pure scalar canonicalizers (PPRL / clean-room match keys; #1128)
+export { canonicalize } from "./canonicalize.js";
+export type { CanonicalizeKind } from "./canonicalize.js";
+
 // Transform registry (imports all transform modules for side-effect registration)
 export {
   registerTransform,

--- a/packages/typescript/goldenflow/tests/unit/canonicalize.test.ts
+++ b/packages/typescript/goldenflow/tests/unit/canonicalize.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the pure scalar canonicalizers (#1128).
+ *
+ * The input→output pairs are copied verbatim from the Python reference tests
+ * (`packages/python/goldenflow/tests/test_canonicalize.py`), so this file
+ * doubles as the byte-for-byte parity fixture: if the TS port ever diverges
+ * from the documented spec, one of these breaks.
+ */
+
+import { describe, it, expect } from "vitest";
+import { canonicalize } from "../../src/index.js";
+import type { CanonicalizeKind } from "../../src/index.js";
+
+const KINDS: CanonicalizeKind[] = ["email", "phone", "name", "postal"];
+
+describe("canonicalize: email", () => {
+  it.each([
+    ["Alice@Example.COM", "alice@example.com"],
+    ["  bob@x.org  ", "bob@x.org"],
+    ["\tCarol@Y.io\n", "carol@y.io"],
+    ["already@clean.com", "already@clean.com"],
+    ["", ""],
+  ])("%j -> %j", (raw, expected) => {
+    expect(canonicalize(raw, "email")).toBe(expected);
+  });
+});
+
+describe("canonicalize: phone", () => {
+  it.each([
+    ["(555) 123-4567", "5551234567"],
+    ["+1 555 123 4567", "5551234567"], // NANP country code stripped
+    ["1-555-123-4567", "5551234567"],
+    ["15551234567", "5551234567"], // bare 11-digit leading 1
+    ["555.123.4567", "5551234567"],
+    ["+44 20 7946 0958", "442079460958"], // not 11 digits -> no strip
+    ["12345678901", "2345678901"], // 11 digits, leading 1 -> strip
+    ["1234567890", "1234567890"], // 10 digits, leading 1 -> KEEP
+    ["phone: n/a", ""],
+    ["", ""],
+  ])("%j -> %j", (raw, expected) => {
+    expect(canonicalize(raw, "phone")).toBe(expected);
+  });
+});
+
+describe("canonicalize: name", () => {
+  it.each([
+    ["  John   SMITH ", "john smith"],
+    ["O'Brien", "obrien"], // punctuation deleted
+    ["Smith-Jones", "smithjones"],
+    ["Dr. Jane Doe, Jr.", "dr jane doe jr"],
+    ["María José", "maría josé"], // non-ASCII passes through
+    ["", ""],
+  ])("%j -> %j", (raw, expected) => {
+    expect(canonicalize(raw, "name")).toBe(expected);
+  });
+});
+
+describe("canonicalize: postal", () => {
+  it.each([
+    ["12345", "12345"],
+    ["12345-6789", "12345"], // ZIP+4 -> first 5
+    ["90210 ", "90210"],
+    ["1234", "1234"], // fewer than 5 digits -> as-is
+    ["SW1A 1AA", "SW1A1AA"], // UK: alnum-upper fallback
+    ["k1a 0b1", "K1A0B1"], // CA: lowercased -> upper
+    ["", ""],
+  ])("%j -> %j", (raw, expected) => {
+    expect(canonicalize(raw, "postal")).toBe(expected);
+  });
+});
+
+describe("canonicalize: cross-cutting guarantees", () => {
+  const CORPUS = [
+    "Alice@Example.COM",
+    "  bob@x.org  ",
+    "(555) 123-4567",
+    "+1 555 123 4567",
+    "O'Brien",
+    "Dr. Jane Doe, Jr.",
+    "María José",
+    "12345-6789",
+    "SW1A 1AA",
+    "k1a 0b1",
+    "",
+    "   ",
+    "!!!",
+    "MixedCASE 123 -- text",
+  ];
+
+  for (const kind of KINDS) {
+    for (const raw of CORPUS) {
+      it(`is idempotent: ${kind}(${JSON.stringify(raw)})`, () => {
+        const once = canonicalize(raw, kind);
+        expect(canonicalize(once, kind)).toBe(once);
+      });
+    }
+
+    it(`maps null/undefined to "" for ${kind}`, () => {
+      expect(canonicalize(null, kind)).toBe("");
+      expect(canonicalize(undefined, kind)).toBe("");
+    });
+  }
+
+  it("case folding is ASCII-only, not locale-aware", () => {
+    // Locale-aware toLowerCase() folds the non-ASCII capitals (Turkish 'İ' ->
+    // 'i̇'); ASCII-only must lowercase ONLY A-Z and leave the rest byte-identical.
+    expect(canonicalize("İSTANBUL", "name")).toBe("İstanbul"); // 'İ' untouched
+    expect(canonicalize("ÉCLAIR", "name")).toBe("Éclair"); // 'É' untouched
+  });
+
+  it("throws on an unknown kind", () => {
+    expect(() => canonicalize("x", "zipcode" as CanonicalizeKind)).toThrow();
+  });
+});


### PR DESCRIPTION
## Why

Closes the byte-identical-parity loop opened by **#1183** (the Python `goldenflow.canonicalize`). PPRL / clean rooms hash field values **client-side in the browser** in the true-clean-room tier, so the browser-side TypeScript and the server-side Python must produce the *exact same* canonical string before hashing — otherwise the CLKs never line up. This ports the four canonicalizers to `goldenflow-js`. (#1128)

## What

`canonicalize(value, kind)` in `goldenflow-js` core (`src/core/canonicalize.ts`), exported from the package root — a literal mirror of the Python reference (`packages/python/goldenflow/goldenflow/canonicalize.py`):

| `kind` | rule |
|---|---|
| `email` | trim ASCII whitespace, ASCII-lowercase |
| `phone` | keep ASCII digits only; if 11 digits starting `1` (NANP), drop the leading `1` → 10 |
| `name` | ASCII-lowercase, delete ASCII punctuation, collapse ASCII whitespace, trim |
| `postal` | has an ASCII letter → keep `[A-Za-z0-9]` ASCII-upper; else digits, first 5 |

**The parity-critical bit:** every rule uses **ASCII-only primitives** — regexes with *no* Unicode flag, and explicit `A–Z`/`a–z`/`0–9` classes. It deliberately avoids `String.prototype.toLowerCase()` / `.trim()` / `\s` / `\d`, which are Unicode-aware and would diverge from Python's ASCII-only choices (e.g. `"İSTANBUL"` → `"İstanbul"`, not `toLowerCase()`'s `"i̇stanbul"`). Same contract as Python: scalar, total (`null`/`undefined` → `""`), idempotent, locale-independent, dependency-free.

## Tests / parity

`tests/unit/canonicalize.test.ts` copies the input→output pairs **verbatim** from the Python reference tests, so it doubles as the byte-for-byte parity fixture — if the port ever drifts from the spec, a case breaks. 90 canonicalize cases pass; full `goldenflow-js` suite **211 passed**; `tsc --noEmit` + `tsup` build clean. (This package is covered by the monorepo `typescript`/Turbo CI lane.)

Part of #1128 (the Python reference + spec is #1183)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_