### PR TITLE
feat(identity): cross-device / channel stitching model (#1110)

### DIFF
--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -231,6 +231,11 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 - **A2A skill count went 12 -> 18**. Update `test_agent_card_has_18_skills` if you add a skill.
 - **`pipeline.run_dedupe_df` result** now has `identity_summary: dict | None` (None when identity disabled).
 
+### CDP/MDM epic (#1108)
+Maturing Identity Graph v2 into a streaming, cross-channel, stewarded identity spine. Phases tracked under epic #1108 (label `cdp-mdm`, milestone "CDP / MDM Identity Resolution"). Each phase = one additive, opt-in PR; byte-identical / no-op when unused; no DB migration unless a phase needs one.
+- **#1109 streaming/micro-batch incremental resolution (DONE, PR #1186):** `identity.resolve_record_incremental()` / `match_record_to_entity()` resolve ONE record at a time by delegating create/absorb/merge to `resolve_clusters` over a mini-frame (matched rows + the new row) — zero duplicated resolution logic. Wired into `core.streaming.StreamProcessor.resolve_to_entity`. `match_one` returns `[]` for exact matchkeys, so an exact-only incremental path is a follow-up.
+- **#1110 cross-device / channel stitching (`identity/stitching.py`):** pure primitive in front of resolution, no DB migration. `classify_channel` (explicit `channel` col → `channel_map` source override → `__source__` substring hints → `unknown`) + `channel_trust` (crm 1.0 … web 0.5, unknown 0.6). `deterministic_stitch_pairs(df, device_keys)` STAR-links (not O(n²)) records sharing a non-null device key (`DEFAULT_DEVICE_KEYS`: cookie_id/device_id/login_id/…). `stitch_frame(df, scored_pairs=…, …)` unions the deterministic layer with the *caller-supplied probabilistic pairs* (it does NOT re-score) into channel-aware `StitchGroup`s; probabilistic edges are scaled by `cross_channel_factor` = geometric mean of the two channels' trust (deterministic device links are NOT downweighted), group `confidence` = weakest holding edge. Config: `IdentityConfig.stitching` (`ChannelStitchConfig`, default None/off); explicit kwargs to `stitch_frame` beat config fields. Tests: `tests/identity/test_stitching.py`.
+
 ## Remote MCP Server
 
 Hosted on Railway, registered on Smithery:

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -869,6 +869,32 @@ class MemoryConfig(BaseModel):
 # ── MatchSettingsConfig ─────────────────────────────────────────────────────
 
 
+class ChannelStitchConfig(BaseModel):
+    """Cross-device / channel stitching configuration (#1110, epic #1108).
+
+    Drives ``goldenmatch.identity.stitching.stitch_frame``: which columns are
+    deterministic device keys, how records map to channels, and the per-channel
+    trust weights used to downweight cross-channel probabilistic matches. Config
+    plumbing only -- attaching it does not change resolution on its own; a caller
+    (or a future pipeline hook) passes it to ``stitch_frame``.
+    """
+
+    enabled: bool = False
+    # Columns whose shared non-null value is a near-certain same-person signal.
+    # Empty -> stitching.DEFAULT_DEVICE_KEYS.
+    device_keys: list[str] = Field(default_factory=list)
+    # Column carrying an explicit channel label per record.
+    channel_column: str = "channel"
+    # Exact ``__source__`` -> channel overrides (beats the substring hints).
+    channel_map: dict[str, str] = Field(default_factory=dict)
+    # Per-channel trust weight in (0, 1]. Empty -> stitching.DEFAULT_CHANNEL_TRUST.
+    channel_trust: dict[str, float] = Field(default_factory=dict)
+    # Scale probabilistic match scores by the channels' trust factor.
+    adjust_cross_channel: bool = True
+    # Drop probabilistic stitch edges below this (post-adjustment) weight.
+    prob_threshold: float = 0.0
+
+
 class IdentityConfig(BaseModel):
     """Identity Graph configuration.
 
@@ -886,6 +912,10 @@ class IdentityConfig(BaseModel):
     # review. 0.6 mirrors the existing ``weak_cluster_threshold`` family. Set
     # to 0 to disable auto-detection.
     weak_confidence_threshold: float = 0.6
+    # #1110: cross-device / channel stitching (CDP/MDM epic #1108). None ->
+    # stitching is not configured (the default; identity resolution is
+    # unchanged).
+    stitching: ChannelStitchConfig | None = None
 
     @field_validator("dataset")
     @classmethod

--- a/packages/python/goldenmatch/goldenmatch/identity/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/__init__.py
@@ -32,6 +32,18 @@ from goldenmatch.identity.resolve import (
     resolve_clusters,
     resolve_record_incremental,
 )
+from goldenmatch.identity.stitching import (
+    DEFAULT_CHANNEL_TRUST,
+    DEFAULT_DEVICE_KEYS,
+    StitchGroup,
+    StitchResult,
+    adjust_score,
+    channel_trust,
+    classify_channel,
+    cross_channel_factor,
+    deterministic_stitch_pairs,
+    stitch_frame,
+)
 from goldenmatch.identity.store import IdentityStore, new_entity_id
 
 __all__ = [
@@ -49,6 +61,16 @@ __all__ = [
     "migrate_record_ids",
     "resolve_clusters",
     "resolve_record_incremental",
+    "DEFAULT_CHANNEL_TRUST",
+    "DEFAULT_DEVICE_KEYS",
+    "StitchGroup",
+    "StitchResult",
+    "adjust_score",
+    "channel_trust",
+    "classify_channel",
+    "cross_channel_factor",
+    "deterministic_stitch_pairs",
+    "stitch_frame",
     "EdgeKind",
     "EventKind",
     "EvidenceEdge",

--- a/packages/python/goldenmatch/goldenmatch/identity/stitching.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/stitching.py
@@ -1,0 +1,429 @@
+"""Cross-device / channel stitching model (#1110, epic #1108).
+
+Identity Graph v2 resolves *records* into entities from PII similarity alone. A
+real CDP/MDM identity spine also has to stitch the SAME person across the
+channels they show up on -- a CRM row, an email open, a web cookie, an offline
+purchase -- where the strongest link is often a shared *device / channel
+identifier* (a cookie id, a login id, a hashed email) rather than fuzzy PII.
+
+This module is the stitching primitive that sits in front of identity
+resolution. It is deliberately a pure, dependency-light function over a frame +
+the probabilistic pairs a normal dedupe already produces -- it does NOT
+re-implement the scorer, and it adds no DB migration. Three pieces, mapping the
+issue's scope bullets:
+
+1. **Channel classification** -- label each record's channel (``classify_channel``)
+   and attach a *trust* weight (``channel_trust``): verified channels (CRM,
+   offline) are trusted; ambient ones (web cookie, social) are not.
+2. **Deterministic + probabilistic stitching** -- records that share a non-null
+   *device key* are the same person with near-certainty (``deterministic_stitch_pairs``);
+   records that don't fall back to the probabilistic PII pairs. ``stitch_frame``
+   unions both into channel-aware groups.
+3. **Cross-channel scoring adjustment** -- a probabilistic match *across* two
+   low-trust channels is weaker than one within trusted channels, so its score
+   is scaled by the channels' trust (``cross_channel_factor`` / ``adjust_score``).
+   A deterministic device-key link is NOT downweighted (a shared cookie is a hard
+   identifier regardless of channel).
+
+The output (``StitchResult``) gives, per stitched group, the channels present
+and a **channel-aware confidence** -- so a person stitched across CRM/email/web
+resolves to one entity, and a steward can see whether that entity rests on a
+hard device link or a downweighted cross-channel guess.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from goldenmatch.config.schemas import ChannelStitchConfig
+
+# ── Channel taxonomy + trust ────────────────────────────────────────────────
+#
+# Trust weight in (0, 1]: how reliably a channel's records carry *verified*
+# identity. CRM / offline are operator-verified (1.0 / 0.95); email is
+# self-asserted but addressable (0.8); app/web/social are ambient device signals
+# (0.7 / 0.5 / 0.4). ``unknown`` sits in the middle (0.6) so an unclassified
+# source is neither trusted nor punished.
+
+CHANNEL_CRM = "crm"
+CHANNEL_OFFLINE = "offline"
+CHANNEL_LOYALTY = "loyalty"
+CHANNEL_EMAIL = "email"
+CHANNEL_APP = "app"
+CHANNEL_WEB = "web"
+CHANNEL_SOCIAL = "social"
+CHANNEL_UNKNOWN = "unknown"
+
+DEFAULT_CHANNEL_TRUST: dict[str, float] = {
+    CHANNEL_CRM: 1.0,
+    CHANNEL_OFFLINE: 0.95,
+    CHANNEL_LOYALTY: 0.9,
+    CHANNEL_EMAIL: 0.8,
+    CHANNEL_APP: 0.7,
+    CHANNEL_WEB: 0.5,
+    CHANNEL_SOCIAL: 0.4,
+    CHANNEL_UNKNOWN: 0.6,
+}
+
+# Source-name substrings -> channel, checked in order (most specific first).
+# Used only when a record carries no explicit channel value.
+_SOURCE_CHANNEL_HINTS: list[tuple[str, str]] = [
+    ("salesforce", CHANNEL_CRM),
+    ("hubspot", CHANNEL_CRM),
+    ("dynamics", CHANNEL_CRM),
+    ("crm", CHANNEL_CRM),
+    ("pos", CHANNEL_OFFLINE),
+    ("store", CHANNEL_OFFLINE),
+    ("instore", CHANNEL_OFFLINE),
+    ("offline", CHANNEL_OFFLINE),
+    ("loyalty", CHANNEL_LOYALTY),
+    ("rewards", CHANNEL_LOYALTY),
+    ("esp", CHANNEL_EMAIL),
+    ("mailchimp", CHANNEL_EMAIL),
+    ("email", CHANNEL_EMAIL),
+    ("newsletter", CHANNEL_EMAIL),
+    ("ios", CHANNEL_APP),
+    ("android", CHANNEL_APP),
+    ("mobile", CHANNEL_APP),
+    ("app", CHANNEL_APP),
+    ("cookie", CHANNEL_WEB),
+    ("clickstream", CHANNEL_WEB),
+    ("web", CHANNEL_WEB),
+    ("site", CHANNEL_WEB),
+    ("facebook", CHANNEL_SOCIAL),
+    ("twitter", CHANNEL_SOCIAL),
+    ("tiktok", CHANNEL_SOCIAL),
+    ("social", CHANNEL_SOCIAL),
+]
+
+# Columns whose shared non-null value is a near-certain same-person signal.
+# These are deterministic identifiers, not PII to fuzzy-match.
+DEFAULT_DEVICE_KEYS: list[str] = [
+    "device_id",
+    "cookie_id",
+    "advertising_id",
+    "idfa",
+    "gaid",
+    "login_id",
+    "user_id",
+    "customer_id",
+    "loyalty_id",
+    "hashed_email",
+    "email_hash",
+]
+
+
+def channel_trust(
+    channel: str | None,
+    trust_map: dict[str, float] | None = None,
+) -> float:
+    """Trust weight in (0, 1] for a channel. Unknown / unmapped -> the
+    ``unknown`` weight (0.6 by default), never 0 (a record is never worthless)."""
+    table = trust_map or DEFAULT_CHANNEL_TRUST
+    if channel and channel in table:
+        return float(table[channel])
+    return float(table.get(CHANNEL_UNKNOWN, 0.6))
+
+
+def classify_channel(
+    row: dict[str, Any],
+    *,
+    channel_column: str | None = "channel",
+    channel_map: dict[str, str] | None = None,
+    default: str = CHANNEL_UNKNOWN,
+) -> str:
+    """Classify one record into a channel.
+
+    Resolution order (first hit wins):
+
+    1. An explicit value in ``channel_column`` (e.g. a ``channel`` column).
+    2. ``channel_map``: an exact ``__source__`` -> channel override.
+    3. A substring hint on ``__source__`` (``_SOURCE_CHANNEL_HINTS``).
+    4. ``default`` (``"unknown"``).
+
+    Always returns a lower-cased label; an explicit channel value is taken
+    verbatim (lower-cased) so callers can use custom channel names.
+    """
+    if channel_column and channel_column in row:
+        val = row.get(channel_column)
+        if val is not None and str(val).strip():
+            return str(val).strip().lower()
+    source = str(row.get("__source__", "") or "").lower()
+    if channel_map:
+        # Exact source match (case-insensitive).
+        for src, chan in channel_map.items():
+            if source == str(src).strip().lower():
+                return str(chan).strip().lower()
+    if source:
+        for needle, chan in _SOURCE_CHANNEL_HINTS:
+            if needle in source:
+                return chan
+    return default
+
+
+def cross_channel_factor(
+    channel_a: str | None,
+    channel_b: str | None,
+    trust_map: dict[str, float] | None = None,
+) -> float:
+    """Trust factor in (0, 1] for a probabilistic match between two channels.
+
+    The geometric mean of the two channels' trust weights: a match within
+    trusted channels (crm/crm -> 1.0) is unscaled; a cross-channel match into a
+    low-trust channel (crm/web -> ~0.71) is downweighted; a low-trust/low-trust
+    match (web/web -> 0.5) most of all. Geometric mean (vs ``min``) keeps the
+    penalty smooth and symmetric.
+    """
+    ta = channel_trust(channel_a, trust_map)
+    tb = channel_trust(channel_b, trust_map)
+    return (ta * tb) ** 0.5
+
+
+def adjust_score(
+    score: float,
+    channel_a: str | None,
+    channel_b: str | None,
+    trust_map: dict[str, float] | None = None,
+) -> float:
+    """Scale a probabilistic match ``score`` by the channels' trust factor.
+
+    Deterministic device-key links should bypass this (a shared cookie is a hard
+    identifier regardless of channel); ``stitch_frame`` only applies it to the
+    probabilistic layer.
+    """
+    return float(score) * cross_channel_factor(channel_a, channel_b, trust_map)
+
+
+# ── Stitch result types ─────────────────────────────────────────────────────
+
+
+@dataclass
+class StitchGroup:
+    """One stitched group of records (members are ``__row_id__`` ints)."""
+
+    members: list[int]
+    channels: list[str]
+    confidence: float
+    deterministic: bool  # joined (in part) via a shared device key
+    cross_channel: bool  # members span >= 2 distinct channels
+    # device key columns that contributed a deterministic link, e.g. {"cookie_id"}
+    device_keys: list[str] = field(default_factory=list)
+
+    @property
+    def size(self) -> int:
+        return len(self.members)
+
+
+@dataclass
+class StitchResult:
+    groups: list[StitchGroup]
+    n_deterministic_pairs: int = 0
+    n_probabilistic_pairs: int = 0
+
+    @property
+    def multi_member_groups(self) -> list[StitchGroup]:
+        return [g for g in self.groups if g.size > 1]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "n_groups": len(self.groups),
+            "n_multi_member": len(self.multi_member_groups),
+            "n_deterministic_pairs": self.n_deterministic_pairs,
+            "n_probabilistic_pairs": self.n_probabilistic_pairs,
+            "n_cross_channel": sum(1 for g in self.groups if g.cross_channel),
+            "n_device_stitched": sum(1 for g in self.groups if g.deterministic),
+        }
+
+
+# ── Deterministic stitching ─────────────────────────────────────────────────
+
+
+def deterministic_stitch_pairs(
+    df: pl.DataFrame,
+    device_keys: list[str] | None = None,
+) -> list[tuple[int, int, str]]:
+    """Star-link records that share a non-null value on any device key.
+
+    Returns ``(row_id_a, row_id_b, key)`` edges. Per (key, value) group we emit
+    a STAR to the group's first member -- a spanning set, not all O(n^2) pairs --
+    which is all Union-Find needs to merge the group and keeps this O(N) per key
+    even when a value is shared by thousands of rows. Keys absent from ``df`` are
+    skipped; null / empty values never link.
+    """
+    keys = device_keys if device_keys is not None else DEFAULT_DEVICE_KEYS
+    present = [k for k in keys if k in df.columns]
+    if not present or "__row_id__" not in df.columns or df.is_empty():
+        return []
+
+    edges: list[tuple[int, int, str]] = []
+    for key in present:
+        sub = df.select(["__row_id__", key]).drop_nulls()
+        if sub.is_empty():
+            continue
+        # Drop empty-string values (a blank cookie is not a link).
+        sub = sub.filter(
+            pl.col(key).cast(pl.Utf8).str.strip_chars().str.len_chars() > 0
+        )
+        if sub.is_empty():
+            continue
+        grouped = sub.group_by(key).agg(pl.col("__row_id__"))
+        for mids in grouped["__row_id__"].to_list():
+            ids = [int(m) for m in mids]
+            if len(ids) < 2:
+                continue
+            anchor = ids[0]
+            for other in ids[1:]:
+                edges.append((anchor, other, key))
+    return edges
+
+
+# ── Top-level stitching ─────────────────────────────────────────────────────
+
+
+def stitch_frame(
+    df: pl.DataFrame,
+    *,
+    scored_pairs: list[tuple[int, int, float]] | None = None,
+    device_keys: list[str] | None = None,
+    channel_column: str | None = "channel",
+    channel_map: dict[str, str] | None = None,
+    trust_map: dict[str, float] | None = None,
+    adjust_cross_channel: bool = True,
+    prob_threshold: float = 0.0,
+    config: ChannelStitchConfig | None = None,
+) -> StitchResult:
+    """Stitch a multi-channel frame into channel-aware identity groups.
+
+    Combines two evidence layers:
+
+    * **Deterministic** -- records sharing a device key (``device_keys``) are
+      linked with certainty (edge weight 1.0, never downweighted).
+    * **Probabilistic** -- the ``scored_pairs`` a normal dedupe produced
+      (``(row_a, row_b, score)``). When ``adjust_cross_channel`` is on, each
+      score is scaled by ``cross_channel_factor`` of the two records' channels,
+      then dropped if it falls below ``prob_threshold``. This module does NOT
+      score pairs itself -- pass the pipeline's pairs in.
+
+    Both layers are unioned (Union-Find). Each group's **confidence** is its
+    weakest holding edge (min over contributing edge weights; deterministic
+    edges contribute 1.0), so a group resting only on a downweighted
+    cross-channel guess reads as low-confidence while a device-stitched group
+    reads as 1.0. Singletons (no edges) get confidence 1.0.
+
+    ``config`` (a ``ChannelStitchConfig``) supplies defaults for every knob; an
+    explicit keyword argument always wins over the config field.
+    """
+    from goldenmatch.core.cluster import UnionFind
+
+    if config is not None:
+        if device_keys is None:
+            device_keys = list(config.device_keys) if config.device_keys else None
+        if channel_column == "channel":
+            channel_column = config.channel_column
+        if channel_map is None:
+            channel_map = config.channel_map or None
+        if trust_map is None:
+            trust_map = config.channel_trust or None
+        # adjust_cross_channel / prob_threshold: only override the *defaults*.
+        if adjust_cross_channel is True:
+            adjust_cross_channel = config.adjust_cross_channel
+        if prob_threshold == 0.0:
+            prob_threshold = config.prob_threshold
+
+    if "__row_id__" not in df.columns or df.is_empty():
+        return StitchResult(groups=[])
+
+    # Per-row channel (computed once).
+    channel_of: dict[int, str] = {}
+    for row in df.to_dicts():
+        rid = row.get("__row_id__")
+        if rid is None:
+            continue
+        channel_of[int(rid)] = classify_channel(
+            row, channel_column=channel_column, channel_map=channel_map,
+        )
+
+    uf = UnionFind()
+    uf.add_many(sorted(channel_of.keys()))
+
+    # Track the best (max) contributing edge weight per directed-into-group is
+    # not what we want -- we want each group's WEAKEST holding edge. Accumulate
+    # every edge's weight against both endpoints' eventual root after unioning.
+    det_pairs = deterministic_stitch_pairs(df, device_keys)
+    # device keys that linked each row (for reporting).
+    keys_for_root: dict[int, set[str]] = {}
+
+    edge_list: list[tuple[int, int, float, bool]] = []  # (a, b, weight, is_det)
+    for a, b, key in det_pairs:
+        if a not in channel_of or b not in channel_of:
+            continue
+        uf.add(a)
+        uf.add(b)
+        uf.union(a, b)
+        edge_list.append((a, b, 1.0, True))
+        keys_for_root.setdefault(a, set()).add(key)
+        keys_for_root.setdefault(b, set()).add(key)
+    n_det = len(edge_list)
+
+    n_prob = 0
+    for a, b, score in scored_pairs or []:
+        ia, ib = int(a), int(b)
+        if ia not in channel_of or ib not in channel_of:
+            continue
+        weight = float(score)
+        if adjust_cross_channel:
+            weight = adjust_score(
+                weight, channel_of[ia], channel_of[ib], trust_map,
+            )
+        if weight < prob_threshold:
+            continue
+        uf.add(ia)
+        uf.add(ib)
+        uf.union(ia, ib)
+        edge_list.append((ia, ib, weight, False))
+        n_prob += 1
+
+    # Group membership.
+    root_members: dict[int, list[int]] = {}
+    for rid in channel_of:
+        root_members.setdefault(uf.find(rid), []).append(rid)
+
+    # Weakest holding edge per group + whether any edge was deterministic.
+    min_edge: dict[int, float] = {}
+    det_root: set[int] = set()
+    det_keys_root: dict[int, set[str]] = {}
+    for a, _b, w, is_det in edge_list:
+        r = uf.find(a)
+        if w < min_edge.get(r, float("inf")):
+            min_edge[r] = w
+        if is_det:
+            det_root.add(r)
+    for rid, ks in keys_for_root.items():
+        det_keys_root.setdefault(uf.find(rid), set()).update(ks)
+
+    groups: list[StitchGroup] = []
+    for root, members in root_members.items():
+        members_sorted = sorted(members)
+        chans = sorted({channel_of[m] for m in members_sorted})
+        if len(members_sorted) == 1:
+            conf = 1.0
+        else:
+            conf = float(min_edge.get(root, 1.0))
+        groups.append(StitchGroup(
+            members=members_sorted,
+            channels=chans,
+            confidence=round(conf, 6),
+            deterministic=root in det_root,
+            cross_channel=len(chans) > 1,
+            device_keys=sorted(det_keys_root.get(root, set())),
+        ))
+    # Stable order: largest groups first, then by smallest member id.
+    groups.sort(key=lambda g: (-g.size, g.members[0]))
+    return StitchResult(
+        groups=groups,
+        n_deterministic_pairs=n_det,
+        n_probabilistic_pairs=n_prob,
+    )

--- a/packages/python/goldenmatch/tests/identity/test_stitching.py
+++ b/packages/python/goldenmatch/tests/identity/test_stitching.py
@@ -1,0 +1,284 @@
+"""Cross-device / channel stitching (#1110, epic #1108)."""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.identity import stitching as st
+from goldenmatch.identity.stitching import (
+    DEFAULT_CHANNEL_TRUST,
+    StitchResult,
+    adjust_score,
+    channel_trust,
+    classify_channel,
+    cross_channel_factor,
+    deterministic_stitch_pairs,
+    stitch_frame,
+)
+
+# ── Channel classification + trust ──────────────────────────────────────────
+
+
+def test_classify_explicit_channel_column_wins():
+    assert classify_channel({"channel": "CRM", "__source__": "web_cookies"}) == "crm"
+
+
+def test_classify_source_substring_hint():
+    assert classify_channel({"__source__": "salesforce_export"}) == st.CHANNEL_CRM
+    assert classify_channel({"__source__": "web_clickstream"}) == st.CHANNEL_WEB
+    assert classify_channel({"__source__": "pos_terminal_3"}) == st.CHANNEL_OFFLINE
+
+
+def test_classify_channel_map_override_beats_hint():
+    # source "acme" carries no hint; map routes it to email.
+    assert (
+        classify_channel(
+            {"__source__": "acme"}, channel_map={"acme": "email"}
+        )
+        == "email"
+    )
+
+
+def test_classify_unknown_default():
+    assert classify_channel({"__source__": "mystery_feed"}) == st.CHANNEL_UNKNOWN
+    assert classify_channel({}) == st.CHANNEL_UNKNOWN
+
+
+def test_channel_trust_known_and_unknown():
+    assert channel_trust("crm") == 1.0
+    assert channel_trust("web") == 0.5
+    # unmapped -> the unknown weight, never 0.
+    assert channel_trust("does_not_exist") == DEFAULT_CHANNEL_TRUST["unknown"]
+    assert channel_trust(None) == DEFAULT_CHANNEL_TRUST["unknown"]
+
+
+def test_channel_trust_custom_map():
+    assert channel_trust("web", {"web": 0.9}) == 0.9
+
+
+# ── Cross-channel scoring adjustment ────────────────────────────────────────
+
+
+def test_cross_channel_factor_geometric_mean():
+    assert cross_channel_factor("crm", "crm") == pytest.approx(1.0)
+    assert cross_channel_factor("web", "web") == pytest.approx(0.5)
+    assert cross_channel_factor("crm", "web") == pytest.approx((1.0 * 0.5) ** 0.5)
+
+
+def test_cross_channel_factor_symmetric():
+    assert cross_channel_factor("crm", "web") == cross_channel_factor("web", "crm")
+
+
+def test_adjust_score_downweights_cross_channel():
+    # A 0.9 PII match across crm<->web is worth less than within crm.
+    within = adjust_score(0.9, "crm", "crm")
+    across = adjust_score(0.9, "crm", "web")
+    assert within == pytest.approx(0.9)
+    assert across < within
+    assert across == pytest.approx(0.9 * (0.5 ** 0.5))
+
+
+# ── Deterministic stitching ─────────────────────────────────────────────────
+
+
+def test_deterministic_stitch_shared_device_key():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2],
+        "cookie_id": ["c1", "c1", "c2"],
+    })
+    pairs = deterministic_stitch_pairs(df, ["cookie_id"])
+    # rows 0,1 share c1 -> one star edge; row 2 alone -> none.
+    assert pairs == [(0, 1, "cookie_id")]
+
+
+def test_deterministic_stitch_ignores_null_and_blank():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "device_id": [None, "", "d", "d"],
+    })
+    pairs = deterministic_stitch_pairs(df, ["device_id"])
+    assert pairs == [(2, 3, "device_id")]
+
+
+def test_deterministic_stitch_star_not_all_pairs():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "login_id": ["u", "u", "u", "u"],
+    })
+    pairs = deterministic_stitch_pairs(df, ["login_id"])
+    # star to anchor 0, NOT 6 all-pairs.
+    assert pairs == [(0, 1, "login_id"), (0, 2, "login_id"), (0, 3, "login_id")]
+
+
+def test_deterministic_stitch_missing_key_column():
+    df = pl.DataFrame({"__row_id__": [0, 1], "name": ["a", "b"]})
+    assert deterministic_stitch_pairs(df, ["cookie_id"]) == []
+
+
+# ── stitch_frame: deterministic path ────────────────────────────────────────
+
+
+def test_stitch_frame_device_stitch_across_channels():
+    # Same person on CRM and web, joined by a shared cookie.
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "__source__": ["salesforce", "web_cookies"],
+        "cookie_id": ["abc", "abc"],
+        "name": ["Jane Doe", None],
+    })
+    res = stitch_frame(df, device_keys=["cookie_id"])
+    assert isinstance(res, StitchResult)
+    assert len(res.multi_member_groups) == 1
+    g = res.multi_member_groups[0]
+    assert g.members == [0, 1]
+    assert g.deterministic is True
+    assert g.cross_channel is True
+    assert set(g.channels) == {"crm", "web"}
+    assert g.device_keys == ["cookie_id"]
+    # Hard device link -> full confidence even across channels.
+    assert g.confidence == 1.0
+
+
+def test_stitch_frame_no_links_all_singletons():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "__source__": ["crm", "web"],
+        "cookie_id": ["a", "b"],
+    })
+    res = stitch_frame(df, device_keys=["cookie_id"])
+    assert res.multi_member_groups == []
+    assert len(res.groups) == 2
+    assert all(g.confidence == 1.0 and not g.deterministic for g in res.groups)
+
+
+# ── stitch_frame: probabilistic + cross-channel confidence ──────────────────
+
+
+def test_stitch_frame_probabilistic_cross_channel_downweighted():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "__source__": ["salesforce", "web_cookies"],
+    })
+    # PII match of 0.9, no shared device -> probabilistic only.
+    res = stitch_frame(df, scored_pairs=[(0, 1, 0.9)])
+    assert len(res.multi_member_groups) == 1
+    g = res.multi_member_groups[0]
+    assert g.deterministic is False
+    assert g.cross_channel is True
+    # confidence is the downweighted cross-channel score, not 0.9.
+    assert g.confidence == pytest.approx(0.9 * (0.5 ** 0.5), abs=1e-6)
+
+
+def test_stitch_frame_probabilistic_within_channel_not_downweighted():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "__source__": ["salesforce", "salesforce_eu"],
+    })
+    res = stitch_frame(df, scored_pairs=[(0, 1, 0.9)])
+    g = res.multi_member_groups[0]
+    assert g.confidence == pytest.approx(0.9)
+
+
+def test_stitch_frame_prob_threshold_drops_weak_edges():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "__source__": ["web_a", "web_b"],
+    })
+    # 0.6 * sqrt(0.5*0.5) = 0.3 < threshold 0.5 -> edge dropped, no group.
+    res = stitch_frame(df, scored_pairs=[(0, 1, 0.6)], prob_threshold=0.5)
+    assert res.multi_member_groups == []
+    assert res.n_probabilistic_pairs == 0
+
+
+def test_stitch_frame_no_adjust_keeps_raw_score():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "__source__": ["crm", "web"],
+    })
+    res = stitch_frame(
+        df, scored_pairs=[(0, 1, 0.8)], adjust_cross_channel=False
+    )
+    assert res.multi_member_groups[0].confidence == pytest.approx(0.8)
+
+
+def test_stitch_frame_confidence_is_weakest_edge():
+    # Chain 0-1 (det, 1.0) and 1-2 (prob, downweighted) -> group of 3 whose
+    # confidence is the weaker probabilistic edge.
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2],
+        "__source__": ["crm", "crm", "web_cookies"],
+        "cookie_id": ["x", "x", None],
+    })
+    res = stitch_frame(
+        df, scored_pairs=[(1, 2, 0.95)], device_keys=["cookie_id"]
+    )
+    assert len(res.multi_member_groups) == 1
+    g = res.multi_member_groups[0]
+    assert g.members == [0, 1, 2]
+    assert g.deterministic is True  # has the device link
+    assert g.cross_channel is True
+    # weakest edge = the crm<->web probabilistic one.
+    assert g.confidence == pytest.approx(0.95 * (0.5 ** 0.5), abs=1e-6)
+
+
+def test_stitch_frame_empty_frame():
+    df = pl.DataFrame({"__row_id__": []}, schema={"__row_id__": pl.Int64})
+    res = stitch_frame(df)
+    assert res.groups == []
+
+
+def test_stitch_result_as_dict_counts():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "__source__": ["crm", "web_cookies", "crm", "web"],
+        "cookie_id": ["a", "a", None, None],
+    })
+    res = stitch_frame(
+        df, scored_pairs=[(2, 3, 0.99)], device_keys=["cookie_id"]
+    )
+    d = res.as_dict()
+    assert d["n_multi_member"] == 2
+    assert d["n_deterministic_pairs"] == 1
+    assert d["n_probabilistic_pairs"] == 1
+    assert d["n_device_stitched"] == 1
+    assert d["n_cross_channel"] == 2
+
+
+# ── Config-driven defaults ──────────────────────────────────────────────────
+
+
+def test_stitch_frame_reads_config_defaults():
+    from goldenmatch.config.schemas import ChannelStitchConfig
+
+    cfg = ChannelStitchConfig(
+        enabled=True,
+        device_keys=["my_key"],
+        channel_column="chan",
+        channel_trust={"crm": 1.0, "web": 0.2},
+        prob_threshold=0.0,
+    )
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "chan": ["crm", "web"],
+        "my_key": ["k", "k"],
+    })
+    res = stitch_frame(df, config=cfg)
+    # device_keys + channel_column came from config.
+    g = res.multi_member_groups[0]
+    assert g.deterministic is True
+    assert set(g.channels) == {"crm", "web"}
+    assert g.device_keys == ["my_key"]
+
+
+def test_explicit_kwarg_overrides_config():
+    from goldenmatch.config.schemas import ChannelStitchConfig
+
+    cfg = ChannelStitchConfig(device_keys=["cfg_key"])
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "kwarg_key": ["k", "k"],
+        "cfg_key": ["x", "y"],
+    })
+    # explicit device_keys wins -> stitch on kwarg_key (shared), not cfg_key.
+    res = stitch_frame(df, config=cfg, device_keys=["kwarg_key"])
+    assert len(res.multi_member_groups) == 1
+    assert res.multi_member_groups[0].members == [0, 1]


