### PR TITLE
Brainstorm: multimodal entity resolution (audio/visual)

### DIFF
--- a/context-network/decisions/0022-multimodal-er-perceptual-crawl-tier.md
+++ b/context-network/decisions/0022-multimodal-er-perceptual-crawl-tier.md
@@ -1,0 +1,88 @@
+# 0022 — Multimodal ER: the perceptual crawl tier (perceptual-core)
+
+**Status:** proposed • **Brainstorm:** [../planning/multimodal-er.md](../planning/multimodal-er.md)
+
+## Context
+
+GoldenMatch resolves entities only when they are described in text/structured
+fields, yet an **entity is modality-independent** — the same person/org/product
+appears as a face, a voiceprint, a logo, a product shot. The North Star ("the
+default tool for entity resolution") has no "…as long as it's text" clause, so
+audio/visual is a frontier where reaching for something else is still the easier
+choice.
+
+The brainstorm split "multimodal ER" into three sub-problems and fixed the order:
+**(3) modality-as-evidence** (media as a high-signal *column* on the existing
+record, the wedge), **(1) within-modality ER** (second step), **(2) cross-modal**
+(moonshot). It also established that the **vector spine is already
+modality-agnostic** in-tree (`embeddings/providers.py` `EmbeddingProvider`
+Protocol, `core/ann_blocker.py`, the LSH/SimHash blockers, scorer, explain) — so
+the semantic "walk" tier is mostly the addition of non-text encoder providers, not
+new ER machinery.
+
+This ADR covers **v1 only**: the deterministic *crawl* tier of the wedge.
+
+## Decision
+
+Add an **in-house, deterministic perceptual-hash crawl tier** for **image and
+audio** as the v1 of modality-as-evidence ER. No ML model in the loop; fully
+auditable.
+
+**New pyo3-free `goldenmatch-perceptual-core` crate**, structured like
+`sketch-core` (NOT `fingerprint-core`, which is the unrelated SHA-256 record-id
+canonicalizer): `phash.rs` (DCT-based image perceptual hash), `audio_fp.rs`
+(spectral-landmark audio fingerprint), shared `hash.rs`, `lib.rs`. Exposed on
+Python (pyo3 `native` module + pure-Python fallback) and, where cheap, TS — same
+host/kernel split as `sketch-core` (the kernel computes per-item signatures; the
+host groups buckets via the existing blocking infrastructure).
+
+**In-house = we own the hashing algorithm**, the same posture as `sketch-core`'s
+hand-rolled hash family (no third-party `imagehash`/`pyacoustid` — version skew
+breaks byte-parity). **Format decoding is NOT in the kernel**: the kernel operates
+on *decoded* input (a luma pixel grid for image, mono PCM samples for audio), so
+`perceptual-core` stays codec-free and parity-clean. PNG/JPEG/WAV → samples is a
+thin Python-side adapter (consistent with "the encoder lives upstream"); raw
+decoded input is also a first-class entrypoint (BYO-decoded).
+
+**Parity-by-construction** (the ADR 0020 contract): a Python reference
+(`core/perceptual.py`) is authoritative; golden vectors
+(`tests/fixtures/perceptual_golden.json`) are checked by the Rust crate and the
+Python impl, plus the `GOLDENMATCH_NATIVE=0/1` native↔python sweep. Determinism is
+the whole point of the crawl tier, so output is byte-identical across surfaces.
+
+**Native gating.** The `perceptual` component ships native-available but is NOT in
+`_native_loader._GATED_ON` (the conservative posture shared with `sketch` /
+`pprl_bloom`): reachable via `GOLDENMATCH_NATIVE=1`, default pure-Python under
+`auto`. Output is deterministic, so a default-on flip is a perf/published-wheel
+decision, not an accuracy one.
+
+**Pipeline wiring** (reuses existing seams, no new pipeline stages):
+- **Block** — `strategy="perceptual"` conforming to the `BlockResult` /
+  `BlockingConfig` seam (mirrors `"lsh"`/`"simhash"`): banded hamming-LSH over the
+  hash bits for candidate generation, recall tunable via the band split.
+- **Score** — a hamming-distance comparator emitting a **calibrated** signal +
+  provenance (`"image pHash hamming=3/64"`) so `core/explain.py` shows *why*. The
+  media stays **corroborating** evidence beside auditable text features, never the
+  sole basis — preserving never-black-box without an ML model.
+- **Auto-config** — recognizes a media column (path / bytes / decoded array) and
+  wires the perceptual feature at a sane default threshold (zero-config first run).
+
+**Recall gate.** An always-on synthetic gate (`test_perceptual_recall.py`):
+image re-encode/crop/relight variants and audio re-encode/trim/noise variants must
+re-block to their source above the pinned threshold — mirroring `test_lsh_recall.py`.
+
+## Consequences
+
+- New crate `goldenmatch-perceptual-core` wired into the rust CI lane and the
+  `native` pyo3 module; new blocking `strategy="perceptual"` + `PerceptualKeyConfig`
+  (re-exported); a scorer comparator + provenance; an auto-config media-column rule.
+- **Scale-invariant tension (inherited):** banded hamming-LSH is approximate; the
+  resolution follows the existing text-ANN path's recall-gate posture rather than a
+  new mechanism (noted in the planning doc).
+- **Deferred, explicitly out of v1:** the `[vision]`/`[audio]` encoder extras and
+  the BYO-vector *walk* tier; the biometric template-protection guardrail (the
+  PPRL/Bloom-CLK privacy differentiator); within-modality (#1) and cross-modal (#2).
+- **Rejected:** third-party perceptual-hash libraries (byte-parity / version-skew
+  footgun, and they bury the algorithm we want to keep auditable); putting codec
+  decoding inside the kernel (drags image/audio codec deps into a crate that must
+  stay pyo3-free and parity-clean across surfaces).

--- a/context-network/planning/multimodal-er.md
+++ b/context-network/planning/multimodal-er.md
@@ -101,41 +101,62 @@ So the real v1 surface is **not** "build vector ER." It is:
   direction that builds on existing assets rather than greenfield — potentially the
   thing that makes GM the *default* here specifically.
 
-## Proposed v1 first slice (the wedge, crawl tier)
+## v1 scope (LOCKED 2026-06-23)
 
-Smallest end-to-end value that respects every commitment:
+Decided via brainstorm:
 
-1. A `perceptual` matchkey/blocker family — pHash for an image-path/bytes column,
-   exposed through the existing `BlockingConfig` strategy seam (mirrors how
-   `strategy="lsh"`/`"simhash"` were added, ADR 0020).
-2. A hamming-distance comparator in the scorer, emitting a **calibrated** signal +
-   provenance ("image pHash hamming=3/64") so `explain` can show *why*.
-3. Auto-config recognizes a media column and wires the perceptual feature with a
-   sane default threshold — zero-config first run.
-4. A parity/recall gate (synthetic image set: re-encode/crop/relight variants),
-   mirroring the `test_lsh_recall.py` posture.
+- **Modality:** **image AND audio together**, as an **in-house native kernel**
+  (no third-party perceptual-hash lib — `imagehash`/`pyacoustid` are out; we own
+  the algorithm, the same posture as `sketch-core`'s hand-rolled hash family).
+- **Encoder posture (walk tier, NOT v1):** ship `goldenmatch[vision]`/`[audio]`
+  optional extras that bundle an encoder. Recorded now; no v1 code.
+- **Release contents:** **crawl tier only** — deterministic perceptual hashing,
+  no ML. (Privacy guardrail and BYO-vector walk are fast-follows, not v1.)
 
-This ships modality-as-evidence on text+image with **no model dependency and full
-auditability**, then "walk" reuses the spine by adding non-text providers.
+### v1 build (the wedge, crawl tier)
 
-## Open questions (to steer next)
+1. **New pyo3-free `goldenmatch-perceptual-core` crate**, mirroring `sketch-core`:
+   `phash.rs` (DCT-based image perceptual hash), `audio_fp.rs` (spectral landmark
+   audio fingerprint), shared `hash.rs`, `lib.rs`. NOT `fingerprint-core` — that's
+   the unrelated SHA-256 record-id canonicalizer.
+2. **Kernel operates on *decoded* input** — a luma pixel grid (image) / mono PCM
+   samples (audio) — so the core stays codec-free and parity-clean. Format
+   decoding (PNG/JPEG/WAV→samples) is a thin Python-side adapter, consistent with
+   the "encoder lives upstream" philosophy; BYO-decoded-input also works.
+3. **Parity-by-construction** (ADR 0020 contract): a Python reference
+   (`core/perceptual.py`) is authoritative; golden vectors
+   (`tests/fixtures/perceptual_golden.json`) checked by Rust + Python, plus the
+   `GOLDENMATCH_NATIVE=0/1` parity sweep. Native ships available but NOT in
+   `_native_loader._GATED_ON` (conservative, like `sketch`/`pprl_bloom`).
+4. **Blocking** `strategy="perceptual"` conforming to the `BlockResult` /
+   `BlockingConfig` seam (mirrors `"lsh"`/`"simhash"`): bucket by hash prefix /
+   banded hamming-LSH for candidate generation.
+5. **Comparator** in the scorer: hamming-distance signal + provenance ("image
+   pHash hamming=3/64") so `explain` shows *why* — keeping the never-black-box
+   commitment without an ML model in the loop.
+6. **Auto-config** recognizes a media column (path/bytes/decoded) and wires the
+   perceptual feature with a sane default threshold — zero-config first run.
+7. **Recall gate** (synthetic variant sets: re-encode/crop/relight for image,
+   re-encode/trim/noise for audio), mirroring `test_lsh_recall.py`.
 
-- **v1 modality:** image (pHash) first, or audio (fingerprint) first? Image has the
-  cleaner deterministic primitive.
-- **Encoder posture:** strictly bring-your-own-vectors for "walk," or do we ship
-  `[vision]`/`[audio]` extras that bundle an encoder (zero-config tension vs. wheel
-  size / GPU)?
-- **Scope of v1:** crawl tier only (deterministic, no ML), or crawl + a BYO-vector
-  walk path in the same release?
-- **Privacy line:** do we make biometric template protection a v1 guardrail, or a
-  fast-follow once within-modality (#1) lands?
+This ships modality-as-evidence on text + image + audio with **no model
+dependency and full auditability**; the "walk" tier then reuses the entire
+existing embedding+ANN+score+explain spine via the optional encoder extras.
+
+## Deferred (fast-follows, not v1)
+
+- **Biometric template-protection guardrail** tied to the existing PPRL/Bloom-CLK
+  work (the privacy differentiator) — lands with or just after within-modality ER.
+- **BYO-vector walk path** + the `[vision]`/`[audio]` encoder extras.
+- **Within-modality ER (#1)** and **cross-modal (#2)** per the priority table.
 
 ## Next steps
 
-- [ ] Lock v1 scope (the four open questions above).
+- [x] Lock v1 scope.
 - [ ] Confirm the `BlockingConfig` strategy seam + scorer comparator seam are the
       right insertion points (read `core/blocker.py`, `core/scorer.py`).
-- [ ] Draft ADR 0022 — Multimodal ER (modality-as-evidence) once scope is locked.
+- [ ] Draft ADR 0022 — Multimodal ER (modality-as-evidence, perceptual crawl tier).
+- [ ] Spec the kernel algorithms + parity contract (`docs/superpowers/specs/`).
 
 ---
 **Classification:** planning/active • **Last updated:** 2026-06-23

--- a/context-network/planning/multimodal-er.md
+++ b/context-network/planning/multimodal-er.md
@@ -1,0 +1,141 @@
+# Multimodal Entity Resolution — brainstorm / planning
+
+> **Status:** brainstorm (not yet a decision). Captures the agreed framing and a
+> crawl→walk→run plan for resolving entities that appear in audio/visual form, not
+> just text/structured data. Hardens into an ADR once v1 scope is locked.
+
+## The premise
+
+An **entity is modality-independent**. A person, an organization, a product, a
+place — the *same* entity manifests as a row of text, a face in a photo, a
+voiceprint in a call, a logo, a product shot, a scanned signature. GoldenMatch
+today resolves entities only when they are *described in text/structured fields*.
+The North Star ("the tool any developer reaches for *by default* for entity
+resolution") does not have a "…as long as it's text" clause. Audio/visual is a
+frontier where reaching for something else is still the easier choice — so it is
+exactly the kind of gap the North Star says to close.
+
+## Three problems hiding in "multimodal ER" (agreed priority)
+
+| # | Problem | Shape | Priority |
+|---|---|---|---|
+| **3** | **Modality-as-evidence** — text/structured record stays the canonical entity; an attached photo/recording *contributes match signal*. The media is a high-signal **column**, not a new entity type. | A new feature/comparator on the existing record-linkage pipeline | **THE WEDGE (v1)** |
+| **1** | **Within-modality ER** — dedupe a pile of faces, cluster voiceprints, match logos. "Same pipeline, comparison space is vectors not strings." | Same pipeline, vector blocking + vector comparator | **Natural second step** |
+| **2** | **Cross-modal linkage** — *this voice = this customer row*. No shared comparison space; needs an anchor (transcribe→text ER) or a joint embedding space (CLIP-style). | New: joint/aligned encoders, cross-modal scoring | **Moonshot** |
+
+Rationale for the order: #3 reuses the most existing machinery, has the least
+black-box exposure (modality corroborates auditable text features rather than
+deciding alone), and ships value on day one. #1 is #3 minus the text anchor. #2
+needs aligned encoders we don't have and carries the worst explainability/privacy
+load.
+
+## The architectural key (and why the gap is small)
+
+**GoldenMatch should never "understand" audio or video. It resolves entities
+given `(vector + structured attributes)`.** The encoder lives *upstream* and is
+pluggable — the same posture as `goldenmatch[native]` and the goldenmatch-kg
+drop-in shims. The instant any modality collapses to `(embedding, metadata)`, it
+is the *same ER problem* already solved.
+
+Crucially, **the vector spine already exists and is modality-agnostic** (verified
+in-tree, 2026-06-23):
+
+| Stage | Existing component | Modality-ready? |
+|---|---|---|
+| encode | `embeddings/providers.py` — `EmbeddingProvider` Protocol (`model_id` + `embed(...) -> (n, dim) ndarray`); `NoneProvider` zero-vector zero-config default | **Output contract is vectors** — input type is the only thing text-bound |
+| block | `core/ann_blocker.py` (`ANNBlocker`, FAISS inner-product), `core/simhash_blocker.py`, `core/lsh_blocker.py` | **Already operates on any `np.ndarray`** |
+| score | `core/scorer.py`, `core/cross_encoder.py`, `core/llm_scorer.py` | Comparator family; cosine/IP path exists for embeddings |
+| cluster | graph WCC | Unchanged |
+| golden | survivorship | Exemplar/medoid for a media cluster (new selector) |
+| explain | `core/explain.py`, `core/explainer.py` | Needs vector-match adaptation (see tension below) |
+
+So the real v1 surface is **not** "build vector ER." It is:
+
+1. **Non-text encoder providers** — generalize the `EmbeddingProvider` seam so a
+   provider can take image bytes / audio frames / file paths, not only
+   `list[str]`. Output contract (`(n, dim) ndarray`) is unchanged, so everything
+   downstream just works. Optional extras: `goldenmatch[vision]`, `[audio]`, plus
+   pure **bring-your-own-vectors** (a column already containing embeddings).
+2. **Deterministic perceptual primitives** — the auditable *crawl* tier (below).
+3. **Evidence fusion + provenance** — teach auto-config + the scorer to treat a
+   media column as a first-class feature, and keep per-decision provenance so the
+   match stays explainable.
+4. **Explainability adapted to vectors** — calibrated probability + nearest
+   exemplar, not a raw cosine.
+
+## Crawl → walk → run
+
+- **Crawl — deterministic perceptual primitives (no model, fully auditable).**
+  Perceptual image hashes (pHash/dHash), audio fingerprints (Chromaprint /
+  Shazam-style landmark hashes), simhash. Zero-config, no model download, fast,
+  and **explainable** (hamming distance on a hash you can show). They slot
+  *directly* into the existing matchkey/blocking machinery as "fuzzy hashes" — the
+  same shape as today's matchkeys. This is the highest-fit, lowest-risk start and
+  it sidesteps the black-box problem entirely. **NOT present in-tree today** — this
+  is genuinely new code, but small and self-contained.
+- **Walk — embeddings (bring-your-own / optional extras).** Semantic matching:
+  cropped/re-encoded/relit images, different recordings of one voice. Reuses the
+  *entire* existing embedding+ANN+score+explain spine; the only new code is the
+  non-text providers.
+- **Run — joint cross-modal space.** Selfie↔ID, voice↔record. Aligned encoders,
+  cross-modal calibration. The moonshot (#2).
+
+## North-Star tensions to design *around*
+
+- **"Advanced, never black-box."** Embedding similarity is *the* black box —
+  "cosine 0.91" is not auditable like "surname exact + DOB exact." Mitigations
+  that should *constrain* the design: calibrated probabilities (not raw cosine),
+  nearest-exemplar evidence surfaced, region/segment attribution, and keeping
+  modality as **corroborating** evidence beside auditable text features rather than
+  sole basis. (Another reason #3 is the wedge.) The crawl tier dodges this entirely.
+- **"Correctness must be scale-invariant."** ANN blocking is *approximate by
+  construction* — brute-force-exact on a laptop, HNSW-approximate at 100M ⇒
+  different answers across scales. Head-on collision with a core commitment; needs
+  its own decision (exact-below-N threshold? recall gate parity with the text ANN
+  path?). Note the text ANN path already faces this — inherit its resolution.
+- **Privacy / the PPRL tie-in (a differentiator).** Voiceprints/faceprints are
+  *biometric special-category data* (GDPR/BIPA); clustering them is a compliance
+  surface text ER never had. But biometric template protection / cancelable
+  biometrics is a *sibling* of the PPRL/Bloom-CLK work GoldenMatch **already
+  ships**. "Privacy-preserving cross-modal ER" is a coherent, differentiated
+  direction that builds on existing assets rather than greenfield — potentially the
+  thing that makes GM the *default* here specifically.
+
+## Proposed v1 first slice (the wedge, crawl tier)
+
+Smallest end-to-end value that respects every commitment:
+
+1. A `perceptual` matchkey/blocker family — pHash for an image-path/bytes column,
+   exposed through the existing `BlockingConfig` strategy seam (mirrors how
+   `strategy="lsh"`/`"simhash"` were added, ADR 0020).
+2. A hamming-distance comparator in the scorer, emitting a **calibrated** signal +
+   provenance ("image pHash hamming=3/64") so `explain` can show *why*.
+3. Auto-config recognizes a media column and wires the perceptual feature with a
+   sane default threshold — zero-config first run.
+4. A parity/recall gate (synthetic image set: re-encode/crop/relight variants),
+   mirroring the `test_lsh_recall.py` posture.
+
+This ships modality-as-evidence on text+image with **no model dependency and full
+auditability**, then "walk" reuses the spine by adding non-text providers.
+
+## Open questions (to steer next)
+
+- **v1 modality:** image (pHash) first, or audio (fingerprint) first? Image has the
+  cleaner deterministic primitive.
+- **Encoder posture:** strictly bring-your-own-vectors for "walk," or do we ship
+  `[vision]`/`[audio]` extras that bundle an encoder (zero-config tension vs. wheel
+  size / GPU)?
+- **Scope of v1:** crawl tier only (deterministic, no ML), or crawl + a BYO-vector
+  walk path in the same release?
+- **Privacy line:** do we make biometric template protection a v1 guardrail, or a
+  fast-follow once within-modality (#1) lands?
+
+## Next steps
+
+- [ ] Lock v1 scope (the four open questions above).
+- [ ] Confirm the `BlockingConfig` strategy seam + scorer comparator seam are the
+      right insertion points (read `core/blocker.py`, `core/scorer.py`).
+- [ ] Draft ADR 0022 — Multimodal ER (modality-as-evidence) once scope is locked.
+
+---
+**Classification:** planning/active • **Last updated:** 2026-06-23


### PR DESCRIPTION
## What

A planning/brainstorm note capturing an in-progress design conversation: extending GoldenMatch's entity resolution beyond text/structured data to **audio and visual** forms. The premise is that an entity is modality-independent — the same person/org/product appears as a row of text, a face, a voiceprint, a logo — but GoldenMatch only resolves it when it's described in text.

This is a **brainstorm capture, not a decision** — no code yet. It hardens into an ADR once v1 scope is locked.

## Key contents

- **Three sub-problems, agreed priority:** modality-as-evidence (the wedge / v1), within-modality ER (second step), cross-modal linkage (moonshot).
- **Architectural key:** GoldenMatch resolves `(vector + attributes)`; encoders live upstream and pluggable. Verified in-tree that the **vector spine is already modality-agnostic** — `EmbeddingProvider` Protocol, `ANNBlocker` (FAISS), LSH/SimHash blockers, scorer/explain. So the real gap is narrow: non-text providers, deterministic perceptual-hash primitives, evidence fusion + provenance, vector explainability.
- **Crawl → walk → run:** deterministic perceptual hashes (auditable, no model) → BYO/optional-extra embeddings (reuses the spine) → joint cross-modal space.
- **North-Star tensions:** never-black-box (calibrated probs + exemplars, not raw cosine), scale-invariant ANN approximation, and a biometric-privacy tie-in to the existing PPRL/Bloom-CLK work as a differentiator.
- **Proposed v1 first slice:** a `perceptual` pHash blocker + hamming comparator + auto-config wiring + recall gate — modality-as-evidence on text+image with no model dependency and full auditability.

## Open questions (in the doc)

Image vs. audio first · encoder posture (BYO vs. bundled extras) · v1 = crawl only vs. crawl + BYO-vector walk · whether biometric template protection is a v1 guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p)_