### PR TITLE
feat(goldengraph): literal attribute values as typed leaf nodes (GOLDENGRAPH_LITERAL_ATTRS)

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -49,6 +49,9 @@ on:
       distill_log:
         description: "goldengraph only: capture (text->extraction)+(entity->fingerprint) pairs to a JSONL artifact for in-house distillation"
         default: "false"
+      literal_attrs:
+        description: "goldengraph only: capture literal attribute values (dates/quantities/amounts) as typed leaf nodes so the graph can answer non-entity questions"
+        default: "false"
 
 permissions:
   contents: read
@@ -115,6 +118,7 @@ jobs:
           GOLDENGRAPH_BUILD_WORKERS: ${{ inputs.build_workers }}
           GOLDENGRAPH_BUILD_DEBUG: ${{ inputs.build_debug }}
           GOLDENGRAPH_EXTRACTOR: ${{ inputs.extractor }}
+          GOLDENGRAPH_LITERAL_ATTRS: ${{ inputs.literal_attrs }}
           GOLDENGRAPH_DISTILL_LOG: ${{ inputs.distill_log == 'true' && format('results/distill_goldengraph_amb{0}.jsonl', matrix.ambiguity) || '' }}
         run: |
           mkdir -p results

--- a/packages/python/goldengraph/goldengraph/extract.py
+++ b/packages/python/goldengraph/goldengraph/extract.py
@@ -10,7 +10,8 @@ dropped rather than poisoning the graph.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 
 from .llm import LLMClient
 
@@ -22,6 +23,25 @@ no prose, in exactly this shape:
 "obj": <entity index>}}]}}
 The `description` is a brief, source-grounded characterization (e.g. "American \
 technology corporation") that disambiguates the entity for resolution. \
