### PR TITLE
feat(erkgbench): shatter-probe — recall-vs-scoring verdict for broken-chain misses

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -25,6 +25,9 @@ on:
       trace:
         description: "goldengraph only: localize where each answer is lost (extraction/retrieval/synthesis)"
         default: "false"
+      trace_limit:
+        description: "goldengraph only: how many questions the localize trace inspects (0 = all; bigger = real SCORING-vs-RECALL shatter distribution)"
+        default: "10"
       cross_doc_link:
         description: "goldengraph only: enable cross-document entity linking (merge bridge entities across paragraphs)"
         default: "false"
@@ -113,6 +116,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
           POLARS_SKIP_CPU_CHECK: "1"
           GOLDENGRAPH_QA_TRACE: ${{ inputs.trace }}
+          GOLDENGRAPH_QA_TRACE_LIMIT: ${{ inputs.trace_limit }}
           GOLDENGRAPH_CROSS_DOC_LINK: ${{ inputs.cross_doc_link }}
           GOLDENGRAPH_LINK_THRESHOLD: ${{ inputs.link_threshold }}
           GOLDENGRAPH_PROFILE_LINK: ${{ inputs.profile_link }}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -126,15 +126,25 @@ class QAEngine(Protocol):
     def answer(self, handle, question: str) -> AnswerResult: ...
 
 
-def _localize_trace(engine, handle, corpus, *, limit: int = 10) -> None:
+#: How many questions the localize trace inspects. `localize` is LLM-free (cached
+#: embeddings), so probing every question is nearly free -- the cap only bounds log
+#: volume. Raise it (GOLDENGRAPH_QA_TRACE_LIMIT=0 -> all) to get a real SCORING-vs-
+#: RECALL distribution from the shatter-probe instead of a first-10 sample.
+_TRACE_LIMIT = int(os.environ.get("GOLDENGRAPH_QA_TRACE_LIMIT") or "10")
+
+
+def _localize_trace(engine, handle, corpus, *, limit: int = _TRACE_LIMIT) -> None:
     """Diagnostic: for each question, classify WHERE the gold answer is lost --
     extraction (gold entity never made it into the graph), retrieval (it's in the
     graph but the seed-walk didn't surface it), or synthesis (it was retrieved but
     the LLM wrote a wrong answer). Opt-in via GOLDENGRAPH_QA_TRACE; only engines
     exposing `localize` (goldengraph) participate. Uses the same token-containment
     as answer_match so "in graph/ball" lines up with the headline scoring."""
-    print(f"== localize trace (first {limit}; where is the answer lost?) ==", flush=True)
-    for q in corpus.questions[:limit]:
+    qs = corpus.questions if limit <= 0 else corpus.questions[:limit]
+    print(f"== localize trace (n={len(qs)}; where is the answer lost?) ==", flush=True)
+    stage_counts: dict[str, int] = {}
+    verdict_counts: dict[str, int] = {}
+    for q in qs:
         try:
             loc = engine.localize(handle, q.question)
         except Exception as exc:  # diagnostic must never break the scored run
@@ -151,6 +161,7 @@ def _localize_trace(engine, handle, corpus, *, limit: int = 10) -> None:
             stage = "RETRIEVAL-BUDGET (reachable from seeds but outside the budget-capped ball)"
         else:
             stage = "SYNTHESIS (retrieved, wrong answer written)"
