### PR TITLE
fix(goldengraph): return the parsed Answer: line, not the full chain-of-thought

### DIFF
--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -62,6 +62,29 @@ _REDUCE_PROMPT = (
 )
 
 
+def _extract_answer(text: str) -> str:
+    """Pull the final answer out of a chain-of-thought completion.
+
+    `_LOCAL_PROMPT` tells the model to show each hop first, then put the final
+    answer on the last line prefixed ``Answer: ``. Returning the raw completion
+    therefore led with the decomposition scaffold, so the bench scored the gold
+    answer against the reasoning text instead of the answer (2026-06-23 MuSiQue
+    trace: ``pred='1. What system did Knight Rider come out on? 2. ...'``).
+
+    Take the text after the last ``Answer:`` marker (first line of it); fall back
+    to the last non-empty line, then to the stripped completion."""
+    if not text or not text.strip():
+        return text
+    idx = text.lower().rfind("answer:")
+    if idx != -1:
+        tail = text[idx + len("answer:"):].lstrip()
+        first = tail.splitlines()[0].strip() if tail else ""
+        if first:
+            return first
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    return lines[-1] if lines else text.strip()
+
+
 def synthesize_local(
     query: str, subgraph: dict, llm: LLMClient, *, seed_names: list[str] | None = None
 ) -> str:
@@ -69,12 +92,17 @@ def synthesize_local(
     embedding-retrieved anchor entities most relevant to the query -- handed to the
     model so it starts the multi-hop walk at the right place instead of guessing
     among every entity in the ball (the measured SYNTHESIS miss: the answer edge was
-    present but the chain went unwalked)."""
+    present but the chain went unwalked).
+
+    Returns the parsed final answer (the ``Answer:`` line), NOT the model's full
+    chain-of-thought -- see `_extract_answer`."""
     seeds = ", ".join(dict.fromkeys(s for s in (seed_names or []) if s)) or (
         "(none identified -- choose the most relevant entities yourself)"
     )
-    return llm.complete(
-        _LOCAL_PROMPT.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
+    return _extract_answer(
+        llm.complete(
+            _LOCAL_PROMPT.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
+        )
     )
 
 

--- a/packages/python/goldengraph/tests/test_synthesize_format.py
+++ b/packages/python/goldengraph/tests/test_synthesize_format.py
@@ -11,8 +11,8 @@ forward. These pure (no native, no LLM) tests pin the new contract: edges read a
 
 from __future__ import annotations
 
-from goldengraph.synthesize import _format_subgraph, synthesize_local
-from conftest import RecordingLLM
+from goldengraph.synthesize import _extract_answer, _format_subgraph, synthesize_local
+from conftest import RecordingLLM, StubLLM
 
 _SUB = {
     "entities": [
@@ -58,3 +58,35 @@ def test_local_prompt_seed_names_optional():
     llm = RecordingLLM()
     synthesize_local("q?", _SUB, llm)
     assert "Anchor entities:" in llm.prompts[-1]  # falls back to a placeholder line
+
+
+# --- output parsing: the prediction is the Answer: line, not the scaffold ---
+
+
+def test_extract_answer_pulls_the_answer_line_off_the_chain_of_thought():
+    cot = (
+        "1. What system did Knight Rider come out on? -> Sega Genesis\n"
+        "2. What advantages did it have? -> 16-bit graphics\n"
+        "Answer: Sega Genesis"
+    )
+    assert _extract_answer(cot) == "Sega Genesis"
+
+
+def test_extract_answer_falls_back_to_last_nonempty_line_without_marker():
+    assert _extract_answer("hop one\nhop two\nExeter College\n") == "Exeter College"
+
+
+def test_extract_answer_is_case_insensitive_and_strips():
+    assert _extract_answer("reasoning...\nanswer:   the Politburo  ") == "the Politburo"
+
+
+def test_extract_answer_handles_empty():
+    assert _extract_answer("") == ""
+    assert _extract_answer("   ") == "   "
+
+
+def test_synthesize_local_returns_parsed_answer_not_full_completion():
+    # The whole point of the 2026-06-23 fix: the bench must see "Sega Genesis",
+    # not the "1. ... 2. ..." decomposition scaffold that capped answer_match at 0.
+    llm = StubLLM("1. sub-q one\n2. sub-q two\nAnswer: Sega Genesis")
+    assert synthesize_local("q?", _SUB, llm) == "Sega Genesis"


### PR DESCRIPTION
## Why

The first real MuSiQue validation run (`bench-graphrag-qa`, N=3, gpt-4o-mini, with the merged anti-shatter engine on `main`) scored `answer_match=0.0` — and the localize trace showed why on the **SYNTHESIS** case: the chain was retrieved (`Mao -[reported to]-> Politburo` was in the ball, `same_component=True`), but the prediction came back as the model's reasoning scaffold:

```
pred="1. What system did Knight Rider come out on? 2. What is the successor to the
Nintendo Entertainment System? 3. ..."
```

`_LOCAL_PROMPT` deliberately asks the model to "show each hop briefly first" and put the final answer "on the last line prefixed `Answer: `". But `synthesize_local` returned the **raw completion**, so the bench scored the gold answer against the chain-of-thought decomposition instead of the answer — capping `answer_match` at 0 independent of whether retrieval succeeded.

## What

- Add `_extract_answer(text)`: take the text after the last `Answer:` marker (its first line); fall back to the last non-empty line, then the stripped completion.
- Apply it in `synthesize_local` so the returned prediction is the parsed answer, not the scaffold. `synthesize_global` (map-reduce, no `Answer:` contract) is unchanged.

## Validation

- 5 new native-free, LLM-free tests in `test_synthesize_format.py` pin the contract: marker extraction, no-marker fallback, case-insensitivity/stripping, empty input, and that `synthesize_local` returns `"Sega Genesis"` not the `"1. ... 2. ..."` scaffold. Full file green (9/9).

## Note / scope

This is one of the two losses the MuSiQue trace localized. The other — the **RETRIEVAL-BROKEN-CHAIN** shatter (Exeter College still in a separate component from its seeds; 65 components uncollapsed even with `profile_link=1`) — is **not** addressed here; that's the deterministic-fingerprint limitation #1218 flagged as "the next slice," and an A/B trace run is measuring it separately.

Because this makes scoring stricter (the gold answer can no longer match incidentally inside the reasoning text), the engineered headline (`answer_match≈0.174`) should be **re-measured** — the prior number was over the full CoT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_