### PR TITLE
docs(goldengraph): pivot phrase-span lever — extraction is not the bottleneck

### DIFF
--- a/docs/superpowers/specs/2026-06-24-goldengraph-phrase-span-extraction-design.md
+++ b/docs/superpowers/specs/2026-06-24-goldengraph-phrase-span-extraction-design.md
@@ -1,9 +1,49 @@
 # goldengraph — phrase-span extraction lever (scoping)
 
-**Status:** scoping / design (not yet implemented)
+**Status:** Part 1 SHIPPED (#1260); **Part 2 DEPRIORITIZED** — see the pivot below
 **Date:** 2026-06-24
 **Author:** measure-driven loop (follows the literal-attribute lever #1236/#1253)
 **Parent:** `2026-06-22-goldengraph-qa-e2e-first-headline-handoff.md`
+
+## 0. UPDATE 2026-06-24 — PIVOT: extraction is not the bottleneck, retrieval is
+
+Part 1 (broadened literal typing → `ordinal|range|region|event`) shipped (#1260)
+and was measured. The result **redirects this whole lever** and is worth pinning
+at the top so no one builds Part 2 on the old premise.
+
+**Part 1 works at the extraction layer.** A `distill_log=true` N=50 run (with the
+distill logger fixed to actually record attributes, #1264) shows the extractor
+emits the new types across 1000 docs: `date` 1198, `text` 744, `quantity` 722,
+**`ordinal` 170, `range` 76, `region` 19, `event` 17** (88% of docs carry ≥1
+attribute). And the *specific* phrase-gold values land as typed leaf nodes — the
+smoking gun:
+- `Piedmont -[average temperature range]-> "upper 40s-lower 50s °F" (range)` — the
+  **exact** gold, captured. Yet the QA answered `"−15 °C"` (wrong).
+- `Mississippi River -[rises in]-> "northern Minnesota" (text)` — captured. QA said
+  "Gulf of Mexico".
+- `Mega Drive -[is built on]-> "16-bit architecture" (text)` — captured. QA said "60%".
+
+**So the binding constraint is RETRIEVAL/SYNTHESIS, not extraction.** The value
+leaf exists 1-hop off its subject, but the multi-hop chain to the subject never
+reaches it, or synthesis fails to select the predicate-matched attribute among the
+subject's several. The earlier 2010-election case (gold extracted as an `event`
+*entity*, still retrieval-missed) points the same way.
+
+**Consequences:**
+1. Part 1 succeeded at its layer and stays (it's the right representation).
+2. **Part 2 (descriptive-span extraction machinery) is DEPRIORITIZED** — the
+   values are already in the graph; more extraction won't move the bench. Building
+   it would have solved the wrong problem.
+3. The next lever is **retrieval/synthesis-side**: pull a reached entity's
+   value-leaves into the answer ball, and have synthesis match the question's
+   predicate to the attribute label. Pin the exact failure mode with a
+   `GOLDENGRAPH_QA_TRACE=1` run on the phrase golds (EXTRACTION /
+   RETRIEVAL-BROKEN-CHAIN / RETRIEVAL-BUDGET / SYNTHESIS) before designing it.
+
+The original scoping below is retained for the record; sections 4-part-2 and 6
+onward are superseded by this pivot.
+
+---
 
 ## 1. Why — the measured loss bucket
 


### PR DESCRIPTION
## Why

Records the **pivot** from the phrase-span lever's original premise, based on measured evidence. Pins it at the **top** of the scope doc (#1259) so no one builds Part 2 on the stale assumption.

## The finding (distill-log run, #1264 logger fix)

Part 1 (#1260, broadened literal typing) shipped and was measured. A `distill_log=true` N=50 run shows:

**Extraction works.** New types emitted across 1000 docs: `ordinal` 170, `range` 76, `region` 19, `event` 17 (88% of docs carry ≥1 attribute). And the specific phrase-gold values are captured as typed leaf nodes:
- `Piedmont -[average temperature range]-> "upper 40s-lower 50s °F" (range)` — **the exact gold** — yet QA answered "−15 °C".
- `Mississippi River -[rises in]-> "northern Minnesota" (text)` — QA said "Gulf of Mexico".
- `Mega Drive -[is built on]-> "16-bit architecture" (text)` — QA said "60%".

**So the bottleneck is RETRIEVAL/SYNTHESIS, not extraction.** The value leaf exists 1-hop off its subject; the multi-hop chain never surfaces it.

## Consequences (in the doc)
1. Part 1 stays — it's the right representation.
2. **Part 2 (descriptive-span extraction machinery) is DEPRIORITIZED** — the values are already in the graph.
3. Next lever is retrieval/synthesis-side; pin the exact failure mode with a `GOLDENGRAPH_QA_TRACE=1` run first.

Doc-only. Pairs with #1264 (the logger fix that produced this evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_