### PR TITLE
Identity-write provenance spine: actor + trust on every event/edge (#1075/#1078)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -23,6 +23,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   fallback when the native wheel is absent.
 
 ### Added
+- **Identity-write provenance spine: `actor` + `trust` on every event/edge
+  (#1075 / #1078, epic Agent Memory #1073).** `IdentityEvent` and `EvidenceEdge`
+  now record WHO made each write (`actor`, e.g. `pipeline` / `agent:claude` /
+  `steward:alice`) and their `trust` (0–1) — so the append-only event log is a
+  real audit trail a reviewer can use to reconstruct exactly which actor changed
+  what, when, and why (`payload['reason']`). Pipeline-driven writes are stamped
+  `actor="pipeline"` (override via `resolve_clusters(actor=...)`); the
+  agent-facing `manual_merge` / `manual_split` and their MCP tools take `actor` /
+  `trust` (trust defaults by actor prefix — steward 1.0, agent 0.5). New
+  `IdentityStore.export_audit_log(dataset=/actor=/since=)` returns the full log in
+  commit order for compliance export. Backward-compatible: nullable columns added
+  to both tables via an idempotent migration (SQLite `PRAGMA`-guarded `ADD COLUMN`;
+  Postgres `ADD COLUMN IF NOT EXISTS`); pre-provenance rows read back as `None`.
+  (Tamper-evident hash-chaining, claim-entity / resolve-conflict tools, and the
+  Postgres bulk-COPY path's provenance are tracked follow-ups.)
 - **`accuracy_febrl3` real-dataset metrics probe (opt-in).** The metrics harness
   gains its first *real* ER-benchmark probe — Febrl3 (5000-record person dedup
   with published ground truth) via `recordlinkage`'s bundled data, so it's still

--- a/packages/python/goldenmatch/goldenmatch/db/alembic/versions/0002_provenance_actor_trust.py
+++ b/packages/python/goldenmatch/goldenmatch/db/alembic/versions/0002_provenance_actor_trust.py
@@ -1,0 +1,40 @@
+"""Provenance spine: actor + trust on identity events and evidence edges.
+
+Adds nullable ``actor`` / ``trust`` columns to ``identity_events`` and
+``evidence_edges`` (#1075 / #1078). Mirrors the runtime ``_pg_init_schema``
+``ADD COLUMN IF NOT EXISTS`` in goldenmatch/identity/store.py, so this rev and
+the store's on-open DDL converge to the same shape.
+
+Revision ID: 0002
+Revises: 0001
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE evidence_edges  ADD COLUMN IF NOT EXISTS actor TEXT;
+        ALTER TABLE evidence_edges  ADD COLUMN IF NOT EXISTS trust DOUBLE PRECISION;
+        ALTER TABLE identity_events ADD COLUMN IF NOT EXISTS actor TEXT;
+        ALTER TABLE identity_events ADD COLUMN IF NOT EXISTS trust DOUBLE PRECISION;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE evidence_edges  DROP COLUMN IF EXISTS actor;
+        ALTER TABLE evidence_edges  DROP COLUMN IF EXISTS trust;
+        ALTER TABLE identity_events DROP COLUMN IF EXISTS actor;
+        ALTER TABLE identity_events DROP COLUMN IF EXISTS trust;
+        """
+    )

--- a/packages/python/goldenmatch/goldenmatch/identity/model.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/model.py
@@ -79,6 +79,12 @@ class EvidenceEdge:
     controller_snapshot: dict[str, Any] | None = None
     run_name: str | None = None
     dataset: str | None = None
+    # Provenance spine (#1075/#1078): WHO created this write and their trust.
+    # ``actor`` is a free-form principal id ("pipeline", "agent:<name>",
+    # "steward:<user>"); ``trust`` in [0, 1]. Both nullable -- pre-provenance rows
+    # and callers that don't supply them read back as None.
+    actor: str | None = None
+    trust: float | None = None
     recorded_at: datetime = field(default_factory=datetime.now)
     edge_id: int | None = None
 
@@ -90,6 +96,10 @@ class IdentityEvent:
     payload: dict[str, Any] | None = None
     run_name: str | None = None
     dataset: str | None = None
+    # Provenance spine (#1075/#1078): WHO made this change and their trust.
+    # See EvidenceEdge for the contract. The "why" rides in ``payload['reason']``.
+    actor: str | None = None
+    trust: float | None = None
     recorded_at: datetime = field(default_factory=datetime.now)
     event_id: int | None = None
 

--- a/packages/python/goldenmatch/goldenmatch/identity/mongo_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/mongo_backend.py
@@ -298,6 +298,8 @@ class MongoIdentityStore:
             "controller_snapshot": edge.controller_snapshot,
             "run_name": edge.run_name,
             "dataset": edge.dataset,
+            "actor": edge.actor,
+            "trust": edge.trust,
             "recorded_at": edge.recorded_at,
         }
         result = self._db[_EDGES].update_one(
@@ -339,10 +341,26 @@ class MongoIdentityStore:
             "payload": event.payload,
             "run_name": event.run_name,
             "dataset": event.dataset,
+            "actor": event.actor,
+            "trust": event.trust,
             "recorded_at": event.recorded_at,
         }
         result = self._db[_EVENTS].insert_one(doc)
         return _objectid_to_int(result.inserted_id)
+
+    def export_audit_log(
+        self, *, dataset: str | None = None, actor: str | None = None,
+        since: datetime | None = None,
+    ) -> list[IdentityEvent]:
+        query: dict[str, Any] = {}
+        if dataset is not None:
+            query["dataset"] = dataset
+        if actor is not None:
+            query["actor"] = actor
+        if since is not None:
+            query["recorded_at"] = {"$gte": since}
+        cur = self._db[_EVENTS].find(query).sort("recorded_at", 1)
+        return [_to_event(d) for d in cur]
 
     def history(
         self, entity_id: str, limit: int | None = None,
@@ -432,6 +450,8 @@ def _to_edge(d: dict[str, Any]) -> EvidenceEdge:
         controller_snapshot=d.get("controller_snapshot"),
         run_name=d.get("run_name"),
         dataset=d.get("dataset"),
+        actor=d.get("actor"),
+        trust=d.get("trust"),
         recorded_at=d.get("recorded_at") or datetime.now(),
         edge_id=_objectid_to_int(d.get("_id")) if d.get("_id") else None,
     )
@@ -444,6 +464,8 @@ def _to_event(d: dict[str, Any]) -> IdentityEvent:
         payload=d.get("payload"),
         run_name=d.get("run_name"),
         dataset=d.get("dataset"),
+        actor=d.get("actor"),
+        trust=d.get("trust"),
         recorded_at=d.get("recorded_at") or datetime.now(),
         event_id=_objectid_to_int(d.get("_id")) if d.get("_id") else None,
     )

