### PR TITLE
feat(retrieval): expose retrieve_similar_records on MCP + A2A + REST (#1089)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Semantic retrieval on the agent surfaces (#1089, epic #1087).** The
+  `retrieve_similar_records` API is now exposed over the wire on all three
+  surfaces: the MCP `retrieve_similar` tool, the A2A `retrieve_similar` skill,
+  and the REST `POST /retrieve` endpoint. Each embeds a column + a free-text
+  query with the zero-config in-house embedder (no cloud/torch by default) and
+  returns the most similar records ranked by cosine similarity, routing through
+  the same core function and `RetrievedRecord` shape. (MCP tool count 59 -> 60;
+  A2A skill count 31 -> 32.)
 - **Corpus-dedup throughput benchmark + per-PR perf gate (#1086, epic #1080).**
   A new `bench-corpus-dedup` harness (`scripts/bench_corpus_dedup/` +
   `.github/workflows/bench-corpus-dedup.yml`) measures the throughput tier (#1083)

--- a/packages/python/goldenmatch/goldenmatch/a2a/server.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/server.py
@@ -251,6 +251,13 @@ _SKILLS = [
         "inputModes": ["application/json"],
         "outputModes": ["application/json"],
     },
+    {
+        "id": "retrieve_similar",
+        "name": "Retrieve Similar",
+        "description": "Semantic retrieval: return the records in a CSV most similar to a free-text query, ranked by cosine similarity (zero-config in-house embedder, no cloud by default).",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
 ]
 
 

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -359,7 +359,7 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
         from goldenmatch.mcp.server import _handle_tool
         return _handle_tool(skill_id, params)
 
-    if skill_id in {"sensitivity", "incremental"}:
+    if skill_id in {"sensitivity", "incremental", "retrieve_similar"}:
         from goldenmatch.mcp.agent_tools import _dispatch as _agent_dispatch
         return _agent_dispatch(skill_id, params, AgentSession)
 

--- a/packages/python/goldenmatch/goldenmatch/api/server.py
+++ b/packages/python/goldenmatch/goldenmatch/api/server.py
@@ -17,6 +17,7 @@ Endpoints:
     POST /shatter             Break a cluster into singletons
     POST /unmerge             Pull a record out of its cluster
     POST /certify-recall      Estimate match recall without ground truth
+    POST /retrieve            Semantic retrieval: records most similar to a query
 """
 
 from __future__ import annotations
@@ -399,6 +400,45 @@ class MatchServer:
             "note": est.note,
         }
 
+    def retrieve_similar(
+        self,
+        query: str,
+        column: str,
+        k: int = 20,
+        threshold: float = 0.0,
+        model: str = "inhouse",
+        filters: dict | None = None,
+    ) -> dict:
+        """Semantic retrieval over the loaded corpus (#1089).
+
+        Returns the loaded records most similar to ``query`` (cosine), ranked
+        highest-first. Embeds ``column`` and the query with the zero-config
+        in-house embedder by default (no cloud/torch). Read-only -- does not
+        touch clustering state.
+        """
+        from goldenmatch.core.retrieval import retrieve_similar_records
+
+        df = getattr(self.engine, "data", None)
+        if df is None:
+            return {"error": "no data loaded"}
+        if column not in df.columns:
+            return {"error": f"column {column!r} not in loaded data (have {df.columns})"}
+        results = retrieve_similar_records(
+            df,
+            query,
+            column,
+            k=k,
+            threshold=threshold,
+            model=model,
+            filters=filters or None,
+        )
+        return {
+            "query": query,
+            "column": column,
+            "count": len(results),
+            "results": [r.as_dict() for r in results],
+        }
+
 
 # Global server instance
 _server_instance: MatchServer | None = None
@@ -562,6 +602,24 @@ class APIHandler(BaseHTTPRequestHandler):
         elif path == "/certify-recall":
             result = _server_instance.certify_recall()
             self._json_response(result, 400 if "error" in result else 200)
+        elif path == "/retrieve":
+            query = data.get("query")
+            column = data.get("column")
+            filters = data.get("filters") or None
+            if not query or not column:
+                self._json_response({"error": "query and column are required"}, 400)
+            elif filters is not None and not isinstance(filters, dict):
+                self._json_response({"error": "filters must be an object"}, 400)
+            else:
+                result = _server_instance.retrieve_similar(
+                    str(query),
+                    str(column),
+                    k=int(data.get("k", 20)),
+                    threshold=float(data.get("threshold", 0.0)),
+                    model=data.get("model") or "inhouse",
+                    filters=filters,
+                )
+                self._json_response(result, 400 if "error" in result else 200)
         else:
             self._json_response({"error": "Not found"}, 404)
 
@@ -634,6 +692,7 @@ def start_server(
     print("   GET  /controller/telemetry Last autoconfig's stop_reason / decisions / NE / priors")
     print("   GET  /reviews             Review queue (steward)")
     print("   POST /reviews/decide      Approve/reject a pair")
+    print("   POST /retrieve            Semantic retrieval by query")
     print("\n   Press Ctrl+C to stop.\n")
 
     try:

--- a/packages/python/goldenmatch/goldenmatch/core/retrieval.py
+++ b/packages/python/goldenmatch/goldenmatch/core/retrieval.py
@@ -12,9 +12,11 @@ with a byte-identical numpy fallback) -- so it adds no new dependency and has
 zero impact on the dedupe/blocking pipeline.
 
 Scope: this is the in-memory retrieval API (embed-then-ANN over the supplied
-frame). A PERSISTENT vector index that survives across runs (#1088) and the
-MCP / A2A / REST surfaces (#1089's exposure half) are follow-ups -- they will
-call this same function / result shape.
+frame). It is exposed over the wire as the MCP ``retrieve_similar`` tool, the
+A2A ``retrieve_similar`` skill, and the REST ``POST /retrieve`` endpoint -- all
+of which call this same function and return its ``RetrievedRecord`` shape. A
+PERSISTENT vector index that survives across runs (#1088) shares the result type
+so a persistent backend is a drop-in for the in-memory path here.
 """
 from __future__ import annotations
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -379,6 +379,42 @@ AGENT_TOOLS = [
             "required": ["file_path"],
         },
     ),
+    Tool(
+        name="retrieve_similar",
+        description=(
+            "Semantic retrieval (#1089): return the records in a CSV most "
+            "similar to a free-text query, ranked by cosine similarity. Embeds "
+            "the chosen column and the query with the zero-config in-house "
+            "embedder (no cloud/torch by default) and runs ANN search. The read "
+            "side of the RAG entity-canonicalization epic -- fetch candidate "
+            "records by query without running a full dedupe."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string", "description": "CSV/Parquet corpus to search"},
+                "query": {"type": "string", "description": "Free-text query to search for"},
+                "column": {"type": "string", "description": "Column of the corpus to embed + search"},
+                "k": {"type": "integer", "description": "Max records to return (default 20)"},
+                "threshold": {
+                    "type": "number",
+                    "description": "Minimum cosine similarity in [-1, 1] (default 0.0)",
+                },
+                "model": {
+                    "type": "string",
+                    "description": (
+                        "Embedder id (default 'inhouse' -- local, deterministic, "
+                        "no cloud/torch). Also 'all-MiniLM-L6-v2', a Vertex/OpenAI model, etc."
+                    ),
+                },
+                "filters": {
+                    "type": "object",
+                    "description": "Optional {column: value} equality pre-filter applied before embedding",
+                },
+            },
+            "required": ["file_path", "query", "column"],
+        },
+    ),
 ]
 
 _AGENT_TOOL_NAMES = frozenset(t.name for t in AGENT_TOOLS)
@@ -823,6 +859,47 @@ def _dispatch(
             "system_overlap": round(est.mean_overlap, 3),
             "estimable": est.estimable,
             "note": est.note,
+        }
+
+    if name == "retrieve_similar":
+        import polars as pl
+
+        from goldenmatch.core.retrieval import retrieve_similar_records
+
+        file_path = args.get("file_path")
+        if not file_path:
+            return {"error": "Missing required parameter: file_path"}
+        query = args.get("query")
+        if not query:
+            return {"error": "Missing required parameter: query"}
+        column = args.get("column")
+        if not column:
+            return {"error": "Missing required parameter: column"}
+
+        try:
+            df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
+        except FileNotFoundError:
+            return {"error": f"File not found: {file_path}"}
+        except Exception as exc:
+            return {"error": f"Could not read CSV '{file_path}': {exc}"}
+        if column not in df.columns:
+            return {"error": f"Column {column!r} not in {file_path} (have {df.columns})"}
+
+        results = retrieve_similar_records(
+            df,
+            str(query),
+            column,
+            k=int(args.get("k", 20)),
+            threshold=float(args.get("threshold", 0.0)),
+            model=args.get("model") or "inhouse",
+            filters=args.get("filters") or None,
+        )
+        return {
+            "file": file_path,
+            "query": query,
+            "column": column,
+            "count": len(results),
+            "results": [r.as_dict() for r in results],
         }
 
     return {"error": f"Unknown agent tool: {name}"}

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1667,7 +1667,7 @@ async def run_server_http(
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenMatch",
-            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 59 MCP tools for matching, explaining, reviewing, evaluating, blocking analysis, config critique, lineage, data quality, transforms, identity graph, distributed-routing config, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
+            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 63 MCP tools for matching, semantic retrieval, explaining, reviewing, evaluating, blocking analysis, config critique, lineage, data quality, transforms, identity graph, distributed-routing config, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
             "homepage": "https://github.com/benseverndev-oss/goldenmatch",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -35,16 +35,18 @@ def test_agent_card_has_required_fields():
     assert card["authentication"]["schemes"] == ["bearer"]
 
 
-def test_agent_card_has_31_skills():
+def test_agent_card_has_32_skills():
     """v1.7-v1.12 added autoconfig+controller_telemetry (10->12); v2.0 added
     six identity_* skills (12->18); v1.19.x Phase 3 added add_correction
-    (18->19); the MCP tool-coverage parity pass added 12 (19->31)."""
+    (18->19); the MCP tool-coverage parity pass added 12 (19->31); #1089 added
+    retrieve_similar (31->32)."""
     from goldenmatch.a2a.server import build_agent_card
 
     card = build_agent_card("http://localhost:8080")
-    assert len(card["skills"]) == 31
+    assert len(card["skills"]) == 32
     ids = {s["id"] for s in card["skills"]}
     assert "autoconfig" in ids
+    assert "retrieve_similar" in ids
     assert "controller_telemetry" in ids
     assert "add_correction" in ids
     assert {

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -16,19 +16,19 @@ import pytest
 # ── Registration ──────────────────────────────────────────────────────────────
 
 
-def test_total_tool_count_is_62():
+def test_total_tool_count_is_63():
     from goldenmatch.mcp.agent_tools import AGENT_TOOLS
     from goldenmatch.mcp.identity_tools import IDENTITY_TOOLS
     from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
     from goldenmatch.mcp.routing_tools import ROUTING_TOOLS
     from goldenmatch.mcp.server import _BASE_TOOLS, TOOLS
 
-    assert len(AGENT_TOOLS) == 17   # +1 certify_recall
+    assert len(AGENT_TOOLS) == 18   # +1 retrieve_similar (#1089)
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 10  # +3 MDM ops (#1114)
     assert len(_BASE_TOOLS) == 25   # +1 config_weaknesses
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 62
+    assert len(TOOLS) == 63
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/packages/python/goldenmatch/tests/test_memory_tools.py
+++ b/packages/python/goldenmatch/tests/test_memory_tools.py
@@ -157,11 +157,11 @@ def test_memory_tools_op_error_returns_structured_error(tmp_path, monkeypatch):
 
 
 def test_server_card_description_count():
-    """server.py description string advertises 59 MCP tools."""
+    """server.py description string advertises 63 MCP tools."""
     server_path = (
         Path(__file__).resolve().parent.parent / "goldenmatch" / "mcp" / "server.py"
     )
     text = server_path.read_text(encoding="utf-8")
     match = re.search(r"(\d+) MCP tools", text)
     assert match is not None
-    assert int(match.group(1)) == 59
+    assert int(match.group(1)) == 63

--- a/packages/python/goldenmatch/tests/test_retrieval_surfaces.py
+++ b/packages/python/goldenmatch/tests/test_retrieval_surfaces.py
@@ -1,0 +1,163 @@
+"""Surface coverage for semantic retrieval (#1089).
+
+``retrieve_similar_records`` (the Python API) is covered in
+``tests/test_retrieval.py``. This file verifies the over-the-wire exposure the
+done-bar requires: the MCP ``retrieve_similar`` tool, the A2A
+``retrieve_similar`` skill, and the REST ``POST /retrieve`` endpoint -- each
+routing through the same core function and returning the ``RetrievedRecord``
+shape. The zero-config in-house embedder keeps these offline (no cloud/torch).
+"""
+from __future__ import annotations
+
+import json
+
+import polars as pl
+import pytest
+
+try:
+    import aiohttp  # noqa: F401  # availability check for the optional [agent] extra
+    HAS_AIOHTTP = True
+except ImportError:
+    HAS_AIOHTTP = False
+
+_ROWS = [
+    {"name": "Acme Corporation", "industry": "tech"},
+    {"name": "Globex Industries", "industry": "manufacturing"},
+    {"name": "Initech Software", "industry": "tech"},
+]
+
+
+@pytest.fixture
+def corpus_csv(tmp_path):
+    path = tmp_path / "corpus.csv"
+    pl.DataFrame(_ROWS).write_csv(path)
+    return str(path)
+
+
+# ── MCP tool ──────────────────────────────────────────────────────────────────
+
+
+def test_mcp_retrieve_similar_ranks_query_match(corpus_csv):
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    out = handle_agent_tool(
+        "retrieve_similar",
+        {"file_path": corpus_csv, "query": "Acme Corporation", "column": "name", "k": 3},
+    )
+    payload = json.loads(out[0].text)
+    assert payload["count"] >= 1
+    assert payload["results"][0]["record"]["name"] == "Acme Corporation"
+    # internal columns are stripped from the returned record
+    assert all(not k.startswith("__") for k in payload["results"][0]["record"])
+
+
+def test_mcp_retrieve_similar_filter_prefilters(corpus_csv):
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    out = handle_agent_tool(
+        "retrieve_similar",
+        {
+            "file_path": corpus_csv,
+            "query": "software",
+            "column": "name",
+            "filters": {"industry": "tech"},
+        },
+    )
+    payload = json.loads(out[0].text)
+    industries = {r["record"]["industry"] for r in payload["results"]}
+    assert industries <= {"tech"}
+
+
+def test_mcp_retrieve_similar_missing_params_error(corpus_csv):
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    out = handle_agent_tool("retrieve_similar", {"file_path": corpus_csv, "column": "name"})
+    assert "error" in json.loads(out[0].text)
+
+
+def test_mcp_retrieve_similar_bad_column_error(corpus_csv):
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    out = handle_agent_tool(
+        "retrieve_similar",
+        {"file_path": corpus_csv, "query": "x", "column": "nope"},
+    )
+    assert "error" in json.loads(out[0].text)
+
+
+def test_mcp_retrieve_similar_file_not_found():
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    out = handle_agent_tool(
+        "retrieve_similar",
+        {"file_path": "/no/such/file.csv", "query": "x", "column": "name"},
+    )
+    assert "error" in json.loads(out[0].text)
+
+
+def test_retrieve_similar_registered_on_mcp_surface():
+    from goldenmatch.mcp.server import TOOLS
+
+    assert "retrieve_similar" in {t.name for t in TOOLS}
+
+
+# ── A2A skill ───────────────────────────────────────────────────────────────
+
+
+def test_a2a_retrieve_similar_skill(corpus_csv):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    result = dispatch_skill(
+        "retrieve_similar",
+        {"file_path": corpus_csv, "query": "Acme Corporation", "column": "name", "k": 3},
+    )
+    assert result["count"] >= 1
+    assert result["results"][0]["record"]["name"] == "Acme Corporation"
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp ([agent] extra) not installed")
+def test_a2a_retrieve_similar_on_agent_card():
+    from goldenmatch.a2a.server import build_agent_card
+
+    ids = {s["id"] for s in build_agent_card("http://localhost:8080")["skills"]}
+    assert "retrieve_similar" in ids
+
+
+# ── REST endpoint ───────────────────────────────────────────────────────────
+
+
+class _StubEngine:
+    """Minimal engine stand-in: the REST retrieve path only reads ``.data``."""
+
+    def __init__(self, df: pl.DataFrame):
+        self.data = df
+
+
+def _make_server():
+    from goldenmatch.api.server import MatchServer
+
+    df = pl.DataFrame(_ROWS).with_row_index("__row_id__")
+    return MatchServer(_StubEngine(df), config=None)  # type: ignore[arg-type]
+
+
+def test_rest_retrieve_similar_ranks_and_passes_row_id():
+    server = _make_server()
+    result = server.retrieve_similar("Acme Corporation", "name", k=3)
+    assert result["count"] >= 1
+    top = result["results"][0]
+    assert top["record"]["name"] == "Acme Corporation"
+    # row_id is threaded through from the loaded frame's __row_id__
+    assert top["row_id"] == 0
+
+
+def test_rest_retrieve_similar_bad_column():
+    server = _make_server()
+    result = server.retrieve_similar("x", "nope")
+    assert "error" in result
+
+
+def test_rest_retrieve_similar_filters():
+    server = _make_server()
+    result = server.retrieve_similar("software", "name", filters={"industry": "tech"})
+    industries = {r["record"]["industry"] for r in result["results"]}
+    assert industries <= {"tech"}


### PR DESCRIPTION
## What

Closes the exposure half of **#1089** (epic #1087, RAG entity canonicalization). The semantic retrieval API `retrieve_similar_records` already existed in Python (`core/retrieval.py`, 11 tests) but was reachable on **none** of the agent surfaces. This wires it onto all three, each routing through the same core function and returning the shared `RetrievedRecord` shape.

| Surface | Added | Notes |
|---|---|---|
| **MCP** | `retrieve_similar` tool | `mcp/agent_tools.py` tool def + `_dispatch` branch |
| **A2A** | `retrieve_similar` skill | `a2a/server.py` card entry + `a2a/skills.py` dispatch (reuses the agent `_dispatch`, same pattern as `sensitivity`/`incremental`) |
| **REST** | `POST /retrieve` | `api/server.py` `MatchServer.retrieve_similar` over the loaded corpus |

Each embeds the chosen column + a free-text query with the **zero-config in-house embedder** (NumPy, no cloud/torch by default) and returns the most similar records ranked by cosine similarity. The MCP/A2A tools read a CSV path; the REST endpoint retrieves over the server's already-loaded data.

## Why this is small

This is pure wiring — no new retrieval logic, no new dependency, zero impact on the dedupe/blocking pipeline. It surfaced from an audit of the RAG epic that found the code was ahead of the issues: the Python API and its tests already shipped; only the over-the-wire surfaces were missing from #1089's done-bar.

## Count bookkeeping (rebased onto main @ #1114)

This branch was rebased over the MDM-ops PR (#1114), which took the MCP tool count to 62. After `retrieve_similar`:
- **MCP tools: 62 → 63** (`AGENT_TOOLS` 17 → 18; `IDENTITY_TOOLS` stays 10).
- **A2A skills: 31 → 32.**
- The server-card description string was **corrected 59 → 63** (main had left it at 59 — a pre-existing undercount; now it matches the real total).

## Validation

- New `tests/test_retrieval_surfaces.py` — ranking, metadata pre-filter, error paths (missing params / bad column / file-not-found), and registration on each surface (MCP tool list, A2A agent card, REST method incl. `__row_id__` passthrough).
- Count assertions synced: `test_mcp_new_tools` (`TOOLS` 62 → 63), `test_memory_tools` server-card count (59 → 63), `test_a2a` (31 → 32).
- All affected suites pass locally (RAG + MCP/A2A/REST); `ruff` clean (E9/F63/F7/F82/F401).
- CHANGELOG `[Unreleased]` noted.

## Follow-ups (still open on #1089's siblings)

- #1088 — pgvector + DuckDB-HNSW backends behind `VectorIndex`.
- #1090 — flip auto-enabled semantic blocking default-on + expose the recall threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA