### PR TITLE
feat(er-kg-bench): on-demand MuSiQue fetch for the QA-e2e real-world anchor

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -22,6 +22,9 @@ on:
       engine:
         description: "all | goldengraph | lightrag | ms_graphrag | graphiti"
         default: "all"
+      trace:
+        description: "goldengraph only: localize where each answer is lost (extraction/retrieval/synthesis)"
+        default: "false"
 
 permissions:
   contents: read
@@ -69,6 +72,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
           POLARS_SKIP_CPU_CHECK: "1"
+          GOLDENGRAPH_QA_TRACE: ${{ inputs.trace }}
         run: |
           python -m erkgbench.qa_e2e.run_qa_e2e \
             --engine goldengraph \

--- a/docs/superpowers/specs/2026-06-22-goldengraph-qa-e2e-first-headline-handoff.md
+++ b/docs/superpowers/specs/2026-06-22-goldengraph-qa-e2e-first-headline-handoff.md
@@ -11,6 +11,46 @@ Related: `2026-06-20-goldengraph-evidence-program-design.md` (the program spec),
 
 ---
 
+## UPDATE 2026-06-22 (evening): real MuSiQue anchor + the loss localized to a SHATTERED GRAPH
+
+PR #1209 made the real-world MuSiQue anchor runnable (on-demand HuggingFace fetch,
+seeded subset, never redistributed) AND added a reusable **localize trace**
+(`GOLDENGRAPH_QA_TRACE=1`, `trace` workflow input) that classifies *where* each
+question's answer is lost: extraction / retrieval-budget / retrieval-broken-chain /
+synthesis. The trace is native-free, LLM-free guarded
+(`tests/test_qa_localize_trace.py`) and is the built-in validator for the fix below.
+
+**First real MuSiQue numbers (goldengraph, gpt-4o-mini): answer_match 0.0.** That is
+NOT a measurement artifact -- the localize trace nails the cause to the graph:
+
+- The 375-378 entity MuSiQue graph **fragments into ~60 disconnected components**
+  (top sizes ~[55,26,16,15,12,10]). For every answerable question, the gold answer
+  sits in a **different component than the question's seeds** (`same_component=False`;
+  e.g. *Exeter College* in an 8-node island, its "Hannibal and Scipio" seeds in a
+  separate 31-node one). The answer entity *is* extracted -- it's the BRIDGE between
+  paragraph-islands that's missing.
+- Ruled out by the trace: **retrieval budget** (wide 8-hop unbudgeted ball ==
+  budget-capped ball -- the island is fully explored, bumping `node_budget`/`hops`
+  does nothing) and **synthesis** (the answer never reaches the synthesizer).
+- **Root cause (code-confirmed):** `goldengraph/resolve.py` runs goldenmatch fuzzy
+  resolution only *within a single document's* mentions; the durable store
+  (`goldengraph-core/src/store.rs::append`) reconciles entities across documents
+  **only by exact `record_key`** (`record_fingerprint({name, typ})`, a hash of the
+  exact surface string). So an entity mentioned as "Thomas Nabbes" in one paragraph
+  and "Nabbes" in another never merges -> each paragraph becomes its own island ->
+  the multi-hop chain is physically severed. This is exactly the cross-document
+  entity resolution goldengraph claims as its moat, failing on real text. It's
+  invisible on the engineered corpus (atomic one-sentence facts, no cross-paragraph
+  bridge to resolve), which is why goldengraph wins there and scores ~0 here.
+
+**The fix is cross-document entity linking** (merge bridge entities across paragraphs
+so the islands join), NOT retrieval or synthesis tuning. Validation is built in: a
+working fix collapses the ~60 components and flips `same_component` to True on the
+localize trace. Tracked on the follow-up branch off #1209.
+
+---
+
+
 ## TL;DR
 
 The 2026-06-21 head-to-head was green-but-degenerate (every engine ~0

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/corpora.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/corpora.py
@@ -3,9 +3,20 @@ ingests, so the harness and metrics never special-case a source."""
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+import random
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+
+#: Default real-world MuSiQue-Ans source on the HuggingFace Hub. The canonical
+#: MuSiQue release ships as a Google-Drive zip; this mirror is the same
+#: MuSiQue-Ans rows in the official schema (id / question / answer / paragraphs /
+#: question_decomposition), loadable with `datasets.load_dataset` and no config.
+MUSIQUE_HF_DATASET = "dgslibisey/MuSiQue"
+MUSIQUE_HF_SPLIT = "validation"
+#: Deterministic-subset seed -- shared with the engineered generator so a "seed
+#: 20260620" run is reproducible across both corpora.
+MUSIQUE_SUBSET_SEED = 20260620
 
 
 @dataclass(frozen=True)
@@ -43,16 +54,61 @@ class QACorpus:
 def load_musique(
     *, path: str | Path, max_questions: int, hf_split: str | None = None
 ) -> QACorpus:
-    """Load MuSiQue-Ans into the normalized QACorpus shape.
+    """Load MuSiQue-Ans from a JSONL file into the normalized QACorpus shape.
 
-    ``path`` points at a JSONL file (the committed fixture, or a downloaded
-    subset). Each *supporting* paragraph becomes a Document keyed
-    ``"<question_id>::p<idx>"``; ``hop_count`` = ``len(question_decomposition)``
-    (falling back to 2 when absent)."""
+    ``path`` points at a JSONL file (the committed fixture, or a previously
+    downloaded subset). For an on-demand HuggingFace fetch (no committed file),
+    use :func:`fetch_musique`."""
     rows = _read_jsonl(Path(path))
+    return _musique_corpus_from_rows(rows, max_questions=max_questions)
+
+
+def fetch_musique(
+    *,
+    dataset: str = MUSIQUE_HF_DATASET,
+    split: str = MUSIQUE_HF_SPLIT,
+    max_questions: int,
+    seed: int = MUSIQUE_SUBSET_SEED,
+) -> QACorpus:
+    """Fetch MuSiQue-Ans on demand from the HuggingFace Hub and normalize it.
+
+    The full validation split is ~2.4k multi-hop questions (CC-BY-4.0). We fetch
+    it on demand -- the corpus is never redistributed in-repo -- and take a
+    *seeded* id-sorted subset of ``max_questions`` so a run is deterministic
+    without committing a question list. ``datasets`` is an opt-in dependency of
+    the bench lane (the engineered corpus needs no network), so the import is
+    local and its absence raises a pointed error."""
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:  # pragma: no cover - exercised in CI install, not unit
+        raise RuntimeError(
+            "fetch_musique needs the `datasets` package (pip install datasets). "
+            "The engineered corpus has no such dependency; only the real-world "
+            "MuSiQue anchor fetches from the Hub."
+        ) from exc
+
+    ds = load_dataset(dataset, split=split)
+    # Sort by id first so the seeded sample is independent of the Hub's row order,
+    # then sample without replacement for a stable, shuffled subset.
+    rows = sorted((dict(r) for r in ds), key=lambda r: str(r["id"]))
+    k = min(max_questions, len(rows))
+    subset = random.Random(seed).sample(rows, k=k)
+    return _musique_corpus_from_rows(subset, max_questions=k)
+
+
+def _musique_corpus_from_rows(
+    rows: Iterable[dict], *, max_questions: int
+) -> QACorpus:
+    """Normalize MuSiQue-Ans rows (from JSONL or the Hub) into a QACorpus.
+
+    Each paragraph (supporting *and* distractor) becomes a Document keyed
+    ``"<question_id>::p<idx>"`` so the graph ingests the realistic noise; only
+    *supporting* paragraphs are recorded as gold support. ``hop_count`` =
+    ``len(question_decomposition)`` (falling back to 2 when absent). MuSiQue has
+    no ambiguity dial, so ``ambiguity_level`` is fixed at 0.0."""
     documents: list[Document] = []
     questions: list[QAItem] = []
-    for row in rows[:max_questions]:
+    for row in list(rows)[:max_questions]:
         qid = str(row["id"])
         support_ids: list[str] = []
         for para in row.get("paragraphs", []):

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -19,6 +19,12 @@ _AS_OF = 10**12
 #: corpus's 1-4 hop range. Overridable for tuning sweeps.
 _RETRIEVAL_HOPS = int(os.environ.get("GOLDENGRAPH_QA_RETRIEVAL_HOPS", "4"))
 
+#: Deep, unbudgeted hop count for the localize trace's "wide ball" -- approximates
+#: "everything reachable from the seeds" to split a retrieval miss (answer in the
+#: graph but outside the budget-capped ball) from a broken-chain miss (answer in
+#: the graph but disconnected from the seeds within any reasonable depth).
+_WIDE_HOPS = 8
+
 
 class _CountingLLM:
     """Wraps any goldengraph LLMClient and estimates token usage per .complete
@@ -96,10 +102,12 @@ class GoldenGraphQAEngine:
     def localize(self, handle, question: str) -> dict:
         """Diagnostic for the harness trace: replay the retrieval half of `ask`
         (seed -> adaptive ball) and surface the raw material to localize a miss --
-        the seed entities, EVERY entity name in the graph, and the entity names in
-        the retrieved ball. The harness checks gold-answer containment against the
-        graph set (extraction) vs the ball set (retrieval). NO LLM call -- only the
-        embedding-based seeding runs, so a trace costs ~nothing beyond the build."""
+        the seed entities, EVERY entity name in the graph, the entity names in the
+        retrieved ball, AND the entity names reachable in a WIDE ball (deep,
+        unbudgeted neighborhood from the same seeds). The harness checks gold
+        containment against graph (extraction) vs wide (reachable-from-seeds) vs
+        ball (budget-capped retrieval). NO LLM call -- only embedding-based seeding
+        runs, so a trace costs ~nothing beyond the build."""
         from goldengraph.answer import _retrieve_local
         from goldengraph.embed import seed_by_query
 
@@ -108,6 +116,10 @@ class GoldenGraphQAEngine:
         subgraph = _retrieve_local(
             slice_graph, seeds, max_hops=self._retrieval_hops, node_budget=64
         )
+        # Wide ball: deep neighborhood, no node budget -- "is the answer reachable
+        # from the seeds at ALL?" Splits a retrieval miss into budget-too-small
+        # (in wide, not in ball) vs disconnected/broken-chain (not even in wide).
+        wide = slice_graph.query(seeds, _WIDE_HOPS) if seeds else {"entities": []}
 
         def _names(ents) -> list[str]:
             out: list[str] = []
@@ -118,12 +130,15 @@ class GoldenGraphQAEngine:
 
         all_ents = slice_graph.entities()
         retr_ents = subgraph.get("entities", [])
+        wide_ents = wide.get("entities", [])
         id_to_name = {e["entity_id"]: e["canonical_name"] for e in all_ents}
         return {
             "seed_names": [id_to_name.get(s, str(s)) for s in seeds],
             "graph_names": _names(all_ents),
             "retrieved_names": _names(retr_ents),
+            "wide_names": _names(wide_ents),
             "n_graph_entities": len(all_ents),
             "n_retrieved_entities": len(retr_ents),
+            "n_wide_entities": len(wide_ents),
             "n_retrieved_edges": len(subgraph.get("edges", ())),
         }

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -92,3 +92,38 @@ class GoldenGraphQAEngine:
             output_tokens=self._llm.output_tokens - before_out,
             latency_s=time.perf_counter() - t0,
         )
+
+    def localize(self, handle, question: str) -> dict:
+        """Diagnostic for the harness trace: replay the retrieval half of `ask`
+        (seed -> adaptive ball) and surface the raw material to localize a miss --
+        the seed entities, EVERY entity name in the graph, and the entity names in
+        the retrieved ball. The harness checks gold-answer containment against the
+        graph set (extraction) vs the ball set (retrieval). NO LLM call -- only the
+        embedding-based seeding runs, so a trace costs ~nothing beyond the build."""
+        from goldengraph.answer import _retrieve_local
+        from goldengraph.embed import seed_by_query
+
+        slice_graph = handle["store"].as_of(handle["valid_t"], handle["tx_t"])
+        seeds = seed_by_query(slice_graph, question, self._embedder, k=5)
+        subgraph = _retrieve_local(
+            slice_graph, seeds, max_hops=self._retrieval_hops, node_budget=64
+        )
+
+        def _names(ents) -> list[str]:
+            out: list[str] = []
+            for e in ents:
+                out.append(e["canonical_name"])
+                out.extend(e.get("surface_names", ()))
+            return out
+
+        all_ents = slice_graph.entities()
+        retr_ents = subgraph.get("entities", [])
+        id_to_name = {e["entity_id"]: e["canonical_name"] for e in all_ents}
+        return {
+            "seed_names": [id_to_name.get(s, str(s)) for s in seeds],
+            "graph_names": _names(all_ents),
+            "retrieved_names": _names(retr_ents),
+            "n_graph_entities": len(all_ents),
+            "n_retrieved_entities": len(retr_ents),
+            "n_retrieved_edges": len(subgraph.get("edges", ())),
+        }

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -132,11 +132,46 @@ class GoldenGraphQAEngine:
         retr_ents = subgraph.get("entities", [])
         wide_ents = wide.get("entities", [])
         id_to_name = {e["entity_id"]: e["canonical_name"] for e in all_ents}
+
+        # Connected components of the WHOLE graph: query 1-hop from every node to get
+        # the full edge set, then union-find. This makes the wide==ball symptom
+        # concrete -- if the answer and the question's seeds land in DIFFERENT
+        # components, the multi-hop chain is severed (a bridge entity that should
+        # connect adjacent paragraphs was never resolved into one node).
+        all_ids = [e["entity_id"] for e in all_ents]
+        full = slice_graph.query(all_ids, 1) if all_ids else {"edges": []}
+        parent = {e["entity_id"]: e["entity_id"] for e in all_ents}
+
+        def _find(x):
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        for ed in full.get("edges", ()):
+            a, b = ed.get("subj"), ed.get("obj")
+            if a in parent and b in parent:
+                parent[_find(a)] = _find(b)
+        comp_members: dict[int, list] = {}
+        for e in all_ents:
+            comp_members.setdefault(_find(e["entity_id"]), []).append(e)
+        components = sorted(comp_members.values(), key=len, reverse=True)
+        seed_set = set(seeds)
+        seed_component_idx = next(
+            (i for i, c in enumerate(components)
+             if any(e["entity_id"] in seed_set for e in c)),
+            -1,
+        )
+
         return {
             "seed_names": [id_to_name.get(s, str(s)) for s in seeds],
             "graph_names": _names(all_ents),
             "retrieved_names": _names(retr_ents),
             "wide_names": _names(wide_ents),
+            "component_names": [_names(c) for c in components],
+            "component_sizes": [len(c) for c in components],
+            "seed_component_idx": seed_component_idx,
+            "n_components": len(components),
             "n_graph_entities": len(all_ents),
             "n_retrieved_entities": len(retr_ents),
             "n_wide_entities": len(wide_ents),

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -56,20 +56,24 @@ def _localize_trace(engine, handle, corpus, *, limit: int = 10) -> None:
             print(f"  [{q.id}] localize failed: {exc!r}", flush=True)
             continue
         in_graph = bool(metrics.answer_match(" ".join(loc["graph_names"]), q.gold_answer))
+        in_wide = bool(metrics.answer_match(" ".join(loc.get("wide_names", [])), q.gold_answer))
         in_ball = bool(metrics.answer_match(" ".join(loc["retrieved_names"]), q.gold_answer))
         if not in_graph:
-            stage = "EXTRACTION (gold entity absent from the graph)"
+            stage = "EXTRACTION (gold not a graph node: never extracted, or a non-entity answer)"
+        elif not in_wide:
+            stage = "RETRIEVAL-BROKEN-CHAIN (in graph but unreachable from the seeds)"
         elif not in_ball:
-            stage = "RETRIEVAL (in graph, missed by the seed-walk)"
+            stage = "RETRIEVAL-BUDGET (reachable from seeds but outside the budget-capped ball)"
         else:
             stage = "SYNTHESIS (retrieved, wrong answer written)"
         print(
             f"  [{q.id}] hop{q.hop_count} gold={q.gold_answer!r} "
-            f"in_graph={in_graph} in_ball={in_ball} -> {stage}",
+            f"in_graph={in_graph} in_wide={in_wide} in_ball={in_ball} -> {stage}",
             flush=True,
         )
         print(
             f"      seeds={loc['seed_names']} graph={loc['n_graph_entities']}ent "
+            f"wide={loc.get('n_wide_entities', '?')}ent "
             f"ball={loc['n_retrieved_entities']}ent/{loc['n_retrieved_edges']}edges",
             flush=True,
         )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -77,6 +77,24 @@ def _localize_trace(engine, handle, corpus, *, limit: int = 10) -> None:
             f"ball={loc['n_retrieved_entities']}ent/{loc['n_retrieved_edges']}edges",
             flush=True,
         )
+        comps = loc.get("component_names")
+        if comps is not None:
+            seed_idx = loc.get("seed_component_idx", -1)
+            ans_idx = next(
+                (i for i, names in enumerate(comps)
+                 if metrics.answer_match(" ".join(names), q.gold_answer)),
+                -1,
+            )
+            same = ans_idx == seed_idx and ans_idx >= 0
+            seed_sz = len(comps[seed_idx]) if seed_idx >= 0 else 0
+            ans_sz = len(comps[ans_idx]) if ans_idx >= 0 else 0
+            sizes = loc.get("component_sizes", [])
+            print(
+                f"      components: {loc.get('n_components', '?')} total "
+                f"(top sizes {sizes[:6]}); seed_comp={seed_sz}ent "
+                f"answer_comp={ans_sz}ent same_component={same}",
+                flush=True,
+            )
 
 
 def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> dict:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -4,6 +4,7 @@ enforces a hard USD cap via goldenmatch's BudgetTracker."""
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -40,6 +41,40 @@ class QAEngine(Protocol):
     def answer(self, handle, question: str) -> AnswerResult: ...
 
 
+def _localize_trace(engine, handle, corpus, *, limit: int = 10) -> None:
+    """Diagnostic: for each question, classify WHERE the gold answer is lost --
+    extraction (gold entity never made it into the graph), retrieval (it's in the
+    graph but the seed-walk didn't surface it), or synthesis (it was retrieved but
+    the LLM wrote a wrong answer). Opt-in via GOLDENGRAPH_QA_TRACE; only engines
+    exposing `localize` (goldengraph) participate. Uses the same token-containment
+    as answer_match so "in graph/ball" lines up with the headline scoring."""
+    print(f"== localize trace (first {limit}; where is the answer lost?) ==", flush=True)
+    for q in corpus.questions[:limit]:
+        try:
+            loc = engine.localize(handle, q.question)
+        except Exception as exc:  # diagnostic must never break the scored run
+            print(f"  [{q.id}] localize failed: {exc!r}", flush=True)
+            continue
+        in_graph = bool(metrics.answer_match(" ".join(loc["graph_names"]), q.gold_answer))
+        in_ball = bool(metrics.answer_match(" ".join(loc["retrieved_names"]), q.gold_answer))
+        if not in_graph:
+            stage = "EXTRACTION (gold entity absent from the graph)"
+        elif not in_ball:
+            stage = "RETRIEVAL (in graph, missed by the seed-walk)"
+        else:
+            stage = "SYNTHESIS (retrieved, wrong answer written)"
+        print(
+            f"  [{q.id}] hop{q.hop_count} gold={q.gold_answer!r} "
+            f"in_graph={in_graph} in_ball={in_ball} -> {stage}",
+            flush=True,
+        )
+        print(
+            f"      seeds={loc['seed_names']} graph={loc['n_graph_entities']}ent "
+            f"ball={loc['n_retrieved_entities']}ent/{loc['n_retrieved_edges']}edges",
+            flush=True,
+        )
+
+
 def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> dict:
     """Build the KG, answer every question under a hard cost cap, score, return a
     result dict. Stops cleanly (partial result) when the budget is exhausted."""
@@ -47,6 +82,11 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
 
     build = engine.build_kg(corpus)
     tracker.record_usage(build.input_tokens, build.output_tokens, model)
+
+    if os.environ.get("GOLDENGRAPH_QA_TRACE", "") not in ("", "0", "false") and hasattr(
+        engine, "localize"
+    ):
+        _localize_trace(engine, build.handle, corpus)
 
     ems: list[float] = []
     matches: list[float] = []

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 
 from . import engineered
-from .corpora import load_musique
+from .corpora import MUSIQUE_HF_DATASET, MUSIQUE_HF_SPLIT, MUSIQUE_SUBSET_SEED, fetch_musique, load_musique
 from .harness import AnswerResult, BuildResult, run_engine, write_results
 
 
@@ -23,15 +23,33 @@ class _MockEngine:
         return AnswerResult(text="?", input_tokens=1, output_tokens=1)
 
 
-def _load_corpus(name: str, max_questions: int, musique_path: str | None, ambiguity: float):
+def _load_corpus(
+    name: str,
+    max_questions: int,
+    musique_path: str | None,
+    ambiguity: float,
+    *,
+    musique_dataset: str = MUSIQUE_HF_DATASET,
+    musique_split: str = MUSIQUE_HF_SPLIT,
+    musique_seed: int = MUSIQUE_SUBSET_SEED,
+):
     if name == "engineered":
         return engineered.generate_engineered(
             seed=20260620, n_questions=max_questions, ambiguity=ambiguity
         )
     if name == "musique":
         # MuSiQue has no ambiguity dial (entities are already canonical); the flag is
-        # ignored here so a sweep over it just re-runs the same corpus.
-        return load_musique(path=musique_path, max_questions=max_questions)
+        # ignored here so a sweep over it just re-runs the same corpus. With an
+        # explicit --musique-path, read that JSONL; otherwise fetch a seeded subset
+        # from the Hub on demand (the corpus is never committed to the repo).
+        if musique_path:
+            return load_musique(path=musique_path, max_questions=max_questions)
+        return fetch_musique(
+            dataset=musique_dataset,
+            split=musique_split,
+            max_questions=max_questions,
+            seed=musique_seed,
+        )
     raise SystemExit(f"unknown corpus: {name}")
 
 
@@ -89,7 +107,15 @@ def main(argv: list[str] | None = None) -> int:
         help="engineered-corpus variant-mention fraction (0.0-1.0); the decay-curve "
         "sweep dial. Ignored for musique.",
     )
