### PR TITLE
docs: refresh package READMEs after the 7-package release

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ flowchart LR
 - **Learning Memory** — corrections persist across runs and re-anchor across row reorders, so the system stops needing the same correction twice (GoldenMatch v1.6.0; off by default).
 - **Identity Graph** — a durable graph layer above run-local clusters: stable `entity_id`s that survive across runs, an append-only event log, and create / absorb / merge / split semantics, surfaced on the CLI, REST, MCP, and SQL interfaces (the Identity Graph v2 feature, shipped in GoldenMatch v1.15).
 - **Privacy-preserving record linkage** — match across organizations without sharing raw data (PPRL, 92.4% F1 on FEBRL4).
-- **AI-native by design** — every package ships an MCP server, a REST API, and an A2A agent surface. 50+ MCP tools across the suite, including `auto_configure` + `controller_telemetry` for v1.7-v1.12 introspection.
+- **AI-native by design** — every package ships an MCP server, a REST API, and an A2A agent surface. 70+ MCP tools across the suite, including `auto_configure` + `controller_telemetry` for auto-config introspection.
 - **AutoConfigController visible everywhere** (v1.7-v1.12 surface-parity arc) — web `ControllerPanel`, TUI `Ctrl+A`, CLI `goldenmatch autoconfig`, REST `/autoconfig` + `/controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDFs, MCP/A2A telemetry tools. One JSON shape across every interface.
 - **Polyglot parity** — the full suite ships on **npm** (goldenmatch, goldencheck, goldenflow, goldenanalysis, infermap, goldenpipe) alongside PyPI; the TypeScript and Python implementations track the same outputs to 4-decimal precision via a cross-language parity harness.
 - **Edge-safe, with optional native speed** — the TypeScript cores are dependency-free and `node:*`-free, so they run in browsers, Cloudflare Workers, Vercel Edge, and Deno. An **opt-in WebAssembly backend** (`await enableWasm()` / `enableAnalysisWasm()`) swaps in the *same* pyo3-free Rust kernels the Python wheels and the SQL UDFs use — pure-TS stays the default and the byte-identical fallback, so default users download zero wasm bytes.
@@ -115,7 +115,7 @@ flowchart LR
 | **[GoldenMatch](packages/python/goldenmatch/README.md)** 🟡 | Python · TS | Zero-config entity resolution. Fuzzy + exact + probabilistic + LLM. Headline package. | `pip install goldenmatch` · `npm i goldenmatch` |
 | **[GoldenCheck](packages/python/goldencheck/README.md)** | Python · TS | Data-quality scanning: encoding, Unicode, format validation, anomaly detection. | `pip install goldencheck` · `npm i goldencheck` |
 | **[GoldenFlow](packages/python/goldenflow/README.md)** | Python · TS | Transforms & standardizers: phone, date, address, categorical normalization. | `pip install goldenflow` · `npm i goldenflow` |
-| **[GoldenPipe](packages/python/goldenpipe/README.md)** | Python · TS | Orchestrator that wires Check → Flow → Match into one declarative pipeline. | `pip install goldenpipe` · `npm i goldenpipe` |
+| **[GoldenPipe](packages/python/goldenpipe/README.md)** | Python · TS | Orchestrator that wires Check → Flow → Match → Identity → Analysis into one declarative pipeline. | `pip install goldenpipe` · `npm i goldenpipe` |
 | **[InferMap](packages/python/infermap/README.md)** | Python · TS | Schema mapping engine — auto-aligns columns across heterogeneous sources. | `pip install infermap` · `npm i infermap` |
 | **[GoldenAnalysis](packages/python/goldenanalysis/README.md)** | Python · TS | Cross-cutting analysis & reporting — consumes any stage's typed artifacts (or a raw DataFrame) and emits a unified, exportable `AnalysisReport`; optional Rust / WASM `histogram`+`quantile` kernels. | `pip install goldenanalysis` · `npm i goldenanalysis` |
 | **[goldenmatch-extensions](packages/rust/extensions/README.md)** | Rust | Postgres extension (pgrx) + DuckDB UDFs. SQL-native fuzzy matching. | source build |
@@ -277,7 +277,7 @@ GoldenMatch is hosted as an MCP server on [Smithery](https://smithery.ai/servers
 }
 ```
 
-50+ MCP tools across the suite: deduplicate, match, explain, review, link privately, configure, scan quality, transform, synthesize golden records, and manage Learning Memory corrections.
+70+ MCP tools across the suite: deduplicate, match, explain, review, link privately, configure, scan quality, transform, synthesize golden records, analyze trends and regressions, and manage Learning Memory corrections.
 
 ---
 

--- a/packages/python/goldencheck/README.md
+++ b/packages/python/goldencheck/README.md
@@ -546,7 +546,9 @@ Add to your Claude Desktop config (`claude_desktop_config.json`):
 }
 ```
 
-**Available tools:**
+**Available tools (19 total):**
+
+9 core tools:
 
 | Tool | Description |
 |------|-------------|
@@ -556,6 +558,13 @@ Add to your Claude Desktop config (`claude_desktop_config.json`):
 | `health_score` | Quick A-F grade for a data file |
 | `get_column_detail` | Deep-dive into a specific column |
 | `list_checks` | List all available profiler checks |
+| `list_domains` | List installed domain rule packs |
+| `get_domain_info` | Inspect a domain rule pack |
+| `install_domain` | Install a domain rule pack |
+
+Plus 10 agent tools for AI-driven workflows: `analyze_data`, `auto_configure`,
+`explain_finding`, `explain_column`, `review_queue`, `approve_reject`,
+`compare_domains`, `suggest_fix`, `pipeline_handoff`, `review_stats`.
 
 ## Remote MCP Server
 

--- a/packages/python/goldenflow/README.md
+++ b/packages/python/goldenflow/README.md
@@ -139,7 +139,7 @@ The manifest is an audit trail — what changed, why, and which rows were affect
 
 ## CLI Commands
 
-GoldenFlow has 14 commands. The most common ones:
+GoldenFlow has 16 commands. The most common ones:
 
 ```bash
 # Core transforms
@@ -563,7 +563,7 @@ result.manifest  # renders transform audit trail
 
 ## TypeScript / JavaScript
 
