### PR TITLE
feat(goldenprofile): Semantic Signature / Virtual Fingerprint engine

### DIFF
--- a/context-network/decisions/0023-semantic-signature-virtual-fingerprint-engine.md
+++ b/context-network/decisions/0023-semantic-signature-virtual-fingerprint-engine.md
@@ -1,0 +1,112 @@
+# 0023 — Semantic Signature / Virtual Fingerprint engine (goldenprofile)
+
+**Status:** accepted • **Shipped:** PR #TBD (2026-06-22)
+
+## Context
+GoldenGraph builds a knowledge graph as `text → LLM extraction → goldenmatch
+entity resolution → durable bi-temporal store`. On multi-hop QA corpora
+(MuSiQue-style), the graph *shatters*: the same real-world entity, described by
+DISJOINT neighborhoods across documents, fails to link, so the multi-hop path
+from question to answer is never physically present in the graph. Two failure
+modes pull against each other:
+
+- **Under-merge (Row 3).** Doc A: "Nabbes wrote Play X". Doc B: "Nabbes born
+  1605". Raw-neighborhood / raw-text comparison sees ~0% overlap → no merge →
+  shatter.
+- **Over-merge (Row 4).** Dense embeddings of raw text blur "Nabbes" and
+  "Shakespeare" (both "17th-century playwright") → spurious merge.
+
+Tuning a single similarity threshold cannot escape this tension: the evidence
+that disambiguates (name, era) and the evidence that diverges across documents
+(the per-document fact) live in the same undifferentiated text blob.
+
+`goldengraph/embed.py` already flagged the adjacent gap: retrieval re-embeds
+every entity per query and brute-force cosines — "a persisted embedding sidecar
++ ANN index is the scale optimization, not built."
+
+## Decision
+Add an **entity-profiling / Virtual Fingerprint** engine: synthesize a rigid,
+standardized fingerprint for every graph element (node AND edge) from its local
+neighborhood, then resolve cross-document by comparing fingerprints instead of
+raw text. The fingerprint is a brutally rigid 4-part pipe-delimited string —
+free-text fingerprints collapse straight back into the Row-4 over-merge:
+
+```
+<name> | <category> | <temporal/spatial anchor> | <defining attribute>
+```
+
+Structuring the evidence is what breaks the tension:
+- the **defining attribute** is EXPECTED to diverge across documents, so it can
+  only ADD confidence, never veto a merge → kills Row-3 under-merge;
+- the **name + category** are the stable identity, gated hard before any merge →
+  kills Row-4 over-merge regardless of embedding proximity;
+- **anchor** and the **embedding cosine** of the rendered fingerprint are soft,
+  tunable signals, and a MISSING (UNKNOWN) field contributes a neutral prior,
+  never a penalty (a second Row-3 guard: absent ≠ contradicting).
+
+### Architecture — reuse the kernels, add the orchestration
+The novel layer is the orchestration + the anti-shatter scorer. Every *signal*
+is reused from an existing shared core, so the engine is byte-identical with the
+surfaces that already ship those kernels:
+
+- **SimHash band hashing** over the host-supplied dense fingerprint embedding
+  (`sketch-core::simhash`) — the **semantic signature** / cosine-LSH blocker.
+  This is the "embedding ANN index" `embed.py` wanted, generalized to blocking.
+- **Field scorers** (`score-core`: jaro_winkler / token_sort) for name/category.
+- **Canonical hashing** (`fingerprint-core`) for the structured block key.
+- **Connected components** (`graph-core`) to cluster kept pairs.
+
+Pipeline: `block (structured token keys ∪ semantic SimHash bands) → score
+(anti-shatter fusion) → WCC cluster`. Mirrors `goldengraph-core`'s
+block→score→cluster shape.
+
+### Surfaces — all four, one core (the established pattern)
+- `goldenprofile-core` — pyo3-free engine + the single `resolve_json` boundary.
+- `goldenprofile-native` — pyo3/maturin abi3 wheel (`resolve_json` str→str).
+- `goldenprofile-wasm` — wasm-bindgen wrapper exposing the pyo3-free
+  `resolve_json_impl` (also linked by the C ABI; wasm-bindgen cfg-gated to
+  wasm32).
+- `goldenprofile-cabi` — C ABI reusing `resolve_json_impl` (no re-implementation).
+
+LLM synthesis and embedding stay in the Python host (`goldengraph/profile.py`),
+exactly as `goldengraph-core` keeps the LLM out of the engine. The engine is
+LLM-free, embedding-model-free, and Arrow-free; the host supplies precomputed
+fingerprint embeddings as the semantic signature.
+
+### One JSON boundary
+All bindings marshal the SAME `goldenprofile_core::resolve_json(&str) -> String`.
+Request: `{profiles:[{kind,name,category,anchor,attribute}], embeddings?:[[f64]],
+config?:{...partial overrides...}}`. Response: `{clusters:[[usize]],
+edges:[{a,b,score:{...breakdown...}}]}`. The per-pair score breakdown is kept
+(not just the scalar) for the never-black-box North Star — a host can show
+exactly WHY two fingerprints merged.
+
+## Consequences / tradeoffs
+- **Lexical-only is conservative on synonym categories.** Without embeddings,
+  "Playwright" vs "Dramatist" does not merge (category gate is lexical). The
+  semantic signature bridges it: a strong embedding cosine satisfies the category
+  gate (`category_embedding_gate`). Documented and tested both ways.
+- **Edge fingerprints are deterministic in v1** (`predicate | predicate | UNKNOWN
+  | subj -> obj`); predicate-synonym merging ("WROTE"/"PENNED") rides on the
+  semantic signature. LLM-synthesized edge fingerprints are a future enhancement.
+- **No pure-Python fallback resolver** (unlike sketch-core). `goldengraph`
+  already requires its native engine; `profile.py` requires `goldenprofile_native`
+  the same way (lazy import, actionable error). The Rust core owns correctness;
+  the new host logic (LLM synthesis + defensive parsing) is what `test_profile.py`
+  covers without the wheel.
+- **Persistence (sidecar index) is deferred.** v1 resolves a batch in memory.
+  A persisted signature index alongside the SP2 store snapshot is the next slice
+  (the `embed.py` "persisted sidecar" note); the JSON boundary doesn't preclude it.
+
+## Validation
+- Rust: 25 core unit tests incl. the headline `musique_shatter_repair_three_docs`
+  (disjoint Nabbes mentions reunite, Shakespeare stays distinct), the Row-4
+  over-merge veto, the embedding-bridged synonym category, and the unknown-field
+  neutrality. wasm/cabi parity tests assert identical bytes to the core boundary.
+- Python: `test_profile.py` covers synthesis parsing + defensive fallbacks with a
+  stub LLM, and a skip-if-absent end-to-end integration test through the wheel.
+
+## Future
+Persisted sidecar signature index in the SP2 store; LLM edge-fingerprint
+synthesis; gate `goldenprofile` into the goldengraph ingest path as an optional
+resolution strategy; ER-KG-Bench / MuSiQue eval to quantify the shatter repair.

--- a/packages/python/goldengraph/goldengraph/__init__.py
+++ b/packages/python/goldengraph/goldengraph/__init__.py
@@ -10,6 +10,12 @@ from .embed import Embedder, GoldenmatchEmbedder, seed_by_query
 from .extract import Extraction, Mention, Relationship, extract, parse_extraction
 from .ingest import build_batch, ingest
 from .llm import LLMClient, OpenAIClient
+from .profile import (
+    Fingerprint,
+    ProfileResolution,
+    resolve_profiles,
+    synthesize_profiles,
+)
 from .resolve import ResolvedEntity, resolve
 from .synthesize import synthesize_global, synthesize_local
 
@@ -33,4 +39,9 @@ __all__ = [
     "synthesize_global",
     "ask",
     "to_cypher",
+    # Semantic Signature engine — Virtual Fingerprint resolution
+    "Fingerprint",
+    "ProfileResolution",
+    "synthesize_profiles",
+    "resolve_profiles",
 ]

