### PR TITLE
feat(bench): radial accuracy + end-to-end pipeline F1/wall + hotspot profiling

### DIFF
--- a/.github/workflows/bench-perceptual.yml
+++ b/.github/workflows/bench-perceptual.yml
@@ -13,7 +13,7 @@ on:
         description: "Which suite to run"
         type: choice
         default: all
-        options: [all, accuracy, perf, robustness]
+        options: [all, accuracy, perf, robustness, e2e, hotspot]
       n_image_bases:
         description: "Image base entities (each yields 7 variants)"
         type: string
@@ -22,6 +22,14 @@ on:
         description: "Audio base entities (each yields 3 variants)"
         type: string
         default: "12"
+      n_radial_bases:
+        description: "Radial-feature base entities (alignment search is O(angles^2)/pair)"
+        type: string
+        default: "12"
+      e2e_bases:
+        description: "End-to-end dedupe base entities"
+        type: string
+        default: "30"
 
 jobs:
   bench:
@@ -48,6 +56,8 @@ jobs:
             --suite "${{ inputs.suite }}" \
             --n-image-bases "${{ inputs.n_image_bases }}" \
             --n-audio-bases "${{ inputs.n_audio_bases }}" \
+            --n-radial-bases "${{ inputs.n_radial_bases }}" \
+            --e2e-bases "${{ inputs.e2e_bases }}" \
             --out perceptual_bench.json | tee bench_summary.md
       - name: Publish summary
         if: ${{ !cancelled() }}

--- a/packages/python/goldenmatch/scripts/bench_perceptual/README.md
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/README.md
@@ -15,8 +15,8 @@ Run it locally or via the `bench-perceptual` workflow (`workflow_dispatch`).
 ```bash
 cd packages/python/goldenmatch
 uv run python scripts/bench_perceptual/run.py --suite all --out report.json
-# or a single suite: --suite accuracy | perf | robustness
-# scale: --n-image-bases 30 --n-audio-bases 12
+# or a single suite: --suite accuracy | perf | robustness | e2e | hotspot
+# scale: --n-image-bases 30 --n-audio-bases 12 --n-radial-bases 12 --e2e-bases 30
 ```
 
 ## Layout (reusable by design)
@@ -25,43 +25,60 @@ uv run python scripts/bench_perceptual/run.py --suite all --out report.json
 |---|---|
 | `metrics.py` | **Generic ER eval core** — `prf_at_threshold`, `threshold_sweep`, `discrimination`, `blocking_eval`, `per_group_recall`. No goldenmatch import; other ER stages (blocking, fuzzy/FS) can reuse it. |
 | `datasets.py` | Deterministic synthetic media-variant datasets (no committed assets). Each *base* is one entity; labelled *variants* under named perturbations. Stdlib-only. |
-| `perf.py` | Throughput under `GOLDENMATCH_NATIVE=0/1` + speedup. |
+| `perf.py` | Kernel throughput under `GOLDENMATCH_NATIVE=0/1` + speedup (image pHash, audio fingerprint, radial). |
+| `hotspot.py` | cProfile self-time hotspots per kernel (Python path; native is opaque to cProfile). |
+| `pipeline_bench.py` | **End-to-end**: runs the real `dedupe_df` pipeline on a pHash column and reports F1 vs ground truth + wall + per-stage timings. |
 | `run.py` | Orchestrates the suites; emits JSON + a markdown summary. |
 
 ## Metrics — what each one tells you
 
 - **Best operating point** — the threshold maximising F1 over *all* pairs. The
-  scorer's achievable precision/recall.
+  scorer's achievable precision/recall. Reported for **image pHash, the radial
+  (rotation/crop-aware) feature, and audio**.
 - **Per-transform recall** — recall split by perturbation. The most useful view:
   it shows *which* transforms the hash survives and which break it, instead of
-  hiding that in an aggregate.
+  hiding that in an aggregate. (The radial lane is where rotate/crop — pHash's
+  ~0.0 — get recalled.)
 - **Blocking band sweep** — recall vs candidate-reduction as `num_bands` varies.
   This is the knob behind `PerceptualKeyConfig.num_bands`; the sweep is how we
   pick its default.
 - **Discrimination** — separation between the matched and non-matched score
   distributions (the signal the threshold then splits). `overlap` counts
   non-match pairs scoring above the lowest match score.
