### PR TITLE
feat(identity): streaming/micro-batch incremental resolution (#1109)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/streaming.py
+++ b/packages/python/goldenmatch/goldenmatch/core/streaming.py
@@ -162,6 +162,32 @@ class StreamProcessor:
 
         return matches
 
+    def resolve_to_entity(self, record: dict, store, run_name: str = "") -> str | None:
+        """Match + cluster a record AND resolve it to a durable identity (#1109).
+
+        Resolves ``record`` against the CURRENT frame into the identity graph
+        (create / absorb / merge via ``resolve_record_incremental``) BEFORE
+        accumulating it, so it never matches itself; then runs the normal
+        ``process_record`` so later records can match it and run-local clusters /
+        stats stay updated. Returns the ``entity_id`` the record resolved to.
+
+        ``store`` is an ``IdentityStore``; ``source_pk_column`` / ``dataset``
+        come from ``config.identity`` when set. (The identity match and
+        ``process_record``'s match are run separately for v1 simplicity -- a
+        single fused pass is a follow-up.)
+        """
+        from goldenmatch.identity.resolve import resolve_record_incremental
+
+        identity = getattr(self._config, "identity", None)
+        src_pk = getattr(identity, "source_pk_column", None)
+        dataset = getattr(identity, "dataset", None)
+        entity_id = resolve_record_incremental(
+            dict(record), self._df, self._matchkeys, store,
+            run_name=run_name, source_pk_col=src_pk, dataset=dataset,
+        )
+        self.process_record(record)
+        return entity_id
+
     def process_batch(self, records: list[dict]) -> list[list[tuple[int, float]]]:
         """Process a batch of records. Returns matches per record."""
         results = []

--- a/packages/python/goldenmatch/goldenmatch/identity/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/__init__.py
@@ -26,7 +26,12 @@ from goldenmatch.identity.query import (
     manual_merge,
     manual_split,
 )
-from goldenmatch.identity.resolve import ResolveSummary, resolve_clusters
+from goldenmatch.identity.resolve import (
+    ResolveSummary,
+    match_record_to_entity,
+    resolve_clusters,
+    resolve_record_incremental,
+)
 from goldenmatch.identity.store import IdentityStore, new_entity_id
 
 __all__ = [
@@ -40,8 +45,10 @@ __all__ = [
     "list_entities",
     "manual_merge",
     "manual_split",
+    "match_record_to_entity",
     "migrate_record_ids",
     "resolve_clusters",
+    "resolve_record_incremental",
     "EdgeKind",
     "EventKind",
     "EvidenceEdge",

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 import polars as pl
 
 if TYPE_CHECKING:
+    from goldenmatch.config.schemas import MatchkeyConfig
     from goldenmatch.core.cluster import ClusterFrames
     from goldenmatch.core.cluster_pairscores import ClusterPairScores
 
@@ -819,3 +820,233 @@ def resolve_clusters(
 def _node_age(store: IdentityStore, entity_id: str):
     node = store.get_identity(entity_id)
     return node.created_at if node else datetime.now()
+
+
+# ── Streaming / micro-batch incremental resolution (#1109) ───────────────────
+#
+# resolve_clusters runs after a batch dedupe. The two helpers below resolve ONE
+# new record at a time -- the streaming primitive -- without re-running the
+# pipeline. resolve_record_incremental matches the record against the existing
+# frame (match_one) and then DELEGATES the create / absorb / merge decision to
+# resolve_clusters over a mini frame (the new record + only its matched rows),
+# so edges, golden records, events, idempotency, and multi-entity merge behave
+# identically to a batch run -- none of that logic is re-implemented here.
+
+
+def _match_record_rows(
+    record: dict[str, Any],
+    df: pl.DataFrame,
+    matchkeys: list[MatchkeyConfig],
+    *,
+    ann_blocker: Any = None,
+    embedder: Any = None,
+    ann_column: str | None = None,
+    top_k: int = 20,
+    base_store: Any = None,
+) -> dict[int, float]:
+    """Best score per existing ``__row_id__`` the record matches, across all
+    matchkeys.
+
+    Uses ``match_one`` per matchkey, so it covers the threshold-bearing matchkey
+    types (weighted / probabilistic / fuzzy). Exact matchkeys (``threshold is
+    None``) contribute nothing -- ``match_one`` returns ``[]`` for them; an
+    exact-only incremental path is a follow-up. A failing matchkey is skipped
+    (logged), never fatal.
+    """
+    from goldenmatch.core.match_one import match_one
+
+    best: dict[int, float] = {}
+    for mk in matchkeys or []:
+        try:
+            hits = match_one(
+                record, df, mk,
+                ann_blocker=ann_blocker, embedder=embedder,
+                ann_column=ann_column, top_k=top_k, store=base_store,
+            )
+        except Exception:
+            log.warning(
+                "match_one failed for matchkey %r; skipping",
+                getattr(mk, "name", "?"),
+            )
+            continue
+        for row_id, score in hits:
+            irid = int(row_id)
+            if score > best.get(irid, float("-inf")):
+                best[irid] = float(score)
+    return best
+
+
+def match_record_to_entity(
+    record: dict[str, Any],
+    df: pl.DataFrame,
+    matchkeys: list[MatchkeyConfig],
+    store: IdentityStore,
+    *,
+    source_pk_col: str | None = None,
+    ann_blocker: Any = None,
+    embedder: Any = None,
+    ann_column: str | None = None,
+    top_k: int = 20,
+    base_store: Any = None,
+) -> dict[str, float]:
+    """Return ``{entity_id: best_score}`` for existing identities a single record
+    matches -- READ-ONLY (never writes to the store).
+
+    Runs ``match_one`` for each matchkey to find similar existing rows, maps the
+    matched rows to their durable ``record_id``s (the SAME scheme
+    ``resolve_clusters`` uses), and looks those up in the store. The score per
+    entity is the best matching-row score. Returns ``{}`` when nothing matches
+    (or no matched row is yet tracked in the identity store).
+    """
+    matches = _match_record_rows(
+        record, df, matchkeys,
+        ann_blocker=ann_blocker, embedder=embedder,
+        ann_column=ann_column, top_k=top_k, base_store=base_store,
+    )
+    if not matches:
+        return {}
+    matched_rows = df.filter(pl.col("__row_id__").is_in(list(matches.keys())))
+    rowid_to_candidates: dict[int, list[str]] = {}
+    for row in matched_rows.to_dicts():
+        rid = row.get("__row_id__")
+        if rid is None:
+            continue
+        src = str(row.get("__source__", "dataframe"))
+        _, candidates = _record_id_candidates(row, src, source_pk_col)
+        rowid_to_candidates[int(rid)] = candidates
+    all_candidates = sorted(
+        {c for cs in rowid_to_candidates.values() for c in cs}
+    )
+    existing_by_id = (
+        store.lookup_entity_ids(all_candidates) if all_candidates else {}
+    )
+    out: dict[str, float] = {}
+    for rid, score in matches.items():
+        candidates = rowid_to_candidates.get(rid, [])
+        chosen = next((c for c in candidates if c in existing_by_id), None)
+        if chosen is None:
+            continue
+        eid = existing_by_id[chosen]
+        if score > out.get(eid, float("-inf")):
+            out[eid] = score
+    return out
+
+
+def resolve_record_incremental(
+    record: dict[str, Any],
+    df: pl.DataFrame,
+    matchkeys: list[MatchkeyConfig],
+    store: IdentityStore,
+    run_name: str = "",
+    *,
+    source: str | None = None,
+    source_pk_col: str | None = None,
+    dataset: str | None = None,
+    ann_blocker: Any = None,
+    embedder: Any = None,
+    ann_column: str | None = None,
+    top_k: int = 20,
+    base_store: Any = None,
+) -> str | None:
+    """Resolve a single new record to an existing entity or create one.
+
+    The streaming counterpart of :func:`resolve_clusters`: it matches ``record``
+    against ``df`` via ``match_one``, then delegates the create / absorb / merge
+    decision to ``resolve_clusters`` over a MINI frame (the new record + ONLY the
+    matched rows). Reusing the batch resolver means evidence edges, golden
+    records, events, idempotency, and multi-entity merge all behave identically
+    to a batch run -- no resolution logic is re-implemented here.
+
+    Args:
+        record: the new record (field -> value); the same shape as ``df`` rows.
+        df: the existing frame, with a ``__row_id__`` column.
+        matchkeys: the resolved matchkeys to match on (threshold-bearing types).
+        store: the ``IdentityStore`` to read/write.
+        run_name: batch/run name for event idempotency.
+        source: source label for the new record's ``record_id``
+            (default: the record's ``__source__`` or ``"dataframe"``).
+        source_pk_col: natural-PK column name (else a content hash id is used).
+        dataset: optional dataset tag.
+        ann_blocker / embedder / ann_column / top_k / base_store: forwarded to
+            ``match_one`` for ANN-accelerated candidate retrieval.
+
+    Returns:
+        The ``entity_id`` the record resolved to (existing or newly created), or
+        ``None`` if it could not be read back. Never raises on a valid input.
+    """
+    source = source or str(record.get("__source__", "dataframe"))
+    matches = _match_record_rows(
+        record, df, matchkeys,
+        ann_blocker=ann_blocker, embedder=embedder,
+        ann_column=ann_column, top_k=top_k, base_store=base_store,
+    )
+
+    matched_ids = list(matches.keys())
+    if matched_ids:
+        mini = df.filter(pl.col("__row_id__").is_in(matched_ids))
+        existing_rowids = [int(r) for r in mini["__row_id__"].to_list()]
+    else:
+        mini = None
+        existing_rowids = []
+
+    # New record row id: unique within the mini frame (the matched rows keep
+    # their original ids so their record_ids -- and thus their entities -- are
+    # rederived identically).
+    new_rid = (max(existing_rowids) + 1) if existing_rowids else 0
+
+    # Build the new row aligned to df's columns AND dtypes, so the vertical
+    # concat below never up-casts a matched column's dtype -- a dtype shift would
+    # change a no-PK row's payload hash and break its record_id lookup.
+    new_row: dict[str, Any] = {}
+    for col in df.columns:
+        if col == "__row_id__":
+            new_row[col] = new_rid
+        elif col == "__source__":
+            new_row[col] = source
+        elif col.startswith("__"):
+            new_row[col] = None
+        else:
+            new_row[col] = record.get(col)
+    schema = {c: df.schema[c] for c in df.columns}
+    new_row_df = pl.DataFrame([new_row], schema=schema)
+    mini_plus = (
+        pl.concat([mini, new_row_df])
+        if mini is not None and not mini.is_empty()
+        else new_row_df
+    )
+
+    members = [new_rid, *existing_rowids]
+    pair_scores = {
+        (min(new_rid, m), max(new_rid, m)): float(s) for m, s in matches.items()
+    }
+    confidence = min(matches.values()) if matches else None
+    clusters = {
+        0: {
+            "members": members,
+            "size": len(members),
+            "pair_scores": pair_scores,
+            "confidence": confidence,
+        }
+    }
+    scored_pairs = [(new_rid, m, float(s)) for m, s in matches.items()]
+    mk_name = getattr(matchkeys[0], "name", None) if matchkeys else None
+
+    resolve_clusters(
+        clusters=clusters,
+        df=mini_plus,
+        scored_pairs=scored_pairs,
+        matchkey_name=mk_name,
+        store=store,
+        run_name=run_name,
+        dataset=dataset,
+        source_pk_col=source_pk_col,
+        emit_singletons=True,
+        # No weak-conflict edges on a single ingest (there's no bottleneck pair).
+        weak_confidence_threshold=0.0,
+    )
+
+    # Derive the new record's id from the SAME df-aligned row resolve_clusters
+    # saw (record fields absent from df are dropped on both sides), so the
+    # lookup matches what was just written.
+    primary_id, _ = _record_id_candidates(new_row, source, source_pk_col)
+    return store.find_entity_by_record(primary_id)

--- a/packages/python/goldenmatch/tests/identity/test_incremental_resolve.py
+++ b/packages/python/goldenmatch/tests/identity/test_incremental_resolve.py
@@ -1,0 +1,180 @@
+"""Streaming / micro-batch incremental identity resolution (#1109).
+
+`resolve_record_incremental` resolves ONE new record at a time -- matching it
+against the existing frame and then create/absorb/merge into the durable
+identity graph -- without re-running the batch pipeline. `match_record_to_entity`
+is the read-only "which entity would this match" companion.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.identity import (
+    IdentityStore,
+    match_record_to_entity,
+    resolve_clusters,
+    resolve_record_incremental,
+)
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = IdentityStore(path=str(tmp_path / "identity.db"))
+    yield s
+    s.close()
+
+
+def _df(rows):
+    out = []
+    for i, r in enumerate(rows):
+        rec = {"__row_id__": i, "__source__": "src"}
+        rec.update(r)
+        out.append(rec)
+    return pl.DataFrame(out)
+
+
+# A weighted matchkey on `name` -- match_one needs a threshold-bearing matchkey.
+MK = MatchkeyConfig(
+    name="mk",
+    type="weighted",
+    threshold=0.8,
+    fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+)
+
+
+@pytest.fixture()
+def base(store):
+    """Two records already resolved into the graph: Alice (src:1), Bob (src:2)."""
+    df = _df([{"id": "1", "name": "Alice"}, {"id": "2", "name": "Bob"}])
+    resolve_clusters(
+        {0: {"members": [0], "size": 1, "pair_scores": {}, "confidence": 1.0},
+         1: {"members": [1], "size": 1, "pair_scores": {}, "confidence": 1.0}},
+        df, [], "mk", store, run_name="batch", source_pk_col="id",
+    )
+    return df
+
+
+def test_creates_new_entity_when_nothing_matches(store, base):
+    before = store.count_identities()
+    eid = resolve_record_incremental(
+        {"id": "9", "name": "Zoe", "__source__": "src"}, base, [MK], store,
+        run_name="stream", source_pk_col="id",
+    )
+    assert eid is not None
+    assert store.count_identities() == before + 1
+    assert store.find_entity_by_record("src:9") == eid
+
+
+def test_absorbs_into_existing_entity_on_match(store, base):
+    alice = store.find_entity_by_record("src:1")
+    before = store.count_identities()
+    eid = resolve_record_incremental(
+        {"id": "3", "name": "Alice", "__source__": "src"}, base, [MK], store,
+        run_name="stream", source_pk_col="id",
+    )
+    # Resolved INTO Alice's entity, no new identity minted.
+    assert eid == alice
+    assert store.count_identities() == before
+    assert store.find_entity_by_record("src:3") == alice
+
+
+def test_match_record_to_entity_is_read_only(store, base):
+    alice = store.find_entity_by_record("src:1")
+    before = store.count_identities()
+    hits = match_record_to_entity(
+        {"id": "5", "name": "Alice"}, base, [MK], store, source_pk_col="id",
+    )
+    assert alice in hits
+    assert hits[alice] >= 0.8
+    # Nothing was written.
+    assert store.count_identities() == before
+    assert store.find_entity_by_record("src:5") is None
+
+
+def test_match_record_to_entity_empty_when_no_match(store, base):
+    assert match_record_to_entity(
+        {"id": "5", "name": "Zoe"}, base, [MK], store, source_pk_col="id",
+    ) == {}
+
+
+def test_idempotent_reingest_same_record(store, base):
+    before = store.count_identities()
+    e1 = resolve_record_incremental(
+        {"id": "7", "name": "Carol"}, base, [MK], store,
+        run_name="s1", source_pk_col="id",
+    )
+    after_first = store.count_identities()
+    e2 = resolve_record_incremental(
+        {"id": "7", "name": "Carol"}, base, [MK], store,
+        run_name="s1", source_pk_col="id",
+    )
+    assert e1 == e2
+    assert after_first == before + 1
+    # Re-ingesting the same record_id absorbs into its own entity, no new mint.
+    assert store.count_identities() == after_first
+
+
+def test_bootstraps_on_empty_base(store):
+    """First record into an empty frame creates the first identity."""
+    empty = pl.DataFrame(
+        {"__row_id__": [], "__source__": [], "id": [], "name": []},
+        schema={"__row_id__": pl.Int64, "__source__": pl.Utf8,
+                "id": pl.Utf8, "name": pl.Utf8},
+    )
+    eid = resolve_record_incremental(
+        {"id": "1", "name": "Alice", "__source__": "src"}, empty, [MK], store,
+        run_name="stream", source_pk_col="id",
+    )
+    assert eid is not None
+    assert store.count_identities() == 1
+    assert store.find_entity_by_record("src:1") == eid
+
+
+def test_stream_processor_resolves_to_entity(store, base):
+    """StreamProcessor.resolve_to_entity wires the streaming path into the
+    identity graph: it absorbs a match AND accumulates the record."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        IdentityConfig,
+    )
+    from goldenmatch.core.streaming import StreamProcessor
+
+    cfg = GoldenMatchConfig(
+        matchkeys=[MK],
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["name"])]
+        ),
+        identity=IdentityConfig(source_pk_column="id"),
+    )
+    alice = store.find_entity_by_record("src:1")
+    sp = StreamProcessor(base, cfg)
+    before_rows = sp.data.height
+
+    eid = sp.resolve_to_entity(
+        {"id": "3", "name": "Alice", "__source__": "src"}, store, run_name="stream",
+    )
+    assert eid == alice
+    # The record was accumulated so later records can match it.
+    assert sp.data.height == before_rows + 1
+    assert sp.stats.records_processed == 1
+
+
+def test_no_pk_content_hash_record_resolves(store):
+    """Without a source PK, the content-hash record_id round-trips correctly
+    (the dtype-aligned mini-frame keeps the matched row's payload hash stable)."""
+    df = _df([{"name": "Alice"}])
+    resolve_clusters(
+        {0: {"members": [0], "size": 1, "pair_scores": {}, "confidence": 1.0}},
+        df, [], "mk", store, run_name="batch",
+    )
+    assert store.count_identities() == 1
+    eid = resolve_record_incremental(
+        {"name": "Alice"}, df, [MK], store, run_name="stream",
+    )
+    # Same content -> matched and absorbed into the single existing identity
+    # (no second identity minted -> the no-PK record_id round-tripped).
+    assert eid is not None
+    assert store.count_identities() == 1