--- a/packages/python/goldengraph/goldengraph/profile.py
+++ b/packages/python/goldengraph/goldengraph/profile.py
@@ -1,0 +1,244 @@
+"""Virtual Fingerprint synthesis + cross-document resolution (Semantic Signature).
+
+The pivot that repairs the multi-hop knowledge-graph "shatter": instead of
+resolving graph elements on raw extraction text or raw neighborhood text, we
+synthesize a *rigid, standardized fingerprint* for every element (entity AND
+relationship) from its local neighborhood, then resolve across documents by
+comparing those fingerprints in the `goldenprofile` engine.
+
+    <name> | <category> | <temporal/spatial anchor> | <defining attribute>
+
+Why this beats the two failure modes that shatter MuSiQue-style graphs:
+
+- **Under-merge (disjoint neighborhoods).** Doc A says "Nabbes wrote Play X";
+  Doc B says "Nabbes born 1605". Raw neighborhoods share ~0%, so they never
+  merge and the multi-hop path breaks. The fingerprint's *defining attribute* is
+  EXPECTED to differ across documents, so the engine treats it as
+  evidence-that-only-adds-confidence, never a veto -- the disjoint mentions
+  reunite on their shared name + category.
+- **Over-merge (semantic bleeding).** Raw-text embeddings blur "Nabbes" and
+  "Shakespeare" (both "17th-century playwright"). The rigid name + category gate
+  keeps them apart no matter how close the vectors are.
+
+LLM access is provider-agnostic (`LLMClient`, reused from `.llm`); the engine is
+`goldenprofile_native` (the pyo3 binding over the pyo3-free Rust core), imported
+lazily so this module imports without the wheel. Embeddings (for the semantic
+signature) are provider-agnostic too (`Embedder`, reused from `.embed`).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from .extract import Extraction
+from .llm import LLMClient
+
+# --- the rigid schema -------------------------------------------------------
+
+UNKNOWN = "UNKNOWN"
+
+_SYNTH_PROMPT = """You generate a rigid identifying FINGERPRINT for each entity \
+in a knowledge graph, using the entity and its local relationships. Return \
+STRICT JSON only, no prose: {{"fingerprints": ["<name> | <category> | <anchor> \
+| <attribute>", ...]}} with EXACTLY one string per entity, in the SAME ORDER as \
+the numbered list below. Each fingerprint has 4 pipe-delimited parts:
+- name: the normalized canonical name of the entity
+- category: its primary class or role (e.g. Person, Company, Playwright)
+- anchor: a temporal OR spatial anchor (a year, an era, or a place); UNKNOWN if none
+- attribute: the single most defining attribute; UNKNOWN if none
+Use the literal UNKNOWN for any unknown part. Keep every part terse -- a few \
+words, never a sentence (flowing prose reintroduces the semantic over-merge this \
+fingerprint exists to prevent). Entities (with their relationships):
+{entities}"""
+
+
+@dataclass
+class Fingerprint:
+    """One synthesized Virtual Fingerprint and what it describes.
+
+    `kind` is "node" or "edge"; `ref` is the index into the extraction's
+    `mentions` (node) or `relationships` (edge) list; `text` is the rigid
+    pipe-delimited fingerprint string.
+    """
+
+    kind: str
+    ref: int
+    text: str
+
+
+@dataclass
+class ProfileResolution:
+    """Result of resolving fingerprints into cross-document entities.
+
+    `clusters` partitions fingerprint indices (into the resolved list) into
+    cross-document elements; `edges` is the list of scored merges (each a dict
+    with `a`, `b`, and a `score` breakdown) -- the never-black-box audit trail.
+    """
+
+    fingerprints: list[Fingerprint]
+    clusters: list[list[int]]
+    edges: list[dict[str, Any]]
+
+
+# --- synthesis (the genuinely new host logic) -------------------------------
+
+
+def _strip_fence(raw: str) -> str:
+    s = raw.strip()
+    if s.startswith("```"):
+        s = s.split("\n", 1)[1] if "\n" in s else s[3:]
+        if s.rstrip().endswith("```"):
+            s = s.rstrip()[:-3]
+    return s.strip()
+
+
+def _neighborhood_lines(extraction: Extraction) -> list[str]:
+    """Render each entity with its local relationships, the context the LLM
+    compresses into a fingerprint. Disjoint across documents by design -- that is
+    the whole point: the fingerprint globalizes the local view."""
+    names = [m.name for m in extraction.mentions]
+    rels_by_entity: dict[int, list[str]] = {i: [] for i in range(len(names))}
+    for r in extraction.relationships:
+        if 0 <= r.subj < len(names) and 0 <= r.obj < len(names):
+            rels_by_entity[r.subj].append(f"{r.predicate} {names[r.obj]}")
+            rels_by_entity[r.obj].append(f"{names[r.subj]} {r.predicate}")
+    lines = []
+    for i, m in enumerate(extraction.mentions):
+        rels = "; ".join(rels_by_entity[i]) or "(no relationships)"
+        ctx = f" -- {m.context}" if m.context else ""
+        lines.append(f"{i}. {m.name} [{m.typ}]{ctx} | relationships: {rels}")
+    return lines
+
+
+def _fingerprint_from_mention(m: Any) -> str:
+    """Deterministic fallback fingerprint when no LLM is available or its output
+    is malformed/misaligned. Uses only the mention's own fields, so it never
+    fabricates -- name | type | UNKNOWN anchor | first words of the context."""
+    name = (m.name or UNKNOWN).strip() or UNKNOWN
+    cat = (m.typ or UNKNOWN).strip() or UNKNOWN
+    attr = " ".join((m.context or "").split()[:6]).strip() or UNKNOWN
+    return f"{name} | {cat} | {UNKNOWN} | {attr}"
+
+
+def synthesize_node_fingerprints(
+    extraction: Extraction, llm: LLMClient | None = None
+) -> list[str]:
+    """One fingerprint string per entity (in `mentions` order). With an `llm`,
+    a single call synthesizes all of them from their neighborhoods; without one
+    (or on malformed/misaligned output) falls back to the deterministic
+    per-mention fingerprint so the pipeline never drops an element."""
+    n = len(extraction.mentions)
+    if n == 0:
+        return []
+    fallback = [_fingerprint_from_mention(m) for m in extraction.mentions]
+    if llm is None:
+        return fallback
+    prompt = _SYNTH_PROMPT.format(entities="\n".join(_neighborhood_lines(extraction)))
+    try:
+        data = json.loads(_strip_fence(llm.complete(prompt)))
+        fps = [str(x) for x in data.get("fingerprints", [])]
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        return fallback
+    # Defensive: the LLM must return exactly one fingerprint per entity, aligned.
+    # On any count drift, fall back wholesale rather than misattribute a row.
+    if len(fps) != n:
+        return fallback
+    return [fp if fp.count("|") >= 1 else fallback[i] for i, fp in enumerate(fps)]
+
+
+def synthesize_edge_fingerprints(
+    extraction: Extraction, node_fingerprints: list[str]
+) -> list[str]:
+    """One fingerprint per relationship, derived deterministically from the
+    predicate and its resolved endpoint names: `predicate | predicate |
+    UNKNOWN | <subj> -> <obj>`. Edge fingerprints let the engine merge redundant
+    relationships across documents (e.g. "WROTE" vs "PENNED" via the semantic
+    signature), which rebuilds the physical multi-hop pathways."""
+    names = [fp.split("|", 1)[0].strip() for fp in node_fingerprints]
+    out = []
+    for r in extraction.relationships:
+        subj = names[r.subj] if 0 <= r.subj < len(names) else UNKNOWN
+        obj = names[r.obj] if 0 <= r.obj < len(names) else UNKNOWN
+        pred = (r.predicate or UNKNOWN).strip() or UNKNOWN
+        out.append(f"{pred} | {pred} | {UNKNOWN} | {subj} -> {obj}")
+    return out
+
+
+def synthesize_profiles(
+    extraction: Extraction,
+    llm: LLMClient | None = None,
+    *,
+    include_edges: bool = True,
+) -> list[Fingerprint]:
+    """Fingerprint every graph element. Nodes first (LLM-synthesized when `llm`
+    is given), then -- when `include_edges` -- one fingerprint per relationship."""
+    node_fps = synthesize_node_fingerprints(extraction, llm)
+    out = [Fingerprint("node", i, fp) for i, fp in enumerate(node_fps)]
+    if include_edges:
+        edge_fps = synthesize_edge_fingerprints(extraction, node_fps)
+        out.extend(Fingerprint("edge", i, fp) for i, fp in enumerate(edge_fps))
+    return out
+
+
+# --- resolution (thin call into the native engine) --------------------------
+
+
+def _engine():
+    """Lazy import of the goldenprofile engine. Raises a clear, actionable error
+    when the wheel is absent (mirrors how the goldengraph store requires
+    goldengraph_native)."""
+    try:
+        from goldenprofile_native import resolve_json
+    except ImportError as e:  # pragma: no cover - exercised only without the wheel
+        raise ImportError(
+            "goldenprofile_native is required to resolve profiles. Build it with "
+            "`maturin develop` in packages/rust/extensions/goldenprofile-native, "
+            "or `pip install goldenprofile-native`."
+        ) from e
+    return resolve_json
+
+
+def resolve_profiles(
+    fingerprints: list[Fingerprint],
+    *,
+    embedder: Any | None = None,
+    config: dict[str, Any] | None = None,
+) -> ProfileResolution:
+    """Resolve fingerprints into cross-document elements via the engine.
+
+    When `embedder` is given, each fingerprint string is embedded and passed as
+    the semantic signature (enabling SimHash-band blocking + the embedding-cosine
+    gate that bridges synonym categories). `config` is an optional partial
+    override of the engine's `ResolveConfig` (e.g.
+    `{"scoring": {"merge_threshold": 0.75}}`).
+    """
+    resolve_json = _engine()
+    profiles = []
+    for fp in fingerprints:
+        parts = [p.strip() for p in fp.text.split("|")]
+        parts += [UNKNOWN] * (4 - len(parts))
+        profiles.append(
+            {
+                "kind": fp.kind,
+                "name": parts[0] or UNKNOWN,
+                "category": parts[1] or UNKNOWN,
+                "anchor": parts[2] or UNKNOWN,
+                # keep any pipes that belonged to the attribute
+                "attribute": " | ".join(parts[3:]).strip() or UNKNOWN,
+            }
+        )
+    request: dict[str, Any] = {"profiles": profiles}
+    if embedder is not None and fingerprints:
+        vecs = embedder.embed([fp.text for fp in fingerprints])
+        request["embeddings"] = [[float(x) for x in row] for row in vecs]
+    if config:
+        request["config"] = config
+
+    result = json.loads(resolve_json(json.dumps(request)))
+    return ProfileResolution(
+        fingerprints=fingerprints,
+        clusters=[list(c) for c in result.get("clusters", [])],
+        edges=list(result.get("edges", [])),
+    )

--- a/packages/python/goldengraph/tests/test_profile.py
+++ b/packages/python/goldengraph/tests/test_profile.py
@@ -1,0 +1,117 @@
+"""Virtual Fingerprint synthesis tests.
+
+Covers the genuinely new host logic -- the LLM synthesis pass and its defensive
+fallbacks -- with a stub LLM. The engine itself (blocking / scoring / clustering)
+is tested in the Rust core; `resolve_profiles` marshaling is covered by a
+skip-if-absent integration test so this file needs no compiled wheel.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from goldengraph.extract import Extraction, Mention, Relationship
+from goldengraph.profile import (
+    Fingerprint,
+    synthesize_edge_fingerprints,
+    synthesize_node_fingerprints,
+    synthesize_profiles,
+)
+
+
+class StubLLM:
+    def __init__(self, response: str):
+        self._response = response
+
+    def complete(self, prompt: str) -> str:
+        self.last_prompt = prompt
+        return self._response
+
+
+def _extraction() -> Extraction:
+    return Extraction(
+        mentions=[
+            Mention(name="Thomas Nabbes", typ="Person", context="English playwright"),
+            Mention(name="Play X", typ="Work"),
+        ],
+        relationships=[Relationship(subj=0, predicate="wrote", obj=1)],
+    )
+
+
+def test_node_synthesis_parses_aligned_llm_output():
+    llm = StubLLM(
+        '{"fingerprints": ["Thomas Nabbes | Playwright | 17th Century | Wrote Play X", '
+        '"Play X | Play | 1638 | Comedy"]}'
+    )
+    fps = synthesize_node_fingerprints(_extraction(), llm)
+    assert fps[0] == "Thomas Nabbes | Playwright | 17th Century | Wrote Play X"
+    assert fps[1].startswith("Play X | Play")
+
+
+def test_node_synthesis_strips_code_fence():
+    llm = StubLLM('```json\n{"fingerprints": ["A | B | C | D", "E | F | G | H"]}\n```')
+    fps = synthesize_node_fingerprints(_extraction(), llm)
+    assert fps == ["A | B | C | D", "E | F | G | H"]
+
+
+def test_node_synthesis_falls_back_on_count_drift():
+    # LLM returns one fingerprint for two entities -> misalignment risk -> fall
+    # back wholesale to the deterministic per-mention fingerprints.
+    llm = StubLLM('{"fingerprints": ["only one"]}')
+    fps = synthesize_node_fingerprints(_extraction(), llm)
+    assert len(fps) == 2
+    assert fps[0].startswith("Thomas Nabbes | Person")
+
+
+def test_node_synthesis_falls_back_on_malformed_json():
+    fps = synthesize_node_fingerprints(_extraction(), StubLLM("not json at all"))
+    assert len(fps) == 2
+    assert "UNKNOWN" in fps[1]  # Play X has no context -> UNKNOWN attribute
+
+
+def test_no_llm_uses_deterministic_fingerprints():
+    fps = synthesize_node_fingerprints(_extraction(), None)
+    assert fps[0] == "Thomas Nabbes | Person | UNKNOWN | English playwright"
+
+
+def test_edge_fingerprints_use_resolved_endpoint_names():
+    node_fps = ["Thomas Nabbes | Playwright | x | y", "Play X | Play | x | y"]
+    edges = synthesize_edge_fingerprints(_extraction(), node_fps)
+    assert edges == ["wrote | wrote | UNKNOWN | Thomas Nabbes -> Play X"]
+
+
+def test_synthesize_profiles_includes_nodes_and_edges():
+    profiles = synthesize_profiles(_extraction(), None, include_edges=True)
+    kinds = [p.kind for p in profiles]
+    assert kinds == ["node", "node", "edge"]
+    assert all(isinstance(p, Fingerprint) for p in profiles)
+
+
+def test_synthesize_profiles_can_skip_edges():
+    profiles = synthesize_profiles(_extraction(), None, include_edges=False)
+    assert [p.kind for p in profiles] == ["node", "node"]
+
+
+def test_empty_extraction_yields_nothing():
+    empty = Extraction(mentions=[], relationships=[])
+    assert synthesize_profiles(empty, None) == []
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("goldenprofile_native") is None,
+    reason="goldenprofile_native wheel not built",
+)
+def test_resolve_profiles_reunites_disjoint_mentions():
+    from goldengraph.profile import resolve_profiles
+
+    fps = [
+        Fingerprint("node", 0, "Thomas Nabbes | Playwright | 17th c | Wrote Play X"),
+        Fingerprint("node", 1, "Nabbes | Playwright | UNKNOWN | Born 1605"),
+        Fingerprint("node", 2, "William Shakespeare | Playwright | UNKNOWN | Wrote Hamlet"),
+    ]
+    res = resolve_profiles(fps)
+    nabbes = next(c for c in res.clusters if 0 in c)
+    assert sorted(nabbes) == [0, 1]
+    assert any(c == [2] for c in res.clusters)