+`subj`/`obj` are 0-based indices into `entities`. Text:
+{text}"""
+
+# Literals-aware variant (GOLDENGRAPH_LITERAL_ATTRS): also captures attribute
+# VALUES (dates, quantities, amounts) that are not themselves entities, so the
+# graph can answer "when/how much" questions an entity-only graph drops.
+_PROMPT_LITERALS = """You extract a knowledge graph from text. Return STRICT JSON \
+only, no prose, in exactly this shape:
+{{"entities": [{{"name": "<surface name>", "type": "<coarse type>", \
+"description": "<one short factual phrase describing the entity>"}}], \
+"relationships": [{{"subj": <entity index>, "predicate": "<verb phrase>", \
+"obj": <entity index>}}], \
+"attributes": [{{"subj": <entity index>, "predicate": "<attribute phrase>", \
+"value": "<literal value>", "type": "date|quantity|text"}}]}}
+`relationships` connect two ENTITIES. `attributes` attach a LITERAL VALUE to an \
+entity -- use them for dates, quantities, money amounts, measurements, and other \
+values that are NOT themselves entities (e.g. {{"subj": 0, "predicate": "born on", \
+"value": "11 February 1929", "type": "date"}}). Do NOT put a date/number/amount in \
+`entities`. The `description` disambiguates an entity for resolution. \
 `subj`/`obj` are 0-based indices into `entities`. Text:
 {text}"""
 
@@ -41,9 +61,20 @@ class Relationship:
 
 
 @dataclass
+class Attribute:
+    """A literal VALUE attached to an entity (entity -[predicate]-> "value").
+    `subj` indexes Extraction.mentions; `value` is a literal, not an entity."""
+    subj: int
+    predicate: str
+    value: str
+    typ: str = "text"  # date | quantity | text
+
+
+@dataclass
 class Extraction:
     mentions: list[Mention]
     relationships: list[Relationship]
+    attributes: list[Attribute] = field(default_factory=list)
 
 
 def _strip_fence(raw: str) -> str:
@@ -54,6 +85,9 @@ def _strip_fence(raw: str) -> str:
         if s.rstrip().endswith("```"):
             s = s.rstrip()[:-3]
     return s.strip()
+
+
+_ATTR_TYPES = ("date", "quantity", "text")
 
 
 def parse_extraction(raw: str) -> Extraction:
@@ -73,9 +107,36 @@ def parse_extraction(raw: str) -> Extraction:
         # defensive: drop endpoints that aren't valid entity indices
         if isinstance(s, int) and isinstance(o, int) and 0 <= s < n and 0 <= o < n:
             rels.append(Relationship(subj=s, predicate=str(r.get("predicate", "")), obj=o))
-    return Extraction(mentions=mentions, relationships=rels)
+    attrs: list[Attribute] = []
+    for a in data.get("attributes", []):
+        s, v = a.get("subj"), a.get("value")
+        # defensive: valid subject entity index + a non-empty scalar value
+        if not (isinstance(s, int) and 0 <= s < n):
+            continue
+        if isinstance(v, bool) or not isinstance(v, (str, int, float)):
+            continue
+        val = str(v).strip()
+        if not val:
+            continue
+        typ = str(a.get("type", "text")).lower()
+        attrs.append(
+            Attribute(
+                subj=s,
+                predicate=str(a.get("predicate", "")),
+                value=val,
+                typ=typ if typ in _ATTR_TYPES else "text",
+            )
+        )
+    return Extraction(mentions=mentions, relationships=rels, attributes=attrs)
 
 
-def extract(text: str, llm: LLMClient) -> Extraction:
-    """Extract entities + relationships from `text` via `llm`."""
-    return parse_extraction(llm.complete(_PROMPT.format(text=text)))
+def extract(text: str, llm: LLMClient, *, literals: bool | None = None) -> Extraction:
+    """Extract entities + relationships (+ literal attributes when `literals`) from
+    `text` via `llm`. `literals=None` (the default) reads the
+    `GOLDENGRAPH_LITERAL_ATTRS` flag, so the build's 2-arg call site stays unchanged
+    (and monkeypatched test stubs keep their `(text, llm)` shape); pass an explicit
+    bool to force it."""
+    if literals is None:
+        literals = os.environ.get("GOLDENGRAPH_LITERAL_ATTRS", "0") not in ("0", "false", "")
+    prompt = _PROMPT_LITERALS if literals else _PROMPT
+    return parse_extraction(llm.complete(prompt.format(text=text)))

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -84,17 +84,58 @@ def build_batch(
             }
         )
 
-    return {
-        "entities": [
+    out_entities = [
+        {
+            "local_id": e.local_id,
+            "canonical_name": e.canonical_name,
+            "typ": e.typ,
+            "surface_names": e.surface_names,
+            "record_keys": e.record_keys,
+        }
+        for e in entities
+    ]
+
+    # Literal attributes -> typed leaf nodes + edges (entity -[predicate]-> literal).
+    # Represented as ordinary nodes (no store schema change) typed 'literal:<kind>';
+    # the same-type + name gate in the cross-doc matcher isolates them (a literal
+    # only ever clusters with an identical-value literal, which is harmless), and
+    # they carry NO record_keys so they never anchor a cross-doc merge. Deduped by
+    # (kind, value) within the doc so one date mentioned twice is one node.
+    next_local = max((e.local_id for e in entities), default=-1) + 1
+    lit_ids: dict[tuple[str, str], int] = {}
+    for a in getattr(extraction, "attributes", ()):  # back-compat: absent -> no-op
+        subj_local = mention_to_local.get(a.subj)
+        val = (a.value or "").strip()
+        if subj_local is None or not val:
+            continue
+        key = (a.typ, val)
+        lid = lit_ids.get(key)
+        if lid is None:
+            lid = next_local
+            next_local += 1
+            lit_ids[key] = lid
+            out_entities.append(
+                {
+                    "local_id": lid,
+                    "canonical_name": val,
+                    "typ": f"literal:{a.typ}",
+                    "surface_names": [val],
+                    "record_keys": [],
+                }
+            )
+        edges.append(
             {
-                "local_id": e.local_id,
-                "canonical_name": e.canonical_name,
-                "typ": e.typ,
-                "surface_names": e.surface_names,
-                "record_keys": e.record_keys,
+                "subj_local": subj_local,
+                "predicate": a.predicate,
+                "obj_local": lid,
+                "valid_from": vf,
+                "valid_to": None,
+                "source_refs": [],
             }
-            for e in entities
-        ],
+        )
+
+    return {
+        "entities": out_entities,
         "edges": edges,
         "ingested_at": at,
     }
@@ -564,6 +605,8 @@ def _prepare_doc(
     critical path; pre-embedding moves that network cost off the serial path."""
     try:
         t0 = time.perf_counter()
