### PR TITLE
test(perceptual): dispatch-only bench harness for accuracy/perf/robustness (ADR 0022)

### DIFF
--- a/.github/workflows/bench-perceptual.yml
+++ b/.github/workflows/bench-perceptual.yml
@@ -1,0 +1,59 @@
+name: bench-perceptual
+
+# Dispatch-only benchmark for the multimodal-ER perceptual crawl tier (ADR 0022):
+# accuracy (operating point, per-transform recall, blocker band sweep,
+# discrimination), performance (native-vs-python throughput), and
+# robustness/determinism. NOT a per-PR gate -- run it when iterating on the
+# perceptual metrics. Writes a markdown summary to the run and uploads the JSON.
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: "Which suite to run"
+        type: choice
+        default: all
+        options: [all, accuracy, perf, robustness]
+      n_image_bases:
+        description: "Image base entities (each yields 7 variants)"
+        type: string
+        default: "30"
+      n_audio_bases:
+        description: "Audio base entities (each yields 3 variants)"
+        type: string
+        default: "12"
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: packages/python/goldenmatch
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Build the native kernel (enables the native perf/parity path)
+        run: uv run python ../../../scripts/build_native.py
+      - name: Run the perceptual bench
+        run: |
+          uv run python scripts/bench_perceptual/run.py \
+            --suite "${{ inputs.suite }}" \
+            --n-image-bases "${{ inputs.n_image_bases }}" \
+            --n-audio-bases "${{ inputs.n_audio_bases }}" \
+            --out perceptual_bench.json | tee bench_summary.md
+      - name: Publish summary
+        if: ${{ !cancelled() }}
+        run: cat bench_summary.md >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        if: ${{ !cancelled() }}
+        with:
+          name: perceptual-bench-report
+          path: packages/python/goldenmatch/perceptual_bench.json

--- a/packages/python/goldenmatch/scripts/bench_perceptual/README.md
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/README.md
@@ -1,0 +1,67 @@
+# Perceptual crawl-tier bench harness
+
+A **dispatch-only** benchmark for the multimodal-ER perceptual crawl tier
+(ADR 0022) — the standing way to measure whether the image/audio perceptual
+hashing is actually *good*, and to iterate on the metrics that matter: the scorer
+operating point, the blocker recall-vs-reduction tradeoff, per-transform
+robustness, the native speedup, and determinism.
+
+It is **not** a per-PR CI gate (the perceptual algorithm is parity-locked by the
+golden fixture; accuracy/perf are judgement calls we iterate on, not pass/fail).
+Run it locally or via the `bench-perceptual` workflow (`workflow_dispatch`).
+
+## Run it
+
+```bash
+cd packages/python/goldenmatch
+uv run python scripts/bench_perceptual/run.py --suite all --out report.json
+# or a single suite: --suite accuracy | perf | robustness
+# scale: --n-image-bases 30 --n-audio-bases 12
+```
+
+## Layout (reusable by design)
+
+| File | Role |
+|---|---|
+| `metrics.py` | **Generic ER eval core** — `prf_at_threshold`, `threshold_sweep`, `discrimination`, `blocking_eval`, `per_group_recall`. No goldenmatch import; other ER stages (blocking, fuzzy/FS) can reuse it. |
+| `datasets.py` | Deterministic synthetic media-variant datasets (no committed assets). Each *base* is one entity; labelled *variants* under named perturbations. Stdlib-only. |
+| `perf.py` | Throughput under `GOLDENMATCH_NATIVE=0/1` + speedup. |
+| `run.py` | Orchestrates the suites; emits JSON + a markdown summary. |
+
+## Metrics — what each one tells you
+
+- **Best operating point** — the threshold maximising F1 over *all* pairs. The
+  scorer's achievable precision/recall.
+- **Per-transform recall** — recall split by perturbation. The most useful view:
+  it shows *which* transforms the hash survives and which break it, instead of
+  hiding that in an aggregate.
+- **Blocking band sweep** — recall vs candidate-reduction as `num_bands` varies.
+  This is the knob behind `PerceptualKeyConfig.num_bands`; the sweep is how we
+  pick its default.
+- **Discrimination** — separation between the matched and non-matched score
+  distributions (the signal the threshold then splits). `overlap` counts
+  non-match pairs scoring above the lowest match score.
+- **Performance** — images/sec and audio-items/sec for the Python vs native path,
+  and the speedup. The number that says whether a kernel optimisation moved the
+  wall.
+- **Robustness** — recompute determinism + native == Python over the suite.
+
+## Baseline findings (first run, 30 image / 12 audio entities) — the backlog
+
+- **pHash is photometric, not geometric** (measured): recall ≈ brightness 0.93,
+  contrast 0.87, recompress 0.93, blur 0.70 — but **noise 0.33, crop 0.0,
+  rotate 0.0**. Geometric transforms are pHash's intrinsic blind spot; the
+  aggregate F1 looks modest only because the dataset deliberately includes those
+  hard cases. *Open question:* keep crop/rotate as a documented "out of envelope"
+  bucket, or add a geometry-tolerant primitive (e.g. ORB/keypoint) as a separate
+  capability.
+- **Blocker default `num_bands=8` is reduction-biased**: recall ≈ 0.72 at 8 bands
+  vs ≈ 0.97 at 16 (reduction 0.77 → 0.28). *Open question:* is 8 the right
+  zero-config default, or should auto-config pick from the recall target?
+- **Audio survives amplitude + time-shift, not additive noise** (recall amplitude
+  1.0, trim 1.0, noise 0.0 at threshold 1.0). *Open question:* lower the
+  `audio_fp` default threshold to recover noisy matches, and measure the precision
+  cost.
+
+Re-run after any change to `perceptual.py` / `perceptual_blocker.py` /
+`perceptual_autoconfig.py` and diff the JSON to see the metric move.

