### PR TITLE
Add unified offline metrics harness (accuracy + perf, baseline-gated)

### DIFF
--- a/.github/workflows/bench-metrics.yml
+++ b/.github/workflows/bench-metrics.yml
@@ -1,0 +1,66 @@
+name: bench-metrics
+
+# Unified metrics harness (scripts/metrics/harness.py): the offline core --
+# synthetic accuracy (F1 / precision / recall) + perf (wall, peak RSS,
+# throughput, deterministic counts) in one run, diffed against the committed
+# baseline (scripts/metrics/baseline.json).
+#
+# Posture (v1): local-iteration tool + dispatch/scheduled run. NOT a blocking
+# per-PR gate -- the report is informational by default and posted to the job
+# summary. Opt into a hard regression check with the `check` input. Fully
+# offline (no datasets, no Postgres, no API keys), so it runs on forks too.
+on:
+  schedule:
+    # Weekly, so trend data accrues. Tuesdays 06:00 UTC (offset from the heavy
+    # `benchmarks` workflow on Mondays).
+    - cron: "0 6 * * 2"
+  workflow_dispatch:
+    inputs:
+      check:
+        description: "Fail the run on a gated metric regression vs the committed baseline"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  metrics:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/python/goldenmatch
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Install
+        run: uv sync --all-packages
+
+      - name: Run metrics harness
+        env:
+          # Reproducible: explicit-config probes don't use auto-config memory,
+          # but pin it off for good measure.
+          GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+          CHECK: ${{ inputs.check && '--check' || '' }}
+        run: |
+          uv run python scripts/metrics/harness.py \
+            --out metrics_report.json \
+            --md "$GITHUB_STEP_SUMMARY" \
+            $CHECK
+
+      - name: Upload metrics report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: metrics-report
+          path: packages/python/goldenmatch/metrics_report.json
+          retention-days: 90

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -23,6 +23,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   fallback when the native wheel is absent.
 
 ### Added