-- **Performance** — images/sec and audio-items/sec for the Python vs native path,
-  and the speedup. The number that says whether a kernel optimisation moved the
-  wall.
+- **Performance** — images/sec, audio-items/sec, and radial-profiles/sec for the
+  Python vs native path, and the speedup. The number that says whether a kernel
+  optimisation moved the wall.
+- **End-to-end (`e2e`)** — runs the *real* `dedupe_df` pipeline on a synthetic
+  pHash column (explicit `phash` matchkey + `perceptual` blocking) and reports
+  **cluster-pair F1 / precision / recall vs ground truth**, **wall**, throughput,
+  and **per-stage timings** (`core.bench.bench_capture`: blocking, scoring,
+  clustering, golden). The component lanes measure pieces; this is the whole pipe.
+- **Hotspots (`hotspot`)** — top functions by **self-time** (`tottime`) per kernel
+  on the Python path, so a slow path is localised to a function, not a stage.
+  cProfile sees only Python frames (the native kernel is opaque — that's measured
+  by `perf`), and `cumtime` is *not* wall, so `tottime` is the sort key.
 - **Robustness** — recompute determinism + native == Python over the suite.
 
-## Baseline findings (first run, 30 image / 12 audio entities) — the backlog
+## The first-run findings — all three resolved (the harness earned its keep)
 
-- **pHash is photometric, not geometric** (measured): recall ≈ brightness 0.93,
-  contrast 0.87, recompress 0.93, blur 0.70 — but **noise 0.33, crop 0.0,
-  rotate 0.0**. Geometric transforms are pHash's intrinsic blind spot; the
-  aggregate F1 looks modest only because the dataset deliberately includes those
-  hard cases. *Open question:* keep crop/rotate as a documented "out of envelope"
-  bucket, or add a geometry-tolerant primitive (e.g. ORB/keypoint) as a separate
-  capability.
-- **Blocker default `num_bands=8` is reduction-biased**: recall ≈ 0.72 at 8 bands
-  vs ≈ 0.97 at 16 (reduction 0.77 → 0.28). *Open question:* is 8 the right
-  zero-config default, or should auto-config pick from the recall target?
-- **Audio survives amplitude + time-shift, not additive noise** (recall amplitude
-  1.0, trim 1.0, noise 0.0 at threshold 1.0). *Open question:* lower the
-  `audio_fp` default threshold to recover noisy matches, and measure the precision
-  cost.
+The harness's first iteration produced three findings; acting on them (with
+*validate-before-build* discipline) **refuted two cheap fixes and shipped the
+real ones**:
 
-Re-run after any change to `perceptual.py` / `perceptual_blocker.py` /
-`perceptual_autoconfig.py` and diff the JSON to see the metric move.
+- **Finding 1 — pHash is photometric, not geometric** (rotate/crop recall 0.0).
+  A dihedral-canonical hash and rotation-*invariant* descriptors were both
+  measured net-negative; the **radial-variance feature** (orientation profile +
+  angular-aligned compare) closes it — rotate/crop **0.0 → ~1.0** (see the
+  `accuracy_radial` lane). *Shipped: ADR 0022 finding 1.*
+- **Finding 2 — blocker `num_bands=8` was reduction-biased** (0.72 recall vs 0.97
+  at 16). Now **recall-target-driven** (`recommend_num_bands`); default 16.
+  *Shipped: finding 2.*
+- **Finding 3 — "audio dies under additive noise"** was a **dataset artifact**:
+  pure tones leave the Haitsma-Kalker bands near-empty. On broadband audio the
+  fingerprint *is* noise-robust; fixed by a broadband suite + the canonical
+  threshold (`audio_fp` 0.80 → 0.65). *Shipped: finding 3.*
+
+The lesson the harness keeps teaching: **measure on a realistic workload before
+designing a fix.** Re-run after any change to `perceptual.py` /
+`perceptual_blocker.py` / `perceptual_autoconfig.py` and diff the JSON to see the
+metric move — and watch the `e2e` F1/wall + `hotspot` self-time when tuning perf.