+        stage_counts[stage.split(" ", 1)[0]] = stage_counts.get(stage.split(" ", 1)[0], 0) + 1
         print(
             f"  [{q.id}] hop{q.hop_count} gold={q.gold_answer!r} "
             f"in_graph={in_graph} in_wide={in_wide} in_ball={in_ball} -> {stage}",
@@ -217,12 +228,22 @@ def _localize_trace(engine, handle, corpus, *, limit: int = 10) -> None:
                 if probe is not None:
                     verdict, fscore, cosine, sname, iname, shared = probe
                     cos_s = f"{cosine:.3f}" if cosine is not None else "n/a"
+                    verdict_counts[verdict.split(" ", 1)[0]] = (
+                        verdict_counts.get(verdict.split(" ", 1)[0], 0) + 1
+                    )
                     print(
                         f"      shatter-probe: {verdict} "
                         f"(cosine={cos_s} fuzzy={fscore:.0f} shared_token={shared} "
                         f"seed={sname!r} island={iname!r})",
                         flush=True,
                     )
+    # Roll-up so the SCORING-vs-RECALL split (the #1090 gate) and the loss-stage mix
+    # are one glance, not a grep across every per-question line.
+    stage_mix = ", ".join(f"{k}:{v}" for k, v in sorted(stage_counts.items()))
+    print(f"== trace summary: stages {{{stage_mix}}} ==", flush=True)
+    if verdict_counts:
+        verdict_mix = ", ".join(f"{k}:{v}" for k, v in sorted(verdict_counts.items()))
+        print(f"== shatter-probe verdicts {{{verdict_mix}}} ==", flush=True)
 
 
 def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> dict:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -15,6 +15,91 @@ from goldenmatch.core.llm_budget import BudgetTracker
 from . import metrics
 
 
+def _name_tokens(name: str) -> set[str]:
+    """Word-ish tokens of an entity name (len>1, lowercased) -- approximates the
+    token rule goldengraph's cross-doc `_LinkIndex` blocks on, so a shared token
+    here means the pair would already be a token-overlap candidate."""
+    return {t for t in "".join(c if c.isalnum() else " " for c in name.lower()).split() if len(t) > 1}
+
+
+#: Cosine threshold the #1090 ANN/semantic blocker uses to PROPOSE a candidate pair
+#: (GOLDENMATCH_SEMANTIC_BLOCKING_THRESHOLD default). A cross-component pair at or
+#: above this is one semantic blocking WOULD surface; below it, it would not -- so
+#: the probe reports the verdict against the same bar the real integration applies.
+_SEMANTIC_BLOCKING_COSINE = float(os.environ.get("GOLDENMATCH_SEMANTIC_BLOCKING_THRESHOLD", "0.6"))
+
+
+def _shatter_probe(seed_names, island_names, *, embedder=None, cap: int = 1500):
+    """Recall-vs-scoring fork for a broken-chain (shattered) miss. The bridge entity
+    that should join the seed component to the answer component was never merged --
+    this decides WHY, and therefore whether #1090 semantic blocking is the fix.
+
+    Two signals across the seed x island name pairs:
+      - fuzzy: best rapidfuzz token_sort_ratio pair + whether it shares a name token
+        (a shared token means token blocking ALREADY proposes the pair).
+      - semantic (when an embedder is given): best cosine pair -- exactly what the
+        #1090 ANN blocker would surface, scored against the SAME 0.6 bar it uses.
+
+    Verdict:
+      - SCORING-miss: the best bridge pair shares a token (token blocking already
+        proposed it) -> goldenprofile under-merged. Semantic blocking does NOT help.
+      - RECALL-miss: the bridge is token-disjoint AND a semantic/string near-duplicate
+        (cosine >= the blocking bar, or fuzzy>=85 when no embedder) -> token blocking
+        never proposes it but ANN blocking WOULD. This is what #1090 fixes.
+      - NO-BRIDGE: no token-disjoint pair clears the semantic/fuzzy bar -> the split
+        is not a blocking miss (genuinely distinct mentions, or an upstream
+        extraction/normalization gap). Semantic blocking won't reconnect it.
+
+    Returns (verdict, fuzzy_score, cosine, seed_name, island_name, shared_token) or
+    None when either component is empty. cosine is None when no embedder is given.
+    Fail-soft: the caller wraps this in try/except."""
+    from rapidfuzz import fuzz, process
+
+    seeds = list(dict.fromkeys(seed_names))[:cap]
+    islands = list(dict.fromkeys(island_names))[:cap]
+    if not seeds or not islands:
+        return None
+    # Best fuzzy pair across the split.
+    best = None  # (score, seed_name, island_name)
+    for iname in islands:
+        m = process.extractOne(iname, seeds, scorer=fuzz.token_sort_ratio)
+        if m is not None and (best is None or m[1] > best[0]):
+            best = (m[1], m[0], iname)
+    if best is None:
+        return None
+    fscore, sname, iname = best
+    shared = bool(_name_tokens(sname) & _name_tokens(iname))
+
+    # Best cosine pair across the split -- the ANN blocker's actual candidate signal.
+    # Entity names were already embedded at build time, so this is a cache hit.
+    cosine = None
+    if embedder is not None:
+        try:
+            import numpy as np
+
+            sv = np.asarray(embedder.embed(seeds), dtype=float)
+            iv = np.asarray(embedder.embed(islands), dtype=float)
+            sv /= np.linalg.norm(sv, axis=1, keepdims=True) + 1e-12
+            iv /= np.linalg.norm(iv, axis=1, keepdims=True) + 1e-12
+            sims = sv @ iv.T  # (len(seeds), len(islands))
+            si, ii = np.unravel_index(int(np.argmax(sims)), sims.shape)
+            cosine = float(sims[si, ii])
+            # Report the actual best-cosine pair (the bridge ANN blocking would pick).
+            sname, iname = seeds[si], islands[ii]
+            shared = bool(_name_tokens(sname) & _name_tokens(iname))
+        except Exception:
+            cosine = None  # fall back to fuzzy-only verdict
+
+    near_dup = cosine >= _SEMANTIC_BLOCKING_COSINE if cosine is not None else fscore >= 85
+    if shared:
+        verdict = "SCORING-miss (candidate exists, under-merged)"
+    elif near_dup:
+        verdict = "RECALL-miss (token-disjoint near-dup; semantic blocking fixes)"
+    else:
+        verdict = "NO-BRIDGE (no token-disjoint pair clears the blocking bar)"
+    return verdict, fscore, cosine, sname, iname, shared
+
+
 @dataclass(frozen=True)
 class BuildResult:
     handle: Any
@@ -114,6 +199,30 @@ def _localize_trace(engine, handle, corpus, *, limit: int = 10) -> None:
                 f"answer_comp={ans_sz}ent same_component={same}",
                 flush=True,
             )