--- a/packages/python/goldenmatch/goldenmatch/identity/query.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/query.py
@@ -167,11 +167,15 @@ def manual_merge(
     absorb_entity_id: str,
     reason: str | None = None,
     run_name: str = "manual",
+    actor: str | None = None,
+    trust: float | None = None,
 ) -> dict[str, Any]:
     """Manually merge ``absorb_entity_id`` into ``keep_entity_id``.
 
     Reassigns every record of the absorbed entity to the kept entity and
-    retires the loser. Emits ``manual_merge`` events on both sides.
+    retires the loser. Emits ``manual_merge`` events on both sides, stamped with
+    ``actor``/``trust`` provenance (#1075) so the audit log records WHO merged
+    these and on what authority.
     """
     winner = store.get_identity(keep_entity_id)
     loser = store.get_identity(absorb_entity_id)
@@ -189,13 +193,13 @@ def manual_merge(
         entity_id=keep_entity_id,
         kind=EventKind.MANUAL_MERGE.value,
         payload={"absorbed": absorb_entity_id, "reason": reason},
-        run_name=run_name, recorded_at=now,
+        run_name=run_name, actor=actor, trust=trust, recorded_at=now,
     ))
     store.emit_event(IdentityEvent(
         entity_id=absorb_entity_id,
         kind=EventKind.MANUAL_MERGE.value,
         payload={"merged_into": keep_entity_id, "reason": reason},
-        run_name=run_name, recorded_at=now,
+        run_name=run_name, actor=actor, trust=trust, recorded_at=now,
     ))
     return {"keep": keep_entity_id, "absorbed": absorb_entity_id, "at": now.isoformat()}
 
@@ -206,12 +210,15 @@ def manual_split(
     record_ids: list[str],
     reason: str | None = None,
     run_name: str = "manual",
+    actor: str | None = None,
+    trust: float | None = None,
 ) -> dict[str, Any]:
     """Detach ``record_ids`` from ``entity_id`` into a brand-new identity.
 
     The original identity keeps its remaining records. The new identity is
     created with no rolled-up golden record (caller can refresh by re-running
-    dedupe or via a steward UI).
+    dedupe or via a steward UI). The ``manual_split`` events carry ``actor``/
+    ``trust`` provenance (#1075).
     """
     from goldenmatch.identity.store import new_entity_id
 
