### PR TITLE
feat(rag): embedding ops — drift, per-field models, canonicalization eval (#1093)

### DIFF
--- a/packages/python/goldenmatch/examples/embedding_ops.py
+++ b/packages/python/goldenmatch/examples/embedding_ops.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""Embedding ops -- drift alarms, per-field models, canonicalization quality (#1093).
+
+The operations layer for running embeddings + canonicalization in production:
+
+1. Detect when the embedding model's output distribution has SHIFTED (drift alarm).
+2. Pick the right embedder PER FIELD (names vs descriptions).
+3. MEASURE canonicalization quality (completeness, provenance, accuracy).
+
+Zero cloud: the in-house embedder + numpy stats need no network or torch.
+"""
+import goldenmatch as gm
+import polars as pl
+from goldenmatch.core.embedder import get_embedder
+
+emb = get_embedder("inhouse")
+
+# 1. ── Drift detection ────────────────────────────────────────────────────────
+# Embed a reference batch, then compare a later batch against it.
+reference = emb.embed_column(
+    ["Acme Corporation", "Globex Inc", "Initech LLC", "Stark Industries"] * 8,
+    cache_key="ref",
+)
+later_same = emb.embed_column(
+    ["Acme Corporation", "Globex Inc", "Initech LLC", "Stark Industries"] * 8,
+    cache_key="same",
+)
+later_shifted = emb.embed_column(
+    ["lorem ipsum dolor", "the quick brown fox", "unrelated topic", "noise words"] * 8,
+    cache_key="shift",
+)
+
+no_drift = gm.embedding_drift(reference, later_same)
+drift = gm.embedding_drift(reference, later_shifted)
+print("1. Drift detection")
+print(f"   same inputs   -> drifted={no_drift.drifted}  psi={no_drift.psi:.3f}")
+print(f"   shifted inputs-> drifted={drift.drifted}  psi={drift.psi:.3f}  "
+      f"(ALARM)" if drift.drifted else "")
+
+# 2. ── Per-field model selection ──────────────────────────────────────────────
+kb = pl.DataFrame(
+    {
+        "name": ["Acme Corp", "Globex Inc", "Initech LLC"],
+        "description": [
+            "A multinational manufacturer of industrial widgets and precision tooling",
+            "Global logistics and supply-chain operator serving enterprise clients",
+            "Boutique software consultancy specialising in legacy system modernisation",
+        ],
+    }
+)
+print("\n2. Per-field model selection")
+for col, choice in gm.select_field_models(kb).items():
+    print(f"   {col:<12} -> {choice.model:<18} ({choice.reason}, "
+          f"mean {choice.mean_chars:.0f} chars)")
+
+# 3. ── Canonicalization quality eval ──────────────────────────────────────────
+clusters = [
+    [
+        {"name": "Bob", "email": "bob@x.com", "phone": None},
+        {"name": "Robert Smith", "email": "bob@x.com", "phone": "555-1234"},
+    ],
+    [
+        {"name": "Jane Doe", "email": "jane@y.com", "phone": "555-9999"},
+        {"name": "Jane A. Doe", "email": None, "phone": "555-9999"},
+    ],
+]
+canon = [gm.canonicalize_cluster(c) for c in clusters]
+gold = [{"name": "Robert Smith", "phone": "555-1234"}, {"name": "Jane A. Doe"}]
+quality = gm.evaluate_canonicalization(canon, gold=gold)
+print("\n3. Canonicalization quality")
+for key, val in quality.summary().items():
+    print(f"   {key}: {val}")

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -151,6 +151,15 @@ from goldenmatch.core.domain_registry import (
 )
 
 # ── Evaluation ───────────────────────────────────────────────────────────
+from goldenmatch.core.embedding_ops import (
+    CanonicalizationEval,
+    EmbeddingDriftReport,
+    FieldModelChoice,
+    embedding_drift,
+    evaluate_canonicalization,
+    select_field_model,
+    select_field_models,
+)
 from goldenmatch.core.evaluate import (
     EvalResult,
     evaluate_clusters,
@@ -344,6 +353,10 @@ __all__ = [
     "entity_aware_retrieve", "Entity", "EntityRetrievalResult",
     # Evaluation
     "evaluate_pairs", "evaluate_clusters", "load_ground_truth_csv", "EvalResult",
+    # Embedding ops (drift, per-field models, canonicalization eval)
+    "embedding_drift", "EmbeddingDriftReport",
+    "select_field_model", "select_field_models", "FieldModelChoice",
+    "evaluate_canonicalization", "CanonicalizationEval",
     "RecallEstimate", "RecallCertificate", "estimate_recall", "certify_recall_df",
     "audit_calibrated_bound",
     # Explain

--- a/packages/python/goldenmatch/goldenmatch/core/embedding_ops.py
+++ b/packages/python/goldenmatch/goldenmatch/core/embedding_ops.py
@@ -1,0 +1,384 @@
+"""Embedding ops -- drift detection, per-field model selection, canonicalization eval (#1093).
+
+The operations layer for running embeddings + canonicalization in production, the
+last phase of the RAG entity-canonicalization epic (#1087). Three capabilities,
+all dependency-light (numpy + the existing primitives), deterministic, and
+offline-testable:
+
+1. **Drift detection** (`embedding_drift`) -- has the embedding model's output
+   distribution shifted between a reference run and now? Compares two embedding
+   sets via centroid cosine drift + a population-stability index (PSI) over the
+   projection onto the reference centroid, and raises an alarm past a threshold.
+
+2. **Per-field model selection** (`select_field_models`) -- names and descriptions
+   want different embedders. Routes short identifier-like text to the zero-config
+   in-house model and long free text to a stronger sentence model, honoring any
+   explicit per-field ``MatchkeyField.model`` override. Returns model ids that
+   ``get_embedder`` accepts.
+
+3. **Canonicalization quality eval** (`evaluate_canonicalization`) -- measure the
+   output of ``canonicalize_cluster``: field completeness, provenance coverage,
+   synthesized-value rate, LLM-vs-deterministic mix, and (against an optional gold)
+   per-field precision/recall/F1 in the ``EvalResult`` shape.
+
+Together these meet the #1093 done-bar: drift alarms + measured canonicalization
+quality.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+# ── 1. Drift detection ───────────────────────────────────────────────────────
+
+
+@dataclass
+class EmbeddingDriftReport:
+    """Drift between a reference embedding set and a current one."""
+
+    n_reference: int
+    n_current: int
+    centroid_cosine_drift: float  # 1 - cos(ref_centroid, cur_centroid), in [0, 2]
+    mean_shift: float  # L2 distance between the two centroids
+    norm_ratio: float  # mean ||current|| / mean ||reference|| (≈1 for normalized)
+    psi: float  # population stability index over projection onto ref centroid
+    drifted: bool  # alarm: psi >= alarm_psi OR centroid drift >= alarm_centroid_cosine
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "n_reference": self.n_reference,
+            "n_current": self.n_current,
+            "centroid_cosine_drift": round(self.centroid_cosine_drift, 6),
+            "mean_shift": round(self.mean_shift, 6),
+            "norm_ratio": round(self.norm_ratio, 6),
+            "psi": round(self.psi, 6),
+            "drifted": self.drifted,
+        }
+
+    # alias for parity with the EvalResult.summary() convention elsewhere
+    summary = as_dict
+
+
+def _psi(ref: np.ndarray, cur: np.ndarray, *, bins: int) -> float:
+    """Population stability index of ``cur`` vs ``ref`` over quantile bins of ref.
+
+    PSI = Σ (cur% - ref%) * ln(cur% / ref%). 0 = identical; the usual ops bands
+    are <0.1 stable, 0.1-0.25 moderate shift, >=0.25 significant shift.
+    """
+    if ref.size == 0 or cur.size == 0:
+        return 0.0
+    # Quantile edges from the reference so each ref bin is ~equally populated.
+    qs = np.linspace(0.0, 1.0, bins + 1)
+    edges = np.quantile(ref, qs)
+    edges[0], edges[-1] = -np.inf, np.inf
+    # Degenerate (all-equal) reference: no meaningful bins -> no measurable drift.
+    if not np.all(np.diff(edges[1:-1]) > 0) and bins > 1 and np.ptp(ref) == 0:
+        return 0.0
+    ref_counts, _ = np.histogram(ref, bins=edges)
+    cur_counts, _ = np.histogram(cur, bins=edges)
+    eps = 1e-6
+    ref_pct = ref_counts / max(ref_counts.sum(), 1) + eps
+    cur_pct = cur_counts / max(cur_counts.sum(), 1) + eps
+    return float(np.sum((cur_pct - ref_pct) * np.log(cur_pct / ref_pct)))
+
+
+def embedding_drift(
+    reference: np.ndarray,
+    current: np.ndarray,
+    *,
+    bins: int = 10,
+    alarm_psi: float = 0.25,
+    alarm_centroid_cosine: float = 0.1,
+) -> EmbeddingDriftReport:
+    """Measure embedding-space drift between a reference set and a current set.
+
+    Args:
+        reference: ``(n_ref, dim)`` reference embeddings (e.g. a stored baseline).
+        current: ``(n_cur, dim)`` current embeddings to check for shift.
+        bins: number of quantile bins for the PSI projection histogram.
+        alarm_psi: PSI at/above which drift alarms (0.25 = the standard
+            "significant shift" band).
+        alarm_centroid_cosine: centroid cosine drift at/above which drift alarms.
+
+    Returns:
+        An ``EmbeddingDriftReport``. ``drifted`` is the alarm. Never raises on
+        non-empty same-dim inputs.
+
+    Raises:
+        ValueError: if the two sets have different embedding dimensionality.
+    """
+    ref = np.asarray(reference, dtype=np.float64)
+    cur = np.asarray(current, dtype=np.float64)
+    if ref.ndim != 2 or cur.ndim != 2:
+        raise ValueError("embedding_drift: inputs must be 2-D (n, dim) arrays")
+    if ref.size == 0 or cur.size == 0:
+        return EmbeddingDriftReport(
+            n_reference=len(ref), n_current=len(cur),
+            centroid_cosine_drift=0.0, mean_shift=0.0, norm_ratio=1.0,
+            psi=0.0, drifted=False,
+        )
+    if ref.shape[1] != cur.shape[1]:
+        raise ValueError(
+            f"embedding_drift: dim mismatch ref={ref.shape[1]} cur={cur.shape[1]}"
+        )
+
+    ref_centroid = ref.mean(axis=0)
+    cur_centroid = cur.mean(axis=0)
+    rc_norm = float(np.linalg.norm(ref_centroid))
+    cc_norm = float(np.linalg.norm(cur_centroid))
+    cos = float(ref_centroid @ cur_centroid) / (rc_norm * cc_norm + 1e-12)
+    centroid_cosine_drift = 1.0 - cos
+    mean_shift = float(np.linalg.norm(cur_centroid - ref_centroid))
+    ref_norms = np.linalg.norm(ref, axis=1)
+    cur_norms = np.linalg.norm(cur, axis=1)
+    ref_radius = float(ref_norms.mean())
+    norm_ratio = float(cur_norms.mean()) / (ref_radius + 1e-12)
+
+    # PSI over the scalar projection onto the unit reference-centroid direction --
+    # captures a shift in how the population spreads along the reference axis.
+    direction = ref_centroid / (rc_norm + 1e-12)
+    psi = _psi(ref @ direction, cur @ direction, bins=bins)
+
+    # PSI is the primary alarm (scale-free, standard). The centroid-cosine signal
+    # is reliable ONLY when the reference centroid has a real direction -- for
+    # embeddings diffuse around the origin (centroid ≈ 0) its direction is noise,
+    # so it joins the alarm only when the centroid is "directional" (a cone).
+    centroid_is_directional = rc_norm >= 0.3 * ref_radius
+    drifted = bool(
+        psi >= alarm_psi
+        or (centroid_is_directional and centroid_cosine_drift >= alarm_centroid_cosine)
+    )
+    return EmbeddingDriftReport(
+        n_reference=len(ref), n_current=len(cur),
+        centroid_cosine_drift=centroid_cosine_drift, mean_shift=mean_shift,
+        norm_ratio=norm_ratio, psi=psi, drifted=drifted,
+    )
+
+
+# ── 2. Per-field model selection ─────────────────────────────────────────────
+
+# Sensible defaults: short identifier-like text → the zero-config in-house model
+# (fast, no cloud/torch, char-n-gram-ish); long free text → a stronger sentence
+# model that captures semantics. Overridable per call.
+DEFAULT_SHORT_MODEL = "inhouse"
+DEFAULT_LONG_MODEL = "all-MiniLM-L6-v2"
+# Mean character length at/above which a text column is treated as "long".
+DEFAULT_LONG_CHAR_THRESHOLD = 40
+
+
+@dataclass
+class FieldModelChoice:
+    """The embedding model chosen for one field + why."""
+
+    column: str
+    model: str
+    reason: str  # "override" | "long-text" | "short-text"
+    mean_chars: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "column": self.column,
+            "model": self.model,
+            "reason": self.reason,
+            "mean_chars": None if self.mean_chars is None else round(self.mean_chars, 2),
+        }
+
+
+def select_field_model(
+    column: str,
+    values: list[Any] | None = None,
+    *,
+    override: str | None = None,
+    short_model: str = DEFAULT_SHORT_MODEL,
+    long_model: str = DEFAULT_LONG_MODEL,
+    long_char_threshold: int = DEFAULT_LONG_CHAR_THRESHOLD,
+) -> FieldModelChoice:
+    """Choose an embedding model for one field.
+
+    An explicit ``override`` (e.g. from ``MatchkeyField.model``) always wins.
+    Otherwise the mean character length of ``values`` routes the column: long
+    free text (descriptions) → ``long_model``, short text (names/ids) →
+    ``short_model``. With no values, defaults to ``short_model``.
+    """
+    if override:
+        return FieldModelChoice(column=column, model=override, reason="override")
+    if not values:
+        return FieldModelChoice(column=column, model=short_model, reason="short-text")
+    lengths = [len(str(v)) for v in values if v is not None and str(v) != ""]
+    mean_chars = float(np.mean(lengths)) if lengths else 0.0
+    if mean_chars >= long_char_threshold:
+        return FieldModelChoice(
+            column=column, model=long_model, reason="long-text", mean_chars=mean_chars
+        )
+    return FieldModelChoice(
+        column=column, model=short_model, reason="short-text", mean_chars=mean_chars
+    )
+
+
+def select_field_models(
+    df: Any,
+    columns: list[str] | None = None,
+    *,
+    overrides: dict[str, str] | None = None,
+    short_model: str = DEFAULT_SHORT_MODEL,
+    long_model: str = DEFAULT_LONG_MODEL,
+    long_char_threshold: int = DEFAULT_LONG_CHAR_THRESHOLD,
+) -> dict[str, FieldModelChoice]:
+    """Choose a per-field embedding model for each text column of ``df``.
+
+    Args:
+        df: a Polars DataFrame (or anything with ``.columns`` + ``df[col].to_list()``).
+        columns: restrict to these columns (default: all string/object columns).
+        overrides: ``{column: model}`` explicit choices that always win
+            (e.g. collected from ``MatchkeyField.model``).
+        short_model / long_model / long_char_threshold: routing knobs.
+
+    Returns:
+        ``{column: FieldModelChoice}``. Non-text columns are skipped (unless an
+        override names them).
+    """
+    overrides = overrides or {}
+    cols = columns if columns is not None else list(getattr(df, "columns", []))
+    out: dict[str, FieldModelChoice] = {}
+    for col in cols:
+        if col in overrides:
+            out[col] = FieldModelChoice(column=col, model=overrides[col], reason="override")
+            continue
+        try:
+            values = df[col].to_list()
+        except Exception:
+            continue
+        # Treat as text only if some value is a non-numeric string.
+        if not any(isinstance(v, str) for v in values):
+            continue
+        out[col] = select_field_model(
+            col, values, short_model=short_model, long_model=long_model,
+            long_char_threshold=long_char_threshold,
+        )
+    return out
+
+
+# ── 3. Canonicalization quality eval ─────────────────────────────────────────
+
+
+@dataclass
+class CanonicalizationEval:
+    """Measured quality of a batch of ``canonicalize_cluster`` outputs.
+
+    The first block is always available (no labels needed); ``tp``/``fp``/``fn``
+    (and the precision/recall/f1 properties) are populated only when a ``gold`` is
+    supplied, mirroring ``EvalResult``.
+    """
+
+    n_records: int = 0
+    n_fields: int = 0  # total canonical cells across all records
+    field_completeness: float = 0.0  # non-null canonical cells / n_fields
+    provenance_coverage: float = 0.0  # cells traceable to a source / n_fields
+    synthesized_rate: float = 0.0  # cells with no source record / n_fields
+    llm_rate: float = 0.0  # records canonicalized by an LLM / n_records
+    # Field-accuracy vs gold (zero unless a gold is supplied).
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+
+    @property
+    def precision(self) -> float:
+        return self.tp / (self.tp + self.fp) if (self.tp + self.fp) else 0.0
+
+    @property
+    def recall(self) -> float:
+        return self.tp / (self.tp + self.fn) if (self.tp + self.fn) else 0.0
+
+    @property
+    def f1(self) -> float:
+        p, r = self.precision, self.recall
+        return 2 * p * r / (p + r) if (p + r) else 0.0
+
+    def summary(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "n_records": self.n_records,
+            "n_fields": self.n_fields,
+            "field_completeness": round(self.field_completeness, 4),
+            "provenance_coverage": round(self.provenance_coverage, 4),
+            "synthesized_rate": round(self.synthesized_rate, 4),
+            "llm_rate": round(self.llm_rate, 4),
+        }
+        if self.tp or self.fp or self.fn:
+            out["field_accuracy"] = {
+                "tp": self.tp, "fp": self.fp, "fn": self.fn,
+                "precision": round(self.precision, 4),
+                "recall": round(self.recall, 4),
+                "f1": round(self.f1, 4),
+            }
+        return out
+
+    as_dict = summary
+
+
+def evaluate_canonicalization(
+    records: list[Any],
+    *,
+    gold: list[dict[str, Any]] | None = None,
+) -> CanonicalizationEval:
+    """Measure the quality of a batch of ``CanonicalRecord`` outputs.
+
+    Args:
+        records: the ``CanonicalRecord`` objects from ``canonicalize_cluster``
+            (anything exposing ``.record``, ``.provenance``, ``.method``).
+        gold: optional list of expected canonical dicts, aligned by index to
+            ``records``. When given, per-field precision/recall/F1 are computed
+            over the gold fields (a gold field matches when the canonical value
+            equals it).
+
+    Returns:
+        A ``CanonicalizationEval``. Never raises on valid input.
+    """
+    ev = CanonicalizationEval(n_records=len(records))
+    if not records:
+        return ev
+
+    total_cells = 0
+    non_null = 0
+    with_source = 0
+    synthesized = 0
+    llm = 0
+    for rec in records:
+        record = getattr(rec, "record", {}) or {}
+        provenance = getattr(rec, "provenance", {}) or {}
+        if getattr(rec, "method", "") == "llm":
+            llm += 1
+        for fname, value in record.items():
+            total_cells += 1
+            if value is not None and str(value) != "":
+                non_null += 1
+            prov = provenance.get(fname)
+            src = getattr(prov, "source_index", None) if prov is not None else None
+            if src is not None:
+                with_source += 1
+            else:
+                synthesized += 1
+
+    ev.n_fields = total_cells
+    if total_cells:
+        ev.field_completeness = non_null / total_cells
+        ev.provenance_coverage = with_source / total_cells
+        ev.synthesized_rate = synthesized / total_cells
+    ev.llm_rate = llm / len(records)
+
+    if gold is not None:
+        for i, rec in enumerate(records):
+            expected = gold[i] if i < len(gold) else {}
+            record = getattr(rec, "record", {}) or {}
+            for fname, exp_val in (expected or {}).items():
+                if exp_val is None or str(exp_val) == "":
+                    continue
+                got = record.get(fname)
+                if got is not None and str(got) == str(exp_val):
+                    ev.tp += 1
+                else:
+                    ev.fn += 1
+                    if got is not None and str(got) != "":
+                        ev.fp += 1  # produced a wrong non-null value
+    return ev

--- a/packages/python/goldenmatch/tests/test_embedding_ops.py
+++ b/packages/python/goldenmatch/tests/test_embedding_ops.py
@@ -1,0 +1,230 @@
+"""Embedding ops -- drift, per-field models, canonicalization eval (#1093).
+
+Fully deterministic + offline: numpy arrays for precise drift control, the
+zero-config in-house embedder for an integration check, and ``canonicalize_cluster``
+(deterministic / stubbed LLM) for the canonicalization eval. No network, no torch.
+"""
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import polars as pl
+import pytest
+from goldenmatch.core.embedding_ops import (
+    CanonicalizationEval,
+    EmbeddingDriftReport,
+    embedding_drift,
+    evaluate_canonicalization,
+    select_field_model,
+    select_field_models,
+)
+from goldenmatch.core.llm_canonicalize import canonicalize_cluster
+
+
+def _normalize(a: np.ndarray) -> np.ndarray:
+    return a / np.linalg.norm(a, axis=1, keepdims=True)
+
+
+def _cone(direction, n, *, noise=0.1, seed=0):
+    """A tight cluster of unit vectors around ``direction`` (a directional centroid)."""
+    rng = np.random.default_rng(seed)
+    d = np.asarray(direction, dtype=float)
+    d = d / np.linalg.norm(d)
+    pts = d + noise * rng.standard_normal((n, len(d)))
+    return _normalize(pts)
+
+
+# ── drift detection ──────────────────────────────────────────────────────────
+
+
+def test_identical_sets_no_drift():
+    rng = np.random.default_rng(1)
+    a = _normalize(rng.standard_normal((100, 16)))
+    rep = embedding_drift(a, a.copy())
+    assert isinstance(rep, EmbeddingDriftReport)
+    assert rep.psi == pytest.approx(0.0, abs=1e-9)
+    assert rep.centroid_cosine_drift == pytest.approx(0.0, abs=1e-9)
+    assert rep.drifted is False
+
+
+def test_shifted_distribution_alarms():
+    rng = np.random.default_rng(2)
+    ref = _normalize(rng.standard_normal((200, 16)))
+    cur = _normalize(ref + 1.5)  # push the whole space along (1,1,...)
+    rep = embedding_drift(ref, cur)
+    assert rep.psi > 0.25
+    assert rep.drifted is True
+
+
+def test_diffuse_independent_sets_no_false_alarm():
+    # Two independent mean-zero sets: the centroid direction is noise -- the cone
+    # guard must keep centroid-cosine OUT of the alarm so this does NOT trip.
+    rng = np.random.default_rng(3)
+    ref = _normalize(rng.standard_normal((300, 16)))
+    cur = _normalize(rng.standard_normal((300, 16)))
+    rep = embedding_drift(ref, cur)
+    assert rep.psi < 0.25
+    assert rep.drifted is False
+
+
+def test_directional_centroid_cosine_path():
+    # A real (directional) centroid: a rotation alarms via centroid cosine even
+    # when PSI is forced not to alarm; the diffuse case stays quiet under the
+    # same forced-PSI setting (proving the cone guard).
+    ref = _cone([1, 0, 0, 0], 100, seed=10)
+    rotated = _cone([0, 1, 0, 0], 100, seed=11)
+    rep = embedding_drift(ref, rotated, alarm_psi=1e9)
+    assert rep.centroid_cosine_drift > 0.1
+    assert rep.drifted is True  # centroid path fires (directional centroid)
+
+    rng = np.random.default_rng(12)
+    diffuse_ref = _normalize(rng.standard_normal((300, 16)))
+    diffuse_cur = _normalize(rng.standard_normal((300, 16)))
+    quiet = embedding_drift(diffuse_ref, diffuse_cur, alarm_psi=1e9)
+    assert quiet.drifted is False  # guard suppresses the noisy-centroid alarm
+
+
+def test_identical_inhouse_embeddings_no_drift():
+    from goldenmatch.core.embedder import get_embedder
+
+    emb = get_embedder("inhouse")
+    vals = ["Acme Corp", "Globex Inc", "Initech LLC", "Stark Industries"] * 6
+    ref = emb.embed_column(vals, cache_key="ops_ref")
+    cur = emb.embed_column(list(vals), cache_key="ops_cur")  # same strings
+    rep = embedding_drift(ref, cur)
+    assert rep.drifted is False
+
+
+def test_dim_mismatch_raises():
+    with pytest.raises(ValueError, match="dim mismatch"):
+        embedding_drift(np.zeros((4, 8)), np.zeros((4, 16)))
+
+
+def test_empty_inputs_no_drift_no_raise():
+    rep = embedding_drift(np.zeros((0, 16)), np.zeros((0, 16)))
+    assert rep.drifted is False
+    assert rep.psi == 0.0
+
+
+def test_alarm_thresholds_respected():
+    rng = np.random.default_rng(4)
+    ref = _normalize(rng.standard_normal((200, 16)))
+    cur = _normalize(ref + 1.5)
+    # An impossibly high PSI threshold + directional guard off -> never alarms.
+    assert embedding_drift(ref, cur, alarm_psi=1e9).drifted is False
+
+
+def test_drift_report_serializable():
+    rng = np.random.default_rng(5)
+    a = _normalize(rng.standard_normal((50, 16)))
+    blob = json.dumps(embedding_drift(a, a.copy()).as_dict())
+    assert "psi" in blob and "drifted" in blob
+
+
+# ── per-field model selection ────────────────────────────────────────────────
+
+
+def test_short_vs_long_text_routing():
+    df = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Globex Inc", "Initech LLC"],
+            "description": [
+                "A lengthy paragraph describing the firm operations across many markets",
+                "Another long description of products, history, and global footprint here",
+                "Detailed multi-sentence overview of the organization and its many ventures",
+            ],
+        }
+    )
+    choices = select_field_models(df)
+    assert choices["name"].model == "inhouse"
+    assert choices["name"].reason == "short-text"
+    assert choices["description"].model == "all-MiniLM-L6-v2"
+    assert choices["description"].reason == "long-text"
+
+
+def test_override_always_wins():
+    df = pl.DataFrame({"name": ["Acme Corp"], "description": ["x" * 100]})
+    choices = select_field_models(df, overrides={"description": "text-embedding-3-large"})
+    assert choices["description"].model == "text-embedding-3-large"
+    assert choices["description"].reason == "override"
+
+
+def test_non_text_columns_skipped():
+    df = pl.DataFrame({"name": ["Acme"], "zip": [90210], "count": [3]})
+    choices = select_field_models(df)
+    assert "name" in choices
+    assert "zip" not in choices and "count" not in choices
+
+
+def test_select_field_model_single_and_defaults():
+    assert select_field_model("name", None).model == "inhouse"  # no values -> short
+    assert select_field_model("x", ["short"], override="custom").model == "custom"
+    long_choice = select_field_model("desc", ["q" * 80, "w" * 90])
+    assert long_choice.model == "all-MiniLM-L6-v2"
+    assert isinstance(long_choice.as_dict(), dict)
+
+
+# ── canonicalization quality eval ────────────────────────────────────────────
+
+RECS = [
+    {"name": "Bob", "email": "bob@x.com", "phone": None},
+    {"name": "Robert Smith", "email": "bob@x.com", "phone": "555-1234"},
+]
+
+
+def test_completeness_and_provenance_no_gold():
+    cr = canonicalize_cluster(RECS)
+    ev = evaluate_canonicalization([cr])
+    assert isinstance(ev, CanonicalizationEval)
+    assert ev.n_records == 1
+    assert ev.field_completeness == 1.0  # every canonical cell filled
+    assert ev.provenance_coverage == 1.0  # every value traced to a source record
+    assert ev.synthesized_rate == 0.0
+    assert ev.llm_rate == 0.0
+    assert "field_accuracy" not in ev.summary()  # omitted without a gold
+
+
+def test_field_accuracy_against_gold():
+    cr = canonicalize_cluster(RECS)
+    ev = evaluate_canonicalization(
+        [cr], gold=[{"name": "Robert Smith", "phone": "555-1234"}]
+    )
+    assert ev.tp == 2 and ev.fp == 0 and ev.fn == 0
+    assert ev.precision == 1.0 and ev.recall == 1.0 and ev.f1 == 1.0
+
+
+def test_wrong_value_counts_fp_and_fn():
+    cr = canonicalize_cluster(RECS)
+    ev = evaluate_canonicalization([cr], gold=[{"name": "Someone Else"}])
+    assert ev.fn == 1  # we didn't produce the expected name
+    assert ev.fp == 1  # we produced a different non-null value
+    assert ev.recall == 0.0
+
+
+def test_synthesized_value_lowers_provenance():
+    # The LLM invents a value present in no source record -> synthesized (no source).
+    payload = {"fields": {"name": {"value": "Bobby Smith", "source": 9}}, "rationale": "r"}
+    cr = canonicalize_cluster(
+        RECS, fields=["name"], llm_call=lambda p: (json.dumps(payload), 1, 1)
+    )
+    ev = evaluate_canonicalization([cr])
+    assert ev.synthesized_rate == 1.0
+    assert ev.provenance_coverage == 0.0
+    assert ev.llm_rate == 1.0
+
+
+def test_llm_rate_mixed_batch():
+    det = canonicalize_cluster(RECS)  # deterministic
+    payload = {"fields": {"name": {"value": "Bob", "source": 0}}, "rationale": "r"}
+    llm = canonicalize_cluster(RECS, llm_call=lambda p: (json.dumps(payload), 1, 1))
+    ev = evaluate_canonicalization([det, llm])
+    assert ev.n_records == 2
+    assert ev.llm_rate == 0.5
+
+
+def test_empty_records():
+    ev = evaluate_canonicalization([])
+    assert ev.n_records == 0
+    assert ev.field_completeness == 0.0
+    assert ev.summary()["n_records"] == 0


