### PR TITLE
feat(er-kg-bench): entity-answerable subset metric + support_recall triage + N=50 baseline

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/RESULTS_QA_E2E_BASELINE.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/RESULTS_QA_E2E_BASELINE.md
@@ -1,0 +1,52 @@
+# GraphRAG QA E2E -- recorded baselines
+
+Durable record of measured `bench-graphrag-qa` headline numbers so every future
+change is scored against a fixed point (the auto-generated `results/*.md` are
+per-run and not committed). Append a new dated block per measured baseline; do
+not rewrite history.
+
+## 2026-06-23 -- goldengraph, MuSiQue N=50 (first non-zero accuracy)
+
+Run: `bench-graphrag-qa` on `main` @ `9a0e272c` (after the anti-shatter engine
+#1218, cross-doc linking #1215, and the synthesis-answer-parse fix #1223).
+Config: `corpus=musique max_questions=50 ambiguity=0.0 cross_doc_link=1
+profile_link=1 profile_merge_threshold=0.72 extractor=api build_debug=1
+trace=1`, model `gpt-4o-mini`, budget `$12` (spent `$0.45`).
+
+Headline:
+
+| metric | value |
+|---|---|
+| answer_match | **0.14** (7/50) |
+| exact_match | 0.12 |
+| token_f1 | 0.164 |
+| support_recall | 0.0 (NOT WIRED -- goldengraph returns no retrieved-fact ids; see engine adapter note) |
+| graph | 4813 entities, 457 components (largest 1882) |
+
+Build-debug hotspots (1000 docs, wall 1587s; summed time per step):
+
+| step | summed | share |
+|---|---|---|
+| extract (LLM) | 8995s | 70% |
+| fingerprint (LLM) | 2420s | 19% |
+| resolve (goldenmatch) | 743s | 6% |
+| pre_embed | 469s | 4% |
+| link (cross-doc) | 136s | 1% |
+| append | ~0s | ~0% |
+
+LLM extraction + fingerprint = ~89% of build wall. The ER core (resolve) and the
+cross-doc linker are not the bottleneck.
+
+Failure-mode split (localize trace, first 10):
+- EXTRACTION ~60% -- gold is a non-entity (date/amount/phrase) the entity-graph
+  cannot emit (the structural ceiling; quantified going forward by the
+  `answer_match (entity-subset)` column).
+- SYNTHESIS ~30% -- chain retrieved + connected, wrong node written (addressed by
+  the edge-direction prompt fix, PR #1227).
+- RETRIEVAL-BROKEN-CHAIN ~10% -- bridge entity still shattered into a separate
+  component despite active LLM fingerprints (a matcher-recall/threshold issue,
+  not a missing feature).
+
+Targets for the next re-run (same config): `answer_match` and especially
+`answer_match (entity-subset)` should rise with PR #1227; the entity-subset
+denominator quantifies how much of the 0.14 ceiling is structural.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -167,7 +167,16 @@ class GoldenGraphQAEngine:
         )
         return AnswerResult(
             text=text,
-            retrieved_fact_ids=(),  # see support-recall note in the plan/spec
+            # support_recall is STRUCTURALLY 0.0 for goldengraph and the bench
+            # JSON's support-recall column should be read as "not wired", not "0%
+            # recall". Root cause (2026-06-23 triage): `ask()` returns only the
+            # answer string -- it does not expose which document/edge ids fell in
+            # the retrieval ball, so there is nothing to intersect with
+            # `gold_supporting_fact_ids`. Fixing it needs `ask()` (or a sibling that
+            # reuses the same retrieval) to return the ball's source-doc ids mapped
+            # to corpus ids (MuSiQue '<qid>::p<idx>'); that is a goldengraph API
+            # change, tracked as a follow-up rather than forced here.
+            retrieved_fact_ids=(),
             input_tokens=self._llm.input_tokens - before_in,
             output_tokens=self._llm.output_tokens - before_out,
             latency_s=time.perf_counter() - t0,

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -133,6 +133,12 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
     matches: list[float] = []
     f1s: list[float] = []
     recalls: list[float] = []
+    # answer_match restricted to entity-answerable golds -- the honest denominator
+    # for an entity-graph engine that can only ever emit a node (see
+    # metrics.classify_answer_type). Non-entity golds (dates/amounts/phrases) are
+    # unanswerable-by-construction and would otherwise mask the real accuracy.
+    matches_entity: list[float] = []
+    type_counts: dict[str, int] = {}
     decay_rows: list[tuple[int, float]] = []
     records: list[dict] = []
     answered = 0
@@ -145,6 +151,10 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
         em = metrics.exact_match(ans.text, q.gold_answer)
         f1 = metrics.token_f1(ans.text, q.gold_answer)
         rec = metrics.supporting_fact_recall(ans.retrieved_fact_ids, q.gold_supporting_fact_ids)
+        atype = metrics.classify_answer_type(q.gold_answer)
+        type_counts[atype] = type_counts.get(atype, 0) + 1
+        if atype == "entity":
+            matches_entity.append(am)
         matches.append(am)
         ems.append(em)
         f1s.append(f1)
@@ -163,6 +173,7 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
                 "gold_answer": q.gold_answer,
                 "prediction": _truncate(ans.text),
                 "hop_count": q.hop_count,
+                "answer_type": atype,
                 "answer_match": am,
                 "exact_match": em,
                 "token_f1": round(f1, 4),
@@ -181,6 +192,11 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
         "n_questions": len(corpus.questions),
         "n_answered": answered,
         "answer_match": _mean(matches),
+        # answer_match over entity-answerable golds only + how many there were, so
+        # the headline can be read against the right denominator.
+        "answer_match_entity": _mean(matches_entity),
+        "n_entity_answerable": len(matches_entity),
+        "answer_type_counts": type_counts,
         "exact_match": _mean(ems),
         "token_f1": _mean(f1s),
         "support_recall": _mean(recalls),
@@ -212,17 +228,27 @@ def write_results(results: list[dict], *, md_path: str | Path, json_path: str | 
     Path(json_path).write_text(json.dumps(results, indent=2, sort_keys=True), encoding="utf-8")
     lines = ["# ER-KG-Bench -- end-to-end multi-hop QA (evidence program #1)", ""]
     lines.append(
-        "| engine | corpus | answer-match | EM | token-F1 | support-recall | "
-        "cost (USD) | answered | budget hit |"
+        "| engine | corpus | answer-match | AM (entity-subset) | EM | token-F1 | "
+        "support-recall | cost (USD) | answered | budget hit |"
     )
-    lines.append("|---|---|---|---|---|---|---|---|---|")
+    lines.append("|---|---|---|---|---|---|---|---|---|---|")
     for r in results:
+        ent_am = r.get("answer_match_entity", 0.0)
+        n_ent = r.get("n_entity_answerable", 0)
         lines.append(
-            f"| {r['engine']} | {r['corpus']} | {r['answer_match']} | {r['exact_match']} | "
+            f"| {r['engine']} | {r['corpus']} | {r['answer_match']} | "
+            f"{ent_am} (n={n_ent}) | {r['exact_match']} | "
             f"{r['token_f1']} | {r['support_recall']} | {r['cost_usd']} | "
             f"{r['n_answered']}/{r['n_questions']} | "
             f"{'yes' if r['budget_exhausted'] else 'no'} |"
         )
+    lines.append("")
+    lines.append("## Gold answer-type mix (entity-graph engines can only answer 'entity')")
+    for r in results:
+        counts = r.get("answer_type_counts") or {}
+        if counts:
+            mix = ", ".join(f"{k}:{v}" for k, v in sorted(counts.items()))
+            lines.append(f"- {r['engine']} ({r['corpus']}): {mix}")
     lines.append("")
     lines.append("## Decay curve (engineered corpus: mean answer-match by hop count)")
     for r in results:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
@@ -65,6 +65,75 @@ def supporting_fact_recall(
     return len(gold & set(retrieved_ids)) / len(gold)
 
 
+# --- answer-type classification ------------------------------------------------
+#
+# An entity-graph engine (goldengraph) can ONLY ever answer with a NODE -- a named
+# entity. MuSiQue gold answers are frequently NOT entities (a date, a money amount,
+# a descriptive phrase), so those questions are unanswerable-by-construction and
+# drag the headline `answer_match` down regardless of retrieval/synthesis quality.
+# Classifying the gold lets the harness report `answer_match` on the entity-
+# answerable subset -- the honest denominator for a graph engine (the 2026-06-23
+# N=50 trace: ~60% of losses were non-entity golds like '$72,641', '11 February
+# 1929', 'built on 16-bit architectures ...'). Heuristic + approximate by design;
+# the subset metric is a framing aid, not a second source of truth.
+
+_MONTHS = (
+    "january|february|march|april|may|june|july|august|september|october"
+    "|november|december"
+)
+_DATE_RE = re.compile(
+    rf"^\s*(\d{{1,2}}\s+)?({_MONTHS})\s+\d{{3,4}}\s*$"  # 11 February 1929 / March 1929
+    rf"|^\s*({_MONTHS})\s+\d{{1,2}}\s*,?\s*\d{{3,4}}\s*$"  # February 11, 1929
+    rf"|^\s*(19|20)\d{{2}}\s*$"  # bare 4-digit year
+    rf"|^\s*\d{{1,2}}[/-]\d{{1,2}}[/-]\d{{2,4}}\s*$",  # 02/11/1929
+    re.IGNORECASE,
+)
+_NUMBER_RE = re.compile(
+    r"^[\$£€]?\s*\d[\d,\.]*\s*"
+    r"(%|am|pm|st|nd|rd|th|km|kg|mi|ft|m|million|billion|thousand|hundred|"
+    r"percent|dollars?|years?)?\s*$",
+    re.IGNORECASE,
+)
+_ARTICLES_LEADING = re.compile(r"^(the|a|an)\s+", re.IGNORECASE)
+_STOPWORDS = frozenset(
+    "the a an of in on at to and or for with by from as".split()
+)
+
+
+def classify_answer_type(gold: str) -> str:
+    """Coarse type of a gold answer: 'entity' | 'date' | 'number' | 'phrase'.
+
+    'entity' = a short, proper-noun-dominated name an entity-graph could emit
+    ('Exeter College', 'the Politburo', 'Sega Genesis'). 'date'/'number' =
+    literals the graph cannot emit. 'phrase' = a descriptive clause
+    ('built on 16-bit architectures ...'). Heuristic, not authoritative."""
+    g = (gold or "").strip()
+    if not g:
+        return "phrase"
+    if _DATE_RE.search(g):
+        return "date"
+    if _NUMBER_RE.match(g):
+        return "number"
+    core = _ARTICLES_LEADING.sub("", g)
+    toks = re.findall(r"[A-Za-z0-9.&'-]+", core)
+    if not toks:
+        return "number" if any(c.isdigit() for c in g) else "phrase"
+    alpha = [t for t in toks if t[:1].isalpha() and t.lower() not in _STOPWORDS]
+    if not alpha:
+        return "phrase"
+    capitalized = sum(1 for t in alpha if t[:1].isupper())
+    # A name is short and mostly Title-Case; a descriptive phrase is longer and
+    # mostly lowercase.
+    if len(toks) <= 6 and capitalized / len(alpha) >= 0.6:
+        return "entity"
+    return "phrase"
+
+
+def is_entity_answer(gold: str) -> bool:
+    """True when the gold answer is a named entity an entity-graph could emit."""
+    return classify_answer_type(gold) == "entity"
+
+
 def decay_curve(rows: Iterable[tuple[int, float]]) -> dict[int, float]:
     """rows: (hop_count, correct in {0.0,1.0}) -> {hop_count: mean correctness}."""
     by_hop: dict[int, list[float]] = defaultdict(list)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -160,6 +160,15 @@ def main(argv: list[str] | None = None) -> int:
         f"token_f1={result['token_f1']} exact_match={result['exact_match']} "
         f"support_recall={result['support_recall']}"
     )
+    # Entity-answerable subset: an entity-graph can only emit a node, so non-entity
+    # golds (dates/amounts/phrases) are unanswerable-by-construction -- this is the
+    # honest denominator.
+    print(
+        f"  scores[{result['engine']}] entity-subset: "
+        f"answer_match={result.get('answer_match_entity', 0.0)} "
+        f"(n={result.get('n_entity_answerable', 0)}/{result['n_answered']}); "
+        f"answer_type_mix={result.get('answer_type_counts', {})}"
+    )
     # A few example Q->A records so the log shows WHAT the engine answered (wrong
     # vs. async-corrupted vs. phrasing) -- the full set rides in the JSON artifact.
     for rec in result.get("per_question", [])[:3]:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_metrics.py
@@ -7,8 +7,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from erkgbench.qa_e2e.metrics import (  # noqa: E402
     answer_match,
+    classify_answer_type,
     decay_curve,
     exact_match,
+    is_entity_answer,
     supporting_fact_recall,
     token_f1,
 )
@@ -51,3 +53,48 @@ def test_supporting_fact_recall():
 def test_decay_curve_groups_by_hop():
     rows = [(1, 1.0), (1, 0.0), (2, 1.0), (2, 1.0), (3, 0.0)]
     assert decay_curve(rows) == {1: 0.5, 2: 1.0, 3: 0.0}
+
+
+# --- answer-type classification (entity-answerable subset) --------------------
+#
+# Cases drawn verbatim from the 2026-06-23 N=50 MuSiQue localize trace, which is
+# what the entity-subset denominator is meant to model.
+
+
+def test_classify_entity_answers():
+    for g in [
+        "Exeter College",
+        "the Politburo",
+        "Sega Genesis",
+        "Firefox",
+        "Lana Wood",
+        "U.S. Marshal Rooster Cogburn",
+    ]:
+        assert classify_answer_type(g) == "entity", g
+        assert is_entity_answer(g) is True
+
+
+def test_classify_number_answers():
+    for g in ["$72,641", "5am", "72,641", "3.5 million"]:
+        assert classify_answer_type(g) == "number", g
+        assert is_entity_answer(g) is False
+
+
+def test_classify_date_answers():
+    for g in ["11 February 1929", "February 11, 1929", "1929", "02/11/1929"]:
+        assert classify_answer_type(g) == "date", g
+        assert is_entity_answer(g) is False
+
+
+def test_classify_phrase_answers():
+    for g in [
+        "built on 16-bit architectures and offered improved graphics and sound",
+        "because it was cheaper to produce",
+    ]:
+        assert classify_answer_type(g) == "phrase", g
+        assert is_entity_answer(g) is False
+
+
+def test_classify_handles_empty():
+    assert classify_answer_type("") == "phrase"
+    assert is_entity_answer("") is False


### PR DESCRIPTION
## Why (P0 #2, P2 #5, P3 #8)

The N=50 MuSiQue run scored `answer_match=0.14`, but the localize trace showed **~60% of losses are non-entity golds** — dates (`11 February 1929`), amounts (`$72,641`), descriptive phrases (`built on 16-bit architectures…`). An entity-graph engine can only ever emit a **node**, so those are unanswerable-by-construction and drag the headline down regardless of retrieval/synthesis quality. We were measuring against the wrong denominator.

## What

**#2 — entity-answerable subset metric**
- `metrics.classify_answer_type(gold) -> entity|date|number|phrase` + `is_entity_answer` (heuristic, documented as approximate; cases drawn verbatim from the N=50 trace).
- Harness reports `answer_match` over the **entity-answerable subset** + the gold answer-type mix; per-question records carry `answer_type`. New results-md column `AM (entity-subset)` and an answer-type-mix section; the runner echoes both to the CI log.

**#5 — `support_recall=0.0` triage**
- Root cause documented at the goldengraph adapter: `support_recall` is **structurally** 0.0 because `ask()` returns only the answer string — it exposes no retrieved doc/edge ids to intersect with `gold_supporting_fact_ids`. Read the column as "not wired", not "0% recall". A real number needs an `ask()` API change (return the ball's source-doc ids mapped to MuSiQue `<qid>::p<idx>`), tracked as a follow-up rather than forced here.

**#8 — durable baseline**
- `RESULTS_QA_E2E_BASELINE.md` records the 2026-06-23 N=50 headline (`answer_match=0.14`), the build-debug hotspots (extract+fingerprint = 89% of wall), and the failure-mode split, so future changes are scored against a fixed point.

## Validation
- 5 new classifier tests (`test_qa_metrics.py` 10/10); `test_qa_aggregate` / `test_qa_harness` / `test_goldengraph_adapter` green (result-dict additions are backward-compatible — new keys, no removals).

## Scope note
The classifier is a framing aid, not a second source of truth — it's heuristic and will mis-tag the occasional borderline group noun. Its job is to surface roughly how much of the `answer_match` ceiling is structural (non-entity golds) vs addressable (synthesis/retrieval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_