### PR TITLE
feat(goldengraph): raise + expose the answer-retrieval budget (hops + node_budget)

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -54,6 +54,12 @@ on:
       extractor:
         description: "goldengraph only: document extractor -- api (LLM) | rebel | gliner (in-house local model prototype-eval)"
         default: "api"
+      retrieval_hops:
+        description: "goldengraph only: answer-time ball hop depth (RETRIEVAL-BUDGET sweep)"
+        default: "6"
+      retrieval_node_budget:
+        description: "goldengraph only: max entities in the answer ball (RETRIEVAL-BUDGET sweep; bigger = more reach + cost)"
+        default: "256"
       distill_log:
         description: "goldengraph only: capture (text->extraction)+(entity->fingerprint) pairs to a JSONL artifact for in-house distillation"
         default: "false"
@@ -128,6 +134,8 @@ jobs:
           GOLDENGRAPH_BUILD_DEBUG: ${{ inputs.build_debug }}
           GOLDENGRAPH_EXTRACTOR: ${{ inputs.extractor }}
           GOLDENGRAPH_LITERAL_ATTRS: ${{ inputs.literal_attrs }}
+          GOLDENGRAPH_QA_RETRIEVAL_HOPS: ${{ inputs.retrieval_hops }}
+          GOLDENGRAPH_QA_NODE_BUDGET: ${{ inputs.retrieval_node_budget }}
           GOLDENGRAPH_DISTILL_LOG: ${{ inputs.distill_log == 'true' && format('results/distill_goldengraph_amb{0}.jsonl', matrix.ambiguity) || '' }}
         run: |
           mkdir -p results

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -43,9 +43,17 @@ def _with_retry(fn, *, attempts: int = 6, base: float = 2.0, cap: float = 45.0):
 _AS_OF = 10**12
 
 #: Local-retrieval expansion depth. The default-1 ball couldn't reach k-hop answers
-#: (the 1->2 hop accuracy cliff in the 2026-06-22 headline); 4 covers the engineered
-#: corpus's 1-4 hop range. Overridable for tuning sweeps.
-_RETRIEVAL_HOPS = int(os.environ.get("GOLDENGRAPH_QA_RETRIEVAL_HOPS", "4"))
+#: (the 1->2 hop accuracy cliff in the 2026-06-22 headline). Raised 4->6 (2026-06-23):
+#: the N=50 trace showed connected answers (same_component=True) sitting JUST outside
+#: the hops=4 ball -- RETRIEVAL-BUDGET misses. Env-tunable for sweeps.
+_RETRIEVAL_HOPS = int(os.environ.get("GOLDENGRAPH_QA_RETRIEVAL_HOPS", "6"))
+
+#: Max entities in the budget-capped answer ball (the `ask` node_budget). 256, not
+#: the library default 64: the N=50 RETRIEVAL-BUDGET misses had balls of ~64-171
+#: entities while the connected answer sat out in the 1300+ "wide" ball -- 64 was
+#: starving multi-hop answers. The budget still BOUNDS the synthesis prompt; this
+#: trades a bigger (costlier) ball for reach. Env-tunable for the sweep.
+_NODE_BUDGET = int(os.environ.get("GOLDENGRAPH_QA_NODE_BUDGET", "256"))
 
 #: Deep, unbudgeted hop count for the localize trace's "wide ball" -- approximates
 #: "everything reachable from the seeds" to split a retrieval miss (answer in the
@@ -113,7 +121,8 @@ class GoldenGraphQAEngine:
         llm: Any,
         embedder: Any,
         resolver: Any | None = None,
-        retrieval_hops: int = _RETRIEVAL_HOPS,
+        retrieval_hops: int | None = None,
+        node_budget: int | None = None,
     ):
         self._llm = _CountingLLM(llm)
         # Cache embeddings across the whole run: the build's cross-doc linking and
@@ -121,7 +130,16 @@ class GoldenGraphQAEngine:
         # is the O(N^2) network wall at large N.
         self._embedder = _CachingEmbedder(embedder)
         self._resolver = resolver  # None -> ingest uses the goldenmatch-backed default
-        self._retrieval_hops = retrieval_hops
+        # Retrieval budget read at construction (None -> env/default) so a sweep can
+        # set GOLDENGRAPH_QA_RETRIEVAL_HOPS / _NODE_BUDGET per run.
+        self._retrieval_hops = (
+            retrieval_hops if retrieval_hops is not None
+            else int(os.environ.get("GOLDENGRAPH_QA_RETRIEVAL_HOPS", "6"))
+        )
+        self._node_budget = (
+            node_budget if node_budget is not None
+            else int(os.environ.get("GOLDENGRAPH_QA_NODE_BUDGET", "256"))
+        )
 
     def build_kg(self, corpus) -> BuildResult:
         from goldengraph.ingest import ingest_corpus