### PR DESCRIPTION
## What

`goldenmatch/core/embedding_ops.py` — the operations layer for running embeddings + canonicalization in production, the **final phase of the RAG epic #1087** (#1093). Three capabilities, all numpy/heuristic, deterministic, and offline:

### 1. Drift detection — `embedding_drift(reference, current) -> EmbeddingDriftReport`
Has the embedding model's output distribution shifted between a reference run and now? Reports centroid cosine drift, mean shift, norm ratio, and a **population-stability index (PSI)** over the projection onto the reference centroid, with a `drifted` **alarm**.
- PSI is the primary (scale-free, industry-standard) alarm.
- The centroid-cosine signal joins the alarm **only when the reference centroid is directional** (embeddings in a cone) — so embeddings diffuse around the origin (centroid ≈ 0, direction is noise) never false-alarm.

### 2. Per-field model selection — `select_field_models(df) -> {col: FieldModelChoice}`
Names and descriptions want different embedders. Routes short identifier-like text to the zero-config `inhouse` model and long free text to a stronger sentence model (`all-MiniLM-L6-v2`), honoring an explicit per-field `MatchkeyField.model` override. Returns `get_embedder`-compatible model ids.

### 3. Canonicalization quality eval — `evaluate_canonicalization(records, *, gold=None) -> CanonicalizationEval`
Measures `canonicalize_cluster` output: **field completeness**, **provenance coverage**, **synthesized-value rate**, **LLM-vs-deterministic mix**, and (against an optional gold) per-field **precision/recall/F1** in the `EvalResult` `tp/fp/fn` shape.

