### PR TITLE
fix(goldenprofile): bridge exact-name cross-doc merges on synonym category labels

### DIFF
--- a/packages/python/goldengraph/goldengraph/profile.py
+++ b/packages/python/goldengraph/goldengraph/profile.py
@@ -210,9 +210,13 @@ def resolve_profiles(
 
     When `embedder` is given, each fingerprint string is embedded and passed as
     the semantic signature (enabling SimHash-band blocking + the embedding-cosine
-    gate that bridges synonym categories). `config` is an optional partial
-    override of the engine's `ResolveConfig` (e.g.
-    `{"scoring": {"merge_threshold": 0.75}}`).
+    gate that bridges synonym categories). The CATEGORY field is ALSO embedded
+    separately and passed as `category_embeddings`: the category gate's synonym
+    escape hatch needs a category-specific signal -- the whole-fingerprint cosine
+    is polluted by the (by-design divergent) defining attribute, so an exact-name
+    bridge whose category label drifted ("Country" vs "Nation") would otherwise
+    never bridge. `config` is an optional partial override of the engine's
+    `ResolveConfig` (e.g. `{"scoring": {"merge_threshold": 0.75}}`).
     """
     resolve_json = _engine()
     profiles = []
@@ -233,6 +237,10 @@ def resolve_profiles(
     if embedder is not None and fingerprints:
         vecs = embedder.embed([fp.text for fp in fingerprints])
         request["embeddings"] = [[float(x) for x in row] for row in vecs]
+        # Category-only embeddings for the gate's synonym escape hatch. Embedding
+        # the (few distinct) category strings is cheap and cache-friendly.
+        cat_vecs = embedder.embed([p["category"] for p in profiles])
+        request["category_embeddings"] = [[float(x) for x in row] for row in cat_vecs]
     if config:
         request["config"] = config
 

--- a/packages/python/goldengraph/tests/test_profile.py
+++ b/packages/python/goldengraph/tests/test_profile.py
@@ -115,3 +115,61 @@ def test_resolve_profiles_reunites_disjoint_mentions():
     nabbes = next(c for c in res.clusters if 0 in c)
     assert sorted(nabbes) == [0, 1]
     assert any(c == [2] for c in res.clusters)
+
+
+class _CatStubEmbedder:
+    """Returns a fixed-dim vector per text; unknown -> zeros. Lets us assert the
+    request shape without the wheel."""
+
+    def embed(self, texts):
+        import numpy as np
+
+        return np.ones((len(texts), 3), dtype=float)
+
+
+def test_resolve_profiles_marshals_category_embeddings(monkeypatch):
+    """With an embedder, the request carries a category-only embedding per profile
+    (the gate's synonym escape-hatch signal) -- wheel-free: we capture the JSON the
+    engine boundary receives instead of running the engine."""
+    import json
+
+    from goldengraph import profile as prof
+
+    captured: dict = {}
+
+    def _fake_resolve_json(req_str: str) -> str:
+        captured["req"] = json.loads(req_str)
+        return json.dumps({"clusters": [[0], [1]], "edges": []})
+
+    monkeypatch.setattr(prof, "_engine", lambda: _fake_resolve_json)
+    fps = [
+        Fingerprint("node", 0, "Australia | Country | UNKNOWN | Federal monarchy"),
+        Fingerprint("node", 1, "Australia | Nation | UNKNOWN | Smallest continent"),
+    ]
+    prof.resolve_profiles(fps, embedder=_CatStubEmbedder())
+    req = captured["req"]
+    assert "category_embeddings" in req
+    # One category embedding per profile, aligned with the fingerprint order.
+    assert len(req["category_embeddings"]) == len(fps)
+    assert all(len(row) == 3 for row in req["category_embeddings"])
+    # The whole-fingerprint embeddings are still sent (blocking + soft term).
+    assert len(req["embeddings"]) == len(fps)
+
+
+def test_resolve_profiles_no_embedder_omits_embeddings(monkeypatch):
+    """Without an embedder, neither embedding array is sent (legacy structured-only
+    path) -- the back-compat contract the Rust core's empty-slice fallback relies on."""
+    import json
+
+    from goldengraph import profile as prof
+
+    captured: dict = {}
+
+    def _fake_resolve_json(req_str: str) -> str:
+        captured["req"] = json.loads(req_str)
+        return json.dumps({"clusters": [[0]], "edges": []})
+
+    monkeypatch.setattr(prof, "_engine", lambda: _fake_resolve_json)
+    prof.resolve_profiles([Fingerprint("node", 0, "A | C | UNKNOWN | UNKNOWN")])
+    assert "embeddings" not in captured["req"]
+    assert "category_embeddings" not in captured["req"]

--- a/packages/rust/extensions/goldenprofile-core/src/lib.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/lib.rs
@@ -43,6 +43,11 @@ pub struct ResolveRequest {
     pub profiles: Vec<Profile>,
     #[serde(default)]
     pub embeddings: Vec<Vec<f64>>,
+    /// Optional category-only embeddings (one per profile) for the category gate's
+    /// synonym escape hatch. Empty -> the hatch falls back to the whole-fingerprint
+    /// `embeddings` (legacy behavior). When non-empty, must align with `profiles`.
+    #[serde(default)]
+    pub category_embeddings: Vec<Vec<f64>>,
     #[serde(default)]
     pub config: ResolveConfig,
 }
@@ -59,7 +64,19 @@ pub fn resolve_json(request: &str) -> Result<String, String> {
             req.profiles.len()
         ));
     }
