### PR TITLE
feat(rag): persistent on-disk vector index — embed once, query across runs (#1088)

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -270,6 +270,7 @@ When you expose any server (MCP, REST, A2A, web UI) on a non-loopback host, it i
 | `GOLDENMATCH_DATABASE_URL` / `GOLDENMATCH_IDENTITY_DSN` | unset | Postgres/SQLite connection for the identity graph + review queue / Alembic migrations. |
 | `GOLDENMATCH_PREPARED_RECORD_STORE_DIR` | unset | Directory for the disk-backed prepared-record store. |
 | `GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST` | `0` | `1` keeps the prepared-record store across calls instead of cleaning it up. |
+| `GOLDENMATCH_VECTOR_INDEX_DIR` | `.goldenmatch_vectors` | Default on-disk directory for the persistent semantic `VectorIndex` (embeddings + records + manifest) when a path isn't passed explicitly. The index survives across runs/processes so embeddings aren't rebuilt every run. |
 
 **Product analytics (opt-in):**
 

--- a/packages/python/goldenmatch/examples/persistent_vector_index.py
+++ b/packages/python/goldenmatch/examples/persistent_vector_index.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Persistent vector index -- embed once, query across runs (#1088).
+
+Build a semantic index over a column of records, persist it to disk, and reopen
+it in a later run/process to query WITHOUT re-embedding. An incremental ``add``
+extends the index; identical text is never re-embedded (an embedding cache).
+
+Zero cloud: the in-house embedder + numpy ANN fallback need no network or torch.
+"""
+import tempfile
+from pathlib import Path
+
+import goldenmatch as gm
+import polars as pl
+
+kb = pl.DataFrame(
+    {
+        "name": ["Acme Corporation", "Globex Incorporated", "Initech Systems"],
+        "industry": ["manufacturing", "logistics", "software"],
+    }
+)
+
+index_dir = Path(tempfile.mkdtemp()) / "company_index"
+
+# --- Run 1: build the index and persist it -------------------------------------
+idx = gm.VectorIndex(index_dir, column="name").build(kb)
+idx.save()
+print(f"Run 1: built + saved {len(idx)} vectors (dim {idx.dim}) to {index_dir}\n")
+
+# --- Run 2 (a fresh process would do exactly this): reopen, no re-embed --------
+reopened = gm.VectorIndex.load(index_dir)
+print(f"Run 2: reopened index with {len(reopened)} records (no re-embedding)")
+for hit in reopened.query("acme", k=2):
+    print(f"    {hit.score:.3f}  {hit.record['name']}  ({hit.record['industry']})")
+
+# --- Incremental add: extend the index, then persist again ---------------------
+reopened.add(pl.DataFrame({"name": ["Umbrella Corp"], "industry": ["biotech"]}))
+reopened.save()
+print(f"\nAfter add + save: {len(reopened)} records")
+top = reopened.query("umbrella", k=1)[0]
+print(f"    new record retrievable: {top.record['name']} ({top.score:.3f})")
+
+# --- Metadata pre-filter -------------------------------------------------------
+software = reopened.query("systems", k=5, filters={"industry": "software"})
+print(f"\nFiltered to industry=software: {[h.record['name'] for h in software]}")

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -247,6 +247,7 @@ from goldenmatch.core.standardize import apply_standardization
 from goldenmatch.core.streaming import StreamProcessor, run_stream
 from goldenmatch.core.threshold import suggest_threshold
 from goldenmatch.core.validate import validate_dataframe
+from goldenmatch.core.vector_index import VectorIndex
 
 # ── Identity Graph ───────────────────────────────────────────────────────
 from goldenmatch.identity import (
@@ -342,6 +343,7 @@ __all__ = [
     "ScreeningResult", "ScreeningHit", "FieldReason",
     "retrieve_similar_records", "RetrievedRecord",
     "entity_aware_retrieve", "Entity", "EntityRetrievalResult",
+    "VectorIndex",
     # Evaluation
     "evaluate_pairs", "evaluate_clusters", "load_ground_truth_csv", "EvalResult",
     "RecallEstimate", "RecallCertificate", "estimate_recall", "certify_recall_df",

--- a/packages/python/goldenmatch/goldenmatch/core/vector_index.py
+++ b/packages/python/goldenmatch/goldenmatch/core/vector_index.py
@@ -1,0 +1,387 @@
+"""Persistent vector index -- stop rebuilding the embedding index every run (#1088).
+
+The on-disk counterpart to ``retrieve_similar_records`` (#1089): embed a column
+of records ONCE, persist the vectors + records + a manifest, and query across
+later runs / processes without re-embedding. An incremental ``add`` extends the
+index, and an embedding cache means re-indexing the same text never re-embeds it.
+
+Built on the existing primitives -- ``get_embedder`` (any provider; the
+zero-config ``"inhouse"`` model needs no cloud/torch) and ``ANNBlocker`` (FAISS
+with a byte-identical numpy fallback). The index is an exact inner-product
+(``IndexFlatIP``) index, so it is reconstituted from the persisted vectors on
+load rather than serializing a FAISS graph -- persistence is therefore
+faiss-independent and works identically under the numpy fallback.
+
+Persistence layout (a directory):
+
+    <dir>/manifest.json   -- {version, model, column, id_column, dim, count, ...}
+    <dir>/vectors.npy     -- (count, dim) float32 corpus embeddings
+    <dir>/records.parquet -- the per-row records (+ __row_id__, __vec_text__)
+
+Scope: this is the local on-disk (FAISS/numpy) backend. The pgvector (Postgres)
+and DuckDB-HNSW backends named in #1088 are follow-ups -- they implement the same
+``build`` / ``add`` / ``query`` / ``save`` / ``load`` surface and
+``RetrievedRecord`` result shape behind the one interface this class defines.
+The query result type is shared with ``retrieve_similar_records`` so the
+in-memory and persistent paths are drop-in interchangeable.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from goldenmatch.core.ann_blocker import ANNBlocker
+from goldenmatch.core.embedder import get_embedder
+from goldenmatch.core.retrieval import RetrievedRecord
+
+logger = logging.getLogger(__name__)
+
+_MANIFEST = "manifest.json"
+_VECTORS = "vectors.npy"
+_RECORDS = "records.parquet"
+_VERSION = 1
+_ROW_ID = "__row_id__"
+_TEXT = "__vec_text__"
+
+# Default on-disk location (mirrors the .goldenmatch_* convention); env override.
+DEFAULT_INDEX_DIR = os.environ.get("GOLDENMATCH_VECTOR_INDEX_DIR", ".goldenmatch_vectors")
+
+
+def _atomic_write_bytes(path: Path, write_fn) -> None:
+    """Write via a temp file in the same dir, then atomically replace ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    os.close(fd)
+    tmp_path = Path(tmp)
+    try:
+        write_fn(tmp_path)
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+class VectorIndex:
+    """A persistent semantic index over records, queryable across runs.
+
+    Create a fresh index with the constructor and ``build`` / ``add``; reopen a
+    saved one with :meth:`load`. ``query`` embeds a free-text query and returns
+    the most similar records as ``RetrievedRecord`` (the same shape as
+    ``retrieve_similar_records``).
+    """
+
+    def __init__(
+        self,
+        path: str | Path = DEFAULT_INDEX_DIR,
+        *,
+        model: str = "inhouse",
+        column: str | None = None,
+        id_column: str | None = None,
+        embedder: Any = None,
+    ):
+        self.path = Path(path)
+        self.model = model
+        self.column = column
+        self.id_column = id_column
+        self._embedder = embedder if embedder is not None else get_embedder(model)
+
+        self._frame: pl.DataFrame | None = None  # records + __row_id__ + __vec_text__
+        self._vectors: np.ndarray | None = None  # (count, dim) float32
+        self._dim: int | None = None
+        self._blocker: ANNBlocker | None = None
+        # Embedding store: text -> vector, so re-indexing the same text never
+        # re-embeds. Repopulated from disk on load.
+        self._vec_cache: dict[str, np.ndarray] = {}
+
+    # ── size / dunders ───────────────────────────────────────────────────────
+
+    @property
+    def size(self) -> int:
+        """How many records are indexed."""
+        return 0 if self._frame is None else self._frame.height
+
+    @property
+    def dim(self) -> int | None:
+        """The embedding dimensionality, or None until the index has content."""
+        return self._dim
+
+    def __len__(self) -> int:
+        return self.size
+
+    def __repr__(self) -> str:
+        return (
+            f"VectorIndex(path={str(self.path)!r}, model={self.model!r}, "
+            f"column={self.column!r}, size={self.size}, dim={self._dim})"
+        )
+
+    # ── embedding (with cache) ───────────────────────────────────────────────
+
+    def _embed_texts(self, texts: list[str]) -> np.ndarray:
+        """Embed ``texts`` to (n, dim) float32, reusing cached vectors. Only the
+        unique, not-yet-cached texts hit the embedder."""
+        todo = [t for t in dict.fromkeys(texts) if t not in self._vec_cache]
+        if todo:
+            arr = self._embedder.embed_column(
+                todo, cache_key=f"vi:{self.model}:{hash(tuple(todo))}"
+            )
+            arr = np.asarray(arr, dtype=np.float32)
+            for t, vec in zip(todo, arr):
+                self._vec_cache[t] = np.asarray(vec, dtype=np.float32)
+        out = np.stack([self._vec_cache[t] for t in texts]).astype(np.float32)
+        return out
+
+    def _rebuild_blocker(self) -> None:
+        self._blocker = None
+        if self._vectors is not None and len(self._vectors):
+            blk = ANNBlocker(top_k=self._vectors.shape[0])
+            blk.build_index(self._vectors)
+            self._blocker = blk
+
+    # ── build / add ──────────────────────────────────────────────────────────
+
+    def _prep_frame(
+        self, df: pl.DataFrame, column: str, id_column: str | None
+    ) -> tuple[pl.DataFrame, list[str]]:
+        if column not in df.columns:
+            raise ValueError(
+                f"VectorIndex: column {column!r} not in dataframe (have {df.columns})"
+            )
+        keep = [c for c in df.columns if not c.startswith("__")]
+        texts = ["" if v is None else str(v) for v in df[column].to_list()]
+        base = self.size
+        if id_column is not None and id_column in df.columns:
+            row_ids = [int(r) for r in df[id_column].to_list()]
+        else:
+            row_ids = list(range(base, base + df.height))
+        frame = df.select(keep).with_columns(
+            pl.Series(_ROW_ID, row_ids, dtype=pl.Int64),
+            pl.Series(_TEXT, texts),
+        )
+        return frame, texts
+
+    def build(
+        self,
+        df: pl.DataFrame,
+        column: str | None = None,
+        *,
+        id_column: str | None = None,
+    ) -> VectorIndex:
+        """(Re)build the index from a frame, replacing any current content.
+
+        Args:
+            df: the corpus frame.
+            column: the text column to embed (defaults to the index's ``column``).
+            id_column: optional column holding stable record ids; otherwise row
+                position is used.
+
+        Returns:
+            ``self`` (for chaining).
+        """
+        column = column or self.column
+        if column is None:
+            raise ValueError("VectorIndex.build: a column to embed is required")
+        self.column = column
+        self.id_column = id_column if id_column is not None else self.id_column
+        self._frame = None
+        self._vectors = None
+        self._dim = None
+        # Fresh build: start from an empty index so row ids are 0-based.
+        frame, texts = self._prep_frame(df, column, id_column)
+        vectors = self._embed_texts(texts)
+        self._frame = frame
+        self._vectors = vectors
+        self._dim = int(vectors.shape[1]) if vectors.size else None
+        self._rebuild_blocker()
+        return self
+
+    def add(
+        self,
+        df: pl.DataFrame,
+        column: str | None = None,
+        *,
+        id_column: str | None = None,
+    ) -> VectorIndex:
+        """Incrementally add records to the index (no full re-embed of existing
+        rows; identical text reuses its cached vector).
+
+        Returns:
+            ``self`` (for chaining).
+        """
+        if self._frame is None:
+            return self.build(df, column, id_column=id_column)
+        column = column or self.column
+        if column is None:
+            raise ValueError("VectorIndex.add: a column to embed is required")
+        frame, texts = self._prep_frame(df, column, id_column)
+        vectors = self._embed_texts(texts)
+        if vectors.shape[1] != self._vectors.shape[1]:
+            raise ValueError(
+                f"VectorIndex.add: embedding dim {vectors.shape[1]} != index dim "
+                f"{self._vectors.shape[1]} (model/column mismatch)"
+            )
+        # diagonal_relaxed: union columns by name (missing -> null), relax dtypes,
+        # so an add carrying a subset/superset of columns still concatenates.
+        self._frame = pl.concat([self._frame, frame], how="diagonal_relaxed")
+        self._vectors = np.vstack([self._vectors, vectors]).astype(np.float32)
+        self._rebuild_blocker()
+        return self
+
+    # ── query ────────────────────────────────────────────────────────────────
+
+    def query(
+        self,
+        query: str,
+        *,
+        k: int = 20,
+        threshold: float = 0.0,
+        filters: dict[str, Any] | None = None,
+    ) -> list[RetrievedRecord]:
+        """Retrieve the top-``k`` indexed records most similar to ``query``.
+
+        Args:
+            query: free-text query, embedded with the index's model.
+            k: maximum records to return (ranked by cosine desc).
+            threshold: minimum cosine similarity in ``[-1, 1]``.
+            filters: optional ``{column: value}`` equality pre-filter on the
+                records, applied before search.
+
+        Returns:
+            ``list[RetrievedRecord]`` ranked highest-similarity first. Empty when
+            the query is blank, the index is empty, the filter excludes
+            everything, or nothing clears ``threshold``.
+        """
+        if not query or self._frame is None or self.size == 0:
+            return []
+
+        frame = self._frame
+        vectors = self._vectors
+        positions = list(range(frame.height))
+        if filters:
+            mask = np.ones(frame.height, dtype=bool)
+            for col, val in filters.items():
+                if col not in frame.columns:
+                    return []
+                mask &= np.asarray((frame[col] == val).to_list(), dtype=bool)
+            positions = [i for i, keep in enumerate(mask) if keep]
+            if not positions:
+                return []
+            frame = frame[positions]
+            vectors = vectors[positions]
+
+        q_vec = self._embed_texts([str(query)])[0]
+
+        if filters or self._blocker is None:
+            blocker = ANNBlocker(top_k=vectors.shape[0])
+            blocker.build_index(vectors)
+        else:
+            blocker = self._blocker
+        neighbors = blocker.query_one(q_vec)  # [(local_pos, score), ...] desc
+
+        rows = frame.to_dicts()
+        out: list[RetrievedRecord] = []
+        for pos, score in neighbors:
+            if score < threshold:
+                continue
+            if pos < 0 or pos >= frame.height:
+                continue
+            row = rows[pos]
+            record = {kk: vv for kk, vv in row.items() if not kk.startswith("__")}
+            out.append(
+                RetrievedRecord(row_id=int(row[_ROW_ID]), score=float(score), record=record)
+            )
+            if len(out) >= k:
+                break
+        return out
+
+    # ── persistence ──────────────────────────────────────────────────────────
+
+    def save(self, path: str | Path | None = None) -> VectorIndex:
+        """Persist the index (manifest + vectors + records) to ``path``.
+
+        Atomic per file: each artifact is written to a temp file in the target
+        directory and renamed into place. Returns ``self``.
+        """
+        if path is not None:
+            self.path = Path(path)
+        if self._frame is None or self._vectors is None:
+            raise ValueError("VectorIndex.save: nothing to save (build the index first)")
+        self.path.mkdir(parents=True, exist_ok=True)
+
+        def _write_vectors(p: Path) -> None:
+            # Write through a handle so np.save uses the path verbatim (passing a
+            # str makes it append a second ".npy", missing the atomic temp file).
+            with open(p, "wb") as fh:
+                np.save(fh, self._vectors, allow_pickle=False)
+
+        _atomic_write_bytes(self.path / _VECTORS, _write_vectors)
+        _atomic_write_bytes(self.path / _RECORDS, lambda p: self._frame.write_parquet(p))
+        manifest = {
+            "version": _VERSION,
+            "model": self.model,
+            "column": self.column,
+            "id_column": self.id_column,
+            "dim": self._dim,
+            "count": self.size,
+            "created_at": time.time(),
+        }
+        _atomic_write_bytes(
+            self.path / _MANIFEST,
+            lambda p: p.write_text(json.dumps(manifest, indent=2)),
+        )
+        logger.info("Saved VectorIndex (%d records) to %s", self.size, self.path)
+        return self
+
+    @classmethod
+    def load(cls, path: str | Path, *, embedder: Any = None) -> VectorIndex:
+        """Load a persisted index from ``path``.
+
+        Raises:
+            FileNotFoundError: if ``path`` is not a saved index directory.
+        """
+        path = Path(path)
+        manifest_path = path / _MANIFEST
+        if not manifest_path.is_file():
+            raise FileNotFoundError(f"VectorIndex.load: no index at {path}")
+        manifest = json.loads(manifest_path.read_text())
+
+        idx = cls(
+            path,
+            model=manifest.get("model", "inhouse"),
+            column=manifest.get("column"),
+            id_column=manifest.get("id_column"),
+            embedder=embedder,
+        )
+        idx._vectors = np.load(str(path / _VECTORS), allow_pickle=False).astype(np.float32)
+        idx._frame = pl.read_parquet(path / _RECORDS)
+        idx._dim = manifest.get("dim") or (
+            int(idx._vectors.shape[1]) if idx._vectors.size else None
+        )
+        # Repopulate the embedding store from the persisted vectors so later
+        # ``add`` calls reuse them (and identical query text is a cache hit).
+        if _TEXT in idx._frame.columns:
+            for text, vec in zip(idx._frame[_TEXT].to_list(), idx._vectors):
+                idx._vec_cache.setdefault(str(text), np.asarray(vec, dtype=np.float32))
+        idx._rebuild_blocker()
+        return idx
+
+    @classmethod
+    def open(
+        cls,
+        path: str | Path = DEFAULT_INDEX_DIR,
+        *,
+        model: str = "inhouse",
+        column: str | None = None,
+        embedder: Any = None,
+    ) -> VectorIndex:
+        """Load the index at ``path`` if it exists, else create a fresh empty one."""
+        if (Path(path) / _MANIFEST).is_file():
+            return cls.load(path, embedder=embedder)
+        return cls(path, model=model, column=column, embedder=embedder)

--- a/packages/python/goldenmatch/tests/test_vector_index.py
+++ b/packages/python/goldenmatch/tests/test_vector_index.py
@@ -1,0 +1,201 @@
+"""Persistent vector index (#1088).
+
+All deterministic and offline: the zero-config in-house embedder + numpy ANN
+fallback need no network or torch. The cross-process test builds the index in a
+subprocess and queries it here, proving the index genuinely survives across runs.
+"""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+
+import numpy as np
+import polars as pl
+import pytest
+from goldenmatch.core import ann_blocker
+from goldenmatch.core.retrieval import RetrievedRecord
+from goldenmatch.core.vector_index import VectorIndex
+
+CORP = pl.DataFrame(
+    {
+        "name": ["acme corporation", "globex incorporated", "initech systems"],
+        "city": ["NYC", "SF", "Austin"],
+    }
+)
+
+
+class _CountingEmbedder:
+    """Deterministic (cross-call stable) stub that records every text embedded."""
+
+    def __init__(self, dim: int = 16):
+        self.dim = dim
+        self.embedded: list[str] = []
+        self.calls = 0
+
+    def embed_column(self, values, cache_key):  # noqa: ARG002
+        self.calls += 1
+        self.embedded.extend(values)
+        return np.stack([self._vec(v) for v in values]).astype(np.float32)
+
+    def _vec(self, text: str) -> np.ndarray:
+        seed = int.from_bytes(hashlib.sha256(text.encode()).digest()[:4], "big")
+        v = np.random.default_rng(seed).standard_normal(self.dim).astype(np.float32)
+        return v / (np.linalg.norm(v) or 1.0)
+
+
+# ── build + query ────────────────────────────────────────────────────────────
+
+
+def test_build_then_query_anchors_exact_text(tmp_path):
+    idx = VectorIndex(tmp_path / "vi", column="name").build(CORP)
+    assert len(idx) == 3
+    hits = idx.query("acme corporation", k=3)
+    assert hits and hits[0].record["name"] == "acme corporation"
+    assert hits[0].score == pytest.approx(1.0, abs=1e-3)
+    assert isinstance(hits[0], RetrievedRecord)
+
+
+def test_query_k_cap_and_threshold(tmp_path):
+    idx = VectorIndex(tmp_path / "vi", column="name").build(CORP)
+    assert len(idx.query("acme", k=1)) == 1
+    # a threshold above every score returns nothing.
+    assert idx.query("acme", k=5, threshold=1.1) == []
+
+
+def test_filters_pre_exclude(tmp_path):
+    idx = VectorIndex(tmp_path / "vi", column="name").build(CORP)
+    hits = idx.query("incorporated", k=5, filters={"city": "SF"})
+    assert [h.record["name"] for h in hits] == ["globex incorporated"]
+    # a filter that matches nothing yields nothing.
+    assert idx.query("acme", k=5, filters={"city": "Mars"}) == []
+
+
+def test_empty_query_and_empty_index(tmp_path):
+    idx = VectorIndex(tmp_path / "vi", column="name").build(CORP)
+    assert idx.query("", k=3) == []
+    empty = VectorIndex(tmp_path / "empty", column="name")
+    assert len(empty) == 0
+    assert empty.query("acme", k=3) == []
+
+
+# ── persistence: survives reload + cross-process ─────────────────────────────
+
+
+def test_persist_and_reload_in_process(tmp_path):
+    d = tmp_path / "vi"
+    VectorIndex(d, column="name").build(CORP).save()
+    assert (d / "manifest.json").is_file()
+    assert (d / "vectors.npy").is_file()
+    assert (d / "records.parquet").is_file()
+
+    reloaded = VectorIndex.load(d)
+    assert len(reloaded) == 3
+    a = reloaded.query("acme corporation", k=1)
+    b = VectorIndex(tmp_path / "fresh", column="name").build(CORP).query(
+        "acme corporation", k=1
+    )
+    assert a[0].record == b[0].record
+    assert a[0].score == pytest.approx(b[0].score, abs=1e-5)
+
+
+def test_index_survives_across_processes(tmp_path):
+    d = tmp_path / "vi"
+    code = (
+        "import polars as pl, goldenmatch as gm;"
+        "df = pl.DataFrame({'name': ['alpha widget','beta gadget','gamma gizmo']});"
+        f"gm.VectorIndex({str(d)!r}, column='name').build(df).save()"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True, capture_output=True)
+
+    idx = VectorIndex.load(d)  # a fresh process loads what the other wrote
+    assert len(idx) == 3
+    hits = idx.query("alpha widget", k=1)
+    assert hits and hits[0].record["name"] == "alpha widget"
+
+
+def test_manifest_records_model_dim_count(tmp_path):
+    import json
+
+    d = tmp_path / "vi"
+    idx = VectorIndex(d, model="inhouse", column="name").build(CORP)
+    idx.save()
+    manifest = json.loads((d / "manifest.json").read_text())
+    assert manifest["model"] == "inhouse"
+    assert manifest["column"] == "name"
+    assert manifest["count"] == 3
+    assert manifest["dim"] == idx.dim
+
+
+def test_load_missing_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        VectorIndex.load(tmp_path / "nope")
+
+
+def test_open_loads_or_creates(tmp_path):
+    d = tmp_path / "vi"
+    created = VectorIndex.open(d, column="name")
+    assert len(created) == 0  # nothing on disk yet
+    created.build(CORP).save()
+    reopened = VectorIndex.open(d)
+    assert len(reopened) == 3
+
+
+# ── incremental add + embedding cache ────────────────────────────────────────
+
+
+def test_incremental_add_grows_and_is_queryable(tmp_path):
+    idx = VectorIndex(tmp_path / "vi", column="name").build(CORP)
+    idx.add(pl.DataFrame({"name": ["umbrella corp"], "city": ["Raccoon"]}))
+    assert len(idx) == 4
+    assert idx.query("umbrella corp", k=1)[0].record["name"] == "umbrella corp"
+    # original rows still retrievable.
+    assert idx.query("acme corporation", k=1)[0].record["name"] == "acme corporation"
+
+
+def test_add_on_empty_index_builds(tmp_path):
+    idx = VectorIndex(tmp_path / "vi", column="name")
+    idx.add(CORP)
+    assert len(idx) == 3
+
+
+def test_embedding_cache_never_reembeds_a_text(tmp_path):
+    stub = _CountingEmbedder()
+    dupe = pl.DataFrame({"name": ["acme", "globex", "acme"]})  # 'acme' twice
+    idx = VectorIndex(tmp_path / "vi", column="name", embedder=stub).build(dupe)
+    # add a row whose text is already indexed + one new text.
+    idx.add(pl.DataFrame({"name": ["acme", "initech"]}))
+    idx.query("acme", k=1)  # query text 'acme' is already cached too
+    # No text is ever embedded twice.
+    assert sorted(stub.embedded) == sorted(set(stub.embedded))
+    assert set(stub.embedded) == {"acme", "globex", "initech"}
+
+
+def test_reload_repopulates_cache_so_add_skips_known_text(tmp_path):
+    d = tmp_path / "vi"
+    # Build + save with a stub so the persisted vectors share the stub's dim.
+    VectorIndex(d, column="name", embedder=_CountingEmbedder()).build(CORP).save()
+    stub = _CountingEmbedder()
+    reloaded = VectorIndex.load(d, embedder=stub)
+    # 'acme corporation' is already on disk -> reused, not re-embedded; only the
+    # genuinely new text hits the embedder.
+    reloaded.add(pl.DataFrame({"name": ["acme corporation", "brand new co"]}))
+    assert stub.embedded == ["brand new co"]
+
+
+# ── numpy fallback parity ────────────────────────────────────────────────────
+
+
+def test_numpy_fallback_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(ann_blocker, "_HAS_FAISS", False)
+    idx = VectorIndex(tmp_path / "vi", column="name").build(CORP)
+    hits = idx.query("acme corporation", k=1)
+    assert hits and hits[0].record["name"] == "acme corporation"
+
+
+def test_id_column_used_for_row_id(tmp_path):
+    df = CORP.with_columns(pl.Series("pk", [100, 200, 300], dtype=pl.Int64))
+    idx = VectorIndex(tmp_path / "vi", column="name").build(df, id_column="pk")
+    hits = idx.query("globex incorporated", k=1)
+    assert hits[0].row_id == 200
+    assert "pk" in hits[0].record  # non-internal columns are preserved


### PR DESCRIPTION
## What

`VectorIndex` in `goldenmatch/core/vector_index.py` — the **on-disk counterpart** to `retrieve_similar_records` (#1089): embed a column of records **once**, persist the vectors + records + a manifest, and query across later runs / processes **without re-embedding**. Satisfies the #1088 done-bar — *embeddings persist and an index survives across runs/processes*.

Part of #1088 (RAG epic #1087).

## API

```python
idx = gm.VectorIndex(path, model="inhouse", column="name").build(df)
idx.save()                                   # manifest.json + vectors.npy + records.parquet
...
idx = gm.VectorIndex.load(path)              # a later run/process — no re-embed
hits = idx.query("acme", k=5, threshold=0.0, filters={"city": "SF"})  # -> list[RetrievedRecord]
idx.add(new_df).save()                       # incremental
```

- `.build(df, column, *, id_column=)` / `.add(df, ...)` / `.query(...) -> list[RetrievedRecord]`
- `.save(path=)` / `.load(path)` / `.open(path)` (load-or-create) / `.size` / `.dim` / `len()`
- Returns the **same `RetrievedRecord` shape** as `retrieve_similar_records`, so the in-memory and persistent retrieval paths are drop-in interchangeable. Exported as `gm.VectorIndex`.

## Design

Built on existing primitives — `get_embedder` (the zero-config `"inhouse"` model needs no cloud/torch) + `ANNBlocker` (FAISS with a byte-identical numpy fallback). The index is an **exact inner-product (`IndexFlatIP`)** index, so it's reconstituted from the persisted vectors on load rather than serializing a FAISS graph — **persistence is faiss-independent and works identically under the numpy fallback** (so it's fully offline-testable).

- **Embedding store with cache:** an internal `text -> vector` cache means re-indexing the same text never re-embeds it; on load the cache is repopulated from the persisted vectors, so a later `add` reuses known text and only embeds genuinely new rows (incremental rebuild).
- **Atomic persistence:** each artifact is written to a temp file in the target dir and `os.replace`d into place.
- **Layout:** `<dir>/manifest.json` + `vectors.npy` + `records.parquet`. Default dir `.goldenmatch_vectors` (`GOLDENMATCH_VECTOR_INDEX_DIR` override).

## Scope & follow-ups

This is the **local on-disk (FAISS/numpy) backend**. The **pgvector (Postgres)** and **DuckDB-HNSW** backends named in #1088 are follow-ups — they implement the same `build`/`add`/`query`/`save`/`load` surface + `RetrievedRecord` result behind this one interface. (A DB-coupled `PersistentANNIndex` already exists in `db/ann_index.py` for the SQL-extensions path; this is the dependency-light frame/records surface the RAG retrieval path needs.)

## Tests

15 tests in `tests/test_vector_index.py`, **fully deterministic + offline**, including:
- a **genuine cross-process test** — a subprocess builds + saves the index; the test process loads + queries it (proves it survives across runs);
- an **embedding-cache assertion** — no text is ever embedded twice, and reload repopulates the cache so a subsequent `add` skips known text;
- build/query anchor (~1.0 on exact text), `k` cap + threshold, metadata `filters` pre-exclude, empty query/index, reload parity, manifest contents, load-missing raises, `open` load-or-create, incremental add, numpy fallback, `id_column` row ids.

`examples/persistent_vector_index.py` demonstrates build+save → reopen (no re-embed) → incremental add → metadata filter.

Standalone PR off `main` (depends only on the merged #1089 `RetrievedRecord`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_