### PR TITLE
feat(er-kg-bench): format-fair LLM-judge metric for the engine head-to-head

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -60,6 +60,9 @@ on:
       literal_attrs:
         description: "goldengraph only: capture literal attribute values (dates/quantities/amounts) as typed leaf nodes so the graph can answer non-entity questions"
         default: "false"
+      judge:
+        description: "ALL engines: also score a format-fair LLM-judge answer-equivalence metric (fixed gpt-4o-mini judge) so terse vs verbose answers compare fairly"
+        default: "true"
 
 permissions:
   contents: read
@@ -137,6 +140,7 @@ jobs:
             --max-questions "${{ inputs.max_questions }}" \
             --ambiguity "${{ matrix.ambiguity }}" \
             --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
             --out-md "results/RESULTS_QA_E2E_goldengraph_amb${{ matrix.ambiguity }}.md" \
             --out-json "results/results_qa_e2e_goldengraph_amb${{ matrix.ambiguity }}.json"
       - name: Upload results
@@ -182,6 +186,7 @@ jobs:
             --max-questions "${{ inputs.max_questions }}" \
             --ambiguity "${{ matrix.ambiguity }}" \
             --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
             --out-md "results/RESULTS_QA_E2E_lightrag_amb${{ matrix.ambiguity }}.md" \
             --out-json "results/results_qa_e2e_lightrag_amb${{ matrix.ambiguity }}.json"
       - name: Upload results
@@ -221,6 +226,7 @@ jobs:
             --max-questions "${{ inputs.max_questions }}" \
             --ambiguity "${{ matrix.ambiguity }}" \
             --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
             --out-md "results/RESULTS_QA_E2E_ms_graphrag_amb${{ matrix.ambiguity }}.md" \
             --out-json "results/results_qa_e2e_ms_graphrag_amb${{ matrix.ambiguity }}.json"
       - name: Upload results
@@ -266,6 +272,7 @@ jobs:
             --max-questions "${{ inputs.max_questions }}" \
             --ambiguity "${{ matrix.ambiguity }}" \
             --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
             --out-md "results/RESULTS_QA_E2E_graphiti_amb${{ matrix.ambiguity }}.md" \
             --out-json "results/results_qa_e2e_graphiti_amb${{ matrix.ambiguity }}.json"
       - name: Upload results

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -246,9 +246,15 @@ def _localize_trace(engine, handle, corpus, *, limit: int = _TRACE_LIMIT) -> Non
         print(f"== shatter-probe verdicts {{{verdict_mix}}} ==", flush=True)
 
 
-def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> dict:
+def run_engine(
+    engine: QAEngine, corpus, *, model: str, budget_usd: float, judge=None
+) -> dict:
     """Build the KG, answer every question under a hard cost cap, score, return a
-    result dict. Stops cleanly (partial result) when the budget is exhausted."""
+    result dict. Stops cleanly (partial result) when the budget is exhausted.
+
+    `judge`, if given, is a callable(prompt)->str used for the format-fair LLM-judge
+    metric (see metrics.judge_prompt); it is eval overhead and is NOT charged against
+    the engine's answer budget."""
     tracker = BudgetTracker(BudgetConfig(max_cost_usd=budget_usd))
 
     build = engine.build_kg(corpus)
@@ -268,6 +274,9 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
     # metrics.classify_answer_type). Non-entity golds (dates/amounts/phrases) are
     # unanswerable-by-construction and would otherwise mask the real accuracy.
     matches_entity: list[float] = []
+    # Format-fair LLM-judge equivalence (None-safe: stays empty when no judge).
+    judges: list[float] = []
+    judges_entity: list[float] = []
     type_counts: dict[str, int] = {}
     decay_rows: list[tuple[int, float]] = []
     records: list[dict] = []
@@ -283,6 +292,17 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
         rec = metrics.supporting_fact_recall(ans.retrieved_fact_ids, q.gold_supporting_fact_ids)
         atype = metrics.classify_answer_type(q.gold_answer)
         type_counts[atype] = type_counts.get(atype, 0) + 1
+        aj: float | None = None
+        if judge is not None:
+            # An empty prediction is a non-answer -- score it NO without a call.
+            aj = (
+                metrics.parse_judge(judge(metrics.judge_prompt(q.question, q.gold_answer, ans.text)))
+                if ans.text.strip()
+                else 0.0
+            )
+            judges.append(aj)
+            if atype == "entity":
+                judges_entity.append(aj)
         if atype == "entity":
             matches_entity.append(am)
         matches.append(am)