--- a/packages/rust/extensions/goldenprofile-cabi/.gitignore
+++ b/packages/rust/extensions/goldenprofile-cabi/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/packages/rust/extensions/goldenprofile-cabi/Cargo.toml
+++ b/packages/rust/extensions/goldenprofile-cabi/Cargo.toml
@@ -1,0 +1,27 @@
+# goldenprofile-cabi -- the C ABI over the Virtual Fingerprint engine. The C
+# analogue of goldenprofile-native (pyo3) and goldenprofile-wasm (wasm-bindgen):
+# it wraps the SAME pyo3-free `resolve_json_impl` the WASM crate exposes, so the
+# engine is byte-identical across Python, WASM, and C by construction (no
+# re-implementation). wasm-bindgen is cfg-gated to wasm32 in that crate, so on a
+# host target this pulls only goldenprofile-core (+ its kernels) -- no wasm
+# toolchain needed.
+#
+# Standalone workspace -- same isolation rationale as goldengraph-cabi.
+[workspace]
+
+[package]
+name = "goldenprofile-cabi"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "C ABI over goldenprofile-core: cross-document Virtual Fingerprint resolution over a JSON boundary"
+
+[lib]
+name = "goldenprofile_cabi"
+# cdylib/staticlib: the artifacts a C caller links or dlopens. rlib: in-crate tests.
+crate-type = ["cdylib", "staticlib", "rlib"]
+
+[dependencies]
+# Reuse the EXACT pyo3-free marshaling shim the WASM binding exposes.
+goldenprofile-wasm = { path = "../goldenprofile-wasm" }

--- a/packages/rust/extensions/goldenprofile-cabi/include/goldenprofile.h
+++ b/packages/rust/extensions/goldenprofile-cabi/include/goldenprofile.h
@@ -1,0 +1,36 @@
+/* goldenprofile.h -- C ABI for the goldenprofile Virtual Fingerprint engine.
+ *
+ * Cross-document entity resolution over rigid, LLM-synthesized profiles. Wraps
+ * the SAME pyo3-free core as the Python (goldenprofile-native) and WASM
+ * (goldenprofile-wasm) surfaces, so results are byte-identical across all three.
+ *
+ * Boundary is JSON. Request:
+ *   { "profiles":  [ {"kind":"node"|"edge","name":..,"category":..,
+ *                     "anchor":..,"attribute":..}, ... ],
+ *     "embeddings": [[f64,...], ...]   // optional; one row per profile
+ *     "config":     { ... }            // optional; partial overrides allowed
+ *   }
+ * Response:
+ *   { "clusters": [[usize,...], ...], "edges": [ {a,b,score:{...}}, ... ] }
+ */
+#ifndef GOLDENPROFILE_H
+#define GOLDENPROFILE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Resolve a NUL-terminated JSON request into a NUL-terminated JSON result.
+ * Returns NULL on NULL / invalid-UTF-8 / malformed-request input. The returned
+ * pointer is owned by the caller and MUST be freed with
+ * goldenprofile_string_free exactly once. */
+char *goldenprofile_resolve_json(const char *request);
+
+/* Free a string returned by goldenprofile_resolve_json. NULL is a no-op. */
+void goldenprofile_string_free(char *s);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* GOLDENPROFILE_H */

--- a/packages/rust/extensions/goldenprofile-cabi/src/lib.rs
+++ b/packages/rust/extensions/goldenprofile-cabi/src/lib.rs
@@ -1,0 +1,87 @@
+//! C ABI over `goldenprofile-core`, via the shared `goldenprofile_wasm`
+//! marshaling shim. A C (or any FFI) caller passes a JSON `ResolveRequest`
+//! string and receives an owned JSON `Resolution` string it must free with
+//! [`goldenprofile_string_free`].
+//!
+//! Contract:
+//! - `goldenprofile_resolve_json(req)` returns a freshly-allocated C string on
+//!   success, or NULL if `req` is NULL / not valid UTF-8 / a malformed request.
+//!   (For a richer error channel, callers can wrap; v1 keeps a single NULL
+//!   sentinel.)
+//! - Every non-NULL pointer returned MUST be passed back to
+//!   `goldenprofile_string_free` exactly once. The strings are heap-allocated by
+//!   Rust; freeing them any other way is UB.
+
+use std::ffi::{c_char, CStr, CString};
+
+use goldenprofile_wasm::resolve_json_impl;
+
+/// Resolve a NUL-terminated JSON request into a NUL-terminated JSON result.
+/// Returns NULL on a NULL/invalid-UTF-8/malformed-request input. The returned
+/// pointer is owned by the caller -- free it with `goldenprofile_string_free`.
+///
+/// # Safety
+/// `request` must be NULL or a valid pointer to a NUL-terminated C string that
+/// stays valid for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn goldenprofile_resolve_json(request: *const c_char) -> *mut c_char {
+    if request.is_null() {
+        return std::ptr::null_mut();
+    }
+    let req = match CStr::from_ptr(request).to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    match resolve_json_impl(req) {
+        // Result JSON never contains an interior NUL, so this unwrap is safe.
+        Ok(out) => CString::new(out)
+            .map(CString::into_raw)
+            .unwrap_or(std::ptr::null_mut()),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a string returned by `goldenprofile_resolve_json`. NULL is a no-op.
+///
+/// # Safety
+/// `s` must be NULL or a pointer previously returned by
+/// `goldenprofile_resolve_json` and not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn goldenprofile_string_free(s: *mut c_char) {
+    if !s.is_null() {
+        drop(CString::from_raw(s));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_through_c_abi() {
+        let req = CString::new(
+            r#"{"profiles":[
+                {"kind":"node","name":"Thomas Nabbes","category":"Playwright","anchor":"UNKNOWN","attribute":"Wrote X"},
+                {"kind":"node","name":"Nabbes","category":"Playwright","anchor":"UNKNOWN","attribute":"Born 1605"}
+            ]}"#,
+        )
+        .unwrap();
+        unsafe {
+            let out = goldenprofile_resolve_json(req.as_ptr());
+            assert!(!out.is_null());
+            let s = CStr::from_ptr(out).to_str().unwrap();
+            assert!(s.contains("\"clusters\""));
+            // Both Nabbes mentions in one cluster.
+            assert!(s.contains("[0,1]"));
+            goldenprofile_string_free(out);
+        }
+    }
+
+    #[test]
+    fn null_input_returns_null() {
+        unsafe {
+            assert!(goldenprofile_resolve_json(std::ptr::null()).is_null());
+            goldenprofile_string_free(std::ptr::null_mut()); // no-op, must not crash
+        }
+    }
+}

--- a/packages/rust/extensions/goldenprofile-core/.gitignore
+++ b/packages/rust/extensions/goldenprofile-core/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/packages/rust/extensions/goldenprofile-core/Cargo.toml
+++ b/packages/rust/extensions/goldenprofile-core/Cargo.toml
@@ -1,0 +1,55 @@
+# goldenprofile-core -- pyo3-free "Virtual Fingerprint" / entity-profiling
+# engine. Turns a rigid, LLM-synthesized profile per graph element (node OR
+# edge) into a cross-document resolution: structured block-key + semantic
+# (SimHash) band blocking, a Row-3/Row-4 anti-shatter fusion scorer, and WCC
+# clustering. The compute core for the Semantic Signature engine; mirrors the
+# `goldengraph-core` / `score-core` pyo3-free pattern. All compute over plain
+# slices -- no Python, no Arrow, no LLM, no embedding model (the host supplies
+# precomputed fingerprint embeddings).
+#
+# The novel layer is the orchestration + the anti-shatter scorer. The signature
+# primitives are REUSED, not reinvented: SimHash band hashing from sketch-core,
+# field scorers from score-core, canonical hashing from fingerprint-core, and
+# connected-components from graph-core -- so every signal is byte-identical with
+# the surfaces that already ship those kernels.
+#
+# Standalone `[workspace]` (empty) so this core can be a path dependency of the
+# `goldenprofile-native` (pyo3 extension-module) and `goldenprofile-wasm`
+# (wasm-bindgen) crates without either workspace claiming it -- same isolation
+# rationale as goldengraph-core / score-core.
+[workspace]
+
+[package]
+name = "goldenprofile-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Pyo3-free entity-profiling (Virtual Fingerprint) engine: structured + semantic signature blocking, anti-shatter scoring, WCC clustering"
+
+[lib]
+name = "goldenprofile_core"
+
+[dependencies]
+# Canonical field scorers (jaro_winkler / token_sort) -- the SAME source of
+# truth every other surface links, so the profile field comparison is identical
+# across Python/WASM/C/pgrx.
+goldenmatch-score-core = { path = "../score-core" }
+# Connected-components (WCC) kernel: turns kept scored profile-pairs into the
+# final cross-document entity clusters.
+goldenmatch-graph-core = { path = "../graph-core" }
+# SimHash (sign random-projection / cosine-LSH) band hashing over dense
+# fingerprint embeddings -- the "semantic signature" blocker. Byte-identical
+# with the Python/TS sketch tier.
+goldenmatch-sketch-core = { path = "../sketch-core" }
+# Canonical, cross-language-stable hash of the rigid identifying fields -- the
+# structured signature / exact block key (same canonicalizer as the :h1: record
+# fingerprint).
+goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
+# serde model is the portable JSON boundary every binding (wasm/cabi) marshals.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[profile.release]
+opt-level = 3
+lto = "thin"