+            # Recall-vs-scoring probe: for a SHATTERED broken-chain miss (answer sits
+            # in a DIFFERENT component than the seeds), decide whether a near-duplicate
+            # bridge entity is stranded in the island that token blocking would miss
+            # (RECALL -> semantic blocking fixes it) vs one that IS already a candidate
+            # but goldenprofile under-merged (SCORING -> semantic blocking won't help).
+            # This is the single signal that gates the #1090 cross-doc integration.
+            if stage.startswith("RETRIEVAL-BROKEN-CHAIN") and not same and ans_idx >= 0 and seed_idx >= 0:
+                # The engine's embedder (cached) lets the probe score the bridge pair
+                # against the real #1090 cosine bar; absent it, the probe is fuzzy-only.
+                embedder = getattr(engine, "_embedder", None)
+                try:
+                    probe = _shatter_probe(comps[seed_idx], comps[ans_idx], embedder=embedder)
+                except Exception as exc:  # diagnostic must never break the scored run
+                    probe = None
+                    print(f"      shatter-probe failed: {exc!r}", flush=True)
+                if probe is not None:
+                    verdict, fscore, cosine, sname, iname, shared = probe
+                    cos_s = f"{cosine:.3f}" if cosine is not None else "n/a"
+                    print(
+                        f"      shatter-probe: {verdict} "
+                        f"(cosine={cos_s} fuzzy={fscore:.0f} shared_token={shared} "
+                        f"seed={sname!r} island={iname!r})",
+                        flush=True,
+                    )
 
 
 def run_engine(engine: QAEngine, corpus, *, model: str, budget_usd: float) -> dict:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