-    let res = resolve(&req.profiles, &req.embeddings, &req.config);
+    if !req.category_embeddings.is_empty() && req.category_embeddings.len() != req.profiles.len() {
+        return Err(format!(
+            "category_embeddings length {} != profiles length {} (supply one per profile, or none)",
+            req.category_embeddings.len(),
+            req.profiles.len()
+        ));
+    }
+    let res = resolve(
+        &req.profiles,
+        &req.embeddings,
+        &req.category_embeddings,
+        &req.config,
+    );
     serde_json::to_string(&res).map_err(|e| e.to_string())
 }
 

--- a/packages/rust/extensions/goldenprofile-core/src/resolve.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/resolve.rs
@@ -68,11 +68,24 @@ pub struct Resolution {
 }
 
 /// Resolve `profiles` into cross-document entities. `embeddings` may be empty
-/// (structured-only blocking + scoring) or aligned with `profiles`.
-pub fn resolve(profiles: &[Profile], embeddings: &[Vec<f64>], cfg: &ResolveConfig) -> Resolution {
+/// (structured-only blocking + scoring) or aligned with `profiles`. The optional
+/// `category_embeddings` (also empty or aligned) drive the category gate's
+/// synonym escape hatch -- a category-specific signal that, unlike the
+/// whole-fingerprint `embeddings`, is not polluted by the by-design-divergent
+/// defining attribute (see `score::score_pair`). Blocking still uses
+/// `embeddings` only.
+pub fn resolve(
+    profiles: &[Profile],
+    embeddings: &[Vec<f64>],
+    category_embeddings: &[Vec<f64>],
+    cfg: &ResolveConfig,
+) -> Resolution {
     let n = profiles.len();
     if n == 0 {
-        return Resolution { clusters: Vec::new(), edges: Vec::new() };
+        return Resolution {
+            clusters: Vec::new(),
+            edges: Vec::new(),
+        };
     }
 
     // 1. Blocking keys: structured (always) ∪ semantic (when embeddings given).
@@ -88,11 +101,28 @@ pub fn resolve(profiles: &[Profile], embeddings: &[Vec<f64>], cfg: &ResolveConfi
     // 2. Score candidates; keep the merges.
     let empty: Vec<f64> = Vec::new();
     let emb = |i: usize| -> &[f64] {
-        embeddings.get(i).map(|v| v.as_slice()).unwrap_or(empty.as_slice())
+        embeddings
+            .get(i)
+            .map(|v| v.as_slice())
+            .unwrap_or(empty.as_slice())
+    };
+    let cat_emb = |i: usize| -> &[f64] {
+        category_embeddings
+            .get(i)
+            .map(|v| v.as_slice())
+            .unwrap_or(empty.as_slice())
     };
     let mut edges: Vec<ResolvedEdge> = Vec::new();
     for (a, b) in cands {
-        let ps = score_pair(&profiles[a], &profiles[b], emb(a), emb(b), &cfg.scoring);
+        let ps = score_pair(
+            &profiles[a],
+            &profiles[b],
+            emb(a),
+            emb(b),
+            cat_emb(a),
+            cat_emb(b),
+            &cfg.scoring,
+        );
         if ps.score >= cfg.scoring.merge_threshold {
             edges.push(ResolvedEdge { a, b, score: ps });
         }
@@ -100,8 +130,10 @@ pub fn resolve(profiles: &[Profile], embeddings: &[Vec<f64>], cfg: &ResolveConfi
 
     // 3. Cluster via WCC. graph-core works in i64 id space; profile indices map
     // 1:1 to ids 0..n.
-    let wcc_edges: Vec<(i64, i64, f64)> =
-        edges.iter().map(|e| (e.a as i64, e.b as i64, e.score.score)).collect();
+    let wcc_edges: Vec<(i64, i64, f64)> = edges
+        .iter()
+        .map(|e| (e.a as i64, e.b as i64, e.score.score))
+        .collect();
     let all_ids: Vec<i64> = (0..n as i64).collect();
     let comps = connected_components(&wcc_edges, &all_ids);
     let clusters: Vec<Vec<usize>> = comps
@@ -137,9 +169,13 @@ mod tests {
             node("Thomas Nabbes | Playwright | London | Covent Garden circle"),
             node("William Shakespeare | Playwright | 1564 1616 | Wrote Hamlet"),
         ];
-        let res = resolve(&profiles, &[], &ResolveConfig::default());
+        let res = resolve(&profiles, &[], &[], &ResolveConfig::default());
         let nabbes = res.clusters.iter().find(|c| c.contains(&0)).unwrap();
-        assert_eq!(nabbes, &vec![0, 1, 2], "disjoint Nabbes mentions must reunite");
+        assert_eq!(
+            nabbes,
+            &vec![0, 1, 2],
+            "disjoint Nabbes mentions must reunite"
+        );
         let shakes = res.clusters.iter().find(|c| c.contains(&3)).unwrap();
         assert_eq!(shakes, &vec![3], "Shakespeare must stay distinct");
     }
@@ -162,21 +198,66 @@ mod tests {
             vec![0.0, 0.1, 1.0, -0.2],
         ];
         // Without embeddings the synonym pair would NOT merge...
-        let no_emb = resolve(&profiles, &[], &ResolveConfig::default());
+        let no_emb = resolve(&profiles, &[], &[], &ResolveConfig::default());
         assert!(
             no_emb.clusters.iter().any(|c| c == &vec![0]),
             "lexical-only must leave the synonym-category pair unmerged (conservative)"
         );
         // ...with embeddings, it does.
-        let res = resolve(&profiles, &embeddings, &ResolveConfig::default());
+        let res = resolve(&profiles, &embeddings, &[], &ResolveConfig::default());
         let nabbes = res.clusters.iter().find(|c| c.contains(&0)).unwrap();
-        assert_eq!(nabbes, &vec![0, 1], "embedding must bridge the synonym category");
-        assert!(res.clusters.iter().any(|c| c == &vec![2]), "Shakespeare stays distinct");
+        assert_eq!(
+            nabbes,
+            &vec![0, 1],
+            "embedding must bridge the synonym category"
+        );
+        assert!(
+            res.clusters.iter().any(|c| c == &vec![2]),
+            "Shakespeare stays distinct"
+        );
+    }
+
+    #[test]
+    fn category_embedding_reunites_exact_name_synonym_category() {
+        // The exact-name shatter end-to-end: two docs, SAME proper name, synonym
+        // category labels, DIVERGENT attributes (so the whole-fingerprint cosine
+        // can't bridge), plus a distinct same-category entity. Only the
+        // category-specific embedding can reunite 0,1 without dragging in 2.
+        let profiles = vec![
+            node("Australia | Country | UNKNOWN | Federal monarchy"),
+            node("Australia | Nation | UNKNOWN | Smallest continent"),
+            node("Canada | Country | UNKNOWN | Maple syrup exporter"),
+        ];
+        // Whole-fingerprint embeddings: all roughly orthogonal (attributes diverge),
+        // so the legacy hatch bridges nothing.
+        let fp = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0],
+        ];
+        // Category embeddings: "Country" ~ "Nation" close; "Country" (Canada) is
+        // the same label as 0 but its NAME differs, so the name gate keeps it out.
+        let cat = vec![
+            vec![1.0, 0.05, 0.0],
+            vec![0.97, 0.12, 0.0],
+            vec![1.0, 0.05, 0.0],
+        ];
+        let res = resolve(&profiles, &fp, &cat, &ResolveConfig::default());
+        let aus = res.clusters.iter().find(|c| c.contains(&0)).unwrap();
+        assert_eq!(
+            aus,
+            &vec![0, 1],
+            "exact-name synonym-category pair must reunite"
+        );
+        assert!(
+            res.clusters.iter().any(|c| c == &vec![2]),
+            "distinct name stays apart"
+        );
     }
 
     #[test]
     fn empty_input_is_empty() {
-        let res = resolve(&[], &[], &ResolveConfig::default());
+        let res = resolve(&[], &[], &[], &ResolveConfig::default());
         assert!(res.clusters.is_empty() && res.edges.is_empty());
     }
 
@@ -186,7 +267,7 @@ mod tests {
             node("Acme | Company | UNKNOWN | UNKNOWN"),
             node("Globex | Company | UNKNOWN | UNKNOWN"),
         ];
-        let res = resolve(&profiles, &[], &ResolveConfig::default());
+        let res = resolve(&profiles, &[], &[], &ResolveConfig::default());
         assert_eq!(res.clusters.len(), 2);
         assert!(res.edges.is_empty());
     }