### PR DESCRIPTION
## Why

Phase 2 of the **CDP/MDM epic #1108**. Identity Graph v2 resolves *records* into entities from PII similarity alone. A real CDP/MDM identity spine also has to stitch the **same person across the channels they show up on** — a CRM row, an email open, a web cookie, an offline purchase — where the strongest link is often a shared *device / channel identifier* (a cookie id, a login id, a hashed email) rather than fuzzy PII.

## What

New module `goldenmatch/identity/stitching.py` — a pure, dependency-light primitive that sits **in front of** identity resolution. It operates over a frame + the probabilistic pairs a normal dedupe already produces; it does **not** re-implement the scorer and adds **no DB migration**. Three pieces, mapping the issue's scope bullets:

1. **Channel classification + trust.** `classify_channel` resolves a record's channel: explicit `channel` column → `channel_map` source override → `__source__` substring hints (`salesforce`→crm, `web_cookies`→web, `pos`→offline, …) → `unknown`. `channel_trust` attaches a weight in (0,1]: crm 1.0, offline 0.95, email 0.8, web 0.5, unknown 0.6.
2. **Deterministic + probabilistic stitching.** `deterministic_stitch_pairs(df, device_keys)` **star-links** (not O(n²)) records that share a non-null device key (`DEFAULT_DEVICE_KEYS`: cookie_id / device_id / login_id / hashed_email / …); nulls and blanks never link. `stitch_frame(df, scored_pairs=…)` unions that hard layer with the caller-supplied probabilistic pairs via Union-Find into channel-aware `StitchGroup`s.
3. **Cross-channel scoring adjustment.** Probabilistic edges are scaled by `cross_channel_factor` — the geometric mean of the two channels' trust — so a CRM↔web PII guess (≈0.71×) is downweighted relative to a CRM↔CRM match (1.0×). A **deterministic device link is never downweighted** (a shared cookie is a hard identifier regardless of channel). Each group's `confidence` is its **weakest holding edge**, so a group resting only on a downweighted cross-channel guess reads low-confidence while a device-stitched group reads 1.0.

