### PR TITLE
Add accuracy_febrl3 real-dataset metrics probe (opt-in)

### DIFF
--- a/.github/workflows/bench-metrics.yml
+++ b/.github/workflows/bench-metrics.yml
@@ -7,8 +7,10 @@ name: bench-metrics
 #
 # Posture (v1): local-iteration tool + dispatch/scheduled run. NOT a blocking
 # per-PR gate -- the report is informational by default and posted to the job
-# summary. Opt into a hard regression check with the `check` input. Fully
-# offline (no datasets, no Postgres, no API keys), so it runs on forks too.
+# summary. Opt into a hard regression check with the `check` input. The synthetic
+# core is fully offline (no datasets, Postgres, or API keys) and runs on forks;
+# the opt-in real-dataset probe (accuracy_febrl3) installs `recordlinkage` (bundled
+# Febrl data -- still no download) and runs by default on schedule/dispatch.
 on:
   schedule:
     # Weekly, so trend data accrues. Tuesdays 06:00 UTC (offset from the heavy
@@ -20,6 +22,10 @@ on:
         description: "Fail the run on a gated metric regression vs the committed baseline"
         type: boolean
         default: false
+      real_datasets:
+        description: "Run the opt-in real-dataset probe (Febrl3 via recordlinkage)"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -45,12 +51,21 @@ jobs:
       - name: Install
         run: uv sync --all-packages
 
+      # Opt-in real-dataset probe: schedule always runs it; dispatch honors the
+      # `real_datasets` input (default true). recordlinkage is NOT a goldenmatch
+      # dep -- installed here only for the bench, so the default offline core is
+      # untouched.
+      - name: Install real-dataset deps
+        if: ${{ github.event_name == 'schedule' || inputs.real_datasets }}
+        run: uv pip install recordlinkage
+
       - name: Run metrics harness
         env:
           # Reproducible: explicit-config probes don't use auto-config memory,
           # but pin it off for good measure.
           GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
           CHECK: ${{ inputs.check && '--check' || '' }}
+          METRICS_REAL_DATASETS: ${{ (github.event_name == 'schedule' || inputs.real_datasets) && '1' || '' }}
         run: |
           uv run python scripts/metrics/harness.py \
             --out metrics_report.json \

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -23,6 +23,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   fallback when the native wheel is absent.
 
 ### Added
+- **`accuracy_febrl3` real-dataset metrics probe (opt-in).** The metrics harness
+  gains its first *real* ER-benchmark probe — Febrl3 (5000-record person dedup
+  with published ground truth) via `recordlinkage`'s bundled data, so it's still
+  offline (no download) and deterministic. Gated opt-in (`METRICS_REAL_DATASETS=1`
+  + `recordlinkage` installed): it skips cleanly — contributing **no** metrics,
+  never an error — when the flag is off or the dep is absent, so the default run
+  and the committed baseline stay dependency-free. F1/precision/recall are gated
+  (±0.02, env-tolerant); the raw tp/fp/fn counts ride as informational diagnostics
+  (real-data fuzzy scoring can wobble a pair or two across environments). Committed
+  baseline: **F1 0.90 / P 0.87 / R 0.94**. The `bench-metrics` workflow runs it on
+  schedule + dispatch (installs `recordlinkage`, sets the flag). Adds a `skipped`
+  status to the probe protocol — the seam for further download/key-gated sets
+  (DBLP-ACM, NCVR) to plug in behind the same opt-in skip pattern.
 - **`accuracy_trained_embedder` metrics probe — trained-embedder recall lift.**
   A new probe in the metrics harness that isolates the value a *trained* in-house
   embedder adds over the untrained char-n-gram projection, measured on the signal

