### PR TITLE
chore(ci): consolidate PyPI publishers onto a reusable workflow

### DIFF
--- a/.github/workflows/_publish-pypi.yml
+++ b/.github/workflows/_publish-pypi.yml
@@ -1,0 +1,63 @@
+# Reusable PyPI-publish template for the simple Python packages. Each
+# packages/python/<pkg> has a thin `publish-<pkg>.yml` caller that fires on its
+# `release: published` (filtered to the `<pkg>-v*` tag) and delegates here -- so
+# this single body replaces the ~40 near-identical lines copy-pasted across six
+# workflows (goldencheck, goldencheck-types, goldenflow, goldenpipe, infermap,
+# goldenanalysis).
+#
+# Every package's dir name under packages/python/ is the one varying value, so a
+# single `package` input parameterizes the working dir + the publish packages-dir.
+# The tag-prefix `if:` gate stays in each caller (it's per-package and needs the
+# sibling-tag exclusions). goldenmatch is intentionally NOT a caller: it has a
+# bespoke web-build + cosign/sigstore + draft-release flow and keeps its own
+# publish-goldenmatch.yml.
+name: _publish-pypi (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: "Python package dir under packages/python/ (== PyPI dist name)"
+        required: true
+        type: string
+      ref:
+        description: "Tag or commit to build (default: the triggering ref)"
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Build + validate without publishing to PyPI"
+        required: false
+        type: string
+        default: "false"
+
+permissions:
+  id-token: write   # PyPI OIDC (declared to match the prior per-package workflows)
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/python/${{ inputs.package }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - name: Publish to PyPI
+        if: inputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: packages/python/${{ inputs.package }}/dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/publish-goldenanalysis.yml
+++ b/.github/workflows/publish-goldenanalysis.yml
@@ -1,5 +1,6 @@
 name: Publish goldenanalysis to PyPI
 
+# Thin caller -> .github/workflows/_publish-pypi.yml (the shared template).
 on:
   release:
     types: [published]
@@ -9,6 +10,10 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
+      dry_run:
+        description: "Build + validate without publishing"
+        required: false
+        default: "false"
 
 permissions:
   id-token: write
@@ -19,22 +24,9 @@ jobs:
     # Only run for goldenanalysis-v* tags. `startsWith` excludes goldenanalysis-js-v*
     # and goldenanalysis-native-v* (the char after `goldenanalysis-` is j / n, not v).
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenanalysis-v')
-    runs-on: ubuntu-latest
-    environment: pypi
-    defaults:
-      run:
-        working-directory: packages/python/goldenanalysis
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
-        with:
-          packages-dir: packages/python/goldenanalysis/dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    uses: ./.github/workflows/_publish-pypi.yml
+    with:
+      package: goldenanalysis
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldencheck-types.yml
+++ b/.github/workflows/publish-goldencheck-types.yml
@@ -1,5 +1,6 @@
 name: Publish goldencheck-types to PyPI
 
+# Thin caller -> .github/workflows/_publish-pypi.yml (the shared template).
 on:
   release:
     types: [published]
@@ -9,6 +10,10 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
+      dry_run:
+        description: "Build + validate without publishing"
+        required: false
+        default: "false"
 
 permissions:
   id-token: write
@@ -19,22 +24,9 @@ jobs:
     # Only run for goldencheck-types-v* tags. Skip goldencheck-v* (handled
     # by publish-goldencheck.yml) and goldencheck-types-js-v* (npm).
     if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'goldencheck-types-v') && !startsWith(github.event.release.tag_name, 'goldencheck-types-js-v'))
-    runs-on: ubuntu-latest
-    environment: pypi
-    defaults:
-      run:
-        working-directory: packages/python/goldencheck-types
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
-        with:
-          packages-dir: packages/python/goldencheck-types/dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    uses: ./.github/workflows/_publish-pypi.yml
+    with:
+      package: goldencheck-types
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldencheck.yml
+++ b/.github/workflows/publish-goldencheck.yml
@@ -1,5 +1,6 @@
 name: Publish goldencheck to PyPI
 
+# Thin caller -> .github/workflows/_publish-pypi.yml (the shared template).
 on:
   release:
     types: [published]
@@ -9,6 +10,10 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
+      dry_run:
+        description: "Build + validate without publishing"
+        required: false
+        default: "false"
 
 permissions:
   id-token: write
@@ -19,22 +24,9 @@ jobs:
     # Only run for goldencheck-v* tags. Skip goldencheck-types-v*
     # (handled by publish-goldencheck-types.yml) and other package tags.
     if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'goldencheck-v') && !startsWith(github.event.release.tag_name, 'goldencheck-types-v'))
-    runs-on: ubuntu-latest
-    environment: pypi
-    defaults:
-      run:
-        working-directory: packages/python/goldencheck
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
-        with:
-          packages-dir: packages/python/goldencheck/dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    uses: ./.github/workflows/_publish-pypi.yml
+    with:
+      package: goldencheck
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenflow.yml
+++ b/.github/workflows/publish-goldenflow.yml
@@ -1,12 +1,8 @@
 name: Publish goldenflow to PyPI
 
-# Brings goldenflow into the same release pipeline as the rest of the suite.
-# Before this workflow goldenflow was published manually via twine, which is
-# why the MCP Registry listing drifted ahead of PyPI (someone bumped the
-# registry to 1.1.4 in advance of a release that didn't ship). Once this
-# lands and goldenflow-v1.1.5 is tagged + released, the pattern matches
-# every other package in the suite.
-
+# Thin caller -> .github/workflows/_publish-pypi.yml (the shared template).
+# (History: goldenflow was once published manually via twine, which drifted the
+# MCP Registry listing ahead of PyPI; it now rides the shared release pipeline.)
 on:
   release:
     types: [published]
