### PR TITLE
fix(perceptual): recall-target blocking band count + record bench findings 1-3 (ADR 0022)

### DIFF
--- a/context-network/planning/multimodal-er.md
+++ b/context-network/planning/multimodal-er.md
@@ -199,14 +199,56 @@ existing embedding+ANN+score+explain spine via the optional encoder extras.
       extras backing the `decode_image_to_luma`/`decode_audio_to_mono` adapters.
       TS port of the `phash`/`perceptual`/`audio_fp` surfaces remains a follow-up.
 
+## Bench-harness findings (first measured iteration, 2026-06-23)
+
+The dispatch-only metrics harness (`scripts/bench_perceptual/`, PR #1229) produced
+its first real numbers on the shipped kernel. They **refuted two of three** plausible
+fixes and **confirmed one** — exactly what the harness is for. Numbers from the
+deterministic image suite (30 bases × 7 transforms) + audio suite (12 bases × 3):
+
+- **Finding 2 (blocking band-count) — CONFIRMED, FIXED.** `num_bands=8` recalls only
+  **0.72** of true near-dup pairs (reduction 0.77); `num_bands=16` recalls **0.97**
+  (reduction 0.28). For a near-dup *media* blocker recall is the priority (a missed
+  dup is unrecoverable; the scorer filters extra candidates cheaply). Fix: the band
+  count is now **recall-target-driven** — `perceptual_blocker.recommend_num_bands`
+  derives it from the scorer threshold via the banded-LSH S-curve (mirrors the
+  semantic-blocking move in #1090). `PerceptualKeyConfig.num_bands` default 8→16;
+  the zero-config path computes it from the image threshold (0.85 → 16 bands @ 0.95
+  recall target). Tests in `test_perceptual_feature.py` / `test_perceptual_autoconfig.py`.
+- **Finding 1 (geometric robustness) — REFUTED, deferred to the walk tier.** The
+  suite's `rotate` (8°) and `crop` (content) recall **0.0**; pHash is photometric,
+  not geometric. The cheap candidate fix (dihedral-min canonical hash, min over the
+  8 rotations/flips) was **measured net-negative**: it leaves 8°-rotate and crop at
+  0.0 (neither is a dihedral symmetry) *and* degrades the photometric cases it
+  should leave alone (brightness 1.0→0.97, noise 0.83→0.57, because min-over-
+  orientations adds distance to near-identical pairs). Real geometric robustness
+  (small-angle rotation, content crop) needs a different representation
+  (feature-point / log-polar / learned) — i.e. the BYO-vector **walk tier**, not a
+  crawl-tier hash trick. Not shipped; documented as a known limitation.
+- **Finding 3 (audio additive noise) — REFUTED, not a threshold problem.** Noisy-pair
+  similarity (0.43–0.54) is **statistically identical** to unrelated pairs (nonmatch
+  mean 0.53): ±0.05 additive noise on the near-pure-tone suite drives BER to ~0.5, so
+  the signal is gone and **no threshold separates it** (at 0.70, precision already
+  collapses to 0.66 with noise recall still 0.0). Lowering the `audio_fp` threshold is
+  measured-harmful; 0.80 stays optimal here. Two compounding causes: (a) pure synthetic
+  tones are pathological for Haitsma-Kalker (most log-bands carry ~zero energy, so the
+  sign-of-double-difference bit is noise-dominated even at ~23 dB SNR — broadband audio
+  degrades more gracefully), and (b) the crawl-tier fingerprint has no bit-reliability /
+  redundancy. A genuinely noise-robust fingerprint is new-kernel work (+ golden-vector
+  parity); deferred. Harness follow-up: make the noise variant broadband so the suite
+  reflects realistic degradation rather than a tone artifact.
+
 ## Status (crawl tier)
 
 The image-and-audio perceptual crawl tier is **complete end-to-end**: reference
 (slice 1) → byte-parity Rust kernel (2) → PyO3 binding (2b) → pipeline match
-feature (3) → audio feature + zero-config auto-wiring + recall gate + extras (3b).
+feature (3) → audio feature + zero-config auto-wiring + recall gate + extras (3b),
+plus the recall-target blocking fix from the first bench iteration (finding 2).
 The wedge (#3 modality-as-evidence) is real. Remaining frontier per the priority
 table: within-modality ER (#1) and cross-modal (#2); plus the biometric
-template-protection / PPRL privacy guardrail and the BYO-vector "walk" tier.
+template-protection / PPRL privacy guardrail and the BYO-vector "walk" tier — which
+findings 1 & 3 now concretely motivate (geometric-robust image vectors + a
+noise-robust audio representation are walk-tier, not crawl-tier, work).
 
 ---
 **Classification:** planning/active • **Last updated:** 2026-06-23

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -462,10 +462,17 @@ class PerceptualKeyConfig(BaseModel):
     probability, so they collide into a candidate block. More bands -> higher
     recall and more candidate pairs. This is the *media* near-duplicate blocker,
     complementing the lexical (``lsh``) and semantic (``simhash``) paths.
+
+    The ``num_bands`` default of 16 is recall-driven, not arbitrary: at the 0.85
+    image-pHash threshold (a 0.15 hamming radius) the bench suite measured 16 bands
+    at 0.97 blocking recall vs only 0.72 for the old default of 8 (ADR 0022). The
+    zero-config path derives the count from the scorer threshold via
+    ``core.perceptual_blocker.recommend_num_bands``; this static default is the
+    knob for an explicit config.
     """
 
     column: str
-    num_bands: int = 8
+    num_bands: int = 16
     hash_bits: int = 64
 
     @model_validator(mode="after")

--- a/packages/python/goldenmatch/goldenmatch/core/perceptual_autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/perceptual_autoconfig.py
@@ -23,6 +23,7 @@ from goldenmatch.config.schemas import (
     MatchkeyField,
     PerceptualKeyConfig,
 )
+from goldenmatch.core.perceptual_blocker import recommend_num_bands
 
 # A 16-char (64-bit) image pHash. An audio fingerprint is two or more 8-char
 # (32-bit) words concatenated -- a 16-char string is ambiguous, so it is read as
@@ -33,6 +34,11 @@ _AUDIO_RE = re.compile(r"^(?:[0-9a-f]{8}){3,}$")
 _SAMPLE = 200
 _IMAGE_THRESHOLD = 0.85  # hamming <= ~10/64
 _AUDIO_THRESHOLD = 0.80
+# Blocking must recall the same near-duplicate radius the scorer accepts, so the
+# band count is derived from the image threshold rather than hardcoded (the old
+# default of 8 under-recalled at 0.72; the recall-target rule picks 16 at 0.97).
+_BLOCK_RECALL_TARGET = 0.95
+_HASH_BITS = 64
 
 
 def _classify(values: list[str]) -> str | None:
@@ -124,7 +130,13 @@ def apply_perceptual_autoconfig(
         blk.strategy == "static" and not blk.keys and not (blk.passes or [])
     )
     if image_cols and no_blocking:
+        num_bands = recommend_num_bands(
+            _HASH_BITS, 1.0 - _IMAGE_THRESHOLD, _BLOCK_RECALL_TARGET
+        )
         config.blocking = BlockingConfig(
-            strategy="perceptual", perceptual=PerceptualKeyConfig(column=image_cols[0])
+            strategy="perceptual",
+            perceptual=PerceptualKeyConfig(
+                column=image_cols[0], num_bands=num_bands, hash_bits=_HASH_BITS
+            ),
         )
     return config

--- a/packages/python/goldenmatch/goldenmatch/core/perceptual_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/perceptual_blocker.py
@@ -20,6 +20,50 @@ import polars as pl
 from goldenmatch.config.schemas import BlockingConfig, PerceptualKeyConfig
 
 
+def _divisor_band_counts(hash_bits: int) -> list[int]:
+    """Ascending band counts that evenly divide ``hash_bits`` (each band >= 1 bit,
+    excluding the degenerate all-bits-one-band case). Ascending == most-reduction
+    first, so the recommender returns the cheapest blocking that meets the target."""
+    return [b for b in range(2, hash_bits + 1) if hash_bits % b == 0]
+
+
+def lsh_collision_probability(
+    hamming_frac: float, num_bands: int, hash_bits: int = 64
+) -> float:
+    """Probability that two hashes at hamming distance ``hamming_frac * hash_bits``
+    share at least one identical band under banded hamming-LSH.
+
+    A band of ``hash_bits // num_bands`` bits matches iff all its bits agree, with
+    per-bit agreement ``1 - hamming_frac``; the hashes collide iff any of the
+    ``num_bands`` bands matches. This is the standard banded-LSH S-curve and the
+    basis for :func:`recommend_num_bands`."""
+    band_width = hash_bits // num_bands
+    per_band = (1.0 - hamming_frac) ** band_width
+    return 1.0 - (1.0 - per_band) ** num_bands
+
+
+def recommend_num_bands(
+    hash_bits: int = 64,
+    target_hamming_frac: float = 0.15,
+    target_recall: float = 0.95,
+) -> int:
+    """Smallest band count whose LSH collision probability at ``target_hamming_frac``
+    meets ``target_recall`` — the recall-vs-reduction knob, set from a recall target
+    instead of a hardcoded count (mirrors the semantic-blocking move in #1090).
+
+    ``target_hamming_frac`` is the near-duplicate radius the blocker must cover,
+    i.e. ``1 - scorer_threshold`` (a 0.85 image-pHash threshold => a 0.15 radius).
+    Returns the cheapest (fewest-bands, highest-reduction) blocking that still
+    recalls the radius; falls back to the finest division if none qualifies.
+    Measured on the bench suite: this picks ``num_bands=16`` for the image default,
+    lifting blocking recall 0.72 -> 0.97 vs the old hardcoded 8 (ADR 0022)."""
+    choices = _divisor_band_counts(hash_bits)
+    for b in choices:
+        if lsh_collision_probability(target_hamming_frac, b, hash_bits) >= target_recall:
+            return b
+    return choices[-1] if choices else 1
+
+
 def _parse_hash(value: str | None) -> int | None:
     """Parse a hex perceptual hash (``0x`` prefix tolerated) to an int, or None."""
     if value is None:

--- a/packages/python/goldenmatch/tests/test_perceptual_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_perceptual_autoconfig.py
@@ -64,6 +64,9 @@ def test_apply_appends_matchkey_and_sets_blocking_when_empty():
     assert "perceptual_image_ph" in names
     assert out.blocking is not None and out.blocking.strategy == "perceptual"
     assert out.blocking.perceptual is not None and out.blocking.perceptual.column == "ph"
+    # band count is recall-target-driven (16 at the 0.85 image threshold), not the
+    # old reduction-biased default of 8 (finding 2: 0.72 -> 0.97 blocking recall).
+    assert out.blocking.perceptual.num_bands == 16
 
 
 def test_apply_preserves_existing_blocking():

--- a/packages/python/goldenmatch/tests/test_perceptual_feature.py
+++ b/packages/python/goldenmatch/tests/test_perceptual_feature.py
@@ -69,6 +69,56 @@ def test_perceptual_key_config_validation():
         PerceptualKeyConfig(column="ph", num_bands=7, hash_bits=64)  # 64 % 7 != 0
 
 
+def test_perceptual_key_config_default_is_recall_driven():
+    # The default is the recall-target band count (16), not the old reduction-biased
+    # 8 — a near-dup MEDIA blocker prioritises recall (a missed dup is unrecoverable;
+    # the scorer filters the extra candidates cheaply). Bench: 0.72 -> 0.97 recall.
+    assert PerceptualKeyConfig(column="ph").num_bands == 16
+
+
+# --------------------------------------------------------------------------- #
+# recall-target band recommender (finding 2: blocking recall vs reduction)     #
+# --------------------------------------------------------------------------- #
+def test_recommend_num_bands_meets_recall_target_at_image_radius():
+    from goldenmatch.core.perceptual_blocker import (
+        lsh_collision_probability,
+        recommend_num_bands,
+    )
+
+    # 0.85 image threshold => 0.15 hamming radius; at 0.95 target the cheapest
+    # divisor band count that recalls the radius is 16 (matches the bench sweep).
+    nb = recommend_num_bands(64, 1.0 - 0.85, 0.95)
+    assert nb == 16
+    assert lsh_collision_probability(0.15, nb, 64) >= 0.95
+    # and it is the CHEAPEST such count (8 bands does not reach the target).
+    assert lsh_collision_probability(0.15, 8, 64) < 0.95
+
+
+def test_recommend_num_bands_monotone_in_target_and_radius():
+    from goldenmatch.core.perceptual_blocker import recommend_num_bands
+
+    # a stricter recall target never needs fewer bands
+    assert recommend_num_bands(64, 0.15, 0.99) >= recommend_num_bands(64, 0.15, 0.90)
+    # a wider near-dup radius (lower scorer threshold) never needs fewer bands
+    assert recommend_num_bands(64, 0.25, 0.95) >= recommend_num_bands(64, 0.10, 0.95)
+    # result always evenly divides hash_bits (PerceptualKeyConfig invariant)
+    assert 64 % recommend_num_bands(64, 0.15, 0.95) == 0
+
+
+def test_recommend_num_bands_lifts_blocking_recall():
+    from goldenmatch.core.perceptual_blocker import recommend_num_bands
+
+    # The recommended count recalls more true near-dup pairs than the old default 8.
+    base = 0x0123456789ABCDEF
+    # 12 near-duplicates at a ~2/64 hamming radius (well inside the 0.85 threshold)
+    hashes = [base] + [base ^ ((1 << k) | (1 << ((k + 7) % 64))) for k in range(12)]
+    gt = {(0, i) for i in range(1, len(hashes))}
+    nb = recommend_num_bands(64, 0.15, 0.95)
+    recalled_hi = len(PerceptualLSHBlocker(nb, 64).candidate_pairs(hashes) & gt)
+    recalled_8 = len(PerceptualLSHBlocker(8, 64).candidate_pairs(hashes) & gt)
+    assert recalled_hi >= recalled_8
+
+
 # --------------------------------------------------------------------------- #
 # end-to-end on real image pHashes                                            #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Acts on the first measured iteration of the perceptual metrics harness (#1229). The harness **refuted two of three** candidate fixes and **confirmed one** — this PR ships the confirmed one and records the refutations so we don't re-try them.

### ✅ Finding 2 (blocking band-count) — confirmed & fixed
The perceptual LSH blocker's default `num_bands=8` recalls only **0.72** of true near-duplicate pairs (reduction 0.77); `num_bands=16` recalls **0.97** (reduction 0.28). For a near-dup *media* blocker, recall is the priority: a missed dup is unrecoverable, while the scorer filters the extra candidates cheaply.

Make the band count **recall-target-driven** instead of a hardcoded count (mirrors the semantic-blocking move in #1090):
- `perceptual_blocker.recommend_num_bands(hash_bits, target_hamming_frac, target_recall)` derives the count from the scorer threshold via the banded-LSH collision S-curve (`lsh_collision_probability`).
- `PerceptualKeyConfig.num_bands` default **8 → 16** (re-earned; it was only introduced in #1221, so blast radius is one release).
- The zero-config path (`apply_perceptual_autoconfig`) computes it from the image threshold (0.85 → 16 bands at a 0.95 recall target) rather than relying on the static default, so a non-default threshold adapts.

Tests: `test_perceptual_feature.py` (recommender meets/monotone/divides + lifts blocking recall, default is 16) and `test_perceptual_autoconfig.py` (zero-config produces 16). The two existing tests that use the default only gain recall, so they still pass.

### ❌ Finding 1 (geometric robustness) — refuted, deferred to the walk tier
The suite's `rotate` (8°) and `crop` (content) recall **0.0**; pHash is photometric, not geometric. The cheap candidate fix (dihedral-min canonical hash — min over the 8 rotations/flips) was **measured net-negative**: it leaves 8°-rotate and crop at 0.0 (neither is a dihedral symmetry) *and* degrades the photometric cases it should leave alone (brightness 1.0→0.97, noise 0.83→0.57). Real geometric robustness needs a different representation (feature-point / log-polar / learned) — i.e. the BYO-vector **walk tier**, not a crawl-tier hash trick. Not shipped; documented as a known limitation.

### ❌ Finding 3 (audio additive noise) — refuted, not a threshold problem
Noisy-pair similarity (0.43–0.54) is **statistically identical** to unrelated pairs (nonmatch mean 0.53): ±0.05 additive noise on the near-pure-tone suite drives BER to ~0.5, so the signal is gone and **no threshold separates it** (at 0.70 precision already collapses to 0.66 with noise recall still 0.0). Lowering the `audio_fp` threshold is measured-harmful; 0.80 stays optimal. Causes: pure tones are pathological for Haitsma-Kalker (near-empty log-bands → sign bit is noise-dominated even at ~23 dB SNR), and the crawl-tier fingerprint has no bit-reliability/redundancy. A noise-robust fingerprint is new-kernel work; deferred. Harness follow-up noted: make the noise variant broadband.

All three findings are recorded in `context-network/planning/multimodal-er.md`.

### Verification
Recommender + S-curve verified numerically (16 at the image default; monotone in target & radius; always divides `hash_bits`). Edited modules `py_compile` clean. Full pytest runs in CI (polars-heavy `__init__` isn't importable in the sandbox; the band math was verified directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p)_