-GoldenFlow has a full TypeScript port with feature parity — same 83 transforms, same engine, same config format. The core is **edge-safe** (runs in browsers, Cloudflare Workers, Vercel Edge) with a Node layer for file I/O and CLI.
+GoldenFlow has a full TypeScript port with feature parity — same 76 transforms, same engine, same config format. The core is **edge-safe** (runs in browsers, Cloudflare Workers, Vercel Edge) with a Node layer for file I/O and CLI.
 
 ### Install
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -70,10 +70,13 @@ npm install goldenmatch
 - **96.4% F1 zero-config** on DBLP-ACM (hand-tuned ceiling: 91.8%). [DQBench ER score: 62.87 no-LLM](https://github.com/benseverndev-oss/dqbench)
 - **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
-- **59 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
+- **68 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
 
-### What's new in v1.17
+### Auto-config & scale safeguards
+
+(Recent release highlights are in the **What's new** callout at the top; this
+section documents the durable auto-config and scale-safety behaviour.)
 
 - **Refuse-on-uncertainty by default** (`confidence_required=True`). At
   `df.height >= 100_000`, when auto-config commits a RED-health config,
@@ -133,7 +136,7 @@ npm install goldenmatch
 
 ### Matching
 - **12+ scoring methods** — exact, Jaro-Winkler, Levenshtein, token sort, soundex, ensemble, embedding, record embedding, dice, jaccard, **`name_freq_weighted_jw`** (surname IDF-weighted), **`given_name_aliased_jw`** (alias-aware) + plugin extensible
-- **8+ blocking strategies** — static, adaptive, sorted neighborhood, multi-pass, ANN, ann_pairs, canopy, **learned** (data-driven predicate selection)
+- **10+ blocking strategies** — static, adaptive, sorted neighborhood, multi-pass, ANN, ann_pairs, canopy, **learned** (data-driven predicate selection), **`lsh`** (MinHash/LSH), **`simhash`** (semantic SimHash)
 - **Bundled OSS reference data** — five packs ship with the wheel: US Census 2010 surnames, given-name aliases, business legal forms, USPS Pub. 28 addresses, NAICS 2022 industries. Auto-config swaps in the matching scorer / transform when a column name AND its profiled data shape agree. See [Reference Data](https://docs.bensevern.dev/goldenmatch/reference-data).
 - **Fellegi-Sunter probabilistic matching** — EM-trained m/u probabilities, automatic threshold estimation
 - **LLM scorer with budget controls** — GPT-4o-mini scores borderline pairs for just $0.04. Budget caps, model tiering, graceful degradation
@@ -157,7 +160,7 @@ npm install goldenmatch
 - **In-house embedding (cloud-free)** — back the `embedding` / `record_embedding` scorer with a small numpy + ONNX model trained in-process on your labeled pairs (`goldenmatch.embeddings.inhouse.train_embedder`); set the matchkey field's `model="inhouse:<path>"`. No cloud calls, no torch. **Within ~0.2pp of Vertex AI on structured ER** (Railway-validated 3-way comparison, #506 / PR #543) — febrl3 in-house 0.9488 vs Vertex 0.9512, DBLP-ACM 0.9709 vs 0.9708, synthetic-20k 0.9814 vs 0.9834. Use it when you want embedding-grade recall without a cloud dependency.
 
 ### Integration
-- **REST API + MCP Server** — 31 tools for matching, explaining, reviewing, data quality, transforms, and AutoConfigController telemetry
+- **REST API + MCP Server** — 68 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
 - **A2A Agent** — 12 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
 - **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
@@ -773,7 +776,7 @@ llm_scorer:
   # model: gpt-4o-mini       # default, cheapest option
 
 blocking:
-  strategy: adaptive         # static | adaptive | sorted_neighborhood | multi_pass | ann | ann_pairs | canopy
+  strategy: adaptive         # static | adaptive | sorted_neighborhood | multi_pass | ann | ann_pairs | canopy | learned | lsh | simhash
   auto_select: true          # auto-pick best key by histogram analysis
   keys:
     - fields: [zip]
@@ -808,6 +811,8 @@ output:
 | `record_embedding` | Embed concatenated fields | Cross-field semantic matching |
 | `dice` | Dice coefficient on bloom filters | Privacy-preserving matching |
 | `jaccard` | Jaccard similarity on bloom filters | Privacy-preserving matching |
+| `name_freq_weighted_jw` | Jaro-Winkler weighted by US Census surname IDF | Person surnames (down-weights common names) |
+| `given_name_aliased_jw` | Alias-aware Jaro-Winkler (nickname/diminutive lookup) | Given names (Bob↔Robert) |
 
 ## Blocking Strategies
 
@@ -821,6 +826,8 @@ output:
 | `ann_pairs` | Direct-pair ANN scoring (50-100x faster than `ann`) |
 | `canopy` | TF-IDF canopy clustering |
 | `learned` | Data-driven predicate selection (auto-discovers blocking rules) |
+| `lsh` | MinHash / Locality-Sensitive Hashing (high-throughput near-duplicate blocking) |
+| `simhash` | Semantic SimHash blocking |
 
 ## Database Integration
 

--- a/packages/python/goldenpipe/README.md
+++ b/packages/python/goldenpipe/README.md
@@ -18,11 +18,13 @@ Built by [Ben Severn](https://bensevern.dev).
 
 ```
 Raw Data
-  | GoldenCheck   -- profile & discover quality issues
-  | GoldenFlow    -- fix issues, standardize, reshape
-  | GoldenMatch   -- deduplicate, match, create golden records
+  | GoldenCheck    -- profile & discover quality issues
+  | GoldenFlow     -- fix issues, standardize, reshape
+  | GoldenMatch    -- deduplicate, match, create golden records
+  | GoldenIdentity -- persist stable entity IDs across runs   (optional)
+  | GoldenAnalysis -- terminal reporting over the run's artifacts  (optional)
   v
-Golden Records
+Golden Records + AnalysisReport
 ```
 
 GoldenPipe orchestrates the full pipeline with adaptive logic:
@@ -34,6 +36,14 @@ GoldenPipe orchestrates the full pipeline with adaptive logic:
 
 ```bash
 pip install goldenpipe
+```
+
+Optional extras:
+
+```bash
+pip install goldenpipe[analysis]      # adds the GoldenAnalysis terminal report stage
+pip install goldenpipe[golden-suite]  # full suite, incl. goldenanalysis
+pip install goldenpipe[tui,api,mcp]   # interactive TUI, REST API, MCP server
 ```
 
 ## Quick Start
@@ -58,6 +68,10 @@ goldenpipe run customers.csv --verbose      # Show reasoning
 goldenpipe run customers.csv --skip-flow    # Check + Match only
 goldenpipe run customers.csv --strategy pprl  # Force privacy mode
 goldenpipe run customers.csv -o golden.csv  # Save golden records
+
+goldenpipe interactive                       # Launch the 4-tab TUI
+goldenpipe interactive customers.csv         # Load a source; press 'r' to run it
+goldenpipe interactive customers.csv -c pipeline.yml  # Load source + YAML config
 ```
 
 ## Remote MCP Server

--- a/packages/python/goldensuite-mcp/README.md
+++ b/packages/python/goldensuite-mcp/README.md
@@ -1,6 +1,6 @@
 # goldensuite-mcp
 
-> One MCP server exposing **every** Golden Suite tool — `goldenmatch`, `goldencheck`, `goldenflow`, `goldenpipe`, `infermap` — under a single endpoint.
+> One MCP server exposing **every** Golden Suite tool — `goldenmatch`, `goldencheck`, `goldenflow`, `goldenpipe`, `infermap`, `goldenanalysis` — under a single endpoint.
 
 ```bash
 pip install goldensuite-mcp
@@ -17,7 +17,7 @@ docker run -p 8300:8300 ghcr.io/benseverndev-oss/goldensuite-mcp:latest
 
 `goldensuite-mcp` imports each sub-package's MCP tool list and dispatcher, composes them into a single `mcp.server.Server` instance, and serves them over stdio or Streamable HTTP.
 
-You point your MCP client at one endpoint and get the full Golden Suite — entity resolution, data quality scanning, transforms, pipeline orchestration, and schema mapping.
+You point your MCP client at one endpoint and get the full Golden Suite — entity resolution, data quality scanning, transforms, pipeline orchestration, schema mapping, and trend analysis & regression detection.
 
 ## Tool collisions
 
@@ -28,6 +28,7 @@ Tool names register on a **first-wins** basis. The registration order is:
 3. **goldenflow** — transforms & standardizers
 4. **goldenpipe** — pipeline orchestrator
 5. **infermap** — schema mapping
+6. **goldenanalysis** — trend analysis & regression detection (registered last)
 
 If two packages register a tool with the same name, the later one is shadowed. **Shadowed tools are logged at WARNING level when the server starts**, so you can see exactly what happened:
 
@@ -64,7 +65,7 @@ Or the hosted variant (when one is published):
 
 ## Why an aggregator?
 
-The Golden Suite ships five Python packages, each with its own MCP server (`goldenmatch mcp-serve`, `goldencheck mcp-serve`, …). For a deployer running all five behind one Claude Desktop config, that's five processes and five mounts.
+The Golden Suite ships six Python packages, each with its own MCP server (`goldenmatch mcp-serve`, `goldencheck mcp-serve`, …). For a deployer running all six behind one Claude Desktop config, that's six processes and six mounts.
 
 `goldensuite-mcp` is the convenience option:
 - One process, one mount, all the tools

--- a/packages/python/infermap/README.md
+++ b/packages/python/infermap/README.md
@@ -140,7 +140,7 @@ export async function POST(req: Request) {
 
 ## How it works
 
-Each field pair runs through a pipeline of **7 scorers**. Each scorer returns a score in `[0.0, 1.0]` or abstains (`None`/`null`). The engine combines scores via weighted average (requiring at least 2 contributors), then uses the **Hungarian algorithm** for optimal one-to-one assignment.
+Each field pair runs through a pipeline of **6 built-in scorers** (plus a pluggable `LLMScorer`, stubbed by default). Each scorer returns a score in `[0.0, 1.0]` or abstains (`None`/`null`). The engine combines scores via weighted average (requiring at least 2 contributors), then uses the **Hungarian algorithm** for optimal one-to-one assignment.
 
 | Scorer | Weight | What it detects |
 |---|---|---|
@@ -160,7 +160,7 @@ The engine also applies **common-prefix canonicalization** — automatically str
 
 | | Python | TypeScript |
 |---|---|---|
-| 7 built-in scorers | ✅ | ✅ |
+| 6 built-in scorers (+ pluggable LLM) | ✅ | ✅ |
 | Hungarian assignment | ✅ (scipy) | ✅ (vendored) |
 | Custom scorers | `@infermap.scorer` | `defineScorer()` |
 | Domain dictionaries | ✅ (YAML) | ✅ (inlined) |
@@ -174,6 +174,7 @@ The engine also applies **common-prefix canonicalization** — automatically str
 | Saved mapping format | YAML | JSON |
 | CLI | ✅ (Typer) | ✅ (`node:util`) |
 | Apply to DataFrame | ✅ | ❌ (CSV rewrite via CLI) |
+| GoldenMatch identity feeder | ✅ (`write_aliases_from_mapping` → `AliasWriteResult`) | ❌ |
 | Edge-runtime compatible | ❌ | ✅ |
 | Zero runtime deps | n/a | ✅ |
 | Accuracy benchmark | ✅ (162 cases, F1 0.84) | ✅ (parity within 0.0005) |


### PR DESCRIPTION
Sweeps the published-package READMEs for staleness against the released state (goldenmatch 2.3.0, goldencheck 1.4.0, goldenflow 1.3.0, goldenanalysis 0.3.0, goldenpipe 1.3.0, goldensuite-mcp 0.3.0, infermap 0.5.1). Every count was verified against source, not just the CHANGELOGs.

**Per-README**
- **root**: `50+ → 70+` MCP tools (×2); dropped the stale `v1.7-v1.12` reference; pipeline line now `Check → Flow → Match → Identity → Analysis`.
- **goldenmatch**: `59 → 68` and `31 → 68` MCP tools; added `lsh`/`simhash` blocking (strategy table + YAML comment, `8+ → 10+`); added `name_freq_weighted_jw` + `given_name_aliased_jw` to the scorers table; relabeled the stale "What's new in v1.17" heading (recent news lives in the auto-synced callout).
- **goldensuite-mcp**: added `goldenanalysis` as the 6th aggregated package (header, value prop, collision order, "five → six").
- **goldenpipe**: diagram now includes the Identity + Analysis stages; added the extras block; documented `interactive SOURCE -c config`.
- **goldencheck**: completed the MCP tools table `6 → 19` (9 core + 10 agent, exact names).
- **goldenflow**: `14 → 16` commands; TS `83 → 76` transforms (parity with Python's 76).
- **infermap**: `7 → 6` built-in scorers (+ pluggable LLM); documented the GoldenMatch identity feeder (`write_aliases_from_mapping`).

**Deliberately not changed** (verification-first): goldenanalysis README was already accurate (the flagged "Phase 4" text is in a source comment, not the README); goldenflow `34 exports` is correct; no goldenanalysis-mcp container exists (tools flow via the aggregator); infermap Node badge left as-is (package.json still declares `>=20` — a source fix, not a README one).

`readme_callouts --check` and version-consistency gates pass locally. The only failing local check is the docs-site `.mdx` orphan detector, a known Windows path-separator false-positive (green on Linux CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)