@@ -197,7 +278,7 @@ mod tests {
             node("Thomas Nabbes | Playwright | 17th c | Wrote Play X"),
             node("Thomas Nabbes | Playwright | UNKNOWN | Born 1605"),
         ];
-        let res = resolve(&profiles, &[], &ResolveConfig::default());
+        let res = resolve(&profiles, &[], &[], &ResolveConfig::default());
         assert_eq!(res.edges.len(), 1);
         assert!(res.edges[0].score.gated_in);
         assert!(res.edges[0].score.name > 0.99);

--- a/packages/rust/extensions/goldenprofile-core/src/score.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/score.rs
@@ -123,11 +123,16 @@ pub fn cosine01(a: &[f64], b: &[f64]) -> Option<f64> {
 
 /// Score one profile pair. `emb_a`/`emb_b` are the host-supplied fingerprint
 /// embeddings (pass empty slices to score on the structured fields alone).
+/// `cat_emb_a`/`cat_emb_b` are OPTIONAL category-only embeddings: when supplied
+/// they drive the category gate's synonym escape hatch (see below); pass empty
+/// slices to fall back to the whole-fingerprint cosine (legacy behavior).
 pub fn score_pair(
     a: &Profile,
     b: &Profile,
     emb_a: &[f64],
     emb_b: &[f64],
+    cat_emb_a: &[f64],
+    cat_emb_b: &[f64],
     cfg: &ScoreConfig,
 ) -> PairScore {
     // Name: the cross-document identity signal. Short forms ("Nabbes") and full
@@ -136,8 +141,8 @@ pub fn score_pair(
     // token-subset of a longer one scores 1.0) -- the token_set behavior the
     // three base scorers lack.
     let name = name_similarity(&a.name, &b.name);
-    // Category: jaro_winkler -- categories are short controlled-ish vocab.
-    let category = field_sim(&a.category, &b.category, cfg.neutral_prior, true);
+    // Category, lexical: jaro_winkler -- categories are short controlled-ish vocab.
+    let category_lex = field_sim(&a.category, &b.category, cfg.neutral_prior, true);
     // Embedding cosine of the rendered fingerprints, computed once. `None` when
     // no embedding was supplied for a side; the soft signals fall back to the
     // neutral prior in that case.
@@ -145,13 +150,40 @@ pub fn score_pair(
     let embedding = emb_cos.unwrap_or(cfg.neutral_prior);
     let anchor = field_sim(&a.anchor, &b.anchor, cfg.neutral_prior, false);
 
+    // Soft category signal: synonym labels ("Country" vs "Nation") score LOW
+    // lexically but HIGH by a category-specific embedding. Credit whichever is
+    // stronger, so the weighted base does not UNDER-count a category the embedding
+    // confirms is the same. Without this, an exact-name bridge lands marginally
+    // below the merge threshold on lexical category noise alone even though the
+    // gate opened via the embedding -- an internal inconsistency (the gate trusts
+    // the embedding; the base must too). The hard gate below is the independent
+    // precision guard, so lifting this soft term cannot itself cause an over-merge.
+    let cat_emb_cos = cosine01(cat_emb_a, cat_emb_b);
+    let category = match cat_emb_cos {
+        Some(c) => category_lex.max(c),
+        None => category_lex,
+    };
+
     // Hard gate. Name is the true Row-4 discriminator (Nabbes vs Shakespeare
     // share a category, not a name), so it is always required. Category guards
     // cross-sense collisions ("Apple" the company vs the fruit) and passes on
     // EITHER lexical agreement OR a strong embedding cosine -- the latter bridges
     // synonym categories the lexical scorer would wrongly veto.
-    let category_ok = category >= cfg.category_gate
-        || emb_cos.is_some_and(|c| c >= cfg.category_embedding_gate);
+    //
+    // The escape-hatch cosine MUST be a category-SPECIFIC signal. The
+    // whole-fingerprint cosine (`emb_cos`) conflates the *defining attribute*,
+    // which is EXPECTED to diverge across documents (the Row-3 case) -- so a true
+    // bridge whose attribute differs scores a low fingerprint cosine and the hatch
+    // never fires, silently re-shattering same-name entities the LLM labeled with
+    // synonym categories ("Country" vs "Nation"). When the host supplies a
+    // category-only embedding we use IT for the hatch (synonyms ~ close, distinct
+    // senses ~ far); otherwise we fall back to the fingerprint cosine so legacy
+    // callers are unchanged. The gate's lexical arm uses the RAW lexical score
+    // (`category_lex`), NOT the embedding-lifted `category`, so gate precision is
+    // unchanged -- only the soft base benefits from the lift.
+    let category_gate_cos = cat_emb_cos.or(emb_cos);
+    let category_ok = category_lex >= cfg.category_gate
+        || category_gate_cos.is_some_and(|c| c >= cfg.category_embedding_gate);
     let gated_in = category_ok && name >= cfg.name_gate;
     if !gated_in {
         return PairScore {
@@ -240,7 +272,7 @@ mod tests {
         let a = node("Thomas Nabbes | Playwright | 17th Century England | Wrote Play X");
         let b = node("Thomas Nabbes | Playwright | UNKNOWN | Born 1605");
         let cfg = ScoreConfig::default();
-        let ps = score_pair(&a, &b, &[], &[], &cfg);
+        let ps = score_pair(&a, &b, &[], &[], &[], &[], &cfg);
         assert!(ps.gated_in);
         assert!(
             ps.score >= cfg.merge_threshold,
@@ -256,7 +288,7 @@ mod tests {
         let a = node("Thomas Nabbes | Playwright | 17th Century | UNKNOWN");
         let b = node("William Shakespeare | Playwright | 17th Century | UNKNOWN");
         let emb = vec![0.3, 0.4, 0.5, 0.6];
-        let ps = score_pair(&a, &b, &emb, &emb, &ScoreConfig::default());
+        let ps = score_pair(&a, &b, &emb, &emb, &[], &[], &ScoreConfig::default());
         assert!(!ps.gated_in);
         assert_eq!(ps.score, 0.0, "name gate must veto the over-merge");
     }
@@ -267,8 +299,8 @@ mod tests {
         let b_same = node("Acme Corp | Company | UNKNOWN | Makes anvils");
         let b_diff = node("Acme Corp | Company | UNKNOWN | Sells rockets");
         let cfg = ScoreConfig::default();
-        let s_same = score_pair(&a, &b_same, &[], &[], &cfg).score;
-        let s_diff = score_pair(&a, &b_diff, &[], &[], &cfg).score;
+        let s_same = score_pair(&a, &b_same, &[], &[], &[], &[], &cfg).score;
+        let s_diff = score_pair(&a, &b_diff, &[], &[], &[], &[], &cfg).score;
         // Matching attribute scores higher, but the divergent one must NOT be
         // penalized below the threshold (no veto).
         assert!(s_same > s_diff);
@@ -281,10 +313,65 @@ mod tests {
         let b_unknown = node("Globex | Company | UNKNOWN | UNKNOWN");
         let b_conflict = node("Globex | Company | 1750 | UNKNOWN");
         let cfg = ScoreConfig::default();
-        let s_unknown = score_pair(&a, &b_unknown, &[], &[], &cfg);
-        let s_conflict = score_pair(&a, &b_conflict, &[], &[], &cfg);
+        let s_unknown = score_pair(&a, &b_unknown, &[], &[], &[], &[], &cfg);
+        let s_conflict = score_pair(&a, &b_conflict, &[], &[], &[], &[], &cfg);
         // An UNKNOWN anchor (neutral 0.5) must beat a genuinely conflicting one.
         assert!(s_unknown.anchor > s_conflict.anchor);
+    }
+
+    #[test]
+    fn category_embedding_bridges_synonym_labels_with_divergent_attributes() {
+        // The exact-name shatter the bench surfaced: SAME proper name, the LLM
+        // labeled the category with synonyms ("Country" vs "Nation"), and the
+        // defining attributes DIVERGE across documents (so the whole-fingerprint
+        // cosine is LOW and the legacy escape hatch never fires). A category-only
+        // embedding (synonyms ~ close) must open the gate and let the pair merge.
+        let a = node("Australia | Country | UNKNOWN | Federal parliamentary monarchy");
+        let b = node("Australia | Nation | UNKNOWN | Smallest continent landmass");
+        let cfg = ScoreConfig::default();
+        // Deliberately FAR whole-fingerprint embeddings (attributes diverge), so
+        // the only thing that can open the gate is the category embedding.
+        let fp_a = vec![1.0, 0.0, 0.0, 0.0];
+        let fp_b = vec![0.0, 1.0, 0.0, 0.0];
+        // Without a category embedding: legacy fingerprint-cosine hatch fails ->
+        // gated out -> the bench's exact-name shatter.
+        let legacy = score_pair(&a, &b, &fp_a, &fp_b, &[], &[], &cfg);
+        assert!(
+            !legacy.gated_in,
+            "divergent-attribute fingerprint cosine must not bridge"
+        );
+        // With CLOSE category embeddings ("Country" ~ "Nation"): hatch opens.
+        let cat_a = vec![1.0, 0.05, 0.0];
+        let cat_b = vec![0.98, 0.1, 0.02];
+        let bridged = score_pair(&a, &b, &fp_a, &fp_b, &cat_a, &cat_b, &cfg);
+        assert!(
+            bridged.gated_in,
+            "synonym category embedding must open the gate"
+        );
+        assert!(
+            bridged.score >= cfg.merge_threshold,
+            "exact-name synonym-category bridge must merge, got {}",
+            bridged.score
+        );
+    }
+
+    #[test]
+    fn category_embedding_does_not_bridge_cross_sense_same_name() {
+        // The over-merge guard the category gate exists for: SAME name, GENUINELY
+        // distinct senses ("Apple" the company vs the fruit). Distant category
+        // embeddings must keep the hatch shut even though the name is identical.
+        let a = node("Apple | Company | UNKNOWN | Makes phones");
+        let b = node("Apple | Fruit | UNKNOWN | Grows on trees");
+        let cfg = ScoreConfig::default();
+        let fp = vec![0.5, 0.5, 0.5, 0.5];
+        let cat_a = vec![1.0, 0.0, 0.0];
+        let cat_b = vec![0.0, 1.0, 0.0]; // orthogonal -> cosine01 = 0.5 < gate
+        let ps = score_pair(&a, &b, &fp, &fp, &cat_a, &cat_b, &cfg);
+        assert!(
+            !ps.gated_in,
+            "distinct-sense category embedding must keep the gate shut"
+        );
+        assert_eq!(ps.score, 0.0);
     }
 
     #[test]

--- a/packages/rust/extensions/goldenprofile-core/src/signature.rs
+++ b/packages/rust/extensions/goldenprofile-core/src/signature.rs
@@ -48,7 +48,8 @@ pub fn structured_block_keys(p: &Profile) -> Vec<String> {
         crate::model::ElementKind::Edge => "edge",
     };
     let cat = Profile::norm(&p.category);
-    p.name_tokens()
+    let mut keys: Vec<String> = p
+        .name_tokens()
         .into_iter()
         .map(|tok| {
             // Canonical, type-tagged hash -- identical bytes on every surface.
@@ -60,7 +61,29 @@ pub fn structured_block_keys(p: &Profile) -> Vec<String> {
             ])
             .expect("string fields never fail fingerprinting")
         })
-        .collect()
+        .collect();
+    // Category-AGNOSTIC exact-name key: two mentions of the SAME proper name block
+    // together even when the LLM labeled their category with divergent synonyms
+    // ("Australia | Country" vs "Australia | Nation"). The per-token keys above are
+    // category-scoped (Row-4 guard at the blocking layer), so a same-name pair whose
+    // category label drifted is otherwise NEVER compared and its multi-hop chain
+    // stays shattered. This key is keyed on the WHOLE normalized name (not per
+    // token), so it groups only genuine same-name mentions -- it does not broaden
+    // recall to everything sharing a common token -- and the scorer (name + category
+    // gate) remains the precision stage that keeps cross-sense same-name entities
+    // ("Apple" company vs fruit) apart.
+    let full = Profile::norm(&p.name);
+    if !full.is_empty() {
+        keys.push(
+            fingerprint_fields(vec![
+                ("kind".to_string(), FpValue::Str(kind.to_string())),
+                ("scope".to_string(), FpValue::Str("fullname".to_string())),
+                ("name".to_string(), FpValue::Str(full)),
+            ])
+            .expect("string fields never fail fingerprinting"),
+        );
+    }
+    keys
 }
 
 /// Semantic band keys for a batch of profiles from their host-supplied
@@ -127,7 +150,10 @@ mod tests {
 
     #[test]
     fn shared_name_token_same_category_blocks_together() {
-        let a = Profile::parse(ElementKind::Node, "Thomas Nabbes | Playwright | 17th c | wrote X");
+        let a = Profile::parse(
+            ElementKind::Node,
+            "Thomas Nabbes | Playwright | 17th c | wrote X",
+        );
         let b = Profile::parse(ElementKind::Node, "Nabbes | Playwright | 1605 | UNKNOWN");
         let ka = structured_block_keys(&a);
         let kb = structured_block_keys(&b);
@@ -136,9 +162,46 @@ mod tests {
     }
 
     #[test]
+    fn same_name_divergent_category_blocks_on_fullname_key() {
+        // The exact-name shatter at the blocking layer: identical proper name, the
+        // LLM drifted the category label. The category-scoped per-token keys differ,
+        // so only the category-agnostic full-name key can recall the pair.
+        let a = Profile::parse(
+            ElementKind::Node,
+            "Australia | Country | UNKNOWN | Federal monarchy",
+        );
+        let b = Profile::parse(
+            ElementKind::Node,
+            "Australia | Nation | UNKNOWN | Smallest continent",
+        );
+        let ka = structured_block_keys(&a);
+        let kb = structured_block_keys(&b);
+        assert!(
+            ka.iter().any(|k| kb.contains(k)),
+            "same name must block despite category drift"
+        );
+        // A genuinely different name must NOT share the full-name key.
+        let c = Profile::parse(
+            ElementKind::Node,
+            "Austria | Country | UNKNOWN | Alpine republic",
+        );
+        let kc = structured_block_keys(&c);
+        assert!(
+            !ka.iter().any(|k| kc.contains(k)),
+            "different name must not block"
+        );
+    }
+
+    #[test]
     fn different_name_same_category_does_not_block() {
-        let nabbes = Profile::parse(ElementKind::Node, "Thomas Nabbes | Playwright | UNKNOWN | UNKNOWN");
-        let shakes = Profile::parse(ElementKind::Node, "William Shakespeare | Playwright | UNKNOWN | UNKNOWN");
+        let nabbes = Profile::parse(
+            ElementKind::Node,
+            "Thomas Nabbes | Playwright | UNKNOWN | UNKNOWN",
+        );
+        let shakes = Profile::parse(
+            ElementKind::Node,
+            "William Shakespeare | Playwright | UNKNOWN | UNKNOWN",
+        );
         let ka = structured_block_keys(&nabbes);
         let kb = structured_block_keys(&shakes);
         assert!(!ka.iter().any(|k| kb.contains(k)));


### PR DESCRIPTION
## Why

The #1244 shatter-probe proved the goldengraph cross-doc shatter is a **merge failure, not a recall gap**: 7/7 probed broken-chain misses were `SCORING-miss`, 3 byte-identical bridges (`Australia`/`Australia`, `England`, `Fujian`) the token blocker already proposes yet goldenprofile never merged.

Root cause, traced through the engine: the anti-shatter matcher gates a merge on **name AND category**, but the LLM labels the *same* entity with **synonym categories** across docs (`Country` in one, `Nation` in another), and that drift defeats **both** layers:

- **Blocking** — the structured key is `(kind, category, name-token)`, so a same-name pair whose category drifted never even blocks together (it could only reunite via a SimHash band on the whole-fingerprint embedding, which the by-design-divergent *defining attribute* pulls apart).
- **Scoring** — the category gate's "synonym escape hatch" was wired to the *whole-fingerprint* cosine (also attribute-polluted), so it never fires for a real bridge; the soft base then scores category at its low **lexical** value and the exact-name pair lands *marginally* below threshold (measured `0.7168` vs `0.72`).

## What (all in pyo3-free `goldenprofile-core` → every binding inherits it; the bench builds the native wheel **from source**, so no republish)

1. **Blocking** (`signature.rs`): a category-agnostic **exact-name key** (hashed on the whole normalized name, not per token) so identical proper names always block together regardless of category drift. Tight — groups only genuine same-name mentions, not everything sharing a token.
2. **Scoring** (`score.rs`): the gate's escape hatch now uses an optional **category-specific embedding** (synonyms ≈ close, distinct senses ≈ far) instead of the attribute-polluted fingerprint cosine; and the soft category term is lifted to `max(lexical, category-embedding)` so a category the embedding confirms is the same isn't under-counted. The gate's **lexical arm still uses the raw lexical score**, so gate precision is unchanged.
3. **Plumbing**: `ResolveRequest.category_embeddings` (optional, serde-default; empty → legacy fallback, byte-identical for existing callers), length-validated, threaded `resolve` → `score_pair`.
4. **Host** (`goldengraph/profile.py`): embed the category field separately and pass it (cheap, cache-friendly — few distinct category strings).

## Precision guard holds (unit-tested both directions)
- `Apple | Company` vs `Apple | Fruit` (distant category embeddings) → **stays gated out**, score 0.
- `Australia | Country` vs `Australia | Nation` (close category embeddings) → **now reunites at ~0.85** (was gated out).

5 new Rust tests (blocking, scoring gate both directions, end-to-end resolve) + 2 wheel-free host marshaling tests. `goldenprofile-core` (29) and goldengraph profile/cross-doc (41) suites green; `cargo clippy --workspace -- -D warnings` clean.

## Status — capability to MEASURE, not a declared win
A traced N=50 MuSiQue run is dispatched on this branch. The bar: the `RETRIEVAL-BROKEN-CHAIN` count drops without an `exact_match`/precision regression. I'll post the before/after on this PR before marking it ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_