--- a/packages/rust/extensions/goldenprofile-core/src/lib.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/lib.rs
@@ -1,0 +1,108 @@
+//! `goldenprofile-core` -- pyo3-free Virtual Fingerprint / entity-profiling
+//! engine.
+//!
+//! The "Semantic Signature engine": resolve graph elements (nodes AND edges)
+//! across documents by comparing rigid, LLM-synthesized profiles instead of raw
+//! extraction or neighborhood text. Built to repair the MuSiQue multi-hop graph
+//! shatter -- see `score.rs` for the Row-3/Row-4 reasoning that motivates the
+//! whole design.
+//!
+//! Layering (each module has the full rationale in its header):
+//! - [`model`]     -- the rigid `name | category | anchor | attribute` schema.
+//! - [`signature`] -- structured (canonical-hash) + semantic (SimHash) blocking.
+//! - [`score`]     -- the anti-shatter fusion scorer.
+//! - [`resolve`]   -- block -> score -> WCC cluster, the end-to-end entry point.
+//!
+//! Intentionally pyo3-free, Arrow-free, LLM-free, and embedding-model-free: the
+//! host synthesizes the profiles (LLM) and supplies the fingerprint embeddings
+//! (goldenembed), exactly as `goldengraph-core` keeps the LLM in the Python
+//! host. The pyo3 binding is `goldenprofile-native`; the wasm-bindgen + C ABI
+//! bindings are `goldenprofile-wasm` / `goldenprofile-cabi`. Every signal is
+//! reused from an existing shared core, so the engine is byte-identical across
+//! surfaces by construction.
+
+pub mod model;
+pub mod resolve;
+pub mod score;
+pub mod signature;
+
+use serde::Deserialize;
+
+pub use model::{ElementKind, Profile};
+pub use resolve::{resolve, Resolution, ResolveConfig, ResolvedEdge};
+pub use score::{cosine01, name_similarity, score_pair, PairScore, ScoreConfig};
+pub use signature::{candidate_pairs, semantic_band_keys, structured_block_keys};
+
+/// The JSON request every binding (pyo3 / wasm / C ABI) marshals. `embeddings`
+/// and `config` are optional -- omit `embeddings` for structured-only
+/// resolution, omit `config` (or any field of it) to take the zero-config
+/// defaults. Keeping ONE boundary here is what makes the engine byte-identical
+/// across surfaces.
+#[derive(Debug, Deserialize)]
+pub struct ResolveRequest {
+    pub profiles: Vec<Profile>,
+    #[serde(default)]
+    pub embeddings: Vec<Vec<f64>>,
+    #[serde(default)]
+    pub config: ResolveConfig,
+}
+
+/// Parse a [`ResolveRequest`], resolve, and serialize the [`Resolution`]. The
+/// single marshaling boundary shared by every binding. Errors are returned as
+/// strings (each binding maps them to its own error type).
+pub fn resolve_json(request: &str) -> Result<String, String> {
+    let req: ResolveRequest = serde_json::from_str(request).map_err(|e| e.to_string())?;
+    if !req.embeddings.is_empty() && req.embeddings.len() != req.profiles.len() {
+        return Err(format!(
+            "embeddings length {} != profiles length {} (supply one embedding per profile, or none)",
+            req.embeddings.len(),
+            req.profiles.len()
+        ));
+    }
+    let res = resolve(&req.profiles, &req.embeddings, &req.config);
+    serde_json::to_string(&res).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod smoke {
+    use super::*;
+
+    #[test]
+    fn crate_builds() {
+        assert_eq!(2 + 2, 4);
+    }
+
+    #[test]
+    fn resolve_json_roundtrip() {
+        let req = r#"{
+            "profiles": [
+                {"kind":"node","name":"Thomas Nabbes","category":"Playwright","anchor":"17th c","attribute":"Wrote Play X"},
+                {"kind":"node","name":"Nabbes","category":"Playwright","anchor":"UNKNOWN","attribute":"Born 1605"}
+            ]
+        }"#;
+        let out = resolve_json(req).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        // Both profiles land in one cluster; one scored edge justifies it.
+        assert_eq!(v["clusters"].as_array().unwrap().len(), 1);
+        assert_eq!(v["edges"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn resolve_json_rejects_mismatched_embeddings() {
+        let req = r#"{
+            "profiles":[{"kind":"node","name":"A","category":"C","anchor":"UNKNOWN","attribute":"UNKNOWN"}],
+            "embeddings":[[1.0],[2.0]]
+        }"#;
+        assert!(resolve_json(req).unwrap_err().contains("embeddings length"));
+    }
+
+    #[test]
+    fn resolve_json_partial_config_override() {
+        // Only one config field supplied; the rest take defaults (serde default).
+        let req = r#"{
+            "profiles":[{"kind":"node","name":"A","category":"C","anchor":"UNKNOWN","attribute":"UNKNOWN"}],
+            "config":{"scoring":{"merge_threshold":0.99}}
+        }"#;
+        assert!(resolve_json(req).is_ok());
+    }
+}

--- a/packages/rust/extensions/goldenprofile-core/src/model.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/model.rs
@@ -1,0 +1,187 @@
+//! The rigid Virtual Fingerprint schema.
+//!
+//! A `Profile` is the standardized, LLM-synthesized identifying summary of ONE
+//! graph element -- a node (entity) OR an edge (relationship). The whole point
+//! of the engine is to move resolution OFF raw extraction text and raw
+//! neighborhood text and ONTO this compressed, deterministic representation, so
+//! cross-document linking compares "what this thing uniquely is" rather than the
+//! happenstance of where it was mentioned.
+//!
+//! The schema is intentionally a brutally rigid 4-part pipe-delimited string
+//! (the #spec lesson: free-text fingerprints collapse straight back into the
+//! Row-4 semantic over-merge). The host (the LLM synthesis pass) MUST emit:
+//!
+//! ```text
+//! <name> | <category> | <anchor> | <attribute>
+//! ```
+//!
+//! - `name`      -- the normalized identifying name (node) / relation phrase (edge).
+//! - `category`  -- the primary class/role (node) / predicate type (edge).
+//! - `anchor`    -- a temporal/spatial anchor ("17th Century England", "1605").
+//! - `attribute` -- the single most defining attribute ("Wrote Play X").
+//!
+//! Any unknown part is the literal `UNKNOWN`. Missing trailing parts are padded
+//! to `UNKNOWN` so a 2-part synth still parses.
+
+use serde::{Deserialize, Serialize};
+
+/// The sentinel an LLM emits for an unknown field. Compared case-insensitively;
+/// canonicalizes to an empty normalized form (so "unknown" never spuriously
+/// matches across two different entities that both happen to lack an anchor).
+pub const UNKNOWN: &str = "UNKNOWN";
+
+/// Whether a profile describes a graph node (entity) or an edge (relationship).
+/// Resolution is run WITHIN a kind: a node never merges with an edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ElementKind {
+    Node,
+    Edge,
+}
+
+impl Default for ElementKind {
+    fn default() -> Self {
+        ElementKind::Node
+    }
+}
+
+/// One Virtual Fingerprint. Fields hold the raw (trimmed) synthesized text;
+/// normalized comparison forms are derived on demand via [`Profile::norm`] so
+/// the stored value stays human-readable and the normalization is centralized.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Profile {
+    #[serde(default)]
+    pub kind: ElementKind,
+    pub name: String,
+    pub category: String,
+    pub anchor: String,
+    pub attribute: String,
+}
+
+impl Profile {
+    /// Parse the rigid `name | category | anchor | attribute` string. Splits on
+    /// the FIRST three `|` only (so a `|` inside the attribute survives), trims
+    /// each part, and pads missing trailing parts with `UNKNOWN`. Never fails --
+    /// a degenerate synth still yields a (mostly-UNKNOWN) profile rather than an
+    /// error, because dropping an element silently shatters the graph worse than
+    /// a weak fingerprint does.
+    pub fn parse(kind: ElementKind, s: &str) -> Profile {
+        let mut parts = s.splitn(4, '|');
+        let name = parts.next().unwrap_or("").trim().to_string();
+        let category = parts.next().unwrap_or(UNKNOWN).trim().to_string();
+        let anchor = parts.next().unwrap_or(UNKNOWN).trim().to_string();
+        let attribute = parts.next().unwrap_or(UNKNOWN).trim().to_string();
+        Profile {
+            kind,
+            name: if name.is_empty() { UNKNOWN.to_string() } else { name },
+            category: if category.is_empty() { UNKNOWN.to_string() } else { category },
+            anchor: if anchor.is_empty() { UNKNOWN.to_string() } else { anchor },
+            attribute: if attribute.is_empty() { UNKNOWN.to_string() } else { attribute },
+        }
+    }
+
+    /// The canonical pipe-delimited rendering -- what the host embeds to get the
+    /// semantic signature, and what a human reads in an explainability dump.
+    /// Stable across runs (no field is reordered).
+    pub fn render(&self) -> String {
+        format!("{} | {} | {} | {}", self.name, self.category, self.anchor, self.attribute)
+    }
+
+    /// Is `field` the UNKNOWN sentinel (case-insensitive, post-trim)? An UNKNOWN
+    /// field is *missing evidence*, never *conflicting evidence* -- the Row-3
+    /// guard. The scorer treats two UNKNOWN anchors as "no information", not "a
+    /// match".
+    pub fn is_unknown(field: &str) -> bool {
+        field.trim().eq_ignore_ascii_case(UNKNOWN) || field.trim().is_empty()
+    }
+
+    /// Normalized comparison form of a field: lowercased, punctuation→space,
+    /// whitespace collapsed, trimmed. UNKNOWN normalizes to `""`. This is the
+    /// form the field scorers and the structured block-key consume.
+    pub fn norm(field: &str) -> String {
+        if Profile::is_unknown(field) {
+            return String::new();
+        }
+        let mut out = String::with_capacity(field.len());
+        let mut prev_space = true; // trims leading space
+        for c in field.chars() {
+            let c = if c.is_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                ' '
+            };
+            if c == ' ' {
+                if !prev_space {
+                    out.push(' ');
+                    prev_space = true;
+                }
+            } else {
+                out.push(c);
+                prev_space = false;
+            }
+        }
+        if out.ends_with(' ') {
+            out.pop();
+        }
+        out
+    }
+
+    /// Significant normalized tokens of the name -- the units of token blocking.
+    /// Empty when the name is UNKNOWN.
+    pub fn name_tokens(&self) -> Vec<String> {
+        Profile::norm(&self.name)
+            .split_whitespace()
+            .map(|t| t.to_string())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_four_parts() {
+        let p = Profile::parse(ElementKind::Node, "Thomas Nabbes | Playwright | 17th Century England | Wrote Play X");
+        assert_eq!(p.name, "Thomas Nabbes");
+        assert_eq!(p.category, "Playwright");
+        assert_eq!(p.anchor, "17th Century England");
+        assert_eq!(p.attribute, "Wrote Play X");
+    }
+
+    #[test]
+    fn parse_pads_missing_trailing_parts() {
+        let p = Profile::parse(ElementKind::Node, "Nabbes | Playwright");
+        assert_eq!(p.name, "Nabbes");
+        assert_eq!(p.category, "Playwright");
+        assert_eq!(p.anchor, UNKNOWN);
+        assert_eq!(p.attribute, UNKNOWN);
+    }
+
+    #[test]
+    fn parse_keeps_pipe_inside_attribute() {
+        let p = Profile::parse(ElementKind::Edge, "wrote | authored | 1638 | play X | and play Y");
+        assert_eq!(p.attribute, "play X | and play Y");
+    }
+
+    #[test]
+    fn norm_strips_punct_and_case() {
+        assert_eq!(Profile::norm("Thomas  NABBES, Jr."), "thomas nabbes jr");
+        assert_eq!(Profile::norm(UNKNOWN), "");
+        assert_eq!(Profile::norm("   "), "");
+    }
+
+    #[test]
+    fn unknown_is_missing_not_matching() {
+        assert!(Profile::is_unknown("unknown"));
+        assert!(Profile::is_unknown("  UNKNOWN "));
+        assert!(Profile::is_unknown(""));
+        assert!(!Profile::is_unknown("1605"));
+    }
+
+    #[test]
+    fn name_tokens_split_and_normalized() {
+        let p = Profile::parse(ElementKind::Node, "Thomas Nabbes | Playwright | UNKNOWN | UNKNOWN");
+        assert_eq!(p.name_tokens(), vec!["thomas", "nabbes"]);
+    }
+}