So a person across CRM/email/web/offline stitches into one entity with channel-aware confidence — the issue's "Done" bar.

## Config

`IdentityConfig.stitching` → new `ChannelStitchConfig` (default `None`/off): `device_keys`, `channel_column`, `channel_map`, `channel_trust`, `adjust_cross_channel`, `prob_threshold`. Config plumbing only — attaching it changes nothing until a caller passes it to `stitch_frame`; an explicit kwarg always beats the config field. Exported from `goldenmatch.identity`.

## Tests

24 tests in `tests/identity/test_stitching.py` (classification precedence, trust map, cross-channel factor symmetry/downweighting, deterministic star-link + null/blank handling, device stitch across channels, probabilistic downweighting, weakest-edge confidence on mixed chains, threshold drop, config-driven defaults + kwarg override). Full identity + config suites green: **159 passed, 6 skipped** (the pre-existing `httpx2` collection error in `test_cross_surface_contract.py` is unrelated — same one noted in PR #1186). ruff clean.

## Scope notes

- This is the **stitching primitive**, matching #1109's "primitive first, minimal wiring" posture. Pipeline auto-population from `IdentityConfig.stitching` (and surfacing stitched groups through `resolve_clusters`) is a follow-up.
- Deterministic linking is value-exact on the device key; fuzzy/normalized device keys (e.g. lowercasing a hashed email) are the caller's job upstream.

Part of #1108. Closes #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_