-    p.add_argument("--musique-path", default=None)
+    p.add_argument(
+        "--musique-path",
+        default=None,
+        help="JSONL file of MuSiQue-Ans rows. If omitted, --corpus musique fetches a "
+        "seeded subset from the HuggingFace Hub on demand.",
+    )
+    p.add_argument("--musique-dataset", default=MUSIQUE_HF_DATASET)
+    p.add_argument("--musique-split", default=MUSIQUE_HF_SPLIT)
+    p.add_argument("--musique-seed", type=int, default=MUSIQUE_SUBSET_SEED)
     p.add_argument("--model", default="gpt-4o-mini")
     p.add_argument("--budget-usd", type=float, default=25.0)
     p.add_argument("--out-md", required=True)
@@ -104,7 +130,15 @@ def main(argv: list[str] | None = None) -> int:
     out_json = Path(args.out_json).resolve()
     out_md.parent.mkdir(parents=True, exist_ok=True)
 
-    corpus = _load_corpus(args.corpus, args.max_questions, args.musique_path, args.ambiguity)
+    corpus = _load_corpus(
+        args.corpus,
+        args.max_questions,
+        args.musique_path,
+        args.ambiguity,
+        musique_dataset=args.musique_dataset,
+        musique_split=args.musique_split,
+        musique_seed=args.musique_seed,
+    )
     engine = _MockEngine() if args.self_test else _build_engine(args.engine)
     result = run_engine(engine, corpus, model=args.model, budget_usd=args.budget_usd)
     write_results([result], md_path=out_md, json_path=out_json)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -8,7 +8,13 @@ import os
 from pathlib import Path
 
 from . import engineered