+        # `_extract` honors GOLDENGRAPH_LITERAL_ATTRS internally, so this call stays
+        # 2-arg (custom rebel/gliner extractors and test stubs keep that shape).
         extraction = (extractor or _extract)(text, llm)
         if timers:
             timers.add("extract", time.perf_counter() - t0)

--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -19,12 +19,24 @@ def _format_subgraph(view: dict) -> str:
     answer was IN the subgraph but went unread). Name-keyed edges spell the chain out
     directly (``Acme -[made]-> Rocket``), so following a path is a lexical walk, not a
     join."""
-    by_id = {e["entity_id"]: e["canonical_name"] for e in view["entities"]}
+    by_id = {e["entity_id"]: e for e in view["entities"]}
 
     def _name(i):
-        return by_id.get(i, str(i))
+        e = by_id.get(i)
+        if e is None:
+            return str(i)
+        nm = e["canonical_name"]
+        # Quote literal-value leaves so a chain reads `X -[born on]-> "1929"` and the
+        # model can tell a value answer from an entity answer.
+        return f'"{nm}"' if str(e.get("typ", "")).startswith("literal:") else nm
 
-    ents = "; ".join(f"{e['canonical_name']} ({e['typ']})" for e in view["entities"])
+    def _label(e):
+        typ = str(e.get("typ", ""))
+        if typ.startswith("literal:"):
+            return f'"{e["canonical_name"]}" ({typ.split(":", 1)[1]} value)'
+        return f"{e['canonical_name']} ({typ})"
+
+    ents = "; ".join(_label(e) for e in view["entities"])
     edges = "\n".join(
         f"  {_name(e['subj'])} -[{e['predicate']}]-> {_name(e['obj'])}"
         for e in view["edges"]
@@ -32,7 +44,11 @@ def _format_subgraph(view: dict) -> str:
     return f"Entities: {ents}\nRelationships (subject -[relation]-> object):\n{edges}"
 
 
-_LOCAL_PROMPT = (
+# The prompt is shared except for the final-answer clause, which is gated on the
+# literal-attributes flag so the entity-only path (flag off) stays byte-identical
+# to the #1227 prompt -- a relaxed "entity OR literal" instruction must not perturb
+# the measured entity-only baseline.
+_LOCAL_HEAD = (
     "Answer the question using ONLY the knowledge subgraph below (entities joined by "
     "directed, labelled relationships).\n"
     "These questions are usually MULTI-HOP: the answer is reached by chaining several "
@@ -54,13 +70,35 @@ _LOCAL_PROMPT = (
     "end of the answering edge from the entity you carried in. Never answer with the "
     "entity you already held going into the final hop.\n"
     "Anchor entities: {seeds}\n"
+)
+_ANSWER_ENTITY = (
     "Your final answer is ALWAYS a single entity that appears in the Entities list -- "
     "output its EXACT name, nothing else, on the last line prefixed 'Answer: '. Commit "
     "to the single most plausible entity even if an intermediate hop is uncertain; do "
     "NOT answer with a description, a phrase, or 'cannot answer' unless NOTHING in the "
     "Entities list is even loosely related. Show each hop briefly first.\n"
-    "Question: {q}\n{sub}"
 )
+_ANSWER_LITERAL = (
+    "Your final answer is a single item from the Entities list -- usually a named "
+    "entity, but it MAY be a literal VALUE leaf (a date, quantity, or amount, shown in "
+    "quotes) when the question asks 'when', 'how much', or 'how many'. Output its EXACT "
+    "text without the quotes, nothing else, on the last line prefixed 'Answer: '. "
+    "Commit to the single most plausible item even if an intermediate hop is uncertain; "
+    "do NOT answer with a free-form description or 'cannot answer' unless NOTHING in the "
+    "Entities list is even loosely related. Show each hop briefly first.\n"
+)
+_LOCAL_TAIL = "Question: {q}\n{sub}"
+
+_LOCAL_PROMPT = _LOCAL_HEAD + _ANSWER_ENTITY + _LOCAL_TAIL
+_LOCAL_PROMPT_LITERALS = _LOCAL_HEAD + _ANSWER_LITERAL + _LOCAL_TAIL
+
+
+def _literals_enabled() -> bool:
+    """Mirror of ingest._literal_attrs_enabled (kept local to avoid importing the
+    build module into synthesis)."""
+    import os
+
+    return os.environ.get("GOLDENGRAPH_LITERAL_ATTRS", "0") not in ("0", "false", "")
 _MAP_PROMPT = "Summarize this community as it bears on the question.\nQuestion: {q}\n{sub}"
 _REDUCE_PROMPT = (
     "Answer the question by combining these community summaries.\n"
@@ -108,9 +146,10 @@ def synthesize_local(
     seeds = ", ".join(dict.fromkeys(s for s in (seed_names or []) if s)) or (
         "(none identified -- choose the most relevant entities yourself)"
     )
+    prompt = _LOCAL_PROMPT_LITERALS if _literals_enabled() else _LOCAL_PROMPT
     return _extract_answer(
         llm.complete(
-            _LOCAL_PROMPT.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
+            prompt.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
         )
     )
 

--- a/packages/python/goldengraph/tests/test_literal_attributes.py
+++ b/packages/python/goldengraph/tests/test_literal_attributes.py
@@ -1,0 +1,164 @@
+"""Literal/attribute-value capability (GOLDENGRAPH_LITERAL_ATTRS).
+
+A KG that drops dates/quantities/amounts can't answer 'when'/'how much' questions
+-- the dominant non-entity loss bucket in the 2026-06-23 N=50 MuSiQue trace. These
+pure (no native, no LLM) tests pin the slice: extraction captures attributes, the
+batch turns them into typed literal leaf nodes + edges, and synthesis is allowed
+to answer with a literal value (only when the flag is on -- the entity-only path
+stays byte-identical).
+"""
+
+from __future__ import annotations
+
+import goldengraph.synthesize as synth
+from goldengraph.extract import Attribute, Extraction, Mention, parse_extraction
+from goldengraph.ingest import build_batch
+from goldengraph.resolve import ResolvedEntity
+from goldengraph.synthesize import _format_subgraph, synthesize_local
+from conftest import RecordingLLM, StubLLM
+
+
+# --- extraction -------------------------------------------------------------
+
+
+def test_parse_extraction_reads_attributes():
+    raw = (
+        '{"entities": [{"name": "Acme", "type": "org"}],'
+        ' "relationships": [],'
+        ' "attributes": [{"subj": 0, "predicate": "founded on",'
+        ' "value": "1 April 1976", "type": "date"}]}'
+    )
+    ex = parse_extraction(raw)
+    assert len(ex.attributes) == 1
+    a = ex.attributes[0]
+    assert (a.subj, a.predicate, a.value, a.typ) == (0, "founded on", "1 April 1976", "date")
+
+
+def test_parse_extraction_attributes_are_defensive():
+    raw = (
+        '{"entities": [{"name": "Acme", "type": "org"}], "relationships": [],'
+        ' "attributes": ['
+        '   {"subj": 9, "predicate": "p", "value": "x", "type": "date"},'   # bad index
+        '   {"subj": 0, "predicate": "p", "value": "", "type": "date"},'    # empty value
+        '   {"subj": 0, "predicate": "p", "value": true, "type": "date"},'  # non-scalar
+        '   {"subj": 0, "predicate": "p", "value": 42, "type": "weird"}'    # coerced type
+        ']}'
+    )
+    ex = parse_extraction(raw)
+    assert len(ex.attributes) == 1
+    assert ex.attributes[0].value == "42"
+    assert ex.attributes[0].typ == "text"  # unknown type -> text
+
+
+def test_parse_extraction_without_attributes_key_is_empty():
+    ex = parse_extraction('{"entities": [], "relationships": []}')
+    assert ex.attributes == []
+
+
+def test_extract_literals_flag_uses_the_attribute_prompt():
+    from goldengraph.extract import extract
+
+    llm = RecordingLLM(response='{"entities": [], "relationships": [], "attributes": []}')
+    extract("some text", llm, literals=True)
+    assert "attributes" in llm.prompts[-1]
+    assert '"date|quantity|text"' in llm.prompts[-1]
+    # default (no literals) keeps the entity-only prompt
+    llm2 = RecordingLLM(response='{"entities": [], "relationships": []}')
+    extract("some text", llm2)
+    assert "attributes" not in llm2.prompts[-1]
+
+
+# --- batch building ---------------------------------------------------------
+
+
+def _ent(local_id, name, typ="org", members=(0,)):
+    return ResolvedEntity(
+        local_id=local_id, canonical_name=name, typ=typ,
+        surface_names=[name], record_keys=[f"k{local_id}"], member_idx=list(members),
+    )
+
+
+def test_build_batch_emits_literal_nodes_and_edges():
+    entities = [_ent(0, "Acme", members=[0])]
+    ex = Extraction(
+        mentions=[Mention("Acme", "org")],
+        relationships=[],
+        attributes=[Attribute(subj=0, predicate="founded on", value="1976", typ="date")],
+    )
+    batch = build_batch(ex, entities, at=1)
+    lits = [e for e in batch["entities"] if e["typ"].startswith("literal:")]
+    assert len(lits) == 1
+    lit = lits[0]
+    assert lit["typ"] == "literal:date"
+    assert lit["canonical_name"] == "1976"
+    assert lit["record_keys"] == []  # never anchors a cross-doc merge
+    # an edge connects the real entity to the literal leaf
+    edge = [e for e in batch["edges"] if e["obj_local"] == lit["local_id"]]
+    assert len(edge) == 1
+    assert edge[0]["subj_local"] == 0 and edge[0]["predicate"] == "founded on"
+
+
+def test_build_batch_dedupes_identical_literals_within_doc():
+    entities = [_ent(0, "Acme", members=[0]), _ent(1, "Globex", members=[1])]
+    ex = Extraction(
+        mentions=[Mention("Acme", "org"), Mention("Globex", "org")],
+        relationships=[],
+        attributes=[
+            Attribute(subj=0, predicate="founded on", value="1976", typ="date"),
+            Attribute(subj=1, predicate="founded on", value="1976", typ="date"),
+        ],
+    )
+    batch = build_batch(ex, entities, at=1)
+    lits = [e for e in batch["entities"] if e["typ"].startswith("literal:")]
+    assert len(lits) == 1  # one shared "1976" date node
+    # but both entities get an edge to it
+    assert sum(1 for e in batch["edges"] if e["obj_local"] == lits[0]["local_id"]) == 2
+
+
+def test_build_batch_no_attributes_is_unchanged():
+    entities = [_ent(0, "Acme", members=[0])]
+    ex = Extraction(mentions=[Mention("Acme", "org")], relationships=[])
+    batch = build_batch(ex, entities, at=1)
+    assert all(not e["typ"].startswith("literal:") for e in batch["entities"])
+    assert batch["edges"] == []
+
+
+# --- synthesis --------------------------------------------------------------
+
+_SUB_LITERAL = {
+    "entities": [
+        {"entity_id": 0, "canonical_name": "Acme", "typ": "org"},
+        {"entity_id": 1, "canonical_name": "1976", "typ": "literal:date"},
+    ],
+    "edges": [{"subj": 0, "predicate": "founded on", "obj": 1}],
+}
+
+
+def test_format_subgraph_quotes_literal_values():
+    text = _format_subgraph(_SUB_LITERAL)
+    assert '"1976" (date value)' in text  # entity-list label
+    assert 'Acme -[founded on]-> "1976"' in text  # quoted in the edge chain
+
+
+def test_synthesize_uses_literal_prompt_only_when_flag_on(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_LITERAL_ATTRS", "1")
+    llm = RecordingLLM(response="Answer: 1976")
+    synthesize_local("When founded?", _SUB_LITERAL, llm)
+    assert "literal VALUE leaf" in llm.prompts[-1]
+
+    monkeypatch.setenv("GOLDENGRAPH_LITERAL_ATTRS", "0")
+    llm2 = RecordingLLM(response="Answer: Acme")
+    synthesize_local("q?", _SUB_LITERAL, llm2)
+    assert "literal VALUE leaf" not in llm2.prompts[-1]
+    assert "ALWAYS a single entity" in llm2.prompts[-1]  # entity-only path intact
+
+
+def test_synthesize_returns_literal_answer():
+    llm = StubLLM("hop one\nAnswer: 1976")
+    assert synthesize_local("When founded?", _SUB_LITERAL, llm) == "1976"
+
+
+def test_entity_only_prompt_is_byte_identical_to_pre_literal():
+    # The flag-off prompt must equal head + entity-clause + tail exactly, so the
+    # measured entity-only baseline is never perturbed by this slice.
+    assert synth._LOCAL_PROMPT == synth._LOCAL_HEAD + synth._ANSWER_ENTITY + synth._LOCAL_TAIL


### PR DESCRIPTION
## Why

The N=50 MuSiQue trace showed **~60% of losses are non-entity gold answers** — dates (`11 February 1929`), amounts (`$72,641`), descriptive values — that an entity-only graph **cannot emit by construction**. Per the North Star (goldenmatch as the default **KG** option, not just classic ER), a graph that silently drops literals is *incomplete*. This adds attribute/literal values so the graph can answer "when / how much / how many" questions.

## Design — zero Rust, no native rebuild

A literal is represented as a **typed leaf node** (`typ="literal:<kind>"`) plus an edge `entity -[predicate]-> "<value>"`, injected in the **Python** `build_batch`. The obvious alternative (an `obj_literal` on the Rust `BatchEdge`) would need a native schema change + wheel rebuild; the leaf-node design needs **none** — the store, retrieval BFS, and resolution are untouched:
- **Isolation is free:** the same-type + name+category gate in the cross-doc matcher means a `literal:date` only ever clusters with an identical-value `literal:date` (harmless dedup); different dates never merge. Literals carry **no `record_keys`**, so they never anchor a cross-doc merge.
- **Retrieval unchanged:** the literal is a terminal leaf reached by the existing entity BFS.

## What
- **`extract.py`** — `Attribute` dataclass + a literals-aware prompt (`_PROMPT_LITERALS`) that asks for attribute *values* separately from entities (with a worked `born on → "11 February 1929"` example); defensive parse (bad index / empty / non-scalar dropped, unknown type → `text`). `extract()` reads `GOLDENGRAPH_LITERAL_ATTRS` so the build's 2-arg call site (and monkeypatched test stubs) stay unchanged.
- **`ingest.build_batch`** — injects one typed literal node per `(kind, value)` + an edge; deduped within a doc; empty `record_keys`.
- **`synthesize.py`** — a literal-aware final-answer clause ("entity **or** literal value"), **gated on the flag so the entity-only path is byte-identical to #1227** (a test pins this); literal values render **quoted** in the subgraph so the model distinguishes a value answer from an entity.
- **bench** — `GOLDENGRAPH_LITERAL_ATTRS` wired via a new `literal_attrs` workflow input.

## Validation
- **Default OFF** — flag-off behavior is byte-identical to today.
- 12 new native-free tests (`test_literal_attributes.py`): extraction parse + defensiveness, batch injection + within-doc dedup + no-attrs-unchanged, synthesis prompt-gating + literal answer extraction + the byte-identical entity prompt. Full goldengraph suite green (the 6 pre-existing `goldengraph_native` import errors are the un-built native store, unaffected).

## Next
Phase 1 is dates + quantities + text. The scout flagged one orthogonal risk — seeding must still find the **entity anchor** for a literal-answer question — which the localize trace shows is usually already retrieved. The real test is a bench run with `literal_attrs=true`, read against the **entity-subset vs date/number split** from #1228: it should convert a chunk of the date/number EXTRACTION losses into answerable questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_