--- a/packages/python/goldenmatch/scripts/bench_perceptual/datasets.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/datasets.py
@@ -1,0 +1,230 @@
+"""Deterministic synthetic media-variant datasets (stdlib-only, no committed assets).
+
+Each *base* is one entity; from it we derive labelled *variants* under named
+perturbations (the transforms a real media dedup faces). Two items derived from
+the same base are a positive pair; cross-base pairs are negatives. The harness
+then hashes every item and measures whether the blocker/scorer keeps the
+positives together and the negatives apart — per transform, so we see exactly
+which perturbations the hash survives.
+
+No numpy / no goldenmatch import: payloads are plain ``list[list[int]]`` (image
+luma) and ``list[float]`` (audio PCM), the decoded-input contract the perceptual
+kernel consumes.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+Grid = list[list[int]]
+
+
+@dataclass
+class Item:
+    item_id: int
+    base_id: int
+    transform: str
+    payload: object  # Grid for image; (samples, sample_rate) for audio
+
+
+@dataclass
+class Suite:
+    kind: str  # "image" | "audio"
+    items: list[Item]
+    gt_pairs: set[tuple[int, int]]  # canonical (min,max) positives (same base)
+    transform_pairs: dict[str, set[tuple[int, int]]]  # (orig, variant) by transform
+
+
+def _canon(a: int, b: int) -> tuple[int, int]:
+    return (a, b) if a < b else (b, a)
+
+
+class _LCG:
+    """Tiny deterministic PRNG (no `random` import for full reproducibility)."""
+
+    def __init__(self, seed: int) -> None:
+        self.s = (seed * 2862933555777941757 + 3037000493) & ((1 << 64) - 1)
+
+    def signed(self, amp: int) -> int:
+        self.s = (self.s * 6364136223846793005 + 1442695040888963407) & ((1 << 64) - 1)
+        return (self.s >> 33) % (2 * amp + 1) - amp
+
+
+# ----------------------------- image ---------------------------------------- #
+def _base_image(seed: int, h: int = 48, w: int = 48) -> Grid:
+    """A frequency-rich procedural pattern (stable mid-band pHash), distinct per seed."""
+    fx = 1.5 + (seed % 5) * 0.4
+    fy = 2.0 + (seed % 7) * 0.3
+    fd = 2.2 + (seed % 3) * 0.6
+    ph = seed * 0.7
+    out: Grid = []
+    for y in range(h):
+        row = []
+        for x in range(w):
+            v = (
+                128
+                + 45 * math.sin(x / fx + ph)
+                + 40 * math.sin(y / fy)
+                + 30 * math.sin((x + y) / fd)
+            )
+            row.append(max(0, min(255, int(round(v)))))
+        out.append(row)
+    return out
+
+
+def _clamp(v: float) -> int:
+    return max(0, min(255, int(round(v))))
+
+
+def _img_brightness(g: Grid) -> Grid:
+    return [[_clamp(v * 0.9 + 22) for v in row] for row in g]
+
+
+def _img_contrast(g: Grid) -> Grid:
+    return [[_clamp((v - 128) * 1.25 + 128) for v in row] for row in g]
+
+
+def _img_blur(g: Grid) -> Grid:
+    h, w = len(g), len(g[0])
+    out = [[0] * w for _ in range(h)]
+    for y in range(h):
+        for x in range(w):
+            acc = cnt = 0
+            for dy in (-1, 0, 1):
+                for dx in (-1, 0, 1):
+                    yy, xx = y + dy, x + dx
+                    if 0 <= yy < h and 0 <= xx < w:
+                        acc += g[yy][xx]
+                        cnt += 1
+            out[y][x] = acc // cnt
+    return out
+
+
+def _img_noise(g: Grid, base_id: int) -> Grid:
+    rng = _LCG(base_id * 101 + 7)
+    return [[_clamp(v + rng.signed(10)) for v in row] for row in g]
+
+
+def _img_recompress(g: Grid) -> Grid:
+    """Downscale by 2 (area average) then nearest-up — a lossy re-encode proxy."""
+    h, w = len(g), len(g[0])
+    hh, ww = h // 2, w // 2
+    small = [
+        [(g[2 * y][2 * x] + g[2 * y][2 * x + 1] + g[2 * y + 1][2 * x] + g[2 * y + 1][2 * x + 1]) // 4
+         for x in range(ww)]
+        for y in range(hh)
+    ]
+    return [[small[y // 2][x // 2] for x in range(w)] for y in range(h)]
+
+
+def _img_crop(g: Grid) -> Grid:
+    """Center-crop ~88% (the pHash resize re-normalizes the smaller grid)."""
+    h, w = len(g), len(g[0])
+    my, mx = h // 16, w // 16
+    return [row[mx : w - mx] for row in g[my : h - my]]
+
+
+def _img_rotate(g: Grid, deg: float = 8.0) -> Grid:
+    """Small nearest-neighbour rotation about the center — a HARD case (pHash is
+    not rotation-invariant); included to measure where the hash breaks down."""
+    h, w = len(g), len(g[0])
+    cy, cx = (h - 1) / 2, (w - 1) / 2
+    rad = math.radians(deg)
+    cos, sin = math.cos(rad), math.sin(rad)
+    out = [[0] * w for _ in range(h)]
+    for y in range(h):
+        for x in range(w):
+            sx = cx + (x - cx) * cos - (y - cy) * sin
+            sy = cy + (x - cx) * sin + (y - cy) * cos
+            ix, iy = int(round(sx)), int(round(sy))
+            out[y][x] = g[iy][ix] if 0 <= iy < h and 0 <= ix < w else 128
+    return out
+
+
+_IMAGE_TRANSFORMS = ("brightness", "contrast", "blur", "noise", "recompress", "crop", "rotate")
+
+
+def build_image_suite(n_bases: int = 30) -> Suite:
+    items: list[Item] = []
+    gt: set[tuple[int, int]] = set()
+    tpairs: dict[str, set[tuple[int, int]]] = {t: set() for t in _IMAGE_TRANSFORMS}
+    nid = 0
+    for b in range(n_bases):
+        base = _base_image(b)
+        orig_id = nid
+        items.append(Item(nid, b, "orig", base))
+        nid += 1
+        group = [orig_id]
+        for t in _IMAGE_TRANSFORMS:
+            if t == "brightness":
+                payload = _img_brightness(base)
+            elif t == "contrast":
+                payload = _img_contrast(base)
+            elif t == "blur":
+                payload = _img_blur(base)
+            elif t == "noise":
+                payload = _img_noise(base, b)
+            elif t == "recompress":
+                payload = _img_recompress(base)
+            elif t == "crop":
+                payload = _img_crop(base)
+            else:
+                payload = _img_rotate(base)
+            items.append(Item(nid, b, t, payload))
+            tpairs[t].add(_canon(orig_id, nid))
+            group.append(nid)
+            nid += 1
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                gt.add(_canon(group[i], group[j]))
+    return Suite("image", items, gt, tpairs)
+
+
+# ----------------------------- audio ---------------------------------------- #
+def _base_audio(seed: int, length: int = 16000, sr: int = 44100) -> list[float]:
+    freqs = [300 + (seed % 6) * 130, 700 + (seed % 4) * 170, 1300 + (seed % 5) * 90]
+    return [sum(math.sin(2 * math.pi * f * n / sr) for f in freqs) / len(freqs) for n in range(length)]
+
+
+def _aud_amplitude(s: list[float]) -> list[float]:
+    return [0.5 * v for v in s]
+
+
+def _aud_noise(s: list[float], base_id: int) -> list[float]:
+    rng = _LCG(base_id * 211 + 13)
+    return [v + rng.signed(50) / 1000.0 for v in s]
+
+
+def _aud_trim(s: list[float]) -> list[float]:
+    return s[4096:]  # drop ~2 frames -> time offset, exercises the alignment search
+
+
+_AUDIO_TRANSFORMS = ("amplitude", "noise", "trim")
+
+
+def build_audio_suite(n_bases: int = 12, sr: int = 44100) -> Suite:
+    items: list[Item] = []
+    gt: set[tuple[int, int]] = set()
+    tpairs: dict[str, set[tuple[int, int]]] = {t: set() for t in _AUDIO_TRANSFORMS}
+    nid = 0
+    for b in range(n_bases):
+        base = _base_audio(b, sr=sr)
+        orig_id = nid
+        items.append(Item(nid, b, "orig", (base, sr)))
+        nid += 1
+        group = [orig_id]
+        for t in _AUDIO_TRANSFORMS:
+            if t == "amplitude":
+                payload = _aud_amplitude(base)
+            elif t == "noise":
+                payload = _aud_noise(base, b)
+            else:
+                payload = _aud_trim(base)
+            items.append(Item(nid, b, t, (payload, sr)))
+            tpairs[t].add(_canon(orig_id, nid))
+            group.append(nid)
+            nid += 1
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                gt.add(_canon(group[i], group[j]))
+    return Suite("audio", items, gt, tpairs)

--- a/packages/python/goldenmatch/scripts/bench_perceptual/metrics.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/metrics.py
@@ -1,0 +1,117 @@
+"""Reusable ER evaluation metrics (stdlib-only, no goldenmatch import).
+
+The framework core of the perceptual bench harness, kept generic so other ER
+stages (blocking, fuzzy/FS scoring) can reuse it: a *scorer* is anything that
+yields ``(is_match, score)`` per pair; a *blocker* yields candidate pairs. These
+functions turn those into the metrics that actually drive iteration — precision /
+recall / F1, the best operating point, candidate-reduction, and the discrimination
+margin between matched and non-matched pairs.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class PRF:
+    threshold: float
+    precision: float
+    recall: float
+    f1: float
+    tp: int
+    fp: int
+    fn: int
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def prf_at_threshold(labeled_scores: list[tuple[bool, float]], threshold: float) -> PRF:
+    """Precision/recall/F1 treating ``score >= threshold`` as a predicted match."""
+    tp = fp = fn = 0
+    for is_match, score in labeled_scores:
+        pred = score >= threshold
+        if pred and is_match:
+            tp += 1
+        elif pred and not is_match:
+            fp += 1
+        elif not pred and is_match:
+            fn += 1
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return PRF(threshold, precision, recall, f1, tp, fp, fn)
+
+
+def threshold_sweep(
+    labeled_scores: list[tuple[bool, float]], thresholds: list[float]
+) -> tuple[list[PRF], PRF]:
+    """Sweep thresholds; return all points and the best-F1 operating point."""
+    points = [prf_at_threshold(labeled_scores, t) for t in thresholds]
+    best = max(points, key=lambda p: (p.f1, p.recall))
+    return points, best
+
+
+@dataclass
+class Discrimination:
+    match_min: float
+    match_mean: float
+    match_max: float
+    nonmatch_min: float
+    nonmatch_mean: float
+    nonmatch_max: float
+    separation: float  # match_mean - nonmatch_mean (higher = cleaner signal)
+    overlap_count: int  # non-match scores >= the lowest match score
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def discrimination(labeled_scores: list[tuple[bool, float]]) -> Discrimination:
+    """Separation of the matched vs non-matched score distributions — the signal
+    quality the threshold then has to split."""
+    m = [s for is_m, s in labeled_scores if is_m]
+    n = [s for is_m, s in labeled_scores if not is_m]
+    if not m or not n:
+        raise ValueError("need both matched and non-matched pairs")
+    mlo = min(m)
+    overlap = sum(1 for s in n if s >= mlo)
+    mm, nm = sum(m) / len(m), sum(n) / len(n)
+    return Discrimination(mlo, mm, max(m), min(n), nm, max(n), mm - nm, overlap)
+
+
+@dataclass
+class BlockingEval:
+    gt_pairs: int
+    candidate_pairs: int
+    total_pairs: int
+    recall: float  # fraction of true pairs that share a candidate block
+    reduction_ratio: float  # 1 - candidates / total possible pairs
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def blocking_eval(
+    candidate_pairs: set[tuple[int, int]], gt_pairs: set[tuple[int, int]], n_items: int
+) -> BlockingEval:
+    """Recall (true pairs covered) vs candidate-reduction for a blocker output.
+
+    Pairs are canonical ``(min, max)`` tuples — the project-wide invariant."""
+    total = n_items * (n_items - 1) // 2
+    covered = len(candidate_pairs & gt_pairs)
+    recall = covered / len(gt_pairs) if gt_pairs else 0.0
+    reduction = 1.0 - (len(candidate_pairs) / total) if total else 0.0
+    return BlockingEval(len(gt_pairs), len(candidate_pairs), total, recall, reduction)
+
+
+def per_group_recall(
+    labeled_scores_by_group: dict[str, list[tuple[bool, float]]], threshold: float
+) -> dict[str, float]:
+    """Recall at a threshold, broken down by group (e.g. per transform) — shows
+    exactly which perturbations the hash survives and which break it."""
+    out: dict[str, float] = {}
+    for group, scores in labeled_scores_by_group.items():
+        prf = prf_at_threshold(scores, threshold)
+        out[group] = prf.recall
+    return out

