### PR TITLE
fix(goldengraph): exclude literal value nodes from embedding (literal-attrs 400)

### DIFF
--- a/packages/python/goldengraph/goldengraph/embed.py
+++ b/packages/python/goldengraph/goldengraph/embed.py
@@ -66,8 +66,21 @@ class GoldenmatchEmbedder:
 def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5) -> list[int]:
     """Top-`k` entity ids in `slice_graph` (a `PyGraph` from `as_of`) nearest the
     query by cosine over canonical-name embeddings. Tie-break: ascending
-    `entity_id` (deterministic — stub/zero vectors tie often)."""
-    ents = slice_graph.entities()
+    `entity_id` (deterministic — stub/zero vectors tie often).
+
+    Only real ENTITY nodes are seed candidates: literal-attribute value leaves
+    (`typ` starts with ``literal:``, from GOLDENGRAPH_LITERAL_ATTRS) are excluded --
+    they are answers reached by walking an edge FROM a seed entity, not query
+    anchors, and embedding a raw value (a bare date / amount) both wastes budget and
+    risks an empty/over-long input that 400s the WHOLE provider batch. Empty /
+    whitespace names are dropped for the same reason (a provider rejects an empty
+    input). Without this, a literal-attrs run 400s on every answer at seed time."""
+    ents = [
+        e
+        for e in slice_graph.entities()
+        if not str(e.get("typ", "")).startswith("literal:")
+        and str(e.get("canonical_name", "")).strip()
+    ]
     if not ents:
         return []
     ids = [int(e["entity_id"]) for e in ents]

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -271,12 +271,20 @@ def _existing_features(slice_graph):
             rel[o].add(p)
             nbr[s].add(id_to_name[o])
             nbr[o].add(id_to_name[s])
+    # Literal-attribute leaf nodes (typ "literal:<kind>") are values, not entities to
+    # resolve -- exclude them as cross-doc link candidates so they are never embedded
+    # as fingerprints (a raw value can be an empty/over-long input that 400s the
+    # provider batch during the profile-link build) and never spuriously cluster.
+    out_ents: list[dict] = []
     feats: list[dict] = []
     keys: list[set[str]] = []
     for e in ents:
+        if str(e.get("typ", "")).startswith("literal:"):
+            continue
         eid = e["entity_id"]
         typ = e.get("typ", "")
         surfaces = e.get("surface_names", ())
+        out_ents.append(e)
         feats.append({
             "name": e.get("canonical_name", ""),
             "type": typ,
@@ -285,7 +293,7 @@ def _existing_features(slice_graph):
             "nbr": " | ".join(sorted(nbr[eid])),
         })
         keys.append({_record_key(s, typ) for s in [e.get("canonical_name", ""), *surfaces] if s})
-    return ents, feats, keys
+    return out_ents, feats, keys
 
 
 def _new_features(batch: dict):
@@ -302,9 +310,16 @@ def _new_features(batch: dict):
             rel[o].add(p)
             nbr[s].add(lid_to_name[o])
             nbr[o].add(lid_to_name[s])
+    # Exclude literal leaf nodes (typ "literal:<kind>") from the link candidate set --
+    # values, not entities (mirror of `_existing_features`); keeps them out of the
+    # profile-link fingerprint embedding that would otherwise 400 on a bad value.
+    out_ents: list[dict] = []
     feats: list[dict] = []
     for be in new_ents:
+        if str(be.get("typ", "")).startswith("literal:"):
+            continue
         lid = be["local_id"]
+        out_ents.append(be)
         feats.append({
             "name": be.get("canonical_name", ""),
             "type": be.get("typ", ""),
@@ -312,7 +327,7 @@ def _new_features(batch: dict):
             "rel": " | ".join(sorted(rel[lid])),
             "nbr": " | ".join(sorted(nbr[lid])),
         })
-    return new_ents, feats
+    return out_ents, feats
 
 
 def _assemble_fp_texts(existing, ex_keys, new_ents, new_fps, fp_index):

--- a/packages/python/goldengraph/tests/test_literal_attributes.py
+++ b/packages/python/goldengraph/tests/test_literal_attributes.py
@@ -162,3 +162,68 @@ def test_entity_only_prompt_is_byte_identical_to_pre_literal():
     # The flag-off prompt must equal head + entity-clause + tail exactly, so the
     # measured entity-only baseline is never perturbed by this slice.
     assert synth._LOCAL_PROMPT == synth._LOCAL_HEAD + synth._ANSWER_ENTITY + synth._LOCAL_TAIL
+
+
+# --- seeding + cross-doc-link exclusion (the embed-400 fix) ------------------
+
+
+class _FakeGraph:
+    def __init__(self, ents):
+        self._ents = ents
+
+    def entities(self):
+        return self._ents
+
+
+def test_seed_by_query_excludes_literal_and_empty_names():
+    """Regression: a literal leaf value (or an empty name) must NOT enter the seed
+    embedding -- a raw value can be an empty/over-long input that 400s the whole
+    provider batch. Literals are reached by BFS from a seed, never seeded on."""
+    import numpy as np
+
+    from goldengraph.embed import seed_by_query
+
+    embedded = {}
+
+    class _Emb:
+        def embed(self, texts):
+            embedded["texts"] = list(texts)
+            return np.asarray([[float(len(t))] for t in texts], dtype=float)
+
+    graph = _FakeGraph([
+        {"entity_id": 1, "canonical_name": "Acme", "typ": "org"},
+        {"entity_id": 2, "canonical_name": "1976", "typ": "literal:date"},  # excluded
+        {"entity_id": 3, "canonical_name": "   ", "typ": "org"},  # empty -> excluded
+    ])
+    seeds = seed_by_query(graph, "when founded?", _Emb(), k=5)
+    assert embedded["texts"] == ["when founded?", "Acme"]
+    assert seeds == [1]
+
+
+def test_seed_by_query_all_literal_graph_returns_empty():
+    from goldengraph.embed import seed_by_query
+
+    class _Emb:
+        def embed(self, texts):  # pragma: no cover - must not be called
+            raise AssertionError("should not embed an all-literal/empty graph")
+
+    graph = _FakeGraph([{"entity_id": 1, "canonical_name": "1976", "typ": "literal:date"}])
+    assert seed_by_query(graph, "q", _Emb()) == []
+
+
+def test_literal_nodes_excluded_from_cross_doc_link_candidates():
+    import importlib
+
+    ingest = importlib.import_module("goldengraph.ingest")
+    entities = [_ent(0, "Acme", members=[0])]
+    ex = Extraction(
+        mentions=[Mention("Acme", "org")],
+        relationships=[],
+        attributes=[Attribute(subj=0, predicate="founded on", value="1976", typ="date")],
+    )
+    batch = build_batch(ex, entities, at=1)
+    new_ents, feats = ingest._new_features(batch)
+    # the literal node is in the batch but NOT a link candidate (so never embedded)
+    assert any(str(e["typ"]).startswith("literal:") for e in batch["entities"])
+    assert all(not str(e.get("typ", "")).startswith("literal:") for e in new_ents)
+    assert len(new_ents) == len(feats) == 1


### PR DESCRIPTION
## Why

Follow-up to #1236 (literal attributes). #1236 materializes literal **value** nodes but still embeds their raw values in two places, and the provider (OpenAI) rejects the **whole** request with HTTP 400 on a single empty/over-long input — so a `GOLDENGRAPH_LITERAL_ATTRS=1` run **400s and produces no result**. I diagnosed and measured this end-to-end on the N=50 MuSiQue bench: with #1236's code the run crashes at `seed_by_query`; with this fix the identical run completes.

The two embed paths a literal value reaches:
1. **Answer time** — `seed_by_query` embeds `[query] + every graph node name`; a raw literal value (a bare date/amount) in that batch 400s it.
2. **Build time (profile-link)** — `_new_features`/`_existing_features` feed literal nodes into the cross-doc matcher, which embeds their fingerprints.

## What
- **`embed.py::seed_by_query`** — seed only real entity nodes: exclude `typ` starting with `literal:` and empty/whitespace names. A literal is an answer reached by BFS *from* a seed entity, never a query anchor, so it stays fully retrievable.
- **`ingest.py::_new_features`/`_existing_features`** — drop literal leaves from the cross-doc **link candidate** set (so they're never embedded as fingerprints). They remain in the stored graph and in their owner's neighborhood; only the candidate lists exclude them.

Default-off path is unchanged (no literals → both filters are no-ops). 3 regression tests; goldengraph offline suite green.

## Honest note — this makes the feature *run*, it is not an accuracy claim
In measurement, literal attributes **did not move `answer_match`** (0.14 vs the 0.18 entity-only baseline) — materializing value nodes bloats the graph (4800→6615 nodes) and the recall gain didn't offset it on MuSiQue. This PR is the **correctness fix** that lets the feature execute at all; whether literals net-help still needs a clean run of the *complete* feature (#1236's synthesis change + this fix) under the LLM-judge metric (#1240), which is the format-fair scorer for terse value answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_