### PR TITLE
feat(retrieval): semantic retrieve_similar_records API (#1089)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -214,6 +214,7 @@ from goldenmatch.core.recall_certificate import (
     certify_recall_df,
     estimate_recall,
 )
+from goldenmatch.core.retrieval import RetrievedRecord, retrieve_similar_records
 from goldenmatch.core.review_queue import ReviewQueue, gate_pairs
 from goldenmatch.core.rollback import rollback_run
 
@@ -333,6 +334,7 @@ __all__ = [
     "match_one", "StreamProcessor", "run_stream",
     "screen_record", "screen_records",
     "ScreeningResult", "ScreeningHit", "FieldReason",
+    "retrieve_similar_records", "RetrievedRecord",
     # Evaluation
     "evaluate_pairs", "evaluate_clusters", "load_ground_truth_csv", "EvalResult",
     "RecallEstimate", "RecallCertificate", "estimate_recall", "certify_recall_df",

--- a/packages/python/goldenmatch/goldenmatch/core/retrieval.py
+++ b/packages/python/goldenmatch/goldenmatch/core/retrieval.py
@@ -1,0 +1,135 @@
+"""Semantic retrieval -- find records similar to a query string (#1089).
+
+The public retrieval surface over the vector machinery: embed a query, embed a
+column of a frame, and return the top-K most similar records with cosine scores.
+This is the read side of the RAG entity-canonicalization epic (#1087) -- an
+agent or app can semantically fetch candidate records by free-text query without
+running a full dedupe.
+
+Built entirely on existing primitives -- ``get_embedder`` (any provider; the
+zero-config ``"inhouse"`` model needs no cloud/torch) and ``ANNBlocker`` (FAISS
+with a byte-identical numpy fallback) -- so it adds no new dependency and has
+zero impact on the dedupe/blocking pipeline.
+
+Scope: this is the in-memory retrieval API (embed-then-ANN over the supplied
+frame). A PERSISTENT vector index that survives across runs (#1088) and the
+MCP / A2A / REST surfaces (#1089's exposure half) are follow-ups -- they will
+call this same function / result shape.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import polars as pl
+
+from goldenmatch.core.ann_blocker import ANNBlocker
+from goldenmatch.core.embedder import get_embedder
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RetrievedRecord:
+    """One record returned by ``retrieve_similar_records``."""
+
+    row_id: int
+    score: float
+    record: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "row_id": self.row_id,
+            "score": round(self.score, 4),
+            "record": self.record,
+        }
+
+
+def retrieve_similar_records(
+    df: pl.DataFrame,
+    query: str,
+    column: str,
+    *,
+    k: int = 20,
+    model: str = "inhouse",
+    threshold: float = 0.0,
+    filters: dict[str, Any] | None = None,
+    embedder: Any = None,
+) -> list[RetrievedRecord]:
+    """Retrieve the top-``k`` records in ``df`` most similar to ``query``.
+
+    Args:
+        df: the corpus frame. ``__row_id__`` is used for the returned id when
+            present; otherwise the row's position is used.
+        query: the free-text query to embed and search for.
+        column: the column of ``df`` to embed as the corpus.
+        k: maximum number of records to return (ranked by similarity desc).
+        model: embedder id passed to ``get_embedder`` -- ``"inhouse"`` (default,
+            local + deterministic, no cloud/torch), ``"all-MiniLM-L6-v2"``,
+            ``"inhouse:<path>"``, a Vertex/OpenAI model, etc.
+        threshold: minimum cosine similarity in ``[-1, 1]`` a record must reach.
+        filters: optional ``{column: value}`` equality predicates applied to
+            ``df`` BEFORE embedding (metadata pre-filter). A filter on a column
+            not in ``df`` yields no results.
+        embedder: an explicit embedder object (must expose
+            ``embed_column(values, cache_key) -> np.ndarray``); overrides
+            ``model``. Handy for tests and custom providers.
+
+    Returns:
+        ``list[RetrievedRecord]`` ranked highest-similarity first. Empty when the
+        query is blank, the frame (or filtered frame) is empty, or nothing clears
+        ``threshold``.
+
+    Raises:
+        ValueError: if ``column`` is not in ``df``.
+    """
+    if column not in df.columns:
+        raise ValueError(
+            f"retrieve_similar_records: column {column!r} not in dataframe "
+            f"(have {df.columns})"
+        )
+    if not query or df.is_empty():
+        return []
+
+    work = df
+    if filters:
+        cond: pl.Expr | None = None
+        for col, val in filters.items():
+            if col not in work.columns:
+                return []
+            pred = pl.col(col) == val
+            cond = pred if cond is None else (cond & pred)
+        if cond is not None:
+            work = work.filter(cond)
+    if work.is_empty():
+        return []
+
+    emb = embedder if embedder is not None else get_embedder(model)
+    values = ["" if v is None else str(v) for v in work[column].to_list()]
+    try:
+        corpus = emb.embed_column(values, cache_key=f"retrieve:{column}:{hash(tuple(values))}")
+        q_vec = emb.embed_column([str(query)], cache_key=f"retrieve_q:{hash(str(query))}")
+    except Exception:
+        logger.warning("retrieve_similar_records: embedding failed", exc_info=True)
+        return []
+
+    blocker = ANNBlocker(top_k=k)
+    blocker.build_index(corpus)
+    neighbors = blocker.query_one(q_vec[0])  # [(position, cosine_score), ...] desc
+
+    if "__row_id__" in work.columns:
+        row_ids = [int(r) for r in work["__row_id__"].to_list()]
+    else:
+        row_ids = list(range(work.height))
+    rows = work.to_dicts()
+
+    out: list[RetrievedRecord] = []
+    for pos, score in neighbors:
+        if score < threshold:
+            continue
+        if pos < 0 or pos >= work.height:
+            continue
+        record = {k2: v2 for k2, v2 in rows[pos].items() if not k2.startswith("__")}
+        out.append(RetrievedRecord(row_id=row_ids[pos], score=float(score), record=record))
+    return out

--- a/packages/python/goldenmatch/tests/test_retrieval.py
+++ b/packages/python/goldenmatch/tests/test_retrieval.py
@@ -1,0 +1,122 @@
+"""Semantic retrieval API (#1089).
+
+Exercised with the zero-config in-house embedder (deterministic, no torch /
+cloud) + ANNBlocker's numpy fallback, so it runs anywhere. Identical strings
+embed to identical unit vectors, so an exact-text query scores ~1.0 against its
+row -- a robust deterministic anchor regardless of the (untrained) projection.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.core.retrieval import RetrievedRecord, retrieve_similar_records
+
+
+def _corpus():
+    return pl.DataFrame({
+        "__row_id__": [10, 11, 12],
+        "title": [
+            "red apple pie recipe",
+            "blue car engine repair",
+            "green apple tart bake",
+        ],
+        "cat": ["food", "auto", "food"],
+    })
+
+
+def test_exact_text_query_ranks_its_row_first():
+    res = retrieve_similar_records(_corpus(), "blue car engine repair", "title", k=3)
+    assert res
+    assert isinstance(res[0], RetrievedRecord)
+    assert res[0].row_id == 11
+    assert res[0].score == pytest.approx(1.0, abs=1e-4)
+    # The record payload drops internal columns.
+    assert res[0].record["cat"] == "auto"
+    assert "__row_id__" not in res[0].record
+
+
+def test_threshold_keeps_only_strong_matches():
+    res = retrieve_similar_records(
+        _corpus(), "blue car engine repair", "title", k=3, threshold=0.999,
+    )
+    assert len(res) == 1
+    assert res[0].row_id == 11
+
+
+def test_k_caps_results():
+    res = retrieve_similar_records(_corpus(), "apple", "title", k=1)
+    assert len(res) <= 1
+
+
+def test_filters_prefilter_before_embedding():
+    # Restrict to food rows: the car row (11) is filtered out BEFORE embedding,
+    # so even a car-text query can never return it. threshold=-1.0 keeps every
+    # filtered row, proving exclusion is by the filter, not by a low score.
+    res = retrieve_similar_records(
+        _corpus(), "blue car engine repair", "title", k=5,
+        filters={"cat": "food"}, threshold=-1.0,
+    )
+    assert {r.row_id for r in res} == {10, 12}
+    assert all(r.record["cat"] == "food" for r in res)
+
+
+def test_filter_on_missing_value_yields_nothing():
+    res = retrieve_similar_records(
+        _corpus(), "apple", "title", filters={"cat": "nonexistent"},
+    )
+    assert res == []
+
+
+def test_blank_query_and_empty_frame_return_empty():
+    assert retrieve_similar_records(_corpus(), "", "title") == []
+    empty = pl.DataFrame({"__row_id__": [], "title": []},
+                         schema={"__row_id__": pl.Int64, "title": pl.Utf8})
+    assert retrieve_similar_records(empty, "apple", "title") == []
+
+
+def test_missing_column_raises():
+    with pytest.raises(ValueError):
+        retrieve_similar_records(_corpus(), "apple", "nope")
+
+
+def test_numpy_fallback_matches(monkeypatch):
+    # Force the no-FAISS path; the exact-text query must still rank its row first.
+    monkeypatch.setattr(
+        "goldenmatch.core.ann_blocker._HAS_FAISS", False, raising=False,
+    )
+    res = retrieve_similar_records(_corpus(), "red apple pie recipe", "title", k=3)
+    assert res[0].row_id == 10
+    assert res[0].score == pytest.approx(1.0, abs=1e-4)
+
+
+def test_no_row_id_column_uses_position():
+    df = pl.DataFrame({"title": ["alpha widget", "beta gadget"]})
+    res = retrieve_similar_records(df, "beta gadget", "title", k=2)
+    assert res[0].row_id == 1  # position of "beta gadget"
+
+
+def test_explicit_embedder_is_used():
+    import numpy as np
+
+    class StubEmbedder:
+        # Maps each distinct text to a fixed unit vector; "match" aligns with row 1.
+        def embed_column(self, values, cache_key):
+            table = {
+                "match": np.array([1.0, 0.0]),
+                "a": np.array([0.0, 1.0]),
+                "b": np.array([1.0, 0.0]),
+            }
+            return np.array([table.get(v, np.array([0.0, 0.0])) for v in values])
+
+    df = pl.DataFrame({"__row_id__": [0, 1], "title": ["a", "b"]})
+    res = retrieve_similar_records(df, "match", "title", k=2, embedder=StubEmbedder())
+    assert res[0].row_id == 1
+    assert res[0].score == pytest.approx(1.0, abs=1e-6)
+
+
+def test_result_as_dict_serializable():
+    import json
+
+    res = retrieve_similar_records(_corpus(), "green apple tart bake", "title")
+    blob = json.dumps([r.as_dict() for r in res])
+    assert "row_id" in blob and "score" in blob


### PR DESCRIPTION
## Why

The RAG entity-canonicalization epic (#1087) starts with embedders, a FAISS `ANNBlocker`, and vector scoring all present — but there's **no retrieval API**: nothing an agent or app can call to "fetch the records semantically similar to this query." This adds that read surface (#1089).

## What

`goldenmatch/core/retrieval.py`:

- **`retrieve_similar_records(df, query, column, *, k=20, model="inhouse", threshold=0.0, filters=None, embedder=None) -> list[RetrievedRecord]`** — embeds the query and the chosen column, runs top-K ANN, returns records ranked by cosine similarity.
- **`RetrievedRecord(row_id, score, record)`** with `.as_dict()` for serialization.

Built entirely on existing primitives — `get_embedder` (any provider; the zero-config **`"inhouse"`** model needs no cloud/torch) and `ANNBlocker` (FAISS with a byte-identical numpy fallback) — so it adds **no new dependency** and has **zero impact** on the dedupe/blocking pipeline. `filters` is an equality metadata pre-filter applied *before* embedding; an explicit `embedder` object can be injected for tests/custom providers. Exported from the package root (`gm.retrieve_similar_records`).

**Scope:** in-memory retrieval over the supplied frame. A **persistent** vector index that survives across runs (#1088) and the **MCP / A2A / REST** exposure are follow-ups — they'll call this same function and `RetrievedRecord` shape.

## Tests

11 tests in `tests/test_retrieval.py`, **fully deterministic and offline** (the in-house embedder + numpy ANN fallback — `import torch` hangs in CI, so this matters): exact-text query anchors at score ~1.0 against its row, threshold floor, `k` cap, metadata `filters` pre-filtering (proven to exclude before embedding), missing-column raises, blank-query/empty-frame, no-`__row_id__` falls back to position, injected stub embedder, forced numpy fallback (`_HAS_FAISS=False`), and JSON-serializable results. ruff clean.

Part of #1089 (epic #1087)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_