### PR TITLE
Tamper-evident hash-chain for the identity audit log (#1078)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -23,6 +23,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   fallback when the native wheel is absent.
 
 ### Added
+- **Tamper-evident audit log: per-event hash + on-demand seal chain (#1078,
+  epic Agent Memory #1073).** The append-only identity event log is now
+  cryptographically tamper-evident in two contention-free layers. (1) Every
+  event is stamped at insert with an `entry_hash` — a sha256 over its own
+  immutable fields (`audit.event_content_hash`); a *pure* function, so it adds
+  no insert-time serialization point and works uniformly with the Postgres
+  bulk-COPY write path. (2) `seal_audit_log()` folds the per-event hashes (in
+  `event_id` order) into a single chained root stored in the new `audit_seals`
+  table; each seal chains to its predecessor. `verify_audit_chain()` replays
+  both layers to detect content edits, deletion, reordering, and insertion of
+  any sealed event, returning `{ok, events_checked, seals_checked}` plus the
+  ids of any failures. Sealing is an explicit, infrequent op (never on the
+  write hot path), so streaming/bulk ingest is untouched; pre-hash-chain rows
+  (`entry_hash` NULL) are hashed on the fly so an existing log can be sealed
+  retroactively. Surfaced via two new MCP/A2A tools `identity_audit_seal` /
+  `identity_audit_verify` (MCP identity tools 13 → 15, total 66 → 68; A2A skills
+  35 → 37). Schema v3 → v4 (idempotent SQLite migration + Postgres
+  `ADD COLUMN IF NOT EXISTS` + Alembic `0003`). This closes the last #1078
+  follow-up; the mongo backend stamps `entry_hash` but the seal chain is
+  SQLite/Postgres-only.
 - **Agent-writable identity ops completed + audit-log export (#1075 / #1078,
   epic Agent Memory #1073).** Building on the provenance spine, all four identity
   mutations are now reachable over MCP **and** A2A with `actor`/`trust`
@@ -34,9 +54,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   tool exports the append-only event log in commit order (who / trust / when /
   why), optionally filtered by dataset / actor — the compliance-export surface for
   #1078. MCP identity tools 10 → 13 (total 63 → 66); A2A skills 32 → 35. No
-  migration (`claimed` is a value in the existing `kind` column). Follow-ups:
-  tamper-evident hash-chaining of the log, and CLI front doors for claim /
-  resolve-conflict.
+  migration (`claimed` is a value in the existing `kind` column). Follow-up
+  (tamper-evident hash-chaining of the log) shipped in the entry above; CLI
+  front doors for claim / resolve-conflict remain open.
 - **Identity-write provenance spine: `actor` + `trust` on every event/edge
   (#1075 / #1078, epic Agent Memory #1073).** `IdentityEvent` and `EvidenceEdge`
   now record WHO made each write (`actor`, e.g. `pipeline` / `agent:claude` /

--- a/packages/python/goldenmatch/goldenmatch/a2a/server.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/server.py
@@ -170,6 +170,27 @@ _SKILLS = [
         "outputModes": ["application/json"],
     },
     {
+        "id": "identity_audit_seal",
+        "name": "Identity Audit Seal",
+        "description": (
+            "Anchor the audit log with a tamper-evidence seal (chained sha256 "
+            "root over events since the last seal). Idempotent; no-op when "
+            "nothing new is logged."
+        ),
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "identity_audit_verify",
+        "name": "Identity Audit Verify",
+        "description": (
+            "Verify the audit log against its seal chain -- detects content "
+            "edits, deletion, reordering, and insertion of any sealed event."
+        ),
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
         "id": "controller_telemetry",
         "name": "Controller Telemetry",
         "description": (

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -249,8 +249,9 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",
         "identity_show",
-        # Agent Memory #1075/#1078: agent-writable ops + audit export
+        # Agent Memory #1075/#1078: agent-writable ops + audit export + seal/verify
         "identity_claim", "identity_resolve_conflict", "identity_audit",
+        "identity_audit_seal", "identity_audit_verify",
     }:
         from goldenmatch.mcp.identity_tools import _dispatch as _identity_dispatch
         # Reuse MCP dispatch since the contract is identical (JSON in/out).

--- a/packages/python/goldenmatch/goldenmatch/db/alembic/versions/0003_audit_hash_chain.py
+++ b/packages/python/goldenmatch/goldenmatch/db/alembic/versions/0003_audit_hash_chain.py
@@ -1,0 +1,47 @@
+"""Tamper-evident audit log: per-event entry_hash + audit_seals chain table.
+
+Adds the nullable ``entry_hash`` column to ``identity_events`` and creates the
+``audit_seals`` seal-chain table (#1078). Mirrors the runtime
+``_pg_init_schema`` DDL in goldenmatch/identity/store.py, so this rev and the
+store's on-open DDL converge to the same shape.
+
+Revision ID: 0003
+Revises: 0002
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE identity_events ADD COLUMN IF NOT EXISTS entry_hash TEXT;
+        CREATE TABLE IF NOT EXISTS audit_seals (
+            seal_id BIGSERIAL PRIMARY KEY,
+            dataset TEXT,
+            root_hash TEXT NOT NULL,
+            event_count BIGINT NOT NULL,
+            last_event_id BIGINT,
+            prev_seal_id BIGINT,
+            prev_root TEXT,
+            actor TEXT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_audit_seals_dataset ON audit_seals(dataset);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DROP TABLE IF EXISTS audit_seals;
+        ALTER TABLE identity_events DROP COLUMN IF EXISTS entry_hash;
+        """
+    )

--- a/packages/python/goldenmatch/goldenmatch/identity/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/__init__.py
@@ -5,6 +5,12 @@ See ``docs/superpowers/specs/2026-05-12-identity-graph-design.md``.
 """
 from __future__ import annotations
 
+from goldenmatch.identity.audit import (
+    AuditVerification,
+    event_content_hash,
+    seal_audit_log,
+    verify_audit_chain,
+)
 from goldenmatch.identity.mediation import (
     ConflictItem,
     ConflictResolution,
@@ -16,6 +22,7 @@ from goldenmatch.identity.mediation import (
 )
 from goldenmatch.identity.migrate_ids import MigrationReport, migrate_record_ids
 from goldenmatch.identity.model import (
+    AuditSeal,
     EdgeKind,
     EventKind,
     EvidenceEdge,
@@ -131,6 +138,11 @@ __all__ = [
     "entity_profile",
     "identity_summary_stats",
     "steward_worklist",
+    "AuditSeal",
+    "AuditVerification",
+    "event_content_hash",
+    "seal_audit_log",
+    "verify_audit_chain",
     "EdgeKind",
     "EventKind",
     "EvidenceEdge",

--- a/packages/python/goldenmatch/goldenmatch/identity/audit.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/audit.py
@@ -1,0 +1,228 @@
+"""Tamper-evident audit log for the Identity Graph (#1078).
+
+The identity event log is append-only, but "append-only by convention" is not
+the same as "provably untampered". This module adds cryptographic
+tamper-evidence in two contention-free layers:
+
+1. **Per-event content hash** (``event_content_hash``) -- a sha256 over an
+   event's own immutable fields, computed at insert time. It's a *pure*
+   function (no prior-state read), so it adds no insert-time serialization
+   point and works uniformly with the Postgres bulk-COPY write path. It catches
+   any after-the-fact edit to a single event's content.
+
+2. **On-demand seal chain** (``seal_audit_log`` / ``verify_audit_chain``) -- a
+   periodic anchor that folds every event's content hash, in ``event_id``
+   order, into a single chained root (git-/Certificate-Transparency-style).
+   Each seal chains to its predecessor, so a verifier replaying the log can
+   detect deletion, reordering, insertion, and content edits of any *sealed*
+   event. Sealing is an explicit, infrequent operation -- never on the write
+   hot path -- so the bulk/streaming ingest path is untouched.
+
+Design note: tamper-evidence here is integrity, not secrecy. Anyone with write
+access to the DB can also rewrite the seals; the value is that doing so
+consistently across the event rows *and* the seal chain is detectable by an
+external party who retains a prior seal root (publish it, mirror it, or store
+it out-of-band). That is the same threat model as an append-only ledger.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from goldenmatch.identity.model import AuditSeal, IdentityEvent
+
+if TYPE_CHECKING:
+    from goldenmatch.identity.store import IdentityStore
+
+
+def _normalize_dt(value: Any) -> str:
+    """Stable string form of a timestamp, identical on the insert side (a
+    ``datetime``) and the read-back side (``_to_dt`` returns a ``datetime``),
+    so the content hash round-trips across a store write/read."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def event_content_hash(event: IdentityEvent) -> str:
+    """sha256 over an event's immutable content fields (everything that
+    identifies *what happened*, excluding the DB-assigned ``event_id`` and the
+    ``entry_hash`` itself). Deterministic across SQLite/Postgres/Mongo and
+    across a write->read round-trip: ``recorded_at`` is normalized to ISO-8601,
+    ``trust`` rounded, ``payload`` canonicalized via sorted-key JSON."""
+    canon = {
+        "entity_id": event.entity_id,
+        "kind": str(event.kind),
+        "payload": event.payload,
+        "run_name": event.run_name,
+        "dataset": event.dataset,
+        "actor": event.actor,
+        "trust": round(event.trust, 6) if event.trust is not None else None,
+        "recorded_at": _normalize_dt(event.recorded_at),
+    }
+    blob = json.dumps(canon, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _effective_hash(event: IdentityEvent) -> str:
+    """The stored ``entry_hash`` if present, else computed on the fly. Lets the
+    seal/verify path cover events written before the hash-chain column existed
+    (migrated rows read back with ``entry_hash=None``)."""
+    return event.entry_hash or event_content_hash(event)
+
+
+def _fold_step(acc: str, entry_hash: str) -> str:
+    """One left-fold step of the chain: ``acc' = sha256(acc || entry_hash)``.
+    A left fold means an incremental seal (seeded by the prior root) yields the
+    same root as folding the whole history from scratch."""
+    return hashlib.sha256((acc + entry_hash).encode("utf-8")).hexdigest()
+
+
+@dataclass
+class AuditVerification:
+    """Result of ``verify_audit_chain``. ``ok`` is the single bottom line; the
+    lists localize *what* failed for an operator/report."""
+
+    ok: bool
+    events_checked: int
+    seals_checked: int
+    # event_ids whose stored entry_hash != recomputed content hash (content edit)
+    content_mismatches: list[int]
+    # seal_ids whose replayed root/count != stored (deletion/reorder/insertion)
+    seal_mismatches: list[int]
+    # seal_ids whose last_event_id no longer exists in the log (sealed event deleted)
+    missing_sealed_events: list[int]
+
+    def summary(self) -> str:
+        if self.ok:
+            return (
+                f"audit chain intact: {self.events_checked} events, "
+                f"{self.seals_checked} seals verified"
+            )
+        parts = []
+        if self.content_mismatches:
+            parts.append(f"{len(self.content_mismatches)} content edit(s)")
+        if self.seal_mismatches:
+            parts.append(f"{len(self.seal_mismatches)} seal mismatch(es)")
+        if self.missing_sealed_events:
+            parts.append(
+                f"{len(self.missing_sealed_events)} sealed event(s) missing"
+            )
+        return "audit chain BROKEN: " + ", ".join(parts)
+
+
+def seal_audit_log(
+    store: IdentityStore,
+    *,
+    actor: str | None = None,
+    dataset: str | None = None,
+) -> AuditSeal | None:
+    """Anchor the current event log with a new seal and return it.
+
+    Chains onto the latest seal for ``dataset`` (``None`` = global chain),
+    folding only the events appended since that seal so cost is proportional to
+    new events, not the whole history. Returns ``None`` when there is nothing
+    new to seal (idempotent: re-sealing an unchanged log is a no-op).
+    """
+    if getattr(store, "_backend", None) == "mongo":
+        raise NotImplementedError(
+            "seal_audit_log is not supported on the mongo backend"
+        )
+    prev = store.latest_seal(dataset=dataset)
+    prev_root = prev.root_hash if prev else ""
+    prev_last_id = prev.last_event_id if prev and prev.last_event_id is not None else -1
+    prev_count = prev.event_count if prev else 0
+
+    new_events = [
+        e
+        for e in store.export_audit_log(dataset=dataset)
+        if e.event_id is not None and e.event_id > prev_last_id
+    ]
+    if not new_events:
+        return None
+
+    acc = prev_root
+    for e in new_events:
+        acc = _fold_step(acc, _effective_hash(e))
+
+    seal = AuditSeal(
+        root_hash=acc,
+        event_count=prev_count + len(new_events),
+        last_event_id=new_events[-1].event_id,
+        dataset=dataset,
+        prev_seal_id=prev.seal_id if prev else None,
+        prev_root=prev_root or None,
+        actor=actor,
+    )
+    seal_id = store.add_seal(seal)
+    seal.seal_id = seal_id
+    return seal
+
+
+def verify_audit_chain(
+    store: IdentityStore,
+    *,
+    dataset: str | None = None,
+) -> AuditVerification:
+    """Replay the event log against its seal chain and report integrity.
+
+    Two independent checks:
+      * **content** -- every event whose ``entry_hash`` was stored must still
+        hash to it (catches an in-place edit of an event's fields);
+      * **chain** -- replaying the fold over the *current* events must
+        reproduce each seal's root and count at its boundary, and every sealed
+        ``last_event_id`` must still exist (catches deletion, reordering, and
+        insertion of sealed events).
+    """
+    if getattr(store, "_backend", None) == "mongo":
+        raise NotImplementedError(
+            "verify_audit_chain is not supported on the mongo backend"
+        )
+    events = store.export_audit_log(dataset=dataset)
+    seals = store.list_seals(dataset=dataset)
+
+    content_mismatches: list[int] = []
+    for e in events:
+        if e.entry_hash is not None and e.event_id is not None:
+            if event_content_hash(e) != e.entry_hash:
+                content_mismatches.append(e.event_id)
+
+    # Single forward pass over events, checking each seal at its boundary.
+    seal_mismatches: list[int] = []
+    missing_sealed_events: list[int] = []
+    seals_sorted = sorted(
+        seals, key=lambda s: (s.last_event_id if s.last_event_id is not None else -1)
+    )
+    acc = ""
+    seen = 0
+    seal_idx = 0
+    for e in events:
+        acc = _fold_step(acc, _effective_hash(e))
+        seen += 1
+        while (
+            seal_idx < len(seals_sorted)
+            and seals_sorted[seal_idx].last_event_id == e.event_id
+        ):
+            s = seals_sorted[seal_idx]
+            if acc != s.root_hash or seen != s.event_count:
+                if s.seal_id is not None:
+                    seal_mismatches.append(s.seal_id)
+            seal_idx += 1
+    # Any seal whose boundary event_id was never reached -> the sealed event was
+    # deleted (or its id renumbered) out of the log.
+    for s in seals_sorted[seal_idx:]:
+        if s.seal_id is not None:
+            missing_sealed_events.append(s.seal_id)
+
+    ok = not (content_mismatches or seal_mismatches or missing_sealed_events)
+    return AuditVerification(
+        ok=ok,
+        events_checked=len(events),
+        seals_checked=len(seals),
+        content_mismatches=content_mismatches,
+        seal_mismatches=seal_mismatches,
+        missing_sealed_events=missing_sealed_events,
+    )

--- a/packages/python/goldenmatch/goldenmatch/identity/model.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/model.py
@@ -103,8 +103,39 @@ class IdentityEvent:
     # See EvidenceEdge for the contract. The "why" rides in ``payload['reason']``.
     actor: str | None = None
     trust: float | None = None
+    # Tamper-evidence (#1078): per-event content hash (sha256 over the event's
+    # own immutable fields), computed at insert by ``audit.event_content_hash``.
+    # A pure function -- no prior-state read, so it imposes no insert-time
+    # serialization point and works uniformly with the Postgres bulk-COPY path.
+    # The chain/seal anchor lives in ``audit_seals`` (see ``AuditSeal``). Nullable:
+    # pre-hash-chain rows read back as None and are hashed on the fly at seal/verify.
+    entry_hash: str | None = None
     recorded_at: datetime = field(default_factory=datetime.now)
     event_id: int | None = None
+
+
+@dataclass
+class AuditSeal:
+    """A periodic tamper-evidence anchor over the append-only event log (#1078).
+
+    Each seal records the chained root hash of every event (in ``event_id``
+    order) up to ``last_event_id`` for a given ``dataset`` scope (``None`` =
+    global chain). Seals chain to their predecessor via ``prev_seal_id`` /
+    ``prev_root`` so the whole history is one verifiable ledger -- detecting
+    deletion, reordering, insertion, and content edits of any sealed event.
+    Created on demand by ``audit.seal_audit_log``; checked by
+    ``audit.verify_audit_chain``.
+    """
+
+    root_hash: str
+    event_count: int
+    last_event_id: int | None = None
+    dataset: str | None = None
+    prev_seal_id: int | None = None
+    prev_root: str | None = None
+    actor: str | None = None
+    created_at: datetime = field(default_factory=datetime.now)
+    seal_id: int | None = None
 
 
 @dataclass

--- a/packages/python/goldenmatch/goldenmatch/identity/mongo_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/mongo_backend.py
@@ -335,6 +335,13 @@ class MongoIdentityStore:
     # ----- events ------------------------------------------------------
 
     def emit_event(self, event: IdentityEvent) -> int | None:
+        # Tamper-evidence (#1078): stamp the per-event content hash. The seal
+        # chain (seal_audit_log/verify_audit_chain) is not supported on mongo,
+        # but the per-event hash carries through so a future mongo seal backend
+        # finds it already populated.
+        from goldenmatch.identity.audit import event_content_hash  # noqa: PLC0415
+        if event.entry_hash is None:
+            event.entry_hash = event_content_hash(event)
         doc = {
             "entity_id": event.entity_id,
             "kind": event.kind,
@@ -343,6 +350,7 @@ class MongoIdentityStore:
             "dataset": event.dataset,
             "actor": event.actor,
             "trust": event.trust,
+            "entry_hash": event.entry_hash,
             "recorded_at": event.recorded_at,
         }
         result = self._db[_EVENTS].insert_one(doc)
@@ -466,6 +474,7 @@ def _to_event(d: dict[str, Any]) -> IdentityEvent:
         dataset=d.get("dataset"),
         actor=d.get("actor"),
         trust=d.get("trust"),
+        entry_hash=d.get("entry_hash"),
         recorded_at=d.get("recorded_at") or datetime.now(),
         event_id=_objectid_to_int(d.get("_id")) if d.get("_id") else None,
     )

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from typing import Any
 
 from goldenmatch.identity.model import (
+    AuditSeal,
     EvidenceEdge,
     IdentityAlias,
     IdentityEvent,
@@ -27,7 +28,7 @@ from goldenmatch.identity.model import (
 
 log = logging.getLogger("goldenmatch.identity")
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS identity_nodes (
@@ -93,11 +94,27 @@ CREATE TABLE IF NOT EXISTS identity_events (
     dataset      TEXT,
     actor        TEXT,
     trust        REAL,
+    entry_hash   TEXT,
     recorded_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_events_entity ON identity_events(entity_id);
 CREATE INDEX IF NOT EXISTS idx_events_kind   ON identity_events(kind);
 CREATE INDEX IF NOT EXISTS idx_events_run    ON identity_events(run_name);
+
+-- Tamper-evidence seal chain (#1078): periodic anchors over identity_events.
+-- One row per ``seal_audit_log`` call; chained via prev_seal_id/prev_root.
+CREATE TABLE IF NOT EXISTS audit_seals (
+    seal_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    dataset       TEXT,
+    root_hash     TEXT NOT NULL,
+    event_count   INTEGER NOT NULL,
+    last_event_id INTEGER,
+    prev_seal_id  INTEGER,
+    prev_root     TEXT,
+    actor         TEXT,
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_audit_seals_dataset ON audit_seals(dataset);
 
 CREATE TABLE IF NOT EXISTS identity_aliases (
     alias        TEXT NOT NULL,
@@ -258,6 +275,14 @@ class IdentityStore:
             # fresh DB whose tables already carry the columns from ``_SCHEMA`` and
             # on the rebuilt-evidence_edges path above (which drops them).
             self._ensure_provenance_columns()
+        if version < 4:
+            # v3 -> v4: tamper-evidence (#1078). Add the per-event ``entry_hash``
+            # column and the ``audit_seals`` chain table. PRAGMA-guarded ADD
+            # COLUMN + CREATE TABLE IF NOT EXISTS, so it's idempotent on a fresh
+            # DB (already carries them from ``_SCHEMA``) and on a migrated v2/v3
+            # DB. Old rows keep entry_hash=NULL and are hashed on the fly by the
+            # seal/verify path.
+            self._ensure_audit_columns()
         if version < SCHEMA_VERSION:
             self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
@@ -274,6 +299,33 @@ class IdentityStore:
                 self._conn.execute(f"ALTER TABLE {table} ADD COLUMN actor TEXT")
             if "trust" not in cols:
                 self._conn.execute(f"ALTER TABLE {table} ADD COLUMN trust REAL")
+
+    def _ensure_audit_columns(self) -> None:
+        """Add the ``entry_hash`` column to identity_events and create the
+        ``audit_seals`` table if absent (#1078). PRAGMA-guarded ADD COLUMN +
+        CREATE TABLE IF NOT EXISTS make this idempotent across fresh and
+        migrated databases."""
+        cols = {r[1] for r in self._conn.execute("PRAGMA table_info(identity_events)")}
+        if "entry_hash" not in cols:
+            self._conn.execute(
+                "ALTER TABLE identity_events ADD COLUMN entry_hash TEXT"
+            )
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS audit_seals (
+                seal_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                dataset       TEXT,
+                root_hash     TEXT NOT NULL,
+                event_count   INTEGER NOT NULL,
+                last_event_id INTEGER,
+                prev_seal_id  INTEGER,
+                prev_root     TEXT,
+                actor         TEXT,
+                created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX IF NOT EXISTS idx_audit_seals_dataset ON audit_seals(dataset);
+            """
+        )
 
     def _pg_init_schema(self) -> None:
         ddl = """
@@ -342,9 +394,23 @@ class IdentityStore:
         );
         ALTER TABLE identity_events ADD COLUMN IF NOT EXISTS actor TEXT;
         ALTER TABLE identity_events ADD COLUMN IF NOT EXISTS trust DOUBLE PRECISION;
+        -- Tamper-evidence (#1078): per-event content hash + seal chain table.
+        ALTER TABLE identity_events ADD COLUMN IF NOT EXISTS entry_hash TEXT;
         CREATE INDEX IF NOT EXISTS idx_events_entity ON identity_events(entity_id);
         CREATE INDEX IF NOT EXISTS idx_events_kind   ON identity_events(kind);
         CREATE INDEX IF NOT EXISTS idx_events_run    ON identity_events(run_name);
+        CREATE TABLE IF NOT EXISTS audit_seals (
+            seal_id BIGSERIAL PRIMARY KEY,
+            dataset TEXT,
+            root_hash TEXT NOT NULL,
+            event_count BIGINT NOT NULL,
+            last_event_id BIGINT,
+            prev_seal_id BIGINT,
+            prev_root TEXT,
+            actor TEXT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_audit_seals_dataset ON audit_seals(dataset);
         CREATE TABLE IF NOT EXISTS identity_aliases (
             alias TEXT NOT NULL,
             entity_id TEXT NOT NULL,
@@ -825,13 +891,21 @@ class IdentityStore:
         if self._backend == "mongo":
             return self._mongo.emit_event(event)
         payload = json.dumps(event.payload) if event.payload is not None else None
+        # Tamper-evidence (#1078): stamp a per-event content hash at insert. Pure
+        # function of the event's own fields -- no DB read, no contention -- so it
+        # imposes no serialization point on the write path. Set it on the object
+        # too so an in-memory caller sees the same value the row carries.
+        from goldenmatch.identity.audit import event_content_hash  # noqa: PLC0415
+        if event.entry_hash is None:
+            event.entry_hash = event_content_hash(event)
         self._exec(
             "INSERT INTO identity_events "
-            "(entity_id, kind, payload, run_name, dataset, actor, trust, recorded_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "(entity_id, kind, payload, run_name, dataset, actor, trust, "
+            "entry_hash, recorded_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 event.entity_id, event.kind, payload, event.run_name,
-                event.dataset, event.actor, event.trust,
+                event.dataset, event.actor, event.trust, event.entry_hash,
                 event.recorded_at.isoformat(),
             ),
         )
@@ -890,6 +964,68 @@ class IdentityStore:
             tuple(params),
         )
         return [self._row_to_event(r) for r in rows]
+
+    # ----- Audit seal chain (#1078) -----
+
+    def add_seal(self, seal: AuditSeal) -> int | None:
+        """Persist a tamper-evidence seal and return its id. Used by
+        ``audit.seal_audit_log``; the chain logic lives there, not here."""
+        if self._backend == "mongo":
+            raise NotImplementedError(
+                "audit seals are not supported on the mongo backend"
+            )
+        self._exec(
+            "INSERT INTO audit_seals "
+            "(dataset, root_hash, event_count, last_event_id, prev_seal_id, "
+            "prev_root, actor, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                seal.dataset, seal.root_hash, seal.event_count,
+                seal.last_event_id, seal.prev_seal_id, seal.prev_root,
+                seal.actor, seal.created_at.isoformat(),
+            ),
+        )
+        row = self._fetchone("SELECT MAX(seal_id) AS seal_id FROM audit_seals", ())
+        return int(row["seal_id"]) if row and row["seal_id"] is not None else None
+
+    def latest_seal(self, *, dataset: str | None = None) -> AuditSeal | None:
+        """The most recent seal for the given ``dataset`` scope (``None`` =
+        global chain), or ``None`` if the chain is empty."""
+        if self._backend == "mongo":
+            raise NotImplementedError(
+                "audit seals are not supported on the mongo backend"
+            )
+        if dataset is None:
+            row = self._fetchone(
+                "SELECT * FROM audit_seals WHERE dataset IS NULL "
+                "ORDER BY seal_id DESC LIMIT 1",
+                (),
+            )
+        else:
+            row = self._fetchone(
+                "SELECT * FROM audit_seals WHERE dataset = ? "
+                "ORDER BY seal_id DESC LIMIT 1",
+                (dataset,),
+            )
+        return self._row_to_seal(row) if row else None
+
+    def list_seals(self, *, dataset: str | None = None) -> list[AuditSeal]:
+        """Every seal for the given ``dataset`` scope in creation order."""
+        if self._backend == "mongo":
+            raise NotImplementedError(
+                "audit seals are not supported on the mongo backend"
+            )
+        if dataset is None:
+            rows = self._fetchall(
+                "SELECT * FROM audit_seals WHERE dataset IS NULL ORDER BY seal_id",
+                (),
+            )
+        else:
+            rows = self._fetchall(
+                "SELECT * FROM audit_seals WHERE dataset = ? ORDER BY seal_id",
+                (dataset,),
+            )
+        return [self._row_to_seal(r) for r in rows]
 
     def has_run_event(self, entity_id: str, run_name: str, kind: str) -> bool:
         if self._backend == "mongo":
@@ -1024,8 +1160,31 @@ class IdentityStore:
             dataset=row["dataset"],
             actor=_row_get(row, "actor"),
             trust=_row_get(row, "trust"),
+            entry_hash=_row_get(row, "entry_hash"),
             recorded_at=_to_dt(row["recorded_at"]),
             event_id=row["event_id"],
+        )
+
+    @staticmethod
+    def _row_to_seal(row: Any) -> AuditSeal:
+        return AuditSeal(
+            root_hash=row["root_hash"],
+            event_count=int(row["event_count"]),
+            last_event_id=(
+                int(row["last_event_id"])
+                if row["last_event_id"] is not None
+                else None
+            ),
+            dataset=row["dataset"],
+            prev_seal_id=(
+                int(row["prev_seal_id"])
+                if row["prev_seal_id"] is not None
+                else None
+            ),
+            prev_root=row["prev_root"],
+            actor=_row_get(row, "actor"),
+            created_at=_to_dt(row["created_at"]),
+            seal_id=int(row["seal_id"]),
         )
 
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
@@ -9,6 +9,8 @@
 - ``identity_claim``     -> claim a record into an identity (move it)
 - ``identity_resolve_conflict`` -> adjudicate a conflicts_with pair
 - ``identity_audit``     -> export the append-only audit log (who/when/why)
+- ``identity_audit_seal``   -> anchor the audit log with a tamper-evidence seal
+- ``identity_audit_verify`` -> verify the audit log against its seal chain
 - ``identity_show``      -> full detail of one identity
 - ``identity_profile``   -> MDM profile of one entity (sources, conflicts, version)
 - ``identity_stats``     -> graph-level summary / health stats
@@ -35,7 +37,9 @@ from goldenmatch.identity import (
     manual_merge,
     manual_split,
     mediate_conflict,
+    seal_audit_log,
     steward_worklist,
+    verify_audit_chain,
 )
 
 logger = logging.getLogger(__name__)
@@ -241,6 +245,47 @@ IDENTITY_TOOLS: list[Tool] = [
         },
     ),
     Tool(
+        name="identity_audit_seal",
+        description=(
+            "Anchor the append-only audit log with a tamper-evidence seal: a "
+            "chained sha256 root over every event since the last seal. Cheap "
+            "and idempotent (a no-op when nothing new has been logged). Run it "
+            "periodically (or after a batch of stewardship actions) so the "
+            "history becomes provably untampered. Optionally scoped to a "
+            "dataset. Publish/mirror the returned root_hash to make tampering "
+            "detectable by an external party."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "dataset": {"type": "string"},
+                "actor": {
+                    "type": "string",
+                    "description": "Principal sealing the log. Defaults to 'agent'.",
+                },
+                "path": {"type": "string", "description": "Identity DB path"},
+            },
+        },
+    ),
+    Tool(
+        name="identity_audit_verify",
+        description=(
+            "Verify the append-only audit log against its seal chain. Replays "
+            "the per-event content hashes and the seal roots to detect content "
+            "edits, deletion, reordering, and insertion of any sealed event. "
+            "Returns {ok, events_checked, seals_checked} plus the ids of any "
+            "content mismatches / broken seals / missing sealed events. "
+            "Optionally scoped to a dataset."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "dataset": {"type": "string"},
+                "path": {"type": "string", "description": "Identity DB path"},
+            },
+        },
+    ),
+    Tool(
         name="identity_show",
         description=(
             "Fetch the full detail of one identity by entity_id: its member "
@@ -431,6 +476,35 @@ def _dispatch(name: str, args: dict) -> dict[str, Any]:
             for e in events[:limit]
         ]
         return {"items": items, "total": len(events)}
+
+    if name == "identity_audit_seal":
+        actor, _ = _actor_trust(args)
+        with _open(args) as s:
+            seal = seal_audit_log(s, actor=actor, dataset=args.get("dataset"))
+        if seal is None:
+            return {"sealed": False, "reason": "no new events to seal"}
+        return {
+            "sealed": True,
+            "seal_id": seal.seal_id,
+            "root_hash": seal.root_hash,
+            "event_count": seal.event_count,
+            "last_event_id": seal.last_event_id,
+            "dataset": seal.dataset,
+            "actor": seal.actor,
+        }
+
+    if name == "identity_audit_verify":
+        with _open(args) as s:
+            result = verify_audit_chain(s, dataset=args.get("dataset"))
+        return {
+            "ok": result.ok,
+            "events_checked": result.events_checked,
+            "seals_checked": result.seals_checked,
+            "content_mismatches": result.content_mismatches,
+            "seal_mismatches": result.seal_mismatches,
+            "missing_sealed_events": result.missing_sealed_events,
+            "summary": result.summary(),
+        }
 
     if name == "identity_show":
         with _open(args) as s:

--- a/packages/python/goldenmatch/tests/identity/test_audit_chain.py
+++ b/packages/python/goldenmatch/tests/identity/test_audit_chain.py
@@ -1,0 +1,293 @@
+"""Tamper-evident audit log (#1078): per-event content hash + seal chain.
+
+The identity event log is append-only, but "append-only by convention" is not
+provable. These tests lock the two integrity layers:
+
+  * ``event_content_hash`` is stamped at insert and round-trips through the DB;
+  * ``seal_audit_log`` / ``verify_audit_chain`` detect content edits, deletion,
+    reordering, and insertion of sealed events.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+from goldenmatch.identity import IdentityStore
+from goldenmatch.identity.audit import (
+    event_content_hash,
+    seal_audit_log,
+    verify_audit_chain,
+)
+from goldenmatch.identity.model import IdentityEvent, IdentityNode
+
+
+@pytest.fixture()
+def store_path(tmp_path):
+    return str(tmp_path / "id.db")
+
+
+@pytest.fixture()
+def store(store_path):
+    s = IdentityStore(backend="sqlite", path=store_path)
+    yield s
+    s.close()
+
+
+def _mk_entity(store: IdentityStore, eid: str) -> None:
+    store.upsert_identity(IdentityNode(entity_id=eid))
+
+
+def _emit(store: IdentityStore, eid: str, kind: str, **kw) -> None:
+    store.emit_event(IdentityEvent(entity_id=eid, kind=kind, run_name="r", **kw))
+
+
+# ── per-event content hash ────────────────────────────────────────────────────
+
+
+def test_entry_hash_stamped_and_round_trips(store):
+    _mk_entity(store, "e1")
+    store.emit_event(IdentityEvent(
+        entity_id="e1", kind="created", actor="agent:x", trust=0.5,
+        payload={"reason": "init"}, run_name="r1",
+    ))
+    [ev] = store.history("e1")
+    assert ev.entry_hash is not None
+    # the stored hash equals a fresh recompute of the read-back event
+    assert ev.entry_hash == event_content_hash(ev)
+
+
+def test_content_hash_is_deterministic_and_field_sensitive():
+    a = IdentityEvent(entity_id="e1", kind="created", actor="x", trust=0.5)
+    b = IdentityEvent(entity_id="e1", kind="created", actor="x", trust=0.5,
+                      recorded_at=a.recorded_at)
+    assert event_content_hash(a) == event_content_hash(b)
+    # any content change flips the hash
+    c = IdentityEvent(entity_id="e1", kind="merged_with", actor="x", trust=0.5,
+                      recorded_at=a.recorded_at)
+    assert event_content_hash(a) != event_content_hash(c)
+
+
+# ── seal ──────────────────────────────────────────────────────────────────────
+
+
+def test_seal_creates_root_and_is_idempotent(store):
+    _mk_entity(store, "e1")
+    _emit(store, "e1", "created")
+    _emit(store, "e1", "merged_with")
+
+    seal = seal_audit_log(store, actor="steward:alice")
+    assert seal is not None
+    assert seal.event_count == 2
+    assert seal.root_hash
+    assert seal.last_event_id is not None
+
+    # nothing new -> no-op
+    assert seal_audit_log(store) is None
+
+    # a new event -> a new chained seal
+    _emit(store, "e1", "retired")
+    seal2 = seal_audit_log(store)
+    assert seal2 is not None
+    assert seal2.event_count == 3
+    assert seal2.prev_seal_id == seal.seal_id
+    assert seal2.prev_root == seal.root_hash
+    assert seal2.root_hash != seal.root_hash
+
+
+def test_verify_clean_log_ok(store):
+    _mk_entity(store, "e1")
+    for k in ("created", "merged_with", "retired"):
+        _emit(store, "e1", k)
+    seal_audit_log(store)
+    res = verify_audit_chain(store)
+    assert res.ok is True
+    assert res.events_checked == 3
+    assert res.seals_checked == 1
+    assert "intact" in res.summary()
+
+
+def test_verify_unsealed_log_ok(store):
+    # content hashes alone verify clean even before any seal exists.
+    _mk_entity(store, "e1")
+    _emit(store, "e1", "created")
+    res = verify_audit_chain(store)
+    assert res.ok is True
+    assert res.seals_checked == 0
+
+
+# ── tamper detection ──────────────────────────────────────────────────────────
+
+
+def test_detects_content_edit(store, store_path):
+    _mk_entity(store, "e1")
+    store.emit_event(IdentityEvent(entity_id="e1", kind="created",
+                                   payload={"reason": "ok"}, run_name="r1"))
+    seal_audit_log(store)
+    [ev] = store.history("e1")
+    store.close()
+
+    # edit the payload in place WITHOUT touching entry_hash (naive tamper)
+    raw = sqlite3.connect(store_path)
+    raw.execute(
+        "UPDATE identity_events SET payload = ? WHERE event_id = ?",
+        ('{"reason": "tampered"}', ev.event_id),
+    )
+    raw.commit()
+    raw.close()
+
+    s2 = IdentityStore(backend="sqlite", path=store_path)
+    try:
+        res = verify_audit_chain(s2)
+        assert res.ok is False
+        assert ev.event_id in res.content_mismatches
+        assert "BROKEN" in res.summary()
+    finally:
+        s2.close()
+
+
+def test_detects_content_edit_with_rehashed_entry(store, store_path):
+    # sophisticated tamper: edit payload AND recompute entry_hash to match.
+    # the content check passes, but the seal-chain replay no longer reproduces
+    # the sealed root -> caught by the seal layer.
+    _mk_entity(store, "e1")
+    store.emit_event(IdentityEvent(entity_id="e1", kind="created",
+                                   payload={"reason": "ok"}, run_name="r1"))
+    seal_audit_log(store)
+    [ev] = store.history("e1")
+    store.close()
+
+    forged = IdentityEvent(
+        entity_id=ev.entity_id, kind=ev.kind, payload={"reason": "tampered"},
+        run_name=ev.run_name, dataset=ev.dataset, actor=ev.actor,
+        trust=ev.trust, recorded_at=ev.recorded_at,
+    )
+    raw = sqlite3.connect(store_path)
+    raw.execute(
+        "UPDATE identity_events SET payload = ?, entry_hash = ? WHERE event_id = ?",
+        ('{"reason": "tampered"}', event_content_hash(forged), ev.event_id),
+    )
+    raw.commit()
+    raw.close()
+
+    s2 = IdentityStore(backend="sqlite", path=store_path)
+    try:
+        res = verify_audit_chain(s2)
+        assert res.ok is False
+        assert res.content_mismatches == []  # content check fooled
+        assert res.seal_mismatches  # but the chain catches it
+    finally:
+        s2.close()
+
+
+def test_detects_deletion_of_sealed_event(store, store_path):
+    _mk_entity(store, "e1")
+    for k in ("created", "merged_with", "retired"):
+        _emit(store, "e1", k)
+    seal_audit_log(store)
+    events = store.history("e1")
+    victim = events[1].event_id  # a non-boundary sealed event
+    store.close()
+
+    raw = sqlite3.connect(store_path)
+    raw.execute("DELETE FROM identity_events WHERE event_id = ?", (victim,))
+    raw.commit()
+    raw.close()
+
+    s2 = IdentityStore(backend="sqlite", path=store_path)
+    try:
+        res = verify_audit_chain(s2)
+        assert res.ok is False
+        # boundary event still present -> count/root differ at the boundary
+        assert res.seal_mismatches
+    finally:
+        s2.close()
+
+
+def test_detects_deletion_of_boundary_event(store, store_path):
+    _mk_entity(store, "e1")
+    for k in ("created", "merged_with", "retired"):
+        _emit(store, "e1", k)
+    seal = seal_audit_log(store)
+    last = seal.last_event_id
+    store.close()
+
+    raw = sqlite3.connect(store_path)
+    raw.execute("DELETE FROM identity_events WHERE event_id = ?", (last,))
+    raw.commit()
+    raw.close()
+
+    s2 = IdentityStore(backend="sqlite", path=store_path)
+    try:
+        res = verify_audit_chain(s2)
+        assert res.ok is False
+        # the seal's boundary event_id no longer exists in the log
+        assert seal.seal_id in res.missing_sealed_events
+    finally:
+        s2.close()
+
+
+# ── dataset-scoped chains ─────────────────────────────────────────────────────
+
+
+def test_dataset_scoped_seal_chain(store):
+    _mk_entity(store, "e1")
+    _mk_entity(store, "e2")
+    _emit(store, "e1", "created", dataset="d1")
+    _emit(store, "e2", "created", dataset="d2")
+
+    s1 = seal_audit_log(store, dataset="d1")
+    assert s1 is not None and s1.event_count == 1 and s1.dataset == "d1"
+
+    res = verify_audit_chain(store, dataset="d1")
+    assert res.ok is True and res.events_checked == 1 and res.seals_checked == 1
+    # d2 has no seal yet but still verifies clean on content hashes
+    assert verify_audit_chain(store, dataset="d2").ok is True
+
+
+# ── migration: pre-hash-chain (v3) events seal via on-the-fly hashing ─────────
+
+
+def test_pre_hashchain_events_seal_and_verify(tmp_path):
+    """A v3 DB (no entry_hash column / audit_seals table) gains them on open;
+    old rows keep entry_hash=NULL but are hashed on the fly so they can be
+    sealed and verified."""
+    db = str(tmp_path / "old.db")
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE identity_nodes (entity_id TEXT PRIMARY KEY, status TEXT,
+            merged_into TEXT, golden_record TEXT, confidence REAL, dataset TEXT,
+            created_at TIMESTAMP, updated_at TIMESTAMP);
+        CREATE TABLE evidence_edges (edge_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            entity_id TEXT, record_a_id TEXT, record_b_id TEXT, kind TEXT,
+            score REAL, matchkey_name TEXT, field_scores TEXT,
+            negative_evidence TEXT, controller_snapshot TEXT, run_name TEXT,
+            dataset TEXT, actor TEXT, trust REAL, recorded_at TIMESTAMP,
+            UNIQUE(entity_id, record_a_id, record_b_id, kind, run_name));
+        CREATE TABLE identity_events (event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            entity_id TEXT, kind TEXT, payload TEXT, run_name TEXT, dataset TEXT,
+            actor TEXT, trust REAL, recorded_at TIMESTAMP);
+        CREATE TABLE identity_aliases (alias TEXT, entity_id TEXT, kind TEXT,
+            dataset TEXT, recorded_at TIMESTAMP, PRIMARY KEY (alias, kind, dataset));
+        INSERT INTO identity_events (entity_id, kind, run_name, recorded_at)
+            VALUES ('e1', 'created', 'r0', '2026-01-01T00:00:00');
+        PRAGMA user_version = 3;
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    s = IdentityStore(backend="sqlite", path=db)
+    try:
+        # old row read back with no stored hash
+        [old] = s.history("e1")
+        assert old.entry_hash is None
+        # a new write carries a hash through the migrated schema
+        s.emit_event(IdentityEvent(entity_id="e1", kind="merged_with",
+                                   run_name="r1"))
+        seal = seal_audit_log(s)
+        assert seal is not None and seal.event_count == 2
+        res = verify_audit_chain(s)
+        assert res.ok is True
+    finally:
+        s.close()

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -35,20 +35,22 @@ def test_agent_card_has_required_fields():
     assert card["authentication"]["schemes"] == ["bearer"]
 
 
-def test_agent_card_has_35_skills():
+def test_agent_card_has_37_skills():
     """v1.7-v1.12 added autoconfig+controller_telemetry (10->12); v2.0 added
     six identity_* skills (12->18); v1.19.x Phase 3 added add_correction
     (18->19); the MCP tool-coverage parity pass added 12 (19->31); #1089 added
     retrieve_similar (31->32); Agent Memory #1075/#1078 added identity_claim /
-    identity_resolve_conflict / identity_audit (32->35)."""
+    identity_resolve_conflict / identity_audit (32->35); #1078 tamper-evidence
+    added identity_audit_seal / identity_audit_verify (35->37)."""
     from goldenmatch.a2a.server import build_agent_card
 
     card = build_agent_card("http://localhost:8080")
-    assert len(card["skills"]) == 35
+    assert len(card["skills"]) == 37
     ids = {s["id"] for s in card["skills"]}
     assert "autoconfig" in ids
     assert "retrieve_similar" in ids
     assert {"identity_claim", "identity_resolve_conflict", "identity_audit"} <= ids
+    assert {"identity_audit_seal", "identity_audit_verify"} <= ids
     assert "controller_telemetry" in ids
     assert "add_correction" in ids
     assert {

--- a/packages/python/goldenmatch/tests/test_mcp_identity_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_identity_tools.py
@@ -19,7 +19,7 @@ from goldenmatch.mcp.identity_tools import (
 
 
 def test_identity_tool_count_and_names():
-    assert len(IDENTITY_TOOLS) == 13
+    assert len(IDENTITY_TOOLS) == 15
     assert IDENTITY_TOOL_NAMES == {
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",
@@ -28,6 +28,8 @@ def test_identity_tool_count_and_names():
         "identity_profile", "identity_stats", "identity_worklist",
         # Agent Memory #1075/#1078: agent-writable ops + audit export
         "identity_claim", "identity_resolve_conflict", "identity_audit",
+        # Agent Memory #1078: tamper-evident audit seal chain
+        "identity_audit_seal", "identity_audit_verify",
     }
 
 
@@ -100,6 +102,29 @@ def test_identity_split_via_mcp(seeded_db):
     # Verify split worked end-to-end
     with IdentityStore(path=path) as s:
         assert s.find_entity_by_record("src:2") == new_eid
+
+
+def test_identity_audit_seal_and_verify_via_mcp(seeded_db):
+    path, ids = seeded_db
+    # emit a couple of events so there's something to seal
+    _dispatch("identity_merge", {
+        "keep_entity_id": ids["eid1"], "absorb_entity_id": ids["eid2"],
+        "reason": "test", "path": path,
+    })
+    sealed = _dispatch("identity_audit_seal", {"path": path, "actor": "steward:alice"})
+    assert sealed["sealed"] is True
+    assert sealed["root_hash"]
+    assert sealed["event_count"] >= 1
+
+    # re-seal with nothing new is a no-op
+    again = _dispatch("identity_audit_seal", {"path": path})
+    assert again["sealed"] is False
+
+    verified = _dispatch("identity_audit_verify", {"path": path})
+    assert verified["ok"] is True
+    assert verified["content_mismatches"] == []
+    assert verified["seal_mismatches"] == []
+    assert verified["missing_sealed_events"] == []
 
 
 def test_identity_tools_in_aggregate_dispatch():

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -25,10 +25,10 @@ def test_total_tool_count_is_66():
 
     assert len(AGENT_TOOLS) == 18   # +1 retrieve_similar (#1089)
     assert len(MEMORY_TOOLS) == 7
-    assert len(IDENTITY_TOOLS) == 13  # +3 MDM ops (#1114) +3 agent-memory ops (#1075/#1078)
+    assert len(IDENTITY_TOOLS) == 15  # +3 MDM ops (#1114) +5 agent-memory ops (#1075/#1078)
     assert len(_BASE_TOOLS) == 25   # +1 config_weaknesses
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 66
+    assert len(TOOLS) == 68
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))


### PR DESCRIPTION
Closes the last remaining piece of **#1078** (epic Agent Memory #1073): cryptographic tamper-evidence over the append-only identity event log.

## What & why
"Append-only by convention" isn't provable. This adds integrity in two **contention-free** layers:

1. **Per-event content hash** (`entry_hash`) — stamped at insert by `audit.event_content_hash`, a *pure* sha256 over the event's own immutable fields. No prior-state read ⇒ no insert-time serialization point, and it works uniformly with the Postgres bulk-COPY write path.
2. **On-demand seal chain** — `seal_audit_log()` folds the per-event hashes (in `event_id` order) into a single chained root stored in the new `audit_seals` table; each seal chains to its predecessor. `verify_audit_chain()` replays both layers to detect **content edits, deletion, reordering, and insertion** of any sealed event, returning `{ok, events_checked, seals_checked}` plus the ids of any failures.

Sealing is explicit and infrequent (never on the write hot path), so streaming/bulk ingest is untouched. Pre-hash-chain rows (`entry_hash` NULL) are hashed on the fly, so an existing log can be sealed retroactively.

## Surfaces
- New `goldenmatch/identity/audit.py`: `event_content_hash`, `AuditVerification`, `seal_audit_log`, `verify_audit_chain`.
- New MCP/A2A tools `identity_audit_seal` / `identity_audit_verify`. MCP identity tools 13 → 15 (total 66 → 68); A2A skills 35 → 37.
- `IdentityEvent.entry_hash` + `AuditSeal` dataclass; store accessors `add_seal` / `latest_seal` / `list_seals`.

## Schema
Schema v3 → v4: idempotent SQLite migration (`_ensure_audit_columns`) + Postgres `ADD COLUMN IF NOT EXISTS` + new `audit_seals` table + Alembic `0003`. The mongo backend stamps `entry_hash` but the seal chain is SQLite/Postgres-only.

## Tests
`tests/identity/test_audit_chain.py` covers: hash round-trip, determinism, seal creation/idempotency, clean verify, and naive + sophisticated content tamper, sealed-event deletion (boundary + non-boundary), dataset-scoped chains, and the v3→v4 migration path. MCP seal/verify dispatch test added. Count assertions updated (MCP ×2, A2A). Full `tests/identity/` suite green (197 passed, 6 skipped); ruff clean.

## Threat model
Integrity, not secrecy — anyone with DB write access can also rewrite the seals. The value is that doing so *consistently* across event rows and the seal chain is detectable by an external party who retained a prior seal root (publish/mirror it). Same posture as an append-only ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_