--- a/packages/python/goldenmatch/scripts/bench_perceptual/hotspot.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/hotspot.py
@@ -1,0 +1,59 @@
+"""cProfile hotspot analysis for the perceptual kernels.
+
+Reports the functions that dominate **self-time** (``tottime``) for a unit of
+work, so a slow path can be localized to a specific function rather than a whole
+stage.
+
+Two caveats, both from the repo's performance-audit lesson:
+
+- It profiles the **pure-Python path** (``GOLDENMATCH_NATIVE=0``). cProfile only
+  sees Python frames; the native Rust kernel is opaque to it. That is the point:
+  on a pure-Python deployment the wall lives in these Python frames, and that is
+  exactly what a hotspot list should localize. The native path's cost is measured
+  by ``perf.py`` (wall + speedup), not here.
+- ``cumtime`` is NOT wall-clock (it double-counts under recursion and is blind to
+  threads / native calls). ``tottime`` (self time) is the primary sort key;
+  ``cumtime`` is reported alongside for context only.
+"""
+from __future__ import annotations
+
+import cProfile
+import os
+import pstats
+
+
+def _short(func: tuple) -> str:
+    """``(filename, lineno, name)`` -> ``name (basename:line)``."""
+    filename, lineno, name = func
+    base = filename.rsplit("/", 1)[-1] if filename else "~"
+    return f"{name} ({base}:{lineno})"
+
+
+def profile_top(work, top_n: int = 12) -> list[dict]:
+    """Run ``work`` under cProfile (Python path) and return the ``top_n`` functions
+    by self-time as ``{func, ncalls, tottime, cumtime}`` dicts."""
+    prev = os.environ.get("GOLDENMATCH_NATIVE")
+    os.environ["GOLDENMATCH_NATIVE"] = "0"  # native kernel is opaque to cProfile
+    pr = cProfile.Profile()
+    try:
+        pr.enable()
+        work()
+        pr.disable()
+    finally:
+        if prev is None:
+            os.environ.pop("GOLDENMATCH_NATIVE", None)
+        else:
+            os.environ["GOLDENMATCH_NATIVE"] = prev
+
+    stats = pstats.Stats(pr)
+    rows = [
+        {
+            "func": _short(func),
+            "ncalls": nc,
+            "tottime": round(tt, 6),
+            "cumtime": round(ct, 6),
+        }
+        for func, (cc, nc, tt, ct, _callers) in stats.stats.items()  # type: ignore[attr-defined]
+    ]
+    rows.sort(key=lambda r: r["tottime"], reverse=True)
+    return rows[:top_n]

--- a/packages/python/goldenmatch/scripts/bench_perceptual/perf.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/perf.py
@@ -54,3 +54,13 @@ def bench_audio_hash(signals: list[tuple[list, int]], repeats: int = 2) -> dict:
             perceptual.fingerprint_audio(samples, sr)
 
     return _both_paths(work, len(signals), repeats)
+
+
+def bench_radial_hash(grids: list, repeats: int = 3) -> dict:
+    """Throughput of the rotation/crop-aware radial-variance profile over a batch of
+    luma grids (the geometric image feature; no batch kernel, so one call per grid)."""
+    def work():
+        for g in grids:
+            perceptual.radial_variance(g)
+
+    return _both_paths(work, len(grids), repeats)

