### PR TITLE
feat(rag): entity-aware RAG surface — retrieve, resolve, canonicalize (#1092)

### DIFF
--- a/packages/python/goldenmatch/examples/rag_entity_dedup.py
+++ b/packages/python/goldenmatch/examples/rag_entity_dedup.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Entity-aware RAG -- collapse duplicate / contradictory facts before the LLM (#1092).
+
+A knowledge base holds several near-duplicate, partly-conflicting facts about the
+same companies (different spellings, missing fields, disagreeing values). A naive
+RAG retriever would hand the LLM every matching chunk -- duplicates and
+contradictions included. ``entity_aware_retrieve`` instead:
+
+    retrieve  ->  resolve to entities (dedupe)  ->  conflict-aware fact merge
+
+so the model sees ONE reconciled record per real-world entity, each field tagged
+with the source it came from.
+
+Zero cloud: the in-house embedder + deterministic most-complete merge run with no
+network or torch. Pass ``llm_call=`` / ``budget=`` to let an LLM reconcile
+borderline fields instead.
+"""
+import goldenmatch as gm
+import polars as pl
+
+# A knowledge base with duplicate + conflicting facts.
+kb = pl.DataFrame(
+    {
+        "company": [
+            "Acme Corp",
+            "Acme Corp",          # dup spelling, fills the missing CEO
+            "Acme Corp",          # dup spelling, adds revenue
+            "Globex",
+            "Globex",             # dup, fills founded year
+            "Initech",
+        ],
+        "ceo": [
+            "Jane Doe",
+            "Jane A. Doe",        # more complete name
+            None,
+            "John Smith",
+            "John Smith",
+            "Bill Lumbergh",
+        ],
+        "founded": ["1999", "1999", "1999", None, "2005", "1998"],
+        "revenue": [None, None, "$10M", "$50M", "$50M", "$2M"],
+    }
+)
+
+print(f"Knowledge base: {kb.height} raw facts\n")
+
+# Retrieve everything about "Acme" and reconcile it into entities.
+# exact=["company"] resolves rows that share a company name into one entity;
+# threshold=-1.0 keeps every retrieved row so the demo focuses on the merge.
+result = gm.entity_aware_retrieve(
+    kb,
+    query="Acme Corp",
+    column="company",
+    exact=["company"],
+    threshold=-1.0,
+    k=10,
+)
+
+print(
+    f"Retrieved {result.retrieved} raw records -> {result.n_entities} distinct "
+    f"entities ({result.collapsed} duplicate/contradictory records collapsed "
+    f"out of the LLM context)\n"
+)
+
+for e in result:
+    print(f"Entity #{e.entity_id}  (merged from {e.size} record(s), "
+          f"best similarity {e.score:.3f})")
+    for field_name, value in e.record.items():
+        prov = e.canonical.provenance.get(field_name)
+        src = "synthesized" if prov is None or prov.source_index is None \
+            else f"record {prov.source_index}"
+        print(f"    {field_name:<8} = {str(value):<14} (from {src})")
+    print()
+
+print(
+    f"The LLM now sees {result.n_entities} clean entities instead of "
+    f"{result.retrieved} noisy rows."
+)

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -206,6 +206,11 @@ from goldenmatch.core.probabilistic import score_probabilistic, train_em
 
 # ── Profiling ────────────────────────────────────────────────────────────
 from goldenmatch.core.profiler import profile_dataframe
+from goldenmatch.core.rag_surface import (
+    Entity,
+    EntityRetrievalResult,
+    entity_aware_retrieve,
+)
 
 # ── Recall certificate (unsupervised) ────────────────────────────────────
 from goldenmatch.core.recall_certificate import (
@@ -336,6 +341,7 @@ __all__ = [
     "screen_record", "screen_records",
     "ScreeningResult", "ScreeningHit", "FieldReason",
     "retrieve_similar_records", "RetrievedRecord",
+    "entity_aware_retrieve", "Entity", "EntityRetrievalResult",
     # Evaluation
     "evaluate_pairs", "evaluate_clusters", "load_ground_truth_csv", "EvalResult",
     "RecallEstimate", "RecallCertificate", "estimate_recall", "certify_recall_df",

--- a/packages/python/goldenmatch/goldenmatch/core/rag_surface.py
+++ b/packages/python/goldenmatch/goldenmatch/core/rag_surface.py
@@ -1,0 +1,268 @@
+"""Entity-aware RAG surface -- collapse retrieved records into canonical entities (#1092).
+
+Composes the read side (semantic retrieval, #1089) with the write side
+(LLM/deterministic canonicalization, #1091) into one call an agent or RAG
+pipeline can reach for:
+
+    retrieve  ->  resolve to entities (dedupe)  ->  conflict-aware fact merge
+
+Instead of handing the LLM a long list of duplicate / contradictory raw chunks,
+``entity_aware_retrieve`` returns a SHORT list of distinct entities -- each one a
+single canonical record reconciled from its duplicates, with per-cell provenance
+(which retrieved record each field came from). Fewer, cleaner, non-contradictory
+entities reach the model's context window.
+
+Built entirely on existing primitives -- ``retrieve_similar_records`` (#1089),
+``dedupe_df`` (the core resolver), and ``canonicalize_cluster`` (#1091) -- so it
+adds no new dependency and has zero impact on the dedupe/blocking pipeline.
+
+Zero cloud by default: the in-house embedder + deterministic most-complete
+canonicalization need no network or torch. Supply ``llm_call`` / ``budget`` to
+let an LLM reconcile borderline fields, and ``exact`` / ``fuzzy`` / ``blocking``
+to steer how retrieved records resolve into entities (zero-config when omitted).
+
+The resolve step never raises: if dedupe degrades on a pathological tiny frame,
+each retrieved record falls back to its own entity (an honest no-op), so the
+surface is always total -- safe to wire into a pipeline.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import polars as pl
+
+from goldenmatch.core.llm_canonicalize import CanonicalRecord, canonicalize_cluster
+from goldenmatch.core.retrieval import RetrievedRecord, retrieve_similar_records
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Entity:
+    """One resolved entity: a canonical record + the retrieved records it absorbed."""
+
+    entity_id: int
+    canonical: CanonicalRecord
+    members: list[RetrievedRecord] = field(default_factory=list)
+    score: float = 0.0  # best (max) retrieval similarity among the members
+
+    @property
+    def size(self) -> int:
+        """How many retrieved records collapsed into this entity."""
+        return len(self.members)
+
+    @property
+    def record(self) -> dict[str, Any]:
+        """The canonical (conflict-merged) record for the entity."""
+        return self.canonical.record
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "entity_id": self.entity_id,
+            "score": round(self.score, 4),
+            "size": self.size,
+            "canonical": self.canonical.as_dict(),
+            "members": [m.as_dict() for m in self.members],
+        }
+
+
+@dataclass
+class EntityRetrievalResult:
+    """The entity-aware retrieval result: distinct entities + the dedup headline.
+
+    Iterable and sized over its ``entities`` for ergonomic use
+    (``for e in result`` / ``len(result)``).
+    """
+
+    entities: list[Entity] = field(default_factory=list)
+    retrieved: int = 0  # raw records retrieved before resolution
+    n_entities: int = 0  # distinct entities after resolution
+    collapsed: int = 0  # retrieved - n_entities (duplicates removed from context)
+    method: str = "deterministic"  # "llm" if any entity was canonicalized by an LLM
+
+    def __iter__(self):
+        return iter(self.entities)
+
+    def __len__(self) -> int:
+        return len(self.entities)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "retrieved": self.retrieved,
+            "n_entities": self.n_entities,
+            "collapsed": self.collapsed,
+            "method": self.method,
+            "entities": [e.as_dict() for e in self.entities],
+        }
+
+
+def _resolve_hits(
+    hits: list[RetrievedRecord],
+    *,
+    exact: list[str] | None,
+    fuzzy: dict[str, float] | None,
+    blocking: list[str] | None,
+    dedupe_threshold: float | None,
+    config: Any | None,
+) -> list[list[RetrievedRecord]]:
+    """Group retrieved records into entities by running the core resolver.
+
+    Returns one list of member ``RetrievedRecord`` per entity. Degrades to one
+    entity per record if dedupe can't run (so the surface never raises).
+    """
+    if len(hits) <= 1:
+        return [[h] for h in hits]
+
+    # Build a frame from the retrieved records; the row position is the id the
+    # resolver reports back in each cluster's members.
+    rows = [dict(h.record) for h in hits]
+    frame = pl.DataFrame(rows).with_columns(
+        pl.Series("__row_id__", list(range(len(hits))), dtype=pl.Int64)
+    )
+
+    try:
+        from goldenmatch import dedupe_df
+
+        result = dedupe_df(
+            frame,
+            config=config,
+            exact=exact,
+            fuzzy=fuzzy,
+            blocking=blocking,
+            threshold=dedupe_threshold,
+        )
+        clusters = result.clusters or {}
+    except Exception:
+        logger.warning(
+            "entity_aware_retrieve: resolve step failed; each record is its own "
+            "entity",
+            exc_info=True,
+        )
+        return [[h] for h in hits]
+
+    groups: list[list[RetrievedRecord]] = []
+    covered: set[int] = set()
+    for info in clusters.values():
+        members = info.get("members") if isinstance(info, dict) else None
+        if not members:
+            continue
+        idxs = sorted({int(m) for m in members if 0 <= int(m) < len(hits)})
+        if not idxs:
+            continue
+        covered.update(idxs)
+        groups.append([hits[i] for i in idxs])
+
+    # Any retrieved record not in a multi-member cluster is its own entity.
+    for i, h in enumerate(hits):
+        if i not in covered:
+            groups.append([h])
+    return groups
+
+
+def entity_aware_retrieve(
+    df: pl.DataFrame,
+    query: str,
+    column: str,
+    *,
+    k: int = 20,
+    model: str = "inhouse",
+    threshold: float = 0.0,
+    filters: dict[str, Any] | None = None,
+    embedder: Any = None,
+    exact: list[str] | None = None,
+    fuzzy: dict[str, float] | None = None,
+    blocking: list[str] | None = None,
+    dedupe_threshold: float | None = None,
+    config: Any | None = None,
+    fields: list[str] | None = None,
+    llm_call: Any = None,
+    budget: Any = None,
+    canon_model: str = "gpt-4o-mini",
+) -> EntityRetrievalResult:
+    """Retrieve, resolve, and canonicalize -- the entity-aware RAG surface.
+
+    Semantically retrieves the top-``k`` records similar to ``query``, resolves
+    them into distinct entities (dedupe), and merges each entity's facts into one
+    canonical record with provenance. Returns fewer, conflict-reconciled entities
+    than raw retrieval would -- the records an LLM should actually see.
+
+    Args:
+        df: the corpus frame.
+        query: free-text query to embed and search for.
+        column: the column of ``df`` to embed + the text to resolve on.
+        k: max records to retrieve before resolution.
+        model: embedder id for retrieval (default ``"inhouse"`` -- local,
+            deterministic, no cloud/torch).
+        threshold: minimum cosine similarity a retrieved record must reach.
+        filters: optional ``{column: value}`` equality pre-filter (metadata),
+            applied before embedding.
+        embedder: explicit embedder object (overrides ``model``; for tests).
+        exact: exact-match columns for the resolve step (passed to ``dedupe_df``).
+        fuzzy: ``{column: threshold}`` fuzzy-match config for the resolve step.
+        blocking: blocking columns for the resolve step.
+        dedupe_threshold: override fuzzy threshold for the resolve step.
+        config: an explicit ``GoldenMatchConfig`` for the resolve step (wins over
+            ``exact`` / ``fuzzy``). When all resolve config is omitted, dedupe is
+            zero-config (auto-configured).
+        fields: which fields to canonicalize per entity (default: all non-internal).
+        llm_call: optional ``llm_call(prompt) -> (text, in_tok, out_tok)`` to let
+            an LLM reconcile each entity's fields; deterministic most-complete
+            merge when omitted.
+        budget: optional ``BudgetTracker`` gating the LLM canonicalization.
+        canon_model: LLM model id for canonicalization + budget accounting.
+
+    Returns:
+        An ``EntityRetrievalResult`` -- the distinct ``entities`` (ranked by best
+        member similarity) plus ``retrieved`` / ``n_entities`` / ``collapsed``
+        counts. Never raises on valid input.
+    """
+    hits = retrieve_similar_records(
+        df,
+        query,
+        column,
+        k=k,
+        model=model,
+        threshold=threshold,
+        filters=filters,
+        embedder=embedder,
+    )
+    if not hits:
+        return EntityRetrievalResult(entities=[], retrieved=0, n_entities=0, collapsed=0)
+
+    groups = _resolve_hits(
+        hits,
+        exact=exact,
+        fuzzy=fuzzy,
+        blocking=blocking,
+        dedupe_threshold=dedupe_threshold,
+        config=config,
+    )
+
+    entities: list[Entity] = []
+    any_llm = False
+    for group in groups:
+        canonical = canonicalize_cluster(
+            [g.record for g in group],
+            fields=fields,
+            llm_call=llm_call,
+            budget=budget,
+            model=canon_model,
+        )
+        any_llm = any_llm or canonical.method == "llm"
+        best = max((g.score for g in group), default=0.0)
+        entities.append(Entity(entity_id=-1, canonical=canonical, members=group, score=best))
+
+    # Rank entities by best member similarity (stable), then assign ids by rank.
+    entities.sort(key=lambda e: e.score, reverse=True)
+    for rank, e in enumerate(entities):
+        e.entity_id = rank
+
+    return EntityRetrievalResult(
+        entities=entities,
+        retrieved=len(hits),
+        n_entities=len(entities),
+        collapsed=len(hits) - len(entities),
+        method="llm" if any_llm else "deterministic",
+    )

--- a/packages/python/goldenmatch/tests/test_rag_surface.py
+++ b/packages/python/goldenmatch/tests/test_rag_surface.py
@@ -1,0 +1,163 @@
+"""Entity-aware RAG surface (#1092).
+
+retrieve -> resolve to entities -> conflict-aware fact merge. All deterministic
+and offline: the in-house embedder + numpy ANN fallback + deterministic
+canonicalization need no network or torch. ``threshold=-1.0`` retrieves the whole
+(filtered) frame so the test asserts the RESOLVE + MERGE composition, not the
+similarity ranking (covered in test_retrieval.py).
+"""
+from __future__ import annotations
+
+import json
+
+import goldenmatch as gm
+import polars as pl
+import pytest
+from goldenmatch.core.rag_surface import (
+    Entity,
+    EntityRetrievalResult,
+    entity_aware_retrieve,
+)
+
+KB = pl.DataFrame(
+    {
+        # two "acme" rows are duplicates (exact name); "globex" is distinct.
+        "name": ["acme", "acme", "globex"],
+        "ceo": ["Jane Doe", "Jane A. Doe", "John Smith"],
+        "phone": [None, "555-1234", "555-9999"],
+    }
+)
+
+
+def _stub_llm(payload: dict):
+    return lambda prompt: (json.dumps(payload), 100, 30)
+
+
+# ── collapse + conflict-aware merge ──────────────────────────────────────────
+
+
+def test_collapses_duplicates_into_fewer_entities():
+    res = entity_aware_retrieve(KB, "acme", "name", exact=["name"], threshold=-1.0, k=10)
+    assert isinstance(res, EntityRetrievalResult)
+    assert res.retrieved == 3
+    assert res.n_entities == 2
+    assert res.collapsed == 1  # one duplicate removed from the LLM context
+    assert res.method == "deterministic"
+
+
+def test_conflict_aware_fact_merge_with_provenance():
+    res = entity_aware_retrieve(KB, "acme", "name", exact=["name"], threshold=-1.0, k=10)
+    acme = next(e for e in res if e.record["name"] == "acme")
+    assert acme.size == 2
+    # most-complete value wins per field; the null phone is filled from member 1.
+    assert acme.record["ceo"] == "Jane A. Doe"
+    assert acme.record["phone"] == "555-1234"
+    assert acme.canonical.provenance["phone"].source_index == 1
+
+
+def test_entities_ranked_by_best_member_similarity():
+    res = entity_aware_retrieve(KB, "acme", "name", exact=["name"], threshold=-1.0, k=10)
+    scores = [e.score for e in res]
+    assert scores == sorted(scores, reverse=True)
+    assert [e.entity_id for e in res] == list(range(len(res)))
+    # the acme cluster (exact query hit) ranks first.
+    assert res.entities[0].record["name"] == "acme"
+
+
+def test_all_distinct_records_stay_separate():
+    df = pl.DataFrame({"name": ["alpha", "beta", "gamma"], "v": [1, 2, 3]})
+    res = entity_aware_retrieve(df, "alpha", "name", exact=["name"], threshold=-1.0, k=10)
+    assert res.retrieved == 3
+    assert res.n_entities == 3
+    assert res.collapsed == 0
+    assert all(e.size == 1 for e in res)
+
+
+# ── retrieval edges ──────────────────────────────────────────────────────────
+
+
+def test_no_hits_returns_empty():
+    res = entity_aware_retrieve(KB, "", "name", exact=["name"])
+    assert len(res) == 0
+    assert res.retrieved == 0 and res.collapsed == 0
+
+    empty = entity_aware_retrieve(pl.DataFrame({"name": []}), "acme", "name")
+    assert len(empty) == 0
+
+
+def test_missing_column_raises():
+    with pytest.raises(ValueError, match="nope"):
+        entity_aware_retrieve(KB, "acme", "nope")
+
+
+def test_filters_pre_exclude_before_resolution():
+    # Restrict to globex only; the acme rows never enter retrieval/resolution.
+    res = entity_aware_retrieve(
+        KB, "globex", "name", exact=["name"], threshold=-1.0, k=10,
+        filters={"name": "globex"},
+    )
+    assert res.retrieved == 1
+    assert res.n_entities == 1
+    assert res.entities[0].record["name"] == "globex"
+
+
+# ── LLM canonicalization path (stubbed) ──────────────────────────────────────
+
+
+def test_llm_canonicalization_path_marks_method():
+    payload = {
+        "fields": {
+            "name": {"value": "acme", "source": 0, "reason": "agree"},
+            "ceo": {"value": "Jane Doe", "source": 0, "reason": "canonical form"},
+            "phone": {"value": "555-1234", "source": 1, "reason": "present"},
+        },
+        "rationale": "merged acme duplicates",
+    }
+    res = entity_aware_retrieve(
+        KB, "acme", "name", exact=["name"], threshold=-1.0, k=10,
+        llm_call=_stub_llm(payload),
+    )
+    acme = next(e for e in res if e.record.get("name") == "acme")
+    assert acme.canonical.method == "llm"
+    assert acme.record["ceo"] == "Jane Doe"
+    assert res.method == "llm"
+
+
+# ── resilience ───────────────────────────────────────────────────────────────
+
+
+def test_resolve_failure_degrades_to_singletons(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("dedupe blew up")
+
+    # Patch the symbol the surface imports lazily from the package root.
+    monkeypatch.setattr(gm, "dedupe_df", boom)
+    res = entity_aware_retrieve(KB, "acme", "name", exact=["name"], threshold=-1.0, k=10)
+    # No crash; every retrieved record becomes its own entity.
+    assert res.retrieved == 3
+    assert res.n_entities == 3
+    assert res.collapsed == 0
+
+
+def test_single_hit_skips_resolver():
+    res = entity_aware_retrieve(
+        KB, "acme", "name", exact=["name"], threshold=-1.0, k=1,
+    )
+    assert res.retrieved == 1
+    assert res.n_entities == 1
+    assert res.entities[0].size == 1
+
+
+# ── serialization / ergonomics ───────────────────────────────────────────────
+
+
+def test_result_iterable_and_sized():
+    res = entity_aware_retrieve(KB, "acme", "name", exact=["name"], threshold=-1.0, k=10)
+    assert len(res) == len(list(res)) == res.n_entities
+    assert all(isinstance(e, Entity) for e in res)
+
+
+def test_as_dict_serializable():
+    res = entity_aware_retrieve(KB, "acme", "name", exact=["name"], threshold=-1.0, k=10)
+    blob = json.dumps(res.as_dict())
+    assert "collapsed" in blob and "canonical" in blob and "members" in blob


### PR DESCRIPTION
## What

`entity_aware_retrieve(df, query, column, ...)` in `goldenmatch/core/rag_surface.py` — the entity-aware RAG surface (epic #1087, phase #1092). One call that composes the read side and the write side of the epic:

```
retrieve  ->  resolve to entities (dedupe)  ->  conflict-aware fact merge
```

Instead of handing the LLM a long list of duplicate / contradictory raw chunks, it returns a **short list of distinct entities** — each a single canonical record reconciled from its duplicates, every field tagged with the source record it came from. Fewer, cleaner, non-contradictory entities reach the context window.

## API

- **`entity_aware_retrieve(df, query, column, *, k=20, model="inhouse", threshold=0.0, filters=None, embedder=None, exact=None, fuzzy=None, blocking=None, dedupe_threshold=None, config=None, fields=None, llm_call=None, budget=None, canon_model="gpt-4o-mini") -> EntityRetrievalResult`**
- **`Entity(entity_id, canonical, members, score)`** — `.record` (canonical merged dict), `.size`, `.as_dict()`.
- **`EntityRetrievalResult`** — `entities` + `retrieved` / `n_entities` / `collapsed` / `method`; iterable and sized; `.as_dict()`.

Exported from the package root (`gm.entity_aware_retrieve`).

## Design

Built **entirely on existing primitives** — `retrieve_similar_records` (#1089), `dedupe_df` (the core resolver), `canonicalize_cluster` (#1091) — so **no new dependency** and **zero impact** on the dedupe/blocking pipeline.

- **Zero cloud by default:** the in-house embedder + deterministic most-complete merge run with no network or torch. Pass `llm_call=` / `budget=` to let an LLM reconcile borderline fields; pass `exact` / `fuzzy` / `blocking` to steer how retrieved records resolve into entities (zero-config when omitted).
- **Total / never raises:** if the resolve step degrades on a pathological tiny frame, each retrieved record falls back to its own entity (an honest no-op) — safe to wire into a pipeline.
- **Provenance:** carried through from `canonicalize_cluster` — each canonical field records which member record (or none, if synthesized) it came from.

## Demo (the #1092 done-bar)

`examples/rag_entity_dedup.py` — a knowledge base with duplicate + conflicting company facts:

```
Retrieved 6 raw records -> 3 distinct entities (3 duplicate/contradictory records collapsed out of the LLM context)

Entity #0  (merged from 3 record(s), best similarity 1.000)
    company  = Acme Corp      (from record 0)
    ceo      = Jane A. Doe    (from record 1)
    founded  = 1999           (from record 0)
    revenue  = $10M           (from record 2)
...
The LLM now sees 3 clean entities instead of 6 noisy rows.
```

## Tests

12 tests in `tests/test_rag_surface.py`, **fully deterministic and offline** (`threshold=-1.0` retrieves the whole frame so the test exercises the resolve + merge composition, not similarity ranking): collapse + dedup counts, conflict-aware merge + provenance, score ranking, all-distinct passthrough, empty / missing-column edges, `filters` pre-exclude, stubbed-LLM path, resolve-failure degrades to singletons, single-hit fast path, iterable/sized, `as_dict`.

Both dependencies (#1089 → #1188, #1091 → #1197) are now merged to `main`; this branch is rebased to a clean 4-file diff on top of them.

Part of #1092 (epic #1087)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA