### PR TITLE
perf(perceptual): vectorize the Python audio DFT (~1.7x, byte-identical)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/perceptual.py
+++ b/packages/python/goldenmatch/goldenmatch/core/perceptual.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Sequence
+from operator import mul
 
 logger = logging.getLogger(__name__)
 
@@ -464,20 +465,18 @@ def _frame_band_energies(samples: Sequence[float], start: int, tw) -> list[float
     n = AUDIO_FRAME
     frame = [_HANN[i] * samples[start + i] for i in range(n)]
     mags: list[float] = []  # |X[k]|^2 for k in [lo, hi)
+    # `sum(map(mul, ...))` accumulates left-to-right starting from 0 exactly as
+    # the naive `re += x * row_c[idx]` loop did, so it is bit-identical to the
+    # Rust kernel and golden vectors -- the multiply/accumulate just moves into C
+    # (~1.7x over the Python loop). Do NOT swap in math.fsum/numpy: that changes
+    # the summation order and breaks cross-language parity.
     for row_c, row_s in zip(cos_table, sin_table):
-        re = 0.0
-        im = 0.0
-        for idx in range(n):
-            x = frame[idx]
-            re += x * row_c[idx]
-            im += x * row_s[idx]
+        re = sum(map(mul, frame, row_c))
+        im = sum(map(mul, frame, row_s))
         mags.append(re * re + im * im)
     energies = []
     for m in range(AUDIO_BANDS):
-        acc = 0.0
-        for k in range(band_bins[m], band_bins[m + 1]):
-            acc += mags[k - lo]
-        energies.append(acc)
+        energies.append(sum(mags[k - lo] for k in range(band_bins[m], band_bins[m + 1])))
     return energies
 
 


### PR DESCRIPTION
## What

The pure-Python `_frame_band_energies` partial DFT in `core/perceptual.py` was the dominant self-time hotspot in the perceptual bench — **13.5s**, surfaced by the new `hotspot` profiling lane (#1242). This swaps the inner Python accumulation loop for a C-level `sum(map(mul, ...))`:

```python
# before
for idx in range(n):
    x = frame[idx]
    re += x * row_c[idx]
    im += x * row_s[idx]
# after
re = sum(map(mul, frame, row_c))
im = sum(map(mul, frame, row_s))
```

The band accumulation collapses to `sum(genexpr)` for the same reason.

## Why it's parity-safe

`sum(...)` accumulates left-to-right starting from `0` — **exactly** the order the naive `re += ...` loop used — so every float comes out bit-for-bit identical. That matters because this function is the stdlib-only reference the Rust `perceptual-core` kernel and the golden-vector fixture mirror byte-for-byte. A comment guards against swapping in `math.fsum`/numpy, which would reorder the sum and break cross-language parity.

## Verification

- Sandbox A/B over 64 broadband frames + 8 full fingerprints: **0 bit-mismatches**, **1.71x** wall.
- `test_perceptual_reference::test_reference_reproduces_audio_fixture` (the golden audio oracle) + audio-noise, feature, autoconfig, radial suites: all green on the pure-Python path (45 passed).
- No Rust change needed — output is identical, so the kernel that already matched the old reference still matches.

The Python path is a fallback (the native kernel is the production fast path); this just makes the reference faster without touching its byte-for-byte contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfw6apNDyDvT6Pr8fNei3p)_