@@ -242,13 +249,13 @@ def manual_split(
         entity_id=entity_id,
         kind=EventKind.MANUAL_SPLIT.value,
         payload={"split_to": new_eid, "records": moved, "reason": reason},
-        run_name=run_name, recorded_at=now,
+        run_name=run_name, actor=actor, trust=trust, recorded_at=now,
     ))
     store.emit_event(IdentityEvent(
         entity_id=new_eid,
         kind=EventKind.MANUAL_SPLIT.value,
         payload={"split_from": entity_id, "records": moved, "reason": reason},
-        run_name=run_name, recorded_at=now,
+        run_name=run_name, actor=actor, trust=trust, recorded_at=now,
     ))
     return {"new_entity_id": new_eid, "moved": moved, "at": now.isoformat()}
 

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -259,6 +259,7 @@ def resolve_clusters(
     weak_confidence_threshold: float = 0.6,
     pair_score_view: ClusterPairScores | None = None,
     cluster_frames: ClusterFrames | None = None,
+    actor: str = "pipeline",
 ) -> ResolveSummary:
     """Resolve run-local clusters to durable identities.
 
@@ -529,6 +530,7 @@ def resolve_clusters(
                         "record_ids": record_ids,
                     },
                     run_name=run_name, dataset=dataset, recorded_at=now,
+                    actor=actor, trust=_cluster_confidence(info),
                 ))
                 summary.events_emitted += 1
             summary.created += 1
@@ -554,6 +556,7 @@ def resolve_clusters(
                     kind=EventKind.ABSORBED_RECORD.value,
                     payload={"record_id": rid, "cluster_id": cluster_id},
                     run_name=run_name, dataset=dataset, recorded_at=now,
+                    actor=actor, trust=_cluster_confidence(info),
                 ))
                 summary.events_emitted += 1
                 summary.absorbed_records += 1
@@ -588,6 +591,7 @@ def resolve_clusters(
                     "member_count": size,
                 },
                 run_name=run_name, dataset=dataset, recorded_at=now,
+                actor=actor, trust=_cluster_confidence(info),
             ))
             summary.events_emitted += 1
             for loser in losers:
@@ -597,6 +601,7 @@ def resolve_clusters(
                     kind=EventKind.MERGED_WITH.value,
                     payload={"merged_into": winner},
                     run_name=run_name, dataset=dataset, recorded_at=now,
+                    actor=actor, trust=_cluster_confidence(info),
                 ))
                 summary.events_emitted += 1
             entity_id = winner
@@ -658,6 +663,7 @@ def resolve_clusters(
                 controller_snapshot=controller_snapshot,
                 run_name=run_name,
                 dataset=dataset,
+                actor=actor, trust=float(score),
             ))
             summary.edges_added += 1
 
@@ -701,6 +707,8 @@ def resolve_clusters(
                     controller_snapshot=controller_snapshot,
                     run_name=run_name,
                     dataset=dataset,
+                    actor=actor,
+                    trust=float(bottleneck_score) if bottleneck_score is not None else None,
                 ))
                 summary.conflicts_flagged += 1
 
@@ -733,6 +741,8 @@ def resolve_clusters(
                         controller_snapshot=controller_snapshot,
                         run_name=run_name,
                         dataset=dataset,
+                        actor=actor,
+                        trust=prior_edge.score,
                     ))
                     summary.conflicts_flagged += 1
 

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -27,7 +27,7 @@ from goldenmatch.identity.model import (
 
 log = logging.getLogger("goldenmatch.identity")
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS identity_nodes (
@@ -72,6 +72,8 @@ CREATE TABLE IF NOT EXISTS evidence_edges (
     controller_snapshot  TEXT,
     run_name             TEXT,
     dataset              TEXT,
+    actor                TEXT,
+    trust                REAL,
     recorded_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     -- v2 schema: ``kind`` is part of the unique key so a single run can record
     -- both a ``same_as`` edge and a ``conflicts_with`` edge for the same
@@ -89,6 +91,8 @@ CREATE TABLE IF NOT EXISTS identity_events (
     payload      TEXT,
     run_name     TEXT,
     dataset      TEXT,
+    actor        TEXT,
+    trust        REAL,
     recorded_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_events_entity ON identity_events(entity_id);
@@ -248,8 +252,28 @@ class IdentityStore:
                 COMMIT;
                 """
             )
+        if version < 3:
+            # v2 -> v3: provenance spine (#1075/#1078). Add actor/trust to the
+            # event + edge logs. Idempotent (PRAGMA-guarded) so it's safe on a
+            # fresh DB whose tables already carry the columns from ``_SCHEMA`` and
+            # on the rebuilt-evidence_edges path above (which drops them).
+            self._ensure_provenance_columns()
         if version < SCHEMA_VERSION:
             self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    def _ensure_provenance_columns(self) -> None:
+        """Add the nullable ``actor``/``trust`` columns to the event + edge tables
+        if absent. SQLite has no ``ADD COLUMN IF NOT EXISTS``, so we probe
+        ``PRAGMA table_info`` first -- making the op idempotent across fresh,
+        v1-rebuilt, and v2 databases."""
+        for table in ("identity_events", "evidence_edges"):
+            cols = {
+                r[1] for r in self._conn.execute(f"PRAGMA table_info({table})")
+            }
+            if "actor" not in cols:
+                self._conn.execute(f"ALTER TABLE {table} ADD COLUMN actor TEXT")
+            if "trust" not in cols:
+                self._conn.execute(f"ALTER TABLE {table} ADD COLUMN trust REAL")
 
     def _pg_init_schema(self) -> None:
         ddl = """
@@ -292,9 +316,16 @@ class IdentityStore:
             controller_snapshot JSONB,
             run_name TEXT,
             dataset TEXT,
+            actor TEXT,
+            trust DOUBLE PRECISION,
             recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             UNIQUE(entity_id, record_a_id, record_b_id, kind, run_name)
         );
+        -- Provenance spine (#1075/#1078): add to pre-existing tables too (the
+        -- CREATE above only covers fresh DBs). ADD COLUMN IF NOT EXISTS is
+        -- idempotent on Postgres, so this runs safely on every store open.
+        ALTER TABLE evidence_edges ADD COLUMN IF NOT EXISTS actor TEXT;
+        ALTER TABLE evidence_edges ADD COLUMN IF NOT EXISTS trust DOUBLE PRECISION;
         CREATE INDEX IF NOT EXISTS idx_edges_entity ON evidence_edges(entity_id);
         CREATE INDEX IF NOT EXISTS idx_edges_pair   ON evidence_edges(record_a_id, record_b_id);
         CREATE INDEX IF NOT EXISTS idx_edges_run    ON evidence_edges(run_name);
@@ -305,8 +336,12 @@ class IdentityStore:
             payload JSONB,
             run_name TEXT,
             dataset TEXT,
+            actor TEXT,
+            trust DOUBLE PRECISION,
             recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         );
+        ALTER TABLE identity_events ADD COLUMN IF NOT EXISTS actor TEXT;
+        ALTER TABLE identity_events ADD COLUMN IF NOT EXISTS trust DOUBLE PRECISION;
         CREATE INDEX IF NOT EXISTS idx_events_entity ON identity_events(entity_id);
         CREATE INDEX IF NOT EXISTS idx_events_kind   ON identity_events(kind);
         CREATE INDEX IF NOT EXISTS idx_events_run    ON identity_events(run_name);
@@ -704,12 +739,13 @@ class IdentityStore:
                 "INSERT OR IGNORE INTO evidence_edges "
                 "(entity_id, record_a_id, record_b_id, kind, score, "
                 "matchkey_name, field_scores, negative_evidence, "
-                "controller_snapshot, run_name, dataset, recorded_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "controller_snapshot, run_name, dataset, actor, trust, recorded_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     edge.entity_id, a, b, edge.kind, edge.score,
                     edge.matchkey_name, fs, ne, cs, edge.run_name,
-                    edge.dataset, edge.recorded_at.isoformat(),
+                    edge.dataset, edge.actor, edge.trust,
+                    edge.recorded_at.isoformat(),
                 ),
             )
         else:
@@ -719,14 +755,15 @@ class IdentityStore:
                     "INSERT INTO evidence_edges "
                     "(entity_id, record_a_id, record_b_id, kind, score, "
                     "matchkey_name, field_scores, negative_evidence, "
-                    "controller_snapshot, run_name, dataset, recorded_at) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+                    "controller_snapshot, run_name, dataset, actor, trust, recorded_at) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
                     "ON CONFLICT (entity_id, record_a_id, record_b_id, "
                     "kind, run_name) DO NOTHING",
                     (
                         edge.entity_id, a, b, edge.kind, edge.score,
                         edge.matchkey_name, fs, ne, cs, edge.run_name,
-                        edge.dataset, edge.recorded_at.isoformat(),
+                        edge.dataset, edge.actor, edge.trust,
+                        edge.recorded_at.isoformat(),
                     ),
                 )
         row = self._fetchone(
@@ -790,11 +827,12 @@ class IdentityStore:
         payload = json.dumps(event.payload) if event.payload is not None else None
         self._exec(
             "INSERT INTO identity_events "
-            "(entity_id, kind, payload, run_name, dataset, recorded_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "(entity_id, kind, payload, run_name, dataset, actor, trust, recorded_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 event.entity_id, event.kind, payload, event.run_name,
-                event.dataset, event.recorded_at.isoformat(),
+                event.dataset, event.actor, event.trust,
+                event.recorded_at.isoformat(),
             ),
         )
         row = self._fetchone(
@@ -819,6 +857,38 @@ class IdentityStore:
                 "SELECT * FROM identity_events WHERE entity_id = ? ORDER BY event_id",
                 (entity_id,),
             )
+        return [self._row_to_event(r) for r in rows]
+
+    def export_audit_log(
+        self, *, dataset: str | None = None, actor: str | None = None,
+        since: datetime | None = None,
+    ) -> list[IdentityEvent]:
+        """The full append-only event log in commit order (event_id ASC), for
+        compliance review/export (#1078). Optional ``dataset`` / ``actor`` /
+        ``since`` filters. Each event carries who (``actor``), trust, when
+        (``recorded_at``), why (``payload['reason']``) -- so a reviewer can
+        reconstruct exactly which actor changed what, when, and on what basis.
+        Callers serialize to JSONL/CSV as needed."""
+        if self._backend == "mongo":
+            return self._mongo.export_audit_log(
+                dataset=dataset, actor=actor, since=since
+            )
+        clauses: list[str] = []
+        params: list[Any] = []
+        if dataset is not None:
+            clauses.append("dataset = ?")
+            params.append(dataset)
+        if actor is not None:
+            clauses.append("actor = ?")
+            params.append(actor)
+        if since is not None:
+            clauses.append("recorded_at >= ?")
+            params.append(since.isoformat())
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        rows = self._fetchall(
+            f"SELECT * FROM identity_events{where} ORDER BY event_id",
+            tuple(params),
+        )
         return [self._row_to_event(r) for r in rows]
 
     def has_run_event(self, entity_id: str, run_name: str, kind: str) -> bool:
@@ -935,6 +1005,8 @@ class IdentityStore:
             controller_snapshot=_maybe_json(row["controller_snapshot"]),
             run_name=row["run_name"],
             dataset=row["dataset"],
+            actor=_row_get(row, "actor"),
+            trust=_row_get(row, "trust"),
             recorded_at=_to_dt(row["recorded_at"]),
             edge_id=row["edge_id"],
         )
@@ -950,6 +1022,8 @@ class IdentityStore:
             payload=payload,
             run_name=row["run_name"],
             dataset=row["dataset"],
+            actor=_row_get(row, "actor"),
+            trust=_row_get(row, "trust"),
             recorded_at=_to_dt(row["recorded_at"]),
             event_id=row["event_id"],
         )
@@ -964,3 +1038,15 @@ def _to_dt(v: Any) -> datetime:
         except ValueError:
             return datetime.strptime(v, "%Y-%m-%d %H:%M:%S")
     return datetime.now()
+
+
+def _row_get(row: Any, key: str) -> Any:
+    """Column value or None if the column is absent -- tolerates rows from a
+    pre-provenance schema (sqlite3.Row raises IndexError, dict raises KeyError on
+    a missing key) so reads never break before the migration runs."""
+    try:
+        if hasattr(row, "keys") and key not in row.keys():
+            return None
+        return row[key]
+    except (KeyError, IndexError):
+        return None

--- a/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
@@ -100,7 +100,9 @@ IDENTITY_TOOLS: list[Tool] = [
         name="identity_merge",
         description=(
             "Manually merge two identities. All records from "
-            "`absorb_entity_id` are reassigned to `keep_entity_id`."
+            "`absorb_entity_id` are reassigned to `keep_entity_id`. The merge "
+            "events are stamped with `actor`/`trust` provenance so the audit "
+            "log records who merged these and on what authority."
         ),
         inputSchema={
             "type": "object",
@@ -108,6 +110,20 @@ IDENTITY_TOOLS: list[Tool] = [
                 "keep_entity_id": {"type": "string"},
                 "absorb_entity_id": {"type": "string"},
                 "reason": {"type": "string"},
+                "actor": {
+                    "type": "string",
+                    "description": (
+                        "Principal making the change, e.g. 'agent:claude' or "
+                        "'steward:alice'. Defaults to 'agent'."
+                    ),
+                },
+                "trust": {
+                    "type": "number",
+                    "description": (
+                        "Trust of the actor in [0,1]. Defaults by actor prefix "
+                        "(steward 1.0, agent 0.5)."
+                    ),
+                },
                 "path": {"type": "string"},
             },
             "required": ["keep_entity_id", "absorb_entity_id"],
@@ -117,7 +133,8 @@ IDENTITY_TOOLS: list[Tool] = [
         name="identity_split",
         description=(
             "Split a subset of records off an identity into a brand-new "
-            "identity. The original keeps the remaining records."
+            "identity. The original keeps the remaining records. The split "
+            "events carry `actor`/`trust` provenance."
         ),
         inputSchema={
             "type": "object",
@@ -125,6 +142,17 @@ IDENTITY_TOOLS: list[Tool] = [
                 "entity_id": {"type": "string"},
                 "record_ids": {"type": "array", "items": {"type": "string"}},
                 "reason": {"type": "string"},
+                "actor": {
+                    "type": "string",
+                    "description": (
+                        "Principal making the change, e.g. 'agent:claude'. "
+                        "Defaults to 'agent'."
+                    ),
+                },
+                "trust": {
+                    "type": "number",
+                    "description": "Trust of the actor in [0,1]. Default by actor prefix.",
+                },
                 "path": {"type": "string"},
             },
             "required": ["entity_id", "record_ids"],
@@ -206,6 +234,24 @@ def _open(args: dict) -> IdentityStore:
     return IdentityStore(path=args.get("path") or _DEFAULT_PATH)
 
 
+def _actor_trust(args: dict) -> tuple[str, float | None]:
+    """Resolve the (actor, trust) provenance for an agent-driven mutation.
+
+    ``actor`` defaults to ``"agent"`` (MCP is the agent surface). When ``trust``
+    is not supplied, it's derived from the actor's prefix
+    (``steward:`` -> 1.0, else 0.5) via the shared trust map, so an agent write
+    is recorded at lower authority than a steward's."""
+    actor = str(args.get("actor") or "agent")
+    trust = args.get("trust")
+    if trust is None:
+        try:
+            from goldenmatch.core.memory.store import trust_for_source
+            trust = trust_for_source(actor.split(":", 1)[0])
+        except Exception:
+            trust = None
+    return actor, (float(trust) if trust is not None else None)
+
+
 def _dispatch(name: str, args: dict) -> dict[str, Any]:
     if name == "identity_resolve":
         with _open(args) as s:
@@ -234,6 +280,7 @@ def _dispatch(name: str, args: dict) -> dict[str, Any]:
         return {"items": edges}
 
     if name == "identity_merge":
+        actor, trust = _actor_trust(args)
         with _open(args) as s:
             return manual_merge(
                 s,
@@ -241,9 +288,12 @@ def _dispatch(name: str, args: dict) -> dict[str, Any]:
                 absorb_entity_id=args["absorb_entity_id"],
                 reason=args.get("reason"),
                 run_name="mcp",
+                actor=actor,
+                trust=trust,
             )
 
     if name == "identity_split":
+        actor, trust = _actor_trust(args)
         with _open(args) as s:
             return manual_split(
                 s,
@@ -251,6 +301,8 @@ def _dispatch(name: str, args: dict) -> dict[str, Any]:
                 record_ids=list(args["record_ids"]),
                 reason=args.get("reason"),
                 run_name="mcp",
+                actor=actor,
+                trust=trust,
             )
 
     if name == "identity_show":

--- a/packages/python/goldenmatch/tests/identity/test_provenance.py
+++ b/packages/python/goldenmatch/tests/identity/test_provenance.py
@@ -1,0 +1,185 @@
+"""Provenance spine (#1075 / #1078): actor + trust on identity writes.
+
+Every event/edge write records WHO made the change (``actor``) and their
+``trust``, so the append-only audit log lets a reviewer reconstruct exactly which
+actor changed what, when, and why. Backward-compatible: pre-provenance rows and
+callers that don't supply provenance read back as None.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+from goldenmatch.identity import IdentityStore
+from goldenmatch.identity.model import (
+    EdgeKind,
+    EvidenceEdge,
+    IdentityEvent,
+    IdentityNode,
+)
+from goldenmatch.identity.query import manual_merge, manual_split
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = IdentityStore(backend="sqlite", path=str(tmp_path / "id.db"))
+    yield s
+    s.close()
+
+
+def _mk_entity(store: IdentityStore, eid: str) -> None:
+    store.upsert_identity(IdentityNode(entity_id=eid))
+
+
+# ── round-trip ────────────────────────────────────────────────────────────────
+
+
+def test_event_actor_trust_round_trip(store):
+    _mk_entity(store, "e1")
+    store.emit_event(IdentityEvent(
+        entity_id="e1", kind="created",
+        actor="agent:claude", trust=0.5, run_name="r1",
+    ))
+    [ev] = store.history("e1")
+    assert ev.actor == "agent:claude"
+    assert ev.trust == 0.5
+
+
+def test_edge_actor_trust_round_trip(store):
+    _mk_entity(store, "e1")
+    store.add_edge(EvidenceEdge(
+        entity_id="e1", record_a_id="s:a", record_b_id="s:b",
+        kind=EdgeKind.SAME_AS.value, score=0.9,
+        actor="pipeline", trust=0.9, run_name="r1",
+    ))
+    [edge] = store.edges_for_entity("e1")
+    assert edge.actor == "pipeline"
+    assert edge.trust == 0.9
+
+
+def test_provenance_defaults_to_none(store):
+    # a writer that doesn't supply actor/trust reads back as None (not an error).
+    _mk_entity(store, "e1")
+    store.emit_event(IdentityEvent(entity_id="e1", kind="created", run_name="r1"))
+    [ev] = store.history("e1")
+    assert ev.actor is None and ev.trust is None
+
+
+# ── manual ops stamp provenance ───────────────────────────────────────────────
+
+
+def test_manual_merge_stamps_actor_trust(store):
+    _mk_entity(store, "keep")
+    _mk_entity(store, "absorb")
+    manual_merge(store, "keep", "absorb", reason="dup",
+                 actor="steward:alice", trust=1.0)
+    # both sides of the merge carry the provenance
+    keep_ev = store.history("keep")[-1]
+    absorb_ev = store.history("absorb")[-1]
+    assert keep_ev.actor == "steward:alice" and keep_ev.trust == 1.0
+    assert absorb_ev.actor == "steward:alice" and absorb_ev.trust == 1.0
+    # the "why" rides in the payload
+    assert keep_ev.payload["reason"] == "dup"
+
+
+def test_manual_split_stamps_actor_trust(store):
+    _mk_entity(store, "e1")
+    from goldenmatch.identity.model import SourceRecord
+    store.upsert_record(SourceRecord(
+        record_id="s:a", source="s", source_pk="a",
+        record_hash="h", entity_id="e1",
+    ))
+    out = manual_split(store, "e1", ["s:a"], actor="agent:bot", trust=0.5)
+    new_eid = out["new_entity_id"]
+    assert store.history("e1")[-1].actor == "agent:bot"
+    assert store.history(new_eid)[-1].trust == 0.5
+
+
+# ── audit-log export (#1078) ──────────────────────────────────────────────────
+
+
+def test_export_audit_log_orders_and_filters(store):
+    _mk_entity(store, "e1")
+    _mk_entity(store, "e2")
+    store.emit_event(IdentityEvent(entity_id="e1", kind="created",
+                                   actor="pipeline", dataset="d1", run_name="r1"))
+    store.emit_event(IdentityEvent(entity_id="e2", kind="created",
+                                   actor="agent:x", dataset="d2", run_name="r1"))
+    store.emit_event(IdentityEvent(entity_id="e1", kind="merged_with",
+                                   actor="agent:x", dataset="d1", run_name="r2"))
+
+    full = store.export_audit_log()
+    assert len(full) == 3
+    # commit order (event_id ASC)
+    assert [e.event_id for e in full] == sorted(e.event_id for e in full)
+    # every event is attributable
+    assert all(e.actor for e in full)
+
+    # filter by actor
+    by_actor = store.export_audit_log(actor="agent:x")
+    assert {e.entity_id for e in by_actor} == {"e1", "e2"}
+    assert len(by_actor) == 2
+
+    # filter by dataset
+    by_ds = store.export_audit_log(dataset="d1")
+    assert all(e.dataset == "d1" for e in by_ds) and len(by_ds) == 2
+
+
+def test_export_audit_log_since_filter(store):
+    _mk_entity(store, "e1")
+    old = datetime.now() - timedelta(days=2)
+    store.emit_event(IdentityEvent(entity_id="e1", kind="created",
+                                   actor="pipeline", recorded_at=old, run_name="r1"))
+    store.emit_event(IdentityEvent(entity_id="e1", kind="merged_with",
+                                   actor="agent:x", run_name="r2"))
+    recent = store.export_audit_log(since=datetime.now() - timedelta(hours=1))
+    assert [e.kind for e in recent] == ["merged_with"]
+
+
+# ── migration from a pre-provenance (v2) database ─────────────────────────────
+
+
+def test_migration_adds_columns_to_pre_provenance_db(tmp_path):
+    """An existing v2 DB (no actor/trust columns) gains them on open, old rows
+    read back as None, and new writes carry provenance."""
+    db = str(tmp_path / "old.db")
+    # hand-build a v2-shape DB: events table WITHOUT actor/trust, user_version=2.
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE identity_nodes (entity_id TEXT PRIMARY KEY, status TEXT,
+            merged_into TEXT, golden_record TEXT, confidence REAL, dataset TEXT,
+            created_at TIMESTAMP, updated_at TIMESTAMP);
+        CREATE TABLE evidence_edges (edge_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            entity_id TEXT, record_a_id TEXT, record_b_id TEXT, kind TEXT,
+            score REAL, matchkey_name TEXT, field_scores TEXT,
+            negative_evidence TEXT, controller_snapshot TEXT, run_name TEXT,
+            dataset TEXT, recorded_at TIMESTAMP,
+            UNIQUE(entity_id, record_a_id, record_b_id, kind, run_name));
+        CREATE TABLE identity_events (event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            entity_id TEXT, kind TEXT, payload TEXT, run_name TEXT, dataset TEXT,
+            recorded_at TIMESTAMP);
+        CREATE TABLE identity_aliases (alias TEXT, entity_id TEXT, kind TEXT,
+            dataset TEXT, recorded_at TIMESTAMP, PRIMARY KEY (alias, kind, dataset));
+        INSERT INTO identity_events (entity_id, kind, run_name, recorded_at)
+            VALUES ('e1', 'created', 'r0', '2026-01-01T00:00:00');
+        PRAGMA user_version = 2;
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    # open through IdentityStore -> migration runs
+    s = IdentityStore(backend="sqlite", path=db)
+    try:
+        # the pre-provenance row reads back with None provenance (not an error)
+        [old_ev] = s.history("e1")
+        assert old_ev.actor is None and old_ev.trust is None
+        # and a new write carries provenance through the migrated schema
+        s.emit_event(IdentityEvent(entity_id="e1", kind="merged_with",
+                                   actor="steward:bob", trust=1.0, run_name="r1"))
+        latest = s.history("e1")[-1]
+        assert latest.actor == "steward:bob" and latest.trust == 1.0
+    finally:
+        s.close()


### PR DESCRIPTION
## What

The foundational slice of the **Agent Memory epic (#1073)** — adds `actor` + `trust` provenance to every identity write. The audit (this session) found three phases independently pointing at the *same* missing thing: `IdentityEvent`/`EvidenceEdge` carried only `run_name`, with no record of *who* made a write or their trust. This one change advances all three:

- **#1075** (agent-writable identity ops) — merges/splits now carry full provenance
- **#1078** (audit log: reconstruct who changed what/when/why) — the event log becomes a real audit trail + export
- **#1076's caveat** — the "who decided this" gap on cross-session links

## The change

`IdentityEvent` and `EvidenceEdge` now record **`actor`** (e.g. `pipeline` / `agent:claude` / `steward:alice`) and **`trust`** (0–1). The append-only event log becomes a compliance-grade audit trail — a reviewer can reconstruct exactly which actor changed what, when, and why (`payload['reason']`).

| Layer | Change |
|---|---|
| **Storage** | nullable `actor`/`trust` on `identity_events` + `evidence_edges`, threaded through `emit_event`/`add_edge` + row mappers (SQLite + Postgres + Mongo parity) |
| **Migration** | backward-compatible: SQLite via PRAGMA-guarded `ADD COLUMN` (idempotent across fresh/v1/v2 DBs), Postgres via `ADD COLUMN IF NOT EXISTS`, + Alembic `0002` rev. Pre-provenance rows read back as `None` |
| **Writers** | `manual_merge`/`manual_split` take `actor`/`trust` (agent path, #1075); `resolve_clusters` stamps pipeline writes `actor="pipeline"` with cluster/edge confidence as trust (override via `actor=`) |
| **Surface** | MCP `identity_merge`/`identity_split` accept `actor`/`trust` (trust defaults by actor prefix — steward 1.0, agent 0.5, via the shared trust map); new `IdentityStore.export_audit_log(dataset=/actor=/since=)` returns the full log in commit order for compliance export (#1078) |

## Safety

- **Backward-compatible by construction:** nullable columns, idempotent migration, the new dataclass fields slot before `recorded_at`/`edge_id` and *all 20 construction sites use keywords* (verified). 190 identity/streaming/graph tests pass unchanged.
- **Migration tested end-to-end:** `tests/identity/test_provenance.py` opens a hand-built pre-provenance (v2) DB and asserts the columns are added, old rows read `None`, and new writes carry provenance — plus round-trip, manual-op stamping, and audit-log filter tests (8 new tests).
- `ruff` clean; docs-staleness clean (no new env flags).

## Scoped follow-ups (noted in CHANGELOG)

Tamper-evident hash-chaining of the audit log, the `claim-entity`/`resolve-conflict` MCP/A2A tools (#1075's other two ops), and provenance on the Postgres bulk-COPY fast-path (currently inserts `NULL` actor/trust — doesn't break, just unattributed).

> Note: the `mcp` and `fastapi` extras aren't installed in the dev sandbox, so the MCP/web test modules couldn't run locally (pre-existing) — the MCP tool wiring is ruff-clean and the underlying `manual_merge`/`manual_split` provenance is fully covered by the identity tests. CI runs those lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_