### PR TITLE
feat(goldengraph): use goldenprofile anti-shatter engine to repair the MuSiQue multi-hop shatter

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -31,6 +31,24 @@ on:
       link_threshold:
         description: "goldengraph only: embedding cosine cutoff for cross-doc linking (lower = more merging)"
         default: "0.82"
+      profile_link:
+        description: "goldengraph only: use the goldenprofile anti-shatter engine as the cross-doc matcher (needs cross_doc_link=true)"
+        default: "false"
+      profile_merge_threshold:
+        description: "goldengraph only: goldenprofile merge threshold (engine ScoreConfig default 0.72)"
+        default: "0.72"
+      build_workers:
+        description: "goldengraph only: concurrent per-doc LLM workers at build (rate-limit-bounded; retry/backoff absorbs 429s)"
+        default: "8"
+      build_debug:
+        description: "goldengraph only: print the per-sub-step build timing breakdown (extract/resolve/fingerprint/link/append) for hotspot analysis"
+        default: "false"
+      extractor:
+        description: "goldengraph only: document extractor -- api (LLM) | rebel | gliner (in-house local model prototype-eval)"
+        default: "api"
+      distill_log:
+        description: "goldengraph only: capture (text->extraction)+(entity->fingerprint) pairs to a JSONL artifact for in-house distillation"
+        default: "false"
 
 permissions:
   contents: read
@@ -55,7 +73,10 @@ jobs:
     needs: setup
     if: ${{ inputs.engine == 'all' || inputs.engine == 'goldengraph' }}
     runs-on: large-new-64GB
-    timeout-minutes: 60
+    # Large-N MuSiQue builds a graph from ~20 docs/question sequentially (per-doc LLM
+    # extraction + fingerprint synthesis), so N=200 (~4000 docs) needs hours, not the
+    # 60 min that fit the small-N runs. Raised under the hosted 360-min job ceiling.
+    timeout-minutes: 330
     strategy:
       fail-fast: false
       matrix:
@@ -71,8 +92,16 @@ jobs:
           python -m pip install --upgrade pip maturin pytest goldenmatch datasets openai
           maturin build --release \
             -m packages/rust/extensions/goldengraph-native/Cargo.toml --out dist
