### PR TITLE
feat(goldengraph): literal-attribute extraction → reachable value nodes

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -57,6 +57,9 @@ on:
       distill_log:
         description: "goldengraph only: capture (text->extraction)+(entity->fingerprint) pairs to a JSONL artifact for in-house distillation"
         default: "false"
+      literal_attrs:
+        description: "goldengraph only: extract literal attributes (dates/quantities/short values) as reachable value nodes -- targets non-entity answers"
+        default: "false"
 
 permissions:
   contents: read
@@ -124,6 +127,7 @@ jobs:
           GOLDENGRAPH_BUILD_WORKERS: ${{ inputs.build_workers }}
           GOLDENGRAPH_BUILD_DEBUG: ${{ inputs.build_debug }}
           GOLDENGRAPH_EXTRACTOR: ${{ inputs.extractor }}
+          GOLDENGRAPH_LITERAL_ATTRS: ${{ inputs.literal_attrs }}
           GOLDENGRAPH_DISTILL_LOG: ${{ inputs.distill_log == 'true' && format('results/distill_goldengraph_amb{0}.jsonl', matrix.ambiguity) || '' }}
         run: |
           mkdir -p results

--- a/packages/python/goldengraph/goldengraph/embed.py
+++ b/packages/python/goldengraph/goldengraph/embed.py
@@ -66,8 +66,19 @@ class GoldenmatchEmbedder:
 def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5) -> list[int]:
     """Top-`k` entity ids in `slice_graph` (a `PyGraph` from `as_of`) nearest the
     query by cosine over canonical-name embeddings. Tie-break: ascending
-    `entity_id` (deterministic — stub/zero vectors tie often)."""
-    ents = slice_graph.entities()
+    `entity_id` (deterministic — stub/zero vectors tie often).
+
+    Only real ENTITY nodes are seed candidates: literal-attribute value nodes
+    (typ="literal") are excluded -- they are answers reached by walking an edge FROM
+    a seed entity, not query anchors themselves, and embedding raw values (a bare
+    date / amount) both wastes budget and risks an empty/invalid embedding input
+    that 400s the whole batch. Empty/whitespace names are skipped for the same
+    reason (a provider rejects an empty input)."""
+    ents = [
+        e
+        for e in slice_graph.entities()
+        if e.get("typ") != "literal" and str(e.get("canonical_name", "")).strip()
+    ]
     if not ents:
         return []
     ids = [int(e["entity_id"]) for e in ents]

--- a/packages/python/goldengraph/goldengraph/extract.py
+++ b/packages/python/goldengraph/goldengraph/extract.py
@@ -10,7 +10,8 @@ dropped rather than poisoning the graph.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 
 from .llm import LLMClient
 
@@ -24,6 +25,25 @@ The `description` is a brief, source-grounded characterization (e.g. "American \
 technology corporation") that disambiguates the entity for resolution. \
 `subj`/`obj` are 0-based indices into `entities`. Text:
 {text}"""
+
+#: Appended to `_PROMPT` (before the `Text:` line) when GOLDENGRAPH_LITERAL_ATTRS is
+#: on. Many questions ask for a LITERAL value (a date, a quantity, a measurement, a
+#: short descriptive phrase) that is NOT a named entity -- "when was X founded?",
+#: "how many people?", "what kind of engine?". The base schema can only emit
+#: entity->entity edges, so those answers never enter the graph and are
+#: unanswerable by construction. This adds an `attributes` array carrying each such
+#: literal fact as (entity, key, value); the host materializes every attribute as a
+#: literal NODE plus an edge from its entity, so the value becomes a reachable,
+#: answerable graph node.
+_ATTRS_SCHEMA = """ Additionally extract an `attributes` array capturing LITERAL \
+facts -- a date/year, a quantity/amount/measurement, or a short defining value -- \
+that answers a "when / how many / how much / what kind / how long" question about \
+an entity but is NOT itself a named entity: \
+{{"attributes": [{{"subj": <entity index>, "key": "<what the value is, e.g. \
+'release date', 'population', 'length'>", "value": "<the literal value EXACTLY as \
+stated, e.g. 'May 1990', '$72,641', '4.3 km'>"}}]}}. \
+`subj` is a 0-based index into `entities`. Keep `value` terse and verbatim; omit \
+attributes you are unsure of."""
 
 
 @dataclass
@@ -41,9 +61,29 @@ class Relationship:
 
 
 @dataclass