@@ -164,6 +182,7 @@ class GoldenGraphQAEngine:
             tx_t=handle["tx_t"],
             mode="local",
             hops=self._retrieval_hops,
+            node_budget=self._node_budget,
         )
         return AnswerResult(
             text=text,
@@ -197,7 +216,7 @@ class GoldenGraphQAEngine:
         slice_graph = handle["store"].as_of(handle["valid_t"], handle["tx_t"])
         seeds = seed_by_query(slice_graph, question, self._embedder, k=5)
         subgraph = _retrieve_local(
-            slice_graph, seeds, max_hops=self._retrieval_hops, node_budget=64
+            slice_graph, seeds, max_hops=self._retrieval_hops, node_budget=self._node_budget
         )
         # Wide ball: deep neighborhood, no node budget -- "is the answer reachable
         # from the seeds at ALL?" Splits a retrieval miss into budget-too-small

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_retrieval_budget.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_retrieval_budget.py
@@ -1,0 +1,49 @@
+"""Retrieval-budget knobs on the goldengraph QA engine.
+
+The 2026-06-23 N=50 trace's dominant failure shifted to RETRIEVAL-BUDGET: answers
+that were connected to the seeds (same_component=True) but fell OUTSIDE the
+budget-capped ball (the adapter called `ask` with node_budget defaulting to 64).
+These pure tests pin that the engine now reads a raised, env-tunable hops +
+node_budget at construction (so a sweep can set them per run) and that explicit
+args win. No native store / LLM needed -- the engine imports goldengraph lazily.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.qa_e2e.engines.goldengraph import GoldenGraphQAEngine  # noqa: E402
+
+
+def _engine(**kw):
+    # __init__ only wraps llm/embedder (no calls), so stubs are fine.
+    return GoldenGraphQAEngine(llm=object(), embedder=object(), **kw)
+
+
+def test_retrieval_budget_defaults_are_raised(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_QA_RETRIEVAL_HOPS", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_QA_NODE_BUDGET", raising=False)
+    eng = _engine()
+    assert eng._retrieval_hops == 6  # was 4
+    assert eng._node_budget == 256  # was the ask() default of 64
+
+
+def test_retrieval_budget_reads_env_at_construction(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_QA_RETRIEVAL_HOPS", "8")
+    monkeypatch.setenv("GOLDENGRAPH_QA_NODE_BUDGET", "512")
+    eng = _engine()
+    assert eng._retrieval_hops == 8
+    assert eng._node_budget == 512
+
+
+def test_explicit_args_beat_env(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_QA_RETRIEVAL_HOPS", "8")
+    monkeypatch.setenv("GOLDENGRAPH_QA_NODE_BUDGET", "512")
+    eng = _engine(retrieval_hops=3, node_budget=99)
+    assert eng._retrieval_hops == 3
+    assert eng._node_budget == 99


### PR DESCRIPTION
## Why (next-action #2 from the head-to-head)

After #1227, goldengraph's dominant failure **shifted to RETRIEVAL-BUDGET**: in the N=50 trace, Exeter and Politburo were `same_component=True` (connected to the seeds in the 4,272-entity core) but `in_wide=True, in_ball=False` — i.e. reachable, just **outside the budget-capped ball**. Root cause: the adapter called `ask()` with `hops=4` and **no `node_budget`**, so it defaulted to **64** entities, while the connected answer sat out in the 1,300+ "wide" ball.

## What

- **`engines/goldengraph.py`**: read `retrieval_hops` + `node_budget` **at construction** (env `GOLDENGRAPH_QA_RETRIEVAL_HOPS` / `GOLDENGRAPH_QA_NODE_BUDGET`, explicit args win) and pass `node_budget` into `ask()`. Raised defaults: **hops 4→6, node_budget 64→256**. The `localize` trace uses the **same** budget so `in_ball` reflects the real answer ball.
- **bench workflow**: `retrieval_hops` (6) + `retrieval_node_budget` (256) inputs → envs, so the budget is **sweepable per run** (non-empty defaults keep `int()` safe).

## Scope / honesty
- The **library `ask` default (64) is unchanged** — this only raises the bench adapter.
- A bigger ball means more reach **but a bigger (costlier, noisier) synthesis prompt** — so this is a **hypothesis to measure**, not a proven win. The right validation is a sweep (`retrieval_node_budget` 64/128/256/512) reading whether RETRIEVAL-BUDGET misses convert to hits **without tanking precision** (now visible via the LLM-judge metric from #1240).

## Validation
- 3 native-free tests: defaults are raised, env is read at construction, explicit args win. (The real-data effect is the bench sweep.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_