-from .corpora import MUSIQUE_HF_DATASET, MUSIQUE_HF_SPLIT, MUSIQUE_SUBSET_SEED, fetch_musique, load_musique
+from .corpora import (
+    MUSIQUE_HF_DATASET,
+    MUSIQUE_HF_SPLIT,
+    MUSIQUE_SUBSET_SEED,
+    fetch_musique,
+    load_musique,
+)
 from .harness import AnswerResult, BuildResult, run_engine, write_results
 
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
@@ -1,0 +1,96 @@
+"""Harness localize-trace unit test -- offline. A fake engine exposes `localize`
+returning canned graph/ball name sets; we assert run_engine's trace block (gated
+by GOLDENGRAPH_QA_TRACE) classifies each question's loss as extraction /
+retrieval / synthesis using the same containment as answer_match. No LLM, no
+native store -- the classification logic is what we're locking down."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from erkgbench.qa_e2e.corpora import Document, QACorpus, QAItem  # noqa: E402
+from erkgbench.qa_e2e.harness import AnswerResult, BuildResult, run_engine  # noqa: E402
+
+
+class _FakeEngine:
+    """Per-question canned localization: maps question id -> (graph, ball) name
+    sets. answer() echoes a fixed wrong answer so scoring still runs."""
+
+    name = "fake"
+    fidelity = "test"
+
+    def __init__(self, table):
+        self._table = table
+        self._qid_by_question = {}
+
+    def build_kg(self, corpus) -> BuildResult:
+        self._qid_by_question = {q.question: q.id for q in corpus.questions}
+        return BuildResult(handle={"ok": True})
+
+    def answer(self, handle, question: str) -> AnswerResult:
+        return AnswerResult(text="some wrong answer")
+
+    def localize(self, handle, question: str) -> dict:
+        qid = self._qid_by_question[question]
+        graph_names, ball_names = self._table[qid]
+        return {
+            "seed_names": ["Seed"],
+            "graph_names": graph_names,
+            "retrieved_names": ball_names,
+            "n_graph_entities": len(graph_names),
+            "n_retrieved_entities": len(ball_names),
+            "n_retrieved_edges": 0,
+        }
+
+
+def _q(qid: str, gold: str) -> QAItem:
+    return QAItem(
+        id=qid,
+        question=f"q for {qid}?",
+        gold_answer=gold,
+        gold_supporting_fact_ids=(),
+        hop_count=2,
+        ambiguity_level=0.0,
+    )
+
+
+def _corpus() -> QACorpus:
+    qs = (
+        _q("extraction_miss", "Exeter College"),
+        _q("retrieval_miss", "the Politburo"),
+        _q("synthesis_miss", "Genesis"),
+    )
+    return QACorpus(name="musique", documents=(Document(id="d", text="x"),), questions=qs)
+
+
+def test_trace_classifies_three_loss_stages(monkeypatch, capsys):
+    monkeypatch.setenv("GOLDENGRAPH_QA_TRACE", "1")
+    table = {
+        # gold absent from graph entirely -> EXTRACTION
+        "extraction_miss": (["Oriel College", "Oxford"], ["Oriel College"]),
+        # gold in graph but not in retrieved ball -> RETRIEVAL
+        "retrieval_miss": (["the Politburo", "Soviet Union"], ["Soviet Union"]),
+        # gold in the retrieved ball, answer still wrong -> SYNTHESIS
+        "synthesis_miss": (["Genesis", "Nintendo"], ["Genesis", "Nintendo"]),
+    }
+    run_engine(_FakeEngine(table), _corpus(), model="gpt-4o-mini", budget_usd=5.0)
+    out = capsys.readouterr().out
+    assert "localize trace" in out
+    assert "[extraction_miss]" in out and "-> EXTRACTION" in out
+    assert "[retrieval_miss]" in out and "-> RETRIEVAL" in out
+    assert "[synthesis_miss]" in out and "-> SYNTHESIS" in out
+    # in_graph/in_ball flags must agree with the classification
+    ex_line = next(ln for ln in out.splitlines() if "[extraction_miss]" in ln)
+    assert "in_graph=False" in ex_line
+    rt_line = next(ln for ln in out.splitlines() if "[retrieval_miss]" in ln)
+    assert "in_graph=True in_ball=False" in rt_line
+    sy_line = next(ln for ln in out.splitlines() if "[synthesis_miss]" in ln)
+    assert "in_graph=True in_ball=True" in sy_line
+
+
+def test_trace_off_by_default(monkeypatch, capsys):
+    monkeypatch.delenv("GOLDENGRAPH_QA_TRACE", raising=False)
+    run_engine(_FakeEngine({}), _corpus(), model="gpt-4o-mini", budget_usd=5.0)
+    assert "localize trace" not in capsys.readouterr().out

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
@@ -98,3 +98,50 @@ def test_trace_off_by_default(monkeypatch, capsys):
     monkeypatch.delenv("GOLDENGRAPH_QA_TRACE", raising=False)
     run_engine(_FakeEngine({}), _corpus(), model="gpt-4o-mini", budget_usd=5.0)
     assert "localize trace" not in capsys.readouterr().out
+
+
+class _ComponentEngine:
+    """Engine whose localize returns explicit connected components, to lock the
+    harness's seed-vs-answer component comparison (the broken-chain confirmation)."""
+
+    name = "comp"
+    fidelity = "test"
+
+    def build_kg(self, corpus) -> BuildResult:
+        return BuildResult(handle={})
+
+    def answer(self, handle, question: str) -> AnswerResult:
+        return AnswerResult(text="wrong")
+
+    def localize(self, handle, question: str) -> dict:
+        # seeds live in component 0 ('Scipio' island); the gold answer 'Exeter
+        # College' lives in a DIFFERENT component -> severed chain.
+        components = [["Hannibal and Scipio", "Scipio"], ["Exeter College", "Oxford"], ["x"]]
+        return {
+            "seed_names": ["Scipio"],
+            "graph_names": [n for c in components for n in c],
+            "wide_names": ["Hannibal and Scipio", "Scipio"],
+            "retrieved_names": ["Hannibal and Scipio", "Scipio"],
+            "component_names": components,
+            "component_sizes": [len(c) for c in components],
+            "seed_component_idx": 0,
+            "n_components": len(components),
+            "n_graph_entities": 5,
+            "n_retrieved_entities": 2,
+            "n_wide_entities": 2,
+            "n_retrieved_edges": 1,
+        }
+
+
+def test_trace_reports_severed_component(monkeypatch, capsys):
+    monkeypatch.setenv("GOLDENGRAPH_QA_TRACE", "1")
+    corpus = QACorpus(
+        name="musique",
+        documents=(Document(id="d", text="x"),),
+        questions=(_q("q1", "Exeter College"),),
+    )
+    run_engine(_ComponentEngine(), corpus, model="gpt-4o-mini", budget_usd=5.0)
+    out = capsys.readouterr().out
+    assert "components: 3 total" in out
+    # seed component (2ent) != answer component (2ent), different islands
+    assert "seed_comp=2ent answer_comp=2ent same_component=False" in out

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
@@ -34,12 +34,14 @@ class _FakeEngine:
 
     def localize(self, handle, question: str) -> dict:
         qid = self._qid_by_question[question]
