### PR TITLE
perf(bench-graphrag-qa): raise build_workers default 8 -> 12

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -39,7 +39,12 @@ on:
         default: "0.72"
       build_workers:
         description: "goldengraph only: concurrent per-doc LLM workers at build (rate-limit-bounded; retry/backoff absorbs 429s)"
-        default: "8"
+        # 12, not 8: the N=50 build-debug showed wall/summed-extract ~= 8x at 8
+        # workers (near-linear, not saturated), so more concurrency still buys
+        # overlap; the adapter's exp-backoff retry absorbs the extra 429 pressure.
+        # The library default stays 8 for arbitrary users on tight RPM tiers; this
+        # only raises it for the bench account, which tolerates it.
+        default: "12"
       build_debug:
         description: "goldengraph only: print the per-sub-step build timing breakdown (extract/resolve/fingerprint/link/append) for hotspot analysis"
         default: "false"


### PR DESCRIPTION
## Why (P2 #6)

The N=50 build-debug showed **extract + fingerprint = 89% of build wall** (1587s over 1000 docs), and `wall / summed-extract ≈ 8×` at 8 workers — i.e. the 8 workers give near-linear overlap and the build is **not saturated**, so more concurrency still buys wall-clock. Larger N (N=200, statistically meaningful) is only affordable if the build is faster.

## What
- Raise the `bench-graphrag-qa` `build_workers` input default **8 → 12**. The goldengraph adapter's `_with_retry` (exponential backoff + jitter on 429/5xx) absorbs the extra rate-limit pressure.

## Scope
- **Only the bench workflow input default.** The library default (`GOLDENGRAPH_BUILD_WORKERS` in `ingest_corpus`) stays **8** — arbitrary users on tight provider RPM tiers shouldn't get a more aggressive default flipped under them. The bench runs on a known account that tolerates 12.
- Workflow-file-only change; `bench-graphrag-qa` is `workflow_dispatch`-only and not `ci-required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_