--- a/packages/python/goldenmatch/scripts/bench_perceptual/pipeline_bench.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/pipeline_bench.py
@@ -21,7 +21,6 @@ def e2e_image_dedupe(n_bases: int = 30, threshold: float = 0.85) -> dict:
     score ~0), so this is the honest end-to-end number for the *photometric*
     crawl-tier feature -- the radial feature is what lifts the geometric cases."""
     import polars as pl
-
     from goldenmatch import dedupe_df
     from goldenmatch.config.schemas import (
         BlockingConfig,

--- a/packages/python/goldenmatch/scripts/bench_perceptual/pipeline_bench.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/pipeline_bench.py
@@ -1,0 +1,79 @@
+"""End-to-end media-dedup F1 + wall over a synthetic image-pHash column.
+
+Closes the gap that the kernel/scorer/blocker lanes measure components in
+isolation: this runs the REAL `dedupe_df` pipeline (explicit `phash` matchkey +
+`perceptual` blocking) on a frame of perceptual-hash variants and reports F1 vs
+ground truth plus wall + per-stage timings (`core.bench.bench_capture`). Imports
+goldenmatch's pipeline (heavy); called only by the bench, never the kernel path.
+"""
+from __future__ import annotations
+
+import time
+
+import datasets  # sibling module; run.py bootstraps sys.path before importing this
+
+
+def e2e_image_dedupe(n_bases: int = 30, threshold: float = 0.85) -> dict:
+    """Hash an image-variant suite to a pHash column, dedupe it through the real
+    pipeline, and report F1 (vs the same-entity ground truth) + wall + stages.
+
+    Recall is intentionally bounded by pHash's geometric blind spot (rotate/crop
+    score ~0), so this is the honest end-to-end number for the *photometric*
+    crawl-tier feature -- the radial feature is what lifts the geometric cases."""
+    import polars as pl
+
+    from goldenmatch import dedupe_df
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+        PerceptualKeyConfig,
+    )
+    from goldenmatch.core import perceptual
+    from goldenmatch.core.bench import bench_capture
+    from goldenmatch.core.evaluate import evaluate_clusters
+
+    suite = datasets.build_image_suite(n_bases)
+    # Item i is row i, so the pipeline's positional __row_id__ matches item_id and
+    # the suite's (item_id, item_id) ground-truth pairs line up with result.clusters.
+    hexes = [perceptual.phash_hex(perceptual.phash_image(it.payload)) for it in suite.items]
+    df = pl.DataFrame({"ph": hexes})
+
+    config = GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="phash_match",
+                type="weighted",
+                threshold=threshold,
+                fields=[MatchkeyField(field="ph", scorer="phash", weight=1.0)],
+            )
+        ],
+        blocking=BlockingConfig(
+            strategy="perceptual", perceptual=PerceptualKeyConfig(column="ph")
+        ),
+    )
+
+    t0 = time.perf_counter()
+    with bench_capture() as bench:
+        result = dedupe_df(df, config=config)
+    wall = time.perf_counter() - t0
+
+    ev = evaluate_clusters(result.clusters, suite.gt_pairs)
+    timings = bench.to_dict().get("stage_timings_seconds", {})
+    return {
+        "records": df.height,
+        "base_entities": n_bases,
+        "threshold": threshold,
+        "f1": round(ev.f1, 4),
+        "precision": round(ev.precision, 4),
+        "recall": round(ev.recall, 4),
+        "tp": ev.tp,
+        "fp": ev.fp,
+        "fn": ev.fn,
+        "wall_sec": round(wall, 4),
+        "throughput_rec_per_sec": round(df.height / wall, 1) if wall else None,
+        "stage_timings_seconds": {k: round(v, 4) for k, v in timings.items()},
+        "note": "recall is bounded by pHash's geometric blind spot (rotate/crop ~0); "
+        "the radial feature addresses those cases",
+    }

--- a/packages/python/goldenmatch/scripts/bench_perceptual/run.py
+++ b/packages/python/goldenmatch/scripts/bench_perceptual/run.py
@@ -21,8 +21,10 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import datasets
+import hotspot
 import metrics
 import perf
+import pipeline_bench
 
 from goldenmatch.core import perceptual
 from goldenmatch.core.perceptual_blocker import PerceptualLSHBlocker
@@ -31,6 +33,8 @@ _HASH_BITS = 64
 # 1.0 down to ~0.55 in single-bit steps — the operating-point search space.
 _THRESHOLDS = [i / _HASH_BITS for i in range(_HASH_BITS, 35, -1)]
 _BAND_COUNTS = [2, 4, 8, 16, 32]
+# Radial similarity is angular-aligned Pearson in [0,1]; sweep the high band.
+_RADIAL_THRESHOLDS = [i / 100 for i in range(99, 49, -1)]
 
 
 def _img_sim(ha: int, hb: int) -> float:
@@ -101,10 +105,68 @@ def accuracy_audio(n_bases: int) -> dict:
     }
 
 
+def accuracy_radial(n_bases: int) -> dict:
+    """Rotation/crop-aware radial-variance feature -- the geometric counterpart to
+    image pHash, on the SAME image-variant suite. Scored by angular-aligned
+    similarity, so rotate/crop (which pHash scores ~0) are recalled here."""
+    suite = datasets.build_image_suite(n_bases)
+    profiles = [perceptual.radial_variance(it.payload) for it in suite.items]
+    n = len(profiles)
+
+    def sim(a: int, b: int) -> float:
+        return perceptual.radial_align_similarity(profiles[a], profiles[b])
+
+    labeled = [
+        ((i, j) in suite.gt_pairs, sim(i, j)) for i in range(n) for j in range(i + 1, n)
+    ]
+    points, best = metrics.threshold_sweep(labeled, _RADIAL_THRESHOLDS)
+    disc = metrics.discrimination(labeled)
+    per_transform = {
+        t: metrics.prf_at_threshold(
+            [(True, sim(a, b)) for (a, b) in pairs], best.threshold
+        ).recall
+        for t, pairs in suite.transform_pairs.items()
+    }
+    return {
+        "items": n,
+        "base_entities": n_bases,
+        "best_operating_point": best.as_dict(),
+        "threshold_sweep": [p.as_dict() for p in points],
+        "discrimination": disc.as_dict(),
+        "per_transform_recall_at_best": per_transform,
+        "note": "angular-aligned similarity; no LSH blocking (rotation breaks "
+        "banded-LSH). Compare rotate/crop recall here vs image pHash's ~0.",
+    }
+
+
 def perf_suite(n_image: int, n_audio: int) -> dict:
     img = [it.payload for it in datasets.build_image_suite(n_image).items]
     aud = [it.payload for it in datasets.build_audio_suite(n_audio).items]
-    return {"image_hash": perf.bench_image_hash(img), "audio_hash": perf.bench_audio_hash(aud)}
+    return {
+        "image_hash": perf.bench_image_hash(img),
+        "audio_hash": perf.bench_audio_hash(aud),
+        "radial_hash": perf.bench_radial_hash(img),
+    }
+
+
+def hotspot_suite(n_image: int, n_audio: int) -> dict:
+    """Per-kernel self-time hotspots (Python path; native is opaque to cProfile)."""
+    imgs = [it.payload for it in datasets.build_image_suite(n_image).items]
+    auds = [it.payload for it in datasets.build_audio_suite(n_audio).items]
+    return {
+        "image_hash": hotspot.profile_top(lambda: perceptual.phash_image_batch(imgs)),
+        "audio_hash": hotspot.profile_top(
+            lambda: [perceptual.fingerprint_audio(s, sr) for s, sr in auds]
+        ),
+        "radial_hash": hotspot.profile_top(
+            lambda: [perceptual.radial_variance(g) for g in imgs]
+        ),
+    }
+
+
+def e2e_suite(n_bases: int) -> dict:
+    """End-to-end dedupe F1 + wall over a synthetic image-pHash column."""
+    return {"image_dedupe": pipeline_bench.e2e_image_dedupe(n_bases)}
 
 
 def robustness_suite(n_image: int, n_audio: int) -> dict:
@@ -162,6 +224,22 @@ def _markdown(report: dict) -> str:
                 f"| {b['num_bands']} | {b['recall']:.4f} | {b['reduction_ratio']:.4f} | {b['candidate_pairs']} |"
             )
         lines.append("")
+    ar = report.get("accuracy_radial")
+    if ar:
+        bop = ar["best_operating_point"]
+        d = ar["discrimination"]
+        lines += [
+            "## Image accuracy — radial (rotation/crop-aware)",
+            f"- items: {ar['items']} ({ar['base_entities']} entities)",
+            f"- **best operating point**: threshold={bop['threshold']:.4f} "
+            f"F1={bop['f1']:.4f} P={bop['precision']:.4f} R={bop['recall']:.4f}",
+            f"- discrimination: match_mean={d['match_mean']:.4f} "
+            f"nonmatch_mean={d['nonmatch_mean']:.4f} separation={d['separation']:.4f} "
+            f"overlap={d['overlap_count']}",
+            "- per-transform recall @ best: "
+            + ", ".join(f"{k}={v:.3f}" for k, v in ar["per_transform_recall_at_best"].items()),
+            "",
+        ]
     aa = report.get("accuracy_audio")
     if aa:
         bop = aa["best_operating_point"]
@@ -193,25 +271,65 @@ def _markdown(report: dict) -> str:
             f"- native available: {rb['native_available']}; native==python: {rb['native_equals_python']}",
             "",
         ]
+    e2e = report.get("e2e")
+    if e2e:
+        r = e2e["image_dedupe"]
+        lines += [
+            "## End-to-end pipeline (image dedupe)",
+            f"- {r['records']} records ({r['base_entities']} entities), threshold={r['threshold']}",
+            f"- **F1={r['f1']:.4f}** P={r['precision']:.4f} R={r['recall']:.4f} "
+            f"(tp={r['tp']} fp={r['fp']} fn={r['fn']})",
+            f"- **wall={r['wall_sec']:.4f}s** ({r['throughput_rec_per_sec']} rec/s)",
+        ]
+        st = r.get("stage_timings_seconds") or {}
+        if st:
+            lines.append(
+                "- stage wall: "
+                + ", ".join(f"{k}={v:.4f}s" for k, v in sorted(st.items(), key=lambda x: -x[1]))
+            )
+        lines += [f"- _{r['note']}_", ""]
+    hs = report.get("hotspots")
+    if hs:
+        lines.append("## Hotspots (Python path; self-time)")
+        for kernel, rows in hs.items():
+            lines += [f"### {kernel}", "| tottime (s) | cumtime (s) | ncalls | function |", "|---|---|---|---|"]
+            for row in rows:
+                lines.append(
+                    f"| {row['tottime']:.4f} | {row['cumtime']:.4f} | {row['ncalls']} | {row['func']} |"
+                )
+            lines.append("")
     return "\n".join(lines)
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--suite", choices=["accuracy", "perf", "robustness", "all"], default="all")
+    ap.add_argument(
+        "--suite",
+        choices=["accuracy", "perf", "robustness", "e2e", "hotspot", "all"],
+        default="all",
+    )
     ap.add_argument("--n-image-bases", type=int, default=30)
     ap.add_argument("--n-audio-bases", type=int, default=12)
+    # radial scoring is an O(angles^2)-per-pair alignment search, so it uses a
+    # smaller default suite than the bit-hamming image/audio paths.
+    ap.add_argument("--n-radial-bases", type=int, default=12)
+    ap.add_argument("--e2e-bases", type=int, default=30)
     ap.add_argument("--out", default=None, help="write JSON report here")
     args = ap.parse_args()
 
     report: dict = {"config": vars(args)}
     if args.suite in ("accuracy", "all"):
         report["accuracy_image"] = accuracy_image(args.n_image_bases)
+        report["accuracy_radial"] = accuracy_radial(args.n_radial_bases)
         report["accuracy_audio"] = accuracy_audio(args.n_audio_bases)
     if args.suite in ("perf", "all"):
         report["perf"] = perf_suite(args.n_image_bases, args.n_audio_bases)
     if args.suite in ("robustness", "all"):
         report["robustness"] = robustness_suite(args.n_image_bases, args.n_audio_bases)
+    if args.suite in ("e2e", "all"):
+        report["e2e"] = e2e_suite(args.e2e_bases)
+    if args.suite in ("hotspot", "all"):
+        report["hotspots"] = hotspot_suite(args.n_image_bases, args.n_audio_bases)
 
     md = _markdown(report)
     print(md)


### PR DESCRIPTION
Closes the two coverage gaps in the perceptual metrics harness (#1229) and adds perf **hotspot** localization — so the suite now reports F1 + wall end-to-end and tells you *which function* to optimize.

### `accuracy_radial` — the geometric feature's metrics
The radial (rotation/crop-aware) feature on the same image-variant suite, scored by angular-aligned similarity. Reports best operating point (F1/P/R), discrimination, per-transform recall. **Measured: F1=1.000, per-transform recall 1.0 on *every* transform — including rotate and crop, where pHash scores ~0.0.** (No blocking band sweep: rotation breaks banded-LSH, so radial is scorer-only.)

### `e2e` — end-to-end pipeline F1 + wall (`pipeline_bench.py`)
Runs the **real `dedupe_df`** (explicit `phash` matchkey + `perceptual` blocking) on a synthetic pHash column and reports **cluster-pair F1 / precision / recall vs ground truth**, **wall**, throughput, and **per-stage timings** via `core.bench.bench_capture` (blocking / scoring / clustering / golden). The component lanes measure pieces; this measures the whole pipe. (Recall is honestly bounded by pHash's rotate/crop blind spot — the radial feature is what lifts those.)

### `hotspot` — self-time per kernel (`hotspot.py`)
cProfile **self-time (`tottime`)** top functions per kernel on the Python path. Two caveats baked in (perf-audit lesson): cProfile sees only Python frames (the native kernel is opaque — that's `perf`'s job), and `cumtime` ≠ wall, so `tottime` is the sort key. Already actionable — on the radial path it localizes the cost to `_radial_variance_python` + **990k `round()` calls** in the NN-sampling loop.

### Also
- `perf.bench_radial_hash` — native-vs-python wall + speedup for `radial_variance`.
- `run.py`: new `--suite e2e|hotspot` (both in `all`), `--n-radial-bases` / `--e2e-bases`; markdown sections for all three.
- README documents the new lanes and marks findings 1–3 **resolved**.

### Verification
Dispatch-only (no CI gate). The stdlib lanes (radial accuracy, hotspot) are verified by direct-load — radial F1=1.0 with rotate/crop recall 1.0; hotspot returns ranked functions. The `e2e` lane uses the confirmed `dedupe_df` → `DedupeResult.clusters` → `evaluate_clusters` → `EvalResult.f1` + `bench_capture` API. `py_compile` clean for all four bench modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p)_