-        graph_names, ball_names = self._table[qid]
+        graph_names, wide_names, ball_names = self._table[qid]
         return {
             "seed_names": ["Seed"],
             "graph_names": graph_names,
+            "wide_names": wide_names,
             "retrieved_names": ball_names,
             "n_graph_entities": len(graph_names),
+            "n_wide_entities": len(wide_names),
             "n_retrieved_entities": len(ball_names),
             "n_retrieved_edges": 0,
         }
@@ -59,35 +61,37 @@ def _q(qid: str, gold: str) -> QAItem:
 def _corpus() -> QACorpus:
     qs = (
         _q("extraction_miss", "Exeter College"),
-        _q("retrieval_miss", "the Politburo"),
+        _q("broken_chain", "the Politburo"),
+        _q("budget_miss", "Lyon"),
         _q("synthesis_miss", "Genesis"),
     )
     return QACorpus(name="musique", documents=(Document(id="d", text="x"),), questions=qs)
 
 
-def test_trace_classifies_three_loss_stages(monkeypatch, capsys):
+def test_trace_classifies_four_loss_stages(monkeypatch, capsys):
     monkeypatch.setenv("GOLDENGRAPH_QA_TRACE", "1")
+    # table: qid -> (graph_names, wide_names, ball_names)
     table = {
         # gold absent from graph entirely -> EXTRACTION
-        "extraction_miss": (["Oriel College", "Oxford"], ["Oriel College"]),
-        # gold in graph but not in retrieved ball -> RETRIEVAL
-        "retrieval_miss": (["the Politburo", "Soviet Union"], ["Soviet Union"]),
+        "extraction_miss": (["Oriel College", "Oxford"], ["Oriel College"], ["Oriel College"]),
+        # gold in graph, NOT reachable from seeds (not in wide) -> BROKEN-CHAIN
+        "broken_chain": (["the Politburo", "Soviet Union"], ["Soviet Union"], ["Soviet Union"]),
+        # gold in graph AND wide (reachable) but outside the ball -> BUDGET
+        "budget_miss": (["Lyon", "France"], ["Lyon", "France"], ["France"]),
         # gold in the retrieved ball, answer still wrong -> SYNTHESIS
-        "synthesis_miss": (["Genesis", "Nintendo"], ["Genesis", "Nintendo"]),
+        "synthesis_miss": (["Genesis", "Nintendo"], ["Genesis", "Nintendo"], ["Genesis", "Nintendo"]),
     }
     run_engine(_FakeEngine(table), _corpus(), model="gpt-4o-mini", budget_usd=5.0)
     out = capsys.readouterr().out
     assert "localize trace" in out
