### PR TITLE
release: coordinated suite version bumps (6 packages)

### DIFF
--- a/packages/python/goldenanalysis/CHANGELOG.md
+++ b/packages/python/goldenanalysis/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to GoldenAnalysis are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.3.0] - 2026-06-24
+
+The Rust accelerator goes live and GoldenAnalysis becomes an MCP server. (First published release since 0.1.0 — the 0.2.0 section below was staged but never tagged/published; its features ship here.)
+
+### Added
+- **MCP server** (`goldenanalysis[mcp]`) — exposes the analysis surface over the Model Context Protocol, surfaced through `goldensuite-mcp` alongside the other suite servers. Streamable-HTTP deploy scaffold (`Dockerfile.mcp` + `railway.json`, port 8300) for hosting it as a Smithery remote. (#817, #1068)
+- **Rust accelerator** (`goldenanalysis[native]`) — `analysis-core` / `analysis-native` crates, parity-proven against the pure-Python/Polars reference, behind the `GOLDENANALYSIS_NATIVE` loader gate. (#816)
+
+### Changed
+- **`histogram` and `quantile` now dispatch to the native kernel** when the accelerator is installed (gate default `auto`). Measured 5.8–9.9× faster than pure Python on Linux, including Arrow conversion; byte-identical output. Set `GOLDENANALYSIS_NATIVE=0` to force the pure-Python path. (#822)
+
 ## [0.2.0] - 2026-06-17
 
 Phase 2a — suite consumption. Produce an `AnalysisReport` from real suite outputs.

--- a/packages/python/goldenanalysis/goldenanalysis/__init__.py
+++ b/packages/python/goldenanalysis/goldenanalysis/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "analyze",

--- a/packages/python/goldenanalysis/pyproject.toml
+++ b/packages/python/goldenanalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldenanalysis"
-version = "0.2.0"
+version = "0.3.0"
 description = "Read-only cross-cutting analysis, metrics, and reporting engine for the Golden Suite"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/python/goldenanalysis/server.json
+++ b/packages/python/goldenanalysis/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenAnalysis",
   "description": "Read-only cross-cutting analysis, metrics, and reporting across the Golden Suite.",
   "websiteUrl": "https://github.com/benseverndev-oss/goldenmatch/tree/main/packages/python/goldenanalysis#readme",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenanalysis",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenanalysis/tests/test_smoke.py
+++ b/packages/python/goldenanalysis/tests/test_smoke.py
@@ -6,4 +6,4 @@ from __future__ import annotations
 def test_import_and_version() -> None:
     import goldenanalysis
 
-    assert goldenanalysis.__version__ == "0.2.0"
+    assert goldenanalysis.__version__ == "0.3.0"

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [1.4.0] - 2026-06-24
+
+### Added
+- **Native acceleration runtime** — optional Rust/Arrow kernels for the CPU-bound deep-profiling work (Benford, composite-key, functional-dependency mining). `pip install goldencheck[native]`; goldencheck stays pure-Python and falls back automatically when the kernel isn't installed. (#793)
+- **Deep-profiling expansion** — new profilers and relation checks: data freshness, fuzzy/near-duplicate values, referential integrity, approximate duplicates, approximate functional dependencies, and composite-key discovery. (#793)
+- **`functional_dependencies(df, ...)`** top-level export — FD-driven negative evidence (surfaces records that violate a discovered functional dependency). (#797)
+- **`cell_quality(...)`** top-level export — per-cell quality scoring for quality-weighted survivorship (wires GoldenCheck signals into GoldenMatch golden-record selection). (#794)
+
+### Changed
+- **Fixer perf** — vectorized the per-cell safe fixes behind a guard; large frames apply the safe fixer significantly faster with identical output. (#843)
+
+### Security
+- Bumped `aiohttp`/`starlette` floors to close known advisories. (#738)
+
 ## [1.3.0] - 2026-06-01
 
 ### Added

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "1.3.0"
+version = "1.4.0"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.3.0 (2026-06-24)
+
+New pure-scalar canonicalizers for clean-room match keys, an opt-in Arrow-native date/phone acceleration runtime, and expanded carceral domain coverage. No breaking changes; existing transform outputs are unchanged.
+
+### Added
+
+- `goldenflow.canonicalize(value, kind)` — pure, scalar, stdlib-only field canonicalizers for `email`, `phone`, `name`, and `postal`. Total, idempotent, and locale-independent (ASCII-only case folding) so they reproduce byte-for-byte in a browser JS/TS port. Built for PPRL / clean-room two-party CLK linkage, where server-Python and browser-JS must agree on the exact canonical string before hashing. Exported from the package root. (#1183, closes #1128)
+- Optional `goldenflow[native]` extra: a Rust/PyO3 acceleration runtime (`goldenflow-native`) with vectorized Arrow-native date and phone kernels. Off by default at runtime, NANP-gated, and output-preserving; the pure-Python path stays the default fallback. (#796)
+- `carceral` domain: state-prison aliases for PA and CA. (#1010)
+
+### Changed
+
+- Vectorized fast paths for the `date_iso8601` and phone transforms, dispatched to the native kernel when `goldenflow[native]` is installed and enabled. Outputs are unchanged from the pure-Python path. (#796)
+
+### Fixed
+
+- `carceral` domain: corrected the Texas (TX) facility prefix. (#1010)
+
 ## 1.2.0 (2026-06-01)
 
 New `carceral` domain pack plus a native-Polars (expr-mode) perf migration of the

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.2.0"
+version = "1.3.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/CHANGELOG.md
+++ b/packages/python/goldenpipe/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.3.0 (2026-06-24)
+
+**Analysis reporting + a live TUI.** GoldenPipe gains an optional terminal reporting stage so one chain runs `Check -> Flow -> Match -> Identity -> Analysis`, and the 4-tab TUI is now wired to the real pipeline.
+
+### Added
+
+- **New stage `goldenanalysis.report`** registered at the `goldenpipe.stages` entry-point. Read-only terminal stage that runs `goldenanalysis` over the run's accumulated artifacts (`clusters`, `scored_pairs`, `match_stats`, `findings`, `manifest`, `identity_summary`) and attaches an `analysis_report` artifact. Writes only that one artifact and never mutates the data or any store; only `df` is hard-required, so it works on any pipeline and degrades to whatever artifacts are present. A reporting failure is logged and returns `FAILED` for the stage; it never breaks the run. (#819)
+- **New extras**: `goldenpipe[analysis]` (pulls `goldenanalysis>=0.1.0`); `goldenpipe[golden-suite]` now includes `goldenanalysis>=0.1.0` so the full-suite extra installs the reporting stage.
+- **`goldenpipe interactive` now accepts an optional `SOURCE` data file** and `-c/--config` YAML config (was no-arg). The TUI loads the source and runs it through `goldenpipe.run` on `r`. (#776)
+
+### Changed
+
+- **The 4-tab TUI is wired to the real pipeline.** Pressing `r` runs the loaded source in a worker thread and populates all four tabs from the `PipeResult` (Pipeline status + timing, Config, Results artifacts, Log). Previously the tabs were empty placeholders. (#776)
+
+### Fixed
+
+- The FastAPI app and `/health` endpoint now report the real package version (`goldenpipe.__version__`) instead of a hardcoded `1.0.0`. (#903)
+
 ## 1.2.1 (2026-06-01)
 
 ### Fixed

--- a/packages/python/goldenpipe/goldenpipe/__init__.py
+++ b/packages/python/goldenpipe/goldenpipe/__init__.py
@@ -1,5 +1,5 @@
 """GoldenPipe -- pluggable pipeline framework for data quality."""
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 
 from goldenpipe._api import run, run_df, run_stages
 from goldenpipe.config.loader import load_config

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldenpipe"
-version = "1.2.1"
+version = "1.3.0"
 description = "Pluggable pipeline framework for data quality workflows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/python/goldenpipe/server.json
+++ b/packages/python/goldenpipe/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenPipe",
   "description": "One command to validate, transform, and deduplicate — chain GoldenCheck + Flow + Match.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenpipe/",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenpipe",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenpipe",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/tests/test_pipeline.py
+++ b/packages/python/goldenpipe/tests/test_pipeline.py
@@ -56,4 +56,4 @@ class TestImports:
         assert hasattr(gp, "PipeResult")
         assert hasattr(gp, "stage")
         assert hasattr(gp, "__version__")
-        assert gp.__version__ == "1.2.1"
+        assert gp.__version__ == "1.3.0"

--- a/packages/python/goldensuite-mcp/CHANGELOG.md
+++ b/packages/python/goldensuite-mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.0 (2026-06-24)
+
+### Added
+
+- **goldenanalysis tool surface** — the aggregator now surfaces a sixth sub-package, `goldenanalysis`. Its MCP tools (`list_analyzers`, `analyze_frame`, `get_trend`, `detect_regressions`) flow through transitively via `goldenanalysis.mcp.server.TOOLS`/`HANDLERS`, registered last in `_SUITE_ORDER` so existing tools keep first-wins precedence on name collisions. (#817)
+
+### Changed
+
+- **Security/hardening** — bumped the `starlette` pin and closed CodeQL findings as part of the suite-wide workflow hardening. (#738)
+
 ## 0.2.0 (2026-05-13)
 
 First real release. The aggregator package was scaffolded as `0.1.0` but

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
@@ -12,5 +12,5 @@ are logged at startup so deployers know which tool was shadowed.
 """
 from goldensuite_mcp.server import create_server
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = ["create_server", "__version__"]

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldensuite-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "One MCP server exposing every Golden Suite tool — goldenmatch, goldencheck, goldenflow, goldenpipe, infermap"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/packages/python/infermap/CHANGELOG.md
+++ b/packages/python/infermap/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-06-24
+
+### Security
+- **SQL-injection hardening in `DBProvider`** (#898). Table names are now escaped as quoted SQL identifiers (`_quote_ident`, doubling embedded quotes) at every interpolation site across the SQLite, Postgres, and DuckDB paths, since bound parameters can only bind values, not identifiers. `extract()` now rejects a non-string `table` and coerces `sample_size` to `int` before it can reach a query. SQLite column introspection moved from `PRAGMA table_info(<ident>)` to the parameterized `pragma_table_info(?)` table-valued function. `sample_size` is bound as a parameter on SQLite/Postgres (int-coerced inline only on DuckDB's `USING SAMPLE`).
+
+### Changed
+- Node runtime baseline bumped from 20 to 22 (Node 20 EOL) across the JS publish/CI workflows. (#898)
+- Dependency bumps: `esbuild` 0.27.7 → 0.28.1, `@babel/core` 7.29.0 → 7.29.6 (#1162); TS bench-runner `vitest` 1.6 → 4.1 (#761).
+
 ## [0.5.0] - 2026-06-01
 
 ### Added

--- a/packages/python/infermap/infermap/__init__.py
+++ b/packages/python/infermap/infermap/__init__.py
@@ -1,6 +1,6 @@
 """infermap — inference-driven schema mapping engine."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from infermap.config import from_config
 from infermap.detect import detect_domain, detect_domain_detailed

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infermap"
-version = "0.5.0"
+version = "0.5.1"
 description = "Inference-driven schema mapping engine"
 readme = "README.md"
 license = "MIT"

--- a/packages/python/infermap/server.json
+++ b/packages/python/infermap/server.json
@@ -4,7 +4,7 @@
   "title": "InferMap",
   "description": "Map messy columns to a known schema — 7 scorers, domain dictionaries, F1 0.84. Zero config.",
   "websiteUrl": "https://benseverndev-oss.github.io/infermap/",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/infermap",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "infermap",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Coordinated suite release — reconciling release drift

Six packages had **merged-but-unlogged work** since their last release tags (empty `[Unreleased]` sections while features shipped to `main`). This audits each package's commits-since-tag, authors the CHANGELOG sections, and bumps the version-lockstep files (`pyproject.toml` / `<pkg>/__init__.py` / `server.json`).

| package | bump | headline |
|---|---|---|
| **goldencheck** | 1.3.0 → 1.4.0 | native accel runtime, `functional_dependencies`, `cell_quality`, fixer perf, sec floors |
| **goldenflow** | 1.2.0 → 1.3.0 | `canonicalize()` API (#1183), Arrow-native date/phone kernels, carceral aliases |
| **goldenanalysis** | 0.2.0 → 0.3.0 | native histogram/quantile gate-flip (5.8–9.9×), MCP server — *first real publish since 0.1.0* |
| **goldenpipe** | 1.2.1 → 1.3.0 | `goldenanalysis.report` stage, live TUI, version-derivation fix |
| **goldensuite-mcp** | 0.2.0 → 0.3.0 | goldenanalysis as 6th aggregated tool surface |
| **infermap** | 0.5.0 → 0.5.1 | SQL-injection hardening (#898), Node 22 — patch |

### Notes
- **goldenanalysis 0.2.0 was staged but never published** (no tag, no PyPI — the release was "the one remaining human step" that never happened, and its `[0.2.0]` changelog was missing #816/#817/#822). It ships **0.3.0** here, folding the undocumented native gate-flip + MCP server in. Version smoke tests updated (`test_smoke.py`, `test_pipeline.py`).
- **goldenmatch 2.3.0** (its `[Unreleased]` queue + the routing lever #1254) is **not** in this PR — it folds in separately once #1254 merges.

### Gates
`check_version_consistency.py` → **OK, 18 packages in lockstep**. `check_docs_consistency.py` → CHANGELOG↔version + callouts + nav all **PASS** (the lone orphan-detection FAIL is a Windows path-separator false positive; green on Linux CI).

### Next (post-merge, separate step)
Once this merges + #1254 lands, I'll cut the 7 git tags / GitHub releases that trigger the per-package PyPI publishes — that irreversible step is gated on an explicit go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