--- a/packages/python/goldenmatch/scripts/metrics/baseline.json
+++ b/packages/python/goldenmatch/scripts/metrics/baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "updated_at": "2026-06-23T16:55:10Z",
+  "updated_at": "2026-06-23T17:53:01Z",
   "metrics": {
     "accuracy_synthetic.f1": {
       "value": 0.8456,
@@ -100,22 +100,64 @@
       "two_sided": true,
       "gated": true
     },
+    "accuracy_febrl3.f1": {
+      "value": 0.9017,
+      "tol": 0.02,
+      "higher_better": true,
+      "two_sided": false,
+      "gated": true
+    },
+    "accuracy_febrl3.precision": {
+      "value": 0.8691,
+      "tol": 0.02,
+      "higher_better": true,
+      "two_sided": false,
+      "gated": true
+    },
+    "accuracy_febrl3.recall": {
+      "value": 0.937,
+      "tol": 0.02,
+      "higher_better": true,
+      "two_sided": false,
+      "gated": true
+    },
+    "accuracy_febrl3.tp": {
+      "value": 6126.0,
+      "tol": 9000000000.0,
+      "higher_better": false,
+      "two_sided": false,
+      "gated": false
+    },
+    "accuracy_febrl3.fp": {
+      "value": 923.0,
+      "tol": 9000000000.0,
+      "higher_better": false,
+      "two_sided": false,
+      "gated": false
+    },
+    "accuracy_febrl3.fn": {
+      "value": 412.0,
+      "tol": 9000000000.0,
+      "higher_better": false,
+      "two_sided": false,
+      "gated": false
+    },
     "perf_synthetic.wall_s": {
-      "value": 3.0731,
+      "value": 3.713,
       "tol": 9000000000.0,
       "higher_better": false,
       "two_sided": false,
       "gated": false
     },
     "perf_synthetic.peak_rss_mb": {
-      "value": 195.1,
+      "value": 329.4,
       "tol": 9000000000.0,
       "higher_better": false,
       "two_sided": false,
       "gated": false
     },
     "perf_synthetic.records_per_s": {
-      "value": 850.6,
+      "value": 704.0,
       "tol": 9000000000.0,
       "higher_better": true,
       "two_sided": false,

--- a/packages/python/goldenmatch/scripts/metrics/harness.py
+++ b/packages/python/goldenmatch/scripts/metrics/harness.py
@@ -13,8 +13,14 @@ Why this exists: the repo's metrics machinery is sophisticated but fragmented
 there was no single "run the numbers and tell me if I regressed" entry point and
 no committed accuracy baseline. This is the offline core: synthetic accuracy +
 perf that runs anywhere (no downloads, no Postgres, no API keys), so it's a
-local-iteration tool today and a CI regression gate tomorrow. The download/key-
-gated real datasets (DBLP-ACM, NCVR, DQbench) plug in as additional probes.
+local-iteration tool today and a CI regression gate tomorrow.
+
+Real-dataset probes plug in opt-in (``METRICS_REAL_DATASETS=1``): ``accuracy_febrl3``
+runs the real Febrl3 ER benchmark via ``recordlinkage`` (bundled data, still
+offline). They skip cleanly -- contributing NO metrics, never an error -- when the
+flag is off or the dep is absent, so the default run and committed baseline stay
+dependency-free. Further download/key-gated sets (DBLP-ACM, NCVR, DQbench) follow
+the same opt-in skip pattern.
 
 Usage::
 
@@ -224,6 +230,14 @@ class ProbeOutcome:
     meta: dict[str, Any] = field(default_factory=dict)
     elapsed_s: float = 0.0
     error: str | None = None
+    # A skipped probe ran no work (opt-in not enabled, or an optional dataset/dep
+    # is absent). It contributes NO metrics, so it never enters the baseline or the
+    # diff -- distinct from ``error`` (a probe that should have run but failed).
+    skipped: str | None = None
+
+
+def _skipped(group: str, reason: str) -> ProbeOutcome:
+    return ProbeOutcome(group=group, metrics={}, skipped=reason)
 
 
 def probe_accuracy() -> ProbeOutcome:
@@ -454,10 +468,84 @@ def probe_trained_embedder() -> ProbeOutcome:
     )
 
 
+# ── real-dataset probe (opt-in) ───────────────────────────────────────────────
+# The synthetic probes run everywhere with no deps; a REAL standard ER benchmark
+# is the counterpart that catches accuracy regressions a hand-built generator
+# can't model. Febrl3 (recordlinkage) is a 5000-record person-dedup benchmark
+# WITH ground truth, bundled in the library -- so it's still fully offline (no
+# download) and deterministic, but gated opt-in so the default run (and the
+# committed baseline) stay dependency-free.
+
+
+def _real_datasets_enabled() -> bool:
+    """Opt-in gate for the real-dataset probes. NOT a ``GOLDENMATCH_*`` runtime
+    flag (those are the user tuning surface) -- this is a dev-harness toggle, so it
+    carries no such prefix and stays out of the tuning-doc reference."""
+    return os.environ.get("METRICS_REAL_DATASETS", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+# Deterministic explicit config for Febrl3 (avoids zero-config nondeterminism):
+# exact soc_sec_id OR fuzzy given_name+surname+date_of_birth. F1 ~0.90.
+def probe_febrl3() -> ProbeOutcome:
+    """F1 / precision / recall on the real Febrl3 ER benchmark (recordlinkage).
+
+    Opt-in (``METRICS_REAL_DATASETS=1`` + ``recordlinkage`` installed): a 5000-row
+    person-dedup set with published ground truth, run through an EXPLICIT config so
+    the numbers are deterministic. Skips cleanly (NO metrics, never an error) when
+    the flag is off or the dep is absent, so the default offline run and the
+    committed baseline are unaffected. This is the real-data counterpart to the
+    synthetic accuracy probe -- the regression net for changes that move accuracy
+    on real corruption the synthetic generator doesn't model.
+    """
+    if not _real_datasets_enabled():
+        return _skipped("accuracy", "set METRICS_REAL_DATASETS=1 to enable real-dataset probes")
+    try:
+        from recordlinkage.datasets import load_febrl3
+    except ImportError:
+        return _skipped("accuracy", "recordlinkage not installed (pip install recordlinkage)")
+
+    import polars as pl
+    from goldenmatch import dedupe_df, evaluate_clusters
+
+    df_pd, links = load_febrl3(return_links=True)
+    df_pd = df_pd.sort_index()  # fixed row order -> deterministic positions
+    pos = {rec: i for i, rec in enumerate(df_pd.index)}
+    rows = df_pd.reset_index(drop=True).fillna("").astype(str).to_dict("records")
+    gt = {(min(pos[a], pos[b]), max(pos[a], pos[b])) for a, b in links if a in pos and b in pos}
+
+    res = dedupe_df(
+        pl.DataFrame(rows),
+        exact=["soc_sec_id"],
+        fuzzy={"given_name": 0.85, "surname": 0.85, "date_of_birth": 0.85},
+        confidence_required=False,
+    )
+    ev = evaluate_clusters(res.clusters or {}, gt)
+    n_multi = sum(1 for c in (res.clusters or {}).values() if c.get("size", 0) > 1)
+    return ProbeOutcome(
+        group="accuracy",
+        # F1/precision/recall are GATED (+/-0.02 absorbs the few boundary pairs that
+        # cross-env fuzzy scoring can flip out of 6538); the raw tp/fp/fn counts ride
+        # as informational diagnostics rather than strict env-independent fingerprints
+        # (real-data scoring is likelier to wobble by a pair or two than the synthetic
+        # path that the strict-count gate was validated on).
+        metrics={
+            "f1": round(ev.f1, 4),
+            "precision": round(ev.precision, 4),
+            "recall": round(ev.recall, 4),
+            "tp": ev.tp,
+            "fp": ev.fp,
+            "fn": ev.fn,
+        },
+        meta={"n_rows": len(rows), "gt_pairs": len(gt), "dataset": "febrl3",
+              "multi_member_clusters": n_multi},
+    )
+
+
 PROBES: dict[str, Callable[[], ProbeOutcome]] = {
     "accuracy_synthetic": probe_accuracy,
     "accuracy_synthetic_semantic": probe_semantic_blocking,
     "accuracy_trained_embedder": probe_trained_embedder,
+    "accuracy_febrl3": probe_febrl3,
     "perf_synthetic": probe_perf,
 }
 
@@ -518,10 +606,13 @@ def run_report(selected: list[str] | None = None) -> dict[str, Any]:
         try:
             outcome = fn()
             outcome.elapsed_s = round(time.perf_counter() - t0, 3)
-            probes_out[name] = {
-                "group": outcome.group, "metrics": outcome.metrics,
-                "meta": outcome.meta, "elapsed_s": outcome.elapsed_s,
-            }
+            if outcome.skipped:
+                probes_out[name] = {"skipped": outcome.skipped, "elapsed_s": outcome.elapsed_s}
+            else:
+                probes_out[name] = {
+                    "group": outcome.group, "metrics": outcome.metrics,
+                    "meta": outcome.meta, "elapsed_s": outcome.elapsed_s,
+                }
         except Exception as exc:  # one probe failing must not kill the report
             probes_out[name] = {"error": f"{type(exc).__name__}: {exc}",
                                 "elapsed_s": round(time.perf_counter() - t0, 3)}
@@ -554,8 +645,11 @@ _GATED_SUFFIXES = ("f1", "precision", "recall", "scored_pairs", "multi_member_cl
                    "ann_pairs_recovered", "ann_candidate_pairs",
                    "alias_recall_untrained", "alias_recall_trained",
                    "untrained_candidates", "trained_candidates")
+# tp/fp/fn are informational: real-data confusion counts can wobble by a pair or
+# two across fuzzy-scoring environments, so the F1/P/R gate (+/-0.02) is the
+# regression signal, not the raw counts.
 _INFO_SUFFIXES = ("wall_s", "peak_rss_mb", "records_per_s", "recall_lift",
-                  "recall_gain", "train_separation")
+                  "recall_gain", "train_separation", "tp", "fp", "fn")
 # direction: True = higher is better (regression = drop); False = lower is better.
 _HIGHER_BETTER = ("f1", "precision", "recall", "records_per_s",
                   "blocking_recall_baseline", "blocking_recall_semantic",
@@ -574,6 +668,7 @@ _TOL = {"f1": 0.02, "precision": 0.02, "recall": 0.02,
         "ann_pairs_recovered": 0.0, "ann_candidate_pairs": 0.0,
         "alias_recall_untrained": 0.02, "alias_recall_trained": 0.02,
         "untrained_candidates": 0.0, "trained_candidates": 0.0,
+        "tp": 9e9, "fp": 9e9, "fn": 9e9,
         "wall_s": 9e9, "peak_rss_mb": 9e9, "records_per_s": 9e9,
         "recall_lift": 9e9, "recall_gain": 9e9, "train_separation": 9e9}
 
@@ -659,6 +754,9 @@ def to_markdown(report: dict[str, Any], diff: dict[str, Any] | None = None) -> s
     for pname, p in report.get("probes", {}).items():
         if p.get("error"):
             lines.append(f"### {pname} — ERROR: {p['error']}")
+            continue
+        if p.get("skipped"):
+            lines.append(f"### {pname} — skipped: {p['skipped']}")
             continue
         lines.append(f"### {pname} ({p.get('group','')}, {p.get('elapsed_s','?')}s)")
         lines.append("")

--- a/packages/python/goldenmatch/tests/test_metrics_harness.py
+++ b/packages/python/goldenmatch/tests/test_metrics_harness.py
@@ -187,3 +187,43 @@ def test_run_report_shape_and_resilience():
     # an unknown probe is recorded as an error, not a crash
     bad = harness.run_report(["nope"])
     assert "error" in bad["probes"]["nope"]
+
+
+# ── real-dataset probe (opt-in) + skip mechanism ─────────────────────────────
+
+
+def test_febrl3_probe_skips_without_optin(monkeypatch):
+    monkeypatch.delenv("METRICS_REAL_DATASETS", raising=False)
+    out = harness.probe_febrl3()
+    # skipped is distinct from error: no metrics, no failure.
+    assert out.skipped and out.metrics == {} and out.error is None
+
+
+def test_skipped_probe_contributes_no_metrics_and_never_regresses(monkeypatch):
+    monkeypatch.delenv("METRICS_REAL_DATASETS", raising=False)
+    report = harness.run_report(["accuracy_febrl3"])
+    assert report["probes"]["accuracy_febrl3"]["skipped"]
+    # a skipped probe flattens to nothing, so it can't enter the baseline...
+    assert harness._flatten(report) == {}
+    # ...and its (committed, gated) baseline metrics show MISSING, never a regression.
+    base = harness.load_baseline()
+    diff = harness.diff_against_baseline(report, base)
+    assert diff["regressions"] == []
+
+
+def test_febrl3_probe_runs_when_enabled(monkeypatch):
+    pytest.importorskip("recordlinkage")
+    monkeypatch.setenv("METRICS_REAL_DATASETS", "1")
+    out = harness.probe_febrl3()
+    assert out.group == "accuracy" and out.error is None and out.skipped is None
+    assert set(out.metrics) >= {"f1", "precision", "recall", "tp", "fp", "fn"}
+    assert out.metrics["f1"] > 0.8  # explicit config recovers most of the real benchmark
+    assert out.metrics["tp"] > out.metrics["fn"]
+
+
+def test_committed_baseline_records_real_febrl3_numbers():
+    # the real-benchmark numbers are committed (gated f1/p/r), so opt-in runs diff
+    # against a known reference -- and they're documented in-repo.
+    base = harness.load_baseline()
+    assert base["metrics"]["accuracy_febrl3.f1"]["gated"] is True
+    assert base["metrics"]["accuracy_febrl3.tp"]["gated"] is False  # counts informational


### PR DESCRIPTION
## What

The metrics harness's first **real** ER-benchmark probe — **Febrl3** (5000-record person dedup with published ground truth) via `recordlinkage`'s bundled data, so it's still offline (no download) and deterministic. This is the real-data counterpart to the synthetic accuracy probe: the regression net for changes that move accuracy on real corruption a hand-built generator can't model.

Follow-up to #1225 (harness) / #1232 (semantic) / #1234 (trained embedder). Implements the "real-dataset tier" rung.

## Result

Explicit deterministic config (`exact soc_sec_id` ∪ `fuzzy given_name+surname+date_of_birth`):

| metric | value |
|---|---|
| F1 | **0.9017** |
| precision | 0.8691 |
| recall | 0.937 |

(For reference, CLAUDE.md notes auto-config gets Febrl3 ~0.944 and multi-pass FS ~0.991; 0.90 from a fixed explicit config is a solid, stable operating point for a regression net.)

## Opt-in by design

The probe **skips cleanly** — contributing *no* metrics, never an error — unless `METRICS_REAL_DATASETS=1` **and** `recordlinkage` is installed. So the default offline run and the committed baseline stay dependency-free. This adds a `skipped` status to the probe protocol (distinct from `error`) — the seam for further download/key-gated sets (DBLP-ACM, NCVR) to plug in behind the same pattern.

- **Default run** (no flag): `accuracy_febrl3 — skipped`; its committed gated metrics show `MISSING`, which is **non-failing**. `--check` exit 0.
- **Opt-in run** (`METRICS_REAL_DATASETS=1` + recordlinkage): runs, diffs against the committed baseline. `--check` exit 0.

Both modes verified green.

## Gating

F1/precision/recall are **gated** (±0.02 — absorbs the handful of boundary pairs cross-env fuzzy scoring can flip out of 6538). The raw `tp`/`fp`/`fn` counts ride as **informational** diagnostics, since real-data scoring is likelier to wobble by a pair or two across environments than the synthetic path the strict-count gate was validated on. The committed baseline records the real numbers so opt-in runs diff against a known reference (and the benchmark result is documented in-repo).

## Wiring

- `bench-metrics` workflow runs the probe on schedule + dispatch (installs `recordlinkage`, sets the flag); a `real_datasets` dispatch input (default true) toggles it.
- The opt-in env var carries **no** `GOLDENMATCH_` prefix on purpose — it's a dev-harness toggle, not a runtime tuning flag, so it stays out of the user tuning-doc reference (and the docs-staleness flag gate). Verified clean.

4 new tests (skip-without-flag, skip-contributes-nothing-and-never-regresses, real-run-when-enabled [dep-gated via `importorskip`], baseline-records-real-numbers); `ruff` clean; 21 harness tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_