-    assert "[extraction_miss]" in out and "-> EXTRACTION" in out
-    assert "[retrieval_miss]" in out and "-> RETRIEVAL" in out
-    assert "[synthesis_miss]" in out and "-> SYNTHESIS" in out
-    # in_graph/in_ball flags must agree with the classification
-    ex_line = next(ln for ln in out.splitlines() if "[extraction_miss]" in ln)
-    assert "in_graph=False" in ex_line
-    rt_line = next(ln for ln in out.splitlines() if "[retrieval_miss]" in ln)
-    assert "in_graph=True in_ball=False" in rt_line
-    sy_line = next(ln for ln in out.splitlines() if "[synthesis_miss]" in ln)
-    assert "in_graph=True in_ball=True" in sy_line
+    ex = next(ln for ln in out.splitlines() if "[extraction_miss]" in ln)
+    assert "in_graph=False" in ex and "-> EXTRACTION" in ex
+    bc = next(ln for ln in out.splitlines() if "[broken_chain]" in ln)
+    assert "in_graph=True in_wide=False" in bc and "-> RETRIEVAL-BROKEN-CHAIN" in bc
+    bg = next(ln for ln in out.splitlines() if "[budget_miss]" in ln)
+    assert "in_graph=True in_wide=True in_ball=False" in bg and "-> RETRIEVAL-BUDGET" in bg
+    sy = next(ln for ln in out.splitlines() if "[synthesis_miss]" in ln)
+    assert "in_ball=True" in sy and "-> SYNTHESIS" in sy
 
 
 def test_trace_off_by_default(monkeypatch, capsys):

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_musique_fetch.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_musique_fetch.py
@@ -1,0 +1,112 @@
+"""fetch_musique unit tests -- offline. A stub `datasets` module is injected into
+sys.modules so the HuggingFace fetch path is exercised without any network or the
+real `datasets` install: we assert the row->corpus normalization, the deterministic
+seeded subset, and the import-absent error message."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from erkgbench.qa_e2e.corpora import QACorpus, fetch_musique  # noqa: E402
+
+
+def _row(qid: str, answer: str, n_para: int, n_decomp: int) -> dict:
+    paragraphs = [
+        {
+            "idx": i,
+            "title": f"T{i}",
+            "paragraph_text": f"{qid} paragraph {i}.",
+            "is_supporting": i < n_decomp,  # first n_decomp are supporting
+        }
+        for i in range(n_para)
+    ]
+    return {
+        "id": qid,
+        "question": f"question for {qid}?",
+        "answer": answer,
+        "paragraphs": paragraphs,
+        "question_decomposition": [{"id": j} for j in range(n_decomp)],
+    }
+
+
+_FAKE_ROWS = [
+    _row("2hop__a", "Alpha", n_para=4, n_decomp=2),
+    _row("3hop__b", "Bravo", n_para=6, n_decomp=3),
+    _row("2hop__c", "Charlie", n_para=3, n_decomp=2),
+    _row("4hop__d", "Delta", n_para=8, n_decomp=4),
+]
+
+
+@pytest.fixture
+def stub_datasets(monkeypatch):
+    """Inject a fake `datasets` module whose load_dataset returns _FAKE_ROWS."""
+    calls = {}
+
+    def load_dataset(dataset, split):
+        calls["dataset"] = dataset
+        calls["split"] = split
+        return list(_FAKE_ROWS)
+
+    mod = types.ModuleType("datasets")
+    mod.load_dataset = load_dataset  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "datasets", mod)
+    return calls
+
+
+def test_fetch_normalizes_rows(stub_datasets):
+    corpus = fetch_musique(dataset="x/y", split="validation", max_questions=10, seed=1)
+    assert isinstance(corpus, QACorpus)
+    assert corpus.name == "musique"
+    assert stub_datasets["dataset"] == "x/y"
+    assert stub_datasets["split"] == "validation"
+    # 4 questions; every paragraph (supporting + distractor) is a Document.
+    assert len(corpus.questions) == 4
+    assert len(corpus.documents) == 4 + 6 + 3 + 8
+    by_id = {q.id: q for q in corpus.questions}
+    qa = by_id["2hop__a"]
+    assert qa.gold_answer == "Alpha"
+    assert qa.hop_count == 2  # len(question_decomposition)
+    assert len(qa.gold_supporting_fact_ids) == 2  # only supporting paragraphs
+    assert all(fid.startswith("2hop__a::p") for fid in qa.gold_supporting_fact_ids)
+    assert by_id["4hop__d"].hop_count == 4
+    # gold support ids resolve to real documents
+    doc_ids = {d.id for d in corpus.documents}
+    assert set(qa.gold_supporting_fact_ids) <= doc_ids
+
+
+def test_fetch_subset_is_deterministic_for_a_seed(stub_datasets):
+    a = fetch_musique(dataset="x/y", split="validation", max_questions=2, seed=20260620)
+    b = fetch_musique(dataset="x/y", split="validation", max_questions=2, seed=20260620)
+    assert [q.id for q in a.questions] == [q.id for q in b.questions]
+    assert len(a.questions) == 2
+
+
+def test_fetch_subset_varies_with_seed(stub_datasets):
+    # Different seeds pick (in general) different subsets/orders from the 4 rows.
+    seeds = {
+        tuple(
+            q.id
+            for q in fetch_musique(
+                dataset="x/y", split="validation", max_questions=2, seed=s
+            ).questions
+        )
+        for s in range(12)
+    }
+    assert len(seeds) > 1
+
+
+def test_fetch_caps_at_available_rows(stub_datasets):
+    corpus = fetch_musique(dataset="x/y", split="validation", max_questions=100, seed=1)
+    assert len(corpus.questions) == 4  # only 4 rows available, no error
+
+
+def test_fetch_without_datasets_raises_pointed_error(monkeypatch):
+    # Simulate `datasets` not installed: the import inside fetch_musique must fail.
+    monkeypatch.setitem(sys.modules, "datasets", None)
+    with pytest.raises(RuntimeError, match="datasets"):
+        fetch_musique(dataset="x/y", split="validation", max_questions=2)


### PR DESCRIPTION
## Why

Follow-up to the QA-e2e head-to-head (#1184, #1208). Makes the **real-world MuSiQue anchor runnable** and adds a reusable **localize trace** that pins *where* any engine loses an answer. With it, the first real MuSiQue numbers produced a decisive, code-confirmed diagnosis (below).

## What changed

- **On-demand MuSiQue fetch** (`corpora.py::fetch_musique`) — pulls `dgslibisey/MuSiQue` (validation, ~2.4k Q) via `datasets`, seeded id-sorted subset, reusing one shared row→`QACorpus` normalizer. CC-BY-4.0: fetched at job time, **never redistributed in-repo**. `run_qa_e2e` fetches when no `--musique-path`; added `--musique-dataset/--musique-split/--musique-seed`.
- **Localize trace** (`GOLDENGRAPH_QA_TRACE=1`, new `trace` workflow input) — for each question, classifies the loss as **extraction / retrieval-budget / retrieval-broken-chain / synthesis** via three graph checks (gold in full graph, in a wide 8-hop ball, in the budget ball) plus **connected-component membership** (is the answer in the same island as the seeds?). No LLM cost (embedding-only seeding + graph queries).
- **Tests** (offline, no native/LLM): `test_qa_musique_fetch.py` (stubbed `datasets`), `test_qa_localize_trace.py` (4-way classification + component summary).

## The finding (now in the handoff doc)

First real MuSiQue: goldengraph `answer_match=0.0`. The trace shows **why**: the 375-entity graph **shatters into ~60 disconnected components**, and the gold answer sits in a *different island* than the question's seeds (`same_component=False`). Retrieval-budget and synthesis are ruled out (wide ball == budget ball; answer never reaches synthesis). **Root cause:** cross-document entity reconciliation is exact-`record_key`-only (`store.rs::append`) while fuzzy resolution runs only within a document (`resolve.py`) — so bridge entities under varied surface forms never merge, severing the multi-hop chain. The fix (cross-document entity linking) is tracked on a follow-up branch; this trace is its built-in validator.

## Notes

- MuSiQue's `ambiguity` dial is inert (real data, `ambiguity_level=0.0`) — run a single ambiguity point. Ingest is heavy (~20 paragraphs/question); start small.
- Validated live: fetch + trace ran end-to-end on a goldengraph-only musique probe at N=3/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)