@@ -16,6 +12,10 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
+      dry_run:
+        description: "Build + validate without publishing"
+        required: false
+        default: "false"
 
 permissions:
   id-token: write
@@ -26,22 +26,9 @@ jobs:
     # Only run for goldenflow-v* tags. The leading `-v` distinguishes from
     # the npm-side `goldenflow-js-v*` tag pattern used by the TypeScript port.
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenflow-v')
-    runs-on: ubuntu-latest
-    environment: pypi
-    defaults:
-      run:
-        working-directory: packages/python/goldenflow
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
-        with:
-          packages-dir: packages/python/goldenflow/dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    uses: ./.github/workflows/_publish-pypi.yml
+    with:
+      package: goldenflow
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-goldenpipe.yml
+++ b/.github/workflows/publish-goldenpipe.yml
@@ -1,5 +1,6 @@
 name: Publish goldenpipe to PyPI
 
+# Thin caller -> .github/workflows/_publish-pypi.yml (the shared template).
 on:
   release:
     types: [published]
@@ -9,6 +10,10 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
+      dry_run:
+        description: "Build + validate without publishing"
+        required: false
+        default: "false"
 
 permissions:
   id-token: write
@@ -18,22 +23,9 @@ jobs:
   publish:
     # Only run for goldenpipe-v* tags.
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-v')
-    runs-on: ubuntu-latest
-    environment: pypi
-    defaults:
-      run:
-        working-directory: packages/python/goldenpipe
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
-        with:
-          packages-dir: packages/python/goldenpipe/dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    uses: ./.github/workflows/_publish-pypi.yml
+    with:
+      package: goldenpipe
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit

--- a/.github/workflows/publish-infermap.yml
+++ b/.github/workflows/publish-infermap.yml
@@ -1,5 +1,6 @@
 name: Publish infermap to PyPI
 
+# Thin caller -> .github/workflows/_publish-pypi.yml (the shared template).
 on:
   release:
     types: [published]
@@ -9,6 +10,10 @@ on:
         description: "Tag or commit to build (default: HEAD of main)"
         required: false
         default: ""
+      dry_run:
+        description: "Build + validate without publishing"
+        required: false
+        default: "false"
 
 permissions:
   id-token: write
@@ -19,22 +24,9 @@ jobs:
     # Only run for infermap-v* tags. Skip infermap-js-v* (handled by
     # publish-infermap-js.yml) and other package tags.
     if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'infermap-v') && !startsWith(github.event.release.tag_name, 'infermap-js-v'))
-    runs-on: ubuntu-latest
-    environment: pypi
-    defaults:
-      run:
-        working-directory: packages/python/infermap
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
-        with:
-          packages-dir: packages/python/infermap/dist
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip-existing: true
+    uses: ./.github/workflows/_publish-pypi.yml
+    with:
+      package: infermap
+      ref: ${{ inputs.ref || '' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+    secrets: inherit


### PR DESCRIPTION
The "recommended next" item from the workflow-consolidation audit in #1250.

## Why
The TypeScript publishers already delegate to a reusable workflow (`_publish-js.yml`, 31-line callers). The six **simple PyPI publishers never got the same treatment** — they were standalone ~40-line copy-pastes differing only in *name, tag-filter, and package dir*.

## What
- **`_publish-pypi.yml`** — new reusable workflow (`workflow_call`) mirroring `_publish-js.yml`. Inputs: `package` / `ref` / `dry_run`. Body is exactly what the six shared: `ubuntu-latest`, `environment: pypi`, `id-token+contents` perms, `checkout(ref)` → `setup-python 3.12` → `python -m build` → `pypa/gh-action-pypi-publish` (`skip-existing`).
- **6 thin callers** (`publish-{goldencheck,goldencheck-types,goldenflow,goldenpipe,infermap,goldenanalysis}.yml`) — each preserves its **exact** tag-prefix `if:` gate (including the sibling-tag exclusions like `!startsWith(..., 'goldencheck-types-v')`) + `secrets: inherit`.

**Net −53 lines** across the six (121 deletions / 68 insertions, plus the one reusable file).

## Behavior-preserving for real releases
- On a `release: published` event the reusable resolves from `main` (as the inline workflows did) and checks out the **tag** to build — definition from main, code from the tag, unchanged.
- `permissions`, `environment: pypi`, and `ref` resolution (`inputs.ref || github.ref`) are identical.
- The new `dry_run` input gates **only** the publish step and defaults to `false`, so a real release still publishes. It's an additive convenience for `workflow_dispatch` validation.

## Scope / risk
- **`goldenmatch` is intentionally NOT a caller** — its bespoke web-frontend build + cosign/sigstore signing + attestation + immutable draft-release flow keeps its own `publish-goldenmatch.yml`. Folding it in would risk the v2.1.0-class late-surfacing release break for no real dedup win.
- The `-native` (maturin) publishers are a separate follow-up (different build matrix); not touched here.

## Validation
All 7 files parse; the six package dirs exist; **`actionlint` clean** (validates the reusable-call input wiring + `secrets: inherit` + caller-job field restrictions). CI already runs actionlint, so this is gated there too. No `uv.lock` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_