@@ -11,7 +11,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from erkgbench.qa_e2e.corpora import Document, QACorpus, QAItem  # noqa: E402
-from erkgbench.qa_e2e.harness import AnswerResult, BuildResult, run_engine  # noqa: E402
+from erkgbench.qa_e2e.harness import (  # noqa: E402
+    AnswerResult,
+    BuildResult,
+    _shatter_probe,
+    run_engine,
+)
 
 
 class _FakeEngine:
@@ -145,3 +150,98 @@ def test_trace_reports_severed_component(monkeypatch, capsys):
     assert "components: 3 total" in out
     # seed component (2ent) != answer component (2ent), different islands
     assert "seed_comp=2ent answer_comp=2ent same_component=False" in out
+
+
+def test_shatter_probe_scoring_miss():
+    # A near-duplicate sharing a token across the split -> the pair is ALREADY a
+    # token-overlap candidate; goldenprofile under-merged. Semantic blocking won't help.
+    res = _shatter_probe(["Barack Obama", "White House"], ["Barack H Obama", "Senate"])
+    verdict, fscore, cosine, sname, iname, shared = res
+    assert verdict.startswith("SCORING-miss")
+    assert shared is True and fscore >= 85 and cosine is None
+
+
+def test_shatter_probe_no_bridge():
+    # Nothing string-similar across the split (no embedder) -> not a blocking miss.
+    res = _shatter_probe(["Apple Inc", "Cupertino"], ["Joseph Stalin", "Politburo"])
+    verdict, fscore, cosine, *_ = res
+    assert verdict.startswith("NO-BRIDGE") and fscore < 85
+
+
+def test_shatter_probe_empty_component_returns_none():
+    assert _shatter_probe([], ["x"]) is None
+    assert _shatter_probe(["x"], []) is None
+
+
+class _FakeEmbedder:
+    """Deterministic toy embedder: 'twin' tokens map near-identical vectors so a
+    token-disjoint pair can still score a high cosine (the semantic-bridge case)."""
+
+    _VECS = {
+        "morgan": [1.0, 0.0, 0.0],
+        "jpmorgan": [0.98, 0.0, 0.2],  # near 'morgan' but no shared TOKEN with 'J P Morgan'
+        "wall": [0.0, 1.0, 0.0],
+        "dimon": [0.0, 0.0, 1.0],
+    }
+
+    def embed(self, texts):
+        import numpy as np
+
+        out = []
+        for t in texts:
+            key = next((k for k in self._VECS if k in t.lower().replace(".", "").replace(" ", "")), None)
+            out.append(self._VECS.get(key, [0.1, 0.1, 0.1]))
+        return np.asarray(out, dtype=float)
+
+
+def test_shatter_probe_recall_miss_via_cosine():
+    # 'JPMorgan Chase' vs 'J P Morgan': token-disjoint (no shared word token) but a
+    # high-cosine semantic near-duplicate -> RECALL-miss the ANN blocker WOULD surface.
+    res = _shatter_probe(
+        ["JPMorgan Chase", "Jamie Dimon"],
+        ["J P Morgan", "Wall Street"],
+        embedder=_FakeEmbedder(),
+    )
+    verdict, fscore, cosine, sname, iname, shared = res
+    assert verdict.startswith("RECALL-miss")
+    assert shared is False and cosine is not None and cosine >= 0.6
+
+
+class _RecallShatterEngine(_ComponentEngine):
+    """Seed island and answer island hold a token-DISJOINT near-duplicate of the
+    same real-world entity -> token blocking never proposes the pair (RECALL miss).
+    Carries the toy embedder so the trace exercises the real cosine verdict path."""
+
+    _embedder = _FakeEmbedder()
+
+    def localize(self, handle, question: str) -> dict:
+        # 'JPMorgan Chase' (seed island) vs 'J.P. Morgan' (answer island): a true
+        # near-duplicate bridge, but the answer gold 'J.P. Morgan' lives in a
+        # different component than the seeds.
+        components = [["JPMorgan Chase", "Jamie Dimon"], ["J P Morgan", "Wall Street"], ["x"]]
+        return {
+            "seed_names": ["Jamie Dimon"],
+            "graph_names": [n for c in components for n in c],
+            "wide_names": ["JPMorgan Chase", "Jamie Dimon"],
+            "retrieved_names": ["JPMorgan Chase", "Jamie Dimon"],
+            "component_names": components,
+            "component_sizes": [len(c) for c in components],
+            "seed_component_idx": 0,
+            "n_components": len(components),
+            "n_graph_entities": 5,
+            "n_retrieved_entities": 2,
+            "n_wide_entities": 2,
+            "n_retrieved_edges": 1,
+        }
+
+
+def test_trace_emits_shatter_probe_on_broken_chain(monkeypatch, capsys):
+    monkeypatch.setenv("GOLDENGRAPH_QA_TRACE", "1")
+    corpus = QACorpus(
+        name="musique",
+        documents=(Document(id="d", text="x"),),
+        questions=(_q("q1", "J P Morgan"),),
+    )
+    run_engine(_RecallShatterEngine(), corpus, model="gpt-4o-mini", budget_usd=5.0)
+    out = capsys.readouterr().out
+    assert "shatter-probe: RECALL-miss" in out

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_localize_trace.py
@@ -245,3 +245,6 @@ def test_trace_emits_shatter_probe_on_broken_chain(monkeypatch, capsys):
     run_engine(_RecallShatterEngine(), corpus, model="gpt-4o-mini", budget_usd=5.0)
     out = capsys.readouterr().out
     assert "shatter-probe: RECALL-miss" in out