Together these meet the **#1093 done-bar: drift alarms + measured canonicalization quality**.

## Design
Built entirely on existing primitives — `get_embedder`, `canonicalize_cluster` (#1091), and the `EvalResult` conventions — so **no new dependency** and **zero pipeline impact**. All public symbols exported from the package root. No new env flags.

## Demo
`examples/embedding_ops.py`:
```
1. Drift detection
   same inputs   -> drifted=False  psi=0.000
   shifted inputs-> drifted=True  psi=26.245  (ALARM)
2. Per-field model selection
   name         -> inhouse            (short-text, mean 10 chars)
   description  -> all-MiniLM-L6-v2   (long-text, mean 71 chars)
3. Canonicalization quality
   field_completeness: 1.0 | provenance_coverage: 1.0 | field_accuracy: P/R/F1 = 1.0
```

## Tests
19 tests in `tests/test_embedding_ops.py`, **fully deterministic + offline**: identical-set zero drift, shifted-distribution alarm, **diffuse-no-false-alarm + directional-centroid cone guard** (the subtle correctness point), in-house-embedder integration, dim-mismatch raise, empty inputs, threshold knobs; short/long routing, override-wins, non-text skip, defaults; completeness/provenance, field accuracy vs gold, wrong-value fp+fn, synthesized-lowers-provenance, llm-rate mix, empty. ruff clean; docs-staleness green.

Standalone PR off `main` (depends only on the merged `embedder` / `canonicalize_cluster` / `evaluate`).

Part of #1093 (epic #1087) — **completes all six RAG phases (#1088–#1093).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_