+- **Unified offline metrics harness (`scripts/metrics/harness.py`).** One entry
+  point that runs the accuracy + perf probes in a single pass and diffs them
+  against a committed baseline (`scripts/metrics/baseline.json`): synthetic
+  labeled-data accuracy (F1 / precision / recall via `evaluate_clusters`) plus
+  perf (wall, peak RSS, throughput, deterministic scored-pair / cluster counts
+  via `bench_capture`). Accuracy metrics and deterministic counts are *gated*
+  (a regression past tolerance fails `--check`); wall/RSS/throughput are
+  environment-dependent and reported *informationally*. Fully offline (no
+  datasets, Postgres, or API keys) so it runs on forks. Driven locally
+  (`--check` / `--update-baseline`) and by the new `bench-metrics` workflow
+  (weekly + `workflow_dispatch`, informational by default). First rung of the
+  metrics-iteration infra for accuracy/perf work.
 - **Pluggable vector-index backends: pgvector + DuckDB-HNSW (#1088, epic #1087).**
   The persistent vector index gained two storage backends behind the existing
   `VectorIndex` surface (`build` / `add` / `query` / `save` / `load` / `open`,

--- a/packages/python/goldenmatch/scripts/metrics/__init__.py
+++ b/packages/python/goldenmatch/scripts/metrics/__init__.py
@@ -1,0 +1,1 @@
+# GoldenMatch unified metrics harness (offline core).

--- a/packages/python/goldenmatch/scripts/metrics/baseline.json
+++ b/packages/python/goldenmatch/scripts/metrics/baseline.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "updated_at": "2026-06-23T15:21:30Z",
+  "metrics": {
+    "accuracy_synthetic.f1": {
+      "value": 0.8456,
+      "tol": 0.02,
+      "higher_better": true,
+      "two_sided": false,
+      "gated": true
+    },
+    "accuracy_synthetic.precision": {
+      "value": 1.0,
+      "tol": 0.02,
+      "higher_better": true,
+      "two_sided": false,
+      "gated": true
+    },
+    "accuracy_synthetic.recall": {
+      "value": 0.7326,
+      "tol": 0.02,
+      "higher_better": true,
+      "two_sided": false,
+      "gated": true
+    },
+    "perf_synthetic.wall_s": {
+      "value": 2.8687,
+      "tol": 9000000000.0,
+      "higher_better": false,
+      "two_sided": false,
+      "gated": false
+    },
+    "perf_synthetic.peak_rss_mb": {
+      "value": 206.5,
+      "tol": 9000000000.0,
+      "higher_better": false,
+      "two_sided": false,
+      "gated": false
+    },
+    "perf_synthetic.records_per_s": {
+      "value": 911.2,
+      "tol": 9000000000.0,
+      "higher_better": true,
+      "two_sided": false,
+      "gated": false
+    },
+    "perf_synthetic.scored_pairs": {
+      "value": 1011.0,
+      "tol": 0.0,
+      "higher_better": false,
+      "two_sided": true,
+      "gated": true
+    },
+    "perf_synthetic.multi_member_clusters": {
+      "value": 713.0,
+      "tol": 0.0,
+      "higher_better": false,
+      "two_sided": true,
+      "gated": true
+    }
+  }
+}

--- a/packages/python/goldenmatch/scripts/metrics/harness.py
+++ b/packages/python/goldenmatch/scripts/metrics/harness.py
@@ -1,0 +1,481 @@
+"""Unified metrics harness -- one command for the metrics that matter.
+
+Runs a suite of offline, deterministic **probes** (accuracy: F1 / precision /
+recall on labeled synthetic data; performance: wall, peak RSS, throughput, stage
+timings) and writes a single structured report. Diffs the report against a
+committed baseline (``baseline.json``) with per-metric tolerances so you can see,
+in one command, whether a code change moved a metric.
+
+Why this exists: the repo's metrics machinery is sophisticated but fragmented
+(``run_benchmarks.py``, ``scale_audit*.py``, ``core/bench.py``, the FS panel) --
+there was no single "run the numbers and tell me if I regressed" entry point and
+no committed accuracy baseline. This is the offline core: synthetic accuracy +
+perf that runs anywhere (no downloads, no Postgres, no API keys), so it's a
+local-iteration tool today and a CI regression gate tomorrow. The download/key-
+gated real datasets (DBLP-ACM, NCVR, DQbench) plug in as additional probes.
+
+Usage::
+
+    python scripts/metrics/harness.py                  # run + print summary
+    python scripts/metrics/harness.py --out report.json --md summary.md
+    python scripts/metrics/harness.py --check          # diff vs baseline (exit 1 on gated regression)
+    python scripts/metrics/harness.py --update-baseline # re-snapshot the baseline from a fresh run
+
+Determinism: the synthetic generator is seeded and the probes use an EXPLICIT
+config (not nondeterministic zero-config auto-config), so accuracy metrics +
+deterministic counts are stable run-to-run. Wall/RSS are machine-dependent and
+recorded as informational (not gated).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import resource
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_HERE = Path(__file__).resolve().parent
+_BASELINE_PATH = _HERE / "baseline.json"
+_SCHEMA = 1
+
+
+# ── synthetic labeled data (deterministic, seeded, with ground truth) ─────────
+
+
+def make_labeled(
+    n_entities: int, *, seed: int = 7, dup_rate: float = 0.55
+) -> tuple[list[dict[str, Any]], set[tuple[int, int]]]:
+    """Build a labeled person dataset: each entity gets a clean row plus 0-2 messy
+    duplicate variants. Returns ``(rows, ground_truth_pairs)`` where pairs are
+    ``(min_pos, max_pos)`` over row POSITIONS (which become ``__row_id__``).
+
+    Deterministic for a fixed ``seed`` -- so F1 and the row/pair counts are
+    stable. The messiness (case / typo / whitespace, occasional email noise)
+    exercises both the exact-email and the fuzzy-name matchkey.
+    """
+    import random
+
+    rng = random.Random(seed)
+    firsts = ["james", "mary", "john", "patricia", "robert", "jennifer", "michael",
+              "linda", "william", "elizabeth", "david", "barbara", "richard", "susan",
+              "joseph", "jessica", "thomas", "sarah", "charles", "karen", "daniel",
+              "nancy", "matthew", "lisa", "anthony", "betty", "mark", "sandra",
+              "donald", "ashley", "steven", "kimberly", "paul", "donna", "andrew",
+              "carol", "joshua", "michelle", "kenneth", "amanda"]
+    lasts = ["smith", "johnson", "williams", "brown", "jones", "garcia", "miller",
+             "davis", "rodriguez", "martinez", "hernandez", "lopez", "wilson",
+             "anderson", "thomas", "taylor", "moore", "jackson", "martin", "lee",
+             "perez", "thompson", "white", "harris", "sanchez", "clark", "ramirez",
+             "lewis", "robinson", "walker", "young", "allen", "king", "wright",
+             "scott", "torres", "nguyen", "hill", "flores", "green"]
+    cities = ["austin", "denver", "seattle", "boston", "miami", "chicago"]
+
+    # Assign each entity a DISTINCT (first, last) so two different entities never
+    # collide on name -- otherwise fuzzy-name would falsely merge same-name
+    # strangers and tank precision. The combinatorial space (40x40=1600) must
+    # exceed n_entities.
+    combos = [(f, ln) for f in firsts for ln in lasts]
+    if n_entities > len(combos):
+        raise ValueError(f"make_labeled: n_entities {n_entities} exceeds {len(combos)} unique name combos")
+    rng.shuffle(combos)
+    names = combos[:n_entities]
+
+    def _typo(s: str) -> str:
+        if len(s) < 3:
+            return s
+        i = rng.randrange(1, len(s) - 1)
+        return s[:i] + rng.choice("abcdefghijklmnopqrstuvwxyz") + s[i + 1:]
+
+    def _mess(s: str) -> str:
+        kind = rng.choice(["case", "typo", "ws", "case"])
+        if kind == "case":
+            return rng.choice([s.upper(), s.title(), s])
+        if kind == "typo":
+            return _typo(s)
+        return rng.choice([" " + s, s + " ", "  " + s])
+
+    rows: list[dict[str, Any]] = []
+    entity_of: list[int] = []
+    for e in range(n_entities):
+        fn, ln = names[e]
+        email = f"{fn}.{ln}{rng.randrange(1000)}@example.com"
+        phone = f"{rng.randint(200, 999)}-{rng.randint(100, 999)}-{rng.randint(1000, 9999)}"
+        zipc = f"{rng.randint(10000, 99999)}"
+        city = rng.choice(cities)
+        base = {"first_name": fn, "last_name": ln, "email": email,
+                "phone": phone, "zip": zipc, "city": city}
+        rows.append(dict(base)); entity_of.append(e)
+        # duplicates
+        n_dupes = rng.choices([0, 1, 2], weights=[1 - dup_rate, dup_rate * 0.7, dup_rate * 0.3])[0]
+        for _ in range(n_dupes):
+            d = dict(base)
+            d["first_name"] = _mess(fn)
+            d["last_name"] = _mess(ln)
+            # ~25% of dupes have a noised email so exact-email alone can't catch them
+            if rng.random() < 0.25:
+                d["email"] = email.replace("@", " @ ")
+            rows.append(d); entity_of.append(e)
+
+    # shuffle so duplicates aren't adjacent (position == __row_id__ after shuffle)
+    order = list(range(len(rows)))
+    rng.shuffle(order)
+    rows = [rows[i] for i in order]
+    entity_of = [entity_of[i] for i in order]
+
+    by_entity: dict[int, list[int]] = {}
+    for pos, e in enumerate(entity_of):
+        by_entity.setdefault(e, []).append(pos)
+    gt: set[tuple[int, int]] = set()
+    for members in by_entity.values():
+        members.sort()
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                gt.add((members[i], members[j]))
+    return rows, gt
+
+
+def _dedupe(rows: list[dict[str, Any]]):
+    """Run dedupe with an EXPLICIT, fixed config (deterministic; avoids zero-config
+    auto-config nondeterminism). Exact-email OR fuzzy first+last name."""
+    import polars as pl
+    from goldenmatch import dedupe_df
+
+    df = pl.DataFrame(rows)
+    return dedupe_df(
+        df,
+        exact=["email"],
+        fuzzy={"first_name": 0.88, "last_name": 0.88},
+        confidence_required=False,
+    )
+
+
+# ── probes ───────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ProbeOutcome:
+    group: str
+    metrics: dict[str, float]
+    meta: dict[str, Any] = field(default_factory=dict)
+    elapsed_s: float = 0.0
+    error: str | None = None
+
+
+def probe_accuracy() -> ProbeOutcome:
+    """F1 / precision / recall on a labeled synthetic dedupe (fixed seed + config)."""
+    from goldenmatch import evaluate_clusters
+
+    rows, gt = make_labeled(n_entities=400, seed=7)
+    res = _dedupe(rows)
+    clusters = res.clusters or {}
+    ev = evaluate_clusters(clusters, gt)
+    return ProbeOutcome(
+        group="accuracy",
+        metrics={
+            "f1": round(ev.f1, 4),
+            "precision": round(ev.precision, 4),
+            "recall": round(ev.recall, 4),
+        },
+        meta={"n_rows": len(rows), "gt_pairs": len(gt),
+              "tp": ev.tp, "fp": ev.fp, "fn": ev.fn},
+    )
+
+
+def probe_perf(n_entities: int = 1500) -> ProbeOutcome:
+    """Wall / peak RSS / throughput + stage timings on synthetic data of ~``n_entities``
+    entities. Wall/RSS are machine-dependent (informational); counts are deterministic."""
+    from goldenmatch.core.bench import bench_capture
+
+    rows, _ = make_labeled(n_entities=n_entities, seed=11)
+    t0 = time.perf_counter()
+    with bench_capture() as rec:
+        res = _dedupe(rows)
+    wall = time.perf_counter() - t0
+    peak_rss_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0  # Linux: KB
+
+    bench = rec.to_dict() if hasattr(rec, "to_dict") else {}
+    bm = bench.get("metrics", {}) if isinstance(bench, dict) else {}
+    clusters = res.clusters or {}
+    multi = sum(1 for c in clusters.values() if c.get("size", 0) > 1)
+    metrics = {
+        "wall_s": round(wall, 4),
+        "peak_rss_mb": round(peak_rss_mb, 1),
+        "records_per_s": round(len(rows) / wall, 1) if wall else 0.0,
+        "scored_pairs": int(bm.get("scored_pair_count", 0) or 0),
+        "multi_member_clusters": multi,
+    }
+    return ProbeOutcome(
+        group="perf",
+        metrics=metrics,
+        meta={"n_rows": len(rows), "stage_timings_s": bench.get("stage_timings_seconds", {})},
+    )
+
+
+PROBES: dict[str, Callable[[], ProbeOutcome]] = {
+    "accuracy_synthetic": probe_accuracy,
+    "perf_synthetic": probe_perf,
+}
+
+
+# ── report assembly ───────────────────────────────────────────────────────────
+
+
+def _git_info() -> dict[str, Any]:
+    def _run(args: list[str]) -> str:
+        try:
+            return subprocess.check_output(
+                ["git", *args], cwd=_HERE, stderr=subprocess.DEVNULL, text=True
+            ).strip()
+        except Exception:
+            return ""
+    return {
+        "sha": _run(["rev-parse", "HEAD"]),
+        "branch": _run(["rev-parse", "--abbrev-ref", "HEAD"]),
+        "dirty": bool(_run(["status", "--porcelain"])),
+    }
+
+
+def _env_info() -> dict[str, Any]:
+    native = False
+    try:
+        from goldenmatch.core._native_loader import native_available
+        native = native_available()
+    except Exception:
+        pass
+    return {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "cpu_count": os.cpu_count(),
+        "native_kernel": native,
+    }
+
+
+def _warmup() -> None:
+    """Run one tiny dedupe so import / first-call costs don't skew the first
+    probe's wall time (the engine, rapidfuzz, polars all init lazily)."""
+    try:
+        rows, _ = make_labeled(n_entities=20, seed=1)
+        _dedupe(rows)
+    except Exception:
+        pass
+
+
+def run_report(selected: list[str] | None = None) -> dict[str, Any]:
+    names = selected or list(PROBES)
+    _warmup()
+    probes_out: dict[str, Any] = {}
+    for name in names:
+        fn = PROBES.get(name)
+        if fn is None:
+            probes_out[name] = {"error": f"unknown probe {name!r}"}
+            continue
+        t0 = time.perf_counter()
+        try:
+            outcome = fn()
+            outcome.elapsed_s = round(time.perf_counter() - t0, 3)
+            probes_out[name] = {
+                "group": outcome.group, "metrics": outcome.metrics,
+                "meta": outcome.meta, "elapsed_s": outcome.elapsed_s,
+            }
+        except Exception as exc:  # one probe failing must not kill the report
+            probes_out[name] = {"error": f"{type(exc).__name__}: {exc}",
+                                "elapsed_s": round(time.perf_counter() - t0, 3)}
+    return {
+        "schema": _SCHEMA,
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "git": _git_info(),
+        "env": _env_info(),
+        "probes": probes_out,
+    }
+
+
+def _flatten(report: dict[str, Any]) -> dict[str, float]:
+    """``probe.metric`` -> value for every numeric metric in the report."""
+    out: dict[str, float] = {}
+    for pname, p in report.get("probes", {}).items():
+        for mname, val in (p.get("metrics") or {}).items():
+            if isinstance(val, (int, float)) and not isinstance(val, bool):
+                out[f"{pname}.{mname}"] = float(val)
+    return out
+
+
+# ── baseline + diff ───────────────────────────────────────────────────────────
+
+# Which metrics are GATED (a regression past tolerance is a real failure) vs
+# informational. Wall/RSS/throughput are machine-dependent -> informational.
+# Accuracy + deterministic counts are gated.
+_GATED_SUFFIXES = ("f1", "precision", "recall", "scored_pairs", "multi_member_clusters")
+_INFO_SUFFIXES = ("wall_s", "peak_rss_mb", "records_per_s")
+# direction: True = higher is better (regression = drop); False = lower is better.
+_HIGHER_BETTER = ("f1", "precision", "recall", "records_per_s")
+# Deterministic counts have no "better" direction -- they're env-independent
+# fingerprints of the pipeline, so ANY drift (up OR down) past tolerance is a
+# regression. A drop here is exactly the signal we want (e.g. blocking losing
+# candidate pairs); the one-sided higher/lower gate would miss it.
+_TWO_SIDED = ("scored_pairs", "multi_member_clusters")
+# default per-metric tolerance bands.
+_TOL = {"f1": 0.02, "precision": 0.02, "recall": 0.02,
+        "scored_pairs": 0.0, "multi_member_clusters": 0.0,
+        "wall_s": 9e9, "peak_rss_mb": 9e9, "records_per_s": 9e9}
+
+
+def _suffix(key: str) -> str:
+    return key.rsplit(".", 1)[-1]
+
+
+def build_baseline(report: dict[str, Any]) -> dict[str, Any]:
+    metrics = {}
+    for key, val in _flatten(report).items():
+        suf = _suffix(key)
+        if suf not in _GATED_SUFFIXES and suf not in _INFO_SUFFIXES:
+            continue
+        metrics[key] = {
+            "value": val,
+            "tol": _TOL.get(suf, 0.0),
+            "higher_better": suf in _HIGHER_BETTER,
+            "two_sided": suf in _TWO_SIDED,
+            "gated": suf in _GATED_SUFFIXES,
+        }
+    return {"schema": _SCHEMA,
+            "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "metrics": metrics}
+
+
+def load_baseline() -> dict[str, Any] | None:
+    if not _BASELINE_PATH.is_file():
+        return None
+    return json.loads(_BASELINE_PATH.read_text())
+
+
+def diff_against_baseline(report: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    """Return ``{rows: [...], regressions: [...]}``. A regression is a GATED metric
+    that moved past its tolerance in the wrong direction."""
+    cur = _flatten(report)
+    rows = []
+    regressions = []
+    for key, spec in baseline.get("metrics", {}).items():
+        base = float(spec["value"])
+        now = cur.get(key)
+        if now is None:
+            rows.append({"metric": key, "baseline": base, "current": None,
+                         "delta": None, "status": "MISSING"})
+            continue
+        delta = now - base
+        tol = float(spec.get("tol", 0.0))
+        higher_better = bool(spec.get("higher_better", True))
+        two_sided = bool(spec.get("two_sided", False))
+        gated = bool(spec.get("gated", False))
+        # regressed if moved in the wrong direction past tolerance. Two-sided
+        # (deterministic-count) metrics regress on ANY drift past tolerance.
+        if two_sided:
+            worse = abs(delta) > tol
+        else:
+            worse = (delta < -tol) if higher_better else (delta > tol)
+        status = "ok"
+        if worse and gated:
+            status = "REGRESSION"
+            regressions.append({"metric": key, "baseline": base, "current": now, "delta": round(delta, 4)})
+        elif worse:
+            status = "moved"
+        rows.append({"metric": key, "baseline": base, "current": now,
+                     "delta": round(delta, 4), "gated": gated, "status": status})
+    return {"rows": rows, "regressions": regressions}
+
+
+# ── rendering ──────────────────────────────────────────────────────────────────
+
+
+def to_markdown(report: dict[str, Any], diff: dict[str, Any] | None = None) -> str:
+    g = report.get("git", {})
+    e = report.get("env", {})
+    lines = [
+        "## GoldenMatch metrics",
+        "",
+        f"- commit `{(g.get('sha') or '')[:12]}`"
+        f"{' (dirty)' if g.get('dirty') else ''} on `{g.get('branch','')}`",
+        f"- python {e.get('python','?')} · {e.get('cpu_count','?')} cpu · "
+        f"native kernel: {'yes' if e.get('native_kernel') else 'no'}",
+        "",
+    ]
+    for pname, p in report.get("probes", {}).items():
+        if p.get("error"):
+            lines.append(f"### {pname} — ERROR: {p['error']}")
+            continue
+        lines.append(f"### {pname} ({p.get('group','')}, {p.get('elapsed_s','?')}s)")
+        lines.append("")
+        lines.append("| metric | value |")
+        lines.append("|---|---|")
+        for k, v in p.get("metrics", {}).items():
+            lines.append(f"| {k} | {v} |")
+        lines.append("")
+    if diff is not None:
+        lines.append("### vs baseline")
+        lines.append("")
+        lines.append("| metric | baseline | current | delta | status |")
+        lines.append("|---|---|---|---|---|")
+        for r in diff.get("rows", []):
+            lines.append(
+                f"| {r['metric']} | {r['baseline']} | {r['current']} | "
+                f"{r['delta']} | {r['status']} |"
+            )
+        lines.append("")
+        regs = diff.get("regressions", [])
+        lines.append(f"**{len(regs)} gated regression(s).**" if regs else "**No gated regressions.**")
+    return "\n".join(lines) + "\n"
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="GoldenMatch unified metrics harness")
+    ap.add_argument("--probes", default="", help="comma-separated probe names (default: all)")
+    ap.add_argument("--out", default="", help="write the JSON report here")
+    ap.add_argument("--md", default="", help="write a markdown summary here (or '-' for stdout)")
+    ap.add_argument("--check", action="store_true", help="diff vs baseline; exit 1 on a gated regression")
+    ap.add_argument("--update-baseline", action="store_true", help="re-snapshot baseline.json from this run")
+    args = ap.parse_args(argv)
+
+    selected = [s.strip() for s in args.probes.split(",") if s.strip()] or None
+    report = run_report(selected)
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(report, indent=2))
+
+    if args.update_baseline:
+        _BASELINE_PATH.write_text(json.dumps(build_baseline(report), indent=2))
+        print(f"Updated baseline: {_BASELINE_PATH}")
+        return 0
+
+    diff = None
+    baseline = load_baseline()
+    if (args.check or args.md) and baseline is not None:
+        diff = diff_against_baseline(report, baseline)
+
+    md = to_markdown(report, diff)
+    if args.md == "-" or not args.md:
+        print(md)
+    elif args.md:
+        Path(args.md).write_text(md)
+
+    if args.check:
+        if baseline is None:
+            print("No baseline to check against (run --update-baseline first).", file=sys.stderr)
+            return 0
+        regs = diff.get("regressions", []) if diff else []
+        if regs:
+            print(f"::error::{len(regs)} gated metric regression(s): "
+                  + ", ".join(r["metric"] for r in regs), file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_metrics_harness.py
+++ b/packages/python/goldenmatch/tests/test_metrics_harness.py
@@ -1,0 +1,146 @@
+"""Unified metrics harness (scripts/metrics/harness.py).
+
+Covers the offline core: the diff/baseline logic (fast, synthetic reports) plus a
+smoke run of each real probe (accuracy F1/P/R + perf wall/RSS) to confirm they
+produce sane, deterministic numbers. The harness lives under scripts/, imported
+here via a sys.path shim (same pattern as the other scripts-importing tests).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from metrics import harness  # noqa: E402
+
+# ── synthetic data generator ─────────────────────────────────────────────────
+
+
+def test_make_labeled_unique_names_and_ground_truth():
+    rows, gt = harness.make_labeled(n_entities=50, seed=7)
+    assert len(rows) >= 50  # entities + their duplicates
+    # ground-truth pairs are canonical (min, max) over positions
+    assert all(a < b for a, b in gt)
+    # distinct entities must not share a (first, last) -> recoverable structure
+    base_names = {(r["first_name"].strip().lower(), r["last_name"].strip().lower())
+                  for r in rows if r["first_name"].islower()}
+    # clean (lowercase, unmessed) rows are the entity anchors; they're unique
+    assert len(base_names) >= 50 - 5
+
+
+def test_make_labeled_is_deterministic():
+    a_rows, a_gt = harness.make_labeled(n_entities=80, seed=7)
+    b_rows, b_gt = harness.make_labeled(n_entities=80, seed=7)
+    assert a_rows == b_rows
+    assert a_gt == b_gt
+
+
+def test_make_labeled_rejects_too_many_entities():
+    with pytest.raises(ValueError, match="unique name combos"):
+        harness.make_labeled(n_entities=100_000)
+
+
+# ── diff / baseline logic (fast, synthetic reports) ──────────────────────────
+
+
+def _report(f1: float, scored: int) -> dict:
+    return {"probes": {
+        "accuracy_synthetic": {"group": "accuracy", "metrics": {"f1": f1, "precision": 1.0, "recall": 0.8}},
+        "perf_synthetic": {"group": "perf", "metrics": {"wall_s": 3.0, "scored_pairs": scored}},
+    }}
+
+
+def test_flatten_keeps_only_numeric_metrics():
+    flat = harness._flatten(_report(0.87, 1061))
+    assert flat["accuracy_synthetic.f1"] == 0.87
+    assert flat["perf_synthetic.scored_pairs"] == 1061.0
+
+
+def test_build_baseline_marks_gated_and_informational():
+    base = harness.build_baseline(_report(0.87, 1061))
+    m = base["metrics"]
+    assert m["accuracy_synthetic.f1"]["gated"] is True
+    assert m["perf_synthetic.wall_s"]["gated"] is False  # wall is informational
+
+
+def test_diff_clean_when_within_tolerance():
+    base = harness.build_baseline(_report(0.87, 1061))
+    # f1 dropped 0.01 (within the 0.02 tol) -> no regression
+    diff = harness.diff_against_baseline(_report(0.86, 1061), base)
+    assert diff["regressions"] == []
+
+
+def test_diff_detects_gated_accuracy_regression():
+    base = harness.build_baseline(_report(0.87, 1061))
+    # f1 dropped 0.10 (past the 0.02 tol) -> regression
+    diff = harness.diff_against_baseline(_report(0.77, 1061), base)
+    assert [r["metric"] for r in diff["regressions"]] == ["accuracy_synthetic.f1"]
+
+
+def test_diff_detects_deterministic_count_drift():
+    base = harness.build_baseline(_report(0.87, 1061))
+    # scored_pairs is gated with zero tolerance -> any drift is a regression
+    diff = harness.diff_against_baseline(_report(0.87, 1100), base)
+    assert any(r["metric"] == "perf_synthetic.scored_pairs" for r in diff["regressions"])
+
+
+def test_diff_detects_count_drift_in_either_direction():
+    # deterministic counts are two-sided: a DROP (e.g. blocking losing candidate
+    # pairs) must regress just as an increase does -- not pass as "lower is better".
+    base = harness.build_baseline(_report(0.87, 1061))
+    diff = harness.diff_against_baseline(_report(0.87, 1011), base)
+    assert any(r["metric"] == "perf_synthetic.scored_pairs" for r in diff["regressions"])
+
+
+def test_diff_wall_swing_is_not_a_regression():
+    base = harness.build_baseline(_report(0.87, 1061))
+    report = _report(0.87, 1061)
+    report["probes"]["perf_synthetic"]["metrics"]["wall_s"] = 30.0  # 10x slower
+    diff = harness.diff_against_baseline(report, base)
+    assert diff["regressions"] == []  # wall is informational, never gates
+
+
+def test_committed_baseline_is_loadable_and_well_formed():
+    base = harness.load_baseline()
+    assert base is not None and base["schema"] == harness._SCHEMA
+    assert "accuracy_synthetic.f1" in base["metrics"]
+
+
+# ── real probes (smoke) ───────────────────────────────────────────────────────
+
+
+def test_accuracy_probe_produces_sane_metrics():
+    out = harness.probe_accuracy()
+    assert out.group == "accuracy" and out.error is None
+    assert set(out.metrics) == {"f1", "precision", "recall"}
+    assert all(0.0 <= v <= 1.0 for v in out.metrics.values())
+    assert out.metrics["f1"] > 0.5  # the explicit config recovers most of the structure
+
+
+def test_accuracy_probe_is_deterministic():
+    a = harness.probe_accuracy().metrics
+    b = harness.probe_accuracy().metrics
+    assert a == b
+
+
+def test_perf_probe_records_wall_and_counts():
+    out = harness.probe_perf(n_entities=120)
+    assert out.group == "perf" and out.error is None
+    assert out.metrics["wall_s"] > 0.0
+    assert out.metrics["scored_pairs"] >= 0
+    assert "stage_timings_s" in out.meta
+
+
+def test_run_report_shape_and_resilience():
+    report = harness.run_report(["accuracy_synthetic"])
+    assert report["schema"] == harness._SCHEMA
+    assert "git" in report and "env" in report
+    assert "accuracy_synthetic" in report["probes"]
+    # an unknown probe is recorded as an error, not a crash
+    bad = harness.run_report(["nope"])
+    assert "error" in bad["probes"]["nope"]


### PR DESCRIPTION
## What

A single entry point — `scripts/metrics/harness.py` — that runs the accuracy and perf probes in one pass and diffs them against a committed baseline (`scripts/metrics/baseline.json`). This is the first rung of the metrics-iteration infra so we can start moving the numbers that matter (accuracy, perf) with a regression net under us.

This implements the agreed scope: **offline core** (synthetic accuracy + core perf/throughput; real datasets opt-in later) on a **local + dispatch** posture (no blocking per-PR gate yet).

## Probes

- **`accuracy_synthetic`** — F1 / precision / recall on a self-contained labeled synthetic dataset, scored via `core.evaluate.evaluate_clusters`. The generator samples a *distinct* `(first, last)` per entity (1600-combo space) so distinct entities never collide on name and the cluster structure is genuinely recoverable; each entity gets a clean anchor row plus 0–2 messy variants (case / typo / whitespace / email noise).
- **`perf_synthetic`** — wall, peak RSS, throughput, plus the **deterministic** scored-pair and multi-member-cluster counts, captured via `core.bench.bench_capture`.

## Gating

| class | metrics | gated? | tolerance |
|---|---|---|---|
| accuracy | f1 / precision / recall | yes | ±0.02 |
| deterministic counts | scored_pairs / multi_member_clusters | yes (two-sided) | exact |
| environment-dependent | wall_s / peak_rss_mb / records_per_s | no (informational) | — |

Deterministic counts are **two-sided**: any drift up *or* down past tolerance is a regression. A drop (e.g. blocking losing candidate pairs) is exactly the signal we want — the previous one-sided "lower is better" framing would have silently passed it.

## Surfaces

- **Local:** `python scripts/metrics/harness.py [--check] [--update-baseline] [--md FILE]`. `--check` exits non-zero on a gated regression.
- **CI:** new `bench-metrics` workflow — weekly schedule + `workflow_dispatch`. Informational by default (report → job summary, artifact uploaded); opt into the hard regression check with the `check` input. Fully offline (no datasets / Postgres / API keys), so it runs on forks too.

## Notes

- Baseline regenerated against current `main` (sketch default-on + pgvector backends merged since the first draft shifted the synthetic clusters).
- Gated metrics verified byte-identical across two runs and env-independent (native vs Python-reference).
- 15 tests in `tests/test_metrics_harness.py` (generator uniqueness/determinism, diff/baseline logic incl. the two-sided count drift, real-probe smoke). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_