### PR TITLE
fix(goldengraph): capture literal attributes in the distillation log

### DIFF
--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -578,6 +578,15 @@ class _DistillLogger:
                 {"subj": r.subj, "predicate": r.predicate, "obj": r.obj}
                 for r in extraction.relationships
             ],
+            # Literal attributes (entity -[predicate]-> typed value). Absent from the
+            # capture before this -- which made the literal/phrase-span extraction
+            # (the very channel the distillation is meant to train) invisible in the
+            # log. getattr keeps it back-compat for an attribute-less Extraction.
+            "attributes": [
+                {"subj": a.subj, "predicate": a.predicate, "value": a.value,
+                 "type": a.typ}
+                for a in getattr(extraction, "attributes", ())
+            ],
             "fingerprints": {str(k): v for k, v in (new_fps or {}).items()},
         }
         line = json.dumps(rec, ensure_ascii=False)

--- a/packages/python/goldengraph/tests/test_ingest_cross_doc_link.py
+++ b/packages/python/goldengraph/tests/test_ingest_cross_doc_link.py
@@ -480,6 +480,32 @@ def test_distill_logger_writes_jsonl(tmp_path):
     assert rec["text"] == "Acme made Rocket"
     assert rec["entities"][0]["name"] == "Acme made Rocket"  # stub: one mention
     assert rec["fingerprints"] == {"0": "Acme | org | UNKNOWN | maker"}
+    assert rec["attributes"] == []  # back-compat: attribute-less extraction
+
+
+def test_distill_logger_captures_attributes(tmp_path):
+    """The capture must record literal attributes (entity -[predicate]-> typed
+    value) -- otherwise the literal/phrase-span extraction channel is invisible in
+    the distillation log it is meant to train."""
+    import json as _json
+
+    from goldengraph.extract import Attribute, Extraction, Mention
+
+    p = tmp_path / "distill.jsonl"
+    ext = Extraction(
+        mentions=[Mention(name="Cairo University", typ="university")],
+        relationships=[],
+        attributes=[
+            Attribute(subj=0, predicate="ranked", value="551-600", typ="range"),
+            Attribute(subj=0, predicate="located in", value="Egypt", typ="region"),
+        ],
+    )
+    ingest._DistillLogger(str(p)).log("Cairo University ...", ext, None)
+    rec = _json.loads(p.read_text().strip())
+    assert rec["attributes"] == [
+        {"subj": 0, "predicate": "ranked", "value": "551-600", "type": "range"},
+        {"subj": 0, "predicate": "located in", "value": "Egypt", "type": "region"},
+    ]
 
 
 def test_resolve_extractor_default_and_unknown(monkeypatch):


### PR DESCRIPTION
## Why

While diagnosing why phrase-span Part 1 (#1260) didn't move its target bucket, I fired a `distill_log=true` run to inspect what the extractor actually emits — and hit a blind spot: **`_DistillLogger` only serializes `text/entities/relationships/fingerprints`**. It predates the literal lever (#1236), so the **`attributes` channel is completely absent from the capture** — the one channel Part 1 changed, and the very data the distillation log exists to train an in-house extractor on.

Net effect: a distill run **cannot show** whether gpt-4o-mini emits the `date|quantity|ordinal|range|region|event` attribute types, which is exactly the question that splits Part 1's miss into *extraction-not-emitting* vs *emitting-but-retrieval-misses*.

## What

Add an `attributes` array (`subj/predicate/value/type` per attribute) to each distill record. `getattr(extraction, "attributes", ())` keeps it back-compat for an attribute-less `Extraction` (records `[]`).

## Validation
- New test `test_distill_logger_captures_attributes` (range + region attributes round-trip verbatim).
- Existing `test_distill_logger_writes_jsonl` now also asserts the back-compat empty list.
- Both green locally.

Small, isolated instrumentation fix. Next: re-run the distill with this on to directly count the attribute types the extractor produces and settle Part 1's diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_