+    # The roll-up summary tallies the stage mix + the SCORING/RECALL verdict split.
+    assert "trace summary: stages" in out
+    assert "shatter-probe verdicts {RECALL-miss:1}" in out


### PR DESCRIPTION
## Why

The N=50 MuSiQue localize trace pins goldengraph's dominant loss as a **shatter**: the gold answer sits in a *different* connected component than the question's seeds because a bridge entity was never merged across documents. The #3 threshold experiment already ruled out threshold tuning → it's a *candidate* problem. But "candidate problem" forks two ways, and the fix is different in each:

- **RECALL miss** — the bridge mention is *token-disjoint*, so goldengraph's token-overlap cross-doc linker never **proposes** the pair. **#1090 semantic/ANN blocking surfaces it.**
- **SCORING miss** — the bridge *shares a token*, so the pair **is** already a candidate, but goldenprofile scored it below the merge threshold. **Semantic blocking does nothing** — the candidate exists; the scorer under-merged.

This is the single signal that gates whether building the #1090 cross-doc integration into goldengraph's `_LinkIndex` is worth it. One traced run now answers it.

## What

`_shatter_probe` in the localize trace (`harness.py`). For a shattered broken-chain question (`answer_comp != seed_comp`) it finds the best bridge pair across the two components and classifies it against the **same signals the real integration uses**:

- **fuzzy** `token_sort_ratio` + shared-name-token — token blocking's candidate rule.
- **cosine** via the engine's already-cached embedder (a build-time cache hit, ~free), scored against the real `GOLDENMATCH_SEMANTIC_BLOCKING_THRESHOLD` (0.6) — exactly the ANN blocker's bar.

Verdict → `SCORING-miss` (shares a token) / `RECALL-miss` (token-disjoint but clears the cosine/fuzzy bar → #1090 fixes) / `NO-BRIDGE` (nothing clears the bar → not a blocking miss, an upstream extraction/normalization gap).

The cosine signal is the decisive add: a **semantic-but-lexically-distant** bridge (fuzzy-invisible) is exactly the case semantic blocking is *for*, and a fuzzy-only probe would have miscalled it `NO-BRIDGE`.

## Safety / scope

- Fail-soft: wrapped in try/except, **never breaks the scored run**. Embedder-optional (fuzzy-only when absent). Lazy `rapidfuzz` import.
- Trace-only, gated on `GOLDENGRAPH_QA_TRACE` (off by default). No scoring or engine behavior changes.
- 5 native-free tests: the three verdicts (incl. a toy-embedder RECALL case end-to-end through the trace) + the empty-component guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_