+class Attribute:
+    """A literal fact about an entity: `mentions[subj]` has `key` = `value`, where
+    `value` is a date/quantity/short defining phrase, NOT a named entity. The host
+    materializes each as a literal node + an edge so the value is answerable."""
+
+    subj: int  # index into the Extraction.mentions list
+    key: str
+    value: str
+
+
+@dataclass
 class Extraction:
     mentions: list[Mention]
     relationships: list[Relationship]
+    # Literal attribute facts (default empty -> back-compat with the base schema and
+    # any extractor/stub that doesn't emit them).
+    attributes: list[Attribute] = field(default_factory=list)
+
+
+def _literal_attrs_enabled() -> bool:
+    """Read inside `extract()` (NOT a call-site kwarg) so monkeypatched 2-arg
+    extractor stubs keep working -- the #1236 lesson."""
+    return os.environ.get("GOLDENGRAPH_LITERAL_ATTRS", "0") not in ("0", "false", "")
 
 
 def _strip_fence(raw: str) -> str:
@@ -73,9 +113,26 @@ def parse_extraction(raw: str) -> Extraction:
         # defensive: drop endpoints that aren't valid entity indices
         if isinstance(s, int) and isinstance(o, int) and 0 <= s < n and 0 <= o < n:
             rels.append(Relationship(subj=s, predicate=str(r.get("predicate", "")), obj=o))
-    return Extraction(mentions=mentions, relationships=rels)
+    attrs: list[Attribute] = []
+    for a in data.get("attributes", []):
+        s = a.get("subj")
+        value = str(a.get("value", "")).strip()
+        # defensive: a valid owner index + a non-empty literal value (an empty value
+        # would materialize a useless blank node).
+        if isinstance(s, int) and 0 <= s < n and value:
+            attrs.append(Attribute(subj=s, key=str(a.get("key", "")).strip(), value=value))
+    return Extraction(mentions=mentions, relationships=rels, attributes=attrs)
 
 
 def extract(text: str, llm: LLMClient) -> Extraction:
-    """Extract entities + relationships from `text` via `llm`."""
-    return parse_extraction(llm.complete(_PROMPT.format(text=text)))
+    """Extract entities + relationships from `text` via `llm`. When
+    GOLDENGRAPH_LITERAL_ATTRS is set, also extract literal attribute facts
+    (dates/quantities/short defining values) so non-entity answers can enter the
+    graph (see `_ATTRS_SCHEMA`)."""
+    prompt = _PROMPT
+    if _literal_attrs_enabled():
+        # Splice the attribute schema in BEFORE the trailing "Text:\n{text}" so the
+        # instruction precedes the document.
+        head, _, tail = _PROMPT.partition(" Text:\n{text}")
+        prompt = head + _ATTRS_SCHEMA + " Text:\n{text}"
+    return parse_extraction(llm.complete(prompt.format(text=text)))

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -84,17 +84,63 @@ def build_batch(
             }
         )
 