--- a/packages/rust/extensions/goldenprofile-core/src/resolve.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/resolve.rs
@@ -1,0 +1,205 @@
+//! End-to-end cross-document resolution over Virtual Fingerprints.
+//!
+//! `profiles[i]` is element `i`'s fingerprint; `embeddings[i]` (optional, but if
+//! present must be aligned and equal-dim) is the dense embedding of its rendered
+//! fingerprint. The pipeline:
+//!
+//! 1. **Block** -- structured token keys ∪ semantic SimHash band keys -> a
+//!    recall-first candidate-pair set (`signature::candidate_pairs`).
+//! 2. **Score** -- the anti-shatter fusion scorer on each candidate pair; keep
+//!    pairs at/above `merge_threshold`.
+//! 3. **Cluster** -- weak connected components over the kept pairs
+//!    (`graph-core`), so transitive evidence chains (A~B, B~C) collapse A,B,C
+//!    into one durable cross-document entity.
+//!
+//! Resolution is per `ElementKind` only by construction: node/edge profiles
+//! never share a structured key and `score_pair` would gate them out anyway, so
+//! a single pass over the mixed list cannot cross-link a node with an edge.
+
+use goldenmatch_graph_core::connected_components;
+use serde::{Deserialize, Serialize};
+
+use crate::model::Profile;
+use crate::score::{score_pair, PairScore, ScoreConfig};
+use crate::signature::{
+    candidate_pairs, semantic_band_keys, structured_block_keys, DEFAULT_SIM_BANDS,
+    DEFAULT_SIM_PLANES,
+};
+
+/// Knobs for the whole pipeline. `scoring` carries the scorer weights/gates;
+/// the rest tune blocking. Defaults are the zero-config stance.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ResolveConfig {
+    pub scoring: ScoreConfig,
+    pub sim_planes: usize,
+    pub sim_bands: usize,
+    /// Skip any block bigger than this (over-broad-key O(n^2) guard).
+    pub max_bucket: usize,
+}
+
+impl Default for ResolveConfig {
+    fn default() -> Self {
+        ResolveConfig {
+            scoring: ScoreConfig::default(),
+            sim_planes: DEFAULT_SIM_PLANES,
+            sim_bands: DEFAULT_SIM_BANDS,
+            max_bucket: 1_000,
+        }
+    }
+}
+
+/// A kept (merged) profile pair with its full score breakdown -- the audit
+/// trail behind every cluster edge.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ResolvedEdge {
+    pub a: usize,
+    pub b: usize,
+    pub score: PairScore,
+}
+
+/// The resolution result. `clusters` partitions every profile index (including
+/// singletons) into cross-document entities; `edges` are the scored merges that
+/// justify them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Resolution {
+    pub clusters: Vec<Vec<usize>>,
+    pub edges: Vec<ResolvedEdge>,
+}
+
+/// Resolve `profiles` into cross-document entities. `embeddings` may be empty
+/// (structured-only blocking + scoring) or aligned with `profiles`.
+pub fn resolve(profiles: &[Profile], embeddings: &[Vec<f64>], cfg: &ResolveConfig) -> Resolution {
+    let n = profiles.len();
+    if n == 0 {
+        return Resolution { clusters: Vec::new(), edges: Vec::new() };
+    }
+
+    // 1. Blocking keys: structured (always) ∪ semantic (when embeddings given).
+    let mut keys: Vec<Vec<String>> = profiles.iter().map(structured_block_keys).collect();
+    if embeddings.len() == n && embeddings.iter().any(|e| !e.is_empty()) {
+        let sem = semantic_band_keys(embeddings, cfg.sim_planes, cfg.sim_bands);
+        for (i, row) in sem.into_iter().enumerate() {
+            keys[i].extend(row);
+        }
+    }
+    let cands = candidate_pairs(&keys, cfg.max_bucket);
+
+    // 2. Score candidates; keep the merges.
+    let empty: Vec<f64> = Vec::new();
+    let emb = |i: usize| -> &[f64] {
+        embeddings.get(i).map(|v| v.as_slice()).unwrap_or(empty.as_slice())
+    };
+    let mut edges: Vec<ResolvedEdge> = Vec::new();
+    for (a, b) in cands {
+        let ps = score_pair(&profiles[a], &profiles[b], emb(a), emb(b), &cfg.scoring);
+        if ps.score >= cfg.scoring.merge_threshold {
+            edges.push(ResolvedEdge { a, b, score: ps });
+        }
+    }
+
+    // 3. Cluster via WCC. graph-core works in i64 id space; profile indices map
+    // 1:1 to ids 0..n.
+    let wcc_edges: Vec<(i64, i64, f64)> =
+        edges.iter().map(|e| (e.a as i64, e.b as i64, e.score.score)).collect();
+    let all_ids: Vec<i64> = (0..n as i64).collect();
+    let comps = connected_components(&wcc_edges, &all_ids);
+    let clusters: Vec<Vec<usize>> = comps
+        .into_iter()
+        .map(|c| {
+            let mut v: Vec<usize> = c.into_iter().map(|x| x as usize).collect();
+            v.sort_unstable();
+            v
+        })
+        .collect();
+
+    Resolution { clusters, edges }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ElementKind;
+
+    fn node(s: &str) -> Profile {
+        Profile::parse(ElementKind::Node, s)
+    }
+
+    #[test]
+    fn musique_shatter_repair_three_docs_one_entity() {
+        // Three documents mention Nabbes with DISJOINT neighborhoods (different
+        // anchors, different defining attributes), plus a distinct Shakespeare.
+        // Structured-only (no embeddings): correct outcome is {0,1,2} merged on
+        // name+category transitivity, 3 alone.
+        let profiles = vec![
+            node("Thomas Nabbes | Playwright | 17th Century England | Wrote Play X"),
+            node("Nabbes | Playwright | UNKNOWN | Born 1605"),
+            node("Thomas Nabbes | Playwright | London | Covent Garden circle"),
+            node("William Shakespeare | Playwright | 1564 1616 | Wrote Hamlet"),
+        ];
+        let res = resolve(&profiles, &[], &ResolveConfig::default());
+        let nabbes = res.clusters.iter().find(|c| c.contains(&0)).unwrap();
+        assert_eq!(nabbes, &vec![0, 1, 2], "disjoint Nabbes mentions must reunite");
+        let shakes = res.clusters.iter().find(|c| c.contains(&3)).unwrap();
+        assert_eq!(shakes, &vec![3], "Shakespeare must stay distinct");
+    }
+
+    #[test]
+    fn synonym_category_bridged_by_embedding() {
+        // Same entity, but one document labels the category "Dramatist" -- a
+        // synonym the lexical category gate rejects. A strong fingerprint
+        // embedding cosine must satisfy the category gate and reunite them,
+        // while the distinct Shakespeare (orthogonal embedding) stays apart.
+        let profiles = vec![
+            node("Thomas Nabbes | Playwright | UNKNOWN | Wrote Play X"),
+            node("Thomas Nabbes | Dramatist | UNKNOWN | Born 1605"),
+            node("William Shakespeare | Playwright | UNKNOWN | Wrote Hamlet"),
+        ];
+        // 0 and 1 near-identical embeddings; 2 orthogonal.
+        let embeddings = vec![
+            vec![1.0, 0.2, 0.0, 0.1],
+            vec![0.98, 0.25, 0.02, 0.08],
+            vec![0.0, 0.1, 1.0, -0.2],
+        ];
+        // Without embeddings the synonym pair would NOT merge...
+        let no_emb = resolve(&profiles, &[], &ResolveConfig::default());
+        assert!(
+            no_emb.clusters.iter().any(|c| c == &vec![0]),
+            "lexical-only must leave the synonym-category pair unmerged (conservative)"
+        );
+        // ...with embeddings, it does.
+        let res = resolve(&profiles, &embeddings, &ResolveConfig::default());
+        let nabbes = res.clusters.iter().find(|c| c.contains(&0)).unwrap();
+        assert_eq!(nabbes, &vec![0, 1], "embedding must bridge the synonym category");
+        assert!(res.clusters.iter().any(|c| c == &vec![2]), "Shakespeare stays distinct");
+    }
+
+    #[test]
+    fn empty_input_is_empty() {
+        let res = resolve(&[], &[], &ResolveConfig::default());
+        assert!(res.clusters.is_empty() && res.edges.is_empty());
+    }
+
+    #[test]
+    fn singletons_are_their_own_clusters() {
+        let profiles = vec![
+            node("Acme | Company | UNKNOWN | UNKNOWN"),
+            node("Globex | Company | UNKNOWN | UNKNOWN"),
+        ];
+        let res = resolve(&profiles, &[], &ResolveConfig::default());
+        assert_eq!(res.clusters.len(), 2);
+        assert!(res.edges.is_empty());
+    }
+
+    #[test]
+    fn edges_carry_score_breakdown_for_audit() {
+        let profiles = vec![
+            node("Thomas Nabbes | Playwright | 17th c | Wrote Play X"),
+            node("Thomas Nabbes | Playwright | UNKNOWN | Born 1605"),
+        ];
+        let res = resolve(&profiles, &[], &ResolveConfig::default());
+        assert_eq!(res.edges.len(), 1);
+        assert!(res.edges[0].score.gated_in);
+        assert!(res.edges[0].score.name > 0.99);
+    }
+}