### PR DESCRIPTION
## Why

Identity Graph v2 is batch-only: `resolve_clusters` runs after a full dedupe. This adds the **streaming primitive** — resolve one record at a time into the durable identity graph, in near-real-time, without re-running the pipeline. (Phase 1 of epic #1108.)

## What

Two new functions in `identity/resolve.py`, exported from `goldenmatch.identity`:

- **`match_record_to_entity(record, df, matchkeys, store, ...) -> {entity_id: best_score}`** — read-only "which entity would this match". Runs `match_one` per matchkey, maps matched rows → their durable `record_id`s (the same scheme `resolve_clusters` uses) → store entities.
- **`resolve_record_incremental(record, df, matchkeys, store, ...) -> entity_id`** — match **+ create/absorb/merge**, returns the resolved `entity_id`.

The key design choice: `resolve_record_incremental` **delegates the create/absorb/merge decision to `resolve_clusters`** over a *mini frame* (the new record + only its matched rows), rather than reimplementing it. So evidence edges, golden records, events, idempotency, and multi-entity merge all behave **identically to a batch run** — zero duplicated resolution logic. The mini frame is dtype-aligned to the base so a no-PK row's content hash (hence its `record_id`) stays stable through the concat.

And the wiring the issue asks for:
- **`StreamProcessor.resolve_to_entity(record, store, run_name)`** — resolves against the current frame *before* accumulating the record (so it never self-matches), then runs the normal `process_record` for cluster/frame/stats.

**Scope note:** matching covers threshold-bearing matchkeys (weighted / probabilistic / fuzzy) — `match_one` returns `[]` for exact matchkeys, so an exact-only incremental path is a documented follow-up.

## Tests

8 new tests in `tests/identity/test_incremental_resolve.py`: brand-new entity, absorb-into-existing on match, read-only `match_record_to_entity`, idempotent re-ingest, empty-base bootstrap, no-PK content-hash round-trip, and the `StreamProcessor` wiring. Full identity + streaming suites: **104 passed, 6 skipped** (one pre-existing collection error in `test_cross_surface_contract.py` from a missing `httpx2` dev dep, unrelated). ruff clean.

Closes #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_