-    return {
-        "entities": [
+    out_entities = [
+        {
+            "local_id": e.local_id,
+            "canonical_name": e.canonical_name,
+            "typ": e.typ,
+            "surface_names": e.surface_names,
+            "record_keys": e.record_keys,
+        }
+        for e in entities
+    ]
+
+    # Literal attributes -> a value NODE + an edge from its owning entity, so a
+    # non-entity answer (a date / quantity / short defining value) becomes a
+    # reachable, answerable graph node instead of being lost (the dominant
+    # EXTRACTION miss on MuSiQue). Empty unless GOLDENGRAPH_LITERAL_ATTRS made the
+    # extractor emit attributes, so this is a no-op on the base schema.
+    #
+    # Literal nodes get UNIQUE per-occurrence record_keys (keyed on this batch's
+    # `at` + a counter), so identical values in different documents do NOT
+    # overlap-merge in the store -- that would fuse unrelated facts into a false
+    # cross-document bridge. Each literal stays a leaf owned by its own entity.
+    next_local = max((e.local_id for e in entities), default=-1) + 1
+    seen_literals: dict[tuple[int, str, str], int] = {}
+    for a in getattr(extraction, "attributes", ()):
+        owner = mention_to_local.get(a.subj)
+        value = (a.value or "").strip()
+        if owner is None or not value:
+            continue
+        key = (a.key or "").strip()
+        dedup = (owner, key.lower(), value.lower())
+        lit_local = seen_literals.get(dedup)
+        if lit_local is None:
+            lit_local = next_local
+            next_local += 1
+            seen_literals[dedup] = lit_local
+            out_entities.append(
+                {
+                    "local_id": lit_local,
+                    "canonical_name": value,
+                    "typ": "literal",
+                    "surface_names": [],
+                    "record_keys": [f"lit:{at}:{lit_local}"],
+                }
+            )
+        edges.append(
             {
-                "local_id": e.local_id,
-                "canonical_name": e.canonical_name,
-                "typ": e.typ,
-                "surface_names": e.surface_names,
-                "record_keys": e.record_keys,
+                "subj_local": owner,
+                "predicate": key or "has value",
+                "obj_local": lit_local,
+                "valid_from": vf,
+                "valid_to": None,
+                "source_refs": [],
             }
-            for e in entities
-        ],
+        )
+
+    return {
+        "entities": out_entities,
         "edges": edges,
         "ingested_at": at,
     }
@@ -230,12 +276,18 @@ def _existing_features(slice_graph):
             rel[o].add(p)
             nbr[s].add(id_to_name[o])
             nbr[o].add(id_to_name[s])
+    # Exclude literal-attribute leaf nodes (typ="literal") from the link candidate
+    # set -- they are values, not entities to resolve (mirror of `_new_features`).
+    out_ents: list[dict] = []
     feats: list[dict] = []
     keys: list[set[str]] = []
     for e in ents:
+        if e.get("typ") == "literal":
+            continue
         eid = e["entity_id"]
         typ = e.get("typ", "")
         surfaces = e.get("surface_names", ())
+        out_ents.append(e)
         feats.append({
             "name": e.get("canonical_name", ""),
             "type": typ,
@@ -244,7 +296,7 @@ def _existing_features(slice_graph):
             "nbr": " | ".join(sorted(nbr[eid])),
         })
         keys.append({_record_key(s, typ) for s in [e.get("canonical_name", ""), *surfaces] if s})
-    return ents, feats, keys
+    return out_ents, feats, keys
 
 
 def _new_features(batch: dict):
@@ -261,9 +313,17 @@ def _new_features(batch: dict):
             rel[o].add(p)
             nbr[s].add(lid_to_name[o])
             nbr[o].add(lid_to_name[s])
+    # Literal-attribute nodes (typ="literal") are leaf VALUES, not entities to
+    # resolve -- exclude them as cross-doc link candidates so two identical values
+    # in different documents never merge into a false bridge. They stay in the batch
+    # (still stored + still in their owner's neighborhood above), just not linked.
+    out_ents: list[dict] = []
     feats: list[dict] = []
     for be in new_ents:
+        if be.get("typ") == "literal":
+            continue
         lid = be["local_id"]
+        out_ents.append(be)
         feats.append({
             "name": be.get("canonical_name", ""),
             "type": be.get("typ", ""),
@@ -271,7 +331,7 @@ def _new_features(batch: dict):
             "rel": " | ".join(sorted(rel[lid])),
             "nbr": " | ".join(sorted(nbr[lid])),
         })
-    return new_ents, feats
+    return out_ents, feats
 
 
 def _assemble_fp_texts(existing, ex_keys, new_ents, new_fps, fp_index):

--- a/packages/python/goldengraph/tests/test_literal_attributes.py
+++ b/packages/python/goldengraph/tests/test_literal_attributes.py
@@ -107,6 +107,52 @@ def test_build_batch_drops_attribute_with_unresolved_owner():
     assert not [e for e in batch["entities"] if e["typ"] == "literal"]
 
 
+class _FakeGraph:
+    def __init__(self, ents):
+        self._ents = ents
+
+    def entities(self):
+        return self._ents
+
+
+def test_seed_by_query_excludes_literal_and_empty_names():
+    """Regression: a literal value node (or an empty name) must NOT enter the
+    embedding batch -- a raw value can be an empty/invalid input that 400s the whole
+    provider request. Literals are reached by BFS from a seed, never seeded on."""
+    from goldengraph.embed import seed_by_query
+
+    embedded: dict = {}
+
+    class _Emb:
+        def embed(self, texts):
+            import numpy as np
+
+            embedded["texts"] = list(texts)
+            # deterministic: first token-char ordinal, enough to rank
+            return np.asarray([[float(len(t))] for t in texts], dtype=float)
+
+    graph = _FakeGraph([
+        {"entity_id": 1, "canonical_name": "Sega Genesis", "typ": "console"},
+        {"entity_id": 2, "canonical_name": "May 1990", "typ": "literal"},  # excluded
+        {"entity_id": 3, "canonical_name": "   ", "typ": "console"},  # empty -> excluded
+    ])
+    seeds = seed_by_query(graph, "when released?", _Emb(), k=5)
+    # only the real, non-empty entity is embedded (plus the query) and seedable
+    assert embedded["texts"] == ["when released?", "Sega Genesis"]
+    assert seeds == [1]
+
+
+def test_seed_by_query_empty_graph_returns_empty():
+    from goldengraph.embed import seed_by_query
+
+    class _Emb:
+        def embed(self, texts):  # pragma: no cover - must not be called
+            raise AssertionError("should not embed an all-literal/empty graph")
+
+    graph = _FakeGraph([{"entity_id": 1, "canonical_name": "May 1990", "typ": "literal"}])
+    assert seed_by_query(graph, "q", _Emb()) == []
+
+
 def test_literal_nodes_excluded_from_cross_doc_link_candidates():
     ingest = importlib.import_module("goldengraph.ingest")
 

--- a/packages/python/goldengraph/tests/test_literal_attributes.py
+++ b/packages/python/goldengraph/tests/test_literal_attributes.py
@@ -1,0 +1,124 @@
+"""Literal-attribute extraction -> reachable value nodes (GOLDENGRAPH_LITERAL_ATTRS).
+
+Targets the dominant MuSiQue EXTRACTION miss: non-entity answers (dates, quantities,
+short defining values) that the entity->entity schema can't represent, so they never
+enter the graph. With the flag on, the extractor emits `attributes` and `build_batch`
+materializes each as a literal NODE + an edge from its owner, making the value a
+reachable, answerable graph node. All offline (no LLM, no native store)."""
+from __future__ import annotations
+
+import importlib
+
+from goldengraph import ResolvedEntity, build_batch
+from goldengraph.extract import Attribute, Extraction, Mention, Relationship, parse_extraction
+
+_ex = importlib.import_module("goldengraph.extract")
+
+
+def test_parse_extraction_reads_attributes():
+    raw = (
+        '{"entities":[{"name":"Sega Genesis","type":"console"}],'
+        '"relationships":[],'
+        '"attributes":['
+        '{"subj":0,"key":"release date","value":"May 1990"},'
+        '{"subj":0,"key":"blank","value":"  "},'  # empty value -> dropped
+        '{"subj":7,"key":"oob","value":"x"}]}'  # out-of-range owner -> dropped
+    )
+    e = parse_extraction(raw)
+    assert [(a.subj, a.key, a.value) for a in e.attributes] == [(0, "release date", "May 1990")]
+
+
+def test_parse_extraction_backward_compatible_without_attributes():
+    e = parse_extraction('{"entities":[{"name":"A","type":"t"}],"relationships":[]}')
+    assert e.attributes == []
+
+
+def test_extract_prompt_includes_attribute_schema_only_when_enabled(monkeypatch):
+    captured = {}
+
+    class _LLM:
+        def complete(self, prompt):
+            captured["p"] = prompt
+            return '{"entities":[],"relationships":[],"attributes":[]}'
+
+    monkeypatch.setenv("GOLDENGRAPH_LITERAL_ATTRS", "1")
+    _ex.extract("DOC", _LLM())
+    assert "attributes" in captured["p"] and captured["p"].count("DOC") == 1
+
+    monkeypatch.delenv("GOLDENGRAPH_LITERAL_ATTRS", raising=False)
+    _ex.extract("DOC", _LLM())
+    assert "attributes" not in captured["p"]
+
+
+def test_build_batch_materializes_literal_node_and_edge():
+    ex = Extraction(
+        mentions=[Mention("Sega Genesis", "console")],
+        relationships=[],
+        attributes=[Attribute(subj=0, key="release date", value="May 1990")],
+    )
+    ents = [ResolvedEntity(0, "Sega Genesis", "console", ["Sega Genesis"], ["k0"], [0])]
+    batch = build_batch(ex, ents, at=5)
+    # one entity node + one literal node
+    lits = [e for e in batch["entities"] if e["typ"] == "literal"]
+    assert len(lits) == 1
+    lit = lits[0]
+    assert lit["canonical_name"] == "May 1990"
+    # unique per-occurrence record key (no cross-doc overlap-merge)
+    assert lit["record_keys"] == [f"lit:5:{lit['local_id']}"]
+    # an edge from the owning entity to the literal, predicate = the attribute key
+    assert {
+        "subj_local": 0,
+        "predicate": "release date",
+        "obj_local": lit["local_id"],
+        "valid_from": 5,
+        "valid_to": None,
+        "source_refs": [],
+    } in batch["edges"]
+
+
+def test_build_batch_dedups_repeated_attribute_but_not_distinct():
+    ex = Extraction(
+        mentions=[Mention("X", "t")],
+        relationships=[],
+        attributes=[
+            Attribute(0, "date", "May 1990"),
+            Attribute(0, "date", "may 1990"),  # case-insensitive dup -> one node
+            Attribute(0, "cost", "$5"),  # distinct -> its own node
+        ],
+    )
+    ents = [ResolvedEntity(0, "X", "t", ["X"], ["k0"], [0])]
+    batch = build_batch(ex, ents, at=1)
+    lits = sorted(e["canonical_name"] for e in batch["entities"] if e["typ"] == "literal")
+    assert lits == ["$5", "May 1990"]
+    assert sum(1 for e in batch["edges"] if e["obj_local"] != 0 or True) >= 0  # sanity
+    lit_edges = [e for e in batch["edges"] if e["predicate"] in ("date", "cost")]
+    assert len(lit_edges) == 3  # both 'date' attrs edge to the SAME node, 'cost' to its own
+
+
+def test_build_batch_drops_attribute_with_unresolved_owner():
+    # owner mention 1 isn't covered by any resolved entity -> attribute dropped
+    ex = Extraction(
+        mentions=[Mention("X", "t"), Mention("Y", "t")],
+        relationships=[],
+        attributes=[Attribute(subj=1, key="k", value="v")],
+    )
+    ents = [ResolvedEntity(0, "X", "t", ["X"], ["k0"], [0])]  # only mention 0 resolved
+    batch = build_batch(ex, ents, at=1)
+    assert not [e for e in batch["entities"] if e["typ"] == "literal"]
+
+
+def test_literal_nodes_excluded_from_cross_doc_link_candidates():
+    ingest = importlib.import_module("goldengraph.ingest")
+
+    ex = Extraction(
+        mentions=[Mention("X", "t")],
+        relationships=[],
+        attributes=[Attribute(0, "date", "May 1990")],
+    )
+    ents = [ResolvedEntity(0, "X", "t", ["X"], ["k0"], [0])]
+    batch = build_batch(ex, ents, at=1)
+    new_ents, feats = ingest._new_features(batch)
+    # the literal node is in the batch but NOT a link candidate
+    assert any(e["typ"] == "literal" for e in batch["entities"])
+    assert all(e.get("typ") != "literal" for e in new_ents)
+    assert len(new_ents) == len(feats) == 1


### PR DESCRIPTION
## Why

The measurement loop localized goldengraph's **dominant** loss as EXTRACTION (~22/50 MuSiQue questions), and the gold answer-type mix is `{entity:30, phrase:9, number:7, date:4}` — **40% of golds are non-entity** (dates/quantities/phrases) the entity→entity schema can't represent, so they never enter the graph and are unanswerable by construction. The cross-doc shatter (#1249) was only ~16% of losses and didn't move the headline; this targets the biggest bucket.

## What (opt-in `GOLDENGRAPH_LITERAL_ATTRS=1`; byte-identical default-off)

- **`extract.py`**: splice an `attributes` schema into the extraction prompt so the LLM also emits literal facts `(entity, key, value)` — a date, quantity, or short defining value that answers "when/how many/how much/what kind" but isn't a named entity. New `Attribute` dataclass + `Extraction.attributes` (default empty → back-compat). Flag read *inside* `extract()` so monkeypatched 2-arg stubs keep working (#1236 lesson). Defensive parse drops empty values + out-of-range owners.
- **`ingest.py::build_batch`**: materialize each attribute as a literal **node** (`canonical_name=value`, `typ="literal"`) + an edge `owner -[key]-> value`. The synthesis prompt already permits answering with *any* node in the Entities list, so a materialized literal is an eligible, reachable answer. Dedups repeated `(owner,key,value)` within a doc.
- **Precision guard**: literal nodes get **unique per-occurrence record keys** (`lit:<at>:<id>`) **and** are excluded from cross-doc link candidates (`_new_features`/`_existing_features` skip `typ="literal"`), so two identical values in different docs never overlap-merge into a false bridge — they stay leaves owned by their own entity.
- **workflow**: a `literal_attrs` input → `GOLDENGRAPH_LITERAL_ATTRS` env.

7 offline tests (parse + back-compat, prompt-splice gating, node+edge materialization, dedup, unresolved-owner drop, link-candidate exclusion). Full goldengraph offline suite green.

## Status — capability to MEASURE, not a declared win
A traced N=50 MuSiQue run with the flag is dispatched. The bar: the EXTRACTION stage count drops and `answer_match` (especially on the date/number golds) rises, **without** a precision regression. I'll post the before/after here before marking ready — same honest loop as #1249, where I refused to ship a flat result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_