+          # goldenprofile-native: the anti-shatter cross-doc matcher (GOLDENGRAPH_PROFILE_LINK)
+          maturin build --release \
+            -m packages/rust/extensions/goldenprofile-native/Cargo.toml --out dist
           python -m pip install dist/*.whl
           python -m pip install --no-deps -e packages/python/goldengraph
+          # In-house local-extractor prototype-eval deps (only when selected).
+          if [ "${{ inputs.extractor }}" != "api" ]; then
+            python -m pip install transformers torch
+            if [ "${{ inputs.extractor }}" = "gliner" ]; then python -m pip install gliner; fi
+          fi
       - name: Run goldengraph end-to-end (real LLM, budget-capped)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:
@@ -81,7 +110,14 @@ jobs:
           GOLDENGRAPH_QA_TRACE: ${{ inputs.trace }}
           GOLDENGRAPH_CROSS_DOC_LINK: ${{ inputs.cross_doc_link }}
           GOLDENGRAPH_LINK_THRESHOLD: ${{ inputs.link_threshold }}
+          GOLDENGRAPH_PROFILE_LINK: ${{ inputs.profile_link }}
+          GOLDENGRAPH_PROFILE_MERGE_THRESHOLD: ${{ inputs.profile_merge_threshold }}
+          GOLDENGRAPH_BUILD_WORKERS: ${{ inputs.build_workers }}
+          GOLDENGRAPH_BUILD_DEBUG: ${{ inputs.build_debug }}
+          GOLDENGRAPH_EXTRACTOR: ${{ inputs.extractor }}
+          GOLDENGRAPH_DISTILL_LOG: ${{ inputs.distill_log == 'true' && format('results/distill_goldengraph_amb{0}.jsonl', matrix.ambiguity) || '' }}
         run: |
+          mkdir -p results
           python -m erkgbench.qa_e2e.run_qa_e2e \
             --engine goldengraph \
             --corpus "${{ inputs.corpus }}" \
@@ -96,6 +132,13 @@ jobs:
         with:
           name: graphrag-qa-results-goldengraph-amb${{ matrix.ambiguity }}
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_goldengraph_amb${{ matrix.ambiguity }}*.*
+          if-no-files-found: ignore
+      - name: Upload distillation pairs
+        if: ${{ always() && inputs.distill_log == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-distill-goldengraph-amb${{ matrix.ambiguity }}
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/distill_goldengraph_amb${{ matrix.ambiguity }}.jsonl
           if-no-files-found: ignore
 
   lightrag:

--- a/docs/superpowers/specs/2026-06-22-goldengraph-crossdoc-linking-experiments.md
+++ b/docs/superpowers/specs/2026-06-22-goldengraph-crossdoc-linking-experiments.md
@@ -57,6 +57,36 @@ statistically robust score). `answer_match` is 0.0 in every row so far; the
 | 3 | goldenmatch on compound key + **graph neighborhood** | 372 | 56 | 77 | **0.036** | **under-merge** (barely links) |
 | 4 | embedding-threshold (cosine ≥ **0.82**) | 368 | 64 | 52 | 0.006 | **under-merge** — threshold too high |
 | 5 | embedding-threshold (cosine ≥ **0.60**) | *sweeping* | | | | finding the Goldilocks cutoff |
+| 6 | **goldenprofile anti-shatter engine** (PR #1217) | *measuring* | | | | structured fingerprint breaks the threshold tension |
+
+### #6 — the goldenprofile Semantic Signature engine (the real fix)
+
+Every matcher #1–#5 rides a SINGLE similarity number, which is why each one sat on
+one side or the other of the under/over-merge line — there is no scalar threshold
+that both merges a bridge's disjoint appearances AND keeps two same-category
+entities apart. PR #1217's **anti-shatter scorer** escapes the tension by
+STRUCTURING the evidence into a rigid `name | category | anchor | attribute`
+fingerprint:
+
+- the **defining attribute** (the per-document neighborhood — exactly what
+  DIVERGES across a bridge's mentions) is a **positive-only bonus**: it can add
+  confidence but never veto. That kills the Row-3 under-merge that sank #3.
+- a **hard name + category gate** must pass before any merge is considered,
+  regardless of embedding proximity. That kills the Row-4 over-merge that sank
+  #1/#2.
+
+Integration (this branch): `ingest._profile_cluster` maps each compound feature
+row to a deterministic fingerprint (name→name, type→category, `rel`+`nbr`→the
+non-vetoing attribute) and routes the merge decision through the engine's
+`resolve_profiles` (SimHash-band blocking + the fusion scorer + WCC), reusing the
+existing record_key-injection merge. Selected by `GOLDENGRAPH_PROFILE_LINK=1`
+(precedence above the embedding matcher); merge threshold tunable via
+`GOLDENGRAPH_PROFILE_MERGE_THRESHOLD` (engine default 0.72). The contract is
+locked offline against the built wheel in
+`tests/test_ingest_cross_doc_link.py::test_profile_cluster_repairs_shatter_but_gates_distinct_names`
+(disjoint-neighborhood Nabbes reunite; Shakespeare stays apart). **Deterministic-
+fingerprint cut** — LLM-synthesized node fingerprints (a real temporal/spatial
+anchor + defining attribute, the full PR #1217 design) are the next slice.
 
 ### Why each failed — the through-line
 
@@ -112,13 +142,63 @@ stays moderate (no 140-blob). The threshold is one env knob from a re-sweep.
 
 ---
 
+## Measured results — the goldenprofile engine + synthesis pivot (2026-06-23)
+
+The goldenprofile anti-shatter engine (#6) was wired in (`GOLDENGRAPH_PROFILE_LINK=1`),
+first with deterministic fingerprints, then the full **LLM-synthesized** `name |
+category | anchor | attribute` fingerprints (`_entity_fps` + `fp_index` persistence).
+In parallel, two non-linking levers landed: the **hop-clamp fix** (retrieve.rs
+`clamp(1,2)`→`clamp(1,8)`) and the **synthesis pivot** (seed-anchored prompt that
+forces a named-entity answer).
+
+| run | N (questions) | docs | graph ent | components | **answer_match** | notes |
+|---|---|---|---|---|---|---|
+| profile (det fp) | 3 | ~60 | 357 | 57 | 0.0 | Politburo chain re-joined (`same_component` F→T) |
+| profile (LLM fp) | 3 | ~60 | 354 | 55 | 0.0 | merges more; 2/3 Qs are non-linking gaps |
+| profile (LLM fp) | **30** | ~600 | 3042 | 342 | **0.2** (6/30) | first real signal off the floor |
+| profile (LLM fp, incr index) | 30 | ~600 | ~3000 | 332 | 0.167 (5/30) | ±1 Q is N=30 noise; perf-validated |
+
+**Where the loss lives at N=30 (traced):** ~6/10 **EXTRACTION** — the gold answer is a
+*non-entity* (a date, money, a descriptive phrase, or a person never extracted), which
+`answer_match` structurally cannot score (a metric ceiling); 2/10 **SYNTHESIS** (answer
+retrieved with its edge in the ball — e.g. `Mozilla Foundation -[developed]-> Firefox`
+— but the LLM still doesn't name it); 1 **RETRIEVAL-BUDGET** (the Politburo: linking
+worked, `same_component=True`, but `node_budget=64` is too small for the now-8×-bigger
+graph); 1 **BROKEN-CHAIN**. The binding constraint has **shifted off cross-doc linking**.
+
+## Scaling the build (the wall that gated N≥30)
+
+Raising N exposed three scaling walls, each fixed measure-first:
+
+1. **Sequential per-doc LLM (~11s/doc)** — N=200 would be ~12 h. Fix: `ingest_corpus`
+   runs the per-doc LLM work (extraction + fingerprint synthesis) CONCURRENTLY, commits
+   to the store serially in document order (identical graph). ~10 min prepare for 600
+   docs.
+2. **`seed_by_query` embeds every entity name in ONE request** — >2048 inputs at N≥30
+   → HTTP 400. Fix: `GoldenmatchEmbedder.embed` chunks under the provider cap; the engine
+   wraps its embedder in a run-wide `_CachingEmbedder` so each entity text embeds once
+   (build AND every query).
+3. **`_cross_doc_link` O(N²·dim)** — it re-fed EVERY existing fingerprint + embedding to
+   `resolve_profiles` per doc (JSON-serializing all embeddings each call) → ~9 min commit
+   at N=30, ~400 min at N=200. Fix: `_LinkIndex` blocks committed entities by name token;
+   a doc matches its new entities only against the candidate set sharing a token (where
+   bridges live). Commit collapsed; N=30 step 26→15.7 min, `answer_match` held.
+
+Net: N=200 projects to ~85 min (≈67 prepare + cheap O(N) commit + ~13 answer), under the
+330-min job cap.
+
+---
+
 ## Artifacts
 
 - Instrument: `erkgbench/qa_e2e/engines/goldengraph.py::localize` + `harness.py`
-  `_localize_trace` (4-way classification + component membership); `trace` /
-  `cross_doc_link` workflow inputs on `bench-graphrag-qa.yml`.
-- Linker: `goldengraph/ingest.py::_cross_doc_link` (+ `_embed_cluster`,
-  `_existing_features`, `_new_features`); offline tests in
-  `goldengraph/tests/test_ingest_cross_doc_link.py` (stub embedder/matcher — no
-  native, no goldenmatch).
+  `_localize_trace` (4-way classification + component membership + answer-edge dump);
+  `trace` / `cross_doc_link` / `profile_link` / `profile_merge_threshold` workflow
+  inputs on `bench-graphrag-qa.yml`.
+- Linker: `goldengraph/ingest.py` — `_cross_doc_link` (store path) + the goldenprofile
+  path (`_profile_cluster`, `_entity_fps`, `_assemble_fp_texts`) + the scaling layer
+  (`ingest_corpus`/`_prepare_doc`/`_commit_doc`, `_LinkIndex`/`_cross_doc_link_incremental`);
+  embedder batching in `embed.py`. Offline tests in
+  `goldengraph/tests/test_ingest_cross_doc_link.py` + `test_embed_batching.py`.
+- Engine: PR #1217 `goldenprofile-{core,native,wasm,cabi}` + `goldengraph/profile.py`.
 - Diagnosis trail: `docs/superpowers/specs/2026-06-22-goldengraph-qa-e2e-first-headline-handoff.md`.

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -69,7 +69,13 @@ def ask(
         raise ValueError(f"mode must be 'local' or 'global', got {mode!r}")
     seeds = seed_by_query(slice_graph, query, embedder, k=k)
     subgraph = _retrieve_local(slice_graph, seeds, max_hops=hops, node_budget=node_budget)
-    return synthesize_local(query, subgraph, llm)
+    # Hand the synthesis the seed entity NAMES (the query-relevant anchors) so the
+    # multi-hop walk starts at the right place instead of guessing among the ball.
+    id_to_name = {
+        e["entity_id"]: e["canonical_name"] for e in subgraph.get("entities", ())
+    }
+    seed_names = [id_to_name[s] for s in seeds if s in id_to_name]
+    return synthesize_local(query, subgraph, llm, seed_names=seed_names)
 
 
 _CYPHER_PROMPT = (

--- a/packages/python/goldengraph/goldengraph/embed.py
+++ b/packages/python/goldengraph/goldengraph/embed.py
@@ -12,9 +12,15 @@ persisted embedding sidecar + ANN index is the scale optimization, not built.
 
 from __future__ import annotations
 
+import os
 from typing import Protocol
 
 import numpy as np
+
+#: Max texts per provider embedding request. `seed_by_query` embeds EVERY entity
+#: name in the graph in one call; past a few thousand entities that exceeds the
+#: provider's per-request input cap (OpenAI: 2048) -> HTTP 400. Chunk under it.
+_MAX_EMBED_BATCH = max(1, int(os.environ.get("GOLDENGRAPH_EMBED_BATCH", "1000")))
 
 
 class Embedder(Protocol):
@@ -43,7 +49,18 @@ class GoldenmatchEmbedder:
         return self._provider
 
     def embed(self, texts: list[str]) -> np.ndarray:
-        return np.asarray(self._ensure().embed(texts), dtype=float)
+        texts = list(texts)
+        if not texts:
+            return np.zeros((0, 0), dtype=float)
+        prov = self._ensure()
+        if len(texts) <= _MAX_EMBED_BATCH:
+            return np.asarray(prov.embed(texts), dtype=float)
+        # Chunk large batches so no single request exceeds the provider input cap.
+        parts = [
+            np.asarray(prov.embed(texts[i : i + _MAX_EMBED_BATCH]), dtype=float)
+            for i in range(0, len(texts), _MAX_EMBED_BATCH)
+        ]
+        return np.vstack(parts)
 
 
 def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5) -> list[int]:

--- a/packages/python/goldengraph/goldengraph/extract_local.py
+++ b/packages/python/goldengraph/goldengraph/extract_local.py
@@ -1,0 +1,135 @@
+"""In-house, network-free extraction backends -- the prototype-eval for replacing
+the per-document LLM extraction call (the build's measured perf bottleneck) with a
+small LOCAL model. The tasks are narrow (text -> typed entities + relations), so a
+distilled/off-the-shelf model is feasible; this module exists to MEASURE the
+answer_match-vs-speed tradeoff against the API extractor before committing to
+training one.
+
+Each backend returns a `text -> Extraction` callable matching `extract.extract`'s
+shape (it takes `(text, llm=None)` and ignores the llm). Heavy deps (transformers /
+gliner / torch) are imported lazily inside the factory, so importing this module is
+free; only selecting a backend pulls them in.
+"""
+
+from __future__ import annotations
+
+from .extract import Extraction, Mention, Relationship
+
+
+def parse_rebel_triplets(text: str) -> list[tuple[str, str, str]]:
+    """Decode REBEL's linearized output into (head, relation, tail) triples.
+
+    REBEL (Babelscape/rebel-large) emits a string with `<triplet>`/`<subj>`/`<obj>`
+    control tokens; this is the canonical decoder from the REBEL repo. Pure (no
+    model), so it is unit-tested directly."""
+    triplets: list[tuple[str, str, str]] = []
+    relation = subject = object_ = ""
+    text = (
+        text.replace("<s>", "").replace("<pad>", "").replace("</s>", "").strip()
+    )
+    current = "x"
+    for token in text.split():
+        if token == "<triplet>":
+            current = "t"
+            if relation != "":
+                triplets.append((subject.strip(), relation.strip(), object_.strip()))
+                relation = ""
+            subject = ""
+        elif token == "<subj>":
+            current = "s"
+            if relation != "":
+                triplets.append((subject.strip(), relation.strip(), object_.strip()))
+            object_ = ""
+        elif token == "<obj>":
+            current = "o"
+            relation = ""
+        else:
+            if current == "t":
+                subject += " " + token
+            elif current == "s":
+                object_ += " " + token
+            elif current == "o":
+                relation += " " + token
+    if subject.strip() and relation.strip() and object_.strip():
+        triplets.append((subject.strip(), relation.strip(), object_.strip()))
+    return triplets
+
+
+def triplets_to_extraction(
+    triplets: list[tuple[str, str, str]], *, default_type: str = "entity"
+) -> Extraction:
+    """Build an `Extraction` from (head, relation, tail) triples: dedup the head/tail
+    spans into mentions (REBEL does not type entities -- a real in-house model would;
+    `default_type` is the placeholder), and one relationship per triple keyed by the
+    mention indices."""
+    name_to_idx: dict[str, int] = {}
+    mentions: list[Mention] = []
+    rels: list[Relationship] = []
+
+    def _idx(name: str) -> int:
+        if name not in name_to_idx:
+            name_to_idx[name] = len(mentions)
+            mentions.append(Mention(name=name, typ=default_type, context=""))
+        return name_to_idx[name]
+
+    for head, rel, tail in triplets:
+        if not head or not tail or not rel:
+            continue
+        s, o = _idx(head), _idx(tail)
+        if s != o:
+            rels.append(Relationship(subj=s, predicate=rel, obj=o))
+    return Extraction(mentions=mentions, relationships=rels)
+
+
+def rebel_extractor(model: str = "Babelscape/rebel-large", *, max_length: int = 256):
+    """A local `text -> Extraction` extractor backed by REBEL (BART end-to-end
+    relation extraction). The model loads ONCE here; the returned callable runs a
+    network-free forward pass per document. Needs `transformers` + `torch`.
+
+    Loads the seq2seq model directly rather than via `pipeline("text2text-generation")`:
+    transformers v5 removed that task alias from the pipeline registry, and the direct
+    `AutoModelForSeq2SeqLM` + `generate` path is stable across versions. The decode keeps
+    REBEL's `<triplet>`/`<subj>`/`<obj>` control tokens (`skip_special_tokens=False`) --
+    `parse_rebel_triplets` keys off them."""
+    from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    mdl = AutoModelForSeq2SeqLM.from_pretrained(model)
+
+    def _extract(text: str, llm=None) -> Extraction:
+        inputs = tokenizer(
+            text, return_tensors="pt", truncation=True, max_length=max_length
+        )
+        out = mdl.generate(**inputs, max_length=max_length)
+        decoded = tokenizer.decode(out[0], skip_special_tokens=False)
+        return triplets_to_extraction(parse_rebel_triplets(decoded))
+
+    return _extract
+
+
+def gliner_extractor(
+    model: str = "urchade/gliner_mediumv2.1",
+    *,
+    labels: tuple[str, ...] = ("person", "organization", "location", "work", "event", "date"),
+    threshold: float = 0.4,
+):
+    """A local NER-only `text -> Extraction` extractor backed by GLiNER (typed
+    entities, CPU-friendly). It produces typed MENTIONS but no relationships, so the
+    graph has nodes without edges -- useful to isolate the entity-coverage half of
+    the tradeoff. Needs `gliner`."""
+    from gliner import GLiNER
+
+    gl = GLiNER.from_pretrained(model)
+
+    def _extract(text: str, llm=None) -> Extraction:
+        ents = gl.predict_entities(text, list(labels), threshold=threshold)
+        seen: dict[str, int] = {}
+        mentions: list[Mention] = []
+        for e in ents:
+            name = e["text"].strip()
+            if name and name not in seen:
+                seen[name] = len(mentions)
+                mentions.append(Mention(name=name, typ=e.get("label", "entity"), context=""))
+        return Extraction(mentions=mentions, relationships=[])
+
+    return _extract

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 import os
+import threading
+import time
 from collections import defaultdict
 from collections.abc import Callable
 
@@ -38,6 +40,13 @@ _FEATURE_COLS = ("name", "type", "surfaces", "rel", "nbr")
 #: surface variants ("Thomas Nabbes" ~ "Nabbes") without conflating distinct
 #: entities; env-tunable for the A/B sweep on the localize trace.
 _LINK_THRESHOLD = float(os.environ.get("GOLDENGRAPH_LINK_THRESHOLD", "0.82"))
+#: Merge threshold for the goldenprofile anti-shatter matcher (overrides the
+#: engine's ScoreConfig.merge_threshold default of 0.72). The engine's hard
+#: name+category GATE is what guards over-merge, so this knob mostly trades a
+#: little recall for precision; env-tunable for the localize-trace sweep.
+_PROFILE_MERGE_THRESHOLD = float(
+    os.environ.get("GOLDENGRAPH_PROFILE_MERGE_THRESHOLD", "0.72")
+)
 
 
 def build_batch(
@@ -93,6 +102,55 @@ def build_batch(
 
 def _cross_doc_link_enabled() -> bool:
     return os.environ.get("GOLDENGRAPH_CROSS_DOC_LINK", "0") not in ("0", "false", "")
+
+
+def _profile_link_enabled() -> bool:
+    """Use the goldenprofile Semantic Signature engine as the cross-doc matcher
+    (`GOLDENGRAPH_PROFILE_LINK=1`). It replaces the ad-hoc embedding-cosine matcher
+    with the anti-shatter fusion scorer: a hard name+category gate (kills the Row-4
+    over-merge) plus a defining-attribute term that can only ADD confidence, never
+    veto (kills the Row-3 under-merge from divergent bridge neighborhoods)."""
+    return os.environ.get("GOLDENGRAPH_PROFILE_LINK", "0") not in ("0", "false", "")
+
+
+def _profile_cluster(
+    rows: list[dict], embedder, fp_texts: list[str | None] | None = None
+) -> list[list[int]]:
+    """Cluster compound feature rows with the goldenprofile engine (PR #1217).
+
+    Each row becomes a rigid Virtual Fingerprint -- `name | category | anchor |
+    attribute`. When `fp_texts[i]` is supplied (the LLM-synthesized node
+    fingerprint, threaded from `ingest`), it is used verbatim -- a real
+    temporal/spatial anchor + defining attribute, the full PR #1217 design.
+    Otherwise the fingerprint is derived deterministically from the row: `name`/
+    `type` -> the stable identity (the hard gate), graph neighborhood (`rel` +
+    `nbr`) -> the defining *attribute*. That attribute placement is the point: a
+    bridge entity's neighborhood DIVERGES across documents, and in the engine a
+    divergent attribute is a positive-only bonus -- it cannot veto the merge the
+    way the neighborhood-key matcher did. The embedder supplies the semantic
+    signature (SimHash-band blocking + the category embedding escape hatch).
+    Returns multi-member clusters' member indices (positional into `rows`)."""
+    from .profile import UNKNOWN, Fingerprint, resolve_profiles
+
+    if len(rows) < 2:
+        return []
+    fps: list[Fingerprint] = []
+    for i, r in enumerate(rows):
+        given = fp_texts[i] if fp_texts is not None and i < len(fp_texts) else None
+        if given and given.count("|") >= 1:
+            fps.append(Fingerprint("node", i, given))
+            continue
+        name = (r.get("name") or "").strip() or UNKNOWN
+        cat = (r.get("type") or "").strip() or UNKNOWN
+        attr_bits = [b for b in (r.get("rel", ""), r.get("nbr", "")) if b]
+        attr = " ; ".join(attr_bits).strip() or UNKNOWN
+        fps.append(Fingerprint("node", i, f"{name} | {cat} | {UNKNOWN} | {attr}"))
+    config = {"scoring": {"merge_threshold": _PROFILE_MERGE_THRESHOLD}}
+    try:
+        res = resolve_profiles(fps, embedder=embedder, config=config)
+    except Exception:
+        return []
+    return [list(c) for c in res.clusters if len(c) > 1]
 
 
 def _gm_cluster(rows: list[dict]) -> list[list[int]]:
@@ -216,8 +274,26 @@ def _new_features(batch: dict):
     return new_ents, feats
 
 
+def _assemble_fp_texts(existing, ex_keys, new_ents, new_fps, fp_index):
+    """Per-row LLM fingerprint texts aligned to the combined (existing ++ new) row
+    order, or None where unavailable. Existing entities are recovered from the
+    persistent `record_key -> fingerprint` index (the store keeps record_keys but
+    not fingerprints, so the index is how a bridge's earlier appearance carries its
+    LLM fingerprint forward); new entities use this batch's freshly synthesized
+    `new_fps` (keyed by `local_id`)."""
+    fp_index = fp_index or {}
+    new_fps = new_fps or {}
+    out: list[str | None] = []
+    for keys in ex_keys:
+        out.append(next((fp_index[k] for k in keys if k in fp_index), None))
+    for be in new_ents:
+        out.append(new_fps.get(be.get("local_id")))
+    return out
+
+
 def _cross_doc_link(
-    store, batch: dict, at: int, *, embedder=None, cluster_fn: ClusterFn | None = None
+    store, batch: dict, at: int, *, embedder=None, cluster_fn: ClusterFn | None = None,
+    new_fps: dict[int, str] | None = None, fp_index: dict[str, str] | None = None,
 ) -> int:
     """Merge this batch's entities into EXISTING store entities judged the same, by
     injecting the existing entity's `record_keys` into the batch entity so the
@@ -227,17 +303,14 @@ def _cross_doc_link(
     the durable store reconciles ACROSS documents only on exact `record_key`, so a
     bridge entity under a varied surface form ("Thomas Nabbes" vs "Nabbes") stays a
     separate node and severs the multi-hop chain. Matcher precedence: explicit
-    `cluster_fn` (tests) > embedding-threshold linking when an `embedder` is given
-    (name-invariant, so bridges with divergent neighborhoods still match) >
-    goldenmatch dedupe over the compound key. Same-type guard on injection. Returns
+    `cluster_fn` (tests) > the goldenprofile anti-shatter engine when
+    `GOLDENGRAPH_PROFILE_LINK=1` (hard name+category gate + non-vetoing attribute;
+    fed the LLM-synthesized fingerprints in `new_fps`/`fp_index` when present) >
+    embedding-threshold linking when an `embedder` is given (name-invariant, so
+    bridges with divergent neighborhoods still match) > goldenmatch dedupe over the
+    compound key. Same-type guard on injection. Returns
     the count of batch entities that gained a cross-document key. Opt-in
     (`GOLDENGRAPH_CROSS_DOC_LINK=1`)."""
-    if cluster_fn is None:
-        cluster_fn = (
-            (lambda rows: _embed_cluster(rows, embedder))
-            if embedder is not None
-            else _gm_cluster
-        )
     if not hasattr(store, "as_of"):
         return 0
     try:
@@ -248,6 +321,15 @@ def _cross_doc_link(
     new_ents, new_feats = _new_features(batch)
     if not existing or not new_ents:
         return 0
+
+    if cluster_fn is None:
+        if _profile_link_enabled():
+            fp_texts = _assemble_fp_texts(existing, ex_keys, new_ents, new_fps, fp_index)
+            cluster_fn = lambda rows: _profile_cluster(rows, embedder, fp_texts)  # noqa: E731
+        elif embedder is not None:
+            cluster_fn = lambda rows: _embed_cluster(rows, embedder)  # noqa: E731
+        else:
+            cluster_fn = _gm_cluster
 
     # Combined rows: existing first, then batch. origin maps a row back to its side.
     rows: list[dict] = list(ex_feats) + list(new_feats)
@@ -276,6 +358,281 @@ def _cross_doc_link(
     return linked
 
 
+def _entity_fps(extraction: Extraction, entities, llm) -> dict[int, str]:
+    """One LLM-synthesized fingerprint per RESOLVED entity, keyed by `local_id`.
+
+    `synthesize_node_fingerprints` produces a fingerprint per MENTION; resolve
+    collapses mentions into entities, so each entity takes the fingerprint of its
+    representative member (the mention whose name is the entity's canonical name,
+    else its first member). One LLM call per document."""
+    from .profile import synthesize_node_fingerprints
+
+    mention_fps = synthesize_node_fingerprints(extraction, llm)
+    n_m = len(extraction.mentions)
+    out: dict[int, str] = {}
+    for e in entities:
+        members = list(getattr(e, "member_idx", ()) or ())
+        if not members:
+            continue
+        rep = next(
+            (mi for mi in members
+             if 0 <= mi < n_m and extraction.mentions[mi].name == e.canonical_name),
+            members[0],
+        )
+        if 0 <= rep < len(mention_fps):
+            out[e.local_id] = mention_fps[rep]
+    return out
+
+
+def _name_tokens(row: dict) -> set[str]:
+    """Lowercased name/alias tokens of a feature row -- the blocking key for the
+    incremental linker. A bridge's variant surface forms share at least one token
+    ("Nabbes" in both "Nabbes" and "Thomas Nabbes"), so token-overlap is a
+    recall-safe candidate filter."""
+    text = row.get("surfaces") or row.get("name") or ""
+    return {t for t in text.lower().replace("|", " ").split() if len(t) > 1}
+
+
+class _LinkIndex:
+    """Incremental, blocked index of already-committed entities for cross-document
+    linking. The store-based `_cross_doc_link` rebuilds features for EVERY existing
+    entity each document and hands them all to `resolve_profiles`, which JSON-
+    serializes every existing fingerprint AND its embedding vector per call -- the
+    O(N^2 * dim) marshaling wall that made large-N builds time out. This indexes
+    committed entities by name token, so a document matches its new entities only
+    against the candidate set that shares a token (where bridges live), bounding
+    per-doc work to O(new + candidates) instead of O(all-existing)."""
+
+    def __init__(self):
+        self._rows: list[dict] = []
+        self._keys: list[set[str]] = []
+        self._fps: list[str | None] = []
+        self._types: list[str] = []
+        self._by_token: dict[str, list[int]] = defaultdict(list)
+
+    def candidates(self, new_rows: list[dict]) -> list[int]:
+        idxs: set[int] = set()
+        for r in new_rows:
+            for tok in _name_tokens(r):
+                idxs.update(self._by_token.get(tok, ()))
+        return sorted(idxs)
+
+    def add(self, row: dict, keys: set[str], fp: str | None) -> None:
+        i = len(self._rows)
+        self._rows.append(row)
+        self._keys.append(set(keys))
+        self._fps.append(fp)
+        self._types.append(row.get("type", ""))
+        for tok in _name_tokens(row):
+            self._by_token[tok].append(i)
+
+
+def _cross_doc_link_incremental(batch: dict, *, embedder, new_fps, index: _LinkIndex) -> int:
+    """Profile-link a batch against the incremental `index` (not the whole store):
+    gather candidate existing entities sharing a name token with some new entity,
+    run the goldenprofile matcher over just (candidates + new), inject the matched
+    existing entity's record_keys (same-type guard) so the store's overlap-merge
+    unions them, then add this batch's entities to the index under their
+    (link-augmented) keys. Same merge semantics as `_cross_doc_link`, O(N) total."""
+    new_ents, new_feats = _new_features(batch)
+    if not new_ents:
+        return 0
+    cand = index.candidates(new_feats)
+    linked = 0
+    if cand:
+        ex_feats = [index._rows[i] for i in cand]
+        ex_keys = [index._keys[i] for i in cand]
+        ex_types = [index._types[i] for i in cand]
+        rows = list(ex_feats) + list(new_feats)
+        fp_texts = [index._fps[i] for i in cand] + [
+            (new_fps or {}).get(be.get("local_id")) for be in new_ents
+        ]
+        origin = [("E", i) for i in range(len(ex_feats))] + [
+            ("N", j) for j in range(len(new_feats))
+        ]
+        for members in _profile_cluster(rows, embedder, fp_texts):
+            exist_idx = [origin[m][1] for m in members if origin[m][0] == "E"]
+            new_idx = [origin[m][1] for m in members if origin[m][0] == "N"]
+            if not exist_idx or not new_idx:
+                continue
+            for nj in new_idx:
+                be = new_ents[nj]
+                be_typ = be.get("typ", "")
+                shared: set[str] = set()
+                for ei in exist_idx:
+                    if ex_types[ei] == be_typ:  # same-type guard
+                        shared |= ex_keys[ei]
+                own = set(be.get("record_keys", []))
+                add = shared - own
+                if add:
+                    be["record_keys"] = sorted(own | add)
+                    linked += 1
+    for j, be in enumerate(new_ents):
+        index.add(new_feats[j], set(be.get("record_keys", [])),
+                  (new_fps or {}).get(be.get("local_id")))
+    return linked
+
+
+class _BuildTimers:
+    """Thread-safe accumulator of SUMMED seconds per build sub-step (extract,
+    resolve, fingerprint, link, append). The summed time per step ranks the
+    hotspots; wall ~ summed/concurrency for the parallel prepare steps, serial for
+    commit. Opt-in via `GOLDENGRAPH_BUILD_DEBUG` -- the foundation for measured
+    perf iteration instead of inferring from log-gap timestamps."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.secs: dict[str, float] = defaultdict(float)
+        self.calls: dict[str, int] = defaultdict(int)
+
+    def add(self, key: str, secs: float) -> None:
+        with self._lock:
+            self.secs[key] += secs
+            self.calls[key] += 1
+
+    def report(self, *, wall: float, n_docs: int) -> str:
+        with self._lock:
+            rows = sorted(self.secs.items(), key=lambda kv: -kv[1])
+        lines = [f"[build-debug] {n_docs} docs, wall={wall:.1f}s -- summed time per step:"]
+        for k, s in rows:
+            c = self.calls[k]
+            lines.append(f"  {k:12s} sum={s:8.1f}s  calls={c:6d}  mean={s / max(c, 1) * 1000:7.1f}ms")
+        return "\n".join(lines)
+
+
+class _DistillLogger:
+    """Append-only JSONL capture of (text -> extraction) and (entity -> fingerprint)
+    pairs from a build -- the training data for distilling an in-house extractor /
+    fingerprinter. Opt-in via `GOLDENGRAPH_DISTILL_LOG=<path>`; thread-safe append
+    (the prepare phase is parallel). We already PRODUCE these pairs every build, so
+    capturing them is free."""
+
+    def __init__(self, path: str):
+        self._path = path
+        self._lock = threading.Lock()
+
+    def log(self, text, extraction, new_fps) -> None:
+        rec = {
+            "text": text,
+            "entities": [
+                {"name": m.name, "type": m.typ, "context": getattr(m, "context", "")}
+                for m in extraction.mentions
+            ],
+            "relationships": [
+                {"subj": r.subj, "predicate": r.predicate, "obj": r.obj}
+                for r in extraction.relationships
+            ],
+            "fingerprints": {str(k): v for k, v in (new_fps or {}).items()},
+        }
+        line = json.dumps(rec, ensure_ascii=False)
+        with self._lock:
+            with open(self._path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+
+
+def _resolve_extractor():
+    """Select the document extractor from `GOLDENGRAPH_EXTRACTOR` (default `api` ->
+    the injected LLM extractor). `rebel`/`gliner` load a LOCAL, network-free model
+    once -- the prototype-eval for replacing the per-doc LLM extraction call."""
+    name = os.environ.get("GOLDENGRAPH_EXTRACTOR", "api").strip().lower()
+    if name in ("", "api", "llm"):
+        return None
+    from . import extract_local
+
+    if name == "rebel":
+        return extract_local.rebel_extractor()
+    if name == "gliner":
+        return extract_local.gliner_extractor()
+    raise ValueError(f"unknown GOLDENGRAPH_EXTRACTOR={name!r} (api|rebel|gliner)")
+
+
+def _prepare_doc(
+    text: str, llm: LLMClient, resolver: Resolver | None, *, profile_fps: bool,
+    timers: _BuildTimers | None = None, embedder=None, extractor=None,
+    distill: _DistillLogger | None = None,
+):
+    """The LLM-bound, store-INDEPENDENT half of ingest: extract + resolve (+ the
+    fingerprint-synthesis LLM call when profile-linking). Pure w.r.t. the store, so
+    a corpus's docs can run this concurrently before the serial commit phase --
+    where the per-doc network latency (the build's dominant cost) actually lives.
+    Fail-soft: a doc whose extraction errors yields an empty extraction rather than
+    sinking the whole build.
+
+    When an `embedder` is given, this also WARMS the embedding cache for the new
+    fingerprints here (in the parallel phase) -- profiling showed the serial link
+    phase was dominated by embedding each doc's not-yet-cached fingerprints on the
+    critical path; pre-embedding moves that network cost off the serial path."""
+    try:
+        t0 = time.perf_counter()
+        extraction = (extractor or _extract)(text, llm)
+        if timers:
+            timers.add("extract", time.perf_counter() - t0)
+        t1 = time.perf_counter()
+        entities = (resolver or _resolve)(extraction.mentions)
+        if timers:
+            timers.add("resolve", time.perf_counter() - t1)
+    except Exception:
+        return Extraction(mentions=[], relationships=[]), [], None
+    new_fps: dict[int, str] | None = None
+    if profile_fps:
+        try:
+            t2 = time.perf_counter()
+            new_fps = _entity_fps(extraction, entities, llm)
+            if timers:
+                timers.add("fingerprint", time.perf_counter() - t2)
+        except Exception:
+            new_fps = None
+        if embedder is not None and new_fps:
+            try:
+                t3 = time.perf_counter()
+                embedder.embed(list(new_fps.values()))  # warm the cache in parallel
+                if timers:
+                    timers.add("pre_embed", time.perf_counter() - t3)
+            except Exception:
+                pass
+    if distill is not None:
+        try:
+            distill.log(text, extraction, new_fps)
+        except Exception:
+            pass
+    return extraction, entities, new_fps
+
+
+def _commit_doc(
+    store, extraction, entities, new_fps, *, at, valid_from, embedder, fp_index,
+    link_index: _LinkIndex | None = None, timers: _BuildTimers | None = None,
+) -> None:
+    """The store-BOUND half of ingest (must run serially, in document order):
+    build the batch, cross-document-link, append, and persist this batch's
+    fingerprints under their (link-augmented) record_keys for later docs. With a
+    `link_index` (profile-link path) the cross-doc match runs against the O(N)
+    incremental blocked index instead of re-reading the whole store each doc."""
+    batch = build_batch(extraction, entities, at=at, valid_from=valid_from)
+    if _cross_doc_link_enabled():
+        tl = time.perf_counter()
+        if link_index is not None and _profile_link_enabled():
+            _cross_doc_link_incremental(
+                batch, embedder=embedder, new_fps=new_fps, index=link_index
+            )
+        else:
+            _cross_doc_link(
+                store, batch, at, embedder=embedder, new_fps=new_fps, fp_index=fp_index
+            )
+        if timers:
+            timers.add("link", time.perf_counter() - tl)
+    ta = time.perf_counter()
+    store.append(json.dumps(batch))
+    if timers:
+        timers.add("append", time.perf_counter() - ta)
+    if fp_index is not None and new_fps:
+        for be in batch.get("entities", []):
+            fp = new_fps.get(be.get("local_id"))
+            if not fp:
+                continue
+            for k in be.get("record_keys", []):
+                fp_index.setdefault(k, fp)
+
+
 def ingest(
     text: str,
     store,
@@ -285,15 +642,89 @@ def ingest(
     valid_from: int | None = None,
     resolver: Resolver | None = None,
     embedder=None,
+    fp_index: dict[str, str] | None = None,
 ) -> None:
     """Extract a KG from `text` and append it to `store` (a `PyStore`).
 
     When `GOLDENGRAPH_CROSS_DOC_LINK=1`, links this batch's entities to existing
     store entities before append. An `embedder` (if supplied) selects the
-    name-invariant embedding-threshold matcher; otherwise goldenmatch dedupe."""
-    extraction = _extract(text, llm)
-    entities = (resolver or _resolve)(extraction.mentions)
-    batch = build_batch(extraction, entities, at=at, valid_from=valid_from)
-    if _cross_doc_link_enabled():
-        _cross_doc_link(store, batch, at, embedder=embedder)
-    store.append(json.dumps(batch))
+    name-invariant embedding-threshold matcher; otherwise goldenmatch dedupe. When
+    `GOLDENGRAPH_PROFILE_LINK=1` the goldenprofile engine matches instead, and --
+    given an `llm` and a caller-owned `fp_index` (a persistent `record_key ->
+    fingerprint` map threaded across documents) -- this batch's entities are
+    fingerprinted by the LLM and those fingerprints drive the merge AND are
+    persisted into `fp_index` for later documents to recover."""
+    profile_fps = _cross_doc_link_enabled() and _profile_link_enabled() and llm is not None
+    extraction, entities, new_fps = _prepare_doc(
+        text, llm, resolver, profile_fps=profile_fps
+    )
+    _commit_doc(
+        store, extraction, entities, new_fps,
+        at=at, valid_from=valid_from, embedder=embedder, fp_index=fp_index,
+    )
+
+
+def ingest_corpus(
+    docs,
+    store,
+    *,
+    llm: LLMClient,
+    resolver: Resolver | None = None,
+    embedder=None,
+    fp_index: dict[str, str] | None = None,
+    max_workers: int | None = None,
+) -> None:
+    """Build the KG from an ordered list of document texts.
+
+    The per-doc LLM work (extraction + fingerprint synthesis) is the build's
+    dominant cost and is store-independent, so it runs CONCURRENTLY across docs
+    (network-latency bound -- threads give real overlap); the store mutation
+    (link + append, order-dependent) stays serial in document order, so the result
+    is identical to a sequential build. `max_workers` defaults to
+    `GOLDENGRAPH_BUILD_WORKERS` (8)."""
+    docs = list(docs)
+    if max_workers is None:
+        max_workers = int(os.environ.get("GOLDENGRAPH_BUILD_WORKERS", "8"))
+    profile_link = _cross_doc_link_enabled() and _profile_link_enabled()
+    profile_fps = profile_link and llm is not None
+    # Profile-link uses the O(N) incremental blocked index; other matchers keep the
+    # store-based path. One index per build, mutated only in the serial commit.
+    link_index = _LinkIndex() if profile_link else None
+
+    _dbg = os.environ.get("GOLDENGRAPH_BUILD_DEBUG", "") not in ("", "0", "false")
+    timers = _BuildTimers() if _dbg else None
+    t_wall = time.perf_counter()
+
+    # Optional in-house local extractor (prototype-eval) + distillation-pair capture.
+    extractor = _resolve_extractor()
+    _distill_path = os.environ.get("GOLDENGRAPH_DISTILL_LOG", "")
+    distill = _DistillLogger(_distill_path) if _distill_path else None
+
+    # Pre-warm the embedding cache in the parallel prepare only when profile-linking
+    # actually runs (the serial link is what consumes those embeddings).
+    _prep_embedder = embedder if (profile_link and link_index is not None) else None
+
+    def _prep(text):
+        return _prepare_doc(text, llm, resolver, profile_fps=profile_fps,
+                            timers=timers, embedder=_prep_embedder,
+                            extractor=extractor, distill=distill)
+
+    def _commit(i, prepared):
+        extraction, entities, new_fps = prepared
+        _commit_doc(store, extraction, entities, new_fps, at=i + 1, valid_from=None,
+                    embedder=embedder, fp_index=fp_index, link_index=link_index,
+                    timers=timers)
+
+    if max_workers <= 1 or len(docs) <= 1:
+        for i, t in enumerate(docs):
+            _commit(i, _prep(t))
+    else:
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            # map preserves input order, so the serial commit stays in document order.
+            for i, prepared in enumerate(ex.map(_prep, docs)):
+                _commit(i, prepared)
+
+    if timers is not None:
+        print(timers.report(wall=time.perf_counter() - t_wall, n_docs=len(docs)), flush=True)

--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -40,16 +40,19 @@ _LOCAL_PROMPT = (
     "question. Work it out like this:\n"
     "1. Decompose the question into an ordered chain of sub-questions, where each "
     "sub-question's answer is the subject of the next.\n"
-    "2. Resolve each sub-question against the subgraph in turn. Treat the relationship "
-    "labels as hints, not exact keys -- if no edge matches a sub-question's wording, "
-    "pick the edge whose meaning is closest (the extraction may have phrased the "
-    "relation differently). Follow edges in EITHER direction.\n"
+    "2. START from the anchor entities below (they were retrieved as the most relevant "
+    "to the question), then resolve each sub-question against the subgraph in turn. "
+    "Treat the relationship labels as hints, not exact keys -- if no edge matches a "
+    "sub-question's wording, pick the edge whose meaning is closest (the extraction may "
+    "have phrased the relation differently). Follow edges in EITHER direction.\n"
     "3. Carry the resolved bridge entity forward to the next sub-question until you "
     "reach the final entity.\n"
-    "Show each hop briefly, then end with the final answer entity's name on the last "
-    "line, prefixed 'Answer: '. Give your single best answer even if the chain is "
-    "partly inferred; only say you cannot answer if the relevant entities are entirely "
-    "absent.\n"
+    "Anchor entities: {seeds}\n"
+    "Your final answer is ALWAYS a single entity that appears in the Entities list -- "
+    "output its EXACT name, nothing else, on the last line prefixed 'Answer: '. Commit "
+    "to the single most plausible entity even if an intermediate hop is uncertain; do "
+    "NOT answer with a description, a phrase, or 'cannot answer' unless NOTHING in the "
+    "Entities list is even loosely related. Show each hop briefly first.\n"
     "Question: {q}\n{sub}"
 )
 _MAP_PROMPT = "Summarize this community as it bears on the question.\nQuestion: {q}\n{sub}"
@@ -59,8 +62,20 @@ _REDUCE_PROMPT = (
 )
 
 
-def synthesize_local(query: str, subgraph: dict, llm: LLMClient) -> str:
-    return llm.complete(_LOCAL_PROMPT.format(q=query, sub=_format_subgraph(subgraph)))
+def synthesize_local(
+    query: str, subgraph: dict, llm: LLMClient, *, seed_names: list[str] | None = None
+) -> str:
+    """Synthesize an answer over the retrieved subgraph. `seed_names` are the
+    embedding-retrieved anchor entities most relevant to the query -- handed to the
+    model so it starts the multi-hop walk at the right place instead of guessing
+    among every entity in the ball (the measured SYNTHESIS miss: the answer edge was
+    present but the chain went unwalked)."""
+    seeds = ", ".join(dict.fromkeys(s for s in (seed_names or []) if s)) or (
+        "(none identified -- choose the most relevant entities yourself)"
+    )
+    return llm.complete(
+        _LOCAL_PROMPT.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
+    )
 
 
 def synthesize_global(query: str, community_views: list[dict], llm: LLMClient) -> str:

--- a/packages/python/goldengraph/tests/test_embed_batching.py
+++ b/packages/python/goldengraph/tests/test_embed_batching.py
@@ -1,0 +1,51 @@
+"""GoldenmatchEmbedder must chunk large embed batches under the provider input
+cap -- seed_by_query embeds every entity name in one call, which 400s past a few
+thousand entities (the N>=30 MuSiQue scaling failure). Pure: a stub provider
+records the per-request batch sizes; no network."""
+from __future__ import annotations
+
+import numpy as np
+from goldengraph.embed import _MAX_EMBED_BATCH, GoldenmatchEmbedder
+
+
+class _StubProvider:
+    def __init__(self):
+        self.batch_sizes = []
+
+    def embed(self, texts):
+        self.batch_sizes.append(len(texts))
+        # 2-d vector encoding the index so we can assert order is preserved
+        return np.array([[float(len(t)), 1.0] for t in texts])
+
+
+def _embedder_with(stub):
+    e = GoldenmatchEmbedder()
+    e._provider = stub  # bypass lazy resolve_provider
+    return e
+
+
+def test_large_batch_is_chunked_under_cap():
+    stub = _StubProvider()
+    e = _embedder_with(stub)
+    n = _MAX_EMBED_BATCH * 2 + 5
+    out = e.embed([f"t{i}" for i in range(n)])
+    assert out.shape == (n, 2)
+    # every request stayed at/under the cap, and they sum to n
+    assert all(b <= _MAX_EMBED_BATCH for b in stub.batch_sizes)
+    assert sum(stub.batch_sizes) == n
+    assert len(stub.batch_sizes) == 3  # 1000 + 1000 + 5
+
+
+def test_small_batch_is_one_request():
+    stub = _StubProvider()
+    out = _embedder_with(stub).embed(["a", "bb", "ccc"])
+    assert stub.batch_sizes == [3]
+    # order preserved (first col = len of each text)
+    assert list(out[:, 0]) == [1.0, 2.0, 3.0]
+
+
+def test_empty_is_noop():
+    stub = _StubProvider()
+    out = _embedder_with(stub).embed([])
+    assert out.shape == (0, 0)
+    assert stub.batch_sizes == []

--- a/packages/python/goldengraph/tests/test_extract_local.py
+++ b/packages/python/goldengraph/tests/test_extract_local.py
@@ -1,0 +1,33 @@
+"""Local-extractor prototype: REBEL output decoding + triples->Extraction. Pure
+(no model download), so the parsing contract is locked offline."""
+from __future__ import annotations
+
+from goldengraph.extract_local import parse_rebel_triplets, triplets_to_extraction
+
+
+def test_parse_rebel_triplets_canonical():
+    # REBEL's linearized format for two triples sharing the head "Goldengraph".
+    out = ("<triplet> Goldengraph <subj> Acme <obj> developed by "
+           "<triplet> Acme <subj> Rocket <obj> made")
+    triples = parse_rebel_triplets(out)
+    assert ("Goldengraph", "developed by", "Acme") in triples
+    assert ("Acme", "made", "Rocket") in triples
+
+
+def test_triplets_to_extraction_dedups_entities_and_indexes_rels():
+    triples = [("Nabbes", "wrote", "Play X"), ("Nabbes", "born in", "London")]
+    ext = triplets_to_extraction(triples)
+    names = [m.name for m in ext.mentions]
+    assert names == ["Nabbes", "Play X", "London"]  # Nabbes deduped to one mention
+    assert all(m.typ == "entity" for m in ext.mentions)
+    assert (ext.relationships[0].subj, ext.relationships[0].predicate,
+            ext.relationships[0].obj) == (0, "wrote", 1)
+    assert (ext.relationships[1].subj, ext.relationships[1].obj) == (0, 2)
+
+
+def test_triplets_to_extraction_drops_self_loops_and_empties():
+    triples = [("A", "rel", "A"), ("", "rel", "B"), ("C", "rel", "D")]
+    ext = triplets_to_extraction(triples)
+    # self-loop A->A dropped; empty head dropped; only C->D survives
+    assert len(ext.relationships) == 1
+    assert ext.mentions[ext.relationships[0].subj].name == "C"

--- a/packages/python/goldengraph/tests/test_ingest_cross_doc_link.py
+++ b/packages/python/goldengraph/tests/test_ingest_cross_doc_link.py
@@ -196,3 +196,317 @@ def test_gating_default_off(monkeypatch):
     assert ingest._cross_doc_link_enabled() is True
     monkeypatch.setenv("GOLDENGRAPH_CROSS_DOC_LINK", "0")
     assert ingest._cross_doc_link_enabled() is False
+
+
+# --- goldenprofile anti-shatter matcher (PR #1217 engine) -----------------
+
+def test_profile_link_gating_default_off(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_PROFILE_LINK", raising=False)
+    assert ingest._profile_link_enabled() is False
+    monkeypatch.setenv("GOLDENGRAPH_PROFILE_LINK", "1")
+    assert ingest._profile_link_enabled() is True
+    monkeypatch.setenv("GOLDENGRAPH_PROFILE_LINK", "0")
+    assert ingest._profile_link_enabled() is False
+
+
+def test_profile_cluster_repairs_shatter_but_gates_distinct_names():
+    """The anti-shatter contract on the cross-doc matcher: two mentions of the
+    same entity with DISJOINT neighborhoods reunite (Row-3 under-merge fixed,
+    because the neighborhood lands in the non-vetoing attribute slot), while a
+    distinct entity sharing a relationship never joins (Row-4 over-merge gated by
+    the hard name+category gate). Needs the built engine wheel; skipped offline."""
+    pytest.importorskip("goldenprofile_native")
+    rows = [
+        {"name": "Nabbes", "type": "person", "surfaces": "Nabbes",
+         "rel": "wrote", "nbr": "Play X"},
+        {"name": "Nabbes", "type": "person", "surfaces": "Nabbes",
+         "rel": "born in", "nbr": "1605"},
+        {"name": "Shakespeare", "type": "person", "surfaces": "Shakespeare",
+         "rel": "wrote", "nbr": "Hamlet"},
+    ]
+    clusters = ingest._profile_cluster(rows, embedder=None)
+    assert any(set(c) == {0, 1} for c in clusters), clusters
+    assert all(2 not in c for c in clusters), clusters
+
+
+def test_profile_cluster_trivial_inputs():
+    assert ingest._profile_cluster([], embedder=None) == []
+    assert ingest._profile_cluster([{"name": "A", "type": "t"}], embedder=None) == []
+
+
+# --- LLM-synthesized node fingerprints (full PR #1217 design) --------------
+
+class _StubMention:
+    def __init__(self, name, typ="person", context=""):
+        self.name = name
+        self.typ = typ
+        self.context = context
+
+
+class _StubRel:
+    def __init__(self, subj, predicate, obj):
+        self.subj, self.predicate, self.obj = subj, predicate, obj
+
+
+class _StubExtraction:
+    def __init__(self, mentions, relationships=()):
+        self.mentions = list(mentions)
+        self.relationships = list(relationships)
+
+
+class _StubEntity:
+    def __init__(self, local_id, canonical_name, member_idx, typ="person"):
+        self.local_id = local_id
+        self.canonical_name = canonical_name
+        self.member_idx = list(member_idx)
+        self.typ = typ
+
+
+class _SeqLLM:
+    """Returns a canned fingerprints JSON; records prompts."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.prompts = []
+
+    def complete(self, prompt):
+        self.prompts.append(prompt)
+        return self._payload
+
+
+def test_entity_fps_picks_representative_member_fingerprint():
+    import json as _json
+
+    ext = _StubExtraction(
+        [_StubMention("Nabbes"), _StubMention("Thomas Nabbes"), _StubMention("London", "place")],
+        [_StubRel(0, "born in", 2)],
+    )
+    # entity 0 = {Nabbes, Thomas Nabbes} canonical "Thomas Nabbes"; entity 1 = London
+    entities = [
+        _StubEntity(0, "Thomas Nabbes", [0, 1]),
+        _StubEntity(1, "London", [2], typ="place"),
+    ]
+    payload = _json.dumps({"fingerprints": [
+        "Nabbes | person | UNKNOWN | wrote plays",
+        "Thomas Nabbes | playwright | 1605 | wrote Hannibal and Scipio",
+        "London | place | UNKNOWN | capital",
+    ]})
+    fps = ingest._entity_fps(ext, entities, _SeqLLM(payload))
+    # entity 0's representative is mention 1 (name == canonical "Thomas Nabbes")
+    assert fps[0] == "Thomas Nabbes | playwright | 1605 | wrote Hannibal and Scipio"
+    assert fps[1] == "London | place | UNKNOWN | capital"
+
+
+def test_assemble_fp_texts_recovers_existing_from_index():
+    existing = [{"typ": "person"}, {"typ": "place"}]
+    ex_keys = [{"person|Nabbes"}, {"place|London"}]
+    new_ents = [{"local_id": 7}, {"local_id": 8}]
+    fp_index = {"person|Nabbes": "Nabbes | playwright | 1605 | wrote X"}
+    new_fps = {7: "Nabbes | playwright | UNKNOWN | born 1605"}
+    out = ingest._assemble_fp_texts(existing, ex_keys, new_ents, new_fps, fp_index)
+    assert out == [
+        "Nabbes | playwright | 1605 | wrote X",  # existing 0 recovered from index
+        None,                                     # existing 1 absent from index
+        "Nabbes | playwright | UNKNOWN | born 1605",  # new 7 from new_fps
+        None,                                     # new 8 has no fp
+    ]
+
+
+def test_profile_cluster_honors_supplied_fingerprint_texts():
+    pytest.importorskip("goldenprofile_native")
+    # Two rows the deterministic path could not tell apart by neighborhood, but the
+    # supplied fingerprints share name+category -> the engine merges them; a third
+    # with a distinct name stays apart.
+    rows = [{"name": "x", "type": "person"}, {"name": "y", "type": "person"},
+            {"name": "z", "type": "person"}]
+    fp_texts = [
+        "Nabbes | playwright | 1605 | wrote Hannibal and Scipio",
+        "Nabbes | playwright | UNKNOWN | educated at Exeter College",
+        "Shakespeare | playwright | UNKNOWN | wrote Hamlet",
+    ]
+    clusters = ingest._profile_cluster(rows, embedder=None, fp_texts=fp_texts)
+    assert any(set(c) == {0, 1} for c in clusters), clusters
+    assert all(2 not in c for c in clusters), clusters
+
+
+# --- parallel corpus build (perf: concurrent LLM, serial commit) -----------
+
+class _RecordingStore:
+    """Captures appended batch JSON in commit order."""
+
+    def __init__(self):
+        self.appends = []
+
+    def append(self, payload):
+        import json as _json
+        self.appends.append(_json.loads(payload))
+
+
+def _stub_extraction(name):
+    # one mention, no relationships; resolver below maps it to one entity.
+    from goldengraph.extract import Extraction, Mention
+    return Extraction(mentions=[Mention(name=name, typ="thing")], relationships=[])
+
+
+def test_ingest_corpus_parallel_commits_in_document_order(monkeypatch):
+    # Stub extraction so each doc text -> a one-entity extraction with that name;
+    # resolver maps it through. No LLM, no store linking (cross_doc off).
+    monkeypatch.setattr(ingest, "_extract", lambda text, llm: _stub_extraction(text))
+    _resolve_mod = importlib.import_module("goldengraph.resolve")
+
+    def _resolver(mentions):
+        return [
+            _resolve_mod.ResolvedEntity(
+                local_id=0, canonical_name=mentions[0].name, typ=mentions[0].typ,
+                surface_names=[mentions[0].name],
+                record_keys=[f"{mentions[0].typ}|{mentions[0].name}"], member_idx=[0],
+            )
+        ]
+
+    docs = [f"doc{i}" for i in range(12)]
+    store = _RecordingStore()
+    ingest.ingest_corpus(docs, store, llm=object(), resolver=_resolver, max_workers=4)
+
+    # commit happened once per doc, IN ORDER, with at = i+1
+    assert [a["ingested_at"] for a in store.appends] == list(range(1, 13))
+    assert [a["entities"][0]["canonical_name"] for a in store.appends] == docs
+
+
+def test_ingest_corpus_serial_path_matches(monkeypatch):
+    monkeypatch.setattr(ingest, "_extract", lambda text, llm: _stub_extraction(text))
+    _resolve_mod = importlib.import_module("goldengraph.resolve")
+
+    def _resolver(mentions):
+        return [_resolve_mod.ResolvedEntity(
+            local_id=0, canonical_name=mentions[0].name, typ=mentions[0].typ,
+            surface_names=[mentions[0].name],
+            record_keys=[f"{mentions[0].typ}|{mentions[0].name}"], member_idx=[0])]
+
+    docs = [f"d{i}" for i in range(5)]
+    store = _RecordingStore()
+    ingest.ingest_corpus(docs, store, llm=object(), resolver=_resolver, max_workers=1)
+    assert [a["entities"][0]["canonical_name"] for a in store.appends] == docs
+
+
+# --- incremental blocked link index (O(N) commit phase) --------------------
+
+def test_link_index_blocks_by_name_token():
+    idx = ingest._LinkIndex()
+    idx.add({"name": "Nabbes", "type": "person", "surfaces": "Nabbes"}, {"k1"}, "fp1")
+    idx.add({"name": "London", "type": "place", "surfaces": "London"}, {"k2"}, "fp2")
+    # a new row sharing the 'nabbes' token sees only the Nabbes entry as candidate
+    cand = idx.candidates([{"name": "Thomas Nabbes", "surfaces": "Thomas Nabbes"}])
+    assert cand == [0]
+    # a row sharing no token sees nothing
+    assert idx.candidates([{"name": "Paris", "surfaces": "Paris"}]) == []
+
+
+def test_cross_doc_link_incremental_injects_and_indexes(monkeypatch):
+    # stub matcher: cluster rows sharing their LAST name token (no wheel needed)
+    from collections import defaultdict as _dd
+
+    def _stub(rows, embedder, fp_texts=None):
+        groups = _dd(list)
+        for i, r in enumerate(rows):
+            groups[r["name"].split()[-1].lower()].append(i)
+        return [g for g in groups.values() if len(g) > 1]
+
+    monkeypatch.setattr(ingest, "_profile_cluster", _stub)
+    idx = ingest._LinkIndex()
+    idx.add({"name": "Nabbes", "type": "person", "surfaces": "Nabbes"},
+            {"person|Nabbes"}, "Nabbes | person | UNKNOWN | x")
+
+    batch = {"entities": [_batch_entity(0, "Thomas Nabbes", "person")], "edges": []}
+    linked = ingest._cross_doc_link_incremental(
+        batch, embedder=None, new_fps=None, index=idx
+    )
+    assert linked == 1
+    assert "person|Nabbes" in batch["entities"][0]["record_keys"]  # bridge merged
+    assert len(idx._rows) == 2  # new entity indexed for later docs
+
+
+def test_cross_doc_link_incremental_no_candidates_is_noop(monkeypatch):
+    monkeypatch.setattr(ingest, "_profile_cluster",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("called")))
+    idx = ingest._LinkIndex()
+    idx.add({"name": "Paris", "type": "place", "surfaces": "Paris"}, {"k"}, "fp")
+    batch = {"entities": [_batch_entity(0, "Nabbes", "person")], "edges": []}
+    # no shared token -> matcher never invoked, but the new entity is still indexed
+    assert ingest._cross_doc_link_incremental(batch, embedder=None, new_fps=None, index=idx) == 0
+    assert len(idx._rows) == 2
+
+
+# --- build timing instrumentation (hotspot analysis foundation) ------------
+
+def test_build_timers_ranks_by_summed_time():
+    t = ingest._BuildTimers()
+    t.add("extract", 1.0); t.add("extract", 1.0)
+    t.add("resolve", 0.5)
+    rep = t.report(wall=2.0, n_docs=3)
+    assert "extract" in rep and "resolve" in rep
+    # extract (sum 2.0) ranked above resolve (0.5)
+    assert rep.index("extract") < rep.index("resolve")
+    assert "calls=     2" in rep  # two extract calls counted
+
+
+def test_ingest_corpus_emits_debug_report(monkeypatch, capsys):
+    monkeypatch.setenv("GOLDENGRAPH_BUILD_DEBUG", "1")
+    monkeypatch.setattr(ingest, "_extract", lambda text, llm: _stub_extraction(text))
+    _resolve_mod = importlib.import_module("goldengraph.resolve")
+
+    def _resolver(mentions):
+        return [_resolve_mod.ResolvedEntity(
+            local_id=0, canonical_name=mentions[0].name, typ=mentions[0].typ,
+            surface_names=[mentions[0].name],
+            record_keys=[f"{mentions[0].typ}|{mentions[0].name}"], member_idx=[0])]
+
+    store = _RecordingStore()
+    ingest.ingest_corpus([f"d{i}" for i in range(4)], store, llm=object(),
+                         resolver=_resolver, max_workers=2)
+    out = capsys.readouterr().out
+    assert "[build-debug]" in out
+    assert "extract" in out and "resolve" in out
+
+
+# --- distillation capture + injectable local extractor ---------------------
+
+def test_distill_logger_writes_jsonl(tmp_path):
+    import json as _json
+    p = tmp_path / "distill.jsonl"
+    logger = ingest._DistillLogger(str(p))
+    ext = _stub_extraction("Acme made Rocket")
+    logger.log("Acme made Rocket", ext, {0: "Acme | org | UNKNOWN | maker"})
+    rec = _json.loads(p.read_text().strip())
+    assert rec["text"] == "Acme made Rocket"
+    assert rec["entities"][0]["name"] == "Acme made Rocket"  # stub: one mention
+    assert rec["fingerprints"] == {"0": "Acme | org | UNKNOWN | maker"}
+
+
+def test_resolve_extractor_default_and_unknown(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_EXTRACTOR", raising=False)
+    assert ingest._resolve_extractor() is None  # api default -> module _extract
+    monkeypatch.setenv("GOLDENGRAPH_EXTRACTOR", "api")
+    assert ingest._resolve_extractor() is None
+    monkeypatch.setenv("GOLDENGRAPH_EXTRACTOR", "bogus")
+    import pytest as _pytest
+    with _pytest.raises(ValueError):
+        ingest._resolve_extractor()
+
+
+def test_prepare_doc_uses_injected_extractor():
+    calls = {"n": 0}
+
+    def _stub_extractor(text, llm=None):
+        calls["n"] += 1
+        return _stub_extraction("FROM-LOCAL-" + text)
+
+    def _resolver(mentions):
+        from goldengraph.resolve import ResolvedEntity
+        return [ResolvedEntity(local_id=0, canonical_name=mentions[0].name,
+                               typ=mentions[0].typ, surface_names=[mentions[0].name],
+                               record_keys=["k"], member_idx=[0])]
+
+    ext, ents, _ = ingest._prepare_doc("doc1", llm=object(), resolver=_resolver,
+                                       profile_fps=False, extractor=_stub_extractor)
+    assert calls["n"] == 1
+    assert ext.mentions[0].name == "FROM-LOCAL-doc1"  # the injected extractor ran

--- a/packages/python/goldengraph/tests/test_synthesize_format.py
+++ b/packages/python/goldengraph/tests/test_synthesize_format.py
@@ -41,3 +41,20 @@ def test_local_prompt_instructs_multihop_decomposition():
     assert "sub-question" in prompt.lower()
     assert "Acme -[made]-> Rocket" in prompt
     assert "Answer:" in prompt
+
+
+def test_local_prompt_anchors_on_seed_names():
+    llm = RecordingLLM()
+    synthesize_local("q?", _SUB, llm, seed_names=["Acme", "Acme", "Rocket"])
+    prompt = llm.prompts[-1]
+    # Seeds are surfaced as anchor entities (deduped) so the walk starts at the
+    # query-relevant nodes rather than guessing among the whole ball.
+    assert "Anchor entities: Acme, Rocket" in prompt
+    # And the model is forced to commit to a named entity, not a description.
+    assert "EXACT name" in prompt
+
+
+def test_local_prompt_seed_names_optional():
+    llm = RecordingLLM()
+    synthesize_local("q?", _SUB, llm)
+    assert "Anchor entities:" in llm.prompts[-1]  # falls back to a placeholder line

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -6,10 +6,38 @@ this module for the registry never drags the wheel."""
 from __future__ import annotations
 
 import os
+import random
+import threading
 import time
 from typing import Any
+from urllib.error import HTTPError, URLError
 
 from ..harness import AnswerResult, BuildResult
+
+#: Provider responses worth retrying: rate limit (429) + transient 5xx. A 400 (bad
+#: request) is a real error and is re-raised immediately.
+_RETRY_CODES = {429, 500, 502, 503, 504}
+
+
+def _with_retry(fn, *, attempts: int = 6, base: float = 2.0, cap: float = 45.0):
+    """Run `fn`, retrying rate-limit/transient provider errors with exponential
+    backoff + jitter. This is what lets the build crank concurrency: when the
+    OpenAI account's RPM/TPM is hit, callers back off and re-issue instead of the
+    fail-soft path silently dropping a document's extraction (which would quietly
+    degrade the graph)."""
+    for i in range(attempts):
+        try:
+            return fn()
+        except HTTPError as e:
+            if getattr(e, "code", None) in _RETRY_CODES and i < attempts - 1:
+                time.sleep(min(cap, base**i) + random.random())
+                continue
+            raise
+        except (URLError, TimeoutError):
+            if i < attempts - 1:
+                time.sleep(min(cap, base**i) + random.random())
+                continue
+            raise
 
 #: as-of coordinates large enough to see every appended batch (ingest uses at=i+1).
 _AS_OF = 10**12
@@ -26,6 +54,34 @@ _RETRIEVAL_HOPS = int(os.environ.get("GOLDENGRAPH_QA_RETRIEVAL_HOPS", "4"))
 _WIDE_HOPS = 8
 
 
+class _CachingEmbedder:
+    """Memoizes embeddings by text across the WHOLE run. Two callers re-embed the
+    same texts repeatedly: cross-document linking re-embeds the growing entity set
+    on every document (O(N^2) at build), and `seed_by_query` re-embeds every entity
+    NAME on every question (O(questions x entities) at answer-time). Text -> vector
+    is deterministic, so each distinct text embeds exactly once; later docs/queries
+    hit the cache. Thread-safe so the parallel build can share one instance."""
+
+    def __init__(self, inner: Any):
+        self._inner = inner
+        self._cache: dict[str, Any] = {}
+        self._lock = threading.Lock()
+
+    def embed(self, texts):
+        import numpy as np
+
+        texts = list(texts)
+        with self._lock:
+            missing = list(dict.fromkeys(t for t in texts if t not in self._cache))
+        if missing:
+            vecs = np.asarray(_with_retry(lambda: self._inner.embed(missing)), dtype=float)
+            with self._lock:
+                for t, v in zip(missing, vecs):
+                    self._cache[t] = v
+        with self._lock:
+            return np.asarray([self._cache[t] for t in texts], dtype=float)
+
+
 class _CountingLLM:
     """Wraps any goldengraph LLMClient and estimates token usage per .complete
     call (len//4), so the bench owns cost accounting regardless of the client."""
@@ -34,11 +90,16 @@ class _CountingLLM:
         self._inner = inner
         self.input_tokens = 0
         self.output_tokens = 0
+        self._lock = threading.Lock()
 
     def complete(self, prompt: str) -> str:
-        self.input_tokens += max(1, len(prompt) // 4)
-        out = self._inner.complete(prompt)
-        self.output_tokens += max(1, len(out) // 4)
+        # Concurrent build calls share this wrapper; guard the counters (the inner
+        # OpenAI client is itself thread-safe for concurrent requests). Retry
+        # rate-limit/transient errors so high concurrency doesn't drop documents.
+        out = _with_retry(lambda: self._inner.complete(prompt))
+        with self._lock:
+            self.input_tokens += max(1, len(prompt) // 4)
+            self.output_tokens += max(1, len(out) // 4)
         return out
 
 
@@ -55,24 +116,32 @@ class GoldenGraphQAEngine:
         retrieval_hops: int = _RETRIEVAL_HOPS,
     ):
         self._llm = _CountingLLM(llm)
-        self._embedder = embedder
+        # Cache embeddings across the whole run: the build's cross-doc linking and
+        # answer-time seeding both re-embed the same entity texts many times, which
+        # is the O(N^2) network wall at large N.
+        self._embedder = _CachingEmbedder(embedder)
         self._resolver = resolver  # None -> ingest uses the goldenmatch-backed default
         self._retrieval_hops = retrieval_hops
 
     def build_kg(self, corpus) -> BuildResult:
-        from goldengraph import ingest
+        from goldengraph.ingest import ingest_corpus
         from goldengraph_native import _native as ggn
 
         t0 = time.perf_counter()
         before_in, before_out = self._llm.input_tokens, self._llm.output_tokens
         store = ggn.PyStore()
-        for i, doc in enumerate(corpus.documents):
-            # Pass the embedder so opt-in cross-document linking
-            # (GOLDENGRAPH_CROSS_DOC_LINK=1) uses the name-invariant embedding matcher.
-            ingest(
-                doc.text, store, at=i + 1, llm=self._llm,
-                resolver=self._resolver, embedder=self._embedder,
-            )
+        # Persistent record_key -> LLM-fingerprint map for GOLDENGRAPH_PROFILE_LINK:
+        # carries each entity's fingerprint across documents (the store doesn't), so
+        # a bridge's later appearance can be matched against its earlier fingerprint.
+        fp_index: dict[str, str] = {}
+        # ingest_corpus parallelizes the per-doc LLM work (extraction + fingerprint
+        # synthesis -- the build's dominant, network-bound cost) across documents,
+        # committing to the store serially in document order (identical result). The
+        # shared caching embedder (self._embedder) embeds each entity text once.
+        ingest_corpus(
+            [doc.text for doc in corpus.documents], store, llm=self._llm,
+            resolver=self._resolver, embedder=self._embedder, fp_index=fp_index,
+        )
         handle = {"store": store, "valid_t": _AS_OF, "tx_t": _AS_OF}
         return BuildResult(
             handle=handle,

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_engine_retry.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_engine_retry.py
@@ -1,0 +1,52 @@
+"""The build's LLM/embedder retry: rate-limit/transient errors back off and
+retry (so high concurrency doesn't drop docs); a 400 is a real error, re-raised."""
+from __future__ import annotations
+
+from urllib.error import HTTPError
+
+import pytest
+from erkgbench.qa_e2e.engines.goldengraph import _with_retry
+
+
+def _http(code):
+    return HTTPError("http://x", code, "msg", None, None)
+
+
+def test_retries_429_then_succeeds(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _http(429)
+        return "ok"
+
+    assert _with_retry(fn, attempts=5) == "ok"
+    assert calls["n"] == 3
+
+
+def test_400_is_not_retried(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        raise _http(400)
+
+    with pytest.raises(HTTPError):
+        _with_retry(fn, attempts=5)
+    assert calls["n"] == 1  # gave up immediately
+
+
+def test_gives_up_after_attempts(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        raise _http(503)
+
+    with pytest.raises(HTTPError):
+        _with_retry(fn, attempts=3)
+    assert calls["n"] == 3


### PR DESCRIPTION
## What

Wires the **goldenprofile Semantic Signature / Virtual Fingerprint engine** (PR #1217) into the goldengraph QA build path as the cross-document matcher, and runs it against the MuSiQue multi-hop QA anchor — the eval that PR #1217 explicitly deferred (*"MuSiQue / ER-KG-Bench eval to quantify the shatter repair is not in this PR"*).

This branch carries **both** halves needed to land that eval:
- PR #1217's engine (`goldenprofile-{core,native,wasm,cabi}` + `goldengraph/profile.py`), merged in.
- The goldengraph graph fixes that isolated the failure (hop-clamp 2→8, multi-hop decomposition synthesis prompt, and the **localize trace** instrument that *measures* the shatter), from the cross-doc-linking line.

## Why — the measured problem

The QA-e2e localize trace pins MuSiQue's ~0 `answer_match` to a **shattered graph**: a ~366-entity graph fragments into ~65 disconnected components, and for the answerable questions the gold answer sits in a *different component* than the seeds (`same_component=False`) — the multi-hop chain is physically severed. Latest N=3 trace (synthesis-prompt branch): 2 of 3 questions are RETRIEVAL-BROKEN-CHAIN; the Exeter College prediction even reads *"identify the author first, which is Thomas Nabbes"* (the literal goldenprofile motivating case) but can't complete because the chain is cut.

Cross-doc matchers #1–#5 (naive, goldenmatch zero-config, compound+neighborhood, embedding-threshold) each rode a **single similarity number**, so each landed on one side of the under/over-merge line. No scalar threshold both merges a bridge's disjoint appearances and keeps two same-category entities apart.

## How — route the merge through the anti-shatter scorer

`ingest._profile_cluster` maps each compound feature row to a rigid `name | category | anchor | attribute` fingerprint (name→name, type→category, graph neighborhood `rel`+`nbr`→the **non-vetoing attribute**) and resolves via `goldengraph.profile.resolve_profiles` (SimHash-band blocking + the fusion scorer + WCC), reusing the existing `record_key`-injection merge:

- the **defining attribute** (the per-document neighborhood, which *diverges* across a bridge's mentions) is a positive-only bonus — never a veto → kills the Row-3 under-merge.
- a **hard name + category gate** must pass before any merge, regardless of embedding proximity → kills the Row-4 over-merge.

Selected by `GOLDENGRAPH_PROFILE_LINK=1` (precedence above the embedding matcher); merge threshold via `GOLDENGRAPH_PROFILE_MERGE_THRESHOLD` (engine default 0.72).

## Validation

- Anti-shatter contract locked offline against the built wheel: `test_profile_cluster_repairs_shatter_but_gates_distinct_names` (disjoint-neighborhood Nabbes reunite; Shakespeare stays apart) + gating/trivial-input tests. Full `test_ingest_cross_doc_link.py` green (16).
- `goldenprofile-core` 25/25 and `goldengraph/test_profile.py` 10/10 pass locally with the freshly-built wheel.
- `bench-graphrag-qa.yml` builds `goldenprofile-native` and exposes `profile_link` / `profile_merge_threshold` inputs; the localize trace is the built-in validator (a working merge **collapses components** and flips `same_component` True).

## Deliberate scope / follow-ups

- **Deterministic-fingerprint cut**: the fingerprint is derived from the post-resolve compound row (anchor = UNKNOWN, attribute = neighborhood). LLM-synthesized node fingerprints (a real temporal/spatial anchor + defining attribute, the full PR #1217 design via `synthesize_node_fingerprints`) are the next slice — they need the store to retain per-entity fingerprints across the incremental build.
- Stacked on PR #1217 (its engine) and the cross-doc-linking line (#1215); the diff vs `main` is the engine + graph fixes + this integration.
- CI-matrix wiring + a `publish-goldenprofile-native.yml` for the four new crates remain PR #1217's follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_