--- a/packages/python/goldenmatch/scripts/bench_perceptual/perf.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/perf.py
@@ -1,0 +1,56 @@
+"""Performance metrics for the perceptual kernel — throughput + native speedup.
+
+Toggles ``GOLDENMATCH_NATIVE`` so each path is measured under the real dispatch
+(`native_enabled("perceptual")` reads the env per call). The native path is
+skipped gracefully when the extension isn't built.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+from goldenmatch.core import perceptual
+
+
+def _time(fn, repeats: int) -> float:
+    t0 = time.perf_counter()
+    for _ in range(repeats):
+        fn()
+    return time.perf_counter() - t0
+
+
+def _both_paths(work, n_units: int, repeats: int) -> dict:
+    """Run ``work`` under GOLDENMATCH_NATIVE=0 and =1, report throughput + speedup."""
+    prev = os.environ.get("GOLDENMATCH_NATIVE")
+    out: dict = {}
+    try:
+        for mode, label in (("0", "python"), ("1", "native")):
+            os.environ["GOLDENMATCH_NATIVE"] = mode
+            try:
+                dt = _time(work, repeats)
+            except RuntimeError:
+                out[label] = None  # native=1 but ext not importable
+                continue
+            out[label] = {"wall_sec": dt, "units_per_sec": repeats * n_units / dt}
+    finally:
+        if prev is None:
+            os.environ.pop("GOLDENMATCH_NATIVE", None)
+        else:
+            os.environ["GOLDENMATCH_NATIVE"] = prev
+    if out.get("python") and out.get("native"):
+        out["speedup"] = out["python"]["wall_sec"] / out["native"]["wall_sec"]
+    return out
+
+
+def bench_image_hash(grids: list, repeats: int = 3) -> dict:
+    """Throughput of the image pHash over a batch of luma grids (the column path)."""
+    return _both_paths(lambda: perceptual.phash_image_batch(grids), len(grids), repeats)
+
+
+def bench_audio_hash(signals: list[tuple[list, int]], repeats: int = 2) -> dict:
+    """Throughput of the audio fingerprint over a batch of (samples, sample_rate)."""
+    def work():
+        for samples, sr in signals:
+            perceptual.fingerprint_audio(samples, sr)
+
+    return _both_paths(work, len(signals), repeats)

--- a/packages/python/goldenmatch/scripts/bench_perceptual/run.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/run.py
@@ -1,0 +1,226 @@
+"""Perceptual crawl-tier benchmark harness — accuracy, performance, robustness.
+
+Dispatch-only (no per-PR gate): run it locally or via the `bench-perceptual`
+workflow. Emits a structured JSON report + a markdown summary, both diffable
+across runs so we can iterate on the metrics that matter — the scorer operating
+point, the blocker recall-vs-reduction tradeoff, per-transform robustness, and
+the native speedup.
+
+    cd packages/python/goldenmatch
+    uv run python scripts/bench_perceptual/run.py --suite all --out report.json
+"""
+# ruff: noqa: E402, I001 - run.py bootstraps sys.path before importing the sibling
+# bench modules, so imports are intentionally not at the top / not isort-ordered.
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import datasets
+import metrics
+import perf
+
+from goldenmatch.core import perceptual
+from goldenmatch.core.perceptual_blocker import PerceptualLSHBlocker
+
+_HASH_BITS = 64
+# 1.0 down to ~0.55 in single-bit steps — the operating-point search space.
+_THRESHOLDS = [i / _HASH_BITS for i in range(_HASH_BITS, 35, -1)]
+_BAND_COUNTS = [2, 4, 8, 16, 32]
+
+
+def _img_sim(ha: int, hb: int) -> float:
+    return 1.0 - perceptual.hamming(ha, hb) / _HASH_BITS
+
+
+def accuracy_image(n_bases: int) -> dict:
+    suite = datasets.build_image_suite(n_bases)
+    hashes = [perceptual.phash_image(it.payload) for it in suite.items]  # item_id == index
+    n = len(hashes)
+
+    labeled: list[tuple[bool, float]] = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            labeled.append(((i, j) in suite.gt_pairs, _img_sim(hashes[i], hashes[j])))
+
+    points, best = metrics.threshold_sweep(labeled, _THRESHOLDS)
+    disc = metrics.discrimination(labeled)
+    per_transform = {
+        t: metrics.prf_at_threshold(
+            [(True, _img_sim(hashes[a], hashes[b])) for (a, b) in pairs], best.threshold
+        ).recall
+        for t, pairs in suite.transform_pairs.items()
+    }
+    band_sweep = []
+    for nb in _BAND_COUNTS:
+        cand = PerceptualLSHBlocker(nb, _HASH_BITS).candidate_pairs(hashes)
+        band_sweep.append({"num_bands": nb, **metrics.blocking_eval(cand, suite.gt_pairs, n).as_dict()})
+
+    return {
+        "items": n,
+        "base_entities": n_bases,
+        "best_operating_point": best.as_dict(),
+        "threshold_sweep": [p.as_dict() for p in points],
+        "discrimination": disc.as_dict(),
+        "per_transform_recall_at_best": per_transform,
+        "blocking_band_sweep": band_sweep,
+    }
+
+
+def accuracy_audio(n_bases: int) -> dict:
+    suite = datasets.build_audio_suite(n_bases)
+    fps = [perceptual.fingerprint_audio(*it.payload) for it in suite.items]
+    n = len(fps)
+
+    def sim(a: int, b: int) -> float:
+        return 1.0 - perceptual.audio_ber_aligned(fps[a], fps[b])
+
+    labeled = [
+        ((i, j) in suite.gt_pairs, sim(i, j)) for i in range(n) for j in range(i + 1, n)
+    ]
+    points, best = metrics.threshold_sweep(labeled, _THRESHOLDS)
+    disc = metrics.discrimination(labeled)
+    per_transform = {
+        t: metrics.prf_at_threshold(
+            [(True, sim(a, b)) for (a, b) in pairs], best.threshold
+        ).recall
+        for t, pairs in suite.transform_pairs.items()
+    }
+    return {
+        "items": n,
+        "base_entities": n_bases,
+        "best_operating_point": best.as_dict(),
+        "threshold_sweep": [p.as_dict() for p in points],
+        "discrimination": disc.as_dict(),
+        "per_transform_recall_at_best": per_transform,
+        "note": "audio has no LSH blocker (variable-length fingerprint); scoring uses offset-aligned BER",
+    }
+
+
+def perf_suite(n_image: int, n_audio: int) -> dict:
+    img = [it.payload for it in datasets.build_image_suite(n_image).items]
+    aud = [it.payload for it in datasets.build_audio_suite(n_audio).items]
+    return {"image_hash": perf.bench_image_hash(img), "audio_hash": perf.bench_audio_hash(aud)}
+
+
+def robustness_suite(n_image: int, n_audio: int) -> dict:
+    """Determinism (recompute is identical) + native==python parity over the suite."""
+    from goldenmatch.core._native_loader import native_available
+
+    imgs = [it.payload for it in datasets.build_image_suite(n_image).items]
+    auds = [it.payload for it in datasets.build_audio_suite(n_audio).items]
+
+    os.environ["GOLDENMATCH_NATIVE"] = "0"
+    py_img = [perceptual.phash_image(g) for g in imgs]
+    py_aud = [perceptual.fingerprint_audio(*a) for a in auds]
+    determinism = (
+        py_img == [perceptual.phash_image(g) for g in imgs]
+        and py_aud == [perceptual.fingerprint_audio(*a) for a in auds]
+    )
+
+    native_parity = None
+    if native_available():
+        os.environ["GOLDENMATCH_NATIVE"] = "1"
+        native_parity = (
+            py_img == [perceptual.phash_image(g) for g in imgs]
+            and py_aud == [perceptual.fingerprint_audio(*a) for a in auds]
+        )
+    os.environ["GOLDENMATCH_NATIVE"] = "0"
+    return {
+        "determinism_holds": determinism,
+        "native_available": native_available(),
+        "native_equals_python": native_parity,
+    }
+
+
+def _markdown(report: dict) -> str:
+    lines = ["# Perceptual crawl-tier bench\n"]
+    ai = report.get("accuracy_image")
+    if ai:
+        bop = ai["best_operating_point"]
+        d = ai["discrimination"]
+        lines += [
+            "## Image accuracy",
+            f"- items: {ai['items']} ({ai['base_entities']} entities)",
+            f"- **best operating point**: threshold={bop['threshold']:.4f} "
+            f"F1={bop['f1']:.4f} P={bop['precision']:.4f} R={bop['recall']:.4f}",
+            f"- discrimination: match_mean={d['match_mean']:.4f} "
+            f"nonmatch_mean={d['nonmatch_mean']:.4f} separation={d['separation']:.4f} "
+            f"overlap={d['overlap_count']}",
+            "- per-transform recall @ best: "
+            + ", ".join(f"{k}={v:.3f}" for k, v in ai["per_transform_recall_at_best"].items()),
+            "",
+            "| num_bands | recall | reduction | candidates |",
+            "|---|---|---|---|",
+        ]
+        for b in ai["blocking_band_sweep"]:
+            lines.append(
+                f"| {b['num_bands']} | {b['recall']:.4f} | {b['reduction_ratio']:.4f} | {b['candidate_pairs']} |"
+            )
+        lines.append("")
+    aa = report.get("accuracy_audio")
+    if aa:
+        bop = aa["best_operating_point"]
+        lines += [
+            "## Audio accuracy",
+            f"- items: {aa['items']} ({aa['base_entities']} entities)",
+            f"- **best operating point**: threshold={bop['threshold']:.4f} F1={bop['f1']:.4f}",
+            "- per-transform recall @ best: "
+            + ", ".join(f"{k}={v:.3f}" for k, v in aa["per_transform_recall_at_best"].items()),
+            "",
+        ]
+    pf = report.get("perf")
+    if pf:
+        lines.append("## Performance")
+        for name, r in pf.items():
+            py = r.get("python")
+            nat = r.get("native")
+            sp = r.get("speedup")
+            seg = f"python={py['units_per_sec']:.0f}/s" if py else "python=?"
+            seg += f" native={nat['units_per_sec']:.0f}/s" if nat else " native=unavailable"
+            seg += f" speedup={sp:.1f}x" if sp else ""
+            lines.append(f"- {name}: {seg}")
+        lines.append("")
+    rb = report.get("robustness")
+    if rb:
+        lines += [
+            "## Robustness",
+            f"- determinism holds: {rb['determinism_holds']}",
+            f"- native available: {rb['native_available']}; native==python: {rb['native_equals_python']}",
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--suite", choices=["accuracy", "perf", "robustness", "all"], default="all")
+    ap.add_argument("--n-image-bases", type=int, default=30)
+    ap.add_argument("--n-audio-bases", type=int, default=12)
+    ap.add_argument("--out", default=None, help="write JSON report here")
+    args = ap.parse_args()
+
+    report: dict = {"config": vars(args)}
+    if args.suite in ("accuracy", "all"):
+        report["accuracy_image"] = accuracy_image(args.n_image_bases)
+        report["accuracy_audio"] = accuracy_audio(args.n_audio_bases)
+    if args.suite in ("perf", "all"):
+        report["perf"] = perf_suite(args.n_image_bases, args.n_audio_bases)
+    if args.suite in ("robustness", "all"):
+        report["robustness"] = robustness_suite(args.n_image_bases, args.n_audio_bases)
+
+    md = _markdown(report)
+    print(md)
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"\nwrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Testing infrastructure to iterate on the metrics that matter for the multimodal-ER perceptual crawl tier ([ADR 0022](https://github.com/benseverndev-oss/goldenmatch/blob/main/context-network/decisions/0022-multimodal-er-perceptual-crawl-tier.md), shipped in #1221). A reusable, **dispatch-only** harness — no per-PR gate — so accuracy/perf/robustness can be measured and improved without coupling iteration speed to CI time.

### What's here (all additive, `scripts/bench_perceptual/`)
- **`metrics.py`** — framework-agnostic metric primitives (no `goldenmatch` import): precision/recall/F1, threshold sweep, discrimination (match-vs-nonmatch score separation), blocking eval (candidate-pair recall vs reduction ratio), per-group recall. Reusable for any future modality, not perceptual-specific.
- **`datasets.py`** — deterministic image/audio variant suites (seeded `_LCG`, no external assets): blur / crop / rotate / amplitude / time-shift / noise variants with known ground-truth groups, so every run is reproducible and diffable.
- **`perf.py`** — native-vs-python A/B via the `GOLDENMATCH_NATIVE` toggle (wall-clock on the perceptual kernel paths).
- **`run.py`** — orchestrator that emits an accuracy + perf + robustness report.
- **`.github/workflows/bench-perceptual.yml`** — `workflow_dispatch` only.
- **`README.md`** — how to run locally and via dispatch.

### Why dispatch-only
Per the scoping decision: the harness is a measurement bench for iterating on metrics, **not** a correctness gate. The crawl-tier's correctness is already locked by the golden-vector parity tests and the always-on recall gate in #1221's `ci.yml` lanes. Keeping this off the per-PR path means heavy variant sweeps don't tax the merge queue.

### First findings (the iteration backlog this unlocks)
Running it against the shipped kernel already surfaced concrete, actionable items:
- **pHash is photometric, not geometric** — blur/amplitude survive (recall ~1.0); crop/rotate do not (recall 0.0). Expected for DCT-pHash; flags where a geometric pre-normalization or a second hash would help.
- **Blocker default `num_bands=8` is reduction-biased** — recall 0.72 vs 0.97 at `num_bands=16` on the image suite. Suggests an auto-config recall-target → band-count rule.
- **Audio survives amplitude + time-shift, not additive noise** — points at the `audio_fp` default threshold and a possible denoise/robustness pass.

These are follow-up changes, not part of this PR — this PR is the measurement infrastructure that makes them quantifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p)_