@@ -305,6 +325,7 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
                 "hop_count": q.hop_count,
                 "answer_type": atype,
                 "answer_match": am,
+                "answer_judge": aj,
                 "exact_match": em,
                 "token_f1": round(f1, 4),
             }
@@ -327,6 +348,10 @@ def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> di
         "answer_match_entity": _mean(matches_entity),
         "n_entity_answerable": len(matches_entity),
         "answer_type_counts": type_counts,
+        # Format-fair LLM-judge equivalence (None when no judge ran), overall + on
+        # the entity-answerable subset -- the apples-to-apples cross-engine number.
+        "answer_judge": _mean(judges) if judges else None,
+        "answer_judge_entity": _mean(judges_entity) if judges_entity else None,
         "exact_match": _mean(ems),
         "token_f1": _mean(f1s),
         "support_recall": _mean(recalls),
@@ -358,16 +383,21 @@ def write_results(results: list[dict], *, md_path: str | Path, json_path: str | 
     Path(json_path).write_text(json.dumps(results, indent=2, sort_keys=True), encoding="utf-8")
     lines = ["# ER-KG-Bench -- end-to-end multi-hop QA (evidence program #1)", ""]
     lines.append(
-        "| engine | corpus | answer-match | AM (entity-subset) | EM | token-F1 | "
-        "support-recall | cost (USD) | answered | budget hit |"
+        "| engine | corpus | answer-match | LLM-judge | judge (entity-subset) | "
+        "AM (entity-subset) | EM | token-F1 | support-recall | cost (USD) | "
+        "answered | budget hit |"
     )
-    lines.append("|---|---|---|---|---|---|---|---|---|---|")
+    lines.append("|---|---|---|---|---|---|---|---|---|---|---|---|")
     for r in results:
         ent_am = r.get("answer_match_entity", 0.0)
         n_ent = r.get("n_entity_answerable", 0)
+        judge = r.get("answer_judge")
+        judge_ent = r.get("answer_judge_entity")
+        judge_s = "n/a" if judge is None else f"{judge}"
+        judge_ent_s = "n/a" if judge_ent is None else f"{judge_ent}"
         lines.append(
             f"| {r['engine']} | {r['corpus']} | {r['answer_match']} | "
-            f"{ent_am} (n={n_ent}) | {r['exact_match']} | "
+            f"{judge_s} | {judge_ent_s} | {ent_am} (n={n_ent}) | {r['exact_match']} | "
             f"{r['token_f1']} | {r['support_recall']} | {r['cost_usd']} | "
             f"{r['n_answered']}/{r['n_questions']} | "
             f"{'yes' if r['budget_exhausted'] else 'no'} |"

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
@@ -65,6 +65,44 @@ def supporting_fact_recall(
     return len(gold & set(retrieved_ids)) / len(gold)
 
 
+# --- LLM-judge answer equivalence ---------------------------------------------
+#
+# `answer_match` (gold-token containment) is FORMAT-SENSITIVE: a verbose essay
+# trivially contains the gold span, while a terse one-entity answer is all-or-
+# nothing -- so it scores essay-style RAG engines generously and precise-answer
+# engines harshly (2026-06-23 head-to-head: ms_graphrag essays vs goldengraph's
+# `Answer: X`). The judge asks a fixed model whether the prediction CONVEYS the
+# gold answer regardless of verbosity, applied uniformly to every engine, so the
+# comparison is fair. Kept ALONGSIDE answer_match (not replacing it). The prompt +
+# parse are pure/unit-testable; the call itself is wired in the harness.
+
+_JUDGE_PROMPT = (
+    "You are grading a question-answering system. Decide whether the PREDICTION "
+    "correctly answers the QUESTION, using the reference GOLD answer as ground "
+    "truth. The prediction is CORRECT if it conveys the same answer as the gold -- "
+    "even if phrased differently, more verbose, or with extra context. It is "
+    "INCORRECT if it gives a different answer, contradicts the gold, only hedges "
+    "without committing, or says it cannot answer. Reply with exactly one word: "
+    "YES or NO.\n"
+    "QUESTION: {question}\nGOLD: {gold}\nPREDICTION: {pred}"
+)
+
+
+def judge_prompt(question: str, gold: str, pred: str) -> str:
+    return _JUDGE_PROMPT.format(question=question, gold=gold, pred=pred)
+
+
+def parse_judge(text: str) -> float:
+    """Map an LLM judge verdict to 1.0 (YES) / 0.0 (NO or anything else). The first
+    token decides; a leading hedge falls back to a standalone 'yes' search."""
+    t = (text or "").strip().lower()
+    if t.startswith("yes"):
+        return 1.0
+    if t.startswith("no"):
+        return 0.0
+    return 1.0 if "yes" in t.replace("'", " ").replace(".", " ").split() else 0.0
+
+
 # --- answer-type classification ------------------------------------------------
 #
 # An entity-graph engine (goldengraph) can ONLY ever answer with a NODE -- a named

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -100,6 +100,34 @@ def _build_engine(name: str):
     raise SystemExit(f"unknown engine: {name}")
 
 
+def _make_judge(model: str):
+    """A judge callable(prompt)->str via OpenAI, or None when no key/SDK. Used for
+    the format-fair LLM-judge metric; a FIXED model across engines keeps the
+    comparison honest. Judge failures return '' (scored NO) so they never crash a
+    run. `openai` is installed in every engine lane."""
+    if not os.environ.get("OPENAI_API_KEY"):
+        return None
+    try:
+        from openai import OpenAI
+    except Exception:
+        return None
+    client = OpenAI()
+
+    def _judge(prompt: str) -> str:
+        try:
+            r = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0,
+                max_tokens=4,
+            )
+            return r.choices[0].message.content or ""
+        except Exception:
+            return ""
+
+    return _judge
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--engine", default=None)
@@ -124,6 +152,18 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--musique-seed", type=int, default=MUSIQUE_SUBSET_SEED)
     p.add_argument("--model", default="gpt-4o-mini")
     p.add_argument("--budget-usd", type=float, default=25.0)
+    p.add_argument(
+        "--judge",
+        action="store_true",
+        help="score a format-fair LLM-judge answer-equivalence metric alongside "
+        "answer_match (one fixed-model call per question; eval overhead, not charged "
+        "to the engine budget). Needs OPENAI_API_KEY.",
+    )
+    p.add_argument(
+        "--judge-model",
+        default="gpt-4o-mini",
+        help="fixed judge model -- the SAME across engines so the comparison is fair.",
+    )
     p.add_argument("--out-md", required=True)
     p.add_argument("--out-json", required=True)
     args = p.parse_args(argv)
@@ -146,7 +186,10 @@ def main(argv: list[str] | None = None) -> int:
         musique_seed=args.musique_seed,
     )
     engine = _MockEngine() if args.self_test else _build_engine(args.engine)
-    result = run_engine(engine, corpus, model=args.model, budget_usd=args.budget_usd)
+    judge = _make_judge(args.judge_model) if (args.judge and not args.self_test) else None
+    result = run_engine(
+        engine, corpus, model=args.model, budget_usd=args.budget_usd, judge=judge
+    )
     write_results([result], md_path=out_md, json_path=out_json)
     print(
         f"wrote {out_md} ({result['n_answered']}/{result['n_questions']} answered, "
@@ -157,6 +200,7 @@ def main(argv: list[str] | None = None) -> int:
     # free-text generative answers).
     print(
         f"  scores[{result['engine']}]: answer_match={result['answer_match']} "
+        f"llm_judge={result.get('answer_judge')} "
         f"token_f1={result['token_f1']} exact_match={result['exact_match']} "
         f"support_recall={result['support_recall']}"
     )
@@ -166,6 +210,7 @@ def main(argv: list[str] | None = None) -> int:
     print(
         f"  scores[{result['engine']}] entity-subset: "
         f"answer_match={result.get('answer_match_entity', 0.0)} "
+        f"llm_judge={result.get('answer_judge_entity')} "
         f"(n={result.get('n_entity_answerable', 0)}/{result['n_answered']}); "
         f"answer_type_mix={result.get('answer_type_counts', {})}"
     )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_harness.py
@@ -133,3 +133,30 @@ def test_cli_self_test_writes_results(tmp_path):
     assert rc == 0
     assert md.exists() and js.exists()
     assert "end-to-end multi-hop QA" in md.read_text(encoding="utf-8")
+
+
+def test_run_engine_llm_judge_metric_populates_when_judge_given():
+    # A stub judge callable(prompt)->str drives the format-fair equivalence metric.
+    # The harness must populate answer_judge (overall + entity-subset) + the
+    # per-question record, and must pass the question into the judge prompt.
+    seen = []
+
+    def _judge(prompt):
+        seen.append(prompt)
+        return "YES"
+
+    res = run_engine(
+        _MockEngine(answer_text="Definitely Ada, no doubt."),
+        _toy_corpus(), model="gpt-4o-mini", budget_usd=25.0, judge=_judge,
+    )
+    assert res["answer_judge"] == 1.0
+    assert res["answer_judge_entity"] == 1.0  # 'Ada' classifies as an entity gold
+    assert res["per_question"][0]["answer_judge"] == 1.0
+    assert len(seen) == 1 and "Who founded Acme?" in seen[0]
+
+
+def test_run_engine_judge_none_by_default():
+    res = run_engine(_MockEngine(), _toy_corpus(), model="gpt-4o-mini", budget_usd=25.0)
+    assert res["answer_judge"] is None
+    assert res["answer_judge_entity"] is None
+    assert res["per_question"][0]["answer_judge"] is None

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_metrics.py
@@ -11,6 +11,8 @@ from erkgbench.qa_e2e.metrics import (  # noqa: E402
     decay_curve,
     exact_match,
     is_entity_answer,
+    judge_prompt,
+    parse_judge,
     supporting_fact_recall,
     token_f1,
 )
@@ -98,3 +100,32 @@ def test_classify_phrase_answers():
 def test_classify_handles_empty():
     assert classify_answer_type("") == "phrase"
     assert is_entity_answer("") is False
+
+
+# --- LLM-judge answer equivalence (format-fair cross-engine metric) ----------
+
+
+def test_parse_judge_yes_no():
+    assert parse_judge("YES") == 1.0
+    assert parse_judge("yes") == 1.0
+    assert parse_judge("Yes, that is correct.") == 1.0
+    assert parse_judge("NO") == 0.0
+    assert parse_judge("no.") == 0.0
+    assert parse_judge("No, the answer differs") == 0.0
+
+
+def test_parse_judge_fallback_and_empty():
+    # leading hedge but a standalone yes later -> correct
+    assert parse_judge("Verdict: YES") == 1.0
+    # no clear verdict / empty / unrelated -> NO (0.0), never crashes
+    assert parse_judge("") == 0.0
+    assert parse_judge("maybe") == 0.0
+    assert parse_judge(None) == 0.0  # type: ignore[arg-type]
+
+
+def test_judge_prompt_includes_all_three_fields():
+    p = judge_prompt("When founded?", "1976", "It was founded in 1976.")
+    assert "When founded?" in p
+    assert "1976" in p
+    assert "It was founded in 1976." in p
+    assert "YES or NO" in p


### PR DESCRIPTION
## Why (next-action #1 from the head-to-head)

The N=50 head-to-head exposed a **metric confound**. `answer_match` is gold-token **containment**, so a verbose essay (ms_graphrag, **0.40**) trivially contains the gold span, while a terse one-entity answer (goldengraph `Answer: X`, **0.10**) is all-or-nothing. The tell: goldengraph **leads on `exact_match` (0.10 vs 0.0)**. So an unknown chunk of the 4× gap is answer **format**, not reasoning quality — we can't trust "0.10 vs 0.40" until the metric is format-neutral.

## What

An **LLM-judge answer-equivalence** metric scored by a **fixed model (gpt-4o-mini) across every engine** — it asks whether the prediction *conveys* the gold answer regardless of verbosity. Kept **alongside** `answer_match` (not replacing it), reported **overall + on the entity-answerable subset**.

- `metrics.judge_prompt` / `parse_judge` — pure, unit-tested (YES/NO → 1.0/0.0, hedge fallback, empty/`None`-safe).
- `harness.run_engine(judge=…)` — one judge call per question (empty pred → NO, no call); judge is **eval overhead, not charged to the engine budget**. New result keys `answer_judge` / `answer_judge_entity` + per-question; new results-md columns.
- `run_qa_e2e` — `--judge` / `--judge-model` flags + an OpenAI judge client (**fail-soft**: errors score NO, never crash). Wired to a `judge` workflow input (**default `true`**) on all four engine jobs.

## Why a judge, not "make goldengraph verbose"
Forcing goldengraph to emit essays just to win a containment metric would distort its value prop (precise terse answers). The judge fixes the **measurement** uniformly instead; terse-vs-grounded output stays a separate product call.

## Validation
- 10 new tests (parse/prompt + harness populates judge overall/entity-subset/per-question + `None` by default). Offline self-test smoke + qa suites green. Self-test keeps `judge=None`, so nothing changes without `--judge` + a key.

## Next
Re-run `engine=all` N=50 with `judge=true` — **that** gives the fair cross-engine number (how much of 0.10-vs-0.40 was real vs format). Pairs with the retrieval-budget fix (#2) and the literal slice (#1236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_