### PR TITLE
feat(quality): auto-config decision-kernel quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
       ts_parity: ${{ steps.filter.outputs.ts_parity }}
       throughput: ${{ steps.filter.outputs.throughput }}
       autoconfig_wasm: ${{ steps.filter.outputs.autoconfig_wasm }}
+      quality_gate: ${{ steps.filter.outputs.quality_gate }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
@@ -198,6 +199,20 @@ jobs:
               - 'packages/python/goldenmatch/goldenmatch/core/golden*.py'
               - 'packages/python/goldenmatch/goldenmatch/core/probabilistic.py'
               - 'packages/python/goldenmatch/goldenmatch/core/learned_blocking.py'
+            # Auto-config quality gate (scripts/autoconfig_quality): the
+            # committed scorecard pins host-independent decision-kernel signals
+            # (classification, matchkeys, blocking fields/cost) + the
+            # anchor_person_match F1 floor. Re-run whenever the decision kernel
+            # (rust core or Python autoconfig/blocking surfaces) or the harness
+            # itself changes, and on ci.yml edits (keeps the gate under test).
+            quality_gate:
+              - 'scripts/autoconfig_quality/**'
+              - 'packages/rust/extensions/autoconfig-core/**'
+              - 'packages/python/goldenmatch/goldenmatch/core/autoconfig*.py'
+              - 'packages/python/goldenmatch/goldenmatch/core/blocker.py'
+              - 'packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py'
+              - 'packages/python/goldenmatch/goldenmatch/core/matchkey.py'
+              - '.github/workflows/ci.yml'
             rust:
               - 'packages/rust/**'
             rust_pgrx:
@@ -922,6 +937,59 @@ jobs:
             echo ""
             echo "Imports + \`--help\` + a real Febrl3 run (the only published dataset that ships via pip)."
             echo "DBLP-ACM / NCVR / DQbench composite reproduce against gitignored datasets in \`benchmarks.yml\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Auto-config quality gate. Runs the harness over the committed anchors (always
+  # present) and diffs the resulting decision-kernel signals against the committed
+  # baseline (scripts/autoconfig_quality/baselines/scorecard.json). A FAIL means a
+  # kernel change moved a host-independent decision (classification / matchkeys /
+  # blocking fields+cost) or dropped the anchor_person_match F1 below its floor.
+  # planner_rung drift (native availability / box size) is informational WARN, so
+  # this normal-runner job (no native wheel) doesn't flap the native-on dev
+  # baseline. Real datasets (DBLP-ACM) skip-when-absent. Iterate loop + how to
+  # re-bless: scripts/autoconfig_quality/README.md.
+  quality_gate:
+    needs: changes
+    if: needs.changes.outputs.quality_gate == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Run auto-config quality gate
+        shell: bash
+        env:
+          # Determinism: pin auto-config memory off so the gate measures the
+          # static decision kernel, not learned per-run adjustments.
+          GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+        run: |
+          # Repo-root cwd so `python -m scripts.autoconfig_quality` resolves the
+          # harness package; the harness adds the goldenmatch package `scripts/`
+          # and bench-attribution paths to sys.path internally. No --fast-only:
+          # the anchors' fast signals AND the anchor_person_match F1 floor are
+          # both gated (anchor_person_match is 400 entities, F1 is seconds).
+          uv run python -m scripts.autoconfig_quality gate
+      - name: Quality scorecard summary
+        if: always()
+        shell: bash
+        env:
+          GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+        run: |
+          {
+            echo "## Auto-config quality scorecard"
+            echo ""
+            echo "Diff of the current decision-kernel signals vs the committed baseline."
+            echo "FAIL = a host-independent kernel decision moved (or the anchor F1 floor dropped); WARN = host-coupled planner routing drift (informational)."
+            echo ""
+            echo '```'
+            uv run python -m scripts.autoconfig_quality report 2>/dev/null || true
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
   typescript:

--- a/docs/superpowers/plans/2026-06-22-autoconfig-quality-harness.md
+++ b/docs/superpowers/plans/2026-06-22-autoconfig-quality-harness.md
@@ -59,10 +59,10 @@ PYTHONPATH="D:/show_case/gm-autoconfig-core;D:/show_case/gm-autoconfig-core/pack
 
 **Files:**
 - Create: `scripts/autoconfig_quality/__init__.py` (empty), `scripts/autoconfig_quality/anchors.py`
-- Modify: `packages/python/goldenmatch/tests/test_quality_gate.py` (import `gen_labeled` from the shared module), `packages/python/goldenmatch/tests/test_autoconfig_multisource.py` (import `_crm_df` from the shared module)
+- Modify: `packages/python/goldenmatch/tests/test_quality_gate.py` (import `gen_labeled` from the shared module), `packages/python/goldenmatch/tests/test_autoconfig_multisource.py` (import `_crm_df` from the shared module), `packages/python/goldenmatch/tests/test_autoconfig_benchmarks.py` (it has a SECOND independent copy of `gen_labeled` at line ~64 — redirect it to the shared module too, to honor the "one definition" goal)
 - Test: `scripts/autoconfig_quality/tests/test_anchors.py`
 
-The spec requires ONE definition of each anchor shape. `gen_labeled` and `_crm_df` currently live inside test modules; extract them so both tests and the harness import them. `make_healthcare_df` already lives in an importable script — re-export it.
+The spec requires ONE definition of each anchor shape. `gen_labeled` lives in BOTH `test_quality_gate.py` and `test_autoconfig_benchmarks.py`; `_crm_df` lives in `test_autoconfig_multisource.py`. Extract to the shared module and point all three test files at it (no copies). `make_healthcare_df` already lives in an importable script — re-export it.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -114,10 +114,10 @@ def gen_labeled(n_entities: int = 400, seed: int = 7) -> tuple[pl.DataFrame, set
 def crm_df() -> pl.DataFrame:
     ...   # body verbatim from test_autoconfig_multisource._crm_df
 ```
-Then update `test_quality_gate.py` to `from autoconfig_quality.anchors import gen_labeled` (the package-conftest sys.path doesn't include repo-root scripts, so add at the top of those test files: `sys.path.insert(0, <repo-root>)` then `from scripts.autoconfig_quality.anchors import ...`) and delete the local copies. Same for `test_autoconfig_multisource.py` (`crm_df` → use as `_crm_df = crm_df` alias to minimize churn).
+Then point all three donor tests at the shared module (the package-conftest sys.path doesn't include repo-root scripts, so add at the top of those test files: `import sys; sys.path.insert(0, <repo-root>)` then `from scripts.autoconfig_quality.anchors import ...`) and delete the local copies: `test_quality_gate.py` → `from scripts.autoconfig_quality.anchors import gen_labeled`; `test_autoconfig_benchmarks.py` → same (delete its line-64 copy); `test_autoconfig_multisource.py` → `from scripts.autoconfig_quality.anchors import crm_df as _crm_df` (alias to minimize churn). In Step 4 re-run all three donor tests to confirm the extraction is behavior-preserving.
 
-- [ ] **Step 4: Run to verify it passes** — the anchors test passes; AND re-run the two donor tests to confirm the extraction didn't break them:
-`cd packages/python/goldenmatch && PYTHONPATH="$(pwd);D:/show_case/gm-autoconfig-core" GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 $PY -m pytest tests/test_quality_gate.py tests/test_autoconfig_multisource.py -q` → PASS.
+- [ ] **Step 4: Run to verify it passes** — the anchors test passes; AND re-run all three donor tests to confirm the extraction didn't break them:
+`cd packages/python/goldenmatch && PYTHONPATH="$(pwd);D:/show_case/gm-autoconfig-core" GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 $PY -m pytest tests/test_quality_gate.py tests/test_autoconfig_multisource.py tests/test_autoconfig_benchmarks.py -q -m "benchmark or not benchmark"` → PASS (the benchmarks file is `-m benchmark`-gated, so include the marker; its data-absent cases skip cleanly).
 
 - [ ] **Step 5: Commit** — `git add scripts/autoconfig_quality/ packages/python/goldenmatch/tests/test_quality_gate.py packages/python/goldenmatch/tests/test_autoconfig_multisource.py && git commit -m "feat(quality): shared anchor generators (extract gen_labeled + crm_df)"`
 
@@ -231,15 +231,24 @@ def test_evaluate_f1_on_gen_labeled():
 ```python
 """SLOW tier: full dedupe -> F1/P/R + blocking-recall/threshold-loss attribution."""
 from __future__ import annotations
+import importlib.util
 from itertools import combinations
-from types import SimpleNamespace
+from pathlib import Path
 from typing import Any
 import polars as pl
 import goldenmatch
 from goldenmatch.core.evaluate import evaluate_clusters
 from goldenmatch.core.autoconfig import profile_columns, build_blocking
 from goldenmatch.core.blocker import build_blocks
-from scripts.bench_er_headtohead.attribution import attribution
+
+# attribution.py lives in scripts/bench_er_headtohead/, which is NOT a real
+# package (no __init__.py). Load it by file path -- the same precedent as
+# packages/python/goldenmatch/tests/bench/test_attribution.py -- so this does
+# NOT depend on the repo root being on sys.path / on PEP 420 namespace packages.
+_ATTR_PATH = Path(__file__).resolve().parents[2] / "scripts/bench_er_headtohead/attribution.py"
+_spec = importlib.util.spec_from_file_location("_qh_attribution", _ATTR_PATH)
+_attr_mod = importlib.util.module_from_spec(_spec); _spec.loader.exec_module(_attr_mod)
+attribution = _attr_mod.attribution
 
 def _candidate_pairs(df: pl.DataFrame) -> set[tuple[int, int]]:
     """Regenerate the post-blocking candidate set in row-index space.

--- a/docs/superpowers/plans/2026-06-22-autoconfig-quality-harness.md
+++ b/docs/superpowers/plans/2026-06-22-autoconfig-quality-harness.md
@@ -1,0 +1,519 @@
+# Auto-config quality harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a harness that runs auto-config across a corpus (real labeled datasets + synthetic failure-shape anchors) and emits a comparative quality scorecard (fast config-signals + F1) with a committed baseline, diff, gate, and bless — so a kernel change's quality impact is measurable in one run.
+
+**Architecture:** A repo-root package `scripts/autoconfig_quality/` of six small single-purpose units behind one CLI. It **consumes** existing decision primitives (`profile_columns`, `build_blocking`, `build_matchkeys`, `measure_blocking_profile`, `apply_planner_rules`, `dedupe_df`, `evaluate_clusters`, `attribution`) and never reimplements decision logic. Two tiers: fast config-signals (no dedupe; the anchor-pinned regression net) and slow F1/P/R on real data (ground truth).
+
+**Tech Stack:** Python 3, Polars, the `goldenmatch` package; pytest for unit tests; pure-stdlib JSON for the scorecard.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md`
+
+---
+
+## Load-bearing facts (verified against the code — do not re-derive)
+
+- **Row-index id space is the universal convention.** `DedupeResult.clusters` is `dict[int, {"members": list[int], ...}]` where members are **0-based row indices** into the input df; `scored_pairs` is `list[(a, b, score)]` of row indices; `evaluate_clusters(clusters, ground_truth)` expands cluster members to pairs and compares to `ground_truth: set[tuple]`. **Therefore every dataset loader returns `(df, gt_pairs)` with `gt_pairs` already in row-index space** (a `set[(i, j)]`, `i<j`). Loaders that have a stable id column build `gt_pairs` by mapping id→position at load time. `gen_labeled` already does this.
+- `measure_blocking_profile(df, config)` reads `config.blocking` — pass the **full config or a `SimpleNamespace(blocking=<BlockingConfig>)`** (the `bench_autoconfig_sample_quality.py` pattern), NOT a bare `BlockingConfig`.
+- `build_blocks(lf, blocking_config)` takes a **bare `BlockingConfig`** and returns `list[BlockResult]`; each block's row ids are in `b.df.collect()["__row_id__"]` — which only exists if the input frame had `df.with_row_index("__row_id__")` added. **Candidate pairs are regenerated this way** (`DedupeResult` has NO candidate set).
+- `evaluate_clusters` is in `goldenmatch/core/evaluate.py`; `dedupe_df`/`DedupeResult` are in `goldenmatch/_api.py` (re-exported as `goldenmatch.dedupe_df`); `attribution(gt, cand, emitted)` is in `scripts/bench_er_headtohead/attribution.py` and canonicalizes pairs internally.
+- `ColumnProfile.col_type` (not `.type`); exact matchkey columns = `{f.field for mk in mks if mk.type == "exact" for f in mk.fields}`.
+- `apply_planner_rules(ComplexityProfile, RuntimeProfile, n_rows_full, DEFAULT_RULES)` → `ExecutionPlan(.backend, .rule_name)`. Pass the real `DEFAULT_RULES` from `goldenmatch.core.autoconfig_planner_rules` (native fast-path engages only for that list). Minimal profile: `ComplexityProfile(blocking=<BlockingProfile>)`.
+- **Repo-root script preamble:** set `os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")` (and `PYTHONIOENCODING=utf-8`) BEFORE importing polars/goldenmatch. Run with `PYTHONPATH=packages/python/goldenmatch`. Do NOT force `GOLDENMATCH_NATIVE=0` — the harness runs native-default-on (it measures production behavior); `--native 0` flips it per-run.
+- **Local test runs:** targeted file runs only (full suite OOMs the box). Pattern used throughout this repo:
+  `cd packages/python/goldenmatch && PYTHONPATH="$(pwd)" GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 <venv>/python.exe -m pytest <files> -q -p no:cacheprovider --timeout=180`.
+  The venv python is `D:/show_case/goldenmatch/.venv/Scripts/python.exe`.
+- The package conftest (`packages/python/goldenmatch/tests/conftest.py`) adds the **package** `scripts/` to `sys.path` (where `repro_issue_715.py` lives) — but NOT the repo-root `scripts/`. The harness lives in repo-root `scripts/`, so its OWN tests live in repo-root `tests/` or use an explicit path add (see Task 7).
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `scripts/autoconfig_quality/__init__.py` | package marker (empty) |
+| `scripts/autoconfig_quality/_preamble.py` | env setdefault + `goldenmatch` import guard (one place) |
+| `scripts/autoconfig_quality/anchors.py` | shared synthetic anchor generators (extracted `_crm_df`, `gen_labeled`; re-export `make_healthcare_df`) |
+| `scripts/autoconfig_quality/datasets.py` | `Dataset` dataclass + `REGISTRY` (anchors + real loaders, skip-when-absent) |
+| `scripts/autoconfig_quality/signals.py` | FAST tier: `extract_signals(df) -> dict` (classification, matchkeys, blocking fields+cost, planner rung) |
+| `scripts/autoconfig_quality/f1.py` | SLOW tier: `evaluate_f1(df, gt_pairs, row_cap) -> dict` (F1/P/R + attribution) |
+| `scripts/autoconfig_quality/scorecard.py` | `build_scorecard(results, meta) -> dict` + `load`/`dump` JSON |
+| `scripts/autoconfig_quality/diff.py` | `diff_scorecards(current, baseline) -> (rows, verdict)` + render table |
+| `scripts/autoconfig_quality/__main__.py` | CLI: `report` / `gate` / `bless`, `--fast-only`/`--datasets`/`--native`/`--row-cap` |
+| `scripts/autoconfig_quality/baselines/scorecard.json` | committed baseline (the bless target) |
+| `scripts/autoconfig_quality/tests/test_*.py` | unit tests per unit + a self-gating smoke test |
+
+Tests live under `scripts/autoconfig_quality/tests/` and run via an explicit `PYTHONPATH` that includes both the repo-root `scripts/` (for `autoconfig_quality` + `bench_er_headtohead`) and `packages/python/goldenmatch` (for `goldenmatch` + `repro_issue_715` on the package scripts path). See each task's run command.
+
+**Shared run-env (used by every test command below), call it `$ENV`:**
+```
+GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 \
+PYTHONPATH="D:/show_case/gm-autoconfig-core;D:/show_case/gm-autoconfig-core/packages/python/goldenmatch;D:/show_case/gm-autoconfig-core/packages/python/goldenmatch/scripts"
+```
+(`D:/show_case/gm-autoconfig-core` on the path makes `scripts.autoconfig_quality` and `scripts.bench_er_headtohead` importable; the package dir makes `goldenmatch` importable; the package `scripts` dir makes `repro_issue_715` importable.) Use `;` separators on Windows. The venv python is `D:/show_case/goldenmatch/.venv/Scripts/python.exe` (call it `$PY`).
+
+---
+
+## Task 1: Shared anchor generators (extract fixtures, no copy)
+
+**Files:**
+- Create: `scripts/autoconfig_quality/__init__.py` (empty), `scripts/autoconfig_quality/anchors.py`
+- Modify: `packages/python/goldenmatch/tests/test_quality_gate.py` (import `gen_labeled` from the shared module), `packages/python/goldenmatch/tests/test_autoconfig_multisource.py` (import `_crm_df` from the shared module)
+- Test: `scripts/autoconfig_quality/tests/test_anchors.py`
+
+The spec requires ONE definition of each anchor shape. `gen_labeled` and `_crm_df` currently live inside test modules; extract them so both tests and the harness import them. `make_healthcare_df` already lives in an importable script — re-export it.
+
+- [ ] **Step 1: Write the failing test**
+
+`scripts/autoconfig_quality/tests/test_anchors.py`:
+```python
+from scripts.autoconfig_quality.anchors import crm_df, gen_labeled, make_healthcare_df
+
+def test_crm_df_shape():
+    df = crm_df()
+    assert df.height == 30
+    assert "email" in df.columns and "phone" in df.columns
+
+def test_gen_labeled_returns_df_and_rowindex_gt():
+    df, gt = gen_labeled(n_entities=50, seed=7)
+    assert df.height >= 50
+    # GT pairs are row-index tuples i<j
+    assert all(isinstance(a, int) and isinstance(b, int) and a < b for a, b in gt)
+    assert max(b for _, b in gt) < df.height  # indices in range
+
+def test_make_healthcare_df_has_zip5():
+    df = make_healthcare_df(2000, seed=715, zip_present=0.5)
+    assert "zip5" in df.columns and "matching_id" in df.columns
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cd D:/show_case/gm-autoconfig-core && $ENV $PY -m pytest scripts/autoconfig_quality/tests/test_anchors.py -q` → FAIL (module not found).
+
+- [ ] **Step 3: Create `anchors.py`** — move the verbatim bodies of `gen_labeled` (from `test_quality_gate.py`, incl. its `_FIRST`/`_SURN`/`_typo` helpers and imports) and `_crm_df` (from `test_autoconfig_multisource.py`, rename the public fn `crm_df`), and re-export `make_healthcare_df`:
+```python
+"""Shared synthetic anchor generators — ONE definition, imported by both the
+tests and the quality harness. Bodies lifted verbatim from the test fixtures."""
+from __future__ import annotations
+import random
+from collections import defaultdict
+from itertools import combinations
+import polars as pl
+import sys
+from pathlib import Path
+# make_healthcare_df lives in the package scripts/ dir
+_PKG_SCRIPTS = Path(__file__).resolve().parents[2] / "packages/python/goldenmatch/scripts"
+if str(_PKG_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_PKG_SCRIPTS))
+from repro_issue_715 import make_healthcare_df  # noqa: E402,F401
+
+_FIRST = [...]   # copy from test_quality_gate.py
+_SURN = [...]    # copy from test_quality_gate.py
+def _typo(s, rng): ...   # copy verbatim
+def gen_labeled(n_entities: int = 400, seed: int = 7) -> tuple[pl.DataFrame, set]:
+    ...   # body verbatim from test_quality_gate.py
+def crm_df() -> pl.DataFrame:
+    ...   # body verbatim from test_autoconfig_multisource._crm_df
+```
+Then update `test_quality_gate.py` to `from autoconfig_quality.anchors import gen_labeled` (the package-conftest sys.path doesn't include repo-root scripts, so add at the top of those test files: `sys.path.insert(0, <repo-root>)` then `from scripts.autoconfig_quality.anchors import ...`) and delete the local copies. Same for `test_autoconfig_multisource.py` (`crm_df` → use as `_crm_df = crm_df` alias to minimize churn).
+
+- [ ] **Step 4: Run to verify it passes** — the anchors test passes; AND re-run the two donor tests to confirm the extraction didn't break them:
+`cd packages/python/goldenmatch && PYTHONPATH="$(pwd);D:/show_case/gm-autoconfig-core" GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 $PY -m pytest tests/test_quality_gate.py tests/test_autoconfig_multisource.py -q` → PASS.
+
+- [ ] **Step 5: Commit** — `git add scripts/autoconfig_quality/ packages/python/goldenmatch/tests/test_quality_gate.py packages/python/goldenmatch/tests/test_autoconfig_multisource.py && git commit -m "feat(quality): shared anchor generators (extract gen_labeled + crm_df)"`
+
+---
+
+## Task 2: Fast-tier config-signal extractor (`signals.py`)
+
+**Files:**
+- Create: `scripts/autoconfig_quality/signals.py`
+- Test: `scripts/autoconfig_quality/tests/test_signals.py`
+
+Extract the five fast signals from a df via the decision path — no dedupe.
+
+- [ ] **Step 1: Write the failing test** — build a tiny df with a known outcome (the sparse-zip anchor at small N is ideal: zip5 should be `zip` and appear in blocking fields):
+```python
+import polars as pl
+from scripts.autoconfig_quality.anchors import make_healthcare_df
+from scripts.autoconfig_quality.signals import extract_signals
+
+def test_extract_signals_sparse_zip():
+    df = make_healthcare_df(2000, seed=715, zip_present=0.5).drop("matching_id")
+    sig = extract_signals(df)
+    assert sig["classification"]["zip5"] == "zip"          # not fooled into identifier
+    assert "zip5" in sig["blocking_fields"]                 # the decouple fix
+    assert sig["blocking_cost"]["candidate_pairs"] < 50_000 # bounded, not 8.9M
+    assert "max_block" in sig["blocking_cost"]
+    assert isinstance(sig["exact_matchkeys"], list)
+    assert "backend" in sig["planner_rung"] and "rule_name" in sig["planner_rung"]
+```
+
+- [ ] **Step 2: Run to verify it fails** — `... pytest scripts/autoconfig_quality/tests/test_signals.py -q` → FAIL (no `extract_signals`).
+
+- [ ] **Step 3: Implement `signals.py`**:
+```python
+"""FAST tier: config-quality signals (no full dedupe)."""
+from __future__ import annotations
+from itertools import combinations
+from types import SimpleNamespace
+from typing import Any
+import polars as pl
+from goldenmatch.core.autoconfig import profile_columns, build_blocking, build_matchkeys
+from goldenmatch.core.blocker import measure_blocking_profile
+from goldenmatch.core.complexity_profile import ComplexityProfile
+from goldenmatch.core.runtime_profile import capture_runtime_profile
+from goldenmatch.core.autoconfig_planner import apply_planner_rules
+from goldenmatch.core.autoconfig_planner_rules import DEFAULT_RULES
+
+def extract_signals(df: pl.DataFrame) -> dict[str, Any]:
+    profiles = profile_columns(df)
+    classification = {p.name: p.col_type for p in profiles}
+    matchkeys = build_matchkeys(profiles, df)
+    exact_matchkeys = sorted({f.field for mk in matchkeys
+                              if mk.type == "exact" for f in mk.fields if f.field})
+    blocking = build_blocking(profiles, df, n_rows_full=df.height)
+    fields: set[str] = set()
+    for k in (blocking.keys or []):
+        fields.update(k.fields)
+    for p in (blocking.passes or []):
+        fields.update(p.fields)
+    bp = measure_blocking_profile(df, SimpleNamespace(blocking=blocking))
+    blocking_cost = (
+        {"candidate_pairs": bp.estimated_pair_count, "n_blocks": bp.n_blocks,
+         "max_block": bp.block_sizes_max, "p99": bp.block_sizes_p99,
+         "reduction_ratio": round(bp.reduction_ratio, 4)}
+        if bp is not None else {"candidate_pairs": None, "error": "measure_returned_none"}
+    )
+    cp = ComplexityProfile(blocking=bp) if bp is not None else ComplexityProfile()
+    plan = apply_planner_rules(cp, capture_runtime_profile(), df.height, DEFAULT_RULES)
+    return {
+        "classification": classification,
+        "exact_matchkeys": exact_matchkeys,
+        "blocking_fields": sorted(fields),
+        "blocking_cost": blocking_cost,
+        "planner_rung": {"backend": plan.backend, "rule_name": plan.rule_name},
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes** — PASS. (If `candidate_pairs` exceeds the bound, the blocking-decouple fix isn't in this tree — confirm you're on main/post-#1205.)
+
+- [ ] **Step 5: Commit** — `git add scripts/autoconfig_quality/signals.py scripts/autoconfig_quality/tests/test_signals.py && git commit -m "feat(quality): fast-tier config-signal extractor"`
+
+---
+
+## Task 3: F1 tier with attribution (`f1.py`)
+
+**Files:**
+- Create: `scripts/autoconfig_quality/f1.py`
+- Test: `scripts/autoconfig_quality/tests/test_f1.py`
+
+Run the full dedupe, compute F1/P/R via `evaluate_clusters`, and the blocking-recall/threshold-loss attribution (candidate pairs regenerated from `build_blocks`).
+
+- [ ] **Step 1: Write the failing test** — `gen_labeled` gives a df + row-index GT, the cleanest F1 fixture:
+```python
+from scripts.autoconfig_quality.anchors import gen_labeled
+from scripts.autoconfig_quality.f1 import evaluate_f1
+
+def test_evaluate_f1_on_gen_labeled():
+    df, gt = gen_labeled(n_entities=200, seed=7)
+    out = evaluate_f1(df, gt, row_cap=None)
+    assert 0.0 <= out["f1"] <= 1.0
+    assert out["f1"] >= 0.80           # synthetic clones are easy
+    assert set(out) >= {"f1", "precision", "recall", "attribution"}
+    attr = out["attribution"]
+    assert {"blocking_recall", "final_recall", "threshold_loss"} <= set(attr)
+    assert attr["blocking_recall"] >= attr["final_recall"]  # blocking is the ceiling
+```
+
+- [ ] **Step 2: Run to verify it fails** → FAIL (no `evaluate_f1`).
+
+- [ ] **Step 3: Implement `f1.py`**:
+```python
+"""SLOW tier: full dedupe -> F1/P/R + blocking-recall/threshold-loss attribution."""
+from __future__ import annotations
+from itertools import combinations
+from types import SimpleNamespace
+from typing import Any
+import polars as pl
+import goldenmatch
+from goldenmatch.core.evaluate import evaluate_clusters
+from goldenmatch.core.autoconfig import profile_columns, build_blocking
+from goldenmatch.core.blocker import build_blocks
+from scripts.bench_er_headtohead.attribution import attribution
+
+def _candidate_pairs(df: pl.DataFrame) -> set[tuple[int, int]]:
+    """Regenerate the post-blocking candidate set in row-index space.
+    DedupeResult has no candidate set, so rebuild via build_blocks + __row_id__."""
+    profiles = profile_columns(df)
+    blocking = build_blocking(profiles, df, n_rows_full=df.height)
+    lf = df.with_row_index("__row_id__").lazy()
+    cand: set[tuple[int, int]] = set()
+    try:
+        for b in build_blocks(lf, blocking):
+            ids = b.df.collect()["__row_id__"].to_list()
+            cand.update((min(a, c), max(a, c)) for a, c in combinations(ids, 2))
+    except Exception:
+        return set()  # attribution degrades to 0 blocking_recall, never crashes F1
+    return cand
+
+def evaluate_f1(df: pl.DataFrame, gt_pairs: set, row_cap: int | None = 20_000) -> dict[str, Any]:
+    if row_cap is not None and df.height > row_cap:
+        df = df.head(row_cap)
+        gt_pairs = {(a, b) for a, b in gt_pairs if a < row_cap and b < row_cap}
+    result = goldenmatch.dedupe_df(df)
+    ev = evaluate_clusters(result.clusters, gt_pairs).summary()
+    emitted = {(min(a, b), max(a, b)) for a, b, _ in result.scored_pairs}
+    attr = attribution(gt_pairs, _candidate_pairs(df), emitted)
+    return {"f1": ev["f1"], "precision": ev["precision"], "recall": ev["recall"],
+            "attribution": {k: attr[k] for k in ("blocking_recall", "final_recall", "threshold_loss")}}
+```
+
+- [ ] **Step 4: Run to verify it passes** → PASS. (dedupe at 200 entities is seconds.)
+
+- [ ] **Step 5: Commit** — `git add scripts/autoconfig_quality/f1.py scripts/autoconfig_quality/tests/test_f1.py && git commit -m "feat(quality): F1 tier + blocking/threshold attribution"`
+
+---
+
+## Task 4: Scorecard build + JSON I/O (`scorecard.py`)
+
+**Files:**
+- Create: `scripts/autoconfig_quality/scorecard.py`
+- Test: `scripts/autoconfig_quality/tests/test_scorecard.py`
+
+Assemble per-dataset records into the JSON shape; stable provenance (git sha + native version, no timestamp/RNG); rounded floats.
+
+- [ ] **Step 1: Write the failing test**:
+```python
+import json
+from scripts.autoconfig_quality.scorecard import build_scorecard, dumps, loads
+
+def test_build_scorecard_shape_and_stability():
+    results = {
+        "anchor_x": {"kind": "anchor", "signals": {"blocking_cost": {"candidate_pairs": 1529}}},
+        "febrl3": {"kind": "real", "signals": {}, "f1": {"f1": 0.991}},
+    }
+    sc = build_scorecard(results, native_version="0.1.11", git_sha="abc123",
+                         skipped={"ncvr": "absent"})
+    assert sc["meta"]["native_version"] == "0.1.11"
+    assert sc["meta"]["git_sha"] == "abc123"
+    assert sc["meta"]["datasets_skipped"] == {"ncvr": "absent"}
+    assert sorted(sc["meta"]["datasets_run"]) == ["anchor_x", "febrl3"]
+    assert "recorded_at" not in json.dumps(sc)        # NO timestamp -> byte-stable
+    assert loads(dumps(sc)) == sc                      # round-trips
+```
+
+- [ ] **Step 2: Run to verify it fails** → FAIL.
+
+- [ ] **Step 3: Implement `scorecard.py`** — `build_scorecard(results, native_version, git_sha, skipped) -> dict` assembling `{"meta": {...}, "datasets": results}`; `dumps`/`loads` as `json.dumps(sc, indent=2, sort_keys=True)` / `json.loads`. Provide a `gather_meta()` helper that reads `git rev-parse HEAD` (subprocess) and `goldenmatch_native.__version__` (try/except → "absent"), but `build_scorecard` takes them as args (so tests are deterministic).
+
+- [ ] **Step 4: Run to verify it passes** → PASS.
+
+- [ ] **Step 5: Commit** — `git add ... && git commit -m "feat(quality): scorecard build + stable JSON I/O"`
+
+---
+
+## Task 5: Diff + gate verdict (`diff.py`)
+
+**Files:**
+- Create: `scripts/autoconfig_quality/diff.py`
+- Test: `scripts/autoconfig_quality/tests/test_diff.py`
+
+The gate logic from the spec: anchor signal change = FAIL, real F1 below floor−tol = FAIL, skipped = neutral, anchor error = FAIL, real error = neutral.
+
+- [ ] **Step 1: Write the failing test** — cover each verdict branch:
+```python
+from scripts.autoconfig_quality.diff import diff_scorecards
+
+BASE = {"datasets": {
+    "anchor_x": {"kind": "anchor", "signals": {"blocking_cost": {"candidate_pairs": 1529}, "classification": {"zip5": "zip"}}},
+    "febrl3":   {"kind": "real", "f1": {"f1": 0.99}},
+}}
+
+def test_anchor_signal_change_fails():
+    cur = {"datasets": {**BASE["datasets"],
+        "anchor_x": {"kind": "anchor", "signals": {"blocking_cost": {"candidate_pairs": 8_931_083}, "classification": {"zip5": "zip"}}}}}
+    rows, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "FAIL"
+    assert any(r["status"] == "FAIL" and r["dataset"] == "anchor_x" for r in rows)
+
+def test_real_f1_drop_beyond_tol_fails():
+    cur = {"datasets": {**BASE["datasets"], "febrl3": {"kind": "real", "f1": {"f1": 0.95}}}}
+    _, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "FAIL"
+
+def test_real_f1_within_tol_passes():
+    cur = {"datasets": {**BASE["datasets"], "febrl3": {"kind": "real", "f1": {"f1": 0.985}}}}
+    _, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "PASS"
+
+def test_skipped_is_neutral_and_anchor_error_fails():
+    cur = {"datasets": {
+        "anchor_x": {"kind": "anchor", "signals": {"error": "boom"}},
+        "febrl3":   {"kind": "real", "error": "flake"}}}
+    rows, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "FAIL"           # anchor error
+    # real error is neutral on its own:
+    cur2 = {"datasets": {**BASE["datasets"], "febrl3": {"kind": "real", "error": "flake"}}}
+    _, verdict2 = diff_scorecards(cur2, BASE, tolerance=0.01)
+    assert verdict2 == "PASS"
+```
+
+- [ ] **Step 2: Run to verify it fails** → FAIL.
+
+- [ ] **Step 3: Implement `diff.py`** — `diff_scorecards(current, baseline, tolerance) -> (rows, verdict)`:
+  - For each dataset in current: if `kind == anchor`: any `signals` value differing from baseline (deep compare) → row `status=FAIL`; an `error` key in anchor signals → `status=FAIL`. If `kind == real`: compare `f1["f1"]` vs baseline; `< baseline_f1 - tolerance` → `FAIL`, else informational row (signals drift rendered as `⚠ changed`, status `OK`); an `error` on a real dataset → `status=NEUTRAL`.
+  - Datasets present in baseline but absent/skipped in current → `status=NEUTRAL`.
+  - `verdict = "FAIL"` if any row `status==FAIL` else `"PASS"`.
+  - Add `render_table(rows) -> str` producing the aligned delta table from the spec (used by the CLI).
+
+- [ ] **Step 4: Run to verify it passes** → PASS.
+
+- [ ] **Step 5: Commit** — `git add ... && git commit -m "feat(quality): scorecard diff + gate verdict"`
+
+---
+
+## Task 6: Dataset registry (`datasets.py`)
+
+**Files:**
+- Create: `scripts/autoconfig_quality/datasets.py`
+- Test: `scripts/autoconfig_quality/tests/test_datasets.py`
+
+`Dataset` dataclass + `REGISTRY`: three anchors (always available) + the real loaders (skip-when-absent).
+
+- [ ] **Step 1: Write the failing test**:
+```python
+from scripts.autoconfig_quality.datasets import REGISTRY, Dataset
+
+def test_anchors_always_load():
+    by_name = {d.name: d for d in REGISTRY}
+    for n in ("anchor_sparse_zip", "anchor_shared_email", "anchor_person_match"):
+        d = by_name[n]
+        assert d.kind == "anchor"
+        loaded = d.loader()
+        assert loaded is not None
+        df, gt = loaded
+        assert df.height > 0
+
+def test_person_anchor_has_gt_others_none():
+    by_name = {d.name: d for d in REGISTRY}
+    _, gt = by_name["anchor_person_match"].loader()
+    assert len(gt) > 0                                   # gen_labeled has GT
+    _, gt2 = by_name["anchor_sparse_zip"].loader()
+    assert gt2 == set()                                  # blocking-shape anchor, no F1
+
+def test_real_loader_skips_when_absent(monkeypatch):
+    by_name = {d.name: d for d in REGISTRY}
+    dblp = by_name["dblp_acm"]
+    assert dblp.kind == "real"
+    # when the data dir doesn't exist the loader returns None (skip), never raises
+    res = dblp.loader()
+    assert res is None or (isinstance(res, tuple) and len(res) == 2)
+```
+
+- [ ] **Step 2: Run to verify it fails** → FAIL.
+
+- [ ] **Step 3: Implement `datasets.py`**:
+```python
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Literal
+import polars as pl
+from scripts.autoconfig_quality.anchors import crm_df, gen_labeled, make_healthcare_df
+
+@dataclass(frozen=True)
+class Dataset:
+    name: str
+    kind: Literal["anchor", "real"]
+    loader: Callable[[], tuple[pl.DataFrame, set] | None]
+    expected: dict | None = None   # pinned fast-signal values (anchors only)
+
+def _sparse_zip():
+    df = make_healthcare_df(20_000, seed=715, zip_present=0.5).drop("matching_id")
+    return df, set()               # no true dups -> blocking-shape anchor, F1 N/A
+
+def _shared_email():
+    return crm_df(), set()         # config-shape anchor, F1 N/A
+
+def _person():
+    return gen_labeled(n_entities=400, seed=7)
+
+_DATASETS_ROOT = Path(__file__).resolve().parents[2] / "packages/python/goldenmatch/tests/benchmarks/datasets"
+
+def _dblp_acm():
+    d = _DATASETS_ROOT / "DBLP-ACM"
+    if not d.exists():
+        return None
+    # load + build row-index GT from the perfectMapping (see test_autoconfig_benchmarks pattern)
+    ...
+
+REGISTRY: list[Dataset] = [
+    Dataset("anchor_sparse_zip", "anchor", _sparse_zip,
+            expected={"classification": {"zip5": "zip"}, "blocking_fields_contains": "zip5",
+                      "candidate_pairs_max": 50_000}),
+    Dataset("anchor_shared_email", "anchor", _shared_email,
+            expected={"exact_matchkeys_contains": "email"}),
+    Dataset("anchor_person_match", "anchor", _person, expected=None),  # F1-floored, not signal-pinned
+    Dataset("dblp_acm", "real", _dblp_acm),
+    # NCVR, FEBRL3, historical_50k, dqbench tiers: same skip-when-absent pattern
+]
+```
+The `expected` block is consumed by `diff.py`/the gate as the pinned baseline for anchors. (Implement `_dblp_acm` and one more real loader concretely following `test_autoconfig_benchmarks.py:122-192` — remap cluster members via the id-column positional lookup to build row-index GT. Other real loaders may be stubs that return `None` until their data is wired, as long as they skip cleanly.)
+
+- [ ] **Step 4: Run to verify it passes** → PASS (anchors load; real skips when absent).
+
+- [ ] **Step 5: Commit** — `git add ... && git commit -m "feat(quality): dataset registry (anchors + real, skip-when-absent)"`
+
+---
+
+## Task 7: CLI + self-gating smoke test (`__main__.py`) + baseline
+
+**Files:**
+- Create: `scripts/autoconfig_quality/__main__.py`, `scripts/autoconfig_quality/baselines/scorecard.json`
+- Test: `scripts/autoconfig_quality/tests/test_cli_smoke.py`
+
+Wire the units into `report` / `gate` / `bless` with flags; generate + commit the baseline; the smoke test runs the harness over the anchors and asserts the gate passes on the committed baseline (the harness gates itself).
+
+- [ ] **Step 1: Write the failing smoke test**:
+```python
+import subprocess, sys, os
+def test_gate_fast_only_passes_on_committed_baseline():
+    env = {**os.environ, "POLARS_SKIP_CPU_CHECK": "1",
+           "PYTHONPATH": os.pathsep.join([REPO, PKG, PKG_SCRIPTS])}
+    r = subprocess.run([sys.executable, "-m", "scripts.autoconfig_quality",
+                        "gate", "--fast-only", "--datasets",
+                        "anchor_sparse_zip,anchor_shared_email,anchor_person_match"],
+                       cwd=REPO, env=env, capture_output=True, text=True)
+    assert r.returncode == 0, r.stdout + r.stderr
+```
+
+- [ ] **Step 2: Run to verify it fails** → FAIL (no `__main__`).
+
+- [ ] **Step 3: Implement `__main__.py`** — argparse with subcommands `report` (default) / `gate` / `bless`; flags `--fast-only`, `--datasets a,b`, `--native {0,1,auto}` (sets `GOLDENMATCH_NATIVE` before importing goldenmatch), `--row-cap N`. The run loop: for each selected `Dataset`, `loader()` → `None` ⇒ record skipped; else `extract_signals(df)` (always) + (`evaluate_f1` unless `--fast-only` or `gt == set()`); collect into `results`; `build_scorecard`. `report` prints `render_table(diff_scorecards(current, baseline))`; `gate` exits nonzero on `FAIL` verdict; `bless` writes `current` to `baselines/scorecard.json`. Wrap each dataset's extraction in try/except → `{"error": str(e)}` (anchor error path).
+
+- [ ] **Step 4: Generate + commit the baseline** — run `python -m scripts.autoconfig_quality bless --fast-only --datasets anchor_sparse_zip,anchor_shared_email,anchor_person_match` (+ any locally-present real datasets), inspect the JSON is sane (anchor signals match the known-good config, F1 floors set), then run the smoke test → PASS.
+
+- [ ] **Step 5: Commit** — `git add scripts/autoconfig_quality/__main__.py scripts/autoconfig_quality/baselines/scorecard.json scripts/autoconfig_quality/tests/test_cli_smoke.py && git commit -m "feat(quality): CLI (report/gate/bless) + committed baseline + self-gating smoke test"`
+
+---
+
+## Task 8: CI wiring + docs
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (add a `quality-gate` job + a `changes` filter entry), the doc-surface inventory if one lists scripts.
+- Create: `scripts/autoconfig_quality/README.md` (how to iterate: change a kernel → `report` → read the diff → `bless` to accept).
+
+- [ ] **Step 1:** Add a `quality_gate` path-filter to the `changes` job (triggers on `packages/rust/extensions/autoconfig-core/**`, `packages/python/goldenmatch/goldenmatch/core/autoconfig*.py`, `.../blocker.py`, `scripts/autoconfig_quality/**`).
+- [ ] **Step 2:** Add a `quality-gate` job gated on that filter: checkout, install the package + deps, run `python -m scripts.autoconfig_quality gate --fast-only` (anchors are committed → always runs) + the F1 tier for any dataset that resolves in CI (DBLP-ACM if committed). Keep it a normal-runner job (fast tier is seconds).
+- [ ] **Step 3:** Write the README (the iterate loop + bless workflow). Reference it from the spec.
+- [ ] **Step 4:** Run `python -m scripts.autoconfig_quality report` locally end-to-end (anchors + any local real datasets) and paste the table into the PR description as the first scorecard.
+- [ ] **Step 5: Commit + PR** — `git add .github/workflows/ci.yml scripts/autoconfig_quality/README.md && git commit -m "ci(quality): autoconfig quality-gate job + iterate docs"`; open the PR. (CI runs on this branch; arm `gh pr merge --auto --squash` once green per the repo SOP.)
+
+---
+
+## Verification & sequencing notes
+
+- **Each task is self-contained and committable.** Tasks 2–6 (the units) have no inter-dependencies beyond Task 1's anchors and are unit-tested in isolation on hand-built / anchor dfs — no real datasets needed. Task 7 ties them together; Task 8 wires CI.
+- **Local runs:** targeted file runs only (never the full xdist suite — OOMs the box). The dedupe in Task 3's F1 test at 200 entities is seconds; the harness `--fast-only` path is seconds across the anchors.
+- **The harness measures production behavior** (native default-on); `--native 0` is the parity knob. Do NOT bake `GOLDENMATCH_NATIVE=0` into the harness itself (only into the *test* commands, for determinism).
+- **YAGNI guardrails (from the spec):** no perf/wall-clock metrics, no web UI, no trend DB (the committed baseline's git log IS the trend), no Splink comparison.

--- a/docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md
+++ b/docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md
@@ -1,0 +1,228 @@
+# Auto-config quality harness — design
+
+- **Date:** 2026-06-22
+- **Branch:** `feat/autoconfig-quality-harness` (off `main`)
+- **Context:** The auto-config decision logic is now a single source of truth — the shared
+  pyo3-free `goldenmatch-autoconfig-core` kernel (planner / classifier / extrapolation /
+  thresholds), default-on across Python / native / TS-wasm (`goldenmatch-native` 0.1.11 on
+  PyPI). We can now *iterate* on that decision logic; this harness makes the quality impact of
+  an iteration measurable.
+
+## Problem
+
+Iterating on the auto-config kernel (a threshold, a classification heuristic, the blocking-key
+selector) currently means discovering quality regressions **one at a time, after the fact**,
+through ~38 scattered `test_autoconfig_*.py` files that each pin one behavior on a small
+fixture. The S1–S3 arc demonstrated the cost vividly: four separate regressions (email-floor
+demotion of shared emails, phone reclassification, the zip5 blocking-coupling 5,800× pair
+explosion, S1 routing) each surfaced on a *different* CI cycle, localized only by hand.
+
+There is **no single harness** that runs auto-config across a corpus of datasets and emits a
+comparative quality scorecard you can diff between two kernel versions. The reusable primitives
+exist and are scattered: `evaluate_clusters` (F1), `measure_blocking_profile` (blocking cost),
+`profile_columns` / `build_blocking` / `build_matchkeys` / `dedupe_df` (the decision path),
+`make_healthcare_df` and the multisource CRM fixture (failure shapes), real labeled datasets
+(FEBRL3 / DBLP-ACM / NCVR / historical_50k / DQbench tiers). What's missing is the **unifying
+runner + scorecard + baseline-diff + gate** that closes the iteration loop.
+
+This harness answers exactly one question: *is the auto-config's decision quality good, and did
+my change move it?* It is **not** a performance bench (`bench.py` / `bench-zero-config`), **not**
+cross-surface byte-parity (the golden vectors), and **not** an engine comparison
+(`bench_er_headtohead`).
+
+## Architecture
+
+A focused package `scripts/autoconfig_quality/` — six small single-purpose units behind one CLI:
+
+```
+scripts/autoconfig_quality/
+├── __main__.py        # CLI: report / gate / bless, filters, --fast-only, --native, --row-cap
+├── datasets.py        # registry: each Dataset = {name, kind, loader, expected?}
+├── signals.py         # FAST tier: config-quality signals (no full dedupe)
+├── f1.py              # SLOW tier: full dedupe -> evaluate_clusters -> F1/P/R
+├── scorecard.py       # build + serialize the per-dataset record (JSON)
+├── diff.py            # current vs baseline -> delta table + gate verdict
+└── baselines/
+    └── scorecard.json # committed baseline (the bless target)
+```
+
+**Key boundary — consume, never reimplement.** The harness calls the existing decision
+primitives (`profile_columns`, `build_blocking`, `build_matchkeys`, `measure_blocking_profile`,
+`dedupe_df`, `evaluate_clusters`, `apply_planner_rules`) and never reimplements decision logic.
+It therefore measures the *real* auto-config — the unified core kernel is exercised exactly as
+production runs it, including the native dispatch.
+
+Each unit has one job and a narrow interface: `datasets.py` yields `Dataset` records;
+`signals.py` maps a df → a fast-signal dict; `f1.py` maps a (df, ground_truth) → an F1 dict;
+`scorecard.py` assembles records → JSON; `diff.py` maps (current, baseline) → a delta table +
+verdict. They can each be understood and tested independently.
+
+## The dataset registry (`datasets.py`)
+
+Each `Dataset` declares `loader() -> (df, ground_truth) | None` and a `kind`:
+
+- **`real`** — FEBRL3, DBLP-ACM, NCVR, historical_50k, DQbench tiers. Loaded from local paths
+  (`tests/benchmarks/datasets/…`, `~/.dqbench/datasets/…`). The loader returns `None` when the
+  data is absent; the harness records the dataset as `skipped` with a reason and proceeds. Each
+  carries its native ground-truth labels (match pairs / cluster ids). These drive the **F1 tier**
+  and are **diffed informationally** in the fast tier (no single "correct" config to pin).
+- **`anchor`** — committed synthetic generators that reproduce the failure shapes this harness
+  exists to catch: a **sparse-zip healthcare** shape (`make_healthcare_df`, the zip5 blocking-
+  coupling / sampling-artifact case), a **shared-email CRM** shape (the multisource demote-phone /
+  keep-shared-email case), and a **person-match** shape (`gen_labeled`, the synthetic F1 floor).
+  Anchors are deterministic (fixed seed), always available (zero setup), and each carries an
+  `expected` block of **pinned fast-signal values** — the hard-gated regression net.
+
+The corpus is **real-primary** (the representative quality signal) with **synthetic anchors** as
+the always-on, deterministic regression net. Anchor generators are lifted from / shared with the
+existing fixtures (`scripts/repro_issue_715.py`, the multisource test fixture) so there is one
+definition of each shape, not a copy.
+
+## The two metric tiers
+
+### Fast tier — config quality, no dedupe (`signals.py`)
+
+Runs the decision path on a sample (no full pipeline) and records, per dataset:
+
+| Signal | Source | Regression it localizes |
+|---|---|---|
+| `classification` — `{col: col_type}` | `profile_columns` | zip5→identifier sampling-artifact mislabel; S2a phone reclassification |
+| `exact_matchkeys` — columns backing exact keys | `build_matchkeys` | S3 email-floor demotion of shared emails |
+| `blocking_fields` — columns in the chosen key/passes | `build_blocking` | the blocking-coupling bug (zip5 dropped from the compound) |
+| `blocking_cost` — candidate pairs, max block, p99, reduction ratio | `measure_blocking_profile` | the 1,529→8.9M candidate-pair explosion |
+| `planner_rung` — backend + rule_name | `apply_planner_rules` | S1 under-provisioning (simple vs chunked) |
+
+Deterministic and fast (seconds per dataset). For **anchors**, each signal is checked against its
+pinned `expected` (exact). For **real datasets**, signals are recorded and diffed informationally.
+
+### Slow tier — ground-truth accuracy, full dedupe (`f1.py`)
+
+Per **real** dataset (row-capped for tractability): `dedupe_df(df)` → cluster assignments →
+`evaluate_clusters(clusters, ground_truth_pairs)` → **F1 / precision / recall**, plus the
+**blocking-recall vs threshold-loss attribution** the head-to-head bench already computes, so an
+F1 drop is localized to "blocking lost candidates" vs "scoring threshold too strict." Anchors may
+optionally carry an F1 floor too (the `gen_labeled` person-match anchor has labels). `--fast-only`
+skips this tier for the tight iterate loop.
+
+**The split:** the fast tier is the always-on, deterministic, anchor-pinned **regression net**;
+the F1 tier is the slower, real-data **ground-truth confirmation**. You iterate against fast,
+confirm against F1.
+
+## Scorecard, baseline-diff, gate & bless
+
+### Scorecard (`scorecard.py`)
+
+One JSON artifact — per-dataset records under a metadata header:
+
+```json
+{
+  "meta": {"native_version": "0.1.11", "git_sha": "<sha>",
+           "datasets_run": ["anchor_sparse_zip", "febrl3", ...],
+           "datasets_skipped": {"ncvr": "absent"}},
+  "datasets": {
+    "anchor_sparse_zip": {
+      "kind": "anchor",
+      "signals": {"classification": {"zip5": "zip"}, "blocking_fields": ["zip5","last_name","first_name"],
+                  "blocking_cost": {"candidate_pairs": 1529, "max_block": 4},
+                  "exact_matchkeys": [...], "planner_rung": "..."}
+    },
+    "febrl3": {"kind": "real",
+               "signals": {...},
+               "f1": {"f1": 0.991, "precision": 0.99, "recall": 0.99,
+                      "attribution": {"blocking_recall": 0.998, "threshold_loss": 0.007}}}
+  }
+}
+```
+
+Provenance is `git_sha` + `native_version`, stamped from the environment — **no wall-clock
+timestamp / RNG in the artifact**, so re-runs on the same code are byte-stable and cleanly
+diffable. Float metrics are rounded to a fixed precision so trivial ULP noise doesn't churn the
+diff.
+
+### Diff (`diff.py`)
+
+Joins current vs `baselines/scorecard.json` and prints a human delta table:
+
+```
+anchor_sparse_zip   candidate_pairs  1,529 → 8,931,083  ✗ (anchor-pinned)
+                    zip5 col_type    identifier → zip   ⚠ changed
+febrl3              f1               0.991 → 0.991      ·
+dblp_acm            f1               0.879 → 0.864      ✗ (below floor−tol)
+```
+
+### Gate verdict (two rules)
+
+- **Anchors → exact.** Any pinned signal that changed = hard FAIL (an anchor encodes known-correct
+  config; a change is a regression or an intended redesign that must be blessed).
+- **Real datasets → floor + tolerance.** F1 must stay ≥ `baseline_f1 − tolerance` (default 0.01);
+  within-band moves pass. **Skipped** datasets are neutral (CI without the licensed data still
+  runs the anchor gate); an **error** on an *anchor* is FAIL (anchors must always run).
+
+### Bless
+
+`python -m autoconfig_quality bless` overwrites `baselines/scorecard.json` with the current run.
+This is the deliberate "I accept this change" step: when a kernel change is intentional and
+correct, you re-bless, and **the diff to the committed baseline file in the same PR is the
+reviewable record of exactly what config behavior changed** — turning an opaque threshold tweak
+into a legible behavioral diff.
+
+## CLI & where it runs (`__main__.py`)
+
+- `report` (default) — run the corpus, print the diff vs baseline, write the current scorecard to
+  a temp path. Read-only; the **iterate loop**.
+- `gate` — same run; exits non-zero on any anchor change or real F1 below floor−tolerance. The
+  **CI/commit gate**.
+- `bless` — overwrite the baseline. The **accept-intended-change** step.
+- Flags: `--fast-only` (skip the F1 tier — the seconds-fast loop), `--datasets a,b` (filter),
+  `--native 0|1|auto` (run against pure-Python or the native kernel — so the harness doubles as a
+  **config-decision** native-parity check, complementing the golden vectors), `--row-cap N` (F1
+  tractability).
+
+**Where it runs:**
+- **Local (primary)** — where the real datasets live. `--fast-only` for the tight loop; full
+  `report` before a kernel PR.
+- **CI** — a `quality-gate` job runs `gate --fast-only` always (anchors are committed,
+  deterministic, zero-setup → an always-on net that would have caught this session's bugs in one
+  run). The F1 tier runs in CI only for datasets that resolve (small committable ones like
+  DBLP-ACM; NCVR / DQbench skip gracefully). Not a heavy paid-runner bench: the fast tier is
+  seconds, capped F1 is minutes.
+
+## Error handling
+
+- A dataset loader that fails / finds no data → recorded `skipped` with a reason; never crashes
+  the run (one missing dataset can't break the harness).
+- A fast-signal extraction that throws on one dataset → that dataset's signals are `error: <msg>`,
+  the rest proceed.
+- Gate treats `skipped` as neutral, `error` on an anchor as FAIL.
+
+## Testing
+
+- Unit-test each unit in isolation: `signals.py` against a tiny hand-built df with a known
+  classification/blocking outcome; `f1.py` against a 2-cluster toy with known pairs;
+  `diff.py`/`scorecard.py` against fixed dicts (verdict logic, rounding, skipped/error handling).
+- A smoke test that runs the full harness over the anchors (always available) and asserts the
+  gate passes on the committed baseline — i.e. the harness gates *itself*.
+- The harness is the test for *auto-config quality*; its own units get ordinary unit tests.
+
+## Non-goals (YAGNI)
+
+- Not a performance / wall-clock bench (`bench.py`, `bench-zero-config`).
+- Not cross-surface byte-parity (the golden-vector harness) — though `--native` adds a
+  config-decision parity check as a cheap bonus.
+- Not a Splink / multi-engine comparison (`bench_er_headtohead`).
+- No web UI, no historical trend storage — the committed baseline JSON *is* the history (its git
+  log is the trend).
+
+## Reuse inventory (nothing reinvented)
+
+| Need | Existing primitive |
+|---|---|
+| F1 / P/R | `evaluate_clusters(clusters, ground_truth_pairs)` |
+| blocking cost | `measure_blocking_profile(df, cfg)` |
+| decision path | `profile_columns`, `build_blocking`, `build_matchkeys`, `apply_planner_rules` |
+| full dedupe | `dedupe_df` |
+| F1 attribution | the blocking-recall / threshold-loss split from `bench_er_headtohead/evaluate.py` |
+| sparse-zip anchor | `scripts/repro_issue_715.py::make_healthcare_df` |
+| shared-email anchor | the multisource CRM fixture (`test_autoconfig_multisource._crm_df`) |
+| person-match anchor | `gen_labeled` (from `test_quality_gate`) |
+| real dataset loaders | partly in `test_autoconfig_benchmarks.py` + the DQbench tests |

--- a/docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md
+++ b/docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md
@@ -32,7 +32,18 @@ cross-surface byte-parity (the golden vectors), and **not** an engine comparison
 
 ## Architecture
 
-A focused package `scripts/autoconfig_quality/` — six small single-purpose units behind one CLI:
+A focused package at **repo-root `scripts/autoconfig_quality/`** — the same `scripts/` tree as the
+existing autoconfig tooling (`gen_autoconfig_golden.py`, `bench_autoconfig_sample_quality.py`,
+`bench_er_headtohead/`), NOT the package-level `packages/python/goldenmatch/scripts/`. It imports
+the `goldenmatch` package via the installed dist / `PYTHONPATH` (as the other repo-root scripts
+do). Two anchor generators live in *other* trees and are imported explicitly: `make_healthcare_df`
+is at `packages/python/goldenmatch/scripts/repro_issue_715.py` (add that dir to `sys.path`, as
+`test_autoconfig_blocking_cost_715.py` already does); the shared-email `_crm_df` and the
+`gen_labeled` person-match generator currently live inside test modules and must be **extracted to
+an importable location** (a small refactor — one definition, no copy) so both the tests and this
+harness share them.
+
+Six small single-purpose units behind one CLI:
 
 ```
 scripts/autoconfig_quality/
@@ -92,17 +103,35 @@ Runs the decision path on a sample (no full pipeline) and records, per dataset:
 | `blocking_cost` — candidate pairs, max block, p99, reduction ratio | `measure_blocking_profile` | the 1,529→8.9M candidate-pair explosion |
 | `planner_rung` — backend + rule_name | `apply_planner_rules` | S1 under-provisioning (simple vs chunked) |
 
-Deterministic and fast (seconds per dataset). For **anchors**, each signal is checked against its
-pinned `expected` (exact). For **real datasets**, signals are recorded and diffed informationally.
+`apply_planner_rules(profile, runtime, n_rows_full, rules, context=None)` takes an assembled
+`ComplexityProfile` + `RuntimeProfile`, not a bare df — so the `planner_rung` signal assembles
+them the same way the controller does: a `BlockingProfile` from `measure_blocking_profile`, a
+`RuntimeProfile` from `capture_runtime_profile()`, wrapped in a minimal `ComplexityProfile`. The
+plan pins this assembly.
+
+Deterministic and fast (seconds per dataset — no full pipeline, only profiling + blocking +
+matchkey selection, NOT the controller's iterative sample-dedupes). For **anchors**, each signal
+is checked against its pinned `expected` (exact). For **real datasets**, signals are recorded and
+diffed informationally.
 
 ### Slow tier — ground-truth accuracy, full dedupe (`f1.py`)
 
 Per **real** dataset (row-capped for tractability): `dedupe_df(df)` → cluster assignments →
-`evaluate_clusters(clusters, ground_truth_pairs)` → **F1 / precision / recall**, plus the
-**blocking-recall vs threshold-loss attribution** the head-to-head bench already computes, so an
-F1 drop is localized to "blocking lost candidates" vs "scoring threshold too strict." Anchors may
-optionally carry an F1 floor too (the `gen_labeled` person-match anchor has labels). `--fast-only`
-skips this tier for the tight iterate loop.
+`evaluate_clusters(clusters, ground_truth)` → an `EvalResult`; the scorecard reads
+`.summary()` (or `.f1` / `.precision` / `.recall`) for **F1 / precision / recall**. Note
+`ground_truth` is a `set[tuple]` of matching record pairs, not a dict.
+
+Plus the **blocking-recall vs threshold-loss attribution** so an F1 drop is localized to
+"blocking lost candidates" vs "scoring threshold too strict." This reuses
+`scripts/bench_er_headtohead/attribution.py::attribution(gt_pairs, candidate_pairs,
+emitted_pairs)` — note it takes **pair sets**, not clusters: `emitted_pairs` comes from the
+dedupe result (`scored_pairs` above threshold), but **`candidate_pairs` (post-blocking,
+pre-scoring) is NOT on `DedupeResult`** — the harness must source it separately from the blocking
+output (run `build_blocks` / `measure_blocking_profile`'s key on the capped df to materialize the
+candidate set). The plan must budget that wiring.
+
+Anchors may optionally carry an F1 floor too (the `gen_labeled` person-match anchor has labels).
+`--fast-only` skips this tier for the tight iterate loop.
 
 **The split:** the fast tier is the always-on, deterministic, anchor-pinned **regression net**;
 the F1 tier is the slower, real-data **ground-truth confirmation**. You iterate against fast,
@@ -155,8 +184,13 @@ dblp_acm            f1               0.879 → 0.864      ✗ (below floor−tol
 - **Anchors → exact.** Any pinned signal that changed = hard FAIL (an anchor encodes known-correct
   config; a change is a regression or an intended redesign that must be blessed).
 - **Real datasets → floor + tolerance.** F1 must stay ≥ `baseline_f1 − tolerance` (default 0.01);
-  within-band moves pass. **Skipped** datasets are neutral (CI without the licensed data still
-  runs the anchor gate); an **error** on an *anchor* is FAIL (anchors must always run).
+  within-band moves pass.
+- **Skipped** datasets (loader returned `None`) are **neutral** — CI without the licensed data
+  still runs the anchor gate.
+- **Error** verdicts: an error on an **anchor** (signal extraction threw) is **FAIL** — anchors
+  must always run. An error on a **real** dataset's signal or F1 extraction is **neutral** (a
+  real-data flake or shape the harness can't profile must not block a kernel PR) — it's recorded
+  as `error: <msg>` and reported, but does not fail the gate.
 
 ### Bless
 
@@ -215,14 +249,14 @@ into a legible behavioral diff.
 
 ## Reuse inventory (nothing reinvented)
 
-| Need | Existing primitive |
-|---|---|
-| F1 / P/R | `evaluate_clusters(clusters, ground_truth_pairs)` |
-| blocking cost | `measure_blocking_profile(df, cfg)` |
-| decision path | `profile_columns`, `build_blocking`, `build_matchkeys`, `apply_planner_rules` |
-| full dedupe | `dedupe_df` |
-| F1 attribution | the blocking-recall / threshold-loss split from `bench_er_headtohead/evaluate.py` |
-| sparse-zip anchor | `scripts/repro_issue_715.py::make_healthcare_df` |
-| shared-email anchor | the multisource CRM fixture (`test_autoconfig_multisource._crm_df`) |
-| person-match anchor | `gen_labeled` (from `test_quality_gate`) |
-| real dataset loaders | partly in `test_autoconfig_benchmarks.py` + the DQbench tests |
+| Need | Existing primitive | Notes |
+|---|---|---|
+| F1 / P/R | `evaluate_clusters(clusters, ground_truth)` | `ground_truth` is `set[tuple]`; returns `EvalResult`, read `.summary()` / `.f1` |
+| blocking cost | `measure_blocking_profile(df, cfg)` | returns a `BlockingProfile` |
+| decision path | `profile_columns`, `build_blocking`, `build_matchkeys`, `apply_planner_rules` | planner needs assembled `ComplexityProfile`+`RuntimeProfile` (see fast tier) |
+| full dedupe | `dedupe_df` | `DedupeResult` has `clusters` + `scored_pairs`; NO raw candidate set |
+| F1 attribution | `scripts/bench_er_headtohead/attribution.py::attribution(gt_pairs, candidate_pairs, emitted_pairs)` | takes pair sets; candidate_pairs sourced from blocking separately |
+| sparse-zip anchor | `packages/python/goldenmatch/scripts/repro_issue_715.py::make_healthcare_df` | `(n, seed=715, zip_present=…, rich_surnames=…)`; import via sys.path |
+| shared-email anchor | `_crm_df` in `tests/test_autoconfig_multisource.py` | module-level fn — **extract to an importable shared location** |
+| person-match anchor | `gen_labeled(n_entities=400, seed=7) -> (df, gt_pairs)` in `tests/test_quality_gate.py` | also **extract to a shared location** |
+| real dataset loaders | partly in `test_autoconfig_benchmarks.py` + the DQbench tests | |

--- a/docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md
+++ b/docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md
@@ -173,11 +173,16 @@ diff.
 Joins current vs `baselines/scorecard.json` and prints a human delta table:
 
 ```
-anchor_sparse_zip   candidate_pairs  1,529 → 8,931,083  ✗ (anchor-pinned)
-                    zip5 col_type    identifier → zip   ⚠ changed
-febrl3              f1               0.991 → 0.991      ·
-dblp_acm            f1               0.879 → 0.864      ✗ (below floor−tol)
+anchor_sparse_zip   candidate_pairs  1,529 → 8,931,083   ✗ (anchor-pinned)
+                    zip5 col_type    identifier → zip    ✗ (anchor-pinned)
+febrl3              blocking_fields  [..,zip] → [..]     ⚠ changed (real → informational)
+febrl3              f1               0.991 → 0.991       ·
+dblp_acm            f1               0.879 → 0.864       ✗ (below floor−tol)
 ```
+
+Every signal on an **anchor** is pinned, so any change renders `✗` (hard FAIL). The `⚠ changed`
+marker is reserved for **real-dataset** signal drift (informational — real datasets have no single
+"correct" config to pin, only the F1 floor gates them).
 
 ### Gate verdict (two rules)
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_multisource.py
@@ -5,6 +5,9 @@ demotion, and the dedupe-only / single-source / match-mode firewalls.
 """
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import polars as pl
 from goldenmatch.core import autoconfig as ac
 from goldenmatch.core.autoconfig import (
@@ -15,6 +18,12 @@ from goldenmatch.core.autoconfig import (
     build_matchkeys,
     profile_columns,
 )
+
+# Shared CRM anchor (one definition for tests + the quality harness).
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+from scripts.autoconfig_quality.anchors import crm_df as _crm_df  # noqa: E402
 
 # ── Task 2: kill-switch ──────────────────────────────────────────────────────
 
@@ -148,21 +157,7 @@ def test_phone_demoted_when_multi_source():
 
 
 # ── Task 7: wired into auto_configure_df ─────────────────────────────────────
-
-def _crm_df():
-    rows = []
-    srcs = ["hubspot", "salesforce", "cvent"]
-    for i in range(30):
-        s = srcs[i % 3]
-        rows.append({
-            "source": s,
-            "rec_id": f"{s}-{i}",                  # disjoint per source
-            "first": f"first{i // 2}",
-            "last": f"last{i // 2}",
-            "email": f"user{i // 2}@ex.com",       # shared across sources
-            "phone": "5551112222" if i < 6 else f"555{i:07d}",
-        })
-    return pl.DataFrame(rows)
+# _crm_df is imported from the shared anchors module (see top of file).
 
 
 def _mk_names(cfg):

--- a/packages/python/goldenmatch/tests/test_quality_gate.py
+++ b/packages/python/goldenmatch/tests/test_quality_gate.py
@@ -24,13 +24,17 @@ ground-truth pairs by construction. Deterministic seed.
 """
 from __future__ import annotations
 
-import random
-from collections import defaultdict
-from itertools import combinations
+import sys
+from pathlib import Path
 
-import polars as pl
 import pytest
 from goldenmatch import dedupe_df
+
+# gen_labeled is the shared person-match anchor (one definition for tests + the
+# quality harness). Add repo-root to sys.path so scripts.* is importable.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 from goldenmatch.config.schemas import (
     BlockingConfig,
     BlockingKeyConfig,
@@ -40,53 +44,7 @@ from goldenmatch.config.schemas import (
 )
 from goldenmatch.core.evaluate import evaluate_clusters
 
-_SURN = [
-    "Smith", "Jones", "Williams", "Brown", "Davis", "Miller", "Wilson", "Moore",
-    "Taylor", "Anderson", "Thomas", "Jackson", "White", "Harris", "Martin",
-    "Thompson", "Garcia", "Martinez", "Robinson", "Clark", "Rodriguez", "Lewis",
-    "Lee", "Walker", "Hall", "Allen", "Young", "King", "Wright", "Lopez",
-]
-_FIRST = [
-    "Alex", "Blair", "Casey", "Dana", "Eli", "Finley", "Gray", "Harper",
-    "Indigo", "Jamie", "Kendall", "Logan", "Morgan", "Noel", "Oakley", "Parker",
-    "Quinn", "Riley", "Sage", "Taylor", "Umi", "Val", "Wren", "Xena", "Yael",
-    "Zane", "Avery", "Brook", "Cleo", "Drew",
-]
-
-
-def _typo(s: str, rng: random.Random) -> str:
-    if len(s) < 3:
-        return s
-    i = rng.randrange(len(s) - 1)
-    return s[:i] + s[i + 1] + s[i] + s[i + 2:]  # adjacent-char swap
-
-
-def gen_labeled(n_entities: int = 400, seed: int = 7) -> tuple[pl.DataFrame, set]:
-    """Synthetic records with known ground truth. Each entity = 1 original +
-    0-2 typo'd clones (sharing email + zip). Returns (df, ground_truth_pairs)
-    where pairs are (row_index, row_index) for rows of the same true entity."""
-    rng = random.Random(seed)
-    n_zip = max(1, n_entities // 2)
-    tagged: list[tuple[dict, int]] = []
-    for e in range(n_entities):
-        f, l = rng.choice(_FIRST), rng.choice(_SURN)
-        z = f"{rng.randrange(n_zip):05d}"
-        email = f"{f}.{l}.{e}@x.com".lower()
-        tagged.append(({"first_name": f, "last_name": l, "email": email, "zip": z}, e))
-        for _ in range(rng.choice([0, 0, 1, 1, 2])):
-            tagged.append(
-                ({"first_name": _typo(f, rng), "last_name": l, "email": email, "zip": z}, e)
-            )
-    rng.shuffle(tagged)
-    df = pl.DataFrame([rec for rec, _ in tagged])
-    by_entity: dict[int, list[int]] = defaultdict(list)
-    for pos, (_, e) in enumerate(tagged):
-        by_entity[e].append(pos)
-    gt: set = set()
-    for positions in by_entity.values():
-        for a, b in combinations(sorted(positions), 2):
-            gt.add((a, b))
-    return df, gt
+from scripts.autoconfig_quality.anchors import gen_labeled  # noqa: E402
 
 
 def _cfg(backend: str | None, kind: str) -> GoldenMatchConfig:

--- a/scripts/autoconfig_quality/README.md
+++ b/scripts/autoconfig_quality/README.md
@@ -1,0 +1,93 @@
+# Auto-config quality harness
+
+A one-run scorecard for the auto-config **decision kernel**
+(`goldenmatch-autoconfig-core` + its Python/blocking surfaces). It exists so a
+kernel change's quality impact is measurable in a single command instead of being
+discovered one regression at a time (the S1–S3 levers each shipped a regression
+that a corpus-wide gate would have caught immediately).
+
+## What it measures
+
+Two tiers, per dataset:
+
+- **Fast (config signals, no dedupe):** classification, exact matchkeys, blocking
+  fields, blocking cost (`candidate_pairs`, `n_blocks`, `max_block`, `p99`,
+  `reduction_ratio`), and the planner rung. Seconds across the whole corpus.
+- **Slow (F1):** full dedupe → `evaluate_clusters` → F1 / precision / recall plus
+  attribution (`blocking_recall`, `final_recall`, `threshold_loss`). Only runs for
+  datasets that carry ground truth.
+
+## Corpus
+
+- **Anchors** (`anchor_*`, always present, deterministic) pin specific
+  failure-shapes this harness was built to defend:
+  - `anchor_sparse_zip` — 30k healthcare rows; `zip5` must stay classified `zip`
+    (not `identifier`) and must NOT blow the compound blocking cost up
+    (`candidate_pairs` stays ~1.5k, the blocking-decouple fix).
+  - `anchor_shared_email` — shared-email CRM; `email` must survive as an exact
+    matchkey while `phone` is demoted (the per-type matchkey floors).
+  - `anchor_person_match` — 400 seeded entities with ground truth; carries an F1
+    floor.
+- **Real datasets** (DBLP-ACM, …) are skip-when-absent: their loaders return
+  `None` when the gitignored data isn't on disk, so the gate stays green in CI
+  while still running them wherever the data exists.
+
+## The gate
+
+`gate` diffs the current scorecard against the committed baseline
+(`baselines/scorecard.json`) and exits non-zero on a regression:
+
+- **Anchor, host-independent signal changed → FAIL.** Classification, matchkeys,
+  blocking fields/cost are pure functions of the data + kernel.
+- **Anchor F1 below `baseline − tolerance` → FAIL** (default tolerance 0.01).
+- **Real dataset F1 below `baseline − tolerance` → FAIL**; its signal drift is
+  informational.
+- **`planner_rung` drift → WARN, never FAIL.** Backend/rule routing is coupled to
+  native-wheel availability and box RAM+cores, not to the decision kernel — so a
+  CI runner without the native wheel never flaps a dev baseline blessed with
+  native on. Still recorded as visible drift.
+- **Skipped / absent dataset → NEUTRAL.**
+
+## The iterate loop
+
+You changed the kernel (a floor, a classifier rule, the blocking decouple). Now:
+
+```bash
+# 1. See the impact. `report` prints the diff vs the committed baseline.
+python -m scripts.autoconfig_quality report
+
+# 2a. Drift is unintended -> fix the kernel, re-run report until the diff is clean.
+# 2b. Drift is the intended improvement -> accept it as the new pinned truth:
+python -m scripts.autoconfig_quality bless
+git add scripts/autoconfig_quality/baselines/scorecard.json
+git commit -m "quality: re-bless baseline (<what changed and why it's better>)"
+```
+
+The committed baseline's **git history is the trend log** — every bless is a
+reviewable diff of how the auto-config's decisions moved and why.
+
+## Flags
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--fast-only` | off | Skip the F1 tier (config signals only). |
+| `--datasets a,b` | all | Restrict to named datasets. |
+| `--row-cap N` | 20000 | Cap rows fed to the F1 tier (tractability). |
+| `--native {0,1,auto}` | run default | `GOLDENMATCH_NATIVE` for the run. The kernel signals are parity-identical across native/Python; only `planner_rung` (WARN) differs. |
+| `--tolerance F` | 0.01 | F1 floor band. |
+
+## Determinism notes
+
+- Kernel signals are host-independent; F1 is parity-identical native vs Python.
+  The only host-coupled signal (`planner_rung`) is WARN by design.
+- The CI job pins `GOLDENMATCH_AUTOCONFIG_MEMORY=0` so the gate measures the
+  static kernel, not learned per-run adjustments. Re-bless under the same setting.
+- The harness sets `POLARS_SKIP_CPU_CHECK=1` itself; no extra env needed locally
+  beyond making `scripts` importable (run from the repo root).
+
+## Scope (YAGNI)
+
+No wall-clock/perf metrics (that's the bench workflows), no web UI, no trend DB
+(git log is the trend), no third-party-tool comparison. This gate answers exactly
+one question: *did this change move an auto-config decision, and is that move
+intended?*

--- a/scripts/autoconfig_quality/__init__.py
+++ b/scripts/autoconfig_quality/__init__.py
@@ -1,0 +1,6 @@
+"""Auto-config quality harness — run auto-config across a corpus (real labeled
+datasets + synthetic failure-shape anchors) and emit a comparative scorecard
+(fast config-signals + F1) with a committed baseline, diff, gate, and bless.
+
+See docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md.
+"""

--- a/scripts/autoconfig_quality/__main__.py
+++ b/scripts/autoconfig_quality/__main__.py
@@ -1,0 +1,108 @@
+"""Auto-config quality harness CLI.
+
+    python -m scripts.autoconfig_quality report   # diff vs baseline (iterate loop)
+    python -m scripts.autoconfig_quality gate     # exit nonzero on regression (CI)
+    python -m scripts.autoconfig_quality bless     # accept current as the baseline
+
+Flags: --fast-only (skip the F1 tier), --datasets a,b (filter), --row-cap N
+(F1 tractability), --native {0,1,auto} (run pure-Python / native / default),
+--tolerance F (real-dataset F1 floor band, default 0.01).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Polars CPU probe can hang on Windows; set before anything imports polars.
+os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
+_BASELINE = Path(__file__).resolve().parent / "baselines" / "scorecard.json"
+
+
+def run(dataset_names: set[str] | None, fast_only: bool, row_cap: int | None):
+    """Run the corpus -> (results, skipped). Heavy imports are deferred so
+    --native can set GOLDENMATCH_NATIVE before goldenmatch loads."""
+    from scripts.autoconfig_quality.datasets import REGISTRY
+    from scripts.autoconfig_quality.f1 import evaluate_f1
+    from scripts.autoconfig_quality.signals import extract_signals
+
+    results: dict[str, dict] = {}
+    skipped: dict[str, str] = {}
+    for d in REGISTRY:
+        if dataset_names and d.name not in dataset_names:
+            continue
+        try:
+            loaded = d.loader()
+        except Exception as e:  # loader failure -> skip with reason, never crash
+            skipped[d.name] = f"loader_error: {e}"
+            continue
+        if loaded is None:
+            skipped[d.name] = "absent"
+            continue
+        df, gt = loaded
+        rec: dict = {"kind": d.kind}
+        try:
+            rec["signals"] = extract_signals(df)
+        except Exception as e:
+            rec["signals"] = {"error": str(e)}  # anchor->FAIL, real->neutral (per diff)
+        if not fast_only and gt:
+            try:
+                rec["f1"] = evaluate_f1(df, gt, row_cap=row_cap)
+            except Exception as e:
+                rec["error"] = str(e)  # real F1 error -> neutral (per diff)
+        results[d.name] = rec
+    return results, skipped
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="autoconfig_quality")
+    p.add_argument("mode", nargs="?", default="report", choices=["report", "gate", "bless"])
+    p.add_argument("--fast-only", action="store_true", help="skip the F1 tier")
+    p.add_argument("--datasets", default="", help="comma-separated dataset filter")
+    p.add_argument("--row-cap", type=int, default=20_000, help="F1-tier row cap")
+    p.add_argument("--native", choices=["0", "1", "auto"], default=None,
+                   help="GOLDENMATCH_NATIVE for this run")
+    p.add_argument("--tolerance", type=float, default=0.01, help="real-dataset F1 floor band")
+    args = p.parse_args(argv)
+
+    if args.native is not None:
+        os.environ["GOLDENMATCH_NATIVE"] = args.native  # before goldenmatch import
+
+    from scripts.autoconfig_quality.diff import diff_scorecards, render_table
+    from scripts.autoconfig_quality.scorecard import (
+        build_scorecard,
+        dumps,
+        gather_meta,
+        loads,
+    )
+
+    names = {s for s in args.datasets.split(",") if s} or None
+    results, skipped = run(names, args.fast_only, args.row_cap)
+    native_version, git_sha = gather_meta()
+    current = build_scorecard(results, native_version=native_version,
+                              git_sha=git_sha, skipped=skipped)
+
+    if args.mode == "bless":
+        _BASELINE.parent.mkdir(parents=True, exist_ok=True)
+        _BASELINE.write_text(dumps(current), encoding="utf-8")
+        print(f"Blessed baseline -> {_BASELINE} ({len(results)} datasets, "
+              f"{len(skipped)} skipped)")
+        return 0
+
+    baseline = loads(_BASELINE.read_text(encoding="utf-8")) if _BASELINE.exists() else {"datasets": {}}
+    rows, verdict = diff_scorecards(current, baseline, tolerance=args.tolerance)
+    print(render_table(rows))
+    print(f"\nverdict: {verdict}  ({len(results)} run, {len(skipped)} skipped)")
+    if skipped:
+        print("skipped: " + ", ".join(f"{k} ({v})" for k, v in skipped.items()))
+
+    if args.mode == "gate":
+        return 0 if verdict == "PASS" else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/autoconfig_quality/anchors.py
+++ b/scripts/autoconfig_quality/anchors.py
@@ -1,0 +1,87 @@
+"""Shared synthetic anchor generators — ONE definition, imported by both the
+tests and the quality harness. Bodies lifted verbatim from the test fixtures
+(test_quality_gate.gen_labeled, test_autoconfig_multisource._crm_df) and the
+package script (repro_issue_715.make_healthcare_df)."""
+from __future__ import annotations
+
+import random
+import sys
+from collections import defaultdict
+from itertools import combinations
+from pathlib import Path
+
+import polars as pl
+
+# make_healthcare_df lives in the package scripts/ dir (not importable as a
+# package); add it to sys.path and re-export, so anchors.py is the one place
+# that knows where each shape lives.
+_PKG_SCRIPTS = Path(__file__).resolve().parents[2] / "packages/python/goldenmatch/scripts"
+if str(_PKG_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_PKG_SCRIPTS))
+from repro_issue_715 import make_healthcare_df  # noqa: E402,F401  (re-export)
+
+# ── person-match anchor (gen_labeled) ──────────────────────────────────────────
+_SURN = [
+    "Smith", "Jones", "Williams", "Brown", "Davis", "Miller", "Wilson", "Moore",
+    "Taylor", "Anderson", "Thomas", "Jackson", "White", "Harris", "Martin",
+    "Thompson", "Garcia", "Martinez", "Robinson", "Clark", "Rodriguez", "Lewis",
+    "Lee", "Walker", "Hall", "Allen", "Young", "King", "Wright", "Lopez",
+]
+_FIRST = [
+    "Alex", "Blair", "Casey", "Dana", "Eli", "Finley", "Gray", "Harper",
+    "Indigo", "Jamie", "Kendall", "Logan", "Morgan", "Noel", "Oakley", "Parker",
+    "Quinn", "Riley", "Sage", "Taylor", "Umi", "Val", "Wren", "Xena", "Yael",
+    "Zane", "Avery", "Brook", "Cleo", "Drew",
+]
+
+
+def _typo(s: str, rng: random.Random) -> str:
+    if len(s) < 3:
+        return s
+    i = rng.randrange(len(s) - 1)
+    return s[:i] + s[i + 1] + s[i] + s[i + 2:]  # adjacent-char swap
+
+
+def gen_labeled(n_entities: int = 400, seed: int = 7) -> tuple[pl.DataFrame, set]:
+    """Synthetic records with known ground truth. Each entity = 1 original +
+    0-2 typo'd clones (sharing email + zip). Returns (df, ground_truth_pairs)
+    where pairs are (row_index, row_index) for rows of the same true entity."""
+    rng = random.Random(seed)
+    n_zip = max(1, n_entities // 2)
+    tagged: list[tuple[dict, int]] = []
+    for e in range(n_entities):
+        f, l = rng.choice(_FIRST), rng.choice(_SURN)
+        z = f"{rng.randrange(n_zip):05d}"
+        email = f"{f}.{l}.{e}@x.com".lower()
+        tagged.append(({"first_name": f, "last_name": l, "email": email, "zip": z}, e))
+        for _ in range(rng.choice([0, 0, 1, 1, 2])):
+            tagged.append(
+                ({"first_name": _typo(f, rng), "last_name": l, "email": email, "zip": z}, e)
+            )
+    rng.shuffle(tagged)
+    df = pl.DataFrame([rec for rec, _ in tagged])
+    by_entity: dict[int, list[int]] = defaultdict(list)
+    for pos, (_, e) in enumerate(tagged):
+        by_entity[e].append(pos)
+    gt: set = set()
+    for positions in by_entity.values():
+        for a, b in combinations(sorted(positions), 2):
+            gt.add((a, b))
+    return df, gt
+
+
+# ── shared-email CRM anchor (multisource demote-phone / keep-shared-email) ─────
+def crm_df() -> pl.DataFrame:
+    rows = []
+    srcs = ["hubspot", "salesforce", "cvent"]
+    for i in range(30):
+        s = srcs[i % 3]
+        rows.append({
+            "source": s,
+            "rec_id": f"{s}-{i}",                  # disjoint per source
+            "first": f"first{i // 2}",
+            "last": f"last{i // 2}",
+            "email": f"user{i // 2}@ex.com",       # shared across sources
+            "phone": "5551112222" if i < 6 else f"555{i:07d}",
+        })
+    return pl.DataFrame(rows)

--- a/scripts/autoconfig_quality/baselines/scorecard.json
+++ b/scripts/autoconfig_quality/baselines/scorecard.json
@@ -4,12 +4,12 @@
       "f1": {
         "attribution": {
           "blocking_recall": 1.0,
-          "final_recall": 0.8839,
-          "threshold_loss": 0.1161
+          "final_recall": 1.0,
+          "threshold_loss": 0.0
         },
-        "f1": 0.9384,
-        "precision": 1.0,
-        "recall": 0.8839
+        "f1": 0.9896,
+        "precision": 0.9793,
+        "recall": 1.0
       },
       "kind": "anchor",
       "signals": {
@@ -110,8 +110,10 @@
       "anchor_shared_email",
       "anchor_sparse_zip"
     ],
-    "datasets_skipped": {},
-    "git_sha": "ffe28c8f92ee58c7e1552ea45e9f993f9a4d577c",
+    "datasets_skipped": {
+      "dblp_acm": "absent"
+    },
+    "git_sha": "d7ce338a565d01ba062dbaa5a1eb343eea4bd982",
     "native_version": "0.1.11"
   }
 }

--- a/scripts/autoconfig_quality/baselines/scorecard.json
+++ b/scripts/autoconfig_quality/baselines/scorecard.json
@@ -1,0 +1,117 @@
+{
+  "datasets": {
+    "anchor_person_match": {
+      "f1": {
+        "attribution": {
+          "blocking_recall": 1.0,
+          "final_recall": 0.8839,
+          "threshold_loss": 0.1161
+        },
+        "f1": 0.9384,
+        "precision": 1.0,
+        "recall": 0.8839
+      },
+      "kind": "anchor",
+      "signals": {
+        "blocking_cost": {
+          "candidate_pairs": 1712,
+          "max_block": 13,
+          "n_blocks": 149,
+          "p99": 13,
+          "reduction_ratio": 0.9931
+        },
+        "blocking_fields": [
+          "zip"
+        ],
+        "classification": {
+          "email": "email",
+          "first_name": "name",
+          "last_name": "name",
+          "zip": "zip"
+        },
+        "exact_matchkeys": [
+          "email"
+        ],
+        "planner_rung": {
+          "backend": "polars-direct",
+          "rule_name": "plan_selected_simple"
+        }
+      }
+    },
+    "anchor_shared_email": {
+      "kind": "anchor",
+      "signals": {
+        "blocking_cost": {
+          "candidate_pairs": 15,
+          "max_block": 2,
+          "n_blocks": 15,
+          "p99": 2,
+          "reduction_ratio": 0.9655
+        },
+        "blocking_fields": [
+          "email"
+        ],
+        "classification": {
+          "email": "email",
+          "first": "string",
+          "last": "string",
+          "phone": "phone",
+          "rec_id": "identifier",
+          "source": "name"
+        },
+        "exact_matchkeys": [
+          "email",
+          "phone"
+        ],
+        "planner_rung": {
+          "backend": "polars-direct",
+          "rule_name": "plan_selected_simple"
+        }
+      }
+    },
+    "anchor_sparse_zip": {
+      "kind": "anchor",
+      "signals": {
+        "blocking_cost": {
+          "candidate_pairs": 1529,
+          "max_block": 4,
+          "n_blocks": 1411,
+          "p99": 3,
+          "reduction_ratio": 1.0
+        },
+        "blocking_fields": [
+          "first_name",
+          "last_name",
+          "zip5"
+        ],
+        "classification": {
+          "email": "email",
+          "first_name": "name",
+          "last_name": "name",
+          "npi": "identifier",
+          "phone_number": "identifier",
+          "source": "string",
+          "zip5": "zip"
+        },
+        "exact_matchkeys": [
+          "email",
+          "npi"
+        ],
+        "planner_rung": {
+          "backend": "polars-direct",
+          "rule_name": "plan_selected_simple"
+        }
+      }
+    }
+  },
+  "meta": {
+    "datasets_run": [
+      "anchor_person_match",
+      "anchor_shared_email",
+      "anchor_sparse_zip"
+    ],
+    "datasets_skipped": {},
+    "git_sha": "ffe28c8f92ee58c7e1552ea45e9f993f9a4d577c",
+    "native_version": "0.1.11"
+  }
+}

--- a/scripts/autoconfig_quality/datasets.py
+++ b/scripts/autoconfig_quality/datasets.py
@@ -1,0 +1,87 @@
+"""Dataset registry: synthetic failure-shape anchors (always available) + real
+labeled datasets (skip-when-absent).
+
+Each Dataset's loader returns (df, gt_pairs) | None, where gt_pairs is a
+set[(i, j)] in ROW-INDEX space (i<j) — the same space cluster members live in,
+so the F1 tier needs no remap. A real loader returns None when its data isn't
+present locally (the harness records it as `skipped`, never crashes).
+
+The committed baseline scorecard is the single source of pinned expectations for
+anchors (the gate compares current signals against the baseline), so Dataset
+carries no separate `expected` block.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import polars as pl
+
+from scripts.autoconfig_quality.anchors import crm_df, gen_labeled, make_healthcare_df
+
+
+@dataclass(frozen=True)
+class Dataset:
+    name: str
+    kind: Literal["anchor", "real"]
+    loader: Callable[[], tuple[pl.DataFrame, set] | None]
+
+
+# ── anchors (always available, deterministic) ──────────────────────────────────
+def _sparse_zip() -> tuple[pl.DataFrame, set]:
+    # n=30k is the scale where the zip5 sampling-artifact + blocking-coupling
+    # regression manifests (zips saturate to ~0.32 cardinality). No true dups
+    # -> blocking-shape anchor, F1 not applicable (gt is empty).
+    df = make_healthcare_df(30_000, seed=715, zip_present=0.5).drop("matching_id")
+    return df, set()
+
+
+def _shared_email() -> tuple[pl.DataFrame, set]:
+    return crm_df(), set()  # config-shape anchor (demote-phone / keep-shared-email)
+
+
+def _person() -> tuple[pl.DataFrame, set]:
+    return gen_labeled(n_entities=400, seed=7)  # has row-index ground truth
+
+
+# ── real labeled datasets (skip-when-absent) ───────────────────────────────────
+_DATASETS_ROOT = Path(__file__).resolve().parents[2] / "packages/python/goldenmatch/tests/benchmarks/datasets"
+
+
+def _dblp_acm() -> tuple[pl.DataFrame, set] | None:
+    """DBLP-ACM bibliographic record-linkage. Concatenate the two tables, build
+    row-index GT from the perfect mapping. Returns None when the data is absent."""
+    d = _DATASETS_ROOT / "DBLP-ACM"
+    dblp_p, acm_p = d / "DBLP2.csv", d / "ACM.csv"
+    map_p = d / "DBLP-ACM_perfectMapping.csv"
+    if not (dblp_p.exists() and acm_p.exists() and map_p.exists()):
+        return None
+    try:
+        dblp = pl.read_csv(dblp_p, encoding="utf8-lossy", ignore_errors=True)
+        acm = pl.read_csv(acm_p, encoding="utf8-lossy", ignore_errors=True)
+        mapping = pl.read_csv(map_p, encoding="utf8-lossy", ignore_errors=True)
+        df = pl.concat([dblp, acm], how="diagonal_relaxed")
+        # row-index lookup keyed by the source 'id' column (present in both tables)
+        pos = {str(v): i for i, v in enumerate(df["id"].to_list())}
+        gt: set[tuple[int, int]] = set()
+        cols = mapping.columns  # standard headers: idDBLP, idACM
+        a_col, b_col = cols[0], cols[1]
+        for a, b in zip(mapping[a_col].to_list(), mapping[b_col].to_list()):
+            ia, ib = pos.get(str(a)), pos.get(str(b))
+            if ia is not None and ib is not None and ia != ib:
+                gt.add((min(ia, ib), max(ia, ib)))
+        return df, gt
+    except Exception:
+        return None  # any malformed piece -> skip, never crash the run
+
+
+REGISTRY: list[Dataset] = [
+    Dataset("anchor_sparse_zip", "anchor", _sparse_zip),
+    Dataset("anchor_shared_email", "anchor", _shared_email),
+    Dataset("anchor_person_match", "anchor", _person),
+    Dataset("dblp_acm", "real", _dblp_acm),
+    # FEBRL3 / NCVR / historical_50k / DQbench tiers: add with the same
+    # skip-when-absent loader pattern as their data lands.
+]

--- a/scripts/autoconfig_quality/diff.py
+++ b/scripts/autoconfig_quality/diff.py
@@ -1,0 +1,91 @@
+"""Scorecard diff + gate verdict.
+
+Verdict rules (from the spec):
+- anchor: ANY pinned signal that changed from baseline = FAIL; an error on an
+  anchor = FAIL (anchors must always run).
+- real: F1 below (baseline_f1 - tolerance) = FAIL; signal drift is informational
+  (WARN, never fails); an error on a real dataset = NEUTRAL.
+- a dataset present in baseline but skipped/absent in current = NEUTRAL.
+The overall verdict is FAIL if any row is FAIL, else PASS.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+_STATUS_FAIL = "FAIL"
+_STATUS_OK = "OK"
+_STATUS_WARN = "WARN"
+_STATUS_NEUTRAL = "NEUTRAL"
+
+
+def _flatten(obj: Any, prefix: str = "") -> dict[str, Any]:
+    """Flatten a nested signals dict to {dotted.path: leaf_value}."""
+    out: dict[str, Any] = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            out.update(_flatten(v, f"{prefix}.{k}" if prefix else str(k)))
+    else:
+        out[prefix] = obj
+    return out
+
+
+def _row(dataset: str, field: str, before: Any, after: Any, status: str) -> dict[str, Any]:
+    return {"dataset": dataset, "field": field, "before": before, "after": after,
+            "status": status}
+
+
+def diff_scorecards(
+    current: dict, baseline: dict, *, tolerance: float = 0.01,
+) -> tuple[list[dict], str]:
+    """Compare current vs baseline -> (delta rows, overall verdict)."""
+    rows: list[dict] = []
+    cur = current.get("datasets", {})
+    base = baseline.get("datasets", {})
+
+    for name, c in cur.items():
+        b = base.get(name)
+        kind = c.get("kind", b.get("kind") if b else "real")
+
+        if kind == "anchor":
+            # An error on an anchor is a hard FAIL (anchors must always run).
+            if "error" in c.get("signals", {}):
+                rows.append(_row(name, "signals", None, c["signals"]["error"], _STATUS_FAIL))
+                continue
+            # Any pinned signal that changed from baseline = FAIL.
+            cur_sig = _flatten(c.get("signals", {}))
+            base_sig = _flatten(b.get("signals", {})) if b else {}
+            for field in sorted(set(cur_sig) | set(base_sig)):
+                before, after = base_sig.get(field), cur_sig.get(field)
+                if before != after:
+                    rows.append(_row(name, field, before, after, _STATUS_FAIL))
+        else:  # real
+            if "error" in c:
+                rows.append(_row(name, "f1", None, c["error"], _STATUS_NEUTRAL))
+                continue
+            cur_f1 = c.get("f1", {}).get("f1")
+            base_f1 = b.get("f1", {}).get("f1") if b else None
+            if cur_f1 is not None and base_f1 is not None:
+                status = _STATUS_FAIL if cur_f1 < base_f1 - tolerance else _STATUS_OK
+                rows.append(_row(name, "f1", base_f1, cur_f1, status))
+            elif cur_f1 is not None:
+                rows.append(_row(name, "f1", None, cur_f1, _STATUS_OK))
+
+    # Datasets in baseline but absent from current -> neutral (skipped).
+    for name in base:
+        if name not in cur:
+            rows.append(_row(name, "*", "present", "absent", _STATUS_NEUTRAL))
+
+    verdict = "FAIL" if any(r["status"] == _STATUS_FAIL for r in rows) else "PASS"
+    return rows, verdict
+
+
+def render_table(rows: list[dict]) -> str:
+    """Aligned delta table. ✗ = FAIL, ⚠ = WARN, · = OK, ~ = NEUTRAL."""
+    mark = {_STATUS_FAIL: "✗", _STATUS_WARN: "⚠", _STATUS_OK: "·", _STATUS_NEUTRAL: "~"}
+    lines = []
+    for r in rows:
+        lines.append(
+            f"{r['dataset']:<22} {r['field']:<18} {r['before']} → {r['after']}  "
+            f"{mark.get(r['status'], '?')} ({r['status']})"
+        )
+    return "\n".join(lines) if lines else "(no differences)"

--- a/scripts/autoconfig_quality/diff.py
+++ b/scripts/autoconfig_quality/diff.py
@@ -7,6 +7,10 @@ Verdict rules (from the spec):
   with the auto-config decision kernel, so they are informational (WARN, never
   fail) -- otherwise a CI runner with no native wheel flaps against a dev box
   baseline blessed with native on.
+  An anchor that pins an F1 floor is gated on F1 too: below (floor - tolerance)
+  = FAIL; if the run produced no F1 at all, a crash (top-level "error") = FAIL
+  (anchors must run cleanly) while an intentional fast-only skip = WARN (visible,
+  never silent, but doesn't fail a config-only run -- the CI gate runs full).
 - real: F1 below (baseline_f1 - tolerance) = FAIL; signal drift is informational
   (WARN, never fails); an error on a real dataset = NEUTRAL.
 - a dataset present in baseline but skipped/absent in current = NEUTRAL.
@@ -75,9 +79,20 @@ def diff_scorecards(
                     rows.append(_row(name, field, before, after, status))
             # An anchor that also carries an F1 floor (e.g. the person-match
             # anchor) is gated on F1 too, floor+tolerance like a real dataset.
+            # The floor must never be silently dropped: if the baseline pins an
+            # F1 but the current run produced none, distinguish a crash (the F1
+            # tier was attempted and raised -> top-level "error" -> FAIL, anchors
+            # must run cleanly) from an intentional fast-only skip (no f1, no
+            # error -> WARN so it's visible, but doesn't fail a config-only run;
+            # the CI gate runs the full tier, so the floor is enforced there).
             cur_f1 = c.get("f1", {}).get("f1")
             base_f1 = b.get("f1", {}).get("f1") if b else None
-            if cur_f1 is not None and base_f1 is not None:
+            if base_f1 is not None and cur_f1 is None:
+                if "error" in c:
+                    rows.append(_row(name, "f1", base_f1, c["error"], _STATUS_FAIL))
+                else:
+                    rows.append(_row(name, "f1", base_f1, "not measured", _STATUS_WARN))
+            elif cur_f1 is not None and base_f1 is not None:
                 status = _STATUS_FAIL if cur_f1 < base_f1 - tolerance else _STATUS_OK
                 rows.append(_row(name, "f1", base_f1, cur_f1, status))
         else:  # real

--- a/scripts/autoconfig_quality/diff.py
+++ b/scripts/autoconfig_quality/diff.py
@@ -1,8 +1,12 @@
 """Scorecard diff + gate verdict.
 
 Verdict rules (from the spec):
-- anchor: ANY pinned signal that changed from baseline = FAIL; an error on an
-  anchor = FAIL (anchors must always run).
+- anchor: any host-INDEPENDENT pinned signal that changed from baseline = FAIL;
+  an error on an anchor = FAIL (anchors must always run). Host-COUPLED routing
+  signals (planner_rung) drift with native availability / box RAM+cores, not
+  with the auto-config decision kernel, so they are informational (WARN, never
+  fail) -- otherwise a CI runner with no native wheel flaps against a dev box
+  baseline blessed with native on.
 - real: F1 below (baseline_f1 - tolerance) = FAIL; signal drift is informational
   (WARN, never fails); an error on a real dataset = NEUTRAL.
 - a dataset present in baseline but skipped/absent in current = NEUTRAL.
@@ -16,6 +20,15 @@ _STATUS_FAIL = "FAIL"
 _STATUS_OK = "OK"
 _STATUS_WARN = "WARN"
 _STATUS_NEUTRAL = "NEUTRAL"
+
+# Flattened anchor-signal fields under these prefixes are host-coupled (native
+# availability, box RAM/cores) rather than pure auto-config decisions. They are
+# recorded as drift but never fail the gate.
+_INFORMATIONAL_PREFIXES = ("planner_rung",)
+
+
+def _is_informational(field: str) -> bool:
+    return any(field == p or field.startswith(p + ".") for p in _INFORMATIONAL_PREFIXES)
 
 
 def _flatten(obj: Any, prefix: str = "") -> dict[str, Any]:
@@ -51,13 +64,22 @@ def diff_scorecards(
             if "error" in c.get("signals", {}):
                 rows.append(_row(name, "signals", None, c["signals"]["error"], _STATUS_FAIL))
                 continue
-            # Any pinned signal that changed from baseline = FAIL.
+            # Host-independent pinned signals that changed from baseline = FAIL;
+            # host-coupled routing (planner_rung) = WARN (informational drift).
             cur_sig = _flatten(c.get("signals", {}))
             base_sig = _flatten(b.get("signals", {})) if b else {}
             for field in sorted(set(cur_sig) | set(base_sig)):
                 before, after = base_sig.get(field), cur_sig.get(field)
                 if before != after:
-                    rows.append(_row(name, field, before, after, _STATUS_FAIL))
+                    status = _STATUS_WARN if _is_informational(field) else _STATUS_FAIL
+                    rows.append(_row(name, field, before, after, status))
+            # An anchor that also carries an F1 floor (e.g. the person-match
+            # anchor) is gated on F1 too, floor+tolerance like a real dataset.
+            cur_f1 = c.get("f1", {}).get("f1")
+            base_f1 = b.get("f1", {}).get("f1") if b else None
+            if cur_f1 is not None and base_f1 is not None:
+                status = _STATUS_FAIL if cur_f1 < base_f1 - tolerance else _STATUS_OK
+                rows.append(_row(name, "f1", base_f1, cur_f1, status))
         else:  # real
             if "error" in c:
                 rows.append(_row(name, "f1", None, c["error"], _STATUS_NEUTRAL))

--- a/scripts/autoconfig_quality/f1.py
+++ b/scripts/autoconfig_quality/f1.py
@@ -1,0 +1,70 @@
+"""SLOW tier: full dedupe -> F1/P/R + blocking-recall/threshold-loss attribution.
+
+Runs the real dedupe pipeline on a (row-capped) labeled dataset and computes
+F1/precision/recall via evaluate_clusters, plus the blocking-recall vs
+threshold-loss attribution so an F1 drop is localized. All ids are ROW INDICES
+(cluster members, scored_pairs, candidate pairs, and the ground-truth pairs all
+share the 0..n-1 row-index space).
+"""
+from __future__ import annotations
+
+import importlib.util
+from itertools import combinations
+from pathlib import Path
+from typing import Any
+
+import goldenmatch
+import polars as pl
+from goldenmatch.core.autoconfig import build_blocking, profile_columns
+from goldenmatch.core.blocker import build_blocks
+from goldenmatch.core.evaluate import evaluate_clusters
+
+# attribution.py lives in scripts/bench_er_headtohead/, which is NOT a real
+# package (no __init__.py). Load it by file path -- the same precedent as
+# packages/python/goldenmatch/tests/bench/test_attribution.py -- so this does
+# NOT depend on the repo root being on sys.path / on PEP 420 namespace packages.
+_ATTR_PATH = Path(__file__).resolve().parents[2] / "scripts/bench_er_headtohead/attribution.py"
+_spec = importlib.util.spec_from_file_location("_qh_attribution", _ATTR_PATH)
+assert _spec is not None and _spec.loader is not None, f"cannot load {_ATTR_PATH}"
+_attr_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_attr_mod)
+attribution = _attr_mod.attribution
+
+
+def _candidate_pairs(df: pl.DataFrame) -> set[tuple[int, int]]:
+    """Regenerate the post-blocking candidate set in row-index space.
+
+    DedupeResult has no candidate set, so rebuild via build_blocks + __row_id__.
+    Degrades to an empty set (attribution -> 0 blocking_recall) rather than
+    crashing the F1 path if blocking can't be materialized.
+    """
+    profiles = profile_columns(df)
+    blocking = build_blocking(profiles, df, n_rows_full=df.height)
+    lf = df.with_row_index("__row_id__").lazy()
+    cand: set[tuple[int, int]] = set()
+    try:
+        for b in build_blocks(lf, blocking):
+            ids = b.df.collect()["__row_id__"].to_list()
+            cand.update((min(a, c), max(a, c)) for a, c in combinations(ids, 2))
+    except Exception:
+        return set()
+    return cand
+
+
+def evaluate_f1(df: pl.DataFrame, gt_pairs: set, row_cap: int | None = 20_000) -> dict[str, Any]:
+    """Full dedupe -> F1/P/R + blocking/threshold attribution (row-index space)."""
+    if row_cap is not None and df.height > row_cap:
+        df = df.head(row_cap)
+        gt_pairs = {(a, b) for a, b in gt_pairs if a < row_cap and b < row_cap}
+    result = goldenmatch.dedupe_df(df)
+    ev = evaluate_clusters(result.clusters, gt_pairs).summary()
+    emitted = {(min(a, b), max(a, b)) for a, b, _ in result.scored_pairs}
+    attr = attribution(gt_pairs, _candidate_pairs(df), emitted)
+    return {
+        "f1": ev["f1"],
+        "precision": ev["precision"],
+        "recall": ev["recall"],
+        "attribution": {
+            k: attr[k] for k in ("blocking_recall", "final_recall", "threshold_loss")
+        },
+    }

--- a/scripts/autoconfig_quality/scorecard.py
+++ b/scripts/autoconfig_quality/scorecard.py
@@ -1,0 +1,68 @@
+"""Scorecard assembly + stable JSON I/O.
+
+The scorecard is one JSON artifact: per-dataset records under a metadata header.
+Provenance is git_sha + native_version (NO wall-clock timestamp / RNG), so
+re-runs on the same code are byte-stable and cleanly diffable. Floats are
+rounded to a fixed precision so trivial ULP noise never churns the diff.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+_FLOAT_PRECISION = 6
+
+
+def _round_floats(obj: Any) -> Any:
+    """Recursively round every float for byte-stable serialization."""
+    if isinstance(obj, float):
+        return round(obj, _FLOAT_PRECISION)
+    if isinstance(obj, dict):
+        return {k: _round_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_round_floats(v) for v in obj]
+    return obj
+
+
+def build_scorecard(
+    results: dict[str, dict],
+    *,
+    native_version: str,
+    git_sha: str,
+    skipped: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Assemble per-dataset records + a stable metadata header."""
+    return {
+        "meta": {
+            "native_version": native_version,
+            "git_sha": git_sha,
+            "datasets_run": sorted(results.keys()),
+            "datasets_skipped": skipped or {},
+        },
+        "datasets": _round_floats(results),
+    }
+
+
+def gather_meta() -> tuple[str, str]:
+    """(native_version, git_sha) from the environment. Best-effort; never raises."""
+    try:
+        import goldenmatch_native  # noqa: PLC0415
+        native_version = getattr(goldenmatch_native, "__version__", "unknown")
+    except Exception:
+        native_version = "absent"
+    try:
+        git_sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip()
+    except Exception:
+        git_sha = "unknown"
+    return native_version, git_sha
+
+
+def dumps(scorecard: dict) -> str:
+    return json.dumps(scorecard, indent=2, sort_keys=True)
+
+
+def loads(text: str) -> dict:
+    return json.loads(text)

--- a/scripts/autoconfig_quality/signals.py
+++ b/scripts/autoconfig_quality/signals.py
@@ -1,0 +1,61 @@
+"""FAST tier: config-quality signals (no full dedupe).
+
+Runs the auto-config decision path on a df and records the signals that have
+historically regressed (classification, exact matchkeys, blocking fields +
+cost, planner rung). Deterministic and fast (seconds): only profiling +
+blocking + matchkey selection, NOT the controller's iterative sample-dedupes.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import polars as pl
+from goldenmatch.core.autoconfig import build_blocking, build_matchkeys, profile_columns
+from goldenmatch.core.autoconfig_planner import apply_planner_rules
+from goldenmatch.core.autoconfig_planner_rules import DEFAULT_RULES
+from goldenmatch.core.blocker import measure_blocking_profile
+from goldenmatch.core.complexity_profile import ComplexityProfile
+from goldenmatch.core.runtime_profile import capture_runtime_profile
+
+
+def extract_signals(df: pl.DataFrame) -> dict[str, Any]:
+    """Extract the fast config-quality signals for one dataset."""
+    profiles = profile_columns(df)
+    classification = {p.name: p.col_type for p in profiles}
+
+    matchkeys = build_matchkeys(profiles, df)
+    exact_matchkeys = sorted(
+        {f.field for mk in matchkeys if mk.type == "exact" for f in mk.fields if f.field}
+    )
+
+    blocking = build_blocking(profiles, df, n_rows_full=df.height)
+    fields: set[str] = set()
+    for k in (blocking.keys or []):
+        fields.update(k.fields)
+    for p in (blocking.passes or []):
+        fields.update(p.fields)
+
+    # measure_blocking_profile reads config.blocking -> wrap in a namespace.
+    bp = measure_blocking_profile(df, SimpleNamespace(blocking=blocking))
+    if bp is not None:
+        blocking_cost = {
+            "candidate_pairs": bp.estimated_pair_count,
+            "n_blocks": bp.n_blocks,
+            "max_block": bp.block_sizes_max,
+            "p99": bp.block_sizes_p99,
+            "reduction_ratio": round(bp.reduction_ratio, 4),
+        }
+    else:
+        blocking_cost = {"candidate_pairs": None, "error": "measure_returned_none"}
+
+    cp = ComplexityProfile(blocking=bp) if bp is not None else ComplexityProfile()
+    plan = apply_planner_rules(cp, capture_runtime_profile(), df.height, DEFAULT_RULES)
+
+    return {
+        "classification": classification,
+        "exact_matchkeys": exact_matchkeys,
+        "blocking_fields": sorted(fields),
+        "blocking_cost": blocking_cost,
+        "planner_rung": {"backend": plan.backend, "rule_name": plan.rule_name},
+    }

--- a/scripts/autoconfig_quality/tests/test_anchors.py
+++ b/scripts/autoconfig_quality/tests/test_anchors.py
@@ -1,0 +1,20 @@
+from scripts.autoconfig_quality.anchors import crm_df, gen_labeled, make_healthcare_df
+
+
+def test_crm_df_shape():
+    df = crm_df()
+    assert df.height == 30
+    assert "email" in df.columns and "phone" in df.columns
+
+
+def test_gen_labeled_returns_df_and_rowindex_gt():
+    df, gt = gen_labeled(n_entities=50, seed=7)
+    assert df.height >= 50
+    # GT pairs are row-index tuples i<j
+    assert all(isinstance(a, int) and isinstance(b, int) and a < b for a, b in gt)
+    assert max(b for _, b in gt) < df.height  # indices in range
+
+
+def test_make_healthcare_df_has_zip5():
+    df = make_healthcare_df(2000, seed=715, zip_present=0.5)
+    assert "zip5" in df.columns and "matching_id" in df.columns

--- a/scripts/autoconfig_quality/tests/test_cli_smoke.py
+++ b/scripts/autoconfig_quality/tests/test_cli_smoke.py
@@ -1,0 +1,35 @@
+"""Self-gating smoke test: the harness gates ITSELF on its committed baseline.
+
+Runs `gate --fast-only` over the anchors via a subprocess and asserts the gate
+passes against baselines/scorecard.json. This catches both harness regressions
+and (more importantly) any auto-config regression that moves an anchor signal.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+_PKG = _REPO / "packages/python/goldenmatch"
+_PKG_SCRIPTS = _PKG / "scripts"
+
+
+def test_gate_fast_only_passes_on_committed_baseline():
+    # Run with native UNPINNED (pop any inherited GOLDENMATCH_NATIVE) so on a box
+    # with the native wheel built this exercises the native-on routing path against
+    # the native-off baseline -- proving the gate is host-independent (planner_rung
+    # drift is WARN, kernel signals match). CI without the wheel trivially matches.
+    env = {
+        **os.environ,
+        "POLARS_SKIP_CPU_CHECK": "1",
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONPATH": os.pathsep.join(str(p) for p in (_REPO, _PKG, _PKG_SCRIPTS)),
+    }
+    env.pop("GOLDENMATCH_NATIVE", None)
+    r = subprocess.run(
+        [sys.executable, "-m", "scripts.autoconfig_quality", "gate", "--fast-only",
+         "--datasets", "anchor_sparse_zip,anchor_shared_email,anchor_person_match"],
+        cwd=str(_REPO), env=env, capture_output=True, text=True, timeout=300,
+    )
+    assert r.returncode == 0, f"gate failed:\nSTDOUT:\n{r.stdout}\nSTDERR:\n{r.stderr}"
+    assert "verdict: PASS" in r.stdout

--- a/scripts/autoconfig_quality/tests/test_datasets.py
+++ b/scripts/autoconfig_quality/tests/test_datasets.py
@@ -1,0 +1,29 @@
+from scripts.autoconfig_quality.datasets import REGISTRY, Dataset
+
+
+def test_anchors_always_load():
+    by_name = {d.name: d for d in REGISTRY}
+    for n in ("anchor_sparse_zip", "anchor_shared_email", "anchor_person_match"):
+        d = by_name[n]
+        assert isinstance(d, Dataset)
+        assert d.kind == "anchor"
+        loaded = d.loader()
+        assert loaded is not None
+        df, gt = loaded
+        assert df.height > 0
+
+
+def test_person_anchor_has_gt_others_none():
+    by_name = {d.name: d for d in REGISTRY}
+    _, gt = by_name["anchor_person_match"].loader()
+    assert len(gt) > 0                              # gen_labeled has GT
+    _, gt2 = by_name["anchor_sparse_zip"].loader()
+    assert gt2 == set()                             # blocking-shape anchor, no F1
+
+
+def test_real_loader_skips_when_absent():
+    by_name = {d.name: d for d in REGISTRY}
+    dblp = by_name["dblp_acm"]
+    assert dblp.kind == "real"
+    res = dblp.loader()                             # data absent locally -> None
+    assert res is None or (isinstance(res, tuple) and len(res) == 2)

--- a/scripts/autoconfig_quality/tests/test_diff.py
+++ b/scripts/autoconfig_quality/tests/test_diff.py
@@ -50,6 +50,42 @@ def test_absent_dataset_is_neutral():
     assert any(r["dataset"] == "febrl3" and r["status"] == "NEUTRAL" for r in rows)
 
 
+def test_anchor_with_f1_floor_is_gated():
+    base = {"datasets": {"anchor_person": {"kind": "anchor", "signals": {"x": 1},
+                                           "f1": {"f1": 0.95}}}}
+    # F1 drop beyond tol on an anchor that carries an F1 floor -> FAIL
+    cur = {"datasets": {"anchor_person": {"kind": "anchor", "signals": {"x": 1},
+                                          "f1": {"f1": 0.90}}}}
+    _, verdict = diff_scorecards(cur, base, tolerance=0.01)
+    assert verdict == "FAIL"
+    # within tol -> PASS
+    cur2 = {"datasets": {"anchor_person": {"kind": "anchor", "signals": {"x": 1},
+                                           "f1": {"f1": 0.945}}}}
+    _, verdict2 = diff_scorecards(cur2, base, tolerance=0.01)
+    assert verdict2 == "PASS"
+
+
+def test_planner_rung_drift_is_warn_not_fail():
+    # planner_rung is host-coupled (native availability / box size) -> WARN, never
+    # FAIL, so a CI runner without the native wheel doesn't flap a native-on baseline.
+    base = {"datasets": {"anchor_x": {"kind": "anchor",
+        "signals": {"classification": {"zip5": "zip"},
+                    "planner_rung": {"backend": "polars-direct", "rule_name": "small"}}}}}
+    cur = {"datasets": {"anchor_x": {"kind": "anchor",
+        "signals": {"classification": {"zip5": "zip"},
+                    "planner_rung": {"backend": "bucket", "rule_name": "small_fast_box"}}}}}
+    rows, verdict = diff_scorecards(cur, base, tolerance=0.01)
+    assert verdict == "PASS"
+    planner_rows = [r for r in rows if r["field"].startswith("planner_rung")]
+    assert planner_rows and all(r["status"] == "WARN" for r in planner_rows)
+    # a real kernel-signal change alongside planner drift still FAILs
+    cur2 = {"datasets": {"anchor_x": {"kind": "anchor",
+        "signals": {"classification": {"zip5": "identifier"},
+                    "planner_rung": {"backend": "bucket", "rule_name": "small"}}}}}
+    _, verdict2 = diff_scorecards(cur2, base, tolerance=0.01)
+    assert verdict2 == "FAIL"
+
+
 def test_render_table_smoke():
     rows, _ = diff_scorecards(BASE, BASE)
     assert isinstance(render_table(rows), str)

--- a/scripts/autoconfig_quality/tests/test_diff.py
+++ b/scripts/autoconfig_quality/tests/test_diff.py
@@ -86,6 +86,30 @@ def test_planner_rung_drift_is_warn_not_fail():
     assert verdict2 == "FAIL"
 
 
+def test_anchor_f1_crash_fails_not_silently_dropped():
+    # The floor must never be silently dropped. If the F1 tier was attempted and
+    # crashed (top-level "error"), the floored anchor FAILs -- not pass-by-omission.
+    base = {"datasets": {"anchor_person": {"kind": "anchor", "signals": {"x": 1},
+                                           "f1": {"f1": 0.99}}}}
+    cur = {"datasets": {"anchor_person": {"kind": "anchor", "signals": {"x": 1},
+                                          "error": "boom in evaluate_f1"}}}
+    rows, verdict = diff_scorecards(cur, base, tolerance=0.01)
+    assert verdict == "FAIL"
+    assert any(r["field"] == "f1" and r["status"] == "FAIL" for r in rows)
+
+
+def test_anchor_f1_fastonly_skip_is_warn_not_fail():
+    # An intentional fast-only run produces no f1 and no error: the floor isn't
+    # measured, but that's surfaced as WARN (visible), never a silent pass and
+    # never a FAIL (config-only runs are legitimate; CI runs the full tier).
+    base = {"datasets": {"anchor_person": {"kind": "anchor", "signals": {"x": 1},
+                                           "f1": {"f1": 0.99}}}}
+    cur = {"datasets": {"anchor_person": {"kind": "anchor", "signals": {"x": 1}}}}
+    rows, verdict = diff_scorecards(cur, base, tolerance=0.01)
+    assert verdict == "PASS"
+    assert any(r["field"] == "f1" and r["status"] == "WARN" for r in rows)
+
+
 def test_render_table_smoke():
     rows, _ = diff_scorecards(BASE, BASE)
     assert isinstance(render_table(rows), str)

--- a/scripts/autoconfig_quality/tests/test_diff.py
+++ b/scripts/autoconfig_quality/tests/test_diff.py
@@ -1,0 +1,55 @@
+from scripts.autoconfig_quality.diff import diff_scorecards, render_table
+
+BASE = {"datasets": {
+    "anchor_x": {"kind": "anchor",
+                 "signals": {"blocking_cost": {"candidate_pairs": 1529},
+                             "classification": {"zip5": "zip"}}},
+    "febrl3": {"kind": "real", "f1": {"f1": 0.99}},
+}}
+
+
+def test_anchor_signal_change_fails():
+    cur = {"datasets": {**BASE["datasets"],
+        "anchor_x": {"kind": "anchor",
+                     "signals": {"blocking_cost": {"candidate_pairs": 8_931_083},
+                                 "classification": {"zip5": "zip"}}}}}
+    rows, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "FAIL"
+    assert any(r["status"] == "FAIL" and r["dataset"] == "anchor_x" for r in rows)
+
+
+def test_real_f1_drop_beyond_tol_fails():
+    cur = {"datasets": {**BASE["datasets"], "febrl3": {"kind": "real", "f1": {"f1": 0.95}}}}
+    _, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "FAIL"
+
+
+def test_real_f1_within_tol_passes():
+    cur = {"datasets": {**BASE["datasets"], "febrl3": {"kind": "real", "f1": {"f1": 0.985}}}}
+    _, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "PASS"
+
+
+def test_skipped_is_neutral_and_anchor_error_fails():
+    # anchor error -> FAIL
+    cur = {"datasets": {
+        "anchor_x": {"kind": "anchor", "signals": {"error": "boom"}},
+        "febrl3": {"kind": "real", "f1": {"f1": 0.99}}}}
+    _, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "FAIL"
+    # real error alone -> neutral (PASS)
+    cur2 = {"datasets": {**BASE["datasets"], "febrl3": {"kind": "real", "error": "flake"}}}
+    _, verdict2 = diff_scorecards(cur2, BASE, tolerance=0.01)
+    assert verdict2 == "PASS"
+
+
+def test_absent_dataset_is_neutral():
+    cur = {"datasets": {"anchor_x": BASE["datasets"]["anchor_x"]}}  # febrl3 absent
+    rows, verdict = diff_scorecards(cur, BASE, tolerance=0.01)
+    assert verdict == "PASS"
+    assert any(r["dataset"] == "febrl3" and r["status"] == "NEUTRAL" for r in rows)
+
+
+def test_render_table_smoke():
+    rows, _ = diff_scorecards(BASE, BASE)
+    assert isinstance(render_table(rows), str)

--- a/scripts/autoconfig_quality/tests/test_f1.py
+++ b/scripts/autoconfig_quality/tests/test_f1.py
@@ -1,0 +1,13 @@
+from scripts.autoconfig_quality.anchors import gen_labeled
+from scripts.autoconfig_quality.f1 import evaluate_f1
+
+
+def test_evaluate_f1_on_gen_labeled():
+    df, gt = gen_labeled(n_entities=200, seed=7)
+    out = evaluate_f1(df, gt, row_cap=None)
+    assert 0.0 <= out["f1"] <= 1.0
+    assert out["f1"] >= 0.80           # synthetic clones are easy
+    assert set(out) >= {"f1", "precision", "recall", "attribution"}
+    attr = out["attribution"]
+    assert {"blocking_recall", "final_recall", "threshold_loss"} <= set(attr)
+    assert attr["blocking_recall"] >= attr["final_recall"]  # blocking is the ceiling

--- a/scripts/autoconfig_quality/tests/test_scorecard.py
+++ b/scripts/autoconfig_quality/tests/test_scorecard.py
@@ -1,0 +1,31 @@
+import json
+
+from scripts.autoconfig_quality.scorecard import build_scorecard, dumps, loads
+
+
+def test_build_scorecard_shape_and_stability():
+    results = {
+        "anchor_x": {"kind": "anchor", "signals": {"blocking_cost": {"candidate_pairs": 1529}}},
+        "febrl3": {"kind": "real", "signals": {}, "f1": {"f1": 0.991}},
+    }
+    sc = build_scorecard(results, native_version="0.1.11", git_sha="abc123",
+                         skipped={"ncvr": "absent"})
+    assert sc["meta"]["native_version"] == "0.1.11"
+    assert sc["meta"]["git_sha"] == "abc123"
+    assert sc["meta"]["datasets_skipped"] == {"ncvr": "absent"}
+    assert sorted(sc["meta"]["datasets_run"]) == ["anchor_x", "febrl3"]
+    assert "recorded_at" not in json.dumps(sc)        # NO timestamp -> byte-stable
+    assert loads(dumps(sc)) == sc                      # round-trips
+
+
+def test_floats_are_rounded_for_byte_stability():
+    results = {"d": {"kind": "real", "f1": {"f1": 0.123456789123}}}
+    sc = build_scorecard(results, native_version="x", git_sha="y")
+    assert sc["datasets"]["d"]["f1"]["f1"] == round(0.123456789123, 6)
+
+
+def test_two_runs_same_input_are_byte_identical():
+    results = {"d": {"kind": "anchor", "signals": {"r": 0.5}}}
+    a = dumps(build_scorecard(results, native_version="v", git_sha="s"))
+    b = dumps(build_scorecard(results, native_version="v", git_sha="s"))
+    assert a == b

--- a/scripts/autoconfig_quality/tests/test_signals.py
+++ b/scripts/autoconfig_quality/tests/test_signals.py
@@ -1,0 +1,17 @@
+from scripts.autoconfig_quality.anchors import make_healthcare_df
+from scripts.autoconfig_quality.signals import extract_signals
+
+
+def test_extract_signals_sparse_zip():
+    # n=30k is the scale where the zip5 regression lives: 5k-distinct zips at
+    # 50% present saturate to ~0.32 cardinality, so the corrected classifier
+    # keeps zip5 as `zip` (the old 0.95 floor was fooled at small N into
+    # `identifier`), and the blocking-decouple keeps zip5 bounding the compound.
+    df = make_healthcare_df(30_000, seed=715, zip_present=0.5).drop("matching_id")
+    sig = extract_signals(df)
+    assert sig["classification"]["zip5"] == "zip"           # not fooled into identifier
+    assert "zip5" in sig["blocking_fields"]                  # the decouple fix
+    assert sig["blocking_cost"]["candidate_pairs"] < 50_000  # bounded, not 8.9M
+    assert "max_block" in sig["blocking_cost"]
+    assert isinstance(sig["exact_matchkeys"], list)
+    assert "backend" in sig["planner_rung"] and "rule_name" in sig["planner_rung"]


### PR DESCRIPTION
## What

A one-run quality harness for the auto-config **decision kernel** (`goldenmatch-autoconfig-core` + the Python autoconfig/blocking surfaces). It runs the kernel over a corpus and diffs the resulting decisions against a committed baseline, so a kernel change's quality impact is measurable in one command instead of being found one regression at a time.

Motivation: the S1-S3 levers (#1202, #1203, #1204, #1205) each shipped a regression that was caught individually after the fact. This gate would have caught all of them in a single run.

## How it works

Two tiers per dataset:
- **Fast (config signals, no dedupe, seconds):** classification, exact matchkeys, blocking fields, blocking cost (`candidate_pairs`, `n_blocks`, `max_block`, `p99`, `reduction_ratio`), planner rung.
- **Slow (F1):** full dedupe -> `evaluate_clusters` -> F1/precision/recall + attribution. Only for datasets with ground truth.

`gate` diffs current vs the committed baseline and exits non-zero on a regression:
- Host-**independent** decision-kernel signal changed on an anchor -> **FAIL**.
- Anchor / real-dataset F1 below `baseline - tolerance` (default 0.01) -> **FAIL**.
- `planner_rung` drift -> **WARN, never FAIL** (it is coupled to native-wheel availability + box RAM/cores, not the decision kernel, so a CI runner without the native wheel does not flap a native-on dev baseline).
- Skipped / absent dataset -> NEUTRAL.

## Committed baseline (the pinned truth this gate enforces)

Blessed under `GOLDENMATCH_AUTOCONFIG_MEMORY=0` (static kernel, no learned per-run drift); F1 is parity-identical native 0 vs 1.

| dataset | kind | zip5 class | blocking fields | candidate_pairs | exact matchkeys | F1 (floor) |
| --- | --- | --- | --- | --- | --- | --- |
| anchor_person_match | anchor | - | zip | 1712 | email | 0.9896 |
| anchor_shared_email | anchor | - | email | 15 | email,phone | n/a |
| anchor_sparse_zip | anchor | zip | first_name,last_name,zip5 | 1529 | email,npi | n/a |

The anchors pin this arc's fixes: `anchor_sparse_zip` keeps `zip5` classified `zip` (not `identifier`) and the compound blocking bounded (`candidate_pairs` ~1529, not millions, the blocking-decouple fix); `anchor_shared_email` keeps `email` as a matchkey while `phone` is demoted. `dblp_acm` is skip-when-absent (its data is gitignored), so it is NEUTRAL in CI and runs wherever the data exists.

## CI

New `quality_gate` job (+ a `changes`-filter entry) runs `python -m scripts.autoconfig_quality gate` (full tier) on a normal runner, pinning `GOLDENMATCH_AUTOCONFIG_MEMORY=0`. Fires when the rust core, the Python autoconfig/blocking surfaces, the harness, or `ci.yml` change.

## Iterate loop

`report` to see the diff vs baseline; fix the kernel until clean, or `bless` to accept the new pinned truth. The committed baseline's git history is the trend log. Full docs: `scripts/autoconfig_quality/README.md`.

## Tests + review

Unit tests per module + a self-gating smoke test (runs the harness with native unpinned against the native-off baseline, proving host-independence). Two-stage subagent review; final review returned APPROVED after one fix: the anchor F1 floor could be silently dropped on an `evaluate_f1` crash (a top-level error on a floored anchor now FAILs; an intentional fast-only skip surfaces as a visible WARN).

Spec: `docs/superpowers/specs/2026-06-22-autoconfig-quality-harness-design.md`
Plan: `docs/superpowers/plans/2026-06-22-autoconfig-quality-harness.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