--- a/packages/rust/extensions/goldenprofile-core/src/score.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/score.rs
@@ -1,0 +1,298 @@
+//! The anti-shatter fusion scorer.
+//!
+//! This is where the MuSiQue multi-hop "graph shatter" is actually fixed. Two
+//! failure modes pull in opposite directions:
+//!
+//! - **Row 3 (under-merge):** the same entity is described by DISJOINT
+//!   neighborhoods across documents -- Doc A "Nabbes wrote Play X", Doc B
+//!   "Nabbes born 1605". Raw-neighborhood comparison sees ~0% overlap and
+//!   refuses to merge, shattering the multi-hop path.
+//! - **Row 4 (over-merge):** raw-text dense embeddings blur entities that share
+//!   a semantic neighborhood -- "Nabbes" and "Shakespeare" both land in
+//!   "17th-century playwright" space and collapse into one entity.
+//!
+//! The fix exploits the rigid fingerprint structure:
+//!
+//! - the *defining attribute* is EXPECTED to diverge across documents (it is the
+//!   per-document evidence), so it can only ADD confidence, never veto a merge
+//!   -- killing the Row-3 under-merge.
+//! - the *name* and *category* are the stable identity, so a hard gate requires
+//!   them to agree before any merge is considered -- killing the Row-4
+//!   over-merge regardless of how close the embeddings are.
+//!
+//! Everything in between (anchor, embedding cosine) is a soft, tunable signal,
+//! and -- crucially -- a MISSING field (UNKNOWN) contributes a neutral prior,
+//! never a penalty (a second Row-3 guard: absent evidence is not contradicting
+//! evidence).
+
+use std::collections::HashSet;
+
+use goldenmatch_score_core::{jaro_winkler_similarity, token_sort_normalized_ratio};
+use serde::{Deserialize, Serialize};
+
+use crate::model::Profile;
+
+/// Tunable weights + gates for the fusion scorer. Defaults are the engine's
+/// zero-config stance; the host can override per corpus. Weights on the soft
+/// signals sum with the gated base -- the attribute term is a positive-only
+/// bonus and is intentionally OUTSIDE the weighted base so it can never drag a
+/// score down.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ScoreConfig {
+    /// Hard gate: category similarity must reach this OR the embedding cosine
+    /// must reach `category_embedding_gate`, else the pair scores 0. The
+    /// embedding escape hatch lets the semantic signature bridge synonym
+    /// categories ("Playwright" vs "Dramatist") that lexical scoring can't.
+    pub category_gate: f64,
+    /// Embedding-cosine (mapped to [0,1]) that alone satisfies the category gate
+    /// when lexical category similarity falls short. Only consulted when an
+    /// embedding is supplied for both sides.
+    pub category_embedding_gate: f64,
+    /// Hard gate: name similarity must reach this or the pair scores 0.
+    pub name_gate: f64,
+    /// Weight on name similarity in the soft base.
+    pub w_name: f64,
+    /// Weight on category similarity in the soft base.
+    pub w_category: f64,
+    /// Weight on the anchor term in the soft base.
+    pub w_anchor: f64,
+    /// Weight on the embedding-cosine term in the soft base.
+    pub w_embedding: f64,
+    /// Positive-only bonus weight for a corroborating defining attribute.
+    pub w_attribute_bonus: f64,
+    /// Neutral prior used when a soft signal is UNKNOWN / unavailable. 0.5 = "no
+    /// information" on the [0,1] scale.
+    pub neutral_prior: f64,
+    /// Pairs scoring at/above this merge into the same entity.
+    pub merge_threshold: f64,
+}
+
+impl Default for ScoreConfig {
+    fn default() -> Self {
+        ScoreConfig {
+            category_gate: 0.60,
+            category_embedding_gate: 0.85,
+            name_gate: 0.80,
+            w_name: 0.45,
+            w_category: 0.25,
+            w_anchor: 0.15,
+            w_embedding: 0.15,
+            w_attribute_bonus: 0.10,
+            neutral_prior: 0.5,
+            merge_threshold: 0.72,
+        }
+    }
+}
+
+/// The per-pair score breakdown -- kept (not just the scalar) because the North
+/// Star is never-black-box: a host can show exactly WHY two fingerprints merged.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct PairScore {
+    pub name: f64,
+    pub category: f64,
+    pub anchor: f64,
+    pub embedding: f64,
+    pub attribute_bonus: f64,
+    /// `true` iff both hard gates passed. When `false`, `score == 0.0`.
+    pub gated_in: bool,
+    pub score: f64,
+}
+
+/// Cosine similarity of two equal-length dense vectors, mapped from [-1,1] to
+/// [0,1]. Returns `None` when either vector is empty or zero-norm (no semantic
+/// signal -> the scorer falls back to the neutral prior).
+pub fn cosine01(a: &[f64], b: &[f64]) -> Option<f64> {
+    if a.is_empty() || a.len() != b.len() {
+        return None;
+    }
+    let mut dot = 0.0;
+    let mut na = 0.0;
+    let mut nb = 0.0;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    if na == 0.0 || nb == 0.0 {
+        return None;
+    }
+    let cos = dot / (na.sqrt() * nb.sqrt());
+    Some(((cos + 1.0) / 2.0).clamp(0.0, 1.0))
+}
+
+/// Score one profile pair. `emb_a`/`emb_b` are the host-supplied fingerprint
+/// embeddings (pass empty slices to score on the structured fields alone).
+pub fn score_pair(
+    a: &Profile,
+    b: &Profile,
+    emb_a: &[f64],
+    emb_b: &[f64],
+    cfg: &ScoreConfig,
+) -> PairScore {
+    // Name: the cross-document identity signal. Short forms ("Nabbes") and full
+    // forms ("Thomas Nabbes") must score high, so combine token_sort (word-order
+    // invariant) with a token-containment coefficient (a short name that is a
+    // token-subset of a longer one scores 1.0) -- the token_set behavior the
+    // three base scorers lack.
+    let name = name_similarity(&a.name, &b.name);
+    // Category: jaro_winkler -- categories are short controlled-ish vocab.
+    let category = field_sim(&a.category, &b.category, cfg.neutral_prior, true);
+    // Embedding cosine of the rendered fingerprints, computed once. `None` when
+    // no embedding was supplied for a side; the soft signals fall back to the
+    // neutral prior in that case.
+    let emb_cos = cosine01(emb_a, emb_b);
+    let embedding = emb_cos.unwrap_or(cfg.neutral_prior);
+    let anchor = field_sim(&a.anchor, &b.anchor, cfg.neutral_prior, false);
+
+    // Hard gate. Name is the true Row-4 discriminator (Nabbes vs Shakespeare
+    // share a category, not a name), so it is always required. Category guards
+    // cross-sense collisions ("Apple" the company vs the fruit) and passes on
+    // EITHER lexical agreement OR a strong embedding cosine -- the latter bridges
+    // synonym categories the lexical scorer would wrongly veto.
+    let category_ok = category >= cfg.category_gate
+        || emb_cos.is_some_and(|c| c >= cfg.category_embedding_gate);
+    let gated_in = category_ok && name >= cfg.name_gate;
+    if !gated_in {
+        return PairScore {
+            name,
+            category,
+            anchor,
+            embedding,
+            attribute_bonus: 0.0,
+            gated_in: false,
+            score: 0.0,
+        };
+    }
+
+    let base = cfg.w_name * name
+        + cfg.w_category * category
+        + cfg.w_anchor * anchor
+        + cfg.w_embedding * embedding;
+
+    // Defining attribute: positive-only. If the two documents happen to state a
+    // similar defining attribute, that's corroboration -> bonus. If they state
+    // DIFFERENT attributes (the common, expected Row-3 case), there is NO
+    // penalty -- the term floors at 0.
+    let attr_sim = field_sim(&a.attribute, &b.attribute, 0.0, false);
+    let attribute_bonus = cfg.w_attribute_bonus * attr_sim.max(0.0);
+
+    let score = (base + attribute_bonus).clamp(0.0, 1.0);
+    PairScore {
+        name,
+        category,
+        anchor,
+        embedding,
+        attribute_bonus,
+        gated_in: true,
+        score,
+    }
+}
+
+/// Name similarity = `max(token_sort_ratio, token_overlap_coefficient)`.
+///
+/// The overlap coefficient `|A∩B| / min(|A|,|B|)` is 1.0 exactly when the
+/// shorter name's tokens are a subset of the longer's -- so "Nabbes" matches
+/// "Thomas Nabbes" perfectly while "Thomas Nabbes" vs "Thomas Heywood" (one
+/// shared token of two) scores 0.5 and is gated out. Both names UNKNOWN -> 0
+/// (no identity evidence; the pair should not have blocked together anyway).
+pub fn name_similarity(a: &str, b: &str) -> f64 {
+    let na = Profile::norm(a);
+    let nb = Profile::norm(b);
+    let ta: HashSet<&str> = na.split_whitespace().collect();
+    let tb: HashSet<&str> = nb.split_whitespace().collect();
+    if ta.is_empty() || tb.is_empty() {
+        return 0.0;
+    }
+    let inter = ta.intersection(&tb).count();
+    let overlap = inter as f64 / ta.len().min(tb.len()) as f64;
+    overlap.max(token_sort_normalized_ratio(&na, &nb))
+}
+
+/// Similarity of two free-text fields with the Row-3 unknown rule. When EITHER
+/// field is UNKNOWN, return `unknown_prior` (no information) rather than 0. When
+/// both are present, score them (`jw` selects jaro_winkler vs token_sort).
+fn field_sim(a: &str, b: &str, unknown_prior: f64, jw: bool) -> f64 {
+    if Profile::is_unknown(a) || Profile::is_unknown(b) {
+        return unknown_prior;
+    }
+    let (na, nb) = (Profile::norm(a), Profile::norm(b));
+    if jw {
+        jaro_winkler_similarity(&na, &nb)
+    } else {
+        token_sort_normalized_ratio(&na, &nb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ElementKind;
+
+    fn node(s: &str) -> Profile {
+        Profile::parse(ElementKind::Node, s)
+    }
+
+    #[test]
+    fn row3_disjoint_attributes_still_merge() {
+        // The headline case: same name+category, DISJOINT defining attributes,
+        // one anchor known one not. Must clear the merge threshold.
+        let a = node("Thomas Nabbes | Playwright | 17th Century England | Wrote Play X");
+        let b = node("Thomas Nabbes | Playwright | UNKNOWN | Born 1605");
+        let cfg = ScoreConfig::default();
+        let ps = score_pair(&a, &b, &[], &[], &cfg);
+        assert!(ps.gated_in);
+        assert!(
+            ps.score >= cfg.merge_threshold,
+            "disjoint-attribute same-entity must merge, got {}",
+            ps.score
+        );
+    }
+
+    #[test]
+    fn row4_distinct_entities_blocked_even_with_close_embeddings() {
+        // Different names, same category, and DELIBERATELY identical embeddings
+        // (the over-merge trap). The name gate must veto regardless.
+        let a = node("Thomas Nabbes | Playwright | 17th Century | UNKNOWN");
+        let b = node("William Shakespeare | Playwright | 17th Century | UNKNOWN");
+        let emb = vec![0.3, 0.4, 0.5, 0.6];
+        let ps = score_pair(&a, &b, &emb, &emb, &ScoreConfig::default());
+        assert!(!ps.gated_in);
+        assert_eq!(ps.score, 0.0, "name gate must veto the over-merge");
+    }
+
+    #[test]
+    fn attribute_agreement_is_bonus_only() {
+        let a = node("Acme Corp | Company | UNKNOWN | Makes anvils");
+        let b_same = node("Acme Corp | Company | UNKNOWN | Makes anvils");
+        let b_diff = node("Acme Corp | Company | UNKNOWN | Sells rockets");
+        let cfg = ScoreConfig::default();
+        let s_same = score_pair(&a, &b_same, &[], &[], &cfg).score;
+        let s_diff = score_pair(&a, &b_diff, &[], &[], &cfg).score;
+        // Matching attribute scores higher, but the divergent one must NOT be
+        // penalized below the threshold (no veto).
+        assert!(s_same > s_diff);
+        assert!(s_diff >= cfg.merge_threshold);
+    }
+
+    #[test]
+    fn unknown_anchor_is_neutral_not_penalty() {
+        let a = node("Globex | Company | 1989 | UNKNOWN");
+        let b_unknown = node("Globex | Company | UNKNOWN | UNKNOWN");
+        let b_conflict = node("Globex | Company | 1750 | UNKNOWN");
+        let cfg = ScoreConfig::default();
+        let s_unknown = score_pair(&a, &b_unknown, &[], &[], &cfg);
+        let s_conflict = score_pair(&a, &b_conflict, &[], &[], &cfg);
+        // An UNKNOWN anchor (neutral 0.5) must beat a genuinely conflicting one.
+        assert!(s_unknown.anchor > s_conflict.anchor);
+    }
+
+    #[test]
+    fn cosine01_maps_and_guards() {
+        assert_eq!(cosine01(&[1.0, 0.0], &[1.0, 0.0]), Some(1.0));
+        assert_eq!(cosine01(&[1.0, 0.0], &[-1.0, 0.0]), Some(0.0));
+        assert!((cosine01(&[1.0, 0.0], &[0.0, 1.0]).unwrap() - 0.5).abs() < 1e-12);
+        assert_eq!(cosine01(&[], &[]), None);
+        assert_eq!(cosine01(&[0.0, 0.0], &[1.0, 1.0]), None);
+    }
+}

--- a/packages/rust/extensions/goldenprofile-core/src/signature.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/signature.rs
@@ -1,0 +1,186 @@
+//! The two signatures a profile carries, and the blocking keys derived from
+//! them.
+//!
+//! 1. **Structured signature** -- a canonical hash over the rigid *identifying*
+//!    fields (kind + category + name tokens). Two profiles can only land in the
+//!    same structured block if their category agrees AND they share a name
+//!    token. This is the Row-4 over-merge guard at the blocking layer: a
+//!    `Playwright | William Shakespeare` profile shares no name token with
+//!    `Playwright | Thomas Nabbes`, so they are never even compared.
+//!
+//! 2. **Semantic signature** -- SimHash band hashes (sign random-projection /
+//!    cosine-LSH) over the host-supplied dense embedding of the *rendered
+//!    fingerprint string*. This recalls paraphrase / morphological variants that
+//!    share no literal token ("Nabbes" vs "Thomas Nabbes", "co-founded" vs
+//!    "was a founder of"). Reused verbatim from `sketch-core` so the bits are
+//!    byte-identical with every surface that already ships SimHash.
+//!
+//! Candidate pairs are the UNION of structured-block co-members and
+//! semantic-band co-members (recall-first; the scorer is the precision stage).
+
+use std::collections::HashMap;
+
+use goldenmatch_fingerprint_core::{fingerprint_fields, FpValue};
+use goldenmatch_sketch_core::simhash::simhash_band_hashes_batch;
+
+use crate::model::Profile;
+
+/// Default SimHash planes -- 64 hyperplanes give a 64-bit semantic signature,
+/// enough resolution for fingerprint-length strings without ballooning the
+/// projection matrix.
+pub const DEFAULT_SIM_PLANES: usize = 64;
+/// Default LSH bands over the 64-bit signature. 8 bands x 8 rows: a pair must
+/// agree on all 8 bits of at least one band to be recalled -- a deliberately
+/// loose semantic gate (recall-first), tightened by the scorer.
+pub const DEFAULT_SIM_BANDS: usize = 8;
+/// Fixed projection seed so every surface (and every run) draws the SAME
+/// hyperplanes -- semantic band hashes are only comparable under one seed.
+pub const SIM_SEED: u64 = 0x6f70_726f_6669_6c65; // "oprofile"
+
+/// Token-blocking keys for one profile: `category||token` for every name token,
+/// scoped by element kind so a node token never collides with an edge token.
+/// Returns the canonical fingerprint hash of each `(kind, category, token)` so
+/// the key is a fixed-width, cross-language-stable string (the same canonical
+/// hashing the `:h1:` record id uses).
+pub fn structured_block_keys(p: &Profile) -> Vec<String> {
+    let kind = match p.kind {
+        crate::model::ElementKind::Node => "node",
+        crate::model::ElementKind::Edge => "edge",
+    };
+    let cat = Profile::norm(&p.category);
+    p.name_tokens()
+        .into_iter()
+        .map(|tok| {
+            // Canonical, type-tagged hash -- identical bytes on every surface.
+            // Unwrap is safe: all three values are plain non-NaN strings.
+            fingerprint_fields(vec![
+                ("kind".to_string(), FpValue::Str(kind.to_string())),
+                ("category".to_string(), FpValue::Str(cat.clone())),
+                ("token".to_string(), FpValue::Str(tok)),
+            ])
+            .expect("string fields never fail fingerprinting")
+        })
+        .collect()
+}
+
+/// Semantic band keys for a batch of profiles from their host-supplied
+/// embeddings. `embeddings[i]` is the dense vector of `profiles[i]`'s rendered
+/// fingerprint (any dim; all rows must share it). Returns, per profile, the
+/// list of `band||hash` keys. An empty embedding row yields no semantic keys
+/// (that profile is still recalled via its structured keys).
+pub fn semantic_band_keys(
+    embeddings: &[Vec<f64>],
+    planes: usize,
+    bands: usize,
+) -> Vec<Vec<String>> {
+    if embeddings.is_empty() {
+        return Vec::new();
+    }
+    // sketch-core builds the projection matrix once and reuses it across rows.
+    let band_hashes = simhash_band_hashes_batch(embeddings, planes, bands, SIM_SEED);
+    band_hashes
+        .into_iter()
+        .map(|row| {
+            row.into_iter()
+                .enumerate()
+                .map(|(b, h)| format!("s{b}:{h:016x}"))
+                .collect()
+        })
+        .collect()
+}
+
+/// Group profile indices that share ANY blocking key into candidate pairs.
+/// `keys_per_item[i]` is the full key set (structured ∪ semantic) of profile
+/// `i`. Returns deduplicated unordered pairs `(a, b)` with `a < b`. A key
+/// shared by a huge bucket is capped by `max_bucket` (skip blocks bigger than
+/// the cap -- a single over-broad key, e.g. an all-UNKNOWN category, must not
+/// explode into an O(n^2) candidate set; those profiles still pair via their
+/// other, more specific keys).
+pub fn candidate_pairs(keys_per_item: &[Vec<String>], max_bucket: usize) -> Vec<(usize, usize)> {
+    let mut buckets: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (i, keys) in keys_per_item.iter().enumerate() {
+        for k in keys {
+            buckets.entry(k.as_str()).or_default().push(i);
+        }
+    }
+    let mut pairs: Vec<(usize, usize)> = Vec::new();
+    for members in buckets.values() {
+        if members.len() < 2 || members.len() > max_bucket {
+            continue;
+        }
+        for a in 0..members.len() {
+            for b in (a + 1)..members.len() {
+                let (x, y) = (members[a], members[b]);
+                pairs.push(if x < y { (x, y) } else { (y, x) });
+            }
+        }
+    }
+    pairs.sort_unstable();
+    pairs.dedup();
+    pairs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ElementKind;
+
+    #[test]
+    fn shared_name_token_same_category_blocks_together() {
+        let a = Profile::parse(ElementKind::Node, "Thomas Nabbes | Playwright | 17th c | wrote X");
+        let b = Profile::parse(ElementKind::Node, "Nabbes | Playwright | 1605 | UNKNOWN");
+        let ka = structured_block_keys(&a);
+        let kb = structured_block_keys(&b);
+        // They share the (node, playwright, nabbes) key.
+        assert!(ka.iter().any(|k| kb.contains(k)));
+    }
+
+    #[test]
+    fn different_name_same_category_does_not_block() {
+        let nabbes = Profile::parse(ElementKind::Node, "Thomas Nabbes | Playwright | UNKNOWN | UNKNOWN");
+        let shakes = Profile::parse(ElementKind::Node, "William Shakespeare | Playwright | UNKNOWN | UNKNOWN");
+        let ka = structured_block_keys(&nabbes);
+        let kb = structured_block_keys(&shakes);
+        assert!(!ka.iter().any(|k| kb.contains(k)));
+    }
+
+    #[test]
+    fn node_and_edge_never_share_a_structured_key() {
+        let node = Profile::parse(ElementKind::Node, "wrote | Playwright | UNKNOWN | UNKNOWN");
+        let edge = Profile::parse(ElementKind::Edge, "wrote | Playwright | UNKNOWN | UNKNOWN");
+        let kn = structured_block_keys(&node);
+        let ke = structured_block_keys(&edge);
+        assert!(!kn.iter().any(|k| ke.contains(k)));
+    }
+
+    #[test]
+    fn candidate_pairs_dedup_and_cap() {
+        // Items 0,1,2 all share key "x"; the cap=2 drops that bucket. Items 0,3
+        // additionally share "y" (bucket size 2, kept).
+        let keys = vec![
+            vec!["x".to_string(), "y".to_string()],
+            vec!["x".to_string()],
+            vec!["x".to_string()],
+            vec!["y".to_string()],
+        ];
+        assert_eq!(candidate_pairs(&keys, 2), vec![(0, 3)]);
+        // With a higher cap the "x" bucket of 3 contributes all its pairs.
+        let mut all = candidate_pairs(&keys, 10);
+        all.sort_unstable();
+        assert_eq!(all, vec![(0, 1), (0, 2), (0, 3), (1, 2)]);
+    }
+
+    #[test]
+    fn semantic_keys_recall_token_disjoint_paraphrase() {
+        // Two near-identical embeddings collide on every band; an orthogonal one
+        // does not share all 8 bits of any band.
+        let e = vec![
+            vec![1.0, 0.9, 0.8, 0.05, 0.0, -0.1, 0.2, 0.3],
+            vec![0.99, 0.92, 0.78, 0.06, 0.01, -0.09, 0.21, 0.29],
+            vec![-1.0, -0.9, -0.8, -0.05, 0.0, 0.1, -0.2, -0.3],
+        ];
+        let keys = semantic_band_keys(&e, 64, 8);
+        let shared01 = keys[0].iter().any(|k| keys[1].contains(k));
+        assert!(shared01, "near-identical vectors must share a band");
+    }
+}

--- a/packages/rust/extensions/goldenprofile-native/.gitignore
+++ b/packages/rust/extensions/goldenprofile-native/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/packages/rust/extensions/goldenprofile-native/Cargo.toml
+++ b/packages/rust/extensions/goldenprofile-native/Cargo.toml
@@ -1,0 +1,35 @@
+# goldenprofile-native -- the PyO3 binding for the pyo3-free
+# `goldenprofile-core` Virtual Fingerprint engine, shipped as a maturin/abi3
+# extension module (mirrors goldengraph-native / goldenmatch-native). The
+# compute lives in the core crate; this crate is a thin marshaling layer over
+# the ONE JSON boundary (`goldenprofile_core::resolve_json`) so Python gets
+# byte-identical results to the WASM / C surfaces by construction.
+#
+# Standalone workspace (empty [workspace]) so pyo3's `extension-module` feature
+# here is NOT unified with the bridge crate's embedding features -- the two are
+# mutually incompatible. Same isolation rationale as goldengraph-native.
+[workspace]
+
+[package]
+name = "goldenprofile-native"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "PyO3 binding for goldenprofile-core: cross-document entity resolution over Virtual Fingerprints"
+
+[lib]
+# Produces _native.<abi3>.so/.pyd; maturin ships it as goldenprofile_native/_native
+# (pymodule `_native`, so the init symbol is PyInit__native).
+name = "_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+# abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
+pyo3 = { version = ">=0.28, <0.30", features = ["extension-module", "abi3-py311"] }
+# The pyo3-free engine. This crate marshals str <-> str over its resolve_json.
+goldenprofile-core = { path = "../goldenprofile-core" }
+
+[profile.release]
+opt-level = 3
+lto = "thin"

--- a/packages/rust/extensions/goldenprofile-native/README.md
+++ b/packages/rust/extensions/goldenprofile-native/README.md
@@ -1,0 +1,33 @@
+# goldenprofile-native
+
+PyO3 binding for [`goldenprofile-core`](../goldenprofile-core) — the
+**Virtual Fingerprint / Semantic Signature engine**.
+
+Cross-document entity resolution over rigid, LLM-synthesized profiles
+(`name | category | anchor | attribute`) for graph nodes **and** edges. Built to
+repair the multi-hop knowledge-graph "shatter": disjoint neighborhoods reunite
+into one entity (the defining attribute can only add confidence, never veto a
+merge) while distinct entities stay apart (a hard name + category gate).
+
+```python
+import json
+from goldenprofile_native import resolve_json
+
+req = {
+    "profiles": [
+        {"kind": "node", "name": "Thomas Nabbes", "category": "Playwright",
+         "anchor": "17th Century England", "attribute": "Wrote Play X"},
+        {"kind": "node", "name": "Nabbes", "category": "Playwright",
+         "anchor": "UNKNOWN", "attribute": "Born 1605"},
+    ],
+    # "embeddings": [[...], [...]],   # optional: one per profile, for semantic blocking
+    # "config": {"scoring": {"merge_threshold": 0.72}},  # optional partial override
+}
+res = json.loads(resolve_json(json.dumps(req)))
+res["clusters"]  # -> [[0, 1]]   the two Nabbes mentions reunited
+```
+
+The compute is in the pyo3-free `goldenprofile-core` crate; this is a thin
+JSON-boundary marshaling layer, so Python, WASM, and C surfaces produce
+byte-identical clusters by construction. Part of the
+[goldengraph](https://github.com/benseverndev-oss/goldenmatch) program.

--- a/packages/rust/extensions/goldenprofile-native/pyproject.toml
+++ b/packages/rust/extensions/goldenprofile-native/pyproject.toml
@@ -1,0 +1,23 @@
+# maturin build for the goldenprofile-native wheel. Mirrors goldengraph-native:
+# the compiled `_native` extension module (PyInit__native) is shipped inside the
+# `goldenprofile_native` package, alongside the thin Python `__init__` that
+# re-exports `resolve_json`.
+[build-system]
+requires = ["maturin>=1.5,<2"]
+build-backend = "maturin"
+
+[project]
+name = "goldenprofile-native"
+version = "0.1.0"
+description = "PyO3 binding for goldenprofile-core: cross-document entity resolution over Virtual Fingerprints (the Semantic Signature engine)"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Ben Severn", email = "benzsevern@gmail.com" }]
+
+[tool.maturin]
+# The Rust cdylib is `_native`; ship it inside the `goldenprofile_native`
+# package so `from goldenprofile_native import resolve_json` works.
+module-name = "goldenprofile_native._native"
+python-source = "python"
+features = ["pyo3/extension-module"]

--- a/packages/rust/extensions/goldenprofile-native/python/goldenprofile_native/__init__.py
+++ b/packages/rust/extensions/goldenprofile-native/python/goldenprofile_native/__init__.py
@@ -1,0 +1,14 @@
+"""goldenprofile-native -- PyO3 binding for the goldenprofile Virtual
+Fingerprint engine.
+
+Re-exports the compiled ``resolve_json`` (str -> str over a JSON boundary). The
+host pipeline (``goldengraph.profile``) builds the request and parses the
+response; this package is just the marshaling surface. See
+``goldenprofile_core::ResolveRequest`` for the JSON schema.
+"""
+
+from __future__ import annotations
+
+from ._native import __version__, resolve_json
+
+__all__ = ["resolve_json", "__version__"]

--- a/packages/rust/extensions/goldenprofile-native/src/lib.rs
+++ b/packages/rust/extensions/goldenprofile-native/src/lib.rs
@@ -1,0 +1,30 @@
+//! `goldenprofile._native` -- PyO3 binding for the pyo3-free
+//! `goldenprofile-core` Virtual Fingerprint engine.
+//!
+//! Deliberately thin: it marshals a JSON request string in and a JSON result
+//! string out over the core's single `resolve_json` boundary -- the SAME
+//! boundary the WASM and C ABI bindings wrap. No resolution logic lives here, so
+//! Python, WASM, and C produce byte-identical clusters by construction. The
+//! Python host (`goldengraph.profile`) builds the request dict and parses the
+//! response; keeping the boundary as JSON avoids pyo3-version-specific dict
+//! marshaling for the nested score breakdowns.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Resolve a JSON `ResolveRequest` into a JSON `Resolution`. See
+/// `goldenprofile_core::ResolveRequest` for the schema:
+/// `{"profiles":[{kind,name,category,anchor,attribute}], "embeddings"?: [[f64]],
+/// "config"?: {...}}`. Raises `ValueError` on malformed input or a
+/// profiles/embeddings length mismatch.
+#[pyfunction]
+fn resolve_json(request: &str) -> PyResult<String> {
+    goldenprofile_core::resolve_json(request).map_err(PyValueError::new_err)
+}
+
+#[pymodule]
+fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(resolve_json, m)?)?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}

--- a/packages/rust/extensions/goldenprofile-wasm/.gitignore
+++ b/packages/rust/extensions/goldenprofile-wasm/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/packages/rust/extensions/goldenprofile-wasm/Cargo.toml
+++ b/packages/rust/extensions/goldenprofile-wasm/Cargo.toml
@@ -1,0 +1,35 @@
+# goldenprofile-wasm -- the wasm-bindgen / TS surface over the pyo3-free
+# `goldenprofile-core` Virtual Fingerprint engine. The TS/WASM analogue of
+# goldenprofile-native (pyo3): it wraps the SAME `resolve_json` boundary, so the
+# engine is byte-identical across Python, WASM, and C by construction (one core,
+# no re-implementation).
+#
+# The pyo3-free `resolve_json_impl` is exposed unconditionally (so the sibling
+# C ABI crate and host parity tests link it); the wasm-bindgen export is gated
+# to wasm32 so a host build pulls only serde_json + the core.
+#
+# Standalone workspace so this wrapper can be a path dependency of
+# goldenprofile-cabi without either crate's workspace claiming it.
+[workspace]
+
+[package]
+name = "goldenprofile-wasm"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "wasm-bindgen wrapper over goldenprofile-core: cross-document Virtual Fingerprint resolution over a JSON boundary"
+
+[lib]
+name = "goldenprofile_wasm"
+crate-type = ["cdylib", "rlib"] # cdylib for wasm; rlib so host parity tests link
+
+[dependencies]
+goldenprofile-core = { path = "../goldenprofile-core" }
+
+[dev-dependencies]
+# Host parity tests parse the JSON result to assert cluster structure.
+serde_json = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"

--- a/packages/rust/extensions/goldenprofile-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenprofile-wasm/src/lib.rs
@@ -1,0 +1,44 @@
+//! `goldenprofile-wasm` -- wasm-bindgen / C-ABI-shared wrapper over
+//! `goldenprofile-core`.
+//!
+//! The pyo3-free [`resolve_json_impl`] is the marshaling shim the sibling
+//! `goldenprofile-cabi` crate and the host parity tests call; the wasm-bindgen
+//! `resolve_json` export (wasm32 only) is the thinnest possible adapter on top
+//! of it. One core, so WASM/C/Python clusters are identical by construction.
+
+/// Resolve a JSON `ResolveRequest` into a JSON `Resolution`. Pyo3-free and
+/// target-agnostic; `Err` is the core's error string. This is the function the
+/// C ABI wraps, so the C and WASM surfaces share exactly one code path.
+pub fn resolve_json_impl(request: &str) -> Result<String, String> {
+    goldenprofile_core::resolve_json(request)
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    /// WASM export: resolve a JSON request string into a JSON result string.
+    /// Throws a JS string on error.
+    #[wasm_bindgen]
+    pub fn resolve_json(request: &str) -> Result<String, JsValue> {
+        super::resolve_json_impl(request).map_err(|e| JsValue::from_str(&e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn impl_resolves_and_matches_core() {
+        let req = r#"{"profiles":[
+            {"kind":"node","name":"Acme Inc","category":"Company","anchor":"UNKNOWN","attribute":"Anvils"},
+            {"kind":"node","name":"Acme","category":"Company","anchor":"UNKNOWN","attribute":"Founded 1900"}
+        ]}"#;
+        // The wasm shim and the core boundary must produce identical bytes.
+        assert_eq!(resolve_json_impl(req), goldenprofile_core::resolve_json(req));
+        let v: serde_json::Value =
+            serde_json::from_str(&resolve_json_impl(req).unwrap()).unwrap();
+        assert_eq!(v["clusters"].as_array().unwrap().len(), 1);
+    }
+}

--- a/scripts/check_docs_staleness.py
+++ b/scripts/check_docs_staleness.py
@@ -16,6 +16,12 @@ Rules
    ``::error::`` annotation + exit 1. (Per .claude/doc-surfaces.md, tuning.mdx is
    the authoritative GOLDENMATCH_* reference; an added/removed flag is the single
    highest-signal doc drift.)
+   To stay false-positive-free, two classes of non-drift are excluded before
+   gating: (a) test files (``**/tests/**``, ``test_*.py``, ``*_test.py``,
+   ``conftest.py``) -- a flag *mention* in a test exercises an existing flag,
+   it does not declare one; (b) flags already in sync with tuning.mdx -- an
+   added flag already documented there, or a removed flag already absent from
+   it, has nothing left to update.
 
 2. public-symbol rule (ADVISORY):
    If the diff changes a package ``__init__.py`` ``__all__`` / re-export and NO
@@ -50,6 +56,32 @@ def _git(*args: str) -> str:
     return proc.stdout
 
 
+def _is_test_file(path: str) -> bool:
+    """A flag *mention* in a test (``monkeypatch.setenv``, ``os.environ[...]``)
+    is exercising an existing flag, not declaring a new one. Test files are
+    therefore excluded from the flag-drift scan -- only non-test source can
+    introduce/remove the canonical flag surface."""
+    name = path.rsplit("/", 1)[-1]
+    return (
+        "/tests/" in path
+        or name.startswith("test_")
+        or name.endswith("_test.py")
+        or name == "conftest.py"
+    )
+
+
+def _documented_flags(head: str) -> set[str]:
+    """GOLDENMATCH_* flags already present in tuning.mdx at ``head``.
+
+    Used to suppress false positives: a flag that is *already documented* has no
+    drift to fix, even if a non-test source line happens to reference it."""
+    try:
+        content = _git("show", f"{head}:{TUNING_MDX}")
+    except RuntimeError:
+        return set()  # tuning.mdx absent at head -> nothing documented yet
+    return set(_FLAG_RE.findall(content))
+
+
 def changed_files(base: str, head: str) -> list[str]:
     out = _git("diff", "--name-only", f"{base}...{head}")
     return [ln for ln in out.splitlines() if ln.strip()]
@@ -81,15 +113,32 @@ def _added_removed_flags(diff_text: str) -> tuple[set[str], set[str]]:
 
 def check_flag_rule(base: str, head: str, files: list[str]) -> tuple[bool, list[str]]:
     """Return (ok, messages). ok=False means gate failure."""
-    py_files = [f for f in files if f.startswith("packages/python/") and f.endswith(".py")]
+    py_files = [
+        f
+        for f in files
+        if f.startswith("packages/python/")
+        and f.endswith(".py")
+        and not _is_test_file(f)
+    ]
     if not py_files:
-        return True, ["flag rule: no packages/python/**/*.py changes -- skipped"]
+        return True, ["flag rule: no non-test packages/python/**/*.py changes -- skipped"]
 
     diff_text = diff_for(base, head, py_files)
     net_added, net_removed = _added_removed_flags(diff_text)
-    touched_flags = sorted(net_added | net_removed)
+
+    # Suppress flags that have no actual doc drift:
+    #  - an *added* flag already present in tuning.mdx is already documented;
+    #  - a *removed* flag absent from tuning.mdx is already undocumented.
+    # Only the complement is real drift the canonical reference must track.
+    documented = _documented_flags(head)
+    drift_added = net_added - documented
+    drift_removed = net_removed & documented
+    touched_flags = sorted(drift_added | drift_removed)
     if not touched_flags:
-        return True, ["flag rule: no GOLDENMATCH_* flag added/removed -- OK"]
+        return True, [
+            "flag rule: no GOLDENMATCH_* flag drift "
+            "(changes are tests, or flags already in sync with tuning.mdx) -- OK"
+        ]
 
     tuning_touched = TUNING_MDX in files
     if tuning_touched:


### PR DESCRIPTION
## What

A native (Rust) **Semantic Signature / Virtual Fingerprint** engine for GoldenGraph: resolve graph elements (nodes **and** edges) across documents by comparing rigid, LLM-synthesized fingerprints instead of raw text — built to repair the multi-hop knowledge-graph **shatter** (MuSiQue-style).

The fingerprint is a brutally rigid 4-part string:

```
<name> | <category> | <temporal/spatial anchor> | <defining attribute>
```

Structuring the evidence breaks the under-merge ↔ over-merge tension that a single similarity threshold can't escape:

| Failure mode | Example | Guard |
|---|---|---|
| **Under-merge (Row 3)** — disjoint neighborhoods | Doc A "Nabbes wrote Play X" vs Doc B "Nabbes born 1605" | the *defining attribute* is expected to diverge across docs, so it can only **add** confidence, never veto a merge; a missing field is a neutral prior, never a penalty |
| **Over-merge (Row 4)** — semantic bleeding | "Nabbes" vs "Shakespeare" (both 17th-c. playwrights) | hard **name + category gate** before any merge, regardless of embedding proximity |

## How — all four surfaces, one core

Established `goldengraph` pattern (one pyo3-free core, thin bindings, a single JSON boundary):

- `goldenprofile-core` — pyo3-free engine + the single `resolve_json` boundary
- `goldenprofile-native` — pyo3/maturin abi3 wheel
- `goldenprofile-wasm` — wasm-bindgen wrapper exposing the shared `resolve_json_impl`
- `goldenprofile-cabi` — C ABI reusing `resolve_json_impl` (no re-implementation)

Every **signal is reused, not reinvented** — so the engine is byte-identical with the surfaces that already ship those kernels:

- **SimHash band hashing** over the host-supplied dense fingerprint embedding (`sketch-core`) → the *semantic signature* / cosine-LSH blocker (this is the "persisted embedding sidecar + ANN index" `goldengraph/embed.py` flagged as unbuilt, generalized to blocking)
- field scorers (`score-core`), canonical hashing (`fingerprint-core`), connected-components (`graph-core`)

Pipeline: **block** (structured token keys ∪ semantic SimHash bands) → **score** (anti-shatter fusion, with a kept per-pair breakdown for the never-black-box North Star) → **WCC cluster**.

LLM synthesis + embedding stay in the Python host (`goldengraph/profile.py`), exactly as `goldengraph-core` keeps the LLM out of the engine.

## Validation

- **Rust:** 25 core unit tests incl. `musique_shatter_repair_three_docs` (disjoint Nabbes mentions reunite, Shakespeare stays distinct), the Row-4 over-merge veto, the embedding-bridged synonym category ("Playwright"/"Dramatist"), unknown-field neutrality; wasm/cabi parity tests assert identical bytes to the core boundary.
- **Python:** `test_profile.py` covers the new synthesis logic + defensive fallbacks with a stub LLM, plus a full Python→Rust→Python integration test through the built wheel (10/10 pass locally with the wheel installed).

## Design

`context-network/decisions/0023-semantic-signature-virtual-fingerprint-engine.md`.

## Deliberate scope / follow-ups

- **CI wiring not included** — the four crates are standalone workspaces (like their `goldengraph-*` siblings); adding them to the CI matrix + a `publish-goldenprofile-native.yml` is a separate slice.
- **Lexical-only is conservative on synonym categories** (bridged by the embedding signal — tested both ways).
- **Edge fingerprints are deterministic in v1**; LLM-synthesized edge fingerprints (predicate-synonym merging beyond the semantic signal) is a follow-up.
- **Persistence deferred** — v1 resolves a batch in memory; a persisted signature index alongside the SP2 store is the next slice.
- **MuSiQue / ER-KG-Bench eval** to quantify the shatter repair is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_