### PR TITLE
feat(suggest): config-suggestion kernel + Python API + benchmark harness (#857)

### DIFF
--- a/.github/workflows/bench-suggest-quality.yml
+++ b/.github/workflows/bench-suggest-quality.yml
@@ -1,0 +1,99 @@
+# Config-suggestion kernel quality gate.
+#
+# Runs the suggest_quality oracle over the always-available deterministic
+# datasets (synthetic + ncvr_synthetic + anchor_*) and gates on regression
+# vs the committed scorecard.json baseline.
+#
+# Three ways to trigger:
+#   1. Automatically on push when relevant paths change.
+#   2. workflow_dispatch (for a manual re-check or one-shot bless).
+#
+# The gate step exits nonzero on a regression; the job fails and blocks
+# the PR.  The bench runner matches the repo default for bench workloads
+# (large-new-64GB, 16c/64GB).
+#
+# To bless a new baseline after an intentional kernel change:
+#   gh workflow run bench-suggest-quality.yml --ref <branch> -f mode=bless
+name: bench-suggest-quality
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "gate (default) or bless (write a new baseline)"
+        required: false
+        default: "gate"
+      datasets:
+        description: "Comma-separated dataset filter (empty = all available)"
+        required: false
+        default: ""
+      runner:
+        description: "Runner label"
+        required: false
+        default: "large-new-64GB"
+  push:
+    paths:
+      - "packages/rust/extensions/suggest-core/**"
+      - "packages/rust/extensions/native/src/suggest.rs"
+      - "packages/python/goldenmatch/goldenmatch/core/suggest/**"
+      - "scripts/suggest_quality/**"
+      - ".github/workflows/bench-suggest-quality.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  suggest-quality:
+    runs-on: ${{ inputs.runner || 'large-new-64GB' }}
+    timeout-minutes: 60
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      GOLDENMATCH_NATIVE: "1"
+      POLARS_SKIP_CPU_CHECK: "1"
+      PYTHONHASHSEED: "0"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Build native extension (suggest_config kernel)
+        run: uv run python scripts/build_native.py
+
+      - name: Assert suggest_config kernel symbol is present
+        run: |
+          uv run python - <<'PY'
+          from goldenmatch.core._native_loader import native_module
+          mod = native_module()
+          assert mod is not None, "native ext did not load after build_native.py"
+          assert hasattr(mod, "suggest_config"), (
+              "native ext loaded but suggest_config is MISSING -- the suggestion "
+              "kernel would silently raise SuggestionsNativeRequired. Rebuild the "
+              "crate or bump goldenmatch-native so the symbol ships."
+          )
+          print("OK: suggest_config present in native ext")
+          PY
+
+      - name: Run suggest_quality ${{ inputs.mode || 'gate' }}
+        run: |
+          MODE="${{ inputs.mode || 'gate' }}"
+          DATASETS="${{ inputs.datasets }}"
+          if [ -n "$DATASETS" ]; then
+            FILTER="--datasets $DATASETS"
+          else
+            FILTER=""
+          fi
+          uv run python -m scripts.suggest_quality "$MODE" $FILTER

--- a/docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md
+++ b/docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md
@@ -541,7 +541,7 @@ fn round2(x: f64) -> f64 { (x * 100.0).round() / 100.0 }
 
 **Files:** `src/rules.rs` (extend)
 
-- [ ] **Step 1: Failing test** — a `ColumnSignal` for an `address`/`name`/free-text column, `scorer == "token_sort"`, `corruption_score > 0.3` (or `variant_rate > 0.02`) → emits a `SwapScorer` to `jaro_winkler`; a clean column or a `qgram`-coded column emits nothing.
+- [ ] **Step 1: Failing test** — a `ColumnSignal` for an `address`/`name`/free-text column, `scorer == "token_sort"`, `corruption_score >= 0.3` (or `variant_rate >= 0.02`) → emits a `SwapScorer` to `jaro_winkler`; a clean column or a `qgram`-coded column emits nothing. (Use a fixture value clearly inside the band, e.g. `corruption_score = 0.5`, so the `>=` boundary is unambiguous.)
 - [ ] **Step 2: Run → fail.**
 - [ ] **Step 3: Implement** `pub fn scorer_swap_rule(matchkey: &str, signals: &[ColumnSignal]) -> Vec<Suggestion>`. Gate: `col_type in {address, string, name}` AND `scorer == token_sort` AND (`corruption_score >= 0.3` OR `variant_rate >= 0.02`). Propose `jaro_winkler`. Rationale cites the corruption/variant number. `confidence: 0.65`. Patch `SetScorer`. (Mirror the #662 noise-aware default and `core/autoconfig.py` guard logic — read it to match thresholds.)
 - [ ] **Step 4: Run → PASS.**

--- a/docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md
+++ b/docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md
@@ -785,4 +785,83 @@ Expected: `True`.
 
 ## Task 0 findings
 
-_(Appended during Task 0 — records the resolved input schema and artifact sources.)_
+_Resolved 2026-06-24 in worktree `feat/config-suggestion-kernel` (off `main` @ 2de2b20e)._
+
+### Step 1 — No pyo3-free autoconfig decision crate exists → `suggest-core` is greenfield
+
+`packages/rust/extensions/` crates: `analysis-core`, `analysis-native`, `bridge`,
+`datafusion-udf`, `embed-py`, `fingerprint-core`, `goldencheck-core`,
+`goldencheck-native`, `goldenembed`, `graph-core`, `native`, `native-flow`,
+`postgres`, `score-core`. **None own autoconfig or suggestion decision logic.**
+`bridge::autoconfig` (`bridge/src/api.rs:311`) imports `goldenmatch.core.autoconfig`
+and calls `auto_configure_df` in Python — it delegates, it does not reimplement.
+The `project_autoconfig_native_core` memory ("native 0.1.11 shipped") is **stale /
+refers to small score-kernel levers**, not a decision crate. `suggest-core` is the
+first decision kernel; build it greenfield on the `score-core` standalone-workspace
+pattern. **No change to the plan.**
+
+### Step 2 — scored_pairs + clusters: use `MatchEngine`, not `run_dedupe`
+
+- **scored_pairs:** `MatchEngine.run()` → `EngineResult.scored_pairs: list[tuple[int,int,float]]`
+  (`tui/engine.py:40`). `run_dedupe()` does NOT carry scored pairs (CLAUDE.md). So
+  `review_config` **and** the benchmark MUST drive the run through `MatchEngine`
+  (`tui/engine.py::MatchEngine`), exactly as `goldenmatch explain`/`lineage` already
+  do. This is the reliable `(id_a, id_b, score)` source for the `scored_pairs` batch.
+- **clusters:** `build_clusters` dicts carry `members`, `size`, `oversized`,
+  `pair_scores`, `confidence`, and `quality` ∈ {`strong`,`weak`,`split`}
+  (`core/cluster.py` — `_confidence_fields`; frame form has a `quality` column at
+  `cluster.py:631`). These map 1:1 to the `clusters` batch
+  `(cluster_id, size, confidence, quality, oversized)`.
+- **Bucket-backend degradation RESOLVED, not a risk:** the earlier worry was that
+  `scored_pairs` is empty on `backend=bucket`. That was a `run_dedupe` limitation;
+  the scorer produces pairs on every backend and `MatchEngine` collects them into
+  `EngineResult.scored_pairs`. **Driving through `MatchEngine` removes the
+  degradation entirely** — the threshold rule has its score distribution on all
+  backends. Supersede the Task 0-Step-4 / line-69 caveat with: "always run via
+  `MatchEngine`; no backend degrades scored_pairs."
+
+### Step 3 — column_signals field sources (all available)
+
+| field | source |
+|-------|--------|
+| `field`, `col_type` | `core/autoconfig.py` `DataProfile` / `profile_columns` (col-type classification) |
+| `scorer` | the committed `GoldenMatchConfig` (matchkey field's scorer) |
+| `in_blocking` | committed config `blocking` fields (`collect_blocking_fields`) |
+| `in_negative_evidence` | committed config matchkey `negative_evidence` lists |
+| `identity_score`, `corruption_score` | `core/indicators.py::compute_column_priors(df) -> dict[str, ColumnPrior]` |
+| `cardinality_ratio`, `null_rate` | `core/autoconfig.py` `DataProfile` (`cardinality_ratio = n_unique/n_non_null`, `null_rate = 1 - n_non_null/n_rows`) |
+| `variant_rate` | `core/quality.py::blocking_risk(df) -> dict[str,float] \| None`; **defaults to 0.0 when goldencheck is absent / returns None** (fail-open) |
+| `collision_rate` | **NOT available off-the-shelf — computed by the Python adapter from run results** (see below) |
+
+**`collision_rate` definition (adapter-computed, result-driven).** There is no
+reusable per-column collision function (`promote_negative_evidence` in
+`core/autoconfig_negative_evidence.py:99` gates on `identity_score >= 0.75` +
+`cardinality_ratio >= 0.5` only; the memory's `compute_identity_collision_signal` /
+`rule_demote_clustered_identity` no longer exist by those names). So the adapter
+computes, per candidate column, **the fraction of multi-member clusters in which
+that column has ≥2 distinct non-null values among members** — i.e. a strong
+identity-like column that *disagrees inside a merged cluster*, which is exactly the
+negative-evidence signal (the merge should have been penalised by that field). This
+is computable purely from `clusters` + the source frame, no sample, no controller
+internals. Rule 3 (Task 7) gates: `identity_score >= 0.75` AND
+`cardinality_ratio >= 0.5` AND `not in_negative_evidence` AND `collision_rate >= 0.5`
+(mirrors `_IDENTITY_SCORE_THRESHOLD` / `_CARDINALITY_THRESHOLD` from
+`autoconfig_negative_evidence.py`, plus the new result-driven collision gate).
+
+### Step 4 — Frozen Arrow input schema
+
+```
+scored_pairs:   id_a:int64, id_b:int64, score:float64
+clusters:       cluster_id:int64, size:int64, confidence:float64,
+                quality:utf8 ("strong"|"weak"|"split"), oversized:bool
+column_signals: field:utf8, col_type:utf8, scorer:utf8, in_blocking:bool,
+                in_negative_evidence:bool, identity_score:float64,
+                corruption_score:float64, collision_rate:float64,
+                cardinality_ratio:float64, null_rate:float64, variant_rate:float64
+```
+
+No rule is fully degraded: rule 1 (threshold) needs `scored_pairs` + cluster counts
+(available via MatchEngine); rule 2 (scorer swap) needs `corruption_score` +
+`variant_rate` (available; `variant_rate` fail-open to 0.0); rule 3 (NE) needs
+`identity_score` + `cardinality_ratio` + `collision_rate` + `in_negative_evidence`
+(available; `collision_rate` adapter-computed). **Schema frozen — proceed to Task 1.**

--- a/docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md
+++ b/docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md
@@ -1,0 +1,788 @@
+# Config-Suggestion Kernel — Plan 1: Kernel + Python API + Benchmark
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Arrow-in, pyo3-free `suggest-core` kernel that reviews a finished dedupe run and emits ranked, explainable config-edit suggestions, expose it through a `goldenmatch[native]` Python API, and ship a benchmark harness that scores the suggester against an oracle ranking of real F1 lifts.
+
+**Architecture:** A new pyo3-free Rust crate (`packages/rust/extensions/suggest-core`) ingests the run's Arrow artifacts (scored pairs, clusters, per-column signals), reduces them (reusing `analysis-core` histogram/quantile), runs three v1 rules (threshold, scorer-swap, negative-evidence), generates rationale text, and ranks. A thin `#[pyfunction]` shim in the existing `goldenmatch-native` crate exposes it; a Python adapter (`review_config`) assembles the Arrow inputs from a run result and `apply_suggestion` patches the Pydantic config. The benchmark (`scripts/suggest_quality`, mirroring `scripts/autoconfig_quality`) measures suggestion intelligence against an oracle.
+
+**Tech Stack:** Rust (arrow, serde, pyo3 via the native crate), Python 3.11+ (polars, pyarrow, Pydantic), maturin build (`scripts/build_native.py`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-24-config-suggestion-kernel-design.md`
+
+**Out of scope (Plan 2):** accept/reject persistence (`suggestion_feedback` table, `MemoryStore`), priors-driven learning at runtime, and CLI/MCP/TUI surfaces. This plan implements the kernel's `AcceptancePriors` *input* and ranking math, but the persistence/loading that feeds it lands in Plan 2. Until then the Python API passes empty priors.
+
+---
+
+## Conventions for the implementing engineer
+
+- **Build the native wheel** after Rust changes: `python scripts/build_native.py` from the repo root (this rebuilds `goldenmatch._native` in-tree; see root CLAUDE.md "goldenmatch-native"). In-tree builds pick up new symbols immediately — no republish needed for local dev.
+- **Rust unit tests:** `cargo test -p goldenmatch-suggest-core` from `packages/rust/extensions/`. Set `CARGO_HOME="C:/Users/bsevern/.cargo"` on Windows (root CLAUDE.md gotcha).
+- **Python tests:** `.venv/Scripts/python.exe -m pytest <path>` (per packages/python/CLAUDE.md — `uv run` is flaky for workspace members on Windows). Set `POLARS_SKIP_CPU_CHECK=1` and `PYTHONIOENCODING=utf-8` (memory `reference_polars_wmi_hang_windows`).
+- **Never run the full pytest suite locally** (OOMs the box — memory `feedback_avoid_full_suite_oom`); run targeted files. The full suite runs in CI.
+- **Arrow version:** `suggest-core` MUST pin the same arrow version as `native/Cargo.toml` (currently **59**, after the #1003/#1005 arrow 55→59 bump — confirm in Task 0). A mismatched arrow version will not unify with `native`'s `PyArrowType<RecordBatch>` at the Task 10 shim and won't compile. `analysis-core` carries no arrow dependency, so ignore it for the version decision.
+- **Commit after every green step.** Use `feat(suggest):` / `test(suggest):` prefixes. End commit messages with the Co-Authored-By + Claude-Session trailers per repo convention.
+- Each rule emits a `Suggestion`; follow the fully-worked Rule 1 (Task 5) as the template for Rules 2–3.
+
+---
+
+## Phase 0 — De-risk: freeze the input schema
+
+### Task 0: Resolve the three open questions and freeze the kernel input schema
+
+No code change — this is an investigation that produces a short findings note appended to this plan and locks the Arrow input columns before any kernel code is written.
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md` (append a `## Task 0 findings` section)
+
+- [ ] **Step 1: Does a pyo3-free autoconfig decision crate already exist?**
+
+Run:
+```bash
+cd /d/show_case/goldenmatch/packages/rust/extensions
+ls */Cargo.toml
+grep -rl "autoconfig\|Lever\|RefitPolicy\|Decision" --include=*.rs . | grep -v target
+```
+Expected: no crate owns autoconfig decision logic (the bridge delegates to Python). Record the verdict. If a crate *does* exist, STOP and revisit whether `suggest-core` should extend it.
+
+- [ ] **Step 2: Where do scored-pair scores come from post-run?**
+
+Read `packages/python/goldenmatch/goldenmatch/tui/engine.py` (look for `EngineResult.scored_pairs`) and `packages/python/goldenmatch/goldenmatch/core/cluster.py` (`build_clusters` returns a dict whose per-cluster `pair_scores` carries `(id_a,id_b)->score`). Confirm at least one reliably-populated source of `(id_a, id_b, score)` after a dedupe run. Record which the adapter will use (prefer `EngineResult.scored_pairs`; fall back to flattening `clusters[*]["pair_scores"]`).
+
+- [ ] **Step 3: Where do per-column signals come from?**
+
+Read `packages/python/goldenmatch/goldenmatch/core/complexity_profile.py` and `core/indicators.py` (`compute_column_priors` gives per-column `identity_score` + `corruption_score`; `core/autoconfig_rules.py::compute_identity_collision_signal` gives collision rate). Confirm `cardinality_ratio`, `null_rate`, and a `variant_rate` (from `core.quality.blocking_risk`) are obtainable. Record the source artifact for each `column_signals` field.
+
+- [ ] **Step 4: Freeze the input schema**
+
+Append the final Arrow schemas to this plan as `## Task 0 findings`. The three batches:
+
+```
+scored_pairs:   id_a:int64, id_b:int64, score:float64
+clusters:       cluster_id:int64, size:int64, confidence:float64,
+                quality:utf8 ("strong"|"weak"|"split"), oversized:bool
+column_signals: field:utf8, col_type:utf8, scorer:utf8, in_blocking:bool,
+                in_negative_evidence:bool, identity_score:float64,
+                corruption_score:float64, collision_rate:float64,
+                cardinality_ratio:float64, null_rate:float64, variant_rate:float64
+```
+If Step 2/3 show a field is unavailable, record the substitute or mark the rule that depends on it as degraded (still ship the rule; it simply emits nothing without its signal). **Most likely degradation:** if `EngineResult.scored_pairs` is not reliably populated on the `backend=bucket` path, the threshold rule (which needs the score distribution) emits nothing for bucket runs — note this explicitly so it isn't a surprise mid-build; the fallback is flattening `clusters[*]["pair_scores"]`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md
+git commit -m "docs(suggest): Task 0 findings — freeze kernel input schema"
+```
+
+---
+
+## Phase 1 — The `suggest-core` crate (pure data contract + reductions)
+
+### Task 1: Scaffold the crate
+
+**Files:**
+- Create: `packages/rust/extensions/suggest-core/Cargo.toml`
+- Create: `packages/rust/extensions/suggest-core/src/lib.rs`
+- Do **NOT** modify the bridge `packages/rust/extensions/Cargo.toml` — see Step 1 note.
+
+- [ ] **Step 1: Write `Cargo.toml`**
+
+`suggest-core` follows the **`score-core` pattern**: it carries its own standalone empty `[workspace]` block so it can be a path dependency of BOTH `native` (pyo3) and later `datafusion-udf` (FFI) without either workspace claiming it. Read `score-core/Cargo.toml` first and mirror its `[workspace]` rationale. Do **NOT** add `suggest-core` to the bridge workspace `members` list (that list is `["bridge"]` with a long `exclude`; `native` and the `-core` crates are deliberately outside it).
+
+```toml
+[package]
+name = "goldenmatch-suggest-core"
+version = "0.1.0"
+edition = "2021"
+
+# Standalone workspace so this pyo3-free core can be a path dep of both `native`
+# and `datafusion-udf` without either workspace claiming it (mirrors score-core).
+[workspace]
+
+[lib]
+# pyo3-free: plain lib, no cdylib. Consumed by `native` (pyo3 shim) and later
+# datafusion-udf (FFI). Mirrors score-core / analysis-core.
+
+[dependencies]
+# MUST equal the arrow version `native/Cargo.toml` pins (currently 59, per the
+# #1003/#1005 arrow 55->59 bump — confirm in Task 0). A different arrow version
+# will NOT unify with the `PyArrowType<RecordBatch>` coming from `native` in
+# Task 10 and the shim will fail to compile. analysis-core carries NO arrow dep
+# (it's a pure &[f64] crate) — do not try to "match" it for arrow.
+arrow = { version = "59", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Reuse the existing reduction kernels — do NOT reimplement histogram/quantile.
+# analysis-core is pure (&[f64] in, no arrow), so it imposes no arrow version.
+analysis-core = { path = "../analysis-core" }
+```
+
+- [ ] **Step 2: Write a trivial `lib.rs` and a compile-check test**
+
+```rust
+//! `goldenmatch-suggest-core` — pyo3-free config-suggestion kernel.
+//!
+//! Canonical source of truth for config suggestions: ingests a finished run's
+//! Arrow artifacts, reduces them, runs the suggestion rules, generates rationale
+//! text, and ranks. Shared by construction across the `goldenmatch-native` pyo3
+//! shim and (later) the datafusion-udf FFI + TS/WASM surfaces. No I/O, no pyo3.
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn crate_builds() {
+        assert_eq!(2 + 2, 4);
+    }
+}
+```
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `cd packages/rust/extensions && CARGO_HOME="C:/Users/bsevern/.cargo" cargo test -p goldenmatch-suggest-core`
+Expected: PASS (`crate_builds`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/rust/extensions/suggest-core
+git commit -m "feat(suggest): scaffold goldenmatch-suggest-core crate"
+```
+(Do not `git add` the bridge `Cargo.toml` — `suggest-core` is its own standalone workspace.)
+
+### Task 2: The data contract types
+
+**Files:**
+- Create: `packages/rust/extensions/suggest-core/src/contract.rs`
+- Modify: `packages/rust/extensions/suggest-core/src/lib.rs` (add `pub mod contract;`)
+
+- [ ] **Step 1: Write the failing serde round-trip test**
+
+In `contract.rs`, after the types, add:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suggestion_json_roundtrip() {
+        let s = Suggestion {
+            id: "thr:name:raise".into(),
+            kind: SuggestionKind::RaiseThreshold,
+            target: "name".into(),
+            current_value: "0.80".into(),
+            proposed_value: "0.88".into(),
+            rationale: "placeholder".into(),
+            predicted_effect: PredictedEffect::PrecisionUp,
+            confidence: 0.7,
+            patch: ConfigPatch::SetThreshold { matchkey: "name".into(), value: 0.88 },
+            evidence: serde_json::json!({"dip": 0.86}),
+        };
+        let txt = serde_json::to_string(&s).unwrap();
+        let back: Suggestion = serde_json::from_str(&txt).unwrap();
+        assert_eq!(back.kind, SuggestionKind::RaiseThreshold);
+        assert_eq!(back.patch, ConfigPatch::SetThreshold { matchkey: "name".into(), value: 0.88 });
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify it fails to compile** (types undefined).
+
+Run: `cargo test -p goldenmatch-suggest-core suggestion_json_roundtrip`
+Expected: compile error.
+
+- [ ] **Step 3: Write the contract types**
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SuggestionKind {
+    RaiseThreshold,
+    LowerThreshold,
+    SwapScorer,
+    AddNegativeEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PredictedEffect { PrecisionUp, RecallUp }
+
+/// Declarative config edit. The kernel defines WHAT changes once; each language
+/// applies it to its own native config object.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum ConfigPatch {
+    SetThreshold { matchkey: String, value: f64 },
+    SetScorer { matchkey: String, field: String, scorer: String },
+    AddNegativeEvidence { field: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Suggestion {
+    pub id: String,
+    pub kind: SuggestionKind,
+    pub target: String,
+    pub current_value: String,
+    pub proposed_value: String,
+    pub rationale: String,
+    pub predicted_effect: PredictedEffect,
+    pub confidence: f64,
+    pub patch: ConfigPatch,
+    pub evidence: serde_json::Value,
+}
+
+/// Reduced, frame-free view of the config (what the rules need to read).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigSummary {
+    pub matchkeys: Vec<MatchkeySummary>,
+    pub negative_evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatchkeySummary {
+    pub name: String,
+    pub kind: String,            // "weighted" | "fuzzy" | "exact" | "probabilistic"
+    pub threshold: Option<f64>,
+    pub fields: Vec<FieldSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FieldSummary {
+    pub field: String,
+    pub scorer: Option<String>,
+    pub weight: Option<f64>,
+}
+
+/// Accept/reject history folded into ranking. Plan 2 fills this from MemoryStore;
+/// Plan 1 always passes an empty map.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AcceptancePriors {
+    /// key = "{snake_case kind}:{target}" -> (accepts, rejects). The key is
+    /// produced by `rank::prior_key` (Task 8) — Plan 2's persistence MUST use
+    /// the same helper so the loop binds.
+    pub counts: std::collections::HashMap<String, (u32, u32)>,
+}
+```
+
+- [ ] **Step 4: Run, verify PASS.** `cargo test -p goldenmatch-suggest-core suggestion_json_roundtrip` → PASS.
+- [ ] **Step 5: Commit** `feat(suggest): contract types (Suggestion, ConfigPatch, ConfigSummary, priors)`
+
+### Task 3: Diagnostics reductions from Arrow (scored_pairs, clusters)
+
+**Files:**
+- Create: `packages/rust/extensions/suggest-core/src/diagnostics.rs`
+- Modify: `src/lib.rs` (`pub mod diagnostics;`)
+
+This computes the reduced `RunDiagnostics` struct from the Arrow batches. It reuses `analysis-core::histogram`. The arrow extraction follows `native/src/score.rs` (downcast `RecordBatch` columns to typed arrays).
+
+- [ ] **Step 1: Write the failing test** (build a small `scored_pairs` RecordBatch in-test, assert histogram + mass bands)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, Int64Array};
+    use arrow::record_batch::RecordBatch;
+    use arrow::datatypes::{Field, Schema, DataType};
+    use std::sync::Arc;
+
+    fn pairs_batch(scores: &[f64]) -> RecordBatch {
+        let n = scores.len();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id_a", DataType::Int64, false),
+            Field::new("id_b", DataType::Int64, false),
+            Field::new("score", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(schema, vec![
+            Arc::new(Int64Array::from((0..n as i64).collect::<Vec<_>>())),
+            Arc::new(Int64Array::from((0..n as i64).map(|x| x+1).collect::<Vec<_>>())),
+            Arc::new(Float64Array::from(scores.to_vec())),
+        ]).unwrap()
+    }
+
+    #[test]
+    fn mass_bands_split_by_threshold() {
+        // 6 scores: 3 above 0.8, 1 in [0.7,0.8), 2 below 0.7
+        let b = pairs_batch(&[0.95, 0.9, 0.85, 0.75, 0.6, 0.5]);
+        let d = ScoreDiagnostics::from_batch(&b, 0.80, 24).unwrap();
+        assert!((d.mass_above - 3.0/6.0).abs() < 1e-9);
+        assert!((d.mass_just_below - 1.0/6.0).abs() < 1e-9); // [0.70,0.80)
+        assert_eq!(d.histogram.len(), 24);
+    }
+}
+```
+
+- [ ] **Step 2: Run → fail** (`ScoreDiagnostics` undefined).
+
+- [ ] **Step 3: Implement**
+
+```rust
+use arrow::array::{Array, Float64Array, Int64Array, BooleanArray, StringArray};
+use arrow::record_batch::RecordBatch;
+
+pub struct ScoreDiagnostics {
+    pub histogram: Vec<(f64, i64)>,
+    pub mass_above: f64,       // fraction of pairs with score >= threshold
+    pub mass_just_below: f64,  // fraction in [threshold-0.10, threshold)
+    pub n_pairs: usize,
+}
+
+impl ScoreDiagnostics {
+    pub fn from_batch(batch: &RecordBatch, threshold: f64, bins: i64) -> Result<Self, String> {
+        let col = batch.column_by_name("score").ok_or("missing score column")?;
+        let scores = col.as_any().downcast_ref::<Float64Array>().ok_or("score not f64")?;
+        let vals: Vec<f64> = scores.iter().flatten().collect();
+        let n = vals.len();
+        if n == 0 {
+            return Ok(Self { histogram: vec![], mass_above: 0.0, mass_just_below: 0.0, n_pairs: 0 });
+        }
+        let above = vals.iter().filter(|&&s| s >= threshold).count();
+        let band_lo = threshold - 0.10;
+        let just_below = vals.iter().filter(|&&s| s >= band_lo && s < threshold).count();
+        // Reuse analysis-core histogram (no second implementation).
+        let histogram = analysis_core::histogram(&vals, bins);
+        Ok(Self {
+            histogram,
+            mass_above: above as f64 / n as f64,
+            mass_just_below: just_below as f64 / n as f64,
+            n_pairs: n,
+        })
+    }
+
+    /// Lowest-count bin strictly between the two highest-mass regions — the
+    /// bimodality "dip". Returns the bin's left edge, or None if no clear valley.
+    pub fn dip(&self) -> Option<f64> {
+        if self.histogram.len() < 3 { return None; }
+        let counts: Vec<i64> = self.histogram.iter().map(|(_, c)| *c).collect();
+        let peak = *counts.iter().max().unwrap();
+        // find the global min that has a higher-count bin on BOTH sides
+        let mut best: Option<(usize, i64)> = None;
+        for i in 1..counts.len()-1 {
+            let left_max = counts[..i].iter().max().copied().unwrap_or(0);
+            let right_max = counts[i+1..].iter().max().copied().unwrap_or(0);
+            if left_max > counts[i] && right_max > counts[i] {
+                if best.map_or(true, |(_, c)| counts[i] < c) {
+                    best = Some((i, counts[i]));
+                }
+            }
+        }
+        // require the valley to be a real dip (< 25% of peak) to avoid noise
+        best.filter(|&(_, c)| (c as f64) < 0.25 * peak as f64)
+            .map(|(i, _)| self.histogram[i].0)
+    }
+}
+```
+
+Add a `ClusterDiagnostics::from_batch` that counts `weak`/`oversized`/`split` from the clusters batch (same downcast pattern, `quality` is a `StringArray`, `oversized` a `BooleanArray`). Add a unit test for it.
+
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(suggest): Arrow score+cluster diagnostics reductions`
+
+### Task 4: Column-signals extraction
+
+**Files:** `src/diagnostics.rs` (extend)
+
+- [ ] **Step 1: Failing test** — build a `column_signals` batch, assert a `Vec<ColumnSignal>` round-trips the rows (field, scorer, corruption_score, collision_rate, identity_score, cardinality_ratio, in_blocking, in_negative_evidence).
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** `pub struct ColumnSignal { ... }` + `pub fn column_signals_from_batch(&RecordBatch) -> Result<Vec<ColumnSignal>, String>` using the downcast pattern.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(suggest): column-signals extraction`
+
+---
+
+## Phase 2 — The rules
+
+### Task 5: Rule 1 — threshold raise/lower (the template rule)
+
+**Files:**
+- Create: `packages/rust/extensions/suggest-core/src/rules.rs`
+- Modify: `src/lib.rs` (`pub mod rules;`)
+
+This is the fully-worked rule; Rules 2–3 follow its shape (a pure fn returning `Vec<Suggestion>`).
+
+- [ ] **Step 1: Failing tests** (three behaviors)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::ScoreDiagnostics;
+    use crate::contract::*;
+
+    fn sd(mass_above: f64, mass_just_below: f64, dip: Option<f64>) -> ScoreDiagnostics {
+        // construct directly for unit isolation
+        ScoreDiagnostics {
+            histogram: dip.map(|_| vec![(0.0,100),(0.5,2),(0.9,100)]).unwrap_or(vec![(0.0,50),(0.5,50)]),
+            mass_above, mass_just_below, n_pairs: 1000,
+        }
+    }
+
+    #[test]
+    fn raises_on_everything_matches() {
+        let out = threshold_rule("name", 0.80, &sd(0.95, 0.0, None), 0, 0);
+        assert!(out.iter().any(|s| s.kind == SuggestionKind::RaiseThreshold));
+    }
+
+    #[test]
+    fn lowers_on_recall_risk() {
+        // lots of mass just below + weak/oversized clusters present
+        let out = threshold_rule("name", 0.80, &sd(0.10, 0.30, None), 5, 2);
+        assert!(out.iter().any(|s| s.kind == SuggestionKind::LowerThreshold));
+    }
+
+    #[test]
+    fn moves_to_dip_when_threshold_off_valley() {
+        let out = threshold_rule("name", 0.80, &sd(0.4, 0.05, Some(0.5)), 0, 0);
+        let s = out.iter().find(|s| matches!(s.patch, ConfigPatch::SetThreshold{..})).unwrap();
+        // dip at 0.5 is below current 0.80 → suggest lowering toward the valley
+        assert!(matches!(&s.patch, ConfigPatch::SetThreshold{value, ..} if (*value-0.5).abs() < 0.11));
+    }
+}
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::contract::*;
+use crate::diagnostics::ScoreDiagnostics;
+
+const EVERYTHING_MATCHES: f64 = 0.90;   // mirrors controller precision_collapse_floor
+const RECALL_RISK_BAND: f64 = 0.20;     // fraction just-below to call recall risk
+
+/// `weak_clusters` / `oversized_clusters` are counts from ClusterDiagnostics.
+pub fn threshold_rule(
+    matchkey: &str,
+    current: f64,
+    sd: &ScoreDiagnostics,
+    weak_clusters: usize,
+    oversized_clusters: usize,
+) -> Vec<Suggestion> {
+    let mut out = Vec::new();
+
+    // (a) bimodality dip not aligned with current threshold
+    if let Some(dip) = sd.dip() {
+        if (dip - current).abs() > 0.05 {
+            let kind = if dip > current { SuggestionKind::RaiseThreshold } else { SuggestionKind::LowerThreshold };
+            let effect = if dip > current { PredictedEffect::PrecisionUp } else { PredictedEffect::RecallUp };
+            out.push(Suggestion {
+                id: format!("thr:dip:{matchkey}"),
+                kind: kind.clone(),
+                target: matchkey.into(),
+                current_value: format!("{current:.2}"),
+                proposed_value: format!("{dip:.2}"),
+                rationale: format!(
+                    "Pair scores split into two groups with a gap near {dip:.2}, but the \
+                     `{matchkey}` threshold sits at {current:.2}. Moving it to {dip:.2} \
+                     separates the two groups cleanly."),
+                predicted_effect: effect,
+                confidence: 0.7,
+                patch: ConfigPatch::SetThreshold { matchkey: matchkey.into(), value: round2(dip) },
+                evidence: serde_json::json!({"dip": dip, "current": current}),
+            });
+        }
+    }
+
+    // (b) "everything matches" → raise
+    if sd.mass_above > EVERYTHING_MATCHES {
+        let proposed = round2((current + 1.0) / 2.0); // halfway to 1.0
+        out.push(Suggestion {
+            id: format!("thr:raise:{matchkey}"),
+            kind: SuggestionKind::RaiseThreshold,
+            target: matchkey.into(),
+            current_value: format!("{current:.2}"),
+            proposed_value: format!("{proposed:.2}"),
+            rationale: format!(
+                "{:.0}% of scored pairs clear the `{matchkey}` threshold of {current:.2} — \
+                 almost everything is matching, which usually means false merges. Raising it \
+                 to {proposed:.2} tightens the match.", sd.mass_above * 100.0),
+            predicted_effect: PredictedEffect::PrecisionUp,
+            confidence: 0.6,
+            patch: ConfigPatch::SetThreshold { matchkey: matchkey.into(), value: proposed },
+            evidence: serde_json::json!({"mass_above": sd.mass_above}),
+        });
+    }
+
+    // (c) recall risk: mass just below + weak/oversized clusters → lower
+    if sd.mass_just_below > RECALL_RISK_BAND && (weak_clusters + oversized_clusters) > 0 {
+        let proposed = round2(current - 0.05);
+        out.push(Suggestion {
+            id: format!("thr:lower:{matchkey}"),
+            kind: SuggestionKind::LowerThreshold,
+            target: matchkey.into(),
+            current_value: format!("{current:.2}"),
+            proposed_value: format!("{proposed:.2}"),
+            rationale: format!(
+                "{:.0}% of pairs score just below the `{matchkey}` threshold ({current:.2}), \
+                 and there are weak/oversized clusters nearby — likely missed matches. \
+                 Lowering it to {proposed:.2} recovers them.", sd.mass_just_below * 100.0),
+            predicted_effect: PredictedEffect::RecallUp,
+            confidence: 0.5,
+            patch: ConfigPatch::SetThreshold { matchkey: matchkey.into(), value: proposed },
+            evidence: serde_json::json!({"mass_just_below": sd.mass_just_below,
+                                         "weak": weak_clusters, "oversized": oversized_clusters}),
+        });
+    }
+
+    out
+}
+
+fn round2(x: f64) -> f64 { (x * 100.0).round() / 100.0 }
+```
+
+- [ ] **Step 4: Run → PASS** (all three behaviors). Fix the dip test expectation if (a)/(c) both fire — dedup is the ranker's job (Task 8); for the unit test assert the dip suggestion is *present*.
+- [ ] **Step 5: Commit** `feat(suggest): rule 1 threshold raise/lower`
+
+### Task 6: Rule 2 — scorer swap (noise-aware)
+
+**Files:** `src/rules.rs` (extend)
+
+- [ ] **Step 1: Failing test** — a `ColumnSignal` for an `address`/`name`/free-text column, `scorer == "token_sort"`, `corruption_score > 0.3` (or `variant_rate > 0.02`) → emits a `SwapScorer` to `jaro_winkler`; a clean column or a `qgram`-coded column emits nothing.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** `pub fn scorer_swap_rule(matchkey: &str, signals: &[ColumnSignal]) -> Vec<Suggestion>`. Gate: `col_type in {address, string, name}` AND `scorer == token_sort` AND (`corruption_score >= 0.3` OR `variant_rate >= 0.02`). Propose `jaro_winkler`. Rationale cites the corruption/variant number. `confidence: 0.65`. Patch `SetScorer`. (Mirror the #662 noise-aware default and `core/autoconfig.py` guard logic — read it to match thresholds.)
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(suggest): rule 2 scorer swap`
+
+### Task 7: Rule 3 — add negative evidence
+
+**Files:** `src/rules.rs` (extend)
+
+- [ ] **Step 1: Failing test** — a `ColumnSignal` with `identity_score >= 0.75`, `cardinality_ratio >= 0.5`, `in_negative_evidence == false`, `collision_rate >= 0.5` → emits `AddNegativeEvidence`; a column already in NE, or low identity/collision, emits nothing.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** `pub fn negative_evidence_rule(signals: &[ColumnSignal]) -> Vec<Suggestion>` mirroring `compute_identity_collision_signal` / `promote_negative_evidence` thresholds (read `core/autoconfig_rules.py` to match). `confidence: 0.55`. Patch `AddNegativeEvidence`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(suggest): rule 3 add negative evidence`
+
+---
+
+## Phase 3 — Rank, suppress, and the top-level entry
+
+### Task 8: Ranking + priors + dedup
+
+**Files:**
+- Create: `packages/rust/extensions/suggest-core/src/rank.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Failing tests**
+  - Two suggestions with different confidence → higher confidence ranks first.
+  - A `(kind, target)` with priors `(0 accepts, 3 rejects)` → suppressed (absent from output).
+  - A `(kind, target)` with priors `(3 accepts, 0 rejects)` → ranked above an equal-confidence one with no history.
+  - Duplicate `id` collapses to one.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::contract::{Suggestion, SuggestionKind, AcceptancePriors};
+
+const SUPPRESS_AFTER_NET_REJECTS: i64 = 2;
+
+/// Canonical priors-map key: `"{snake_case kind}:{target}"`. Pin this here so
+/// Plan 2's MemoryStore persistence writes the SAME key — otherwise the
+/// accept/reject loop silently won't bind. Uses the snake_case serde names
+/// (NOT Debug-format, which would drop the underscores).
+pub fn prior_key(kind: &SuggestionKind, target: &str) -> String {
+    let k = match kind {
+        SuggestionKind::RaiseThreshold => "raise_threshold",
+        SuggestionKind::LowerThreshold => "lower_threshold",
+        SuggestionKind::SwapScorer => "swap_scorer",
+        SuggestionKind::AddNegativeEvidence => "add_negative_evidence",
+    };
+    format!("{k}:{target}")
+}
+
+pub fn rank(mut suggestions: Vec<Suggestion>, priors: &AcceptancePriors) -> Vec<Suggestion> {
+    // dedup by id (keep first)
+    let mut seen = std::collections::HashSet::new();
+    suggestions.retain(|s| seen.insert(s.id.clone()));
+
+    // suppress repeatedly-rejected (kind,target)
+    suggestions.retain(|s| {
+        match priors.counts.get(&prior_key(&s.kind, &s.target)) {
+            Some((acc, rej)) => (*rej as i64 - *acc as i64) < SUPPRESS_AFTER_NET_REJECTS,
+            None => true,
+        }
+    });
+
+    // score = confidence + acceptance nudge
+    suggestions.sort_by(|a, b| {
+        score(b, priors).partial_cmp(&score(a, priors)).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    suggestions
+}
+
+fn score(s: &Suggestion, priors: &AcceptancePriors) -> f64 {
+    let nudge = match priors.counts.get(&prior_key(&s.kind, &s.target)) {
+        Some((acc, rej)) => 0.05 * (*acc as f64 - *rej as f64),
+        None => 0.0,
+    };
+    s.confidence + nudge
+}
+```
+
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(suggest): ranking + priors suppression`
+
+### Task 9: Top-level `suggest()` over Arrow + golden vectors
+
+**Files:**
+- Create: `packages/rust/extensions/suggest-core/src/api.rs`
+- Create: `packages/rust/extensions/suggest-core/tests/golden/*.json` (fixtures)
+- Modify: `src/lib.rs` (`pub mod api; pub use api::suggest;`)
+
+- [ ] **Step 1: Failing test** — call `suggest(scored_pairs, clusters, column_signals, config_json, priors_json)` with a fixture that should produce a known scorer-swap as #1, assert the top suggestion's `kind`/`target`.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** `pub fn suggest(scored_pairs: &RecordBatch, clusters: &RecordBatch, column_signals: &RecordBatch, config_json: &str, priors_json: &str) -> Result<String, String>` that: parses `ConfigSummary`/`AcceptancePriors` from JSON, builds diagnostics, calls each rule per matchkey, ranks, and returns `serde_json::to_string(&RankedSuggestions)`. Returns a JSON string (the FFI/pyo3-friendly boundary).
+
+  **v1 cluster-count simplification:** `ClusterDiagnostics` (Task 3) counts `weak`/`oversized` **globally**, not per-matchkey. Pass those same global counts to every matchkey's `threshold_rule`. This is an accepted v1 simplification — zero-config datasets typically have one weighted matchkey, so global == per-matchkey in practice. Note it in a code comment so a future multi-matchkey extension knows to revisit.
+- [ ] **Step 4: Add a golden-vector test** that loads `tests/golden/ncvr_address.json` (inputs + expected top suggestion) and asserts the kernel output matches. This is the determinism pin.
+- [ ] **Step 5: Run → PASS.**
+- [ ] **Step 6: Commit** `feat(suggest): top-level suggest() over Arrow + golden vectors`
+
+---
+
+## Phase 4 — Python binding
+
+### Task 10: `suggest.rs` pyo3 shim in `goldenmatch-native`
+
+**Files:**
+- Create: `packages/rust/extensions/native/src/suggest.rs`
+- Modify: `packages/rust/extensions/native/src/lib.rs` (add `mod suggest;` + register `suggest::suggest_config`)
+- Modify: `packages/rust/extensions/native/Cargo.toml` (add `goldenmatch-suggest-core = { path = "../suggest-core" }`)
+
+- [ ] **Step 1: Write the shim** (delegates to the core; receives pyarrow batches via `PyArrowType`, like `score.rs::score_block_pairs_arrow`)
+
+```rust
+use arrow::pyarrow::PyArrowType;
+use arrow::record_batch::RecordBatch;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn suggest_config(
+    scored_pairs: PyArrowType<RecordBatch>,
+    clusters: PyArrowType<RecordBatch>,
+    column_signals: PyArrowType<RecordBatch>,
+    config_json: &str,
+    priors_json: &str,
+) -> PyResult<String> {
+    goldenmatch_suggest_core::suggest(
+        &scored_pairs.0, &clusters.0, &column_signals.0, config_json, priors_json,
+    ).map_err(|e| PyValueError::new_err(e))
+}
+```
+
+- [ ] **Step 2: Register** in `_native` pymodule: `m.add_function(wrap_pyfunction!(suggest::suggest_config, m)?)?;`
+- [ ] **Step 3: Build the wheel.** Run: `python scripts/build_native.py`. Expected: builds, no errors.
+- [ ] **Step 4: Smoke test** in Python:
+
+```python
+import goldenmatch._native as n
+assert hasattr(n, "suggest_config")
+```
+
+Run: `.venv/Scripts/python.exe -c "import goldenmatch._native as n; print(hasattr(n,'suggest_config'))"`
+Expected: `True`.
+
+- [ ] **Step 5: Commit** `feat(suggest): native pyo3 shim for suggest_config`
+
+### Task 11: Python adapter — `review_config`
+
+**Files:**
+- Create: `packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py`
+- Create: `packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py`
+- Create: `packages/python/goldenmatch/goldenmatch/core/suggest/types.py`
+- Test: `packages/python/goldenmatch/tests/test_suggest_adapter.py`
+
+`adapter.review_config(result, config)`:
+1. Build the three pyarrow tables from the run result (per Task 0 findings): scored pairs `(id_a,id_b,score)`, clusters `(cluster_id,size,confidence,quality,oversized)`, column signals (one row per column from the profile/indicators).
+2. Serialize `config` → `ConfigSummary` JSON via a small `_config_summary(config)` mapper (read `config.get_matchkeys()`; `MatchkeyConfig.negative_evidence`).
+3. Call `goldenmatch._native.suggest_config(...)`; parse the JSON back into `Suggestion` dataclasses (`types.py`).
+4. If native is absent → raise `SuggestionsNativeRequired` with the "install goldenmatch[native]" message.
+
+- [ ] **Step 1: Failing test** — a tiny synthetic dedupe result (use `_person_df` from `tests/test_autoconfig_regressions.py`, run `dedupe_df` with a known-loose threshold) → `review_config` returns a non-empty list whose items are `Suggestion` dataclasses with a `rationale` string. Guard the test with `pytest.importorskip` on `goldenmatch._native` + a `hasattr(..., "suggest_config")` skip.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** `types.py` (`@dataclass Suggestion`, `ConfigPatch` union mirror), `adapter.py` (the four steps), `__init__.py` re-exports.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(suggest): python review_config adapter`
+
+### Task 12: `apply_suggestion`
+
+**Files:** `core/suggest/apply.py`; test `tests/test_suggest_apply.py`
+
+- [ ] **Step 1: Failing tests** — `apply_suggestion(config, suggestion)` returns a NEW `GoldenMatchConfig` (Pydantic `model_copy(deep=True)`) with: SetThreshold → the named matchkey's `threshold` updated; SetScorer → the named field's `scorer` updated; AddNegativeEvidence → the field appended to the matchkey's `negative_evidence`. Original config unmutated.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** a pure function dispatching on `suggestion.patch.op`. Use the typed-accessor pattern; write through `model_copy`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(suggest): apply_suggestion config patcher`
+
+### Task 13: Native-absent degradation
+
+**Files:** `core/suggest/adapter.py` (already raises); test `tests/test_suggest_native_required.py`
+
+- [ ] **Step 1: Failing test** — monkeypatch the native loader to simulate absence; assert `review_config` raises `SuggestionsNativeRequired` and the message contains `goldenmatch[native]`.
+- [ ] **Step 2: Run → fail / Step 3: implement the guard / Step 4: PASS.**
+- [ ] **Step 5: Commit** `feat(suggest): clean native-required degradation`
+
+---
+
+## Phase 5 — Benchmark harness
+
+### Task 14: `scripts/suggest_quality` scaffold + dataset loaders
+
+**Files:**
+- Create: `scripts/suggest_quality/__init__.py`
+- Create: `scripts/suggest_quality/datasets.py` (reuse loaders from `scripts/autoconfig_quality` + `tests/benchmarks/`)
+- Create: `scripts/suggest_quality/cli.py` (`report` / `gate` / `bless` subcommands — mirror `scripts/autoconfig_quality`)
+
+- [ ] **Step 1:** Read `scripts/autoconfig_quality/` end to end; mirror its CLI shape, determinism env (`GOLDENMATCH_AUTOCONFIG_MEMORY=0`, fixed seed), and dataset loaders (Febrl3/4, DBLP-ACM, NCVR sample, historical_50k, synthetic). Skip datasets whose files are absent (gitignored) with a logged note (memory `feedback`: no silent caps).
+- [ ] **Step 2:** `report` runs nothing yet — prints "0 datasets" — but the CLI wires up. Smoke: `python -m scripts.suggest_quality.cli report --datasets synthetic`.
+- [ ] **Step 3: Commit** `feat(suggest): suggest_quality harness scaffold`
+
+### Task 15: Oracle enumeration + metrics
+
+**Files:**
+- Create: `scripts/suggest_quality/oracle.py`
+- Create: `scripts/suggest_quality/metrics.py`
+- Test: `packages/python/goldenmatch/tests/test_suggest_metrics.py`
+
+- [ ] **Step 1: Failing unit tests for the metrics** (pure functions, no dedupe):
+  - `rank_correlation(suggested_order, oracle_lifts)` → Spearman; identical order → 1.0, reversed → -1.0.
+  - `suggester_precision(applied_lifts)` → fraction with `lift >= 0`.
+  - `convergence(steps)` → final F1 + step count from a list of (suggestion, f1_after).
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement metrics.py** (use `scipy.stats.spearmanr`; it's already a dep via sklearn/scipy).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Implement `oracle.py`** — per dataset: zero-config → baseline F1 (use `core/evaluate.py::evaluate_pairs` + `load_ground_truth_csv`); `review_config` → suggestions; for each candidate edit, `apply_suggestion` → re-run `dedupe_df` → F1; assemble the per-dataset record (baseline, suggestions, oracle lifts, applied lifts, convergence). This is integration code (no unit test; exercised by `report`).
+- [ ] **Step 6: Wire `report`** to print the per-dataset table + headline suggester-score (mean rank-correlation across datasets). Run on `synthetic` locally; full set in CI.
+- [ ] **Step 7: Commit** `feat(suggest): oracle enumeration + suggester metrics`
+
+### Task 16: Regression anchors, baseline, CI gate
+
+**Files:**
+- Create: `scripts/suggest_quality/baseline.json` (blessed scores; created by `bless`)
+- Create: `.github/workflows/bench-suggest-quality.yml`
+- Test: `packages/python/goldenmatch/tests/test_suggest_anchors.py`
+
+- [ ] **Step 1: Anchor test (the hard contract)** — on NCVR (skip if dataset absent), `review_config` after zero-config must rank the `res_street_address` token_sort→jaro_winkler `SwapScorer` as the #1 suggestion. Assert `suggestions[0].kind == SwapScorer and suggestions[0].target == "res_street_address"`. Mark `@pytest.mark.benchmark` (excluded from default CI; runs in the bench workflow).
+- [ ] **Step 2: Run** the anchor in the bench context; if it fails, the rule thresholds (Task 6) need tuning — iterate there, not in the test. This is the loop the whole plan exists to enable.
+- [ ] **Step 3: `bless`** writes `baseline.json` (per-dataset rank-correlation, suggester-precision, convergence F1). `gate` loads it and fails if any metric regresses beyond a tolerance (e.g. rank-corr drops > 0.05).
+- [ ] **Step 4: CI workflow** — `workflow_dispatch` + `on: push` paths covering ALL code the harness depends on, not just the core: `packages/rust/extensions/suggest-core/**`, `packages/rust/extensions/native/src/suggest.rs`, `packages/python/goldenmatch/goldenmatch/core/suggest/**`, and `scripts/suggest_quality/**`. `runs-on: large-new-64GB` (memory `feedback_bench_default_runner`); builds the native wheel, runs `python -m scripts.suggest_quality.cli gate`. Default datasets = those available in CI.
+- [ ] **Step 5: Commit** `feat(suggest): anchors + blessed baseline + bench-suggest-quality CI`
+
+---
+
+## Done criteria for Plan 1
+
+- `cargo test -p goldenmatch-suggest-core` green; golden-vector fixture pins the kernel.
+- `goldenmatch._native.suggest_config` present in the in-tree wheel.
+- `review_config(result, config)` returns ranked `Suggestion`s with rationale text; `apply_suggestion` round-trips a new config; native-absent raises the clean message.
+- `python -m scripts.suggest_quality.cli report` produces the per-dataset table; the NCVR address-swap anchor passes; `bless` + `gate` wired in CI.
+- Feature stays default-off (no auto-config or pipeline path calls `review_config`); it is opt-in via the Python API only. Surfaces + the default-on flip are Plan 2 + its benchmark sign-off.
+
+## Task 0 findings
+
+_(Appended during Task 0 — records the resolved input schema and artifact sources.)_

--- a/docs/superpowers/specs/2026-06-24-config-suggestion-kernel-design.md
+++ b/docs/superpowers/specs/2026-06-24-config-suggestion-kernel-design.md
@@ -1,0 +1,284 @@
+# Config-Suggestion Kernel — Design
+
+**Date:** 2026-06-24
+**Status:** Approved (brainstorm); pending plan
+**Author:** Ben Severn (with Claude)
+
+## Problem & vision
+
+We want to push GoldenMatch users onto a clear path: **zero-config for the
+first run, then iterate.** The user runs zero-config, sees the results, and the
+system reviews those results against the config that produced them and offers
+**ranked, explainable suggestions** for config edits that would make the next
+run more accurate. The user accepts or rejects each suggestion; accepted ones
+mutate the config, rejected ones train the suggester to stop offering them.
+
+Today this surface is shallow and Python-only: the MCP `suggest_config` tool
+requires the user to hand it bad-merge examples, runs ad-hoc heuristics inline
+in the MCP server, and has no result-driven review, no accept/reject loop, and
+no learning. The auto-config *decision* logic that does exist
+(`autoconfig_rules.py`, `autoconfig_planner_rules.py`) is pure-Python and runs
+only during sample iteration inside the controller; the Rust `bridge::autoconfig`
+delegates back into Python rather than owning any decision logic.
+
+The goal: a **native source-of-truth kernel** for config suggestions so every
+language surface (Python, SQL/DataFusion, TS) benefits from one implementation,
+and a **benchmark harness** that makes the *intelligence* of the suggestions a
+measurable, iterable number.
+
+### Scope
+
+In scope (v1): the **config-suggestion engine** — review run results, emit
+ranked suggestions, accept/reject with learning, plus the benchmark harness.
+
+Out of scope (filed as follow-up issues):
+- Pair/cluster verdicts as the feedback signal (infer the guilty knob from
+  approve/reject of specific match results).
+- Direct config edits as feedback (user edits config; kernel predicts impact).
+- Natural-language intent ("too many false merges on company names") → delta.
+- Unifying the kernel with the live auto-config refit rule table (Approach B
+  below) — the right *eventual* end state, but only after the suggestion rules
+  are proven by the benchmark.
+
+## Approach
+
+Three approaches were considered:
+
+- **A — New pyo3-free `suggest-core` kernel + thin bindings.** Follows the
+  established `score-core` / `analysis-core` pattern: Rust is the canonical
+  source of truth, parity is structural. Never touches the shipped, gated
+  auto-config controller path. **Chosen.**
+- **B — Promote the existing Python refit rule table into the kernel and reuse
+  it for both internal refit and user-facing suggestions.** DRYest, but the
+  biggest blast radius — rewrites logic on the live benchmark-gated controller,
+  and those rules are shaped for *sample* signals during iteration, not
+  *full-result* diagnostics. Rejected for v1; the right eventual end state.
+- **C — Python-first prototype, harden to native later.** Lowest risk on
+  suggestion quality, but defers (and risks never doing) the native ask and
+  writes the decision logic twice. Rejected; its measurement discipline is
+  folded into A instead.
+
+**Decision: Approach A**, with C's measurement discipline folded in — build the
+native kernel from the start, but make the benchmark harness a first-class
+deliverable so we can iterate on suggestion quality, and gate the feature's
+default-on flip behind that benchmark proving non-regression on real F1.
+
+## Architecture
+
+### The kernel: `suggest-core` (Arrow-in, pyo3-free)
+
+New crate `packages/rust/extensions/suggest-core/` (`goldenmatch-suggest-core`),
+pyo3-free, following the `score-core` model: Rust owns the logic; parity is
+structural, not asserted after the fact.
+
+The kernel **ingests the run's artifacts as Arrow** and does everything inward
+of that — extraction, reduction, decision, and rationale generation. Nothing of
+substance is duplicated per language. The repo already runs Arrow-in-Rust for
+its native-direct kernels (the #509 graph/embed UDFs on DuckDB+DataFusion; the
+whole pyarrow stack is on arrow 59), so this is a trodden lane.
+
+Entry point (shape, not final signature):
+
+```
+suggest(
+    scored_pairs:    RecordBatch,   // (id_a, id_b, score) — run already has this
+    clusters:        RecordBatch,   // (cluster_id, size, confidence, quality, oversized)
+    column_signals:  RecordBatch,   // one row per column: (field, col_type, scorer,
+                                    //  identity_score, corruption_score, collision_rate,
+                                    //  cardinality, null_rate, variant_rate)
+    config:          ConfigSummary, // small struct (JSON)
+    priors:          AcceptancePriors,
+) -> RankedSuggestions              // structs incl. the rendered display string
+```
+
+Inside, in Rust: histogram the scores, compute mass-above / mass-just-below
+bands, percentile the block sizes, read the collision/corruption signals, run
+the decision rules, **generate the rationale text**, and rank. The reductions
+reuse the `analysis-core` `histogram` / `quantile` kernels — no second
+implementation of those.
+
+**Rationale text is generated in the kernel, not per-language.** The explanation
+string ("raise `name` threshold 0.82→0.88 because bad-merge mass clusters just
+below it") must be identical on every surface, so the kernel emits it. Surfaces
+only wrap it in their own UI chrome (a TUI panel, a JSON field, an MCP content
+block).
+
+### Consumers
+
+1. **Python** — a thin `suggest.rs` `#[pyfunction]` module added to the existing
+   `goldenmatch-native` crate (same way `score.rs` delegates to `score-core`).
+   Ships in the `goldenmatch[native]` wheel. Python zero-copies its polars
+   frames out via `.to_arrow()`.
+2. **SQL / DataFusion** — hands the kernel its Arrow batches directly,
+   native-direct, like the graph/embed UDFs. Promoted from "staged" to nearly
+   free by the Arrow-in contract. *Staged for v1* (contract ready, wiring later.)
+3. **TS** — a WASM build of `suggest-core` over Arrow IPC. *Staged for v1.*
+
+### No-native behaviour
+
+**Config suggestions are a `goldenmatch[native]` feature.** Pulling extraction
+into the Arrow kernel means there is exactly one implementation; we deliberately
+do **not** maintain a pure-Python extraction mirror (that would re-duplicate the
+thing the Arrow kernel exists to unify). Without the native wheel, every surface
+emits a clear "install `goldenmatch[native]` for config suggestions" message and
+degrades to today's shallow `suggest_config`. "Parity" therefore means the kernel
+is deterministic against fixtures, not Rust-vs-Python.
+
+### Boundary
+
+The shipped, benchmark-gated auto-config controller path is **never touched** —
+the suggestion engine reads run *outputs*; it does not reach into the controller.
+Learning re-enters only as the `priors` input, keeping the kernel a stateless
+pure function of `(diagnostics, config, priors)`.
+
+## v1 suggestion rules
+
+Three high-signal, ground-truth-free rules. Each reads diagnostics the run
+already produces and emits a
+`Suggestion { kind, target, current_value, proposed_value, rationale, evidence,
+predicted_effect, confidence, config_patch, fingerprint }`.
+
+**1. Threshold raise / lower** — driven by the score histogram over
+`scored_pairs`:
+- *Bimodality dip:* if the score distribution has a clear valley and the current
+  threshold isn't in it → suggest moving to the dip.
+- *Mass bands:* high `mass_above_threshold` (the "everything matches" pathology
+  the controller already guards) → suggest **raise**; significant mass just
+  below threshold on **weak/oversized** clusters → recall risk → suggest
+  **lower**.
+
+**2. Scorer swap** — the shipped noise-aware (#662) logic, surfaced as a
+suggestion instead of a silent auto-config default. A free-text / address / name
+column with high `corruption_score` / `variant_rate` still scored by
+`token_sort` → suggest `jaro_winkler`. This is the NCVR `res_street_address`
+lever (F1 0.871→0.981), the single biggest known win, now offered with its
+evidence.
+
+**3. Add negative evidence** — the collision signal: an identity-ish column
+(`identity_score ≥ 0.75`, `cardinality ≥ 0.5`) not already negative evidence,
+showing a high in-cluster `collision_rate` → suggest adding it as NE. Mirrors
+`compute_identity_collision_signal` / `promote_negative_evidence`, surfaced with
+evidence.
+
+**Staged (designed, not built in v1):**
+- *Add / drop blocking pass* (recall via block-size percentiles + orthogonal
+  keys).
+- *Field-weight adjustment* — needs per-field pair scores materialized, which
+  the pipeline does not emit today (it is why `MemoryLearner._compute_weights`
+  is stubbed). Filed as the bridge issue; it also unblocks the weight-learning
+  stub.
+
+The unifying thread: every v1 rule is a signal the codebase *already computes*
+but currently either applies silently (scorer swap), only during sample
+iteration (collision), or not at all post-run (threshold). The kernel turns
+those latent signals into explicit, explainable, user-approvable suggestions.
+
+## Learning loop (accept / reject → priors)
+
+Each `Suggestion` carries a declarative **`ConfigPatch`** (e.g.
+`set matchkey["name"].threshold = 0.88`; `set field["addr"].scorer = jaro_winkler`;
+`add negative_evidence "email"`). The kernel defines *what* to change once; each
+language applies the patch to its own native config object (Python: Pydantic
+`model_copy`; YAML save is atomic via `os.replace`, mirroring `web/rules.py`).
+
+**Persistence reuses `MemoryStore`** — a new `suggestion_feedback` row
+(suggestion fingerprint, `kind`, target signature, decision, dataset,
+timestamp), alongside corrections and learned adjustments. The **fingerprint** is
+a stable hash of `(kind, target-signature, patch shape)` so accept/reject
+re-anchors across runs — the same durability idea as `record_hash` for
+corrections.
+
+**Priors close the loop without ML in v1:** before each `suggest()`, the adapter
+loads accept/reject counts and passes `AcceptancePriors` in; the kernel
+(a) suppresses a `(kind, target)` the user keeps rejecting, and (b) nudges
+ranking by net acceptance. Counts → multiplier + suppression threshold. The
+kernel stays a pure function — fully golden-vector testable. ML ranking is a
+future lever.
+
+## Benchmark & iteration harness
+
+A first-class deliverable, not just an end gate — the value of the kernel is the
+*quality* of its suggestions, so suggestion intelligence must be measurable and
+iterable.
+
+`scripts/suggest_quality/` mirrors the proven `scripts/autoconfig_quality`
+harness: `report` / `gate` / `bless` ergonomics, deterministic posture
+(`GOLDENMATCH_AUTOCONFIG_MEMORY=0`, fixed seeds). Datasets are the labeled ER
+sets with ground truth: Febrl3/4, DBLP-ACM, NCVR sample, `historical_50k`,
+synthetic.
+
+### The measured loop, per dataset
+
+1. Zero-config → run dedupe → record baseline F1.
+2. Assemble diagnostics → kernel emits ranked suggestions.
+3. **Oracle enumeration:** actually apply *every candidate edit the kernel could
+   propose* (threshold sweep, each scorer swap, each NE candidate), re-run
+   dedupe, measure the true F1 lift of each. This gives ground truth for "which
+   suggestions are good" and the oracle-best edit.
+4. Score the suggester against that oracle.
+
+### Metrics
+
+- **North star — oracle-ranking correlation:** rank correlation between the
+  suggester's order and the measured F1 lift of each candidate. A smart
+  suggester ranks the highest-impact edit first.
+- **Suggester precision:** fraction of emitted suggestions that, when applied,
+  do **not** regress F1. A suggestion that drops F1 is a bug.
+- **Convergence-to-ceiling:** accept top suggestion, re-run, repeat until no
+  positive suggestion remains; report final F1 vs the known hand-tuned /
+  zero-config ceiling and the step count.
+
+### Regression anchors
+
+The harness pins specific known wins as hard anchors. Above all: on NCVR, rule
+#2 **must** emit the `res_street_address` token_sort→jaro_winkler swap as its #1
+suggestion (F1 0.871→0.981), or the bench fails. Same posture for the DBLP-ACM
+and `historical_50k` gaps.
+
+### Ergonomics & CI
+
+`report` runs the loop and prints the per-dataset table + a headline
+suggester-score. `bless` snapshots current scores as the baseline. `gate` (CI,
+`workflow_dispatch` + on `suggest-core` changes, `large-new-64GB` runner) fails
+on regression vs blessed baseline. Dev loop for improving the kernel: tweak a
+rule → `report` → watch rank-correlation / convergence move → `bless` when
+better. The feature's default-on flip is gated behind this bench proving
+non-regression on real F1.
+
+## Surfaces (v1 wiring)
+
+- **Python API:** `review_config(result, config) → RankedSuggestions`,
+  `apply_suggestion(config, suggestion) → config`,
+  `record_suggestion_feedback(suggestion, decision)`.
+- **CLI:** `goldenmatch suggest` (review last/named run → table) with an
+  interactive accept/reject loop that writes the updated `goldenmatch.yml`
+  atomically.
+- **MCP:** upgrade `suggest_config` to the result-driven engine (keep
+  `bad_merges` as one back-compat evidence source), add `accept_suggestion` /
+  `reject_suggestion`; bump the server-card tool count.
+- **TUI:** a Suggestions panel in the Config tab post-run, reusing the Ctrl+T
+  triage accept/reject pattern.
+- **Staged (cheap later, by design):** SQL/DataFusion (Arrow-direct), TS (WASM),
+  Web/REST/A2A.
+
+## Data contract & testing
+
+- **Contract** lives in `suggest-core` (Rust structs + serde JSON); Python typed
+  wrappers mirror it; the boundary is JSON/Arrow.
+- **Tests:** per-rule kernel unit tests; **golden-vector fixtures** (JSON inputs
+  → expected suggestions) pinning determinism; the suggester-quality bench;
+  Python-binding tests; CLI/MCP integration; and a native-absent degradation
+  test asserting the clean "install `[native]`" message.
+
+## Open questions for planning
+
+- Confirm whether any pyo3-free autoconfig decision crate already exists (memory
+  note suggests one shipped; the `bridge::autoconfig` delegates to Python, so it
+  may be stale or refer to specific small levers). Resolve before assuming
+  `suggest-core` is the first decision crate.
+- Exact column set for the `column_signals` batch and which already-computed
+  artifact each field comes from (`ComplexityProfile`, indicators, clusters).
+- Whether `scored_pairs` is materialized at the size needed post-run for all
+  backends, or whether the histogram should be read from `ComplexityProfile`
+  where the run already computed it.
+```

--- a/docs/superpowers/specs/2026-06-24-config-suggestion-kernel-design.md
+++ b/docs/superpowers/specs/2026-06-24-config-suggestion-kernel-design.md
@@ -288,4 +288,48 @@ non-regression on real F1.
 - Whether `scored_pairs` is materialized at the size needed post-run for all
   backends, or whether the histogram should be read from `ComplexityProfile`
   where the run already computed it.
+
+## Implementation addendum (2026-06-24): self-verification
+
+The original design had `review_config` emit the kernel's ranked suggestions
+**blind**. The benchmark immediately exposed the flaw: on `ncvr_synthetic`
+(zero-config baseline F1 already 0.983), the kernel emitted two suggestions that
+*both lowered F1* (`suggester_precision = 0.0`). A suggester that can suggest
+harm is worse than no suggester.
+
+**Fix (Task 17): `review_config(df, config, *, verify=True)` self-verifies.**
+After the kernel returns ranked suggestions, the adapter simulates each one
+(`apply_suggestion` → re-run the engine) and keeps it only if an **unsupervised
+config-health proxy** does not worsen. There is no ground truth at suggest-time,
+so the proxy is computed from the run's own outputs:
+`health = matched_rate * avg_confidence - concentration_penalty`, where the
+penalty is a graded Herfindahl concentration over multi-member clusters
+(`sum((size/n)²)`) — a threshold-lower that over-merges raises concentration and
+drops `avg_confidence`; a threshold-raise that loses matches drops
+`matched_rate`. Survivors keep the kernel's rank order. `verify=False` (or
+`GOLDENMATCH_SUGGEST_VERIFY=0`) returns the raw kernel list; candidates are
+capped at 8. Cost: one extra pipeline run per candidate (suggestions are few).
+
+**Measured result:** `suggester_precision = 1.0` across all benchmark datasets.
+The suggester now **declines** to suggest on already-near-optimal configs
+(`ncvr_synthetic`/`synthetic` → 0 suggestions) while still emitting genuinely
+helpful ones (`anchor_person_match`: 1 suggestion lifts F1 0.9896 → 1.0; the
+NCVR address scorer-swap survives verify). "Don't emit net-negative" is now a
+structural property, not per-rule tuning.
+
+**Honest limitation:** the proxy is unsupervised and can disagree with F1; it
+reduces but cannot perfectly eliminate net-negative suggestions. The benchmark's
+`suggester_precision` metric is the standing check. Rule-quality iteration (the
+threshold/NE rules are still simple) and proving a default-on flip remain the
+Plan-2 frontier; this addendum makes the v1 suggester *safe*, not yet *optimal*.
+
+## Status
+
+Plan 1 SHIPPED on branch `feat/config-suggestion-kernel` (PR #1267): the
+pyo3-free `suggest-core` kernel (29 Rust tests + golden vectors), the native
+pyo3 shim, the Python `review_config`/`apply_suggestion` adapters with
+self-verification, and the `scripts/suggest_quality` oracle benchmark
+(report/gate/bless + CI gate). Feature is opt-in via the Python API and
+default-off in pipelines. Surfaces (CLI/MCP/TUI), accept/reject persistence,
+and the default-on flip are Plan 2.
 ```

--- a/docs/superpowers/specs/2026-06-24-config-suggestion-kernel-design.md
+++ b/docs/superpowers/specs/2026-06-24-config-suggestion-kernel-design.md
@@ -85,7 +85,9 @@ suggest(
     clusters:        RecordBatch,   // (cluster_id, size, confidence, quality, oversized)
     column_signals:  RecordBatch,   // one row per column: (field, col_type, scorer,
                                     //  identity_score, corruption_score, collision_rate,
-                                    //  cardinality, null_rate, variant_rate)
+                                    //  cardinality_ratio, null_rate, variant_rate)
+                                    //  cardinality is a RATIO in [0,1], matching the
+                                    //  existing cardinality_ratio used by autoconfig guards
     config:          ConfigSummary, // small struct (JSON)
     priors:          AcceptancePriors,
 ) -> RankedSuggestions              // structs incl. the rendered display string
@@ -255,7 +257,9 @@ non-regression on real F1.
   atomically.
 - **MCP:** upgrade `suggest_config` to the result-driven engine (keep
   `bad_merges` as one back-compat evidence source), add `accept_suggestion` /
-  `reject_suggestion`; bump the server-card tool count.
+  `reject_suggestion`; bump the server-card tool count. The plan must make the
+  `server.json` → MCP-registry sync an explicit task (lockstep footgun per
+  CLAUDE.md), not an afterthought.
 - **TUI:** a Suggestions panel in the Config tab post-run, reusing the Ctrl+T
   triage accept/reject pattern.
 - **Staged (cheap later, by design):** SQL/DataFusion (Arrow-direct), TS (WASM),
@@ -272,10 +276,13 @@ non-regression on real F1.
 
 ## Open questions for planning
 
-- Confirm whether any pyo3-free autoconfig decision crate already exists (memory
-  note suggests one shipped; the `bridge::autoconfig` delegates to Python, so it
-  may be stale or refer to specific small levers). Resolve before assuming
-  `suggest-core` is the first decision crate.
+- Confirm whether any pyo3-free autoconfig decision crate already exists. The
+  `project_autoconfig_native_core` memory note claims one shipped ("PyPI native
+  0.1.11"), but `bridge::autoconfig` delegates to Python and no autoconfig crate
+  was found under `packages/rust/extensions/`, so the note may be stale or refer
+  to specific small levers. Resolve in planning before assuming `suggest-core` is
+  the first decision crate — it affects whether we extend an existing crate or
+  go greenfield.
 - Exact column set for the `column_signals` batch and which already-computed
   artifact each field comes from (`ComplexityProfile`, indicators, clusters).
 - Whether `scored_pairs` is materialized at the size needed post-run for all

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -256,6 +256,10 @@ from goldenmatch.core.sensitivity import SensitivityResult, SweepParam, run_sens
 from goldenmatch.core.standardize import apply_standardization
 from goldenmatch.core.streaming import StreamProcessor, run_stream
 from goldenmatch.core.threshold import suggest_threshold
+# Note: config-suggestion review (review_config, apply_suggestion) is
+# intentionally NOT re-exported here -- it is opt-in, accessed via
+# `from goldenmatch.core.suggest import review_config, apply_suggestion`.
+# Promotion to the top-level public surface is a Plan 2 decision.
 from goldenmatch.core.validate import validate_dataframe
 from goldenmatch.core.vector_index import VectorIndex
 from goldenmatch.core.vector_store import (

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py
@@ -15,13 +15,16 @@ See ``goldenmatch.core.suggest.health`` for the proxy formula.
 """
 from goldenmatch.core.suggest.adapter import review_config
 from goldenmatch.core.suggest.apply import apply_suggestion
-from goldenmatch.core.suggest.health import suggestion_health, suggestion_health_from_clusters
+from goldenmatch.core.suggest.health import suggestion_health_from_clusters
 from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired
 
+# suggestion_health (scored-pairs proxy) is intentionally NOT in __all__: the
+# pipeline returns only pairs >= threshold so mass_above is always 1.0 there,
+# making the proxy meaningless on _run_pipeline output.  Access it explicitly
+# via `from goldenmatch.core.suggest.health import suggestion_health`.
 __all__ = [
     "review_config",
     "apply_suggestion",
-    "suggestion_health",
     "suggestion_health_from_clusters",
     "Suggestion",
     "SuggestionsNativeRequired",

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py
@@ -8,9 +8,21 @@ Public surface::
 the three Arrow batches required by the native kernel, and returns a list of
 :class:`Suggestion` dataclasses.  Raises :exc:`SuggestionsNativeRequired` when
 the native wheel is absent.
+
+Self-verification (verify=True, the default) filters suggestions whose
+application would worsen the score distribution's unsupervised health proxy.
+See ``goldenmatch.core.suggest.health`` for the proxy formula.
 """
 from goldenmatch.core.suggest.adapter import review_config
 from goldenmatch.core.suggest.apply import apply_suggestion
+from goldenmatch.core.suggest.health import suggestion_health, suggestion_health_from_clusters
 from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired
 
-__all__ = ["review_config", "apply_suggestion", "Suggestion", "SuggestionsNativeRequired"]
+__all__ = [
+    "review_config",
+    "apply_suggestion",
+    "suggestion_health",
+    "suggestion_health_from_clusters",
+    "Suggestion",
+    "SuggestionsNativeRequired",
+]

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py
@@ -1,0 +1,15 @@
+"""Config-suggestion adapter for goldenmatch.
+
+Public surface::
+
+    from goldenmatch.core.suggest import review_config, Suggestion, SuggestionsNativeRequired
+
+``review_config(df, config)`` runs the dedupe pipeline internally, assembles
+the three Arrow batches required by the native kernel, and returns a list of
+:class:`Suggestion` dataclasses.  Raises :exc:`SuggestionsNativeRequired` when
+the native wheel is absent.
+"""
+from goldenmatch.core.suggest.adapter import review_config
+from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired
+
+__all__ = ["review_config", "Suggestion", "SuggestionsNativeRequired"]

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py
@@ -10,6 +10,7 @@ the three Arrow batches required by the native kernel, and returns a list of
 the native wheel is absent.
 """
 from goldenmatch.core.suggest.adapter import review_config
+from goldenmatch.core.suggest.apply import apply_suggestion
 from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired
 
-__all__ = ["review_config", "Suggestion", "SuggestionsNativeRequired"]
+__all__ = ["review_config", "apply_suggestion", "Suggestion", "SuggestionsNativeRequired"]

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import os
 from typing import Any
 
 import polars as pl
@@ -405,8 +406,6 @@ def _build_column_signals_batch(
 
 # ── Environment flag ───────────────────────────────────────────────────────
 
-import os as _os
-
 def _verify_enabled_by_env() -> bool:
     """Check if GOLDENMATCH_SUGGEST_VERIFY env var disables verification.
 
@@ -414,7 +413,7 @@ def _verify_enabled_by_env() -> bool:
     "0", "false", or "disabled" (case-insensitive).  Mirrors the repo-wide
     env-flag pattern for kill-switches.
     """
-    val = _os.environ.get("GOLDENMATCH_SUGGEST_VERIFY", "").strip().lower()
+    val = os.environ.get("GOLDENMATCH_SUGGEST_VERIFY", "").strip().lower()
     return val not in {"0", "false", "disabled"}
 
 
@@ -618,4 +617,10 @@ def review_config(
 
     # Tail (beyond _MAX_VERIFY_CANDIDATES) passes through unverified.
     # In practice the kernel returns at most 5 suggestions so this is a no-op.
+    if tail:
+        logger.debug(
+            "review_config verify: %d suggestion(s) beyond _MAX_VERIFY_CANDIDATES=%d "
+            "passed through unverified",
+            len(tail), _MAX_VERIFY_CANDIDATES,
+        )
     return verified + tail

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
@@ -21,19 +21,19 @@ is slightly cheaper but adds caller boilerplate that hides the integration path.
 """
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from typing import Any
 
 import polars as pl
+import pyarrow as pa
 
 from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired
 
 logger = logging.getLogger(__name__)
 
 # ── Arrow schemas (frozen - must match the Rust kernel exactly) ────────────
-
-import pyarrow as pa
 
 _SCORED_PAIRS_SCHEMA = pa.schema([
     pa.field("id_a", pa.int64()),
@@ -164,7 +164,7 @@ def _collision_rates(
     # Work on string columns only (what blockers and scorers actually use)
     string_cols = [
         c for c in df.columns
-        if not c.startswith("__") and df[c].dtype == pl.Utf8
+        if not c.startswith("__") and df[c].dtype == pl.String
     ]
     if not string_cols:
         return {}
@@ -239,7 +239,9 @@ def _config_summary(config: Any) -> dict:
                     if ne.field not in ne_fields:
                         ne_fields.append(ne.field)
     except Exception:
-        pass
+        logger.warning(
+            "_config_summary: failed to serialize config", exc_info=True
+        )
 
     return {
         "matchkeys": matchkeys_summary,
@@ -430,26 +432,25 @@ def review_config(
     # -- Run the pipeline to get scored_pairs + clusters --
     from goldenmatch.tui.engine import MatchEngine
 
+    # Deep-copy the config so disabling rerank below NEVER mutates the caller's
+    # object (the engine + the suggestion summary all run against the copy).
+    _config = copy.deepcopy(config)
+
     # Disable rerank to avoid HuggingFace model downloads in tests/offline env
     try:
-        _config = config
-        matchkeys = _config.get_matchkeys()
-        for mk in matchkeys:
+        for mk in _config.get_matchkeys():
             if mk.rerank:
                 mk.rerank = False
     except Exception:
-        pass
+        logger.debug(
+            "review_config: failed to disable rerank on config copy", exc_info=True
+        )
 
-    # We call _run_pipeline directly (no file loading needed)
-    engine = object.__new__(MatchEngine)
-    engine._files = []
-    engine._data = df
-    engine._profile = None
-    engine._last_result = None
-    engine._last_telemetry = None
+    # Build an engine over the in-memory frame (no file loading).
+    engine = MatchEngine.from_dataframe(df)
 
     try:
-        result = engine._run_pipeline(df, config)
+        result = engine._run_pipeline(df, _config)
     except Exception as exc:
         raise RuntimeError(
             f"review_config: pipeline failed on the provided df/config: {exc}"
@@ -461,9 +462,9 @@ def review_config(
     # -- Build Arrow batches --
     scored_pairs_batch = _build_scored_pairs_batch(scored_pairs)
     clusters_batch = _build_clusters_batch(clusters)
-    column_signals_batch = _build_column_signals_batch(df, config, clusters)
+    column_signals_batch = _build_column_signals_batch(df, _config, clusters)
 
-    config_json = json.dumps(_config_summary(config), default=str)
+    config_json = json.dumps(_config_summary(_config), default=str)
     priors_dict = priors if priors is not None else {"counts": {}}
     priors_json = json.dumps(priors_dict, default=str)
 

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
@@ -12,12 +12,26 @@ If the native wheel is absent, :exc:`SuggestionsNativeRequired` is raised
 with an "install goldenmatch[native]" message.
 
 Signature chosen:
-    ``review_config(df, config, *, priors=None) -> list[Suggestion]``
+    ``review_config(df, config, *, priors=None, verify=True) -> list[Suggestion]``
 
 We accept a raw ``pl.DataFrame`` + ``GoldenMatchConfig`` and run MatchEngine
 internally. This is the simplest shape for Task 15's benchmark: run dedupe,
 ask for suggestions, compare.  An alternative (pre-computed EngineResult + df)
 is slightly cheaper but adds caller boilerplate that hides the integration path.
+
+Self-verification (verify=True, the default)
+--------------------------------------------
+After the kernel returns ranked suggestions, each one is applied to a candidate
+config and the pipeline is re-run.  The candidate's score distribution is
+compared to the baseline using an unsupervised health proxy (see
+``goldenmatch.core.suggest.health.suggestion_health``).  A suggestion is kept
+only if the candidate's health is >= baseline health - EPS.  This prevents
+net-negative suggestions (e.g. a threshold change that lowers F1 on an
+already-healthy config) from reaching the user.
+
+Cost: one extra pipeline run per candidate (2-5 typical).  Verification can be
+disabled with ``verify=False`` (returns raw kernel suggestions for debugging /
+bench A/B) or with the environment variable ``GOLDENMATCH_SUGGEST_VERIFY=0``.
 """
 from __future__ import annotations
 
@@ -389,6 +403,30 @@ def _build_column_signals_batch(
     )
 
 
+# ── Environment flag ───────────────────────────────────────────────────────
+
+import os as _os
+
+def _verify_enabled_by_env() -> bool:
+    """Check if GOLDENMATCH_SUGGEST_VERIFY env var disables verification.
+
+    Returns True (verify ON) unless GOLDENMATCH_SUGGEST_VERIFY is set to
+    "0", "false", or "disabled" (case-insensitive).  Mirrors the repo-wide
+    env-flag pattern for kill-switches.
+    """
+    val = _os.environ.get("GOLDENMATCH_SUGGEST_VERIFY", "").strip().lower()
+    return val not in {"0", "false", "disabled"}
+
+
+# Maximum number of candidate suggestions to verify (avoids runaway cost
+# when the kernel returns an unusually large list).
+_MAX_VERIFY_CANDIDATES: int = 8
+
+# Epsilon: keep a suggestion if cand_health >= baseline_health - EPS.
+# Near-zero so we only suppress genuine health regressions.
+_VERIFY_EPS: float = 1e-6
+
+
 # ── Public API ─────────────────────────────────────────────────────────────
 
 def review_config(
@@ -396,6 +434,7 @@ def review_config(
     config: Any,
     *,
     priors: dict | None = None,
+    verify: bool = True,
 ) -> list[Suggestion]:
     """Analyze a dedupe run and return config improvement suggestions.
 
@@ -412,16 +451,30 @@ def review_config(
                 ``.blocking``, and ``model_dump()``).
         priors: Optional priors dict passed to the kernel (``{"counts": {}}``
                 by default; Plan 2 fills this with cross-run memory).
+        verify: When True (default), each suggestion is applied to a candidate
+                config and the pipeline is re-run.  Only suggestions whose
+                candidate health >= baseline health - EPS are kept.  This
+                prevents net-negative suggestions from reaching the user.
+                Set False to return raw kernel suggestions (for debugging /
+                bench A/B).  Can also be disabled globally with the env var
+                ``GOLDENMATCH_SUGGEST_VERIFY=0``.
+
+                Cost: one extra pipeline run per candidate (2-5 typical,
+                capped at 8).  Negligible vs the baseline run itself.
 
     Returns:
         A list of :class:`Suggestion` dataclasses.  Empty when the kernel
-        finds nothing to improve.
+        finds nothing to improve (or when all suggestions are health-worsening
+        and verify=True).
 
     Raises:
         SuggestionsNativeRequired: When the native wheel is absent or the
             ``suggest_config`` symbol is missing.
     """
     nm = _require_kernel()
+
+    # Resolve verify: kwarg AND env flag must both be True
+    _do_verify = verify and _verify_enabled_by_env()
 
     # Ensure the df has __row_id__ so collision-rate lookups work
     if "__row_id__" not in df.columns:
@@ -508,4 +561,61 @@ def review_config(
         except Exception:
             logger.debug("Skipping malformed suggestion item: %r", item, exc_info=True)
 
-    return suggestions
+    if not _do_verify or not suggestions:
+        return suggestions
+
+    # -- Self-verification pass (verify=True) --
+    # Compute baseline health from the baseline run's scored pairs + threshold.
+    from goldenmatch.core.suggest.apply import apply_suggestion
+    from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+
+    # Cluster-based health proxy: immune to the scored-pairs threshold-filter
+    # issue (_run_pipeline returns only pairs >= threshold, so mass_above is
+    # always 1.0 in scored_pairs -- the scored-pairs proxy is not useful here).
+    n_records = df.height
+    baseline_health = suggestion_health_from_clusters(clusters, n_records)
+    logger.debug(
+        "review_config verify: baseline_health=%.4f n_records=%d n_clusters=%d",
+        baseline_health, n_records, len(clusters),
+    )
+
+    # Cap verification at _MAX_VERIFY_CANDIDATES (cost guard)
+    candidates = suggestions[:_MAX_VERIFY_CANDIDATES]
+    tail = suggestions[_MAX_VERIFY_CANDIDATES:]  # pass through unverified if any
+
+    verified: list[Suggestion] = []
+    for s in candidates:
+        try:
+            cfg_cand = apply_suggestion(_config, s)
+            # Disable rerank on the candidate config too
+            try:
+                for mk in cfg_cand.get_matchkeys():
+                    if getattr(mk, "rerank", False):
+                        mk.rerank = False
+            except Exception:
+                pass
+
+            cand_result = engine._run_pipeline(df, cfg_cand)
+            cand_health = suggestion_health_from_clusters(cand_result.clusters, n_records)
+
+            logger.debug(
+                "review_config verify: suggestion %r cand_health=%.4f (baseline=%.4f) -> %s",
+                s.id, cand_health, baseline_health,
+                "KEEP" if cand_health >= baseline_health - _VERIFY_EPS else "DROP",
+            )
+
+            if cand_health >= baseline_health - _VERIFY_EPS:
+                verified.append(s)
+        except Exception as exc:
+            # Verification failure is conservative: keep the suggestion
+            # (better to surface a potentially-bad suggestion than to silently
+            # suppress one that couldn't be checked).
+            logger.debug(
+                "review_config verify: suggestion %r verification failed (%s) -- keeping",
+                s.id, exc, exc_info=True,
+            )
+            verified.append(s)
+
+    # Tail (beyond _MAX_VERIFY_CANDIDATES) passes through unverified.
+    # In practice the kernel returns at most 5 suggestions so this is a no-op.
+    return verified + tail

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
@@ -1,0 +1,510 @@
+"""Python adapter that drives the native ``suggest_config`` kernel.
+
+Usage::
+
+    from goldenmatch.core.suggest import review_config
+
+    suggestions = review_config(df, config)
+    for s in suggestions:
+        print(s.rationale, s.patch)
+
+If the native wheel is absent, :exc:`SuggestionsNativeRequired` is raised
+with an "install goldenmatch[native]" message.
+
+Signature chosen:
+    ``review_config(df, config, *, priors=None) -> list[Suggestion]``
+
+We accept a raw ``pl.DataFrame`` + ``GoldenMatchConfig`` and run MatchEngine
+internally. This is the simplest shape for Task 15's benchmark: run dedupe,
+ask for suggestions, compare.  An alternative (pre-computed EngineResult + df)
+is slightly cheaper but adds caller boilerplate that hides the integration path.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import polars as pl
+
+from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired
+
+logger = logging.getLogger(__name__)
+
+# ── Arrow schemas (frozen - must match the Rust kernel exactly) ────────────
+
+import pyarrow as pa
+
+_SCORED_PAIRS_SCHEMA = pa.schema([
+    pa.field("id_a", pa.int64()),
+    pa.field("id_b", pa.int64()),
+    pa.field("score", pa.float64()),
+])
+
+_CLUSTERS_SCHEMA = pa.schema([
+    pa.field("cluster_id", pa.int64()),
+    pa.field("size", pa.int64()),
+    pa.field("confidence", pa.float64()),
+    pa.field("quality", pa.utf8()),
+    pa.field("oversized", pa.bool_()),
+])
+
+_COLUMN_SIGNALS_SCHEMA = pa.schema([
+    pa.field("field", pa.utf8()),
+    pa.field("col_type", pa.utf8()),
+    pa.field("scorer", pa.utf8()),
+    pa.field("in_blocking", pa.bool_()),
+    pa.field("in_negative_evidence", pa.bool_()),
+    pa.field("identity_score", pa.float64()),
+    pa.field("corruption_score", pa.float64()),
+    pa.field("collision_rate", pa.float64()),
+    pa.field("cardinality_ratio", pa.float64()),
+    pa.field("null_rate", pa.float64()),
+    pa.field("variant_rate", pa.float64()),
+])
+
+
+# ── Kernel access ──────────────────────────────────────────────────────────
+
+def _require_kernel() -> Any:
+    """Return the native module, raising SuggestionsNativeRequired if absent."""
+    from goldenmatch.core._native_loader import native_module
+    nm = native_module()
+    if nm is None or not hasattr(nm, "suggest_config"):
+        raise SuggestionsNativeRequired(
+            "Config suggestions require the native kernel. "
+            "Install with: pip install goldenmatch[native]"
+        )
+    return nm
+
+
+# ── Arrow batch builders ───────────────────────────────────────────────────
+
+def _build_scored_pairs_batch(
+    scored_pairs: list[tuple[int, int, float]],
+) -> pa.RecordBatch:
+    """Convert ``[(id_a, id_b, score), ...]`` to the frozen Arrow schema."""
+    if not scored_pairs:
+        return pa.record_batch(
+            {"id_a": pa.array([], type=pa.int64()),
+             "id_b": pa.array([], type=pa.int64()),
+             "score": pa.array([], type=pa.float64())},
+            schema=_SCORED_PAIRS_SCHEMA,
+        )
+    id_a_list, id_b_list, score_list = zip(*scored_pairs)
+    return pa.record_batch(
+        {
+            "id_a": pa.array(list(id_a_list), type=pa.int64()),
+            "id_b": pa.array(list(id_b_list), type=pa.int64()),
+            "score": pa.array(list(score_list), type=pa.float64()),
+        },
+        schema=_SCORED_PAIRS_SCHEMA,
+    )
+
+
+def _build_clusters_batch(
+    clusters: dict[int, dict],
+) -> pa.RecordBatch:
+    """Convert ``EngineResult.clusters`` dict to the frozen Arrow schema."""
+    # Only multi-member clusters carry meaningful quality/confidence signals.
+    # Singletons are included so the kernel can compute the match rate.
+    rows = []
+    for cid, info in clusters.items():
+        rows.append({
+            "cluster_id": cid,
+            "size": int(info.get("size", 1)),
+            "confidence": float(info.get("confidence", 0.0)),
+            "quality": str(info.get("cluster_quality", info.get("quality", "strong"))),
+            "oversized": bool(info.get("oversized", False)),
+        })
+    if not rows:
+        return pa.record_batch(
+            {
+                "cluster_id": pa.array([], type=pa.int64()),
+                "size": pa.array([], type=pa.int64()),
+                "confidence": pa.array([], type=pa.float64()),
+                "quality": pa.array([], type=pa.utf8()),
+                "oversized": pa.array([], type=pa.bool_()),
+            },
+            schema=_CLUSTERS_SCHEMA,
+        )
+    return pa.record_batch(
+        {
+            "cluster_id": pa.array([r["cluster_id"] for r in rows], type=pa.int64()),
+            "size": pa.array([r["size"] for r in rows], type=pa.int64()),
+            "confidence": pa.array([r["confidence"] for r in rows], type=pa.float64()),
+            "quality": pa.array([r["quality"] for r in rows], type=pa.utf8()),
+            "oversized": pa.array([r["oversized"] for r in rows], type=pa.bool_()),
+        },
+        schema=_CLUSTERS_SCHEMA,
+    )
+
+
+def _collision_rates(
+    clusters: dict[int, dict],
+    df: pl.DataFrame,
+) -> dict[str, float]:
+    """Compute per-column collision rate over multi-member clusters.
+
+    collision_rate[col] = fraction of multi-member clusters where that column
+    has >= 2 distinct non-null values among the cluster's member rows.
+
+    A high rate signals the column disagrees inside merged clusters -- the
+    negative-evidence signal the kernel uses for Rule 3.
+    """
+    # Only multi-member clusters are interesting
+    multi = {
+        cid: info
+        for cid, info in clusters.items()
+        if info.get("size", 1) > 1 and not info.get("oversized", False)
+    }
+    if not multi:
+        return {}
+
+    # Work on string columns only (what blockers and scorers actually use)
+    string_cols = [
+        c for c in df.columns
+        if not c.startswith("__") and df[c].dtype == pl.Utf8
+    ]
+    if not string_cols:
+        return {}
+
+    collision_count: dict[str, int] = {c: 0 for c in string_cols}
+    n_multi = len(multi)
+
+    id_col = "__row_id__" if "__row_id__" in df.columns else None
+
+    for _cid, info in multi.items():
+        member_ids: list[int] = list(info.get("members", []))
+        if not member_ids:
+            continue
+
+        if id_col:
+            cluster_df = df.filter(pl.col(id_col).is_in(member_ids))
+        else:
+            # Fallback: slice by positional index (row_id == positional index)
+            valid_ids = [m for m in member_ids if 0 <= m < df.height]
+            if not valid_ids:
+                continue
+            cluster_df = df[valid_ids]
+
+        for col in string_cols:
+            distinct_non_null = (
+                cluster_df[col]
+                .drop_nulls()
+                .n_unique()
+            )
+            if distinct_non_null >= 2:
+                collision_count[col] += 1
+
+    return {col: cnt / n_multi for col, cnt in collision_count.items()}
+
+
+def _config_summary(config: Any) -> dict:
+    """Serialize the config to the ConfigSummary shape the kernel expects.
+
+    The kernel expects::
+
+        {
+            "matchkeys": [
+                {
+                    "name": str,
+                    "kind": "weighted" | "exact" | "probabilistic",
+                    "threshold": float | null,
+                    "fields": [{"field": str, "scorer": str | null, "weight": float | null}]
+                }
+            ],
+            "negative_evidence": ["field_name", ...]
+        }
+    """
+    matchkeys_summary = []
+    ne_fields: list[str] = []
+    try:
+        for mk in config.get_matchkeys():
+            fields_summary = []
+            for f in mk.fields:
+                fields_summary.append({
+                    "field": f.field or "",
+                    "scorer": f.scorer,
+                    "weight": f.weight,
+                })
+            matchkeys_summary.append({
+                "name": mk.name,
+                "kind": mk.type or "weighted",
+                "threshold": mk.threshold,
+                "fields": fields_summary,
+            })
+            if mk.negative_evidence:
+                for ne in mk.negative_evidence:
+                    if ne.field not in ne_fields:
+                        ne_fields.append(ne.field)
+    except Exception:
+        pass
+
+    return {
+        "matchkeys": matchkeys_summary,
+        "negative_evidence": ne_fields,
+    }
+
+
+def _build_column_signals_batch(
+    df: pl.DataFrame,
+    config: Any,
+    clusters: dict[int, dict],
+) -> pa.RecordBatch:
+    """Build the column_signals Arrow batch from the df + config + run results.
+
+    One row per column referenced by the config (or all data columns).
+
+    Sources:
+    - col_type: from autoconfig ColumnProfile classification
+    - scorer: from matchkey fields
+    - in_blocking: from config.blocking fields (via collect_blocking_fields)
+    - in_negative_evidence: from matchkey NE fields
+    - identity_score, corruption_score: compute_column_priors()
+    - cardinality_ratio, null_rate: computed directly from df
+    - collision_rate: _collision_rates()
+    - variant_rate: blocking_risk() -- defaults to 0.0 when goldencheck absent
+    """
+    from goldenmatch.core.indicators import compute_column_priors
+    from goldenmatch.core.quality import blocking_risk
+
+    # -- Which columns to include (all non-internal data columns) --
+    data_cols = [c for c in df.columns if not c.startswith("__")]
+
+    # -- Gather priors (identity + corruption scores) --
+    try:
+        col_priors = compute_column_priors(df.select(data_cols))
+    except Exception:
+        logger.debug("compute_column_priors failed; using defaults", exc_info=True)
+        col_priors = {}
+
+    # -- Blocking fields --
+    blocking_fields: set[str] = set()
+    try:
+        if config.blocking is not None:
+            from goldenmatch.core.blocker import collect_blocking_fields
+            blocking_fields = set(collect_blocking_fields(config.blocking))
+    except Exception:
+        logger.debug("collect_blocking_fields failed; using empty set", exc_info=True)
+
+    # -- Matchkey field → scorer mapping and negative-evidence set --
+    field_scorer: dict[str, str] = {}
+    ne_fields: set[str] = set()
+    try:
+        matchkeys = config.get_matchkeys()
+        for mk in matchkeys:
+            for f in mk.fields:
+                fname = f.field or ""
+                if fname and f.scorer:
+                    field_scorer[fname] = f.scorer
+            if mk.negative_evidence:
+                for ne in mk.negative_evidence:
+                    ne_fields.add(ne.field)
+    except Exception:
+        logger.debug("matchkey field introspection failed", exc_info=True)
+
+    # -- col_type via the same classifier autoconfig uses --
+    col_types: dict[str, str] = {}
+    try:
+        from goldenmatch.core.autoconfig import profile_columns
+        profiles = profile_columns(df.select(data_cols))
+        for p in profiles:
+            col_types[p.name] = p.col_type
+    except Exception:
+        logger.debug("profile_columns failed; col_type defaults to 'string'", exc_info=True)
+
+    # -- cardinality_ratio and null_rate directly from df --
+    n_rows = max(df.height, 1)
+    cardinality_ratios: dict[str, float] = {}
+    null_rates: dict[str, float] = {}
+    for col in data_cols:
+        series = df[col]
+        n_non_null = series.drop_nulls().len()
+        null_rates[col] = 1.0 - n_non_null / n_rows
+        if n_non_null > 0:
+            cardinality_ratios[col] = series.drop_nulls().n_unique() / n_non_null
+        else:
+            cardinality_ratios[col] = 0.0
+
+    # -- collision_rate from run results --
+    collision_rates = _collision_rates(clusters, df)
+
+    # -- variant_rate from goldencheck blocking_risk (fail-open: 0.0) --
+    try:
+        variant_risk = blocking_risk(df.select(data_cols)) or {}
+    except Exception:
+        variant_risk = {}
+
+    # -- Assemble rows --
+    rows_field: list[str] = []
+    rows_col_type: list[str] = []
+    rows_scorer: list[str] = []
+    rows_in_blocking: list[bool] = []
+    rows_in_ne: list[bool] = []
+    rows_identity: list[float] = []
+    rows_corruption: list[float] = []
+    rows_collision: list[float] = []
+    rows_cardinality: list[float] = []
+    rows_null: list[float] = []
+    rows_variant: list[float] = []
+
+    for col in data_cols:
+        prior = col_priors.get(col)
+        rows_field.append(col)
+        rows_col_type.append(col_types.get(col, "string"))
+        rows_scorer.append(field_scorer.get(col, ""))
+        rows_in_blocking.append(col in blocking_fields)
+        rows_in_ne.append(col in ne_fields)
+        rows_identity.append(float(prior.identity_score) if prior else 0.0)
+        rows_corruption.append(float(prior.corruption_score) if prior else 0.0)
+        rows_collision.append(float(collision_rates.get(col, 0.0)))
+        rows_cardinality.append(float(cardinality_ratios.get(col, 0.0)))
+        rows_null.append(float(null_rates.get(col, 0.0)))
+        rows_variant.append(float(variant_risk.get(col, 0.0)))
+
+    if not rows_field:
+        return pa.record_batch(
+            {f.name: pa.array([], type=f.type) for f in _COLUMN_SIGNALS_SCHEMA},
+            schema=_COLUMN_SIGNALS_SCHEMA,
+        )
+
+    return pa.record_batch(
+        {
+            "field": pa.array(rows_field, type=pa.utf8()),
+            "col_type": pa.array(rows_col_type, type=pa.utf8()),
+            "scorer": pa.array(rows_scorer, type=pa.utf8()),
+            "in_blocking": pa.array(rows_in_blocking, type=pa.bool_()),
+            "in_negative_evidence": pa.array(rows_in_ne, type=pa.bool_()),
+            "identity_score": pa.array(rows_identity, type=pa.float64()),
+            "corruption_score": pa.array(rows_corruption, type=pa.float64()),
+            "collision_rate": pa.array(rows_collision, type=pa.float64()),
+            "cardinality_ratio": pa.array(rows_cardinality, type=pa.float64()),
+            "null_rate": pa.array(rows_null, type=pa.float64()),
+            "variant_rate": pa.array(rows_variant, type=pa.float64()),
+        },
+        schema=_COLUMN_SIGNALS_SCHEMA,
+    )
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+def review_config(
+    df: pl.DataFrame,
+    config: Any,
+    *,
+    priors: dict | None = None,
+) -> list[Suggestion]:
+    """Analyze a dedupe run and return config improvement suggestions.
+
+    Runs the pipeline (``MatchEngine._run_pipeline``) internally on ``df`` +
+    ``config`` to obtain scored pairs and clusters, then assembles the three
+    Arrow batches required by the native kernel and calls
+    ``goldenmatch._native.suggest_config``.
+
+    Args:
+        df: The DataFrame that was (or will be) deduped.  Must already carry
+            ``__row_id__`` if you want collision-rate computation to work;
+            the adapter adds one automatically if absent.
+        config: A ``GoldenMatchConfig`` (or any object with ``get_matchkeys()``,
+                ``.blocking``, and ``model_dump()``).
+        priors: Optional priors dict passed to the kernel (``{"counts": {}}``
+                by default; Plan 2 fills this with cross-run memory).
+
+    Returns:
+        A list of :class:`Suggestion` dataclasses.  Empty when the kernel
+        finds nothing to improve.
+
+    Raises:
+        SuggestionsNativeRequired: When the native wheel is absent or the
+            ``suggest_config`` symbol is missing.
+    """
+    nm = _require_kernel()
+
+    # Ensure the df has __row_id__ so collision-rate lookups work
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
+
+    # -- Run the pipeline to get scored_pairs + clusters --
+    from goldenmatch.tui.engine import MatchEngine
+
+    # Disable rerank to avoid HuggingFace model downloads in tests/offline env
+    try:
+        _config = config
+        matchkeys = _config.get_matchkeys()
+        for mk in matchkeys:
+            if mk.rerank:
+                mk.rerank = False
+    except Exception:
+        pass
+
+    # We call _run_pipeline directly (no file loading needed)
+    engine = object.__new__(MatchEngine)
+    engine._files = []
+    engine._data = df
+    engine._profile = None
+    engine._last_result = None
+    engine._last_telemetry = None
+
+    try:
+        result = engine._run_pipeline(df, config)
+    except Exception as exc:
+        raise RuntimeError(
+            f"review_config: pipeline failed on the provided df/config: {exc}"
+        ) from exc
+
+    scored_pairs = result.scored_pairs
+    clusters = result.clusters
+
+    # -- Build Arrow batches --
+    scored_pairs_batch = _build_scored_pairs_batch(scored_pairs)
+    clusters_batch = _build_clusters_batch(clusters)
+    column_signals_batch = _build_column_signals_batch(df, config, clusters)
+
+    config_json = json.dumps(_config_summary(config), default=str)
+    priors_dict = priors if priors is not None else {"counts": {}}
+    priors_json = json.dumps(priors_dict, default=str)
+
+    # -- Call the native kernel --
+    try:
+        raw_json: str = nm.suggest_config(
+            scored_pairs_batch,
+            clusters_batch,
+            column_signals_batch,
+            config_json,
+            priors_json,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"review_config: native suggest_config kernel failed: {exc}"
+        ) from exc
+
+    # -- Parse results --
+    try:
+        items = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"review_config: kernel returned invalid JSON: {exc}"
+        ) from exc
+
+    suggestions: list[Suggestion] = []
+    for item in items:
+        try:
+            suggestions.append(Suggestion(
+                id=str(item.get("id", "")),
+                kind=str(item.get("kind", "")),
+                target=str(item.get("target", "")),
+                current_value=item.get("current_value"),
+                proposed_value=item.get("proposed_value"),
+                rationale=str(item.get("rationale", "")),
+                predicted_effect=str(item.get("predicted_effect", "")),
+                confidence=float(item.get("confidence", 0.0)),
+                patch=dict(item.get("patch", {})),
+                evidence=dict(item.get("evidence", {})),
+            ))
+        except Exception:
+            logger.debug("Skipping malformed suggestion item: %r", item, exc_info=True)
+
+    return suggestions

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/apply.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/apply.py
@@ -31,6 +31,7 @@ promote_negative_evidence constants):
 from __future__ import annotations
 
 import copy
+import logging
 
 from goldenmatch.config.schemas import (
     GoldenMatchConfig,
@@ -38,6 +39,8 @@ from goldenmatch.config.schemas import (
     NegativeEvidenceField,
 )
 from goldenmatch.core.suggest.types import Suggestion
+
+logger = logging.getLogger(__name__)
 
 # Defaults for a kernel-suggested NE field.  Mirror the constants in
 # autoconfig_negative_evidence.py (_DEFAULT_NE_THRESHOLD / _DEFAULT_NE_PENALTY).
@@ -125,11 +128,19 @@ def _apply_add_negative_evidence(config: GoldenMatchConfig, patch: dict) -> None
         return
 
     # Pick target matchkey.
-    target = (
-        next((m for m in matchkeys if m.type == "weighted"), None)
-        or next((m for m in matchkeys if m.type == "exact"), None)
-        or matchkeys[0]
-    )
+    weighted = next((m for m in matchkeys if m.type == "weighted"), None)
+    exact = next((m for m in matchkeys if m.type == "exact"), None)
+    target = weighted or exact
+    if target is None:
+        # The kernel should only emit AddNegativeEvidence when a weighted or
+        # exact matchkey exists; reaching this branch indicates an unexpected
+        # kernel output.
+        logger.warning(
+            "_apply_add_negative_evidence: no weighted or exact matchkey found; "
+            "falling back to first matchkey %r (unexpected kernel output for field %r)",
+            matchkeys[0].name, field_name,
+        )
+        target = matchkeys[0]
 
     # Initialise NE list if absent.
     if target.negative_evidence is None:

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/apply.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/apply.py
@@ -1,0 +1,150 @@
+"""apply_suggestion: apply a ConfigPatch to a GoldenMatchConfig.
+
+The function is a pure, side-effect-free transformation: it deep-copies the
+config first so the caller's original is never mutated.
+
+Supported patch ops (matching the Rust kernel's serde snake_case tag):
+
+    {"op": "set_threshold", "matchkey": "<name>", "value": <float>}
+        Set the threshold of the named matchkey.
+
+    {"op": "set_scorer", "matchkey": "<name>", "field": "<field>", "scorer": "<scorer>"}
+        Set the scorer of a named field within a named matchkey.
+
+    {"op": "add_negative_evidence", "field": "<field>"}
+        Add a NegativeEvidenceField to the first weighted matchkey.
+        If the field is already present, the list is left unchanged (idempotent).
+        The patch carries no matchkey name; this op targets the first weighted
+        matchkey because NE is meaningful only on weighted/exact matchkeys and
+        the kernel emits this op only when it has already identified the relevant
+        matchkey type.  If no weighted matchkey exists, the first matchkey of any
+        type is used as a fallback.
+
+NegativeEvidenceField defaults when constructed from an add_negative_evidence
+patch (the patch carries only the field name; defaults mirror the autoconfig
+promote_negative_evidence constants):
+    scorer:    "ensemble"
+    threshold: 0.4
+    penalty:   0.3
+    transforms: []
+"""
+from __future__ import annotations
+
+import copy
+
+from goldenmatch.config.schemas import (
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    NegativeEvidenceField,
+)
+from goldenmatch.core.suggest.types import Suggestion
+
+# Defaults for a kernel-suggested NE field.  Mirror the constants in
+# autoconfig_negative_evidence.py (_DEFAULT_NE_THRESHOLD / _DEFAULT_NE_PENALTY).
+_DEFAULT_NE_SCORER = "ensemble"
+_DEFAULT_NE_THRESHOLD = 0.4
+_DEFAULT_NE_PENALTY = 0.3
+
+
+def apply_suggestion(
+    config: GoldenMatchConfig,
+    suggestion: Suggestion,
+) -> GoldenMatchConfig:
+    """Return a NEW GoldenMatchConfig with *suggestion*'s patch applied.
+
+    The original *config* is never modified.
+
+    Raises
+    ------
+    ValueError
+        If the patch op is unknown, or if the patch references a matchkey or
+        field that does not exist in the config.
+    """
+    # Deep-copy first — never mutate the caller's config.
+    new_config: GoldenMatchConfig = copy.deepcopy(config)
+
+    patch = suggestion.patch
+    op = patch.get("op", "")
+
+    if op == "set_threshold":
+        _apply_set_threshold(new_config, patch)
+    elif op == "set_scorer":
+        _apply_set_scorer(new_config, patch)
+    elif op == "add_negative_evidence":
+        _apply_add_negative_evidence(new_config, patch)
+    else:
+        raise ValueError(f"unknown patch op: {op!r}")
+
+    return new_config
+
+
+# ── private dispatch helpers ───────────────────────────────────────────────────
+
+def _find_matchkey(config: GoldenMatchConfig, name: str) -> MatchkeyConfig:
+    """Return the matchkey with the given name, or raise ValueError."""
+    for mk in config.get_matchkeys():
+        if mk.name == name:
+            return mk
+    raise ValueError(
+        f"patch references matchkey {name!r} which does not exist in the config "
+        f"(available: {[m.name for m in config.get_matchkeys()]})"
+    )
+
+
+def _apply_set_threshold(config: GoldenMatchConfig, patch: dict) -> None:
+    mk = _find_matchkey(config, patch["matchkey"])
+    mk.threshold = float(patch["value"])
+
+
+def _apply_set_scorer(config: GoldenMatchConfig, patch: dict) -> None:
+    mk = _find_matchkey(config, patch["matchkey"])
+    field_name = patch["field"]
+    for f in mk.fields:
+        if f.field == field_name:
+            f.scorer = patch["scorer"]
+            return
+    raise ValueError(
+        f"patch references field {field_name!r} in matchkey {mk.name!r} "
+        f"which does not exist (available: {[f.field for f in mk.fields]})"
+    )
+
+
+def _apply_add_negative_evidence(config: GoldenMatchConfig, patch: dict) -> None:
+    """Add a NegativeEvidenceField to the first weighted matchkey.
+
+    Selection order:
+    1. First matchkey with type == "weighted".
+    2. First matchkey with type == "exact" (also supports NE).
+    3. First matchkey of any type (fallback).
+
+    Idempotent: if the field is already in the NE list, nothing changes.
+    """
+    field_name: str = patch["field"]
+    matchkeys = config.get_matchkeys()
+    if not matchkeys:
+        return
+
+    # Pick target matchkey.
+    target = (
+        next((m for m in matchkeys if m.type == "weighted"), None)
+        or next((m for m in matchkeys if m.type == "exact"), None)
+        or matchkeys[0]
+    )
+
+    # Initialise NE list if absent.
+    if target.negative_evidence is None:
+        target.negative_evidence = []
+
+    # Idempotency guard.
+    if any(ne.field == field_name for ne in target.negative_evidence):
+        return
+
+    target.negative_evidence.append(
+        NegativeEvidenceField(
+            field=field_name,
+            transforms=[],
+            scorer=_DEFAULT_NE_SCORER,
+            threshold=_DEFAULT_NE_THRESHOLD,
+            penalty=_DEFAULT_NE_PENALTY,
+        )
+    )

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/health.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/health.py
@@ -47,9 +47,13 @@ _COLLAPSE_FLOOR: float = 0.90
 # Penalty applied when mass_above exceeds the collapse floor
 _COLLAPSE_PENALTY: float = 0.50
 
-# Collapse threshold for the cluster-based health proxy: a single cluster
-# absorbing more than this fraction of all records signals a merge pathology.
-_COLLAPSE_FLOOR_CLUSTER: float = 0.50
+# Concentration floor for the cluster-based health proxy (Herfindahl index).
+# Below this HHI the clustering is considered well-distributed (no penalty);
+# above it the graded merge-collapse penalty ramps in.  0.25 means: a single
+# cluster holding ~half the records (HHI 0.25) is the point where over-merge
+# concern begins; the two-equal-50%-clusters case (HHI 0.50) lands solidly in
+# the penalized band; many small clusters (HHI -> 0) pay nothing.
+_COLLAPSE_FLOOR_CLUSTER: float = 0.25
 
 
 def suggestion_health(
@@ -110,19 +114,38 @@ def suggestion_health_from_clusters(
     therefore immune to the threshold-filtering issue (``_run_pipeline`` returns
     only pairs >= threshold, so ``mass_above`` is always 1.0 in the pairs list).
 
-    Formula::
+    Basis: ``matched_rate * avg_conf - concentration_penalty``.
 
         matched_rate = (records in multi-member clusters) / n_records
         avg_conf     = mean confidence over multi-member clusters
-        collapse     = (largest cluster size / n_records) > 0.50
-        health       = matched_rate * avg_conf - 0.5 * collapse
+        hhi          = Herfindahl concentration = sum((size / n_records)**2)
+                       over multi-member clusters  (a few giant clusters => high)
+        penalty      = COLLAPSE_PENALTY * clamp01((hhi - FLOOR) / (1 - FLOOR))
+        health       = matched_rate * avg_conf - penalty
+
+    Why HHI (concentration) and not max-cluster-size: a single-max check
+    (``max_size / n_records > 0.5``) misses over-merge SPREAD across a few big
+    clusters -- e.g. two clusters each at 50% of records (a degenerate
+    over-merge) keeps ``max_size`` at exactly 0.5 and would slip the gate.  HHI
+    sums the squared mass of EVERY cluster, so the two-50% case scores
+    ``0.5^2 + 0.5^2 = 0.5`` and is penalized just like one 71%-cluster
+    (``0.71^2 ~= 0.5``).  The penalty is GRADED (continuous) above ``FLOOR``
+    rather than a hard flag, so a borderline concentration degrades smoothly
+    instead of snapping.  A healthy frame of many small clusters has
+    ``hhi -> 0`` and pays no penalty.
 
     Interpretation:
         - A threshold raise that drops true matches lowers ``matched_rate``.
-        - A threshold lower that causes over-merging lowers ``avg_conf`` and
-          may trigger ``collapse``.
+        - A threshold lower that over-merges raises ``hhi`` (and usually lowers
+          ``avg_conf``), so the penalty grows.
         - Returns -1.0 when ``n_records == 0`` (degenerate).
         - Returns 0.0 when no multi-member clusters exist (no matches found).
+
+    Known limitation: this is an UNSUPERVISED proxy, NOT F1.  It cannot see
+    ground truth -- it rewards "confident, non-degenerate clustering" and
+    penalizes recall collapse and merge collapse, which empirically tracks the
+    direction of F1 on already-healthy configs (the self-verify use case) but
+    is not a substitute for a labeled metric.
 
     Args:
         clusters: Dict mapping cluster_id -> cluster_info dict (as returned by
@@ -157,11 +180,17 @@ def suggestion_health_from_clusters(
         float(info.get("confidence", 0.5)) for info in multi_member
     ) / len(multi_member)
 
-    # Collapse pathology: a single cluster absorbing > 50% of records
-    max_size = max(info.get("size", 2) for info in multi_member)
-    collapse = 1.0 if max_size / n_records > _COLLAPSE_FLOOR_CLUSTER else 0.0
+    # Concentration pathology via Herfindahl index over multi-member clusters.
+    # Catches over-merge spread across several big clusters, not just one.
+    hhi = sum((info.get("size", 2) / n_records) ** 2 for info in multi_member)
 
-    return matched_rate * avg_conf - _COLLAPSE_PENALTY * collapse
+    # Graded penalty above the floor: 0 at hhi <= FLOOR, ramps to the full
+    # COLLAPSE_PENALTY at hhi == 1.0 (one cluster == all records).
+    over = (hhi - _COLLAPSE_FLOOR_CLUSTER) / (1.0 - _COLLAPSE_FLOOR_CLUSTER)
+    concentration = min(1.0, max(0.0, over))
+    penalty = _COLLAPSE_PENALTY * concentration
+
+    return matched_rate * avg_conf - penalty
 
 
 def _extract_threshold(config: object) -> float:

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/health.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/health.py
@@ -1,0 +1,180 @@
+"""Unsupervised config-health proxy for the self-verification gate.
+
+Used by ``review_config(verify=True)`` to filter suggestions that would worsen
+the score distribution's separation between matches and non-matches -- without
+any ground-truth labels.
+
+Two complementary health functions
+-----------------------------------
+``suggestion_health(scored_pairs, threshold) -> float``
+    Computes health from the scored-pairs list.  Works best when pairs include
+    scores across the full [0, 1] range.  NOTE: ``_run_pipeline`` returns pairs
+    FILTERED by threshold (only pairs >= threshold are emitted), so this function
+    sees ``mass_above = 1.0`` by construction and always fires the
+    precision-collapse penalty.  Use ``suggestion_health_from_clusters`` for
+    the self-verify gate instead.
+
+``suggestion_health_from_clusters(clusters, n_records) -> float``
+    Computes health from cluster statistics.  This is the PRIMARY function used
+    by the self-verification pass in ``review_config``.  It is threshold-agnostic
+    and correctly detects recall collapse (too few matches) and merge collapse
+    (everything merged into giant clusters).
+
+    Formula:
+        matched_rate = fraction of records that ended up in a multi-member cluster
+        avg_conf     = mean cluster confidence over multi-member clusters
+        collapse     = largest cluster covers > 50% of records  (merge pathology)
+        health       = matched_rate * avg_conf - 0.5 * collapse
+
+    A config that raises the threshold too aggressively drops true matches,
+    reducing matched_rate.  A config that lowers it too aggressively over-merges,
+    increasing matched_rate but reducing avg_conf AND triggering the collapse flag.
+
+Reuse philosophy:
+    The formula is extracted directly from the signals the controller already
+    emits (ScoringProfile.mass_above_threshold, ScoringProfile.mass_in_borderline,
+    RunHistory.pick_committed precision_collapse_floor).  No new measurement;
+    we just compute the same signals from a raw scored-pairs list.
+"""
+from __future__ import annotations
+
+# Fraction of scored pairs within this band just below threshold = "borderline"
+_BORDER_WIDTH: float = 0.10
+
+# Precision-collapse floor (matches controller's precision_collapse_floor=0.9)
+_COLLAPSE_FLOOR: float = 0.90
+
+# Penalty applied when mass_above exceeds the collapse floor
+_COLLAPSE_PENALTY: float = 0.50
+
+# Collapse threshold for the cluster-based health proxy: a single cluster
+# absorbing more than this fraction of all records signals a merge pathology.
+_COLLAPSE_FLOOR_CLUSTER: float = 0.50
+
+
+def suggestion_health(
+    scored_pairs: list[tuple[int, int, float]],
+    threshold: float,
+) -> float:
+    """Unsupervised config-health proxy.
+
+    Higher is healthier.  Returns a float in roughly [-1.5, +1.0].
+
+    Args:
+        scored_pairs: List of (id_a, id_b, score) tuples from the pipeline.
+            Score is in [0, 1].
+        threshold: The matchkey threshold used for this run (the dividing line
+            between matches and non-matches).
+
+    Returns:
+        float: health score.  Typical healthy range is [0.2, 1.0]; typical
+        degenerate range is [-1.5, 0.0].
+
+    Notes:
+        Runs in O(N) over scored_pairs with no extra allocation beyond a
+        counter loop.  Cost is negligible vs the pipeline run itself.
+    """
+    n = len(scored_pairs)
+    if n == 0:
+        # No scored pairs -> worst possible (no discrimination possible)
+        return -1.0
+
+    border_lo = threshold - _BORDER_WIDTH
+
+    above = 0
+    border = 0
+    for _, _, score in scored_pairs:
+        if score >= threshold:
+            above += 1
+        elif score >= border_lo:
+            border += 1
+
+    mass_above = above / n
+    mass_border = border / n
+    mass_sep = mass_above - mass_border
+
+    # Precision-collapse penalty: same guard as the controller's
+    # RunHistory.pick_committed(precision_collapse_floor=0.9) demotion
+    pathology = 1.0 if mass_above > _COLLAPSE_FLOOR else 0.0
+    return mass_sep - _COLLAPSE_PENALTY * pathology
+
+
+def suggestion_health_from_clusters(
+    clusters: dict,
+    n_records: int,
+) -> float:
+    """Unsupervised health proxy computed from cluster statistics.
+
+    This is the PRIMARY function used by ``review_config``'s self-verification
+    pass.  Unlike ``suggestion_health``, it does NOT rely on scored pairs and is
+    therefore immune to the threshold-filtering issue (``_run_pipeline`` returns
+    only pairs >= threshold, so ``mass_above`` is always 1.0 in the pairs list).
+
+    Formula::
+
+        matched_rate = (records in multi-member clusters) / n_records
+        avg_conf     = mean confidence over multi-member clusters
+        collapse     = (largest cluster size / n_records) > 0.50
+        health       = matched_rate * avg_conf - 0.5 * collapse
+
+    Interpretation:
+        - A threshold raise that drops true matches lowers ``matched_rate``.
+        - A threshold lower that causes over-merging lowers ``avg_conf`` and
+          may trigger ``collapse``.
+        - Returns -1.0 when ``n_records == 0`` (degenerate).
+        - Returns 0.0 when no multi-member clusters exist (no matches found).
+
+    Args:
+        clusters: Dict mapping cluster_id -> cluster_info dict (as returned by
+            ``EngineResult.clusters``).  Each info dict must have at least
+            ``"size"`` and optionally ``"confidence"`` and ``"members"``.
+        n_records: Total number of records in the frame (used to compute rates).
+
+    Returns:
+        float: health score in roughly [-0.5, 1.0].
+    """
+    if n_records == 0:
+        return -1.0
+
+    multi_member = [
+        info
+        for info in clusters.values()
+        if info.get("size", 1) > 1 and not info.get("oversized", False)
+    ]
+
+    if not multi_member:
+        # No multi-member clusters: nothing matched.  Score of 0 (not -1)
+        # because a config that legitimately matches nothing in a dataset with
+        # no true duplicates IS healthy.  The relative comparison in the
+        # verify gate handles this: if baseline is also 0, tie => keep.
+        return 0.0
+
+    n_matched = sum(info.get("size", 2) for info in multi_member)
+    matched_rate = n_matched / n_records
+
+    # Average confidence (default 0.5 when not present)
+    avg_conf = sum(
+        float(info.get("confidence", 0.5)) for info in multi_member
+    ) / len(multi_member)
+
+    # Collapse pathology: a single cluster absorbing > 50% of records
+    max_size = max(info.get("size", 2) for info in multi_member)
+    collapse = 1.0 if max_size / n_records > _COLLAPSE_FLOOR_CLUSTER else 0.0
+
+    return matched_rate * avg_conf - _COLLAPSE_PENALTY * collapse
+
+
+def _extract_threshold(config: object) -> float:
+    """Extract the first weighted/exact matchkey threshold from a config.
+
+    Returns 0.5 as a safe default when no threshold is found -- a mid-range
+    value that works for both above/below evaluation.
+    """
+    try:
+        for mk in config.get_matchkeys():  # type: ignore[attr-defined]
+            t = getattr(mk, "threshold", None)
+            if t is not None:
+                return float(t)
+    except Exception:
+        pass
+    return 0.5

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/types.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/types.py
@@ -1,0 +1,46 @@
+"""Public types for the config-suggestion adapter."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class SuggestionsNativeRequired(RuntimeError):
+    """Raised when the native kernel is required but not available.
+
+    Install with: pip install goldenmatch[native]
+    """
+
+
+@dataclass
+class Suggestion:
+    """A single config suggestion returned by the native kernel.
+
+    Mirrors the JSON shape produced by ``suggest_config`` in the Rust crate.
+
+    Attributes:
+        id: stable identifier for this suggestion (e.g. "raise_threshold:fuzzy_match").
+        kind: broad category ("threshold", "scorer", "negative_evidence", ...).
+        target: dotted path within the config the suggestion addresses
+                (e.g. "matchkeys[0].threshold").
+        current_value: the config value as it stands now (any JSON-safe type).
+        proposed_value: the suggested replacement value.
+        rationale: human-readable explanation of *why* this change is suggested.
+        predicted_effect: short description of the expected outcome.
+        confidence: 0.0-1.0 confidence in the suggestion.
+        patch: machine-readable patch dict with at minimum an "op" key
+               ("replace", "add", "remove") and a "path" key.
+        evidence: structured evidence bag supporting the suggestion (scores,
+                  rates, etc.) -- kernel-defined, may be empty.
+    """
+
+    id: str
+    kind: str
+    target: str
+    current_value: Any
+    proposed_value: Any
+    rationale: str
+    predicted_effect: str
+    confidence: float
+    patch: dict[str, Any] = field(default_factory=dict)
+    evidence: dict[str, Any] = field(default_factory=dict)

--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -92,6 +92,25 @@ class MatchEngine:
         profile_cols = [c for c in combined.columns if not c.startswith("__")]
         self._profile = profile_dataframe(combined.select(profile_cols))
 
+    @classmethod
+    def from_dataframe(cls, df: pl.DataFrame) -> MatchEngine:
+        """Build an engine over an in-memory frame (no file loading).
+
+        For callers like config-suggestion review (``core/suggest``) that
+        already hold the data and only need ``_run_pipeline``/``run_full``.
+        Mirrors every instance field ``__init__`` assigns so it can't break
+        silently if ``__init__`` evolves -- ``_data`` is the passed frame,
+        the rest take ``__init__``'s post-load defaults (profile is left None;
+        callers that need it should go through the file constructor).
+        """
+        engine = object.__new__(cls)
+        engine._files = []
+        engine._data = df
+        engine._profile = None
+        engine._last_result = None
+        engine._last_telemetry = None
+        return engine
+
     @property
     def data(self) -> pl.DataFrame:
         return self._data

--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -100,13 +100,14 @@ class MatchEngine:
         already hold the data and only need ``_run_pipeline``/``run_full``.
         Mirrors every instance field ``__init__`` assigns so it can't break
         silently if ``__init__`` evolves -- ``_data`` is the passed frame,
-        the rest take ``__init__``'s post-load defaults (profile is left None;
-        callers that need it should go through the file constructor).
+        the rest take ``__init__``'s post-load defaults.
+        Note: ``profile`` is None until a file-constructor run populates it;
+        callers that need it should use the file constructor instead.
         """
         engine = object.__new__(cls)
         engine._files = []
         engine._data = df
-        engine._profile = None
+        engine._profile = None  # not populated by from_dataframe
         engine._last_result = None
         engine._last_telemetry = None
         return engine
@@ -116,7 +117,7 @@ class MatchEngine:
         return self._data
 
     @property
-    def profile(self) -> dict:
+    def profile(self) -> dict | None:
         return self._profile
 
     @property

--- a/packages/python/goldenmatch/tests/test_suggest_adapter.py
+++ b/packages/python/goldenmatch/tests/test_suggest_adapter.py
@@ -268,6 +268,49 @@ def test_missing_native_raises():
             _adapter.review_config(df, config)
 
 
+def test_review_config_raises_when_native_loader_absent():
+    """review_config raises SuggestionsNativeRequired when the loader returns None.
+
+    This test exercises the real _require_kernel guard (not a mock of the guard
+    itself) by patching the loader so native_module() returns None.  The guard
+    fires at the top of review_config -- before MatchEngine runs -- so the test
+    does not need to supply a valid df/config shape, but we supply one anyway for
+    clarity.
+
+    Two variants are tested:
+    - loader-absent: native_module() returns None.
+    - symbol-absent: native_module() returns an object without suggest_config.
+    Both arms of the ``if nm is None or not hasattr(nm, "suggest_config")`` guard
+    must raise with "goldenmatch[native]" in the message.
+    """
+    import types
+    import unittest.mock as mock
+
+    import goldenmatch.core._native_loader as _loader
+    from goldenmatch.core.suggest import SuggestionsNativeRequired
+    from goldenmatch.core.suggest.adapter import review_config
+
+    df = _make_df()
+    config = _make_config()
+
+    # Arm 1: loader returns None (wheel not installed / not built)
+    with mock.patch.object(_loader, "native_module", return_value=None):
+        with pytest.raises(SuggestionsNativeRequired) as exc_info:
+            review_config(df, config)
+        assert "goldenmatch[native]" in str(exc_info.value), (
+            f"Expected 'goldenmatch[native]' in error message; got: {exc_info.value!r}"
+        )
+
+    # Arm 2: loader returns a module object that lacks suggest_config
+    stub = types.SimpleNamespace()  # no suggest_config attribute
+    with mock.patch.object(_loader, "native_module", return_value=stub):
+        with pytest.raises(SuggestionsNativeRequired) as exc_info:
+            review_config(df, config)
+        assert "goldenmatch[native]" in str(exc_info.value), (
+            f"Expected 'goldenmatch[native]' in error message; got: {exc_info.value!r}"
+        )
+
+
 @requires_native
 def test_review_config_adds_row_id_if_absent():
     """review_config works even when __row_id__ is not pre-set on the df."""

--- a/packages/python/goldenmatch/tests/test_suggest_adapter.py
+++ b/packages/python/goldenmatch/tests/test_suggest_adapter.py
@@ -8,9 +8,8 @@ Guards:
 """
 from __future__ import annotations
 
-import pytest
 import polars as pl
-
+import pytest
 
 # ── Native guard ──────────────────────────────────────────────────────────
 
@@ -23,11 +22,121 @@ def _native_suggest_available() -> bool:
         return False
 
 
-if not _native_suggest_available():
-    pytest.skip(
-        "native suggest_config not built -- skipping adapter tests",
-        allow_module_level=True,
+# ── Pure-Python helper tests (no native needed) ───────────────────────────
+# These run unconditionally -- they exercise _collision_rates and
+# _config_summary, which never touch the kernel.
+
+def _helper_config():
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
     )
+
+    mk = MatchkeyConfig(
+        name="fuzzy_match",
+        type="weighted",
+        threshold=0.3,
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", weight=0.5),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", weight=0.5),
+        ],
+    )
+    blocking = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["last_name"])],
+        auto_suggest=False,
+    )
+    return GoldenMatchConfig(matchkeys=[mk], blocking=blocking)
+
+
+def test_collision_rates_all_identical_is_zero():
+    """A multi-member cluster where the column is all-identical -> 0.0."""
+    from goldenmatch.core.suggest.adapter import _collision_rates
+
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "name": ["Alice", "Alice"],  # identical
+    })
+    clusters = {0: {"size": 2, "oversized": False, "members": [0, 1]}}
+    rates = _collision_rates(clusters, df)
+    assert rates.get("name") == 0.0
+
+
+def test_collision_rates_two_distinct_is_one():
+    """A multi-member cluster with two distinct non-null values -> 1.0."""
+    from goldenmatch.core.suggest.adapter import _collision_rates
+
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "name": ["Alice", "Bob"],  # distinct
+    })
+    clusters = {0: {"size": 2, "oversized": False, "members": [0, 1]}}
+    rates = _collision_rates(clusters, df)
+    assert rates.get("name") == 1.0
+
+
+def test_collision_rates_single_member_ignored():
+    """Single-member clusters are not counted (no multi-member -> empty)."""
+    from goldenmatch.core.suggest.adapter import _collision_rates
+
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "name": ["Alice", "Bob"],
+    })
+    clusters = {
+        0: {"size": 1, "oversized": False, "members": [0]},
+        1: {"size": 1, "oversized": False, "members": [1]},
+    }
+    rates = _collision_rates(clusters, df)
+    assert rates == {}  # no multi-member clusters
+
+
+def test_collision_rates_mixed_clusters():
+    """Two multi-member clusters: one collides, one doesn't -> 0.5."""
+    from goldenmatch.core.suggest.adapter import _collision_rates
+
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "name": ["Alice", "Alice", "Bob", "Carol"],  # cluster1 same, cluster2 differs
+    })
+    clusters = {
+        0: {"size": 2, "oversized": False, "members": [0, 1]},  # identical -> no collision
+        1: {"size": 2, "oversized": False, "members": [2, 3]},  # distinct -> collision
+    }
+    rates = _collision_rates(clusters, df)
+    assert rates.get("name") == 0.5
+
+
+def test_config_summary_shape():
+    """_config_summary returns the kernel ConfigSummary shape with 'kind'."""
+    from goldenmatch.core.suggest.adapter import _config_summary
+
+    summary = _config_summary(_helper_config())
+    assert set(summary.keys()) == {"matchkeys", "negative_evidence"}
+    assert isinstance(summary["matchkeys"], list)
+    assert len(summary["matchkeys"]) == 1
+    mk = summary["matchkeys"][0]
+    assert mk["name"] == "fuzzy_match"
+    assert mk["kind"] == "weighted"  # the required field discovered at runtime
+    assert mk["threshold"] == 0.3
+    assert len(mk["fields"]) == 2
+    assert mk["fields"][0]["field"] == "first_name"
+    assert mk["fields"][0]["scorer"] == "jaro_winkler"
+    assert summary["negative_evidence"] == []
+
+
+# ── Native-gated tests below ──────────────────────────────────────────────
+# The helper tests above run unconditionally; everything below needs the
+# kernel, so they carry a per-test skipif marker (NOT a module-level skip,
+# which would also skip the pure-Python helper tests above).
+
+requires_native = pytest.mark.skipif(
+    not _native_suggest_available(),
+    reason="native suggest_config not built",
+)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
@@ -90,9 +199,10 @@ def _make_config():
 
 # ── Tests ─────────────────────────────────────────────────────────────────
 
+@requires_native
 def test_review_config_returns_suggestions():
     """review_config returns a non-empty list of Suggestion objects."""
-    from goldenmatch.core.suggest import review_config, Suggestion
+    from goldenmatch.core.suggest import Suggestion, review_config
 
     df = _make_df()
     config = _make_config()
@@ -101,12 +211,13 @@ def test_review_config_returns_suggestions():
     assert isinstance(suggestions, list), "review_config must return a list"
     assert len(suggestions) > 0, (
         "Expected at least one suggestion for a loose-threshold config "
-        f"(got zero; kernel output may be empty or adapter failed silently)"
+        "(got zero; kernel output may be empty or adapter failed silently)"
     )
     for s in suggestions:
         assert isinstance(s, Suggestion), f"Expected Suggestion, got {type(s)}"
 
 
+@requires_native
 def test_suggestion_has_rationale_and_patch():
     """Every returned Suggestion has a non-empty rationale and a patch with an op key."""
     from goldenmatch.core.suggest import review_config
@@ -127,6 +238,7 @@ def test_suggestion_has_rationale_and_patch():
     )
 
 
+@requires_native
 def test_suggestion_confidence_in_range():
     """Confidence scores must be in [0.0, 1.0]."""
     from goldenmatch.core.suggest import review_config
@@ -144,6 +256,7 @@ def test_missing_native_raises():
     We simulate absence by patching _native_loader.native_module to return None.
     """
     import unittest.mock as mock
+
     from goldenmatch.core.suggest import SuggestionsNativeRequired
     from goldenmatch.core.suggest import adapter as _adapter
 
@@ -155,6 +268,7 @@ def test_missing_native_raises():
             _adapter.review_config(df, config)
 
 
+@requires_native
 def test_review_config_adds_row_id_if_absent():
     """review_config works even when __row_id__ is not pre-set on the df."""
     from goldenmatch.core.suggest import review_config
@@ -168,16 +282,34 @@ def test_review_config_adds_row_id_if_absent():
     assert isinstance(suggestions, list)
 
 
+@requires_native
+def test_review_config_does_not_mutate_caller_config():
+    """review_config must deep-copy the config; the caller's rerank stays set."""
+    from goldenmatch.core.suggest import review_config
+
+    config = _make_config()
+    # Force rerank ON on the caller's config; the adapter disables it on its
+    # OWN copy, so the caller's object must come back unchanged.
+    for mk in config.get_matchkeys():
+        mk.rerank = True
+
+    review_config(_make_df(), config)
+
+    for mk in config.get_matchkeys():
+        assert mk.rerank is True, (
+            "review_config mutated the caller's config (rerank was flipped off)"
+        )
+
+
 def test_arrow_batch_helpers():
     """Unit-test the three Arrow batch builders directly for schema correctness."""
-    import pyarrow as pa
     from goldenmatch.core.suggest.adapter import (
-        _build_clusters_batch,
-        _build_column_signals_batch,
-        _build_scored_pairs_batch,
         _CLUSTERS_SCHEMA,
         _COLUMN_SIGNALS_SCHEMA,
         _SCORED_PAIRS_SCHEMA,
+        _build_clusters_batch,
+        _build_column_signals_batch,
+        _build_scored_pairs_batch,
     )
 
     # scored_pairs

--- a/packages/python/goldenmatch/tests/test_suggest_adapter.py
+++ b/packages/python/goldenmatch/tests/test_suggest_adapter.py
@@ -1,0 +1,203 @@
+"""End-to-end test for the review_config adapter (Task 11).
+
+Guards:
+- Skips when the native kernel is absent or doesn't expose ``suggest_config``.
+- Never loads torch / HuggingFace models (rerank disabled explicitly in adapter).
+- Uses a tiny synthetic person-like DataFrame with known duplicates so the
+  kernel has real signal to work with.
+"""
+from __future__ import annotations
+
+import pytest
+import polars as pl
+
+
+# ── Native guard ──────────────────────────────────────────────────────────
+
+def _native_suggest_available() -> bool:
+    try:
+        from goldenmatch.core._native_loader import native_module
+        nm = native_module()
+        return nm is not None and hasattr(nm, "suggest_config")
+    except Exception:
+        return False
+
+
+if not _native_suggest_available():
+    pytest.skip(
+        "native suggest_config not built -- skipping adapter tests",
+        allow_module_level=True,
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+def _make_df() -> pl.DataFrame:
+    """Small synthetic person dataset with genuine duplicates.
+
+    - Row 0 and row 1 are the same person (name + zip match).
+    - Row 2 and row 3 are the same person.
+    - Rows 4-9 are unique.
+    Loose threshold (0.3) ensures they get merged.
+    """
+    records = [
+        {"first_name": "Alice", "last_name": "Smith",   "zip_code": "10001", "email": "alice@example.com"},
+        {"first_name": "Alice", "last_name": "Smith",   "zip_code": "10001", "email": "alice@example.com"},
+        {"first_name": "Bob",   "last_name": "Jones",   "zip_code": "20002", "email": "bob@example.com"},
+        {"first_name": "Bob",   "last_name": "Jones",   "zip_code": "20002", "email": "bob@example.com"},
+        {"first_name": "Carol", "last_name": "White",   "zip_code": "30003", "email": "carol@example.com"},
+        {"first_name": "Dave",  "last_name": "Brown",   "zip_code": "40004", "email": "dave@example.com"},
+        {"first_name": "Eve",   "last_name": "Davis",   "zip_code": "50005", "email": "eve@example.com"},
+        {"first_name": "Frank", "last_name": "Wilson",  "zip_code": "60006", "email": "frank@example.com"},
+        {"first_name": "Grace", "last_name": "Moore",   "zip_code": "70007", "email": "grace@example.com"},
+        {"first_name": "Hank",  "last_name": "Taylor",  "zip_code": "80008", "email": "hank@example.com"},
+    ]
+    return pl.DataFrame(records)
+
+
+def _make_config():
+    """Build an explicit (non-auto-config) config with a loose threshold.
+
+    Using a direct config avoids the auto-config controller hitting the
+    BUDGET_TIME=RED path on this tiny frame, which would complicate the test.
+    Threshold 0.3 is intentionally loose to produce merges the kernel can
+    critique.
+    """
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    mk = MatchkeyConfig(
+        name="fuzzy_match",
+        type="weighted",
+        threshold=0.3,  # intentionally loose -- gives kernel something to raise
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", weight=0.5),
+            MatchkeyField(field="last_name",  scorer="jaro_winkler", weight=0.5),
+        ],
+    )
+    blocking = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["last_name"])],
+        auto_suggest=False,
+    )
+    return GoldenMatchConfig(matchkeys=[mk], blocking=blocking)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+def test_review_config_returns_suggestions():
+    """review_config returns a non-empty list of Suggestion objects."""
+    from goldenmatch.core.suggest import review_config, Suggestion
+
+    df = _make_df()
+    config = _make_config()
+    suggestions = review_config(df, config)
+
+    assert isinstance(suggestions, list), "review_config must return a list"
+    assert len(suggestions) > 0, (
+        "Expected at least one suggestion for a loose-threshold config "
+        f"(got zero; kernel output may be empty or adapter failed silently)"
+    )
+    for s in suggestions:
+        assert isinstance(s, Suggestion), f"Expected Suggestion, got {type(s)}"
+
+
+def test_suggestion_has_rationale_and_patch():
+    """Every returned Suggestion has a non-empty rationale and a patch with an op key."""
+    from goldenmatch.core.suggest import review_config
+
+    df = _make_df()
+    config = _make_config()
+    suggestions = review_config(df, config)
+
+    # At least the first suggestion should be well-formed
+    assert suggestions, "Need at least one suggestion to check fields"
+    s = suggestions[0]
+    assert isinstance(s.rationale, str) and s.rationale.strip(), (
+        f"rationale must be a non-empty string; got {s.rationale!r}"
+    )
+    assert isinstance(s.patch, dict), f"patch must be a dict; got {type(s.patch)}"
+    assert "op" in s.patch, (
+        f"patch must contain an 'op' key; got keys: {list(s.patch.keys())}"
+    )
+
+
+def test_suggestion_confidence_in_range():
+    """Confidence scores must be in [0.0, 1.0]."""
+    from goldenmatch.core.suggest import review_config
+
+    suggestions = review_config(_make_df(), _make_config())
+    for s in suggestions:
+        assert 0.0 <= s.confidence <= 1.0, (
+            f"confidence out of range: {s.confidence!r} for suggestion id={s.id!r}"
+        )
+
+
+def test_missing_native_raises():
+    """SuggestionsNativeRequired is raised when the kernel is unavailable.
+
+    We simulate absence by patching _native_loader.native_module to return None.
+    """
+    import unittest.mock as mock
+    from goldenmatch.core.suggest import SuggestionsNativeRequired
+    from goldenmatch.core.suggest import adapter as _adapter
+
+    df = _make_df()
+    config = _make_config()
+
+    with mock.patch.object(_adapter, "_require_kernel", side_effect=SuggestionsNativeRequired("mock")):
+        with pytest.raises(SuggestionsNativeRequired):
+            _adapter.review_config(df, config)
+
+
+def test_review_config_adds_row_id_if_absent():
+    """review_config works even when __row_id__ is not pre-set on the df."""
+    from goldenmatch.core.suggest import review_config
+
+    # _make_df() returns a plain df without __row_id__
+    df = _make_df()
+    assert "__row_id__" not in df.columns
+
+    # Should not raise; adapter adds __row_id__ internally
+    suggestions = review_config(df, _make_config())
+    assert isinstance(suggestions, list)
+
+
+def test_arrow_batch_helpers():
+    """Unit-test the three Arrow batch builders directly for schema correctness."""
+    import pyarrow as pa
+    from goldenmatch.core.suggest.adapter import (
+        _build_clusters_batch,
+        _build_column_signals_batch,
+        _build_scored_pairs_batch,
+        _CLUSTERS_SCHEMA,
+        _COLUMN_SIGNALS_SCHEMA,
+        _SCORED_PAIRS_SCHEMA,
+    )
+
+    # scored_pairs
+    pairs = [(0, 1, 0.95), (2, 3, 0.88)]
+    sp = _build_scored_pairs_batch(pairs)
+    assert sp.schema.equals(_SCORED_PAIRS_SCHEMA)
+    assert sp.num_rows == 2
+
+    # clusters
+    clusters = {
+        0: {"size": 2, "confidence": 0.9, "cluster_quality": "strong", "oversized": False, "members": [0, 1]},
+        1: {"size": 1, "confidence": 0.0, "cluster_quality": "strong", "oversized": False, "members": [2]},
+    }
+    cb = _build_clusters_batch(clusters)
+    assert cb.schema.equals(_CLUSTERS_SCHEMA)
+    assert cb.num_rows == 2
+
+    # column_signals
+    df = _make_df().with_row_index("__row_id__").with_columns(pl.col("__row_id__").cast(pl.Int64))
+    config = _make_config()
+    csb = _build_column_signals_batch(df, config, clusters)
+    assert csb.schema.equals(_COLUMN_SIGNALS_SCHEMA)
+    assert csb.num_rows >= 1  # at least one column

--- a/packages/python/goldenmatch/tests/test_suggest_anchors.py
+++ b/packages/python/goldenmatch/tests/test_suggest_anchors.py
@@ -1,0 +1,443 @@
+"""Regression anchors for the config-suggestion kernel.
+
+Two pins on the NCVR address-swap rule (Rule 2 in suggest-core):
+  * test_anchor_ncvr_address_swap_real   -- real NCVR file, skipped when absent
+  * test_anchor_address_swap_synthetic   -- always-available CI-safe anchor
+
+Both guards skip when native ``suggest_config`` is unavailable.
+
+The hard contract:
+    Given NCVR-shaped data where ``res_street_address`` is scored with
+    ``token_sort`` AND has enough character-noise to cross Rule 2's
+    corruption threshold (>= 0.30), ``review_config`` must emit at least
+    one SwapScorer suggestion targeting the address column.
+"""
+from __future__ import annotations
+
+import os
+import random
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _has_native_suggest() -> bool:
+    """Return True iff the native suggest_config kernel is available."""
+    try:
+        from goldenmatch.core._native_loader import native_module  # noqa: PLC0415
+        nm = native_module()
+        return nm is not None and hasattr(nm, "suggest_config")
+    except Exception:
+        return False
+
+
+_NATIVE_AVAILABLE = _has_native_suggest()
+_SKIP_NO_NATIVE = pytest.mark.skipif(
+    not _NATIVE_AVAILABLE,
+    reason="native suggest_config kernel not available (install goldenmatch[native])",
+)
+
+
+def _make_zero_config_with_token_sort(df: pl.DataFrame, address_col: str):
+    """Build a minimal GoldenMatchConfig where ``address_col`` uses token_sort.
+
+    We deliberately use a manually-constructed config (not auto_configure_df)
+    so the test is independent of the noise-aware-scorer default
+    (GOLDENMATCH_NOISE_AWARE_SCORERS) that would upgrade token_sort -> jaro_winkler
+    before Rule 2 gets a chance to fire.
+
+    The config targets the NCVR-shaped blocking structure: block on birth_year,
+    score on first_name + last_name + address_col with token_sort on the address.
+    Adjust field list to whatever columns are actually present in df.
+    """
+    from goldenmatch.config.schemas import (  # noqa: PLC0415
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    data_cols = [c for c in df.columns if not c.startswith("__")]
+
+    # Choose a blocking key (prefer birth_year, else first available string col)
+    blocking_key = None
+    for cand in ("birth_year", "zip_code", "zip5", "last_name"):
+        if cand in data_cols:
+            blocking_key = cand
+            break
+    if blocking_key is None:
+        blocking_key = data_cols[0]
+
+    # Build fuzzy matchkey fields
+    fields = []
+    for cand in ("first_name", "last_name", "middle_name"):
+        if cand in data_cols:
+            fields.append(MatchkeyField(field=cand, scorer="token_sort", weight=1.0))
+
+    # The address column: explicitly token_sort (NOT jaro_winkler) -- the anchor
+    if address_col in data_cols:
+        fields.append(MatchkeyField(field=address_col, scorer="token_sort", weight=1.5))
+
+    if not fields:
+        # Fallback: score all non-blocking string columns with token_sort
+        for col in data_cols:
+            if col != blocking_key and df[col].dtype == pl.String:
+                fields.append(MatchkeyField(field=col, scorer="token_sort", weight=1.0))
+
+    matchkeys = [MatchkeyConfig(
+        name="fuzzy_match",
+        type="weighted",
+        threshold=0.7,
+        fields=fields,
+    )]
+
+    blocking = BlockingConfig(
+        strategy="multi_pass",
+        passes=[BlockingKeyConfig(fields=[blocking_key])],
+    )
+
+    return GoldenMatchConfig(matchkeys=matchkeys, blocking=blocking)
+
+
+def _corrupt_address(val: str, rng: random.Random) -> str:
+    """Add character-level noise to a street address value."""
+    if not val or len(val) < 4:
+        return val
+    ops = ["typo", "swap", "drop"]
+    op = rng.choice(ops)
+    if op == "typo":
+        pos = rng.randint(0, len(val) - 1)
+        return val[:pos] + rng.choice("abcdefghijklmnopqrstuvwxyz ") + val[pos + 1:]
+    if op == "swap" and len(val) >= 3:
+        pos = rng.randint(0, len(val) - 2)
+        return val[:pos] + val[pos + 1] + val[pos] + val[pos + 2:]
+    if op == "drop" and len(val) >= 3:
+        pos = rng.randint(0, len(val) - 1)
+        return val[:pos] + val[pos + 1:]
+    return val
+
+
+def _make_address_anchor_dataset(
+    n_entities: int = 300,
+    seed: int = 857,
+    corruption_rate: float = 0.55,
+) -> tuple[pl.DataFrame, set]:
+    """Small synthetic dataset whose zero-config should trigger Rule 2.
+
+    Layout: id, first_name, last_name, birth_year, res_street_address.
+    Each entity has 1 original + 1 duplicate with a corrupted address.
+    Corruption rate is set high enough that corruption_score >= 0.30 in
+    the oracle's column-signals batch (Rule 2 threshold).
+
+    The dataset uses only ``res_street_address`` for the address signal.
+    No email / zip / phone so auto_configure cannot build an exact matchkey
+    that would make the address column irrelevant.
+    """
+    rng = random.Random(seed)
+
+    street_names = [
+        "Main St", "Oak Ave", "Maple Dr", "Cedar Ln", "Elm St",
+        "Pine Rd", "River Blvd", "Park Ave", "Hill St", "Lake Dr",
+        "Forest Way", "Valley Rd", "Church St", "Mill Rd", "Grove Ave",
+        "Spring St", "Union Ave", "Market St", "High St", "Center Rd",
+    ]
+
+    records: list[dict] = []
+    entity_to_rows: dict[int, list[int]] = {}
+    row_idx = 0
+
+    for eid in range(n_entities):
+        number = rng.randint(100, 9999)
+        street = rng.choice(street_names)
+        address = f"{number} {street}"
+        birth_year = str(rng.randint(1950, 2000))
+        # Use a syllable-based name pool to avoid surname collisions
+        first = rng.choice([
+            "Alex", "Blair", "Casey", "Dana", "Eli", "Finley", "Gray", "Harper",
+            "Indigo", "Jamie", "Kendall", "Logan", "Morgan", "Noel", "Oakley",
+        ])
+        last = rng.choice([
+            "Smith", "Jones", "Williams", "Brown", "Davis", "Miller", "Wilson",
+            "Moore", "Taylor", "Anderson", "Thomas", "Jackson", "White", "Harris",
+            "Martin", "Thompson", "Garcia", "Martinez", "Robinson", "Clark",
+        ])
+
+        # Original record
+        orig = {
+            "id": f"E{eid:04d}_A",
+            "first_name": first,
+            "last_name": last,
+            "birth_year": birth_year,
+            "res_street_address": address,
+        }
+        records.append(orig)
+        entity_to_rows.setdefault(eid, []).append(row_idx)
+        row_idx += 1
+
+        # Duplicate with corrupted address (high corruption rate -> Rule 2)
+        if rng.random() < corruption_rate:
+            corrupted_address = _corrupt_address(address, rng)
+            dup = {
+                "id": f"E{eid:04d}_B",
+                "first_name": first,
+                "last_name": last,
+                "birth_year": birth_year,
+                "res_street_address": corrupted_address,
+            }
+            records.append(dup)
+            entity_to_rows.setdefault(eid, []).append(row_idx)
+            row_idx += 1
+
+    # Shuffle
+    paired = list(enumerate(records))
+    rng.shuffle(paired)
+
+    # Rebuild entity_to_rows with shuffled positions
+    new_entity_to_rows: dict[int, list[int]] = {}
+    old_to_new = {old_idx: new_idx for new_idx, (old_idx, _) in enumerate(paired)}
+    for eid, old_rows in entity_to_rows.items():
+        new_entity_to_rows[eid] = [old_to_new[r] for r in old_rows]
+
+    shuffled_records = [rec for _, rec in paired]
+    df = pl.DataFrame(shuffled_records)
+
+    # Build canonical (min, max) row-index pairs
+    from itertools import combinations  # noqa: PLC0415
+    gt: set[tuple[int, int]] = set()
+    for rows in new_entity_to_rows.values():
+        for a, b in combinations(sorted(rows), 2):
+            gt.add((a, b))
+
+    return df, gt
+
+
+# ---------------------------------------------------------------------------
+# Part A — Regression anchors
+# ---------------------------------------------------------------------------
+
+@pytest.mark.benchmark
+@_SKIP_NO_NATIVE
+def test_anchor_ncvr_address_swap_real() -> None:
+    """On REAL NCVR data: review_config ranks res_street_address swap #1.
+
+    This is the hard F1 0.871 -> 0.981 lever from the NCVR benchmark.
+    Skipped when the real NCVR dataset file is absent (gitignored PII data).
+    """
+    _root = (
+        Path(__file__).resolve().parents[1]
+        / "tests/benchmarks/datasets/NCVR/ncvoter_sample_10k.txt"
+    )
+    if not _root.exists():
+        pytest.skip(f"Real NCVR file absent: {_root}")
+
+    # Set determinism env before goldenmatch auto-configure import
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    os.environ.setdefault("PYTHONHASHSEED", "0")
+
+    from scripts.dqbench_adapters.ncvr import build_ncvr_df_and_gt  # noqa: PLC0415
+    from scripts.suggest_quality.datasets import _pairs_to_row_index  # noqa: PLC0415
+
+    loaded = build_ncvr_df_and_gt(_root, seed=42)
+    assert loaded is not None, "build_ncvr_df_and_gt returned None"
+    df, ncid_pairs = loaded
+    gt = _pairs_to_row_index(df, "ncid", ncid_pairs)
+
+    zero_config = _make_zero_config_with_token_sort(df, "res_street_address")
+
+    from goldenmatch.core.suggest import review_config  # noqa: PLC0415
+
+    suggestions = review_config(df, zero_config)
+    assert suggestions, "review_config returned no suggestions for real NCVR data"
+
+    # Hard contract: res_street_address swap must be the #1 suggestion.
+    top = suggestions[0]
+    assert top.kind == "swap_scorer", (
+        f"Expected top suggestion kind='swap_scorer' but got kind='{top.kind}' "
+        f"(target='{top.target}'). All suggestions: "
+        + ", ".join(f"{s.kind}:{s.target}" for s in suggestions)
+    )
+    assert "res_street_address" in top.target.lower() or "address" in top.target.lower(), (
+        f"Expected address column in top suggestion target, got: '{top.target}'"
+    )
+
+
+@_SKIP_NO_NATIVE
+def test_anchor_address_swap_synthetic() -> None:
+    """CI-safe anchor: on the dedicated address-anchor synthetic dataset,
+    review_config emits a swap_scorer for res_street_address.
+
+    We pass a manually-crafted zero_config that uses token_sort on the
+    address column, bypassing the noise-aware-scorer auto-upgrade
+    (GOLDENMATCH_NOISE_AWARE_SCORERS). This ensures Rule 2 sees token_sort
+    in the column_signals batch and can fire regardless of env defaults.
+
+    Assertion: swap_scorer targeting res_street_address is present in the
+    suggestions. We assert #1 ranking where possible (corruption_rate=0.55
+    generates strong enough signal), but fall back to 'any suggestion' if
+    the rank varies due to dataset randomness.
+    """
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    os.environ.setdefault("PYTHONHASHSEED", "0")
+
+    df, _gt = _make_address_anchor_dataset(n_entities=300, seed=857)
+
+    assert "res_street_address" in df.columns, "anchor dataset missing res_street_address"
+    assert df.height > 0, "anchor dataset is empty"
+
+    zero_config = _make_zero_config_with_token_sort(df, "res_street_address")
+
+    from goldenmatch.core.suggest import review_config  # noqa: PLC0415
+
+    suggestions = review_config(df, zero_config)
+    assert suggestions, (
+        "review_config returned no suggestions on the address-anchor synthetic dataset. "
+        "Check that token_sort is present in the config and that corruption_score >= 0.30."
+    )
+
+    # Find a swap_scorer for the address column
+    address_swaps = [
+        s for s in suggestions
+        if s.kind == "swap_scorer"
+        and ("res_street_address" in s.target.lower() or "address" in s.target.lower())
+    ]
+    assert address_swaps, (
+        "No swap_scorer suggestion for res_street_address found. "
+        f"Emitted suggestions: {[(s.kind, s.target) for s in suggestions]}"
+    )
+
+    # Strong claim: the swap should be ranked #1 (highest confidence).
+    # If the assertion breaks it means the corruption signal isn't dominant
+    # enough on this dataset shape; relax to 'present' and note the position.
+    top = suggestions[0]
+    if not (top.kind == "swap_scorer" and (
+        "res_street_address" in top.target.lower() or "address" in top.target.lower()
+    )):
+        # Relaxed: accept any position but note rank for debugging.
+        rank = next(
+            (i for i, s in enumerate(suggestions) if s in address_swaps),
+            -1,
+        )
+        pytest.xfail(
+            f"address swap is present but not #1 (rank={rank}). "
+            f"Top suggestion: kind='{top.kind}' target='{top.target}'. "
+            "Consider increasing corruption_rate in _make_address_anchor_dataset."
+        )
+
+
+@_SKIP_NO_NATIVE
+def test_anchor_address_swap_token_sort_triggers_rule2() -> None:
+    """Unit-level pin: Rule 2 fires when token_sort + high corruption.
+
+    This test constructs the column_signals batch directly and calls the
+    native kernel without going through the full pipeline. Faster than the
+    oracle loop and pinned to the exact Rule 2 preconditions.
+    """
+    import json  # noqa: PLC0415
+    import pyarrow as pa  # noqa: PLC0415
+
+    from goldenmatch.core._native_loader import native_module  # noqa: PLC0415
+
+    nm = native_module()
+    assert nm is not None and hasattr(nm, "suggest_config")
+
+    # Minimal scored_pairs (no real pairs needed — Rule 2 is signals-only)
+    scored_pairs_schema = pa.schema([
+        pa.field("id_a", pa.int64()),
+        pa.field("id_b", pa.int64()),
+        pa.field("score", pa.float64()),
+    ])
+    scored_pairs_batch = pa.record_batch(
+        {"id_a": pa.array([], type=pa.int64()),
+         "id_b": pa.array([], type=pa.int64()),
+         "score": pa.array([], type=pa.float64())},
+        schema=scored_pairs_schema,
+    )
+
+    # Minimal clusters batch
+    clusters_schema = pa.schema([
+        pa.field("cluster_id", pa.int64()),
+        pa.field("size", pa.int64()),
+        pa.field("confidence", pa.float64()),
+        pa.field("quality", pa.utf8()),
+        pa.field("oversized", pa.bool_()),
+    ])
+    clusters_batch = pa.record_batch(
+        {
+            "cluster_id": pa.array([], type=pa.int64()),
+            "size": pa.array([], type=pa.int64()),
+            "confidence": pa.array([], type=pa.float64()),
+            "quality": pa.array([], type=pa.utf8()),
+            "oversized": pa.array([], type=pa.bool_()),
+        },
+        schema=clusters_schema,
+    )
+
+    # Column signals: res_street_address with token_sort + corruption 0.5 (> 0.30)
+    col_signals_schema = pa.schema([
+        pa.field("field", pa.utf8()),
+        pa.field("col_type", pa.utf8()),
+        pa.field("scorer", pa.utf8()),
+        pa.field("in_blocking", pa.bool_()),
+        pa.field("in_negative_evidence", pa.bool_()),
+        pa.field("identity_score", pa.float64()),
+        pa.field("corruption_score", pa.float64()),
+        pa.field("collision_rate", pa.float64()),
+        pa.field("cardinality_ratio", pa.float64()),
+        pa.field("null_rate", pa.float64()),
+        pa.field("variant_rate", pa.float64()),
+    ])
+    col_signals_batch = pa.record_batch(
+        {
+            "field": pa.array(["res_street_address"], type=pa.utf8()),
+            "col_type": pa.array(["address"], type=pa.utf8()),
+            "scorer": pa.array(["token_sort"], type=pa.utf8()),
+            "in_blocking": pa.array([False], type=pa.bool_()),
+            "in_negative_evidence": pa.array([False], type=pa.bool_()),
+            "identity_score": pa.array([0.7], type=pa.float64()),
+            "corruption_score": pa.array([0.5], type=pa.float64()),  # >= 0.30 threshold
+            "collision_rate": pa.array([0.0], type=pa.float64()),
+            "cardinality_ratio": pa.array([0.9], type=pa.float64()),
+            "null_rate": pa.array([0.0], type=pa.float64()),
+            "variant_rate": pa.array([0.0], type=pa.float64()),
+        },
+        schema=col_signals_schema,
+    )
+
+    config_json = json.dumps({
+        "matchkeys": [{
+            "name": "fuzzy_match",
+            "kind": "weighted",
+            "threshold": 0.7,
+            "fields": [{"field": "res_street_address", "scorer": "token_sort", "weight": 1.0}],
+        }],
+        "negative_evidence": [],
+    })
+    priors_json = json.dumps({"counts": {}})
+
+    raw_json = nm.suggest_config(
+        scored_pairs_batch,
+        clusters_batch,
+        col_signals_batch,
+        config_json,
+        priors_json,
+    )
+
+    items = json.loads(raw_json)
+    assert items, "Native kernel returned no suggestions for token_sort + corruption 0.5"
+    swap = [i for i in items if i.get("kind") == "swap_scorer"]
+    assert swap, (
+        f"No swap_scorer suggestion from native kernel. Got: {items}"
+    )
+    top = swap[0]
+    assert top.get("target", "").endswith("res_street_address") or \
+           "res_street_address" in top.get("target", ""), (
+        f"swap_scorer target does not reference res_street_address: {top}"
+    )
+    assert top.get("proposed_value") == "jaro_winkler", (
+        f"Expected proposed_value='jaro_winkler', got: {top.get('proposed_value')}"
+    )

--- a/packages/python/goldenmatch/tests/test_suggest_apply.py
+++ b/packages/python/goldenmatch/tests/test_suggest_apply.py
@@ -1,0 +1,241 @@
+"""Tests for apply_suggestion — the config patcher.
+
+TDD: tests written first; run against the apply.py implementation.
+
+Coverage:
+- set_threshold: updates the named matchkey's threshold; original is unchanged
+- set_scorer: updates the named field's scorer within a matchkey; original unchanged
+- add_negative_evidence: appends a NegativeEvidenceField; original unchanged
+- unknown op: raises ValueError
+"""
+from __future__ import annotations
+
+import pytest
+
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+from goldenmatch.core.suggest.apply import apply_suggestion
+from goldenmatch.core.suggest.types import Suggestion
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _mk_suggestion(patch: dict) -> Suggestion:
+    """Build a minimal Suggestion with placeholder values for all non-patch fields."""
+    return Suggestion(
+        id="test-suggestion",
+        kind="test",
+        target="matchkeys[0]",
+        current_value=None,
+        proposed_value=None,
+        rationale="test",
+        predicted_effect="test",
+        confidence=0.9,
+        patch=patch,
+    )
+
+
+def _build_weighted_config(
+    mk_name: str = "person",
+    threshold: float = 0.80,
+    field_name: str = "name",
+    scorer: str = "jaro_winkler",
+    addr_scorer: str = "token_sort",
+) -> GoldenMatchConfig:
+    """Minimal weighted GoldenMatchConfig for patching tests."""
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name=mk_name,
+                type="weighted",
+                threshold=threshold,
+                fields=[
+                    MatchkeyField(field=field_name, scorer=scorer, weight=0.7),
+                    MatchkeyField(field="addr", scorer=addr_scorer, weight=0.3),
+                ],
+            )
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=[field_name])],
+        ),
+    )
+
+
+# ── set_threshold ──────────────────────────────────────────────────────────────
+
+def test_apply_set_threshold_updates_named_matchkey():
+    config = _build_weighted_config(threshold=0.80)
+    suggestion = _mk_suggestion(
+        {"op": "set_threshold", "matchkey": "person", "value": 0.88}
+    )
+
+    result = apply_suggestion(config, suggestion)
+
+    mk = next(m for m in result.get_matchkeys() if m.name == "person")
+    assert mk.threshold == pytest.approx(0.88)
+
+
+def test_apply_set_threshold_leaves_original_unchanged():
+    config = _build_weighted_config(threshold=0.80)
+    suggestion = _mk_suggestion(
+        {"op": "set_threshold", "matchkey": "person", "value": 0.88}
+    )
+
+    apply_suggestion(config, suggestion)
+
+    # Original must be untouched.
+    orig_mk = next(m for m in config.get_matchkeys() if m.name == "person")
+    assert orig_mk.threshold == pytest.approx(0.80)
+
+
+def test_apply_set_threshold_unknown_matchkey_raises():
+    config = _build_weighted_config()
+    suggestion = _mk_suggestion(
+        {"op": "set_threshold", "matchkey": "nonexistent", "value": 0.88}
+    )
+
+    with pytest.raises(ValueError, match="matchkey"):
+        apply_suggestion(config, suggestion)
+
+
+# ── set_scorer ─────────────────────────────────────────────────────────────────
+
+def test_apply_set_scorer_updates_named_field():
+    config = _build_weighted_config(addr_scorer="token_sort")
+    suggestion = _mk_suggestion(
+        {"op": "set_scorer", "matchkey": "person", "field": "addr", "scorer": "jaro_winkler"}
+    )
+
+    result = apply_suggestion(config, suggestion)
+
+    mk = next(m for m in result.get_matchkeys() if m.name == "person")
+    addr_field = next(f for f in mk.fields if f.field == "addr")
+    assert addr_field.scorer == "jaro_winkler"
+
+
+def test_apply_set_scorer_leaves_original_unchanged():
+    config = _build_weighted_config(addr_scorer="token_sort")
+    suggestion = _mk_suggestion(
+        {"op": "set_scorer", "matchkey": "person", "field": "addr", "scorer": "jaro_winkler"}
+    )
+
+    apply_suggestion(config, suggestion)
+
+    orig_mk = next(m for m in config.get_matchkeys() if m.name == "person")
+    orig_addr = next(f for f in orig_mk.fields if f.field == "addr")
+    assert orig_addr.scorer == "token_sort"
+
+
+def test_apply_set_scorer_unknown_matchkey_raises():
+    config = _build_weighted_config()
+    suggestion = _mk_suggestion(
+        {"op": "set_scorer", "matchkey": "ghost", "field": "addr", "scorer": "jaro_winkler"}
+    )
+
+    with pytest.raises(ValueError, match="matchkey"):
+        apply_suggestion(config, suggestion)
+
+
+def test_apply_set_scorer_unknown_field_raises():
+    config = _build_weighted_config()
+    suggestion = _mk_suggestion(
+        {"op": "set_scorer", "matchkey": "person", "field": "ghost_field", "scorer": "jaro_winkler"}
+    )
+
+    with pytest.raises(ValueError, match="field"):
+        apply_suggestion(config, suggestion)
+
+
+# ── add_negative_evidence ──────────────────────────────────────────────────────
+
+def test_apply_add_negative_evidence_adds_field():
+    config = _build_weighted_config()
+    suggestion = _mk_suggestion(
+        {"op": "add_negative_evidence", "field": "email"}
+    )
+
+    result = apply_suggestion(config, suggestion)
+
+    mk = result.get_matchkeys()[0]
+    assert mk.negative_evidence is not None
+    ne_fields = [ne.field for ne in mk.negative_evidence]
+    assert "email" in ne_fields
+
+
+def test_apply_add_negative_evidence_leaves_original_unchanged():
+    config = _build_weighted_config()
+    # Original has no NE.
+    assert config.get_matchkeys()[0].negative_evidence is None
+
+    suggestion = _mk_suggestion(
+        {"op": "add_negative_evidence", "field": "email"}
+    )
+
+    apply_suggestion(config, suggestion)
+
+    # Original must still have no NE.
+    assert config.get_matchkeys()[0].negative_evidence is None
+
+
+def test_apply_add_negative_evidence_idempotent():
+    """Applying NE for a field already in the list doesn't duplicate it."""
+    existing_ne = NegativeEvidenceField(
+        field="email", transforms=[], scorer="token_sort", threshold=0.4, penalty=0.3
+    )
+    config = GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="person",
+                type="weighted",
+                threshold=0.80,
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+                negative_evidence=[existing_ne],
+            )
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["name"])],
+        ),
+    )
+    suggestion = _mk_suggestion(
+        {"op": "add_negative_evidence", "field": "email"}
+    )
+
+    result = apply_suggestion(config, suggestion)
+
+    mk = result.get_matchkeys()[0]
+    assert mk.negative_evidence is not None
+    count = sum(1 for ne in mk.negative_evidence if ne.field == "email")
+    assert count == 1
+
+
+def test_apply_add_negative_evidence_ne_fields_are_ne_objects():
+    """The NE list must contain NegativeEvidenceField objects, not plain strings."""
+    config = _build_weighted_config()
+    suggestion = _mk_suggestion(
+        {"op": "add_negative_evidence", "field": "phone"}
+    )
+
+    result = apply_suggestion(config, suggestion)
+
+    mk = result.get_matchkeys()[0]
+    assert mk.negative_evidence is not None
+    for ne in mk.negative_evidence:
+        assert isinstance(ne, NegativeEvidenceField)
+
+
+# ── unknown op ────────────────────────────────────────────────────────────────
+
+def test_apply_unknown_op_raises():
+    config = _build_weighted_config()
+    suggestion = _mk_suggestion({"op": "bogus"})
+
+    with pytest.raises(ValueError, match="bogus"):
+        apply_suggestion(config, suggestion)

--- a/packages/python/goldenmatch/tests/test_suggest_metrics.py
+++ b/packages/python/goldenmatch/tests/test_suggest_metrics.py
@@ -1,0 +1,135 @@
+"""Unit tests for scripts/suggest_quality/metrics.py — pure functions, no data.
+
+Sign-convention reminder (from metrics.py docstring):
+  rank_correlation([highest_lift_first, ...]) -> +1.0
+  rank_correlation([lowest_lift_first, ...])  -> -1.0
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ lives at the repo root; make sure it's importable regardless of CWD.
+_REPO_ROOT = Path(__file__).resolve().parents[5]  # …/goldenmatch/
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.suggest_quality.metrics import convergence, rank_correlation, suggester_precision
+
+
+# ─── rank_correlation ────────────────────────────────────────────────────────
+
+class TestRankCorrelation:
+    def test_perfect_descending_order_gives_plus_one(self):
+        """Lifts already in descending order: suggester is perfect -> +1.0."""
+        lifts = [0.3, 0.2, 0.1]
+        rho = rank_correlation(lifts)
+        assert abs(rho - 1.0) < 1e-9, f"expected +1.0, got {rho}"
+
+    def test_perfect_ascending_order_gives_minus_one(self):
+        """Lifts in ascending order: worst-first suggester -> -1.0."""
+        lifts = [0.1, 0.2, 0.3]
+        rho = rank_correlation(lifts)
+        assert abs(rho - (-1.0)) < 1e-9, f"expected -1.0, got {rho}"
+
+    def test_empty_returns_nan(self):
+        assert math.isnan(rank_correlation([]))
+
+    def test_single_element_returns_nan(self):
+        assert math.isnan(rank_correlation([0.5]))
+
+    def test_two_elements_descending_gives_plus_one(self):
+        lifts = [0.2, 0.1]
+        rho = rank_correlation(lifts)
+        assert abs(rho - 1.0) < 1e-9
+
+    def test_two_elements_ascending_gives_minus_one(self):
+        lifts = [0.1, 0.2]
+        rho = rank_correlation(lifts)
+        assert abs(rho - (-1.0)) < 1e-9
+
+    def test_all_equal_lifts_returns_nan(self):
+        # Zero variance -> Spearman undefined
+        lifts = [0.1, 0.1, 0.1]
+        rho = rank_correlation(lifts)
+        assert math.isnan(rho)
+
+    def test_mixed_positive_negative_lifts(self):
+        # Descending with negatives still -> +1.0
+        lifts = [0.1, 0.0, -0.1]
+        rho = rank_correlation(lifts)
+        assert abs(rho - 1.0) < 1e-9
+
+    def test_sign_convention_documented(self):
+        """Explicit sanity: rank0 = best, rank_last = worst -> perfect ordering -> +1."""
+        # rank position 0 has lift 0.5, rank position 2 has lift 0.1
+        # Negated: 0 -> -0.5, 1 -> -0.2, 2 -> -0.1
+        # Ranks [0,1,2] vs neg_lifts [-0.5,-0.2,-0.1]: ascending vs ascending -> +1
+        lifts = [0.5, 0.2, 0.1]
+        assert abs(rank_correlation(lifts) - 1.0) < 1e-9
+
+
+# ─── suggester_precision ─────────────────────────────────────────────────────
+
+class TestSuggesterPrecision:
+    def test_all_positive_gives_one(self):
+        assert suggester_precision([0.1, 0.2, 0.3]) == 1.0
+
+    def test_all_negative_gives_zero(self):
+        assert suggester_precision([-0.1, -0.2]) == 0.0
+
+    def test_empty_gives_one(self):
+        assert suggester_precision([]) == 1.0
+
+    def test_mixed_two_thirds(self):
+        # 0.1 (ok), -0.2 (bad), 0.0 (ok = no regression) -> 2/3
+        result = suggester_precision([0.1, -0.2, 0.0])
+        assert abs(result - 2 / 3) < 1e-9, f"expected 2/3, got {result}"
+
+    def test_zero_lift_counts_as_non_harmful(self):
+        assert suggester_precision([0.0]) == 1.0
+
+    def test_single_positive(self):
+        assert suggester_precision([0.05]) == 1.0
+
+    def test_single_negative(self):
+        assert suggester_precision([-0.05]) == 0.0
+
+
+# ─── convergence ─────────────────────────────────────────────────────────────
+
+class TestConvergence:
+    def test_empty_steps(self):
+        result = convergence([])
+        assert result == {"final_f1": 0.0, "steps": 0, "improved": False}
+
+    def test_single_step(self):
+        result = convergence([("raise_threshold:mk1", 0.75)])
+        assert result["final_f1"] == pytest.approx(0.75)
+        assert result["steps"] == 1
+        assert result["improved"] is True
+
+    def test_multiple_steps(self):
+        trail = [
+            ("raise_threshold:mk1", 0.72),
+            ("swap_scorer:mk1:name", 0.78),
+            ("add_ne:email", 0.80),
+        ]
+        result = convergence(trail)
+        assert result["final_f1"] == pytest.approx(0.80)
+        assert result["steps"] == 3
+        assert result["improved"] is True
+
+    def test_improved_false_only_when_empty(self):
+        # Even a single step (even if small gain) counts as improved
+        result = convergence([("some_suggestion", 0.0)])
+        assert result["improved"] is True
+
+    def test_final_f1_is_last_not_max(self):
+        # Convergence may regress after the cap; final_f1 = the last step
+        trail = [("a", 0.9), ("b", 0.85)]
+        result = convergence(trail)
+        assert result["final_f1"] == pytest.approx(0.85)

--- a/packages/python/goldenmatch/tests/test_suggest_oracle_smoke.py
+++ b/packages/python/goldenmatch/tests/test_suggest_oracle_smoke.py
@@ -1,0 +1,73 @@
+"""Oracle smoke test: evaluate_dataset on the always-available synthetic dataset.
+
+Guards:
+- Skips when the native kernel is unavailable (graceful degradation path).
+- Verifies the returned dict has all expected keys and a numeric baseline_f1.
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _native_available() -> bool:
+    try:
+        from goldenmatch.core._native_loader import native_module  # noqa: PLC0415
+        nm = native_module()
+        return nm is not None and hasattr(nm, "suggest_config")
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native suggest_config kernel not available",
+)
+def test_evaluate_dataset_synthetic_returns_expected_keys():
+    """evaluate_dataset('synthetic') returns a dict with expected keys + numeric baseline_f1."""
+    import os
+    os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+
+    from scripts.suggest_quality.datasets import _synthetic  # noqa: PLC0415
+    from scripts.suggest_quality.oracle import evaluate_dataset  # noqa: PLC0415
+
+    loaded = _synthetic()
+    assert loaded is not None, "synthetic dataset failed to load"
+    df, gt_pairs = loaded
+
+    result = evaluate_dataset("synthetic", df, gt_pairs)
+
+    # All expected keys must be present
+    expected_keys = {
+        "name", "rows", "gt_pairs", "baseline_f1",
+        "n_suggestions", "suggested_order_lifts",
+        "convergence_final_f1", "convergence_steps",
+        "native_available", "error",
+    }
+    assert expected_keys.issubset(result.keys()), (
+        f"Missing keys: {expected_keys - result.keys()}"
+    )
+
+    # baseline_f1 must be numeric (not nan, not None)
+    baseline_f1 = result["baseline_f1"]
+    assert isinstance(baseline_f1, float), f"baseline_f1 type: {type(baseline_f1)}"
+    assert not math.isnan(baseline_f1), "baseline_f1 is NaN (gt_pairs present, should be numeric)"
+    assert 0.0 <= baseline_f1 <= 1.0, f"baseline_f1 out of range: {baseline_f1}"
+
+    # rows must match df
+    assert result["rows"] == df.height
+
+    # gt_pairs must be non-negative
+    assert result["gt_pairs"] >= 0
+
+    # No error
+    assert result["error"] is None, f"evaluate_dataset returned error: {result['error']}"

--- a/packages/python/goldenmatch/tests/test_suggest_oracle_smoke.py
+++ b/packages/python/goldenmatch/tests/test_suggest_oracle_smoke.py
@@ -6,6 +6,13 @@ Guards:
 """
 from __future__ import annotations
 
+# Set BEFORE any goldenmatch import so the native-loader probe at collection
+# time (in _suggest_available below, evaluated by the skipif) can't hit the
+# Polars CPU-check WMI hang on Windows.
+import os
+
+os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+
 import math
 import sys
 from pathlib import Path
@@ -18,23 +25,31 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 
-def _native_available() -> bool:
+def _suggest_available() -> bool:
+    """True when both the native suggest_config kernel AND the worktree engine
+    surface (MatchEngine.from_dataframe) are present.
+
+    The from_dataframe check skips (not errors) when this test runs against a
+    stale installed package without the worktree on PYTHONPATH.
+    """
     try:
         from goldenmatch.core._native_loader import native_module  # noqa: PLC0415
         nm = native_module()
-        return nm is not None and hasattr(nm, "suggest_config")
+        if nm is None or not hasattr(nm, "suggest_config"):
+            return False
+        from goldenmatch.tui.engine import MatchEngine  # noqa: PLC0415
+        return hasattr(MatchEngine, "from_dataframe")
     except Exception:
         return False
 
 
 @pytest.mark.skipif(
-    not _native_available(),
-    reason="native suggest_config kernel not available",
+    not _suggest_available(),
+    reason="native suggest_config kernel absent or requires worktree package "
+           "(MatchEngine.from_dataframe missing)",
 )
 def test_evaluate_dataset_synthetic_returns_expected_keys():
     """evaluate_dataset('synthetic') returns a dict with expected keys + numeric baseline_f1."""
-    import os
-    os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
     os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
 
     from scripts.suggest_quality.datasets import _synthetic  # noqa: PLC0415

--- a/packages/python/goldenmatch/tests/test_suggest_verify.py
+++ b/packages/python/goldenmatch/tests/test_suggest_verify.py
@@ -1,0 +1,511 @@
+"""Tests for the self-verification gate in review_config (Task 17).
+
+Two test groups:
+
+1. Pure-Python unit tests of ``suggestion_health()`` and
+   ``suggestion_health_from_clusters()`` -- no native required.
+   Tests that healthier score distributions produce higher health scores,
+   and that degenerate distributions score low.
+
+2. Native-gated integration tests of ``review_config(verify=True/False)``.
+   Constructs a case where a net-negative suggestion is emitted by the kernel,
+   and asserts that verify=True suppresses it while verify=False keeps it.
+
+The native-gated tests skip when the ``suggest_config`` kernel is absent.
+The pure-Python health tests always run.
+"""
+from __future__ import annotations
+
+import os
+
+import polars as pl
+import pytest
+
+
+# ── Native guard ──────────────────────────────────────────────────────────────
+
+def _native_suggest_available() -> bool:
+    try:
+        from goldenmatch.core._native_loader import native_module
+        nm = native_module()
+        return nm is not None and hasattr(nm, "suggest_config")
+    except Exception:
+        return False
+
+
+requires_native = pytest.mark.skipif(
+    not _native_suggest_available(),
+    reason="native suggest_config not built",
+)
+
+
+# ── Unit tests of suggestion_health() -- always run ──────────────────────────
+
+class TestSuggestionHealth:
+    """Pure unit tests of the scored-pairs health proxy; no native kernel."""
+
+    def test_empty_pairs_is_worst(self):
+        """Empty scored_pairs returns -1.0 (worst possible)."""
+        from goldenmatch.core.suggest.health import suggestion_health
+
+        h = suggestion_health([], threshold=0.7)
+        assert h == -1.0
+
+    def test_perfectly_separated_is_positive(self):
+        """Most pairs above threshold, few below -> positive health."""
+        from goldenmatch.core.suggest.health import suggestion_health
+
+        # 60 above threshold (score 0.9), 40 well below (score 0.3).
+        # mass_above=0.6, mass_border=0 (0.3 < threshold-0.1=0.6), mass_sep=0.6.
+        # 0.6 < collapse floor (0.9) so no pathology penalty.  health=0.6.
+        pairs = (
+            [(i, i + 1, 0.9) for i in range(60)]
+            + [(i + 60, i + 61, 0.3) for i in range(40)]
+        )
+        h = suggestion_health(pairs, threshold=0.7)
+        assert h > 0.0, f"Expected positive health for well-separated pairs, got {h}"
+
+    def test_all_in_border_is_negative(self):
+        """All scores just below threshold (in borderline) -> negative health."""
+        from goldenmatch.core.suggest.health import suggestion_health
+
+        # All scores at threshold - 0.05 -> all in the 0.10-wide border band
+        threshold = 0.7
+        pairs = [(i, i + 1, threshold - 0.05) for i in range(100)]
+        h = suggestion_health(pairs, threshold=threshold)
+        # mass_above=0, mass_border=1.0, mass_sep = -1.0
+        assert h < 0.0, f"Expected negative health for all-borderline pairs, got {h}"
+
+    def test_precision_collapse_penalty(self):
+        """When > 90% of pairs are above threshold, health is penalised."""
+        from goldenmatch.core.suggest.health import suggestion_health
+
+        # 95% above threshold (precision collapse)
+        n = 100
+        above_count = 95
+        pairs = (
+            [(i, i + 1, 0.95) for i in range(above_count)]
+            + [(i, i + 1, 0.5) for i in range(above_count, n)]
+        )
+        h_collapsed = suggestion_health(pairs, threshold=0.7)
+
+        # 50% above threshold (healthy separation)
+        pairs_healthy = (
+            [(i, i + 1, 0.95) for i in range(50)]
+            + [(i, i + 1, 0.3) for i in range(50, 100)]
+        )
+        h_healthy = suggestion_health(pairs_healthy, threshold=0.7)
+
+        assert h_collapsed < h_healthy, (
+            f"Collapsed config (h={h_collapsed:.3f}) should score below "
+            f"healthy config (h={h_healthy:.3f})"
+        )
+
+    def test_healthier_beats_unhealthy(self):
+        """A distribution with good separation beats one with poor separation."""
+        from goldenmatch.core.suggest.health import suggestion_health
+
+        threshold = 0.7
+
+        # Good: many above threshold, few in border
+        good = (
+            [(i, i + 1, 0.9) for i in range(70)]  # 70 above
+            + [(i, i + 1, 0.5) for i in range(70, 100)]  # 30 below border
+        )
+        # Bad: few above threshold, many in border
+        bad = (
+            [(i, i + 1, 0.75) for i in range(10)]  # 10 above
+            + [(i, i + 1, 0.65) for i in range(10, 100)]  # 90 in border
+        )
+
+        h_good = suggestion_health(good, threshold)
+        h_bad = suggestion_health(bad, threshold)
+
+        assert h_good > h_bad, (
+            f"Good distribution (h={h_good:.3f}) should beat "
+            f"bad distribution (h={h_bad:.3f})"
+        )
+
+    def test_no_matches_is_negative(self):
+        """All scores well below threshold -> negative mass_sep, negative health."""
+        from goldenmatch.core.suggest.health import suggestion_health
+
+        # All scores at 0.2, threshold 0.7 -> nothing in border or above
+        pairs = [(i, i + 1, 0.2) for i in range(100)]
+        h = suggestion_health(pairs, threshold=0.7)
+        # mass_above=0, mass_border=0 -> mass_sep=0, no pathology, h=0
+        # Exact zero is neutral, but at minimum not positive
+        assert h <= 0.0, f"No-match config should not have positive health, got {h}"
+
+
+# ── Unit tests of suggestion_health_from_clusters() -- always run ─────────────
+
+class TestSuggestionHealthFromClusters:
+    """Pure unit tests of the cluster-based health proxy used by the verify gate."""
+
+    def _make_clusters(self, sizes, confidences=None):
+        """Build a fake clusters dict with the given multi-member sizes."""
+        clusters = {}
+        row_id = 0
+        for i, sz in enumerate(sizes):
+            members = list(range(row_id, row_id + sz))
+            row_id += sz
+            conf = confidences[i] if confidences else 0.8
+            clusters[i] = {
+                "size": sz,
+                "members": members,
+                "confidence": conf,
+                "oversized": False,
+            }
+        return clusters
+
+    def test_no_records_is_worst(self):
+        """n_records=0 returns -1.0 (degenerate)."""
+        from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+
+        h = suggestion_health_from_clusters({}, n_records=0)
+        assert h == -1.0
+
+    def test_no_clusters_is_zero(self):
+        """No multi-member clusters -> matched_rate=0 -> health=0."""
+        from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+
+        # Only singleton clusters
+        clusters = {0: {"size": 1, "members": [0], "confidence": 0.9, "oversized": False}}
+        h = suggestion_health_from_clusters(clusters, n_records=10)
+        assert h == 0.0
+
+    def test_high_recall_high_confidence_is_positive(self):
+        """Many matched records with high confidence -> positive health."""
+        from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+
+        # 80 records matched in 40 pairs of 2, confidence 0.9
+        clusters = self._make_clusters([2] * 40, [0.9] * 40)
+        h = suggestion_health_from_clusters(clusters, n_records=100)
+        assert h > 0.0, f"Expected positive health for high-recall config, got {h}"
+
+    def test_recall_collapse_scores_lower(self):
+        """Config matching fewer records (higher threshold) scores lower than baseline."""
+        from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+
+        # Baseline: 80 matched records, 100 total
+        baseline_clusters = self._make_clusters([2] * 40, [0.85] * 40)
+        h_baseline = suggestion_health_from_clusters(baseline_clusters, n_records=100)
+
+        # After aggressive threshold raise: only 20 matched records remain
+        cand_clusters = self._make_clusters([2] * 10, [0.85] * 10)
+        h_cand = suggestion_health_from_clusters(cand_clusters, n_records=100)
+
+        assert h_cand < h_baseline, (
+            f"Recall-collapsed config (h={h_cand:.3f}) should score below "
+            f"baseline (h={h_baseline:.3f})"
+        )
+
+    def test_merge_collapse_is_penalised(self):
+        """A single giant cluster absorbing > 50% of records triggers the penalty."""
+        from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+
+        # One cluster with 60 of 100 records -> collapse flag
+        clusters = {0: {"size": 60, "members": list(range(60)), "confidence": 0.6, "oversized": False}}
+        h_collapsed = suggestion_health_from_clusters(clusters, n_records=100)
+
+        # Healthy: 60 records in 30 clusters of 2
+        clusters_healthy = self._make_clusters([2] * 30, [0.8] * 30)
+        h_healthy = suggestion_health_from_clusters(clusters_healthy, n_records=100)
+
+        assert h_collapsed < h_healthy, (
+            f"Merge-collapsed config (h={h_collapsed:.3f}) should score below "
+            f"healthy config (h={h_healthy:.3f})"
+        )
+
+    def test_threshold_extraction_from_config(self):
+        """_extract_threshold extracts the first non-None threshold."""
+        from unittest.mock import MagicMock
+
+        from goldenmatch.core.suggest.health import _extract_threshold
+
+        mk = MagicMock()
+        mk.threshold = 0.85
+        config = MagicMock()
+        config.get_matchkeys.return_value = [mk]
+        assert _extract_threshold(config) == 0.85
+
+    def test_threshold_extraction_fallback(self):
+        """_extract_threshold returns 0.5 when no threshold found."""
+        from unittest.mock import MagicMock
+
+        from goldenmatch.core.suggest.health import _extract_threshold
+
+        mk = MagicMock()
+        mk.threshold = None
+        config = MagicMock()
+        config.get_matchkeys.return_value = [mk]
+        assert _extract_threshold(config) == 0.5
+
+
+# ── Integration tests of review_config verify gate (native required) ─────────
+
+def _make_ncvr_like_df() -> pl.DataFrame:
+    """Construct a small NCVR-shaped dataset where the baseline F1 is already high.
+
+    This mimics the ncvr_synthetic scenario: auto-config gets F1~0.983 and the
+    kernel then emits threshold suggestions that lower F1.
+
+    We build a synthetic CRM-like dataset where:
+    - 2500 duplicate pairs exist (one entity = two rows)
+    - The naming/birth_year blocking naturally produces good separation
+    - Any threshold change (raise or lower) would hurt F1
+
+    The exact dataset shape doesn't need to match real NCVR -- we just need a
+    scenario where the kernel is likely to emit suggestions on a near-optimal
+    config, and those suggestions are health-worsening.
+    """
+    import random
+
+    rng = random.Random(42)
+
+    rows = []
+    entity_id = 0
+    # 200 entities, each with 2 variants (true duplicate pair)
+    for _ in range(200):
+        fn = rng.choice(["Alice", "Bob", "Carol", "Dave", "Eve"])
+        ln = rng.choice(["Smith", "Jones", "Williams", "Taylor", "Brown"])
+        birth_year = str(rng.randint(1950, 1990))
+        zip_code = f"{rng.randint(10000, 99999):05d}"
+        # Row 1: clean
+        rows.append({
+            "first_name": fn,
+            "last_name": ln,
+            "birth_year": birth_year,
+            "zip_code": zip_code,
+            "entity_id": entity_id,
+        })
+        # Row 2: slight name noise
+        noise_fn = fn if rng.random() > 0.1 else fn[:-1]
+        rows.append({
+            "first_name": noise_fn,
+            "last_name": ln,
+            "birth_year": birth_year,
+            "zip_code": zip_code,
+            "entity_id": entity_id,
+        })
+        entity_id += 1
+    # 100 unique entities (singletons)
+    for _ in range(100):
+        rows.append({
+            "first_name": rng.choice(["Frank", "Grace", "Hank", "Iris", "Jack"]),
+            "last_name": rng.choice(["Miller", "Wilson", "Moore", "Anderson", "Thomas"]),
+            "birth_year": str(rng.randint(1950, 1990)),
+            "zip_code": f"{rng.randint(10000, 99999):05d}",
+            "entity_id": entity_id,
+        })
+        entity_id += 1
+
+    return pl.DataFrame(rows).drop("entity_id")
+
+
+def _make_auto_config(df: pl.DataFrame):
+    """Auto-configure df with rerank disabled."""
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    try:
+        config = auto_configure_df(df, confidence_required=False)
+    except Exception:
+        config = auto_configure_df(df, confidence_required=False, allow_red_config=True)
+
+    try:
+        for mk in config.get_matchkeys():
+            if getattr(mk, "rerank", False):
+                mk.rerank = False
+    except Exception:
+        pass
+    return config
+
+
+@requires_native
+def test_verify_true_never_returns_health_worsening():
+    """Every suggestion returned by verify=True has cand_health >= baseline_health.
+
+    This is the strongest safety guarantee: we re-check each survivor using the
+    cluster-based health proxy (same function used by the verify gate).
+    """
+    import copy
+
+    from goldenmatch.core.suggest import apply_suggestion, review_config
+    from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+    from goldenmatch.tui.engine import MatchEngine
+
+    df = _make_ncvr_like_df()
+    config = _make_auto_config(df)
+
+    # Get verified suggestions
+    verified = review_config(df, config, verify=True)
+
+    if not verified:
+        # All suggestions were suppressed or none were emitted -- that's fine
+        return
+
+    # Ensure __row_id__ present for the re-check
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
+
+    engine = MatchEngine.from_dataframe(df)
+    _config = copy.deepcopy(config)
+    try:
+        for mk in _config.get_matchkeys():
+            if getattr(mk, "rerank", False):
+                mk.rerank = False
+    except Exception:
+        pass
+
+    n_records = df.height
+    baseline_result = engine._run_pipeline(df, _config)
+    baseline_health = suggestion_health_from_clusters(baseline_result.clusters, n_records)
+
+    EPS = 1e-6
+    for s in verified:
+        try:
+            cfg_cand = apply_suggestion(_config, s)
+            try:
+                for mk in cfg_cand.get_matchkeys():
+                    if getattr(mk, "rerank", False):
+                        mk.rerank = False
+            except Exception:
+                pass
+            cand_result = engine._run_pipeline(df, cfg_cand)
+            cand_health = suggestion_health_from_clusters(cand_result.clusters, n_records)
+            assert cand_health >= baseline_health - EPS, (
+                f"Suggestion {s.id!r} passed verify=True but its health "
+                f"({cand_health:.4f}) < baseline ({baseline_health:.4f}). "
+                f"The gate has a false negative."
+            )
+        except Exception as exc:
+            pytest.skip(f"Could not re-verify suggestion {s.id!r}: {exc}")
+
+
+@requires_native
+def test_verify_false_may_return_more_suggestions():
+    """verify=False returns the raw kernel output; may include more suggestions.
+
+    On an already-healthy config, verify=True should suppress at least one
+    harmful suggestion that verify=False keeps -- OR they return the same
+    count if the kernel happened to emit only good suggestions on this run.
+
+    We assert the structural property: verify=True returns <= verify=False.
+    """
+    from goldenmatch.core.suggest import review_config
+
+    df = _make_ncvr_like_df()
+    config = _make_auto_config(df)
+
+    verified = review_config(df, config, verify=True)
+    raw = review_config(df, config, verify=False)
+
+    assert len(verified) <= len(raw), (
+        f"verify=True returned MORE suggestions ({len(verified)}) than "
+        f"verify=False ({len(raw)}).  This is a bug: the gate must be monotonically "
+        "non-increasing."
+    )
+
+
+@requires_native
+def test_env_flag_disables_verify():
+    """GOLDENMATCH_SUGGEST_VERIFY=0 disables verification globally.
+
+    Even when verify=True is passed, the env flag wins -- the function
+    returns raw suggestions identical to verify=False.
+    """
+    from goldenmatch.core.suggest import review_config
+
+    df = _make_ncvr_like_df()
+    config = _make_auto_config(df)
+
+    raw = review_config(df, config, verify=False)
+
+    # Temporarily disable verify via env
+    old_val = os.environ.get("GOLDENMATCH_SUGGEST_VERIFY")
+    try:
+        os.environ["GOLDENMATCH_SUGGEST_VERIFY"] = "0"
+        env_off = review_config(df, config, verify=True)
+    finally:
+        if old_val is None:
+            os.environ.pop("GOLDENMATCH_SUGGEST_VERIFY", None)
+        else:
+            os.environ["GOLDENMATCH_SUGGEST_VERIFY"] = old_val
+
+    assert len(env_off) == len(raw), (
+        f"With GOLDENMATCH_SUGGEST_VERIFY=0, got {len(env_off)} suggestions; "
+        f"expected {len(raw)} (same as verify=False)."
+    )
+
+
+@requires_native
+def test_verify_suppresses_ncvr_synthetic_net_negatives():
+    """On the ncvr_synthetic dataset, verify=True suppresses all net-negative
+    suggestions that the kernel emits on an already-healthy config.
+
+    This is the canonical regression test for Task 17: the scorecard shows
+    ncvr_synthetic has suggester_prec=0.0 (both suggestions are harmful).
+    After self-verify, the emitted set must have cand_health >= baseline.
+
+    Uses the same ncvr_synthetic generator as the suggest_quality harness.
+    Falls back to the synthetic NCVR-like frame if the generator is missing.
+    """
+    import copy
+
+    try:
+        from scripts.dqbench_adapters.ncvr import build_ncvr_synthetic_df_and_gt  # noqa: PLC0415
+        df, _ = build_ncvr_synthetic_df_and_gt(seed=42)
+    except Exception:
+        df = _make_ncvr_like_df()
+
+    from goldenmatch.core.suggest import apply_suggestion, review_config
+    from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+    from goldenmatch.tui.engine import MatchEngine
+
+    config = _make_auto_config(df)
+    suggestions = review_config(df, config, verify=True)
+
+    # Re-check each survivor using the cluster-based proxy (same as adapter uses).
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
+
+    engine = MatchEngine.from_dataframe(df)
+    _cfg = copy.deepcopy(config)
+    try:
+        for mk in _cfg.get_matchkeys():
+            if getattr(mk, "rerank", False):
+                mk.rerank = False
+    except Exception:
+        pass
+
+    n_records = df.height
+    baseline_result = engine._run_pipeline(df, _cfg)
+    baseline_health = suggestion_health_from_clusters(baseline_result.clusters, n_records)
+
+    EPS = 1e-6
+    failing = []
+    for s in suggestions:
+        try:
+            cfg_cand = apply_suggestion(_cfg, s)
+            try:
+                for mk in cfg_cand.get_matchkeys():
+                    if getattr(mk, "rerank", False):
+                        mk.rerank = False
+            except Exception:
+                pass
+            cand_result = engine._run_pipeline(df, cfg_cand)
+            cand_health = suggestion_health_from_clusters(cand_result.clusters, n_records)
+            if cand_health < baseline_health - EPS:
+                failing.append((s.id, cand_health, baseline_health))
+        except Exception:
+            pass  # verification failure is conservative (suggestion is kept); tolerated
+
+    assert not failing, (
+        f"ncvr_synthetic: {len(failing)} health-worsening suggestions leaked through "
+        f"verify=True: {failing}.  The cluster-based proxy is not catching these."
+    )

--- a/packages/python/goldenmatch/tests/test_suggest_verify.py
+++ b/packages/python/goldenmatch/tests/test_suggest_verify.py
@@ -202,20 +202,54 @@ class TestSuggestionHealthFromClusters:
         )
 
     def test_merge_collapse_is_penalised(self):
-        """A single giant cluster absorbing > 50% of records triggers the penalty."""
+        """A single giant cluster absorbing most records triggers the penalty."""
         from goldenmatch.core.suggest.health import suggestion_health_from_clusters
 
-        # One cluster with 60 of 100 records -> collapse flag
+        # One cluster with 60 of 100 records -> high concentration (HHI 0.36)
         clusters = {0: {"size": 60, "members": list(range(60)), "confidence": 0.6, "oversized": False}}
         h_collapsed = suggestion_health_from_clusters(clusters, n_records=100)
 
-        # Healthy: 60 records in 30 clusters of 2
+        # Healthy: 60 records in 30 clusters of 2 (HHI ~ 0.012)
         clusters_healthy = self._make_clusters([2] * 30, [0.8] * 30)
         h_healthy = suggestion_health_from_clusters(clusters_healthy, n_records=100)
 
         assert h_collapsed < h_healthy, (
             f"Merge-collapsed config (h={h_collapsed:.3f}) should score below "
             f"healthy config (h={h_healthy:.3f})"
+        )
+
+    def test_two_equal_mega_clusters_is_penalised(self):
+        """Over-merge SPREAD across two equal 50% clusters must score below healthy.
+
+        This is the case a single-max collapse check (max_size/n > 0.5) misses:
+        each cluster holds exactly 50% so max_size/n == 0.5 (not > 0.5), yet the
+        clustering is degenerate.  HHI = 0.5^2 + 0.5^2 = 0.5 catches it.
+
+        To isolate the concentration penalty from confidence/recall, hold both
+        avg_conf and matched_rate IDENTICAL between the degenerate and healthy
+        cases -- the ONLY difference is how the matched records are distributed.
+        """
+        from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+
+        # Degenerate: 100 matched records spread across two 50-record clusters.
+        # matched_rate = 1.0, avg_conf = 0.8, HHI = 0.5.
+        two_mega = self._make_clusters([50, 50], [0.8, 0.8])
+        h_two_mega = suggestion_health_from_clusters(two_mega, n_records=100)
+
+        # Healthy: the SAME 100 matched records, SAME avg_conf, but in 50 pairs.
+        # matched_rate = 1.0, avg_conf = 0.8, HHI = 50 * (2/100)^2 = 0.02.
+        fifty_pairs = self._make_clusters([2] * 50, [0.8] * 50)
+        h_fifty_pairs = suggestion_health_from_clusters(fifty_pairs, n_records=100)
+
+        assert h_two_mega < h_fifty_pairs, (
+            f"Two-equal-mega-cluster config (h={h_two_mega:.3f}) should score "
+            f"below the healthy many-small-cluster config (h={h_fifty_pairs:.3f}) "
+            "-- the concentration penalty must catch over-merge spread across a "
+            "few big clusters, not just a single giant one."
+        )
+        # And the gap must come from the penalty alone (recall + conf are equal).
+        assert h_fifty_pairs - h_two_mega > 0.05, (
+            "The two-mega-cluster penalty should be a meaningful margin, not noise"
         )
 
     def test_threshold_extraction_from_config(self):

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -26,6 +26,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "analysis-core"
+version = "0.1.0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +567,7 @@ dependencies = [
  "goldenmatch-perceptual-core",
  "goldenmatch-score-core",
  "goldenmatch-sketch-core",
+ "goldenmatch-suggest-core",
  "hmac",
  "numpy",
  "pyo3",
@@ -587,6 +592,16 @@ name = "goldenmatch-sketch-core"
 version = "0.1.0"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "goldenmatch-suggest-core"
+version = "0.1.0"
+dependencies = [
+ "analysis-core",
+ "arrow",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -56,6 +56,9 @@ goldenmatch-perceptual-core = { path = "../perceptual-core" }
 # across surfaces. Thin PyO3 shims in autoconfig.rs expose these via JSON
 # in / JSON out so Python can call the same deterministic logic.
 goldenmatch-autoconfig-core = { path = "../autoconfig-core" }
+# Config-suggestion kernel — ingests a finished run's Arrow artifacts and
+# emits ranked config adjustments. Thin PyO3 shim in suggest.rs delegates here.
+goldenmatch-suggest-core = { path = "../suggest-core" }
 serde_json = "1"
 rayon = "1.12.0"
 # CLK bloom-filter hashing (bloom.rs) -- MUST match Python hashlib.sha256 /

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -16,6 +16,7 @@ mod pairs;
 mod perceptual;
 mod score;
 mod sketch;
+mod suggest;
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -63,5 +64,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(autoconfig::autoconfig_extrapolate_pair_count, m)?)?;
     m.add_function(wrap_pyfunction!(autoconfig::autoconfig_sparse_match_floor, m)?)?;
     m.add_function(wrap_pyfunction!(autoconfig::autoconfig_exact_matchkey_floor, m)?)?;
+    m.add_function(wrap_pyfunction!(suggest::suggest_config, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/native/src/suggest.rs
+++ b/packages/rust/extensions/native/src/suggest.rs
@@ -11,9 +11,9 @@ use pyo3::prelude::*;
 /// Suggest config adjustments from a finished run's Arrow artifacts.
 ///
 /// Parameters mirror `goldenmatch_suggest_core::suggest`:
-/// - `scored_pairs`    – RecordBatch with columns `id_a`, `id_b`, `score`
-/// - `clusters`        – RecordBatch with columns `record_id`, `cluster_id`
-/// - `column_signals`  – RecordBatch with per-column diagnostic signals
+/// - `scored_pairs`    – RecordBatch with columns `id_a:i64, id_b:i64, score:f64`
+/// - `clusters`        – RecordBatch with columns `cluster_id:i64, size:i64, confidence:f64, quality:utf8, oversized:bool`
+/// - `column_signals`  – RecordBatch with columns `field:utf8, col_type:utf8, scorer:utf8, in_blocking:bool, in_negative_evidence:bool, identity_score:f64, corruption_score:f64, collision_rate:f64, cardinality_ratio:f64, null_rate:f64, variant_rate:f64`
 /// - `config_json`     – current domain config serialized as JSON
 /// - `priors_json`     – learned priors (empty object `"{}"` if none)
 ///

--- a/packages/rust/extensions/native/src/suggest.rs
+++ b/packages/rust/extensions/native/src/suggest.rs
@@ -1,0 +1,38 @@
+//! Thin PyO3 shim exposing `goldenmatch_suggest_core::suggest` to Python.
+//!
+//! Receives pyarrow RecordBatches via the Arrow C Data Interface (same pattern
+//! as `score.rs::score_block_pairs_arrow`) and delegates entirely to the
+//! pyo3-free `goldenmatch-suggest-core` crate. No logic lives here.
+use arrow::pyarrow::PyArrowType;
+use arrow::record_batch::RecordBatch;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Suggest config adjustments from a finished run's Arrow artifacts.
+///
+/// Parameters mirror `goldenmatch_suggest_core::suggest`:
+/// - `scored_pairs`    – RecordBatch with columns `id_a`, `id_b`, `score`
+/// - `clusters`        – RecordBatch with columns `record_id`, `cluster_id`
+/// - `column_signals`  – RecordBatch with per-column diagnostic signals
+/// - `config_json`     – current domain config serialized as JSON
+/// - `priors_json`     – learned priors (empty object `"{}"` if none)
+///
+/// Returns a JSON string `[{suggestion}, ...]` (ranked list of
+/// `ConfigSuggestion` objects). Raises `ValueError` on any kernel error.
+#[pyfunction]
+pub fn suggest_config(
+    scored_pairs: PyArrowType<RecordBatch>,
+    clusters: PyArrowType<RecordBatch>,
+    column_signals: PyArrowType<RecordBatch>,
+    config_json: &str,
+    priors_json: &str,
+) -> PyResult<String> {
+    goldenmatch_suggest_core::suggest(
+        &scored_pairs.0,
+        &clusters.0,
+        &column_signals.0,
+        config_json,
+        priors_json,
+    )
+    .map_err(PyValueError::new_err)
+}

--- a/packages/rust/extensions/suggest-core/Cargo.toml
+++ b/packages/rust/extensions/suggest-core/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "goldenmatch-suggest-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Pyo3-free config-suggestion kernel; ingests run artifacts, applies rules, ranks suggestions"
+
+# Standalone workspace so this pyo3-free core can be a path dep of both `native`
+# and `datafusion-udf` without either workspace claiming it (mirrors score-core).
+[workspace]
+
+[lib]
+# pyo3-free: plain lib, no cdylib. Consumed by `native` (pyo3 shim) and later
+# datafusion-udf (FFI). Mirrors score-core / analysis-core.
+
+[dependencies]
+# MUST equal the arrow version `native/Cargo.toml` pins (currently 59, per the
+# #1003/#1005 arrow 55->59 bump). A different arrow version will NOT unify with
+# the `PyArrowType<RecordBatch>` coming from `native` later and the shim will
+# fail to compile. analysis-core carries NO arrow dep (it's a pure &[f64] crate)
+# -- do not try to "match" it for arrow.
+arrow = { version = "59", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Reuse the existing reduction kernels -- do NOT reimplement histogram/quantile.
+# analysis-core is pure (&[f64] in, no arrow), so it imposes no arrow version.
+analysis-core = { path = "../analysis-core" }

--- a/packages/rust/extensions/suggest-core/src/api.rs
+++ b/packages/rust/extensions/suggest-core/src/api.rs
@@ -1,0 +1,309 @@
+//! Top-level `suggest()` entry point -- integrates all kernel modules over Arrow batches.
+
+use arrow::record_batch::RecordBatch;
+
+use crate::contract::{AcceptancePriors, ConfigSummary, Suggestion};
+use crate::diagnostics::{column_signals_from_batch, ClusterDiagnostics, ScoreDiagnostics};
+use crate::rank::rank;
+use crate::rules::{negative_evidence_rule, scorer_swap_rule, threshold_rule};
+
+/// Main entry point for the config-suggestion kernel.
+///
+/// Accepts three Arrow `RecordBatch`es produced by a finished goldenmatch run:
+/// - `scored_pairs`:   schema `id_a:i64, id_b:i64, score:f64` (one row per candidate pair)
+/// - `clusters`:       schema `cluster_id:i64, size:i64, confidence:f64, quality:utf8, oversized:bool`
+/// - `column_signals`: schema `field:utf8, col_type:utf8, scorer:utf8, in_blocking:bool,
+///                      in_negative_evidence:bool, identity_score:f64, corruption_score:f64,
+///                      collision_rate:f64, cardinality_ratio:f64, null_rate:f64, variant_rate:f64`
+///
+/// `config_json` must serialise to `ConfigSummary`; `priors_json` to `AcceptancePriors`.
+///
+/// Returns a JSON array of `Suggestion` objects sorted by descending ranking score.
+pub fn suggest(
+    scored_pairs: &RecordBatch,
+    clusters: &RecordBatch,
+    column_signals: &RecordBatch,
+    config_json: &str,
+    priors_json: &str,
+) -> Result<String, String> {
+    // 1. Parse inputs.
+    let config: ConfigSummary =
+        serde_json::from_str(config_json).map_err(|e| e.to_string())?;
+    let priors: AcceptancePriors =
+        serde_json::from_str(priors_json).map_err(|e| e.to_string())?;
+
+    // 2. One-shot reductions shared across all matchkeys.
+    let cluster_diag = ClusterDiagnostics::from_batch(clusters)?;
+    let signals = column_signals_from_batch(column_signals)?;
+
+    // 3. Collect suggestions.
+    let mut all: Vec<Suggestion> = Vec::new();
+
+    // Per-matchkey threshold + scorer-swap rules.
+    // v1 simplification: ClusterDiagnostics counts weak/oversized GLOBALLY
+    // and those global counts are passed to every matchkey's threshold_rule.
+    // This is correct for the common zero-config case where a single weighted
+    // matchkey dominates; revisit when multi-matchkey configs are common.
+    for mk in &config.matchkeys {
+        if let Some(t) = mk.threshold {
+            let sd = ScoreDiagnostics::from_batch(scored_pairs, t, 24)?;
+            all.extend(threshold_rule(
+                &mk.name,
+                t,
+                &sd,
+                cluster_diag.weak,
+                cluster_diag.oversized,
+            ));
+        }
+        // scorer_swap runs for every matchkey (threshold or not); rank() deduplicates
+        // by id ("swap:{field}") so duplicates from multi-matchkey configs are harmless.
+        all.extend(scorer_swap_rule(&mk.name, &signals));
+    }
+
+    // negative_evidence_rule produces at most one suggestion per field and is
+    // matchkey-agnostic, so run it once globally.
+    all.extend(negative_evidence_rule(&signals));
+
+    // 4. Rank (deduplicates by id, suppresses repeatedly-rejected, sorts by score).
+    let ranked = rank(all, &priors);
+
+    // 5. Serialise.
+    serde_json::to_string(&ranked).map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests (both unit and golden live here to avoid a dev-dependency on arrow
+// in a separate `tests/` integration crate).
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{BooleanArray, Float64Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use std::sync::Arc;
+
+    // -----------------------------------------------------------------------
+    // Batch builders (mirrors the helpers in diagnostics.rs tests)
+    // -----------------------------------------------------------------------
+
+    /// Empty scored_pairs batch (0 rows, correct schema).
+    fn empty_scored_pairs() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id_a", DataType::Int64, false),
+            Field::new("id_b", DataType::Int64, false),
+            Field::new("score", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(Vec::<i64>::new())),
+                Arc::new(Int64Array::from(Vec::<i64>::new())),
+                Arc::new(Float64Array::from(Vec::<f64>::new())),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Empty clusters batch (0 rows, correct schema).
+    fn empty_clusters() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("cluster_id", DataType::Int64, false),
+            Field::new("size", DataType::Int64, false),
+            Field::new("confidence", DataType::Float64, false),
+            Field::new("quality", DataType::Utf8, false),
+            Field::new("oversized", DataType::Boolean, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(Vec::<i64>::new())),
+                Arc::new(Int64Array::from(Vec::<i64>::new())),
+                Arc::new(Float64Array::from(Vec::<f64>::new())),
+                Arc::new(StringArray::from(Vec::<&str>::new())),
+                Arc::new(BooleanArray::from(Vec::<bool>::new())),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Build a column_signals batch from parallel arrays of the 11 fields.
+    fn column_signals_batch(
+        fields: &[&str],
+        col_types: &[&str],
+        scorers: &[&str],
+        in_blocking: &[bool],
+        in_negative_evidence: &[bool],
+        identity_scores: &[f64],
+        corruption_scores: &[f64],
+        collision_rates: &[f64],
+        cardinality_ratios: &[f64],
+        null_rates: &[f64],
+        variant_rates: &[f64],
+    ) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("field", DataType::Utf8, false),
+            Field::new("col_type", DataType::Utf8, false),
+            Field::new("scorer", DataType::Utf8, false),
+            Field::new("in_blocking", DataType::Boolean, false),
+            Field::new("in_negative_evidence", DataType::Boolean, false),
+            Field::new("identity_score", DataType::Float64, false),
+            Field::new("corruption_score", DataType::Float64, false),
+            Field::new("collision_rate", DataType::Float64, false),
+            Field::new("cardinality_ratio", DataType::Float64, false),
+            Field::new("null_rate", DataType::Float64, false),
+            Field::new("variant_rate", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(fields.to_vec())),
+                Arc::new(StringArray::from(col_types.to_vec())),
+                Arc::new(StringArray::from(scorers.to_vec())),
+                Arc::new(BooleanArray::from(in_blocking.to_vec())),
+                Arc::new(BooleanArray::from(in_negative_evidence.to_vec())),
+                Arc::new(Float64Array::from(identity_scores.to_vec())),
+                Arc::new(Float64Array::from(corruption_scores.to_vec())),
+                Arc::new(Float64Array::from(collision_rates.to_vec())),
+                Arc::new(Float64Array::from(cardinality_ratios.to_vec())),
+                Arc::new(Float64Array::from(null_rates.to_vec())),
+                Arc::new(Float64Array::from(variant_rates.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // Unit test: scorer-swap should be the top suggestion when scored_pairs
+    // is empty (no threshold suggestions) and we have a corrupted address
+    // column using token_sort.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn scorer_swap_is_top_when_no_threshold_signal() {
+        let pairs = empty_scored_pairs();
+        let clusters = empty_clusters();
+        let signals = column_signals_batch(
+            &["res_street_address"],
+            &["address"],
+            &["token_sort"],
+            &[false],
+            &[false],
+            &[0.0],  // identity_score
+            &[0.6],  // corruption_score >= 0.30 -> triggers swap
+            &[0.0],  // collision_rate
+            &[0.5],  // cardinality_ratio
+            &[0.0],  // null_rate
+            &[0.0],  // variant_rate
+        );
+        let config_json = r#"{
+            "matchkeys": [{
+                "name": "person",
+                "kind": "weighted",
+                "threshold": 0.8,
+                "fields": [{"field": "res_street_address", "scorer": "token_sort", "weight": 1.0}]
+            }],
+            "negative_evidence": []
+        }"#;
+        let priors_json = r#"{"counts": {}}"#;
+
+        let result_json = suggest(&pairs, &clusters, &signals, config_json, priors_json)
+            .expect("suggest should not error");
+
+        let suggestions: Vec<serde_json::Value> =
+            serde_json::from_str(&result_json).expect("result should be valid JSON array");
+
+        assert!(!suggestions.is_empty(), "should produce at least one suggestion");
+        let top = &suggestions[0];
+        assert_eq!(
+            top["kind"].as_str().unwrap(),
+            "swap_scorer",
+            "top suggestion should be swap_scorer, got: {top}"
+        );
+        assert_eq!(
+            top["target"].as_str().unwrap(),
+            "res_street_address",
+            "top suggestion target should be res_street_address"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Golden-vector test: loads tests/golden/ncvr_address.json and asserts
+    // the kernel output matches the expected top suggestion.  This is the
+    // determinism pin.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn golden_ncvr_address() {
+        let fixture_path =
+            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/golden/ncvr_address.json");
+        let raw = std::fs::read_to_string(fixture_path)
+            .unwrap_or_else(|e| panic!("failed to read golden fixture: {e}"));
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&raw).expect("golden fixture must be valid JSON");
+
+        // Build column_signals RecordBatch from the JSON array in the fixture.
+        let cs_rows = doc["column_signals"].as_array().expect("column_signals array");
+        let (
+            mut flds, mut ctypes, mut scorers, mut in_bl, mut in_ne,
+            mut id_sc, mut cor_sc, mut coll, mut card, mut null_r, mut var_r,
+        ) = (
+            vec![], vec![], vec![], vec![], vec![],
+            vec![], vec![], vec![], vec![], vec![], vec![],
+        );
+        for row in cs_rows {
+            flds.push(row["field"].as_str().unwrap().to_owned());
+            ctypes.push(row["col_type"].as_str().unwrap().to_owned());
+            scorers.push(row["scorer"].as_str().unwrap().to_owned());
+            in_bl.push(row["in_blocking"].as_bool().unwrap());
+            in_ne.push(row["in_negative_evidence"].as_bool().unwrap());
+            id_sc.push(row["identity_score"].as_f64().unwrap());
+            cor_sc.push(row["corruption_score"].as_f64().unwrap());
+            coll.push(row["collision_rate"].as_f64().unwrap());
+            card.push(row["cardinality_ratio"].as_f64().unwrap());
+            null_r.push(row["null_rate"].as_f64().unwrap());
+            var_r.push(row["variant_rate"].as_f64().unwrap());
+        }
+
+        // Convert Vec<String> -> Vec<&str> for the batch builder.
+        let fld_refs: Vec<&str> = flds.iter().map(|s| s.as_str()).collect();
+        let ctype_refs: Vec<&str> = ctypes.iter().map(|s| s.as_str()).collect();
+        let scorer_refs: Vec<&str> = scorers.iter().map(|s| s.as_str()).collect();
+
+        let signals_batch = column_signals_batch(
+            &fld_refs, &ctype_refs, &scorer_refs,
+            &in_bl, &in_ne,
+            &id_sc, &cor_sc, &coll, &card, &null_r, &var_r,
+        );
+
+        let pairs = empty_scored_pairs();
+        let clusters = empty_clusters();
+
+        let config_json = serde_json::to_string(&doc["config"]).unwrap();
+        let priors_json = serde_json::to_string(&doc["priors"]).unwrap();
+
+        let result_json = suggest(&pairs, &clusters, &signals_batch, &config_json, &priors_json)
+            .expect("golden suggest should not error");
+
+        let suggestions: Vec<serde_json::Value> =
+            serde_json::from_str(&result_json).expect("result should be valid JSON array");
+
+        let expected_top = &doc["expected_top"];
+        assert!(
+            !suggestions.is_empty(),
+            "golden test should produce at least one suggestion"
+        );
+        let top = &suggestions[0];
+        assert_eq!(
+            top["kind"].as_str().unwrap(),
+            expected_top["kind"].as_str().unwrap(),
+            "golden top suggestion kind mismatch"
+        );
+        assert_eq!(
+            top["target"].as_str().unwrap(),
+            expected_top["target"].as_str().unwrap(),
+            "golden top suggestion target mismatch"
+        );
+    }
+}

--- a/packages/rust/extensions/suggest-core/src/api.rs
+++ b/packages/rust/extensions/suggest-core/src/api.rs
@@ -7,6 +7,9 @@ use crate::diagnostics::{column_signals_from_batch, ClusterDiagnostics, ScoreDia
 use crate::rank::rank;
 use crate::rules::{negative_evidence_rule, scorer_swap_rule, threshold_rule};
 
+/// Bins for the score histogram feeding dip() detection.
+const HISTOGRAM_BINS: i64 = 24;
+
 /// Main entry point for the config-suggestion kernel.
 ///
 /// Accepts three Arrow `RecordBatch`es produced by a finished goldenmatch run:
@@ -46,7 +49,7 @@ pub fn suggest(
     // matchkey dominates; revisit when multi-matchkey configs are common.
     for mk in &config.matchkeys {
         if let Some(t) = mk.threshold {
-            let sd = ScoreDiagnostics::from_batch(scored_pairs, t, 24)?;
+            let sd = ScoreDiagnostics::from_batch(scored_pairs, t, HISTOGRAM_BINS)?;
             all.extend(threshold_rule(
                 &mk.name,
                 t,
@@ -78,6 +81,7 @@ pub fn suggest(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::diagnostics::ColumnSignal;
     use arrow::array::{BooleanArray, Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
@@ -127,20 +131,10 @@ mod tests {
         .unwrap()
     }
 
-    /// Build a column_signals batch from parallel arrays of the 11 fields.
-    fn column_signals_batch(
-        fields: &[&str],
-        col_types: &[&str],
-        scorers: &[&str],
-        in_blocking: &[bool],
-        in_negative_evidence: &[bool],
-        identity_scores: &[f64],
-        corruption_scores: &[f64],
-        collision_rates: &[f64],
-        cardinality_ratios: &[f64],
-        null_rates: &[f64],
-        variant_rates: &[f64],
-    ) -> RecordBatch {
+    /// Build a column_signals batch by reading the fields off each `ColumnSignal`.
+    /// Taking `&[ColumnSignal]` (vs 11 positional slices) makes each call site read
+    /// what it means and removes the silent-transposition footgun.
+    fn column_signals_batch(rows: &[ColumnSignal]) -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
             Field::new("field", DataType::Utf8, false),
             Field::new("col_type", DataType::Utf8, false),
@@ -157,17 +151,39 @@ mod tests {
         RecordBatch::try_new(
             schema,
             vec![
-                Arc::new(StringArray::from(fields.to_vec())),
-                Arc::new(StringArray::from(col_types.to_vec())),
-                Arc::new(StringArray::from(scorers.to_vec())),
-                Arc::new(BooleanArray::from(in_blocking.to_vec())),
-                Arc::new(BooleanArray::from(in_negative_evidence.to_vec())),
-                Arc::new(Float64Array::from(identity_scores.to_vec())),
-                Arc::new(Float64Array::from(corruption_scores.to_vec())),
-                Arc::new(Float64Array::from(collision_rates.to_vec())),
-                Arc::new(Float64Array::from(cardinality_ratios.to_vec())),
-                Arc::new(Float64Array::from(null_rates.to_vec())),
-                Arc::new(Float64Array::from(variant_rates.to_vec())),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|c| c.field.as_str()).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|c| c.col_type.as_str()).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|c| c.scorer.as_str()).collect::<Vec<_>>(),
+                )),
+                Arc::new(BooleanArray::from(
+                    rows.iter().map(|c| c.in_blocking).collect::<Vec<_>>(),
+                )),
+                Arc::new(BooleanArray::from(
+                    rows.iter().map(|c| c.in_negative_evidence).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float64Array::from(
+                    rows.iter().map(|c| c.identity_score).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float64Array::from(
+                    rows.iter().map(|c| c.corruption_score).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float64Array::from(
+                    rows.iter().map(|c| c.collision_rate).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float64Array::from(
+                    rows.iter().map(|c| c.cardinality_ratio).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float64Array::from(
+                    rows.iter().map(|c| c.null_rate).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float64Array::from(
+                    rows.iter().map(|c| c.variant_rate).collect::<Vec<_>>(),
+                )),
             ],
         )
         .unwrap()
@@ -183,19 +199,19 @@ mod tests {
     fn scorer_swap_is_top_when_no_threshold_signal() {
         let pairs = empty_scored_pairs();
         let clusters = empty_clusters();
-        let signals = column_signals_batch(
-            &["res_street_address"],
-            &["address"],
-            &["token_sort"],
-            &[false],
-            &[false],
-            &[0.0],  // identity_score
-            &[0.6],  // corruption_score >= 0.30 -> triggers swap
-            &[0.0],  // collision_rate
-            &[0.5],  // cardinality_ratio
-            &[0.0],  // null_rate
-            &[0.0],  // variant_rate
-        );
+        let signals = column_signals_batch(&[ColumnSignal {
+            field: "res_street_address".into(),
+            col_type: "address".into(),
+            scorer: "token_sort".into(),
+            in_blocking: false,
+            in_negative_evidence: false,
+            identity_score: 0.0,
+            corruption_score: 0.6, // >= 0.30 -> triggers swap
+            collision_rate: 0.0,
+            cardinality_ratio: 0.5,
+            null_rate: 0.0,
+            variant_rate: 0.0,
+        }]);
         let config_json = r#"{
             "matchkeys": [{
                 "name": "person",
@@ -245,38 +261,27 @@ mod tests {
 
         // Build column_signals RecordBatch from the JSON array in the fixture.
         let cs_rows = doc["column_signals"].as_array().expect("column_signals array");
-        let (
-            mut flds, mut ctypes, mut scorers, mut in_bl, mut in_ne,
-            mut id_sc, mut cor_sc, mut coll, mut card, mut null_r, mut var_r,
-        ) = (
-            vec![], vec![], vec![], vec![], vec![],
-            vec![], vec![], vec![], vec![], vec![], vec![],
-        );
-        for row in cs_rows {
-            flds.push(row["field"].as_str().unwrap().to_owned());
-            ctypes.push(row["col_type"].as_str().unwrap().to_owned());
-            scorers.push(row["scorer"].as_str().unwrap().to_owned());
-            in_bl.push(row["in_blocking"].as_bool().unwrap());
-            in_ne.push(row["in_negative_evidence"].as_bool().unwrap());
-            id_sc.push(row["identity_score"].as_f64().unwrap());
-            cor_sc.push(row["corruption_score"].as_f64().unwrap());
-            coll.push(row["collision_rate"].as_f64().unwrap());
-            card.push(row["cardinality_ratio"].as_f64().unwrap());
-            null_r.push(row["null_rate"].as_f64().unwrap());
-            var_r.push(row["variant_rate"].as_f64().unwrap());
-        }
+        let signals: Vec<ColumnSignal> = cs_rows
+            .iter()
+            .map(|row| ColumnSignal {
+                field: row["field"].as_str().unwrap().to_owned(),
+                col_type: row["col_type"].as_str().unwrap().to_owned(),
+                scorer: row["scorer"].as_str().unwrap().to_owned(),
+                in_blocking: row["in_blocking"].as_bool().unwrap(),
+                in_negative_evidence: row["in_negative_evidence"].as_bool().unwrap(),
+                identity_score: row["identity_score"].as_f64().unwrap(),
+                corruption_score: row["corruption_score"].as_f64().unwrap(),
+                collision_rate: row["collision_rate"].as_f64().unwrap(),
+                cardinality_ratio: row["cardinality_ratio"].as_f64().unwrap(),
+                null_rate: row["null_rate"].as_f64().unwrap(),
+                variant_rate: row["variant_rate"].as_f64().unwrap(),
+            })
+            .collect();
+        let signals_batch = column_signals_batch(&signals);
 
-        // Convert Vec<String> -> Vec<&str> for the batch builder.
-        let fld_refs: Vec<&str> = flds.iter().map(|s| s.as_str()).collect();
-        let ctype_refs: Vec<&str> = ctypes.iter().map(|s| s.as_str()).collect();
-        let scorer_refs: Vec<&str> = scorers.iter().map(|s| s.as_str()).collect();
-
-        let signals_batch = column_signals_batch(
-            &fld_refs, &ctype_refs, &scorer_refs,
-            &in_bl, &in_ne,
-            &id_sc, &cor_sc, &coll, &card, &null_r, &var_r,
-        );
-
+        // This golden scenario is scorer-swap only: it uses empty scored_pairs and
+        // clusters by design (no threshold/cluster signal), so the fixture carries
+        // no pairs/clusters arrays -- the batches are built empty unconditionally.
         let pairs = empty_scored_pairs();
         let clusters = empty_clusters();
 

--- a/packages/rust/extensions/suggest-core/src/contract.rs
+++ b/packages/rust/extensions/suggest-core/src/contract.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SuggestionKind {
+    RaiseThreshold,
+    LowerThreshold,
+    SwapScorer,
+    AddNegativeEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PredictedEffect { PrecisionUp, RecallUp }
+
+/// Declarative config edit. The kernel defines WHAT to change once; each language
+/// applies it to its own native config object.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum ConfigPatch {
+    SetThreshold { matchkey: String, value: f64 },
+    SetScorer { matchkey: String, field: String, scorer: String },
+    AddNegativeEvidence { field: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Suggestion {
+    pub id: String,
+    pub kind: SuggestionKind,
+    pub target: String,
+    pub current_value: String,
+    pub proposed_value: String,
+    pub rationale: String,
+    pub predicted_effect: PredictedEffect,
+    pub confidence: f64,
+    pub patch: ConfigPatch,
+    pub evidence: serde_json::Value,
+}
+
+/// Reduced, frame-free view of the config (what the rules need to read).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigSummary {
+    pub matchkeys: Vec<MatchkeySummary>,
+    pub negative_evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatchkeySummary {
+    pub name: String,
+    pub kind: String,            // "weighted" | "fuzzy" | "exact" | "probabilistic"
+    pub threshold: Option<f64>,
+    pub fields: Vec<FieldSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FieldSummary {
+    pub field: String,
+    pub scorer: Option<String>,
+    pub weight: Option<f64>,
+}
+
+/// Accept/reject history folded into ranking. Plan 2 fills this from MemoryStore;
+/// Plan 1 always passes an empty map. key = "{snake_case kind}:{target}" -> (accepts, rejects).
+/// The key is produced by `rank::prior_key` (Task 8) -- Plan 2's persistence MUST
+/// use the same helper so the loop binds.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AcceptancePriors {
+    pub counts: std::collections::HashMap<String, (u32, u32)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suggestion_json_roundtrip() {
+        let s = Suggestion {
+            id: "thr:name:raise".into(),
+            kind: SuggestionKind::RaiseThreshold,
+            target: "name".into(),
+            current_value: "0.80".into(),
+            proposed_value: "0.88".into(),
+            rationale: "placeholder".into(),
+            predicted_effect: PredictedEffect::PrecisionUp,
+            confidence: 0.7,
+            patch: ConfigPatch::SetThreshold { matchkey: "name".into(), value: 0.88 },
+            evidence: serde_json::json!({"dip": 0.86}),
+        };
+        let txt = serde_json::to_string(&s).unwrap();
+        let back: Suggestion = serde_json::from_str(&txt).unwrap();
+        assert_eq!(back.kind, SuggestionKind::RaiseThreshold);
+        assert_eq!(back.patch, ConfigPatch::SetThreshold { matchkey: "name".into(), value: 0.88 });
+    }
+}

--- a/packages/rust/extensions/suggest-core/src/diagnostics.rs
+++ b/packages/rust/extensions/suggest-core/src/diagnostics.rs
@@ -12,6 +12,8 @@ pub struct ScoreDiagnostics {
     pub histogram: Vec<(f64, i64)>,
     pub mass_above: f64,      // fraction of pairs with score >= threshold
     pub mass_just_below: f64, // fraction in [threshold-0.10, threshold)
+    // Total scored_pairs rows (incl. null scores); the mass fractions divide by
+    // the count of NON-NULL scores so blocked/null pairs don't dilute them.
     pub n_pairs: usize,
 }
 
@@ -25,17 +27,20 @@ impl ScoreDiagnostics {
             .downcast_ref::<Float64Array>()
             .ok_or("score not f64")?;
         let vals: Vec<f64> = scores.iter().flatten().collect();
+        // Total rows (incl. null scores) -- surfaced in rationale text. The mass
+        // fractions divide by non-null score count so null pairs don't dilute them.
+        let n_pairs = batch.num_rows();
         let n = vals.len();
         if n == 0 {
             return Ok(Self {
                 histogram: vec![],
                 mass_above: 0.0,
                 mass_just_below: 0.0,
-                n_pairs: 0,
+                n_pairs,
             });
         }
         let above = vals.iter().filter(|&&s| s >= threshold).count();
-        let band_lo = threshold - 0.10;
+        let band_lo = (threshold - 0.10).max(0.0);
         let just_below = vals
             .iter()
             .filter(|&&s| s >= band_lo && s < threshold)
@@ -46,7 +51,7 @@ impl ScoreDiagnostics {
             histogram,
             mass_above: above as f64 / n as f64,
             mass_just_below: just_below as f64 / n as f64,
-            n_pairs: n,
+            n_pairs,
         })
     }
 
@@ -57,7 +62,10 @@ impl ScoreDiagnostics {
             return None;
         }
         let counts: Vec<i64> = self.histogram.iter().map(|(_, c)| *c).collect();
-        let peak = *counts.iter().max().unwrap();
+        let peak = counts.iter().max().copied().unwrap_or(0);
+        if peak == 0 {
+            return None;
+        }
         // find the global min that has a higher-count bin on BOTH sides
         let mut best: Option<(usize, i64)> = None;
         for i in 1..counts.len() - 1 {
@@ -159,6 +167,35 @@ mod tests {
         assert!((d.mass_above - 3.0 / 6.0).abs() < 1e-9);
         assert!((d.mass_just_below - 1.0 / 6.0).abs() < 1e-9); // [0.70,0.80)
         assert_eq!(d.histogram.len(), 24);
+    }
+
+    #[test]
+    fn n_pairs_counts_total_rows_fractions_over_non_null() {
+        // 4 rows: scores [0.9, null, 0.85, 0.5]. n_pairs = 4 (total rows),
+        // but mass fractions divide by the 3 non-null scores.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id_a", DataType::Int64, false),
+            Field::new("id_b", DataType::Int64, false),
+            Field::new("score", DataType::Float64, true),
+        ]));
+        let b = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![0i64, 1, 2, 3])),
+                Arc::new(Int64Array::from(vec![1i64, 2, 3, 4])),
+                Arc::new(Float64Array::from(vec![
+                    Some(0.9),
+                    None,
+                    Some(0.85),
+                    Some(0.5),
+                ])),
+            ],
+        )
+        .unwrap();
+        let d = ScoreDiagnostics::from_batch(&b, 0.80, 8).unwrap();
+        assert_eq!(d.n_pairs, 4); // total rows, incl. the null
+        // 2 of 3 non-null scores are >= 0.80
+        assert!((d.mass_above - 2.0 / 3.0).abs() < 1e-9);
     }
 
     #[test]

--- a/packages/rust/extensions/suggest-core/src/diagnostics.rs
+++ b/packages/rust/extensions/suggest-core/src/diagnostics.rs
@@ -8,6 +8,128 @@
 use arrow::array::{Array, BooleanArray, Float64Array, StringArray};
 use arrow::record_batch::RecordBatch;
 
+// ---------------------------------------------------------------------------
+// ColumnSignal — per-column signals extracted from the column_signals batch.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnSignal {
+    pub field: String,
+    pub col_type: String,
+    pub scorer: String,
+    pub in_blocking: bool,
+    pub in_negative_evidence: bool,
+    pub identity_score: f64,
+    pub corruption_score: f64,
+    pub collision_rate: f64,
+    pub cardinality_ratio: f64,
+    pub null_rate: f64,
+    pub variant_rate: f64,
+}
+
+/// Extract one `ColumnSignal` per row from a `column_signals` RecordBatch.
+///
+/// Schema (one row per column):
+/// `field:utf8, col_type:utf8, scorer:utf8, in_blocking:bool,
+///  in_negative_evidence:bool, identity_score:f64, corruption_score:f64,
+///  collision_rate:f64, cardinality_ratio:f64, null_rate:f64, variant_rate:f64`
+pub fn column_signals_from_batch(batch: &RecordBatch) -> Result<Vec<ColumnSignal>, String> {
+    let field_arr = batch
+        .column_by_name("field")
+        .ok_or("missing field column")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or("field not utf8")?;
+
+    let col_type_arr = batch
+        .column_by_name("col_type")
+        .ok_or("missing col_type column")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or("col_type not utf8")?;
+
+    let scorer_arr = batch
+        .column_by_name("scorer")
+        .ok_or("missing scorer column")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or("scorer not utf8")?;
+
+    let in_blocking_arr = batch
+        .column_by_name("in_blocking")
+        .ok_or("missing in_blocking column")?
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .ok_or("in_blocking not bool")?;
+
+    let in_neg_arr = batch
+        .column_by_name("in_negative_evidence")
+        .ok_or("missing in_negative_evidence column")?
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .ok_or("in_negative_evidence not bool")?;
+
+    let identity_score_arr = batch
+        .column_by_name("identity_score")
+        .ok_or("missing identity_score column")?
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .ok_or("identity_score not f64")?;
+
+    let corruption_score_arr = batch
+        .column_by_name("corruption_score")
+        .ok_or("missing corruption_score column")?
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .ok_or("corruption_score not f64")?;
+
+    let collision_rate_arr = batch
+        .column_by_name("collision_rate")
+        .ok_or("missing collision_rate column")?
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .ok_or("collision_rate not f64")?;
+
+    let cardinality_ratio_arr = batch
+        .column_by_name("cardinality_ratio")
+        .ok_or("missing cardinality_ratio column")?
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .ok_or("cardinality_ratio not f64")?;
+
+    let null_rate_arr = batch
+        .column_by_name("null_rate")
+        .ok_or("missing null_rate column")?
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .ok_or("null_rate not f64")?;
+
+    let variant_rate_arr = batch
+        .column_by_name("variant_rate")
+        .ok_or("missing variant_rate column")?
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .ok_or("variant_rate not f64")?;
+
+    let mut signals = Vec::with_capacity(batch.num_rows());
+    for i in 0..batch.num_rows() {
+        signals.push(ColumnSignal {
+            field: field_arr.value(i).to_owned(),
+            col_type: col_type_arr.value(i).to_owned(),
+            scorer: scorer_arr.value(i).to_owned(),
+            in_blocking: in_blocking_arr.value(i),
+            in_negative_evidence: in_neg_arr.value(i),
+            identity_score: identity_score_arr.value(i),
+            corruption_score: corruption_score_arr.value(i),
+            collision_rate: collision_rate_arr.value(i),
+            cardinality_ratio: cardinality_ratio_arr.value(i),
+            null_rate: null_rate_arr.value(i),
+            variant_rate: variant_rate_arr.value(i),
+        });
+    }
+    Ok(signals)
+}
+
 pub struct ScoreDiagnostics {
     pub histogram: Vec<(f64, i64)>,
     pub mass_above: f64,      // fraction of pairs with score >= threshold
@@ -287,5 +409,115 @@ mod tests {
         assert_eq!(d.split, 0);
         assert_eq!(d.oversized, 0);
         assert_eq!(d.n_clusters, 3);
+    }
+
+    fn column_signals_batch(
+        fields: &[&str],
+        col_types: &[&str],
+        scorers: &[&str],
+        in_blocking: &[bool],
+        in_negative_evidence: &[bool],
+        identity_scores: &[f64],
+        corruption_scores: &[f64],
+        collision_rates: &[f64],
+        cardinality_ratios: &[f64],
+        null_rates: &[f64],
+        variant_rates: &[f64],
+    ) -> RecordBatch {
+        use arrow::datatypes::DataType;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("field", DataType::Utf8, false),
+            Field::new("col_type", DataType::Utf8, false),
+            Field::new("scorer", DataType::Utf8, false),
+            Field::new("in_blocking", DataType::Boolean, false),
+            Field::new("in_negative_evidence", DataType::Boolean, false),
+            Field::new("identity_score", DataType::Float64, false),
+            Field::new("corruption_score", DataType::Float64, false),
+            Field::new("collision_rate", DataType::Float64, false),
+            Field::new("cardinality_ratio", DataType::Float64, false),
+            Field::new("null_rate", DataType::Float64, false),
+            Field::new("variant_rate", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(fields.to_vec())),
+                Arc::new(StringArray::from(col_types.to_vec())),
+                Arc::new(StringArray::from(scorers.to_vec())),
+                Arc::new(BooleanArray::from(in_blocking.to_vec())),
+                Arc::new(BooleanArray::from(in_negative_evidence.to_vec())),
+                Arc::new(Float64Array::from(identity_scores.to_vec())),
+                Arc::new(Float64Array::from(corruption_scores.to_vec())),
+                Arc::new(Float64Array::from(collision_rates.to_vec())),
+                Arc::new(Float64Array::from(cardinality_ratios.to_vec())),
+                Arc::new(Float64Array::from(null_rates.to_vec())),
+                Arc::new(Float64Array::from(variant_rates.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn column_signals_round_trip() {
+        // Row 0: corrupted address column scored with token_sort, used in blocking
+        // Row 1: clean id column scored with exact, not in blocking
+        let batch = column_signals_batch(
+            &["street_address", "record_id"],
+            &["text", "id"],
+            &["token_sort", "exact"],
+            &[true, false],
+            &[false, true],
+            &[0.72, 0.99],
+            &[0.45, 0.02],
+            &[0.08, 0.001],
+            &[0.88, 1.0],
+            &[0.12, 0.0],
+            &[0.30, 0.01],
+        );
+        let signals = column_signals_from_batch(&batch).unwrap();
+        assert_eq!(signals.len(), 2);
+
+        let addr = &signals[0];
+        assert_eq!(addr.field, "street_address");
+        assert_eq!(addr.col_type, "text");
+        assert_eq!(addr.scorer, "token_sort");
+        assert!(addr.in_blocking);
+        assert!(!addr.in_negative_evidence);
+        assert!((addr.identity_score - 0.72).abs() < 1e-9);
+        assert!((addr.corruption_score - 0.45).abs() < 1e-9);
+        assert!((addr.collision_rate - 0.08).abs() < 1e-9);
+        assert!((addr.cardinality_ratio - 0.88).abs() < 1e-9);
+        assert!((addr.null_rate - 0.12).abs() < 1e-9);
+        assert!((addr.variant_rate - 0.30).abs() < 1e-9);
+
+        let id_col = &signals[1];
+        assert_eq!(id_col.field, "record_id");
+        assert_eq!(id_col.col_type, "id");
+        assert_eq!(id_col.scorer, "exact");
+        assert!(!id_col.in_blocking);
+        assert!(id_col.in_negative_evidence);
+        assert!((id_col.identity_score - 0.99).abs() < 1e-9);
+        assert!((id_col.corruption_score - 0.02).abs() < 1e-9);
+    }
+
+    #[test]
+    fn column_signals_missing_column_returns_error() {
+        // Build a batch that is missing the `scorer` column — should error cleanly.
+        use arrow::datatypes::DataType;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("field", DataType::Utf8, false),
+            Field::new("col_type", DataType::Utf8, false),
+            // scorer intentionally omitted
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["name"])),
+                Arc::new(StringArray::from(vec!["text"])),
+            ],
+        )
+        .unwrap();
+        let err = column_signals_from_batch(&batch).unwrap_err();
+        assert!(err.contains("scorer"), "expected scorer in error: {err}");
     }
 }

--- a/packages/rust/extensions/suggest-core/src/diagnostics.rs
+++ b/packages/rust/extensions/suggest-core/src/diagnostics.rs
@@ -1,0 +1,254 @@
+//! Diagnostic reductions from Arrow run artifacts.
+//!
+//! `ScoreDiagnostics::from_batch` reduces the `scored_pairs` RecordBatch to
+//! frame-free stats the suggestion rules consume.  `ClusterDiagnostics::from_batch`
+//! does the same for the `clusters` RecordBatch.  Both reuse `analysis_core`
+//! kernels -- do NOT add a second histogram / quantile implementation here.
+
+use arrow::array::{Array, BooleanArray, Float64Array, StringArray};
+use arrow::record_batch::RecordBatch;
+
+pub struct ScoreDiagnostics {
+    pub histogram: Vec<(f64, i64)>,
+    pub mass_above: f64,      // fraction of pairs with score >= threshold
+    pub mass_just_below: f64, // fraction in [threshold-0.10, threshold)
+    pub n_pairs: usize,
+}
+
+impl ScoreDiagnostics {
+    pub fn from_batch(batch: &RecordBatch, threshold: f64, bins: i64) -> Result<Self, String> {
+        let col = batch
+            .column_by_name("score")
+            .ok_or("missing score column")?;
+        let scores = col
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .ok_or("score not f64")?;
+        let vals: Vec<f64> = scores.iter().flatten().collect();
+        let n = vals.len();
+        if n == 0 {
+            return Ok(Self {
+                histogram: vec![],
+                mass_above: 0.0,
+                mass_just_below: 0.0,
+                n_pairs: 0,
+            });
+        }
+        let above = vals.iter().filter(|&&s| s >= threshold).count();
+        let band_lo = threshold - 0.10;
+        let just_below = vals
+            .iter()
+            .filter(|&&s| s >= band_lo && s < threshold)
+            .count();
+        // Reuse analysis-core histogram (no second implementation).
+        let histogram = analysis_core::histogram(&vals, bins);
+        Ok(Self {
+            histogram,
+            mass_above: above as f64 / n as f64,
+            mass_just_below: just_below as f64 / n as f64,
+            n_pairs: n,
+        })
+    }
+
+    /// Lowest-count bin strictly between the two highest-mass regions -- the
+    /// bimodality "dip". Returns the bin's left edge, or None if no clear valley.
+    pub fn dip(&self) -> Option<f64> {
+        if self.histogram.len() < 3 {
+            return None;
+        }
+        let counts: Vec<i64> = self.histogram.iter().map(|(_, c)| *c).collect();
+        let peak = *counts.iter().max().unwrap();
+        // find the global min that has a higher-count bin on BOTH sides
+        let mut best: Option<(usize, i64)> = None;
+        for i in 1..counts.len() - 1 {
+            let left_max = counts[..i].iter().max().copied().unwrap_or(0);
+            let right_max = counts[i + 1..].iter().max().copied().unwrap_or(0);
+            if left_max > counts[i] && right_max > counts[i] {
+                if best.map_or(true, |(_, c)| counts[i] < c) {
+                    best = Some((i, counts[i]));
+                }
+            }
+        }
+        // require the valley to be a real dip (< 25% of peak) to avoid noise
+        best.filter(|&(_, c)| (c as f64) < 0.25 * peak as f64)
+            .map(|(i, _)| self.histogram[i].0)
+    }
+}
+
+pub struct ClusterDiagnostics {
+    pub weak: usize,
+    pub oversized: usize,
+    pub split: usize,
+    pub n_clusters: usize,
+}
+
+impl ClusterDiagnostics {
+    pub fn from_batch(batch: &RecordBatch) -> Result<Self, String> {
+        let n_clusters = batch.num_rows();
+
+        let quality_col = batch
+            .column_by_name("quality")
+            .ok_or("missing quality column")?;
+        let quality = quality_col
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or("quality not utf8")?;
+
+        let oversized_col = batch
+            .column_by_name("oversized")
+            .ok_or("missing oversized column")?;
+        let oversized_arr = oversized_col
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .ok_or("oversized not bool")?;
+
+        let mut weak = 0usize;
+        let mut split = 0usize;
+        for v in quality.iter().flatten() {
+            match v {
+                "weak" => weak += 1,
+                "split" => split += 1,
+                _ => {}
+            }
+        }
+
+        let oversized = oversized_arr.iter().flatten().filter(|&b| b).count();
+
+        Ok(Self {
+            weak,
+            oversized,
+            split,
+            n_clusters,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{BooleanArray, Float64Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use std::sync::Arc;
+
+    fn pairs_batch(scores: &[f64]) -> RecordBatch {
+        let n = scores.len();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id_a", DataType::Int64, false),
+            Field::new("id_b", DataType::Int64, false),
+            Field::new("score", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from((0..n as i64).collect::<Vec<_>>())),
+                Arc::new(Int64Array::from(
+                    (0..n as i64).map(|x| x + 1).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float64Array::from(scores.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn mass_bands_split_by_threshold() {
+        // 6 scores: 3 above 0.8, 1 in [0.7,0.8), 2 below 0.7
+        let b = pairs_batch(&[0.95, 0.9, 0.85, 0.75, 0.6, 0.5]);
+        let d = ScoreDiagnostics::from_batch(&b, 0.80, 24).unwrap();
+        assert!((d.mass_above - 3.0 / 6.0).abs() < 1e-9);
+        assert!((d.mass_just_below - 1.0 / 6.0).abs() < 1e-9); // [0.70,0.80)
+        assert_eq!(d.histogram.len(), 24);
+    }
+
+    #[test]
+    fn empty_batch_returns_zero_mass() {
+        let b = pairs_batch(&[]);
+        let d = ScoreDiagnostics::from_batch(&b, 0.80, 24).unwrap();
+        assert_eq!(d.n_pairs, 0);
+        assert_eq!(d.mass_above, 0.0);
+        assert_eq!(d.mass_just_below, 0.0);
+        assert!(d.histogram.is_empty());
+    }
+
+    #[test]
+    fn dip_detection_bimodal() {
+        // Build a batch with a clear bimodal distribution: many low and many high,
+        // few in the middle. With 10 bins over [0,1] each bin is width 0.1.
+        // Bins 0..4 each get 5 counts, bin 4 gets ~0, bins 5..9 each get 5.
+        // The valley at ~0.5 should be detected.
+        let mut scores: Vec<f64> = Vec::new();
+        for _ in 0..5 {
+            scores.extend_from_slice(&[0.05, 0.15, 0.25, 0.35]);
+        }
+        for _ in 0..5 {
+            scores.extend_from_slice(&[0.65, 0.75, 0.85, 0.95]);
+        }
+        // one in the middle to avoid triggering the "all equal" collapse
+        scores.push(0.50);
+
+        let b = pairs_batch(&scores);
+        let d = ScoreDiagnostics::from_batch(&b, 0.60, 10).unwrap();
+        assert!(d.dip().is_some(), "expected a dip in bimodal distribution");
+    }
+
+    #[test]
+    fn dip_returns_none_for_uniform() {
+        // Uniform distribution has no clear valley
+        let scores: Vec<f64> = (0..50).map(|i| i as f64 / 50.0).collect();
+        let b = pairs_batch(&scores);
+        let d = ScoreDiagnostics::from_batch(&b, 0.80, 10).unwrap();
+        // uniform won't have a bin below 25% of peak, so dip should be None
+        assert!(d.dip().is_none(), "uniform distribution should have no dip");
+    }
+
+    fn clusters_batch(
+        qualities: &[&str],
+        oversized_flags: &[bool],
+    ) -> RecordBatch {
+        let n = qualities.len();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("cluster_id", DataType::Int64, false),
+            Field::new("size", DataType::Int64, false),
+            Field::new("confidence", DataType::Float64, false),
+            Field::new("quality", DataType::Utf8, false),
+            Field::new("oversized", DataType::Boolean, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from((0..n as i64).collect::<Vec<_>>())),
+                Arc::new(Int64Array::from(vec![2i64; n])),
+                Arc::new(Float64Array::from(vec![0.9f64; n])),
+                Arc::new(StringArray::from(qualities.to_vec())),
+                Arc::new(BooleanArray::from(oversized_flags.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cluster_diagnostics_counts_correctly() {
+        // 2 weak, 1 split, 2 strong, 3 oversized (indices 0, 2, 3)
+        let qualities = ["weak", "weak", "split", "strong", "strong"];
+        let oversized = [true, false, true, true, false];
+        let b = clusters_batch(&qualities, &oversized);
+        let d = ClusterDiagnostics::from_batch(&b).unwrap();
+        assert_eq!(d.weak, 2);
+        assert_eq!(d.split, 1);
+        assert_eq!(d.oversized, 3);
+        assert_eq!(d.n_clusters, 5);
+    }
+
+    #[test]
+    fn cluster_diagnostics_all_strong_none_oversized() {
+        let qualities = ["strong", "strong", "strong"];
+        let oversized = [false, false, false];
+        let b = clusters_batch(&qualities, &oversized);
+        let d = ClusterDiagnostics::from_batch(&b).unwrap();
+        assert_eq!(d.weak, 0);
+        assert_eq!(d.split, 0);
+        assert_eq!(d.oversized, 0);
+        assert_eq!(d.n_clusters, 3);
+    }
+}

--- a/packages/rust/extensions/suggest-core/src/lib.rs
+++ b/packages/rust/extensions/suggest-core/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod contract;
 pub mod diagnostics;
+pub mod rules;
 
 #[cfg(test)]
 mod tests {

--- a/packages/rust/extensions/suggest-core/src/lib.rs
+++ b/packages/rust/extensions/suggest-core/src/lib.rs
@@ -5,6 +5,8 @@
 //! text, and ranks. Shared by construction across the `goldenmatch-native` pyo3
 //! shim and (later) the datafusion-udf FFI + TS/WASM surfaces. No I/O, no pyo3.
 
+pub mod contract;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/packages/rust/extensions/suggest-core/src/lib.rs
+++ b/packages/rust/extensions/suggest-core/src/lib.rs
@@ -6,6 +6,7 @@
 //! shim and (later) the datafusion-udf FFI + TS/WASM surfaces. No I/O, no pyo3.
 
 pub mod contract;
+pub mod diagnostics;
 
 #[cfg(test)]
 mod tests {

--- a/packages/rust/extensions/suggest-core/src/lib.rs
+++ b/packages/rust/extensions/suggest-core/src/lib.rs
@@ -1,0 +1,14 @@
+//! `goldenmatch-suggest-core` -- pyo3-free config-suggestion kernel.
+//!
+//! Canonical source of truth for config suggestions: ingests a finished run's
+//! Arrow artifacts, reduces them, runs the suggestion rules, generates rationale
+//! text, and ranks. Shared by construction across the `goldenmatch-native` pyo3
+//! shim and (later) the datafusion-udf FFI + TS/WASM surfaces. No I/O, no pyo3.
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn crate_builds() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/packages/rust/extensions/suggest-core/src/lib.rs
+++ b/packages/rust/extensions/suggest-core/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod contract;
 pub mod diagnostics;
+pub mod rank;
 pub mod rules;
 
 #[cfg(test)]

--- a/packages/rust/extensions/suggest-core/src/lib.rs
+++ b/packages/rust/extensions/suggest-core/src/lib.rs
@@ -5,10 +5,13 @@
 //! text, and ranks. Shared by construction across the `goldenmatch-native` pyo3
 //! shim and (later) the datafusion-udf FFI + TS/WASM surfaces. No I/O, no pyo3.
 
+pub mod api;
 pub mod contract;
 pub mod diagnostics;
 pub mod rank;
 pub mod rules;
+
+pub use api::suggest;
 
 #[cfg(test)]
 mod tests {

--- a/packages/rust/extensions/suggest-core/src/rank.rs
+++ b/packages/rust/extensions/suggest-core/src/rank.rs
@@ -1,0 +1,135 @@
+use crate::contract::{AcceptancePriors, Suggestion, SuggestionKind};
+
+const SUPPRESS_AFTER_NET_REJECTS: i64 = 2;
+
+
+/// Canonical priors-map key: `"{snake_case kind}:{target}"`. Pin this here so
+/// Plan 2's MemoryStore persistence writes the SAME key -- otherwise the
+/// accept/reject loop silently won't bind. Uses the snake_case serde names
+/// (NOT Debug-format, which would drop the underscores).
+pub fn prior_key(kind: &SuggestionKind, target: &str) -> String {
+    let k = match kind {
+        SuggestionKind::RaiseThreshold => "raise_threshold",
+        SuggestionKind::LowerThreshold => "lower_threshold",
+        SuggestionKind::SwapScorer => "swap_scorer",
+        SuggestionKind::AddNegativeEvidence => "add_negative_evidence",
+    };
+    format!("{k}:{target}")
+}
+
+pub fn rank(mut suggestions: Vec<Suggestion>, priors: &AcceptancePriors) -> Vec<Suggestion> {
+    // dedup by id (keep first)
+    let mut seen = std::collections::HashSet::new();
+    suggestions.retain(|s| seen.insert(s.id.clone()));
+
+    // suppress repeatedly-rejected (kind,target)
+    suggestions.retain(|s| {
+        match priors.counts.get(&prior_key(&s.kind, &s.target)) {
+            Some((acc, rej)) => (*rej as i64 - *acc as i64) < SUPPRESS_AFTER_NET_REJECTS,
+            None => true,
+        }
+    });
+
+    // score = confidence + acceptance nudge
+    suggestions.sort_by(|a, b| {
+        score(b, priors)
+            .partial_cmp(&score(a, priors))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    suggestions
+}
+
+fn score(s: &Suggestion, priors: &AcceptancePriors) -> f64 {
+    let nudge = match priors.counts.get(&prior_key(&s.kind, &s.target)) {
+        Some((acc, rej)) => 0.05 * (*acc as f64 - *rej as f64),
+        None => 0.0,
+    };
+    s.confidence + nudge
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::{ConfigPatch, PredictedEffect};
+    use std::collections::HashMap;
+
+    /// Quick Suggestion builder for rank tests. Fills non-essential fields with
+    /// placeholders so tests can focus on the fields that drive ranking/suppression.
+    fn mk(id: &str, kind: SuggestionKind, target: &str, confidence: f64) -> Suggestion {
+        Suggestion {
+            id: id.into(),
+            kind,
+            target: target.into(),
+            current_value: "old".into(),
+            proposed_value: "new".into(),
+            rationale: String::new(),
+            predicted_effect: PredictedEffect::PrecisionUp,
+            confidence,
+            patch: ConfigPatch::SetThreshold {
+                matchkey: target.into(),
+                value: 0.9,
+            },
+            evidence: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn higher_confidence_ranks_first() {
+        let suggestions = vec![
+            mk("a", SuggestionKind::RaiseThreshold, "name", 0.5),
+            mk("b", SuggestionKind::RaiseThreshold, "name", 0.8),
+        ];
+        let priors = AcceptancePriors::default();
+        let ranked = rank(suggestions, &priors);
+        assert_eq!(ranked[0].id, "b", "higher confidence should rank first");
+        assert_eq!(ranked[1].id, "a");
+    }
+
+    #[test]
+    fn net_rejects_above_threshold_suppresses() {
+        // (0 accepts, 3 rejects) -> net = 3 >= SUPPRESS_AFTER_NET_REJECTS(2) -> suppressed
+        let kind = SuggestionKind::RaiseThreshold;
+        let target = "name";
+        let suggestions = vec![mk("s1", kind.clone(), target, 0.7)];
+        let priors = AcceptancePriors {
+            counts: HashMap::from([(prior_key(&kind, target), (0u32, 3u32))]),
+        };
+        let ranked = rank(suggestions, &priors);
+        assert!(
+            ranked.is_empty(),
+            "suggestion with 3 net rejects should be suppressed"
+        );
+    }
+
+    #[test]
+    fn acceptance_history_nudges_above_equal_confidence_no_history() {
+        // Two suggestions, same confidence 0.6; one has 3 accepts -> score 0.6 + 0.15 = 0.75
+        let kind = SuggestionKind::SwapScorer;
+        let target = "address";
+        let suggestions = vec![
+            mk("with_history", kind.clone(), target, 0.6),
+            mk("no_history", SuggestionKind::LowerThreshold, "other", 0.6),
+        ];
+        let priors = AcceptancePriors {
+            counts: HashMap::from([(prior_key(&kind, target), (3u32, 0u32))]),
+        };
+        let ranked = rank(suggestions, &priors);
+        assert_eq!(
+            ranked[0].id, "with_history",
+            "3 accepts should nudge the score above the equal-confidence no-history suggestion"
+        );
+    }
+
+    #[test]
+    fn duplicate_id_collapses_to_one() {
+        let suggestions = vec![
+            mk("dup", SuggestionKind::RaiseThreshold, "name", 0.7),
+            mk("dup", SuggestionKind::RaiseThreshold, "name", 0.7),
+            mk("unique", SuggestionKind::LowerThreshold, "addr", 0.5),
+        ];
+        let priors = AcceptancePriors::default();
+        let ranked = rank(suggestions, &priors);
+        assert_eq!(ranked.len(), 2, "duplicate id should collapse to one entry");
+        assert!(ranked.iter().filter(|s| s.id == "dup").count() == 1);
+    }
+}

--- a/packages/rust/extensions/suggest-core/src/rules.rs
+++ b/packages/rust/extensions/suggest-core/src/rules.rs
@@ -1,0 +1,161 @@
+use crate::contract::*;
+use crate::diagnostics::ScoreDiagnostics;
+
+const EVERYTHING_MATCHES: f64 = 0.90; // mirrors controller precision_collapse_floor
+const RECALL_RISK_BAND: f64 = 0.20; // fraction just-below to call recall risk
+
+/// Returns config suggestions for a single matchkey's threshold.
+///
+/// `weak_clusters` / `oversized_clusters` are counts from ClusterDiagnostics.
+pub fn threshold_rule(
+    matchkey: &str,
+    current: f64,
+    sd: &ScoreDiagnostics,
+    weak_clusters: usize,
+    oversized_clusters: usize,
+) -> Vec<Suggestion> {
+    let mut out = Vec::new();
+
+    // (a) bimodality dip not aligned with current threshold
+    if let Some(dip) = sd.dip() {
+        if (dip - current).abs() > 0.05 {
+            let kind = if dip > current {
+                SuggestionKind::RaiseThreshold
+            } else {
+                SuggestionKind::LowerThreshold
+            };
+            let effect = if dip > current {
+                PredictedEffect::PrecisionUp
+            } else {
+                PredictedEffect::RecallUp
+            };
+            out.push(Suggestion {
+                id: format!("thr:dip:{matchkey}"),
+                kind: kind.clone(),
+                target: matchkey.into(),
+                current_value: format!("{current:.2}"),
+                proposed_value: format!("{dip:.2}"),
+                rationale: format!(
+                    "Pair scores split into two groups with a gap near {dip:.2}, but the \
+                     `{matchkey}` threshold sits at {current:.2}. Moving it to {dip:.2} \
+                     separates the two groups cleanly."
+                ),
+                predicted_effect: effect,
+                confidence: 0.7,
+                patch: ConfigPatch::SetThreshold {
+                    matchkey: matchkey.into(),
+                    value: round2(dip),
+                },
+                evidence: serde_json::json!({"dip": dip, "current": current}),
+            });
+        }
+    }
+
+    // (b) "everything matches" -> raise
+    if sd.mass_above > EVERYTHING_MATCHES {
+        let proposed = round2((current + 1.0) / 2.0); // halfway to 1.0
+        out.push(Suggestion {
+            id: format!("thr:raise:{matchkey}"),
+            kind: SuggestionKind::RaiseThreshold,
+            target: matchkey.into(),
+            current_value: format!("{current:.2}"),
+            proposed_value: format!("{proposed:.2}"),
+            rationale: format!(
+                "{:.0}% of scored pairs clear the `{matchkey}` threshold of {current:.2} -- \
+                 almost everything is matching, which usually means false merges. Raising it \
+                 to {proposed:.2} tightens the match.",
+                sd.mass_above * 100.0
+            ),
+            predicted_effect: PredictedEffect::PrecisionUp,
+            confidence: 0.6,
+            patch: ConfigPatch::SetThreshold {
+                matchkey: matchkey.into(),
+                value: proposed,
+            },
+            evidence: serde_json::json!({"mass_above": sd.mass_above}),
+        });
+    }
+
+    // (c) recall risk: mass just below + weak/oversized clusters -> lower
+    if sd.mass_just_below > RECALL_RISK_BAND && (weak_clusters + oversized_clusters) > 0 {
+        let proposed = round2(current - 0.05);
+        out.push(Suggestion {
+            id: format!("thr:lower:{matchkey}"),
+            kind: SuggestionKind::LowerThreshold,
+            target: matchkey.into(),
+            current_value: format!("{current:.2}"),
+            proposed_value: format!("{proposed:.2}"),
+            rationale: format!(
+                "{:.0}% of pairs score just below the `{matchkey}` threshold ({current:.2}), \
+                 and there are weak/oversized clusters nearby -- likely missed matches. \
+                 Lowering it to {proposed:.2} recovers them.",
+                sd.mass_just_below * 100.0
+            ),
+            predicted_effect: PredictedEffect::RecallUp,
+            confidence: 0.5,
+            patch: ConfigPatch::SetThreshold {
+                matchkey: matchkey.into(),
+                value: proposed,
+            },
+            evidence: serde_json::json!({
+                "mass_just_below": sd.mass_just_below,
+                "weak": weak_clusters,
+                "oversized": oversized_clusters
+            }),
+        });
+    }
+
+    out
+}
+
+fn round2(x: f64) -> f64 {
+    (x * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::ScoreDiagnostics;
+
+    fn sd(mass_above: f64, mass_just_below: f64, dip: Option<f64>) -> ScoreDiagnostics {
+        // construct directly for unit isolation
+        ScoreDiagnostics {
+            histogram: dip
+                .map(|_| vec![(0.0, 100), (0.5, 2), (0.9, 100)])
+                .unwrap_or_else(|| vec![(0.0, 50), (0.5, 50)]),
+            mass_above,
+            mass_just_below,
+            n_pairs: 1000,
+        }
+    }
+
+    #[test]
+    fn raises_on_everything_matches() {
+        let out = threshold_rule("name", 0.80, &sd(0.95, 0.0, None), 0, 0);
+        assert!(out
+            .iter()
+            .any(|s| s.kind == SuggestionKind::RaiseThreshold));
+    }
+
+    #[test]
+    fn lowers_on_recall_risk() {
+        // lots of mass just below + weak/oversized clusters present
+        let out = threshold_rule("name", 0.80, &sd(0.10, 0.30, None), 5, 2);
+        assert!(out
+            .iter()
+            .any(|s| s.kind == SuggestionKind::LowerThreshold));
+    }
+
+    #[test]
+    fn moves_to_dip_when_threshold_off_valley() {
+        let out = threshold_rule("name", 0.80, &sd(0.4, 0.05, Some(0.5)), 0, 0);
+        let s = out
+            .iter()
+            .find(|s| matches!(s.patch, ConfigPatch::SetThreshold { .. }))
+            .unwrap();
+        // dip at 0.5 is below current 0.80 -> suggest lowering toward the valley
+        assert!(
+            matches!(&s.patch, ConfigPatch::SetThreshold { value, .. } if (*value - 0.5).abs() < 0.11)
+        );
+    }
+}

--- a/packages/rust/extensions/suggest-core/src/rules.rs
+++ b/packages/rust/extensions/suggest-core/src/rules.rs
@@ -34,7 +34,7 @@ pub fn threshold_rule(
                 kind: kind.clone(),
                 target: matchkey.into(),
                 current_value: format!("{current:.2}"),
-                proposed_value: format!("{dip:.2}"),
+                proposed_value: format!("{:.2}", round2(dip)),
                 rationale: format!(
                     "Pair scores split into two groups with a gap near {dip:.2}, but the \
                      `{matchkey}` threshold sits at {current:.2}. Moving it to {dip:.2} \

--- a/packages/rust/extensions/suggest-core/src/rules.rs
+++ b/packages/rust/extensions/suggest-core/src/rules.rs
@@ -1,10 +1,14 @@
 use crate::contract::*;
-use crate::diagnostics::ScoreDiagnostics;
+use crate::diagnostics::{ColumnSignal, ScoreDiagnostics};
 
 const EVERYTHING_MATCHES: f64 = 0.90; // mirrors controller precision_collapse_floor
 const RECALL_RISK_BAND: f64 = 0.20; // fraction just-below to call recall risk
 const DIP_MIN_GAP: f64 = 0.05; // min |dip - threshold| before the dip suggestion fires
 const RECALL_STEP_DOWN: f64 = 0.05; // fixed lowering step for the recall-risk suggestion
+
+const SWAP_CORRUPTION_MIN: f64 = 0.30; // corruption_score at/above which token_sort is noise-fragile
+const SWAP_VARIANT_MIN: f64 = 0.02; // fraction of fuzzy-variant rows that also triggers the swap
+const SWAP_TARGET_SCORER: &str = "jaro_winkler";
 
 /// Returns config suggestions for a single matchkey's threshold.
 ///
@@ -110,6 +114,59 @@ pub fn threshold_rule(
     out
 }
 
+/// Returns scorer-swap suggestions for each column signal in a matchkey.
+///
+/// Fires when a free-text/name/address column is still scored by `token_sort`
+/// but carries corruption or variant-rate signal above the threshold.  `token_sort`
+/// is robust to word reordering but fragile to character-level noise; `jaro_winkler`
+/// handles the noise better.  Mirrors the #662 noise-aware auto-config behavior.
+pub fn scorer_swap_rule(matchkey: &str, signals: &[ColumnSignal]) -> Vec<Suggestion> {
+    let mut out = Vec::new();
+    for c in signals {
+        let is_free_text = matches!(c.col_type.as_str(), "address" | "string" | "name");
+        let is_token_sort = c.scorer == "token_sort";
+        let is_noisy = c.corruption_score >= SWAP_CORRUPTION_MIN
+            || c.variant_rate >= SWAP_VARIANT_MIN;
+        if !is_free_text || !is_token_sort || !is_noisy {
+            continue;
+        }
+        let trigger = if c.corruption_score >= SWAP_CORRUPTION_MIN {
+            format!(
+                "corruption_score {:.0}%",
+                c.corruption_score * 100.0
+            )
+        } else {
+            format!("variant_rate {:.0}%", c.variant_rate * 100.0)
+        };
+        out.push(Suggestion {
+            id: format!("swap:{}", c.field),
+            kind: SuggestionKind::SwapScorer,
+            target: c.field.clone(),
+            current_value: "token_sort".into(),
+            proposed_value: SWAP_TARGET_SCORER.into(),
+            rationale: format!(
+                "`{}` has {} signal, but `token_sort` is robust to word reordering \
+                 while fragile to character noise. Switching to `jaro_winkler` will score \
+                 the corrupted values better.",
+                c.field, trigger
+            ),
+            predicted_effect: PredictedEffect::PrecisionUp,
+            confidence: 0.65,
+            patch: ConfigPatch::SetScorer {
+                matchkey: matchkey.into(),
+                field: c.field.clone(),
+                scorer: SWAP_TARGET_SCORER.into(),
+            },
+            evidence: serde_json::json!({
+                "corruption_score": c.corruption_score,
+                "variant_rate": c.variant_rate,
+                "col_type": c.col_type
+            }),
+        });
+    }
+    out
+}
+
 fn round2(x: f64) -> f64 {
     (x * 100.0).round() / 100.0
 }
@@ -117,7 +174,7 @@ fn round2(x: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::diagnostics::ScoreDiagnostics;
+    use crate::diagnostics::{ColumnSignal, ScoreDiagnostics};
 
     fn sd(mass_above: f64, mass_just_below: f64, dip: Option<f64>) -> ScoreDiagnostics {
         // construct directly for unit isolation
@@ -166,5 +223,74 @@ mod tests {
         // mass_above 0.5 (< 0.90), mass_just_below 0.05 (< 0.20), no dip
         let out = threshold_rule("name", 0.80, &sd(0.50, 0.05, None), 0, 0);
         assert!(out.is_empty());
+    }
+
+    // ---------------------------------------------------------------------------
+    // scorer_swap_rule helpers + tests
+    // ---------------------------------------------------------------------------
+
+    /// Build a ColumnSignal with sane defaults; override the fields under test.
+    fn cs(
+        field: &str,
+        col_type: &str,
+        scorer: &str,
+        corruption_score: f64,
+        variant_rate: f64,
+    ) -> ColumnSignal {
+        ColumnSignal {
+            field: field.into(),
+            col_type: col_type.into(),
+            scorer: scorer.into(),
+            in_blocking: false,
+            in_negative_evidence: false,
+            identity_score: 0.5,
+            corruption_score,
+            collision_rate: 0.0,
+            cardinality_ratio: 0.5,
+            null_rate: 0.0,
+            variant_rate,
+        }
+    }
+
+    #[test]
+    fn swaps_token_sort_on_corrupted_address() {
+        // address + token_sort + corruption_score 0.5 (>= 0.30) -> one SwapScorer suggestion
+        let signals = vec![cs("res_street_address", "address", "token_sort", 0.5, 0.0)];
+        let out = scorer_swap_rule("person", &signals);
+        assert_eq!(out.len(), 1, "expected exactly one suggestion");
+        let s = &out[0];
+        assert_eq!(s.kind, SuggestionKind::SwapScorer);
+        assert_eq!(s.id, "swap:res_street_address");
+        assert_eq!(s.current_value, "token_sort");
+        assert_eq!(s.proposed_value, "jaro_winkler");
+        assert!(
+            matches!(&s.patch, ConfigPatch::SetScorer { matchkey, field, scorer }
+                if matchkey == "person" && field == "res_street_address" && scorer == "jaro_winkler")
+        );
+    }
+
+    #[test]
+    fn swaps_on_high_variant_even_if_low_corruption() {
+        // name + token_sort + variant_rate 0.05 (>= 0.02), corruption 0.0 -> fires
+        let signals = vec![cs("given_name", "name", "token_sort", 0.0, 0.05)];
+        let out = scorer_swap_rule("person", &signals);
+        assert_eq!(out.len(), 1, "expected one suggestion from variant_rate trigger");
+        assert_eq!(out[0].kind, SuggestionKind::SwapScorer);
+    }
+
+    #[test]
+    fn no_swap_on_clean_column() {
+        // corruption 0.1 (< 0.30) and variant_rate 0.0 (< 0.02) -> empty
+        let signals = vec![cs("address_line", "address", "token_sort", 0.1, 0.0)];
+        let out = scorer_swap_rule("person", &signals);
+        assert!(out.is_empty(), "clean column should emit no suggestion");
+    }
+
+    #[test]
+    fn no_swap_when_not_token_sort() {
+        // qgram scorer with high corruption -> no swap (rule only targets token_sort)
+        let signals = vec![cs("address_line", "address", "qgram", 0.9, 0.0)];
+        let out = scorer_swap_rule("person", &signals);
+        assert!(out.is_empty(), "non-token_sort scorer should not trigger swap");
     }
 }

--- a/packages/rust/extensions/suggest-core/src/rules.rs
+++ b/packages/rust/extensions/suggest-core/src/rules.rs
@@ -3,6 +3,8 @@ use crate::diagnostics::ScoreDiagnostics;
 
 const EVERYTHING_MATCHES: f64 = 0.90; // mirrors controller precision_collapse_floor
 const RECALL_RISK_BAND: f64 = 0.20; // fraction just-below to call recall risk
+const DIP_MIN_GAP: f64 = 0.05; // min |dip - threshold| before the dip suggestion fires
+const RECALL_STEP_DOWN: f64 = 0.05; // fixed lowering step for the recall-risk suggestion
 
 /// Returns config suggestions for a single matchkey's threshold.
 ///
@@ -18,7 +20,7 @@ pub fn threshold_rule(
 
     // (a) bimodality dip not aligned with current threshold
     if let Some(dip) = sd.dip() {
-        if (dip - current).abs() > 0.05 {
+        if (dip - current).abs() > DIP_MIN_GAP {
             let kind = if dip > current {
                 SuggestionKind::RaiseThreshold
             } else {
@@ -78,7 +80,7 @@ pub fn threshold_rule(
 
     // (c) recall risk: mass just below + weak/oversized clusters -> lower
     if sd.mass_just_below > RECALL_RISK_BAND && (weak_clusters + oversized_clusters) > 0 {
-        let proposed = round2(current - 0.05);
+        let proposed = round2(current - RECALL_STEP_DOWN);
         out.push(Suggestion {
             id: format!("thr:lower:{matchkey}"),
             kind: SuggestionKind::LowerThreshold,
@@ -151,11 +153,18 @@ mod tests {
         let out = threshold_rule("name", 0.80, &sd(0.4, 0.05, Some(0.5)), 0, 0);
         let s = out
             .iter()
-            .find(|s| matches!(s.patch, ConfigPatch::SetThreshold { .. }))
+            .find(|s| s.id == "thr:dip:name")
             .unwrap();
         // dip at 0.5 is below current 0.80 -> suggest lowering toward the valley
         assert!(
-            matches!(&s.patch, ConfigPatch::SetThreshold { value, .. } if (*value - 0.5).abs() < 0.11)
+            matches!(&s.patch, ConfigPatch::SetThreshold { value, .. } if (*value - 0.5).abs() < 1e-9)
         );
+    }
+
+    #[test]
+    fn no_suggestions_when_nothing_triggered() {
+        // mass_above 0.5 (< 0.90), mass_just_below 0.05 (< 0.20), no dip
+        let out = threshold_rule("name", 0.80, &sd(0.50, 0.05, None), 0, 0);
+        assert!(out.is_empty());
     }
 }

--- a/packages/rust/extensions/suggest-core/src/rules.rs
+++ b/packages/rust/extensions/suggest-core/src/rules.rs
@@ -167,6 +167,58 @@ pub fn scorer_swap_rule(matchkey: &str, signals: &[ColumnSignal]) -> Vec<Suggest
     out
 }
 
+const NE_IDENTITY_MIN: f64 = 0.75; // identity_score floor (mirrors _IDENTITY_SCORE_THRESHOLD)
+const NE_CARDINALITY_MIN: f64 = 0.50; // cardinality_ratio floor (mirrors _CARDINALITY_THRESHOLD)
+const NE_COLLISION_MIN: f64 = 0.50; // in-cluster disagreement rate that flags over-trust
+
+/// Returns add-negative-evidence suggestions for each column signal.
+///
+/// Fires when a column looks like a strong identity field (high identity_score,
+/// high cardinality_ratio) that is NOT already in negative evidence, but disagrees
+/// within merged clusters at a rate above the collision threshold.  Adding it as
+/// negative evidence penalises future merges where the field conflicts.  Mirrors
+/// the shipped `promote_negative_evidence` thresholds plus a result-driven
+/// collision gate.
+pub fn negative_evidence_rule(signals: &[ColumnSignal]) -> Vec<Suggestion> {
+    let mut out = Vec::new();
+    for c in signals {
+        if c.identity_score < NE_IDENTITY_MIN
+            || c.cardinality_ratio < NE_CARDINALITY_MIN
+            || c.in_negative_evidence
+            || c.collision_rate < NE_COLLISION_MIN
+        {
+            continue;
+        }
+        out.push(Suggestion {
+            id: format!("ne:{}", c.field),
+            kind: SuggestionKind::AddNegativeEvidence,
+            target: c.field.clone(),
+            current_value: "none".into(),
+            proposed_value: "negative_evidence".into(),
+            rationale: format!(
+                "`{}` looks like a strong identity column (identity_score {:.2}, \
+                 cardinality_ratio {:.2}) yet disagrees within {:.0}% of merged clusters. \
+                 Adding it as negative evidence will penalise merges where it conflicts.",
+                c.field,
+                c.identity_score,
+                c.cardinality_ratio,
+                c.collision_rate * 100.0
+            ),
+            predicted_effect: PredictedEffect::PrecisionUp,
+            confidence: 0.55,
+            patch: ConfigPatch::AddNegativeEvidence {
+                field: c.field.clone(),
+            },
+            evidence: serde_json::json!({
+                "identity_score": c.identity_score,
+                "collision_rate": c.collision_rate,
+                "cardinality_ratio": c.cardinality_ratio
+            }),
+        });
+    }
+    out
+}
+
 fn round2(x: f64) -> f64 {
     (x * 100.0).round() / 100.0
 }
@@ -292,5 +344,74 @@ mod tests {
         let signals = vec![cs("address_line", "address", "qgram", 0.9, 0.0)];
         let out = scorer_swap_rule("person", &signals);
         assert!(out.is_empty(), "non-token_sort scorer should not trigger swap");
+    }
+
+    // ---------------------------------------------------------------------------
+    // negative_evidence_rule tests
+    // ---------------------------------------------------------------------------
+
+    /// Build a ColumnSignal for NE-rule tests, reusing the cs() helper's base
+    /// but overriding the NE-relevant fields explicitly.
+    fn ne_signal(
+        field: &str,
+        identity_score: f64,
+        cardinality_ratio: f64,
+        collision_rate: f64,
+        in_negative_evidence: bool,
+    ) -> ColumnSignal {
+        ColumnSignal {
+            field: field.into(),
+            col_type: "string".into(),
+            scorer: "exact".into(),
+            in_blocking: false,
+            in_negative_evidence,
+            identity_score,
+            corruption_score: 0.0,
+            collision_rate,
+            cardinality_ratio,
+            null_rate: 0.0,
+            variant_rate: 0.0,
+        }
+    }
+
+    #[test]
+    fn adds_ne_for_colliding_identity_column() {
+        // identity 0.9, cardinality 0.8, collision 0.6, not already NE -> one suggestion
+        let signals = vec![ne_signal("npi", 0.9, 0.8, 0.6, false)];
+        let out = negative_evidence_rule(&signals);
+        assert_eq!(out.len(), 1, "expected exactly one suggestion");
+        let s = &out[0];
+        assert_eq!(s.kind, SuggestionKind::AddNegativeEvidence);
+        assert_eq!(s.id, "ne:npi");
+        assert_eq!(s.current_value, "none");
+        assert_eq!(s.proposed_value, "negative_evidence");
+        assert!(
+            matches!(&s.patch, ConfigPatch::AddNegativeEvidence { field } if field == "npi"),
+            "patch should be AddNegativeEvidence for npi"
+        );
+    }
+
+    #[test]
+    fn no_ne_when_already_negative_evidence() {
+        // same strong signals but already in NE -> empty
+        let signals = vec![ne_signal("npi", 0.9, 0.8, 0.6, true)];
+        let out = negative_evidence_rule(&signals);
+        assert!(out.is_empty(), "already-NE column should not re-suggest NE");
+    }
+
+    #[test]
+    fn no_ne_when_low_collision() {
+        // identity 0.9, cardinality 0.8, but collision 0.1 (< 0.50) -> empty
+        let signals = vec![ne_signal("npi", 0.9, 0.8, 0.1, false)];
+        let out = negative_evidence_rule(&signals);
+        assert!(out.is_empty(), "low collision_rate should not trigger NE");
+    }
+
+    #[test]
+    fn no_ne_when_low_identity() {
+        // identity 0.3 (< 0.75), cardinality 0.8, collision 0.9 -> empty
+        let signals = vec![ne_signal("weak_field", 0.3, 0.8, 0.9, false)];
+        let out = negative_evidence_rule(&signals);
+        assert!(out.is_empty(), "low identity_score should not trigger NE");
     }
 }

--- a/packages/rust/extensions/suggest-core/tests/golden/ncvr_address.json
+++ b/packages/rust/extensions/suggest-core/tests/golden/ncvr_address.json
@@ -14,8 +14,6 @@
       "variant_rate": 0.0
     }
   ],
-  "scored_pairs": [],
-  "clusters": [],
   "config": {
     "matchkeys": [
       {

--- a/packages/rust/extensions/suggest-core/tests/golden/ncvr_address.json
+++ b/packages/rust/extensions/suggest-core/tests/golden/ncvr_address.json
@@ -1,0 +1,43 @@
+{
+  "column_signals": [
+    {
+      "field": "res_street_address",
+      "col_type": "address",
+      "scorer": "token_sort",
+      "in_blocking": false,
+      "in_negative_evidence": false,
+      "identity_score": 0.0,
+      "corruption_score": 0.6,
+      "collision_rate": 0.0,
+      "cardinality_ratio": 0.5,
+      "null_rate": 0.0,
+      "variant_rate": 0.0
+    }
+  ],
+  "scored_pairs": [],
+  "clusters": [],
+  "config": {
+    "matchkeys": [
+      {
+        "name": "person",
+        "kind": "weighted",
+        "threshold": 0.8,
+        "fields": [
+          {
+            "field": "res_street_address",
+            "scorer": "token_sort",
+            "weight": 1.0
+          }
+        ]
+      }
+    ],
+    "negative_evidence": []
+  },
+  "priors": {
+    "counts": {}
+  },
+  "expected_top": {
+    "kind": "swap_scorer",
+    "target": "res_street_address"
+  }
+}

--- a/scripts/suggest_quality/__init__.py
+++ b/scripts/suggest_quality/__init__.py
@@ -1,0 +1,10 @@
+"""Config-suggestion quality harness — measure whether applying suggestions
+improves F1 across a corpus of labeled ER datasets.
+
+Mirrors the structure and design of ``scripts.autoconfig_quality``:
+same ``report`` / ``gate`` / ``bless`` CLI subcommands, same dataset
+registry + skip-when-absent pattern, same determinism env.
+
+See docs/superpowers/specs/ for the design spec once Task 15 wires the
+oracle and metrics.
+"""

--- a/scripts/suggest_quality/__main__.py
+++ b/scripts/suggest_quality/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point for ``python -m scripts.suggest_quality``."""
+import sys
+from scripts.suggest_quality.cli import main
+
+sys.exit(main())

--- a/scripts/suggest_quality/baselines/scorecard.json
+++ b/scripts/suggest_quality/baselines/scorecard.json
@@ -1,6 +1,105 @@
 {
-  "datasets": {},
+  "datasets": {
+    "anchor_person_match": {
+      "baseline_f1": 0.989556,
+      "convergence_final_f1": 1.0,
+      "convergence_steps": 1,
+      "error": null,
+      "gt_pairs": 379,
+      "kind": "anchor",
+      "n_suggestions": 1,
+      "name": "anchor_person_match",
+      "native_available": true,
+      "rank_corr": null,
+      "rows": 706,
+      "suggested_order_lifts": [
+        0.010444
+      ],
+      "suggester_prec": 1.0
+    },
+    "anchor_shared_email": {
+      "baseline_f1": null,
+      "convergence_final_f1": null,
+      "convergence_steps": 0,
+      "error": null,
+      "gt_pairs": 0,
+      "kind": "anchor",
+      "n_suggestions": 2,
+      "name": "anchor_shared_email",
+      "native_available": true,
+      "rank_corr": null,
+      "rows": 30,
+      "suggested_order_lifts": [
+        null,
+        null
+      ],
+      "suggester_prec": 1.0
+    },
+    "anchor_sparse_zip": {
+      "baseline_f1": null,
+      "convergence_final_f1": null,
+      "convergence_steps": 0,
+      "error": null,
+      "gt_pairs": 0,
+      "kind": "anchor",
+      "n_suggestions": 3,
+      "name": "anchor_sparse_zip",
+      "native_available": true,
+      "rank_corr": null,
+      "rows": 20000,
+      "suggested_order_lifts": [
+        null,
+        null,
+        null
+      ],
+      "suggester_prec": 1.0
+    },
+    "ncvr_synthetic": {
+      "baseline_f1": 0.982804,
+      "convergence_final_f1": 0.982804,
+      "convergence_steps": 0,
+      "error": null,
+      "gt_pairs": 2500,
+      "kind": "real",
+      "n_suggestions": 2,
+      "name": "ncvr_synthetic",
+      "native_available": true,
+      "rank_corr": -1.0,
+      "rows": 7500,
+      "suggested_order_lifts": [
+        -0.254421,
+        -0.072603
+      ],
+      "suggester_prec": 0.0
+    },
+    "synthetic": {
+      "baseline_f1": 0.988662,
+      "convergence_final_f1": 1.0,
+      "convergence_steps": 1,
+      "error": null,
+      "gt_pairs": 218,
+      "kind": "real",
+      "n_suggestions": 1,
+      "name": "synthetic",
+      "native_available": true,
+      "rank_corr": null,
+      "rows": 373,
+      "suggested_order_lifts": [
+        0.011338
+      ],
+      "suggester_prec": 1.0
+    }
+  },
   "meta": {
-    "note": "Empty baseline — Task 16 will bless the first real scorecard."
+    "datasets_run": [
+      "anchor_person_match",
+      "anchor_shared_email",
+      "anchor_sparse_zip",
+      "ncvr_synthetic",
+      "synthetic"
+    ],
+    "datasets_skipped": {},
+    "git_sha": "a79675d71e5e13dc1da71b4f01794a4e14efed2f",
+    "native_version": "0.1.5"
   }
 }

--- a/scripts/suggest_quality/baselines/scorecard.json
+++ b/scripts/suggest_quality/baselines/scorecard.json
@@ -1,0 +1,6 @@
+{
+  "datasets": {},
+  "meta": {
+    "note": "Empty baseline — Task 16 will bless the first real scorecard."
+  }
+}

--- a/scripts/suggest_quality/baselines/scorecard.json
+++ b/scripts/suggest_quality/baselines/scorecard.json
@@ -42,14 +42,12 @@
       "error": null,
       "gt_pairs": 0,
       "kind": "anchor",
-      "n_suggestions": 3,
+      "n_suggestions": 1,
       "name": "anchor_sparse_zip",
       "native_available": true,
       "rank_corr": null,
       "rows": 20000,
       "suggested_order_lifts": [
-        null,
-        null,
         null
       ],
       "suggester_prec": 1.0
@@ -61,32 +59,27 @@
       "error": null,
       "gt_pairs": 2500,
       "kind": "real",
-      "n_suggestions": 2,
+      "n_suggestions": 0,
       "name": "ncvr_synthetic",
       "native_available": true,
-      "rank_corr": -1.0,
+      "rank_corr": null,
       "rows": 7500,
-      "suggested_order_lifts": [
-        -0.254421,
-        -0.072603
-      ],
-      "suggester_prec": 0.0
+      "suggested_order_lifts": [],
+      "suggester_prec": 1.0
     },
     "synthetic": {
       "baseline_f1": 0.988662,
-      "convergence_final_f1": 1.0,
-      "convergence_steps": 1,
+      "convergence_final_f1": 0.988662,
+      "convergence_steps": 0,
       "error": null,
       "gt_pairs": 218,
       "kind": "real",
-      "n_suggestions": 1,
+      "n_suggestions": 0,
       "name": "synthetic",
       "native_available": true,
       "rank_corr": null,
       "rows": 373,
-      "suggested_order_lifts": [
-        0.011338
-      ],
+      "suggested_order_lifts": [],
       "suggester_prec": 1.0
     }
   },
@@ -99,7 +92,7 @@
       "synthetic"
     ],
     "datasets_skipped": {},
-    "git_sha": "a79675d71e5e13dc1da71b4f01794a4e14efed2f",
+    "git_sha": "db0c761cdc69c3bc60a07608ec7f974e65cce531",
     "native_version": "0.1.5"
   }
 }

--- a/scripts/suggest_quality/cli.py
+++ b/scripts/suggest_quality/cli.py
@@ -1,0 +1,184 @@
+"""Config-suggestion quality harness CLI.
+
+    python -m scripts.suggest_quality report   # enumerate datasets + stub metrics
+    python -m scripts.suggest_quality gate     # exit nonzero on regression (CI)
+    python -m scripts.suggest_quality bless    # accept current as the baseline
+
+Flags:
+    --datasets a,b  filter to a subset of registered datasets
+    --row-cap N     oracle row cap (default 20 000); ignored for full_scan datasets
+    --native {0,1,auto}  GOLDENMATCH_NATIVE for this run
+    --tolerance F   delta-F1 floor band for the gate (default 0.01)
+
+Task 14 scope:
+    ``report`` loads each dataset, prints name + row count + GT pair count
+    (or ``SKIPPED: <reason>``), and prints a placeholder metrics line.
+    ``gate`` and ``bless`` are wired but not yet implemented (Task 15/16).
+
+Determinism: set before any goldenmatch import — mirrors autoconfig_quality.
+"""
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+import sys
+from pathlib import Path
+
+# Polars CPU probe can hang on Windows; set before anything imports polars.
+os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
+_BASELINE = Path(__file__).resolve().parent / "baselines" / "scorecard.json"
+
+
+# ── determinism helper ────────────────────────────────────────────────────────
+
+def _pin_determinism(native: str | None = None) -> None:
+    """Pin the determinism environment before any goldenmatch import.
+
+    Mirrors autoconfig_quality's approach exactly:
+    - GOLDENMATCH_AUTOCONFIG_MEMORY=0  disables cross-run memory (CI-safe)
+    - PYTHONHASHSEED=0                 stable dict iteration
+    - POLARS_SKIP_CPU_CHECK=1          avoid Windows WMI hang
+    - GOLDENMATCH_NATIVE               passed as --native flag value, if given
+
+    Called once at the top of main() before deferred imports.
+    """
+    os.environ["GOLDENMATCH_AUTOCONFIG_MEMORY"] = "0"
+    os.environ.setdefault("PYTHONHASHSEED", "0")
+    os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+    if native is not None:
+        os.environ["GOLDENMATCH_NATIVE"] = native
+
+
+# ── run loop ──────────────────────────────────────────────────────────────────
+
+def run(
+    dataset_names: set[str] | None,
+    row_cap: int | None,
+) -> tuple[dict[str, dict], dict[str, str]]:
+    """Load the corpus -> (results, skipped).
+
+    Heavy imports are deferred so ``--native`` can set GOLDENMATCH_NATIVE
+    before goldenmatch loads.  Same pattern as autoconfig_quality.run().
+
+    Task 14: results records carry only ``kind`` + ``rows`` + ``gt_pairs``.
+    Task 15 will add the oracle + metrics (before_f1, after_f1, delta).
+    """
+    from scripts.suggest_quality.datasets import REGISTRY, effective_row_cap  # noqa: PLC0415
+
+    results: dict[str, dict] = {}
+    skipped: dict[str, str] = {}
+
+    for d in REGISTRY:
+        if dataset_names and d.name not in dataset_names:
+            continue
+        try:
+            loaded = d.loader()
+        except Exception as e:  # loader failure -> skip with reason, never crash
+            skipped[d.name] = f"loader_error: {e}"
+            continue
+        if loaded is None:
+            skipped[d.name] = "absent"
+            continue
+        df, gt = loaded
+        cap = effective_row_cap(d, row_cap)
+        results[d.name] = {
+            "kind": d.kind,
+            "rows": min(df.height, cap) if cap is not None else df.height,
+            "gt_pairs": len(gt),
+        }
+        del loaded, df, gt
+        gc.collect()
+
+    return results, skipped
+
+
+# ── scorecard helpers (stubs — Task 15 wires the oracle + metrics) ────────────
+
+def _gather_meta() -> tuple[str, str]:
+    """(native_version, git_sha) — best-effort, never raises."""
+    try:
+        import goldenmatch_native  # noqa: PLC0415
+        native_version = getattr(goldenmatch_native, "__version__", "unknown")
+    except Exception:
+        native_version = "absent"
+    try:
+        import subprocess  # noqa: PLC0415
+        git_sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip()
+    except Exception:
+        git_sha = "unknown"
+    return native_version, git_sha
+
+
+def _render_report_table(
+    results: dict[str, dict], skipped: dict[str, str]
+) -> str:
+    """Print a simple summary table (no metrics yet — Task 15 adds them)."""
+    lines: list[str] = []
+    for name, rec in results.items():
+        gt = rec["gt_pairs"]
+        rows = rec["rows"]
+        kind = rec["kind"]
+        lines.append(f"  {name:<30} {kind:<7}  rows={rows:<7}  gt_pairs={gt}")
+    for name, reason in skipped.items():
+        lines.append(f"  {name:<30} SKIPPED: {reason}")
+    return "\n".join(lines)
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="suggest_quality")
+    p.add_argument(
+        "mode", nargs="?", default="report",
+        choices=["report", "gate", "bless"],
+    )
+    p.add_argument("--datasets", default="", help="comma-separated dataset filter")
+    p.add_argument("--row-cap", type=int, default=20_000, help="oracle row cap")
+    p.add_argument(
+        "--native", choices=["0", "1", "auto"], default=None,
+        help="GOLDENMATCH_NATIVE for this run",
+    )
+    p.add_argument(
+        "--tolerance", type=float, default=0.01,
+        help="delta-F1 floor band for the gate",
+    )
+    args = p.parse_args(argv)
+
+    # Pin determinism env BEFORE any goldenmatch import.
+    _pin_determinism(args.native)
+
+    names: set[str] | None = {s for s in args.datasets.split(",") if s} or None
+    results, skipped = run(names, args.row_cap)
+    native_version, git_sha = _gather_meta()
+
+    if args.mode == "report":
+        print("suggest_quality report")
+        print(f"  native={native_version}  sha={git_sha[:12] if git_sha != 'unknown' else 'unknown'}")
+        print()
+        print(_render_report_table(results, skipped))
+        print()
+        print(f"  {len(results)} dataset(s) loaded, {len(skipped)} skipped")
+        print("  0 metrics yet (Task 15 wires the oracle and delta-F1 measurement)")
+        return 0
+
+    if args.mode == "bless":
+        print("suggest_quality bless: not implemented until Task 16")
+        print("(Task 16 will wire the oracle, build the scorecard, and commit the baseline.)")
+        return 0
+
+    if args.mode == "gate":
+        print("suggest_quality gate: not implemented until Task 15/16")
+        print("(Task 15 wires the oracle; Task 16 adds the CI gate against the bless'd baseline.)")
+        # Exit 0 (never fail) until the gate is implemented.
+        return 0
+
+    return 0  # unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/suggest_quality/cli.py
+++ b/scripts/suggest_quality/cli.py
@@ -1,6 +1,6 @@
 """Config-suggestion quality harness CLI.
 
-    python -m scripts.suggest_quality report   # enumerate datasets + stub metrics
+    python -m scripts.suggest_quality report   # oracle + metrics per dataset
     python -m scripts.suggest_quality gate     # exit nonzero on regression (CI)
     python -m scripts.suggest_quality bless    # accept current as the baseline
 
@@ -10,17 +10,13 @@ Flags:
     --native {0,1,auto}  GOLDENMATCH_NATIVE for this run
     --tolerance F   delta-F1 floor band for the gate (default 0.01)
 
-Task 14 scope:
-    ``report`` loads each dataset, prints name + row count + GT pair count
-    (or ``SKIPPED: <reason>``), and prints a placeholder metrics line.
-    ``gate`` and ``bless`` are wired but not yet implemented (Task 15/16).
-
-Determinism: set before any goldenmatch import — mirrors autoconfig_quality.
+Determinism: set before any goldenmatch import -- mirrors autoconfig_quality.
 """
 from __future__ import annotations
 
 import argparse
 import gc
+import math
 import os
 import sys
 from pathlib import Path
@@ -58,15 +54,17 @@ def run(
     dataset_names: set[str] | None,
     row_cap: int | None,
 ) -> tuple[dict[str, dict], dict[str, str]]:
-    """Load the corpus -> (results, skipped).
+    """Load the corpus, run the oracle for each dataset -> (results, skipped).
 
     Heavy imports are deferred so ``--native`` can set GOLDENMATCH_NATIVE
     before goldenmatch loads.  Same pattern as autoconfig_quality.run().
 
-    Task 14: results records carry only ``kind`` + ``rows`` + ``gt_pairs``.
-    Task 15 will add the oracle + metrics (before_f1, after_f1, delta).
+    Each result record carries the oracle output from evaluate_dataset plus
+    the computed metrics (rank_corr, suggester_prec) ready for the table.
     """
     from scripts.suggest_quality.datasets import REGISTRY, effective_row_cap  # noqa: PLC0415
+    from scripts.suggest_quality.metrics import rank_correlation, suggester_precision  # noqa: PLC0415
+    from scripts.suggest_quality.oracle import evaluate_dataset  # noqa: PLC0415
 
     results: dict[str, dict] = {}
     skipped: dict[str, str] = {}
@@ -84,10 +82,31 @@ def run(
             continue
         df, gt = loaded
         cap = effective_row_cap(d, row_cap)
+
+        try:
+            oracle_rec = evaluate_dataset(d.name, df, gt, row_cap=cap)
+        except Exception as e:
+            skipped[d.name] = f"oracle_error: {e}"
+            del loaded, df, gt
+            gc.collect()
+            continue
+
+        # Compute derived metrics
+        lifts = oracle_rec.get("suggested_order_lifts", [])
+        # Filter NaN lifts before passing to metrics (oracle may produce NaN
+        # per-suggestion on error; exclude them from correlation/precision)
+        clean_lifts = [x for x in lifts if not math.isnan(x)]
+
+        rank_corr = rank_correlation(clean_lifts)
+        sugg_prec = suggester_precision(clean_lifts)
+
         results[d.name] = {
             "kind": d.kind,
-            "rows": min(df.height, cap) if cap is not None else df.height,
-            "gt_pairs": len(gt),
+            # oracle output
+            **oracle_rec,
+            # derived metrics
+            "rank_corr": rank_corr,
+            "suggester_prec": sugg_prec,
         }
         del loaded, df, gt
         gc.collect()
@@ -95,10 +114,10 @@ def run(
     return results, skipped
 
 
-# ── scorecard helpers (stubs — Task 15 wires the oracle + metrics) ────────────
+# ── scorecard helpers ─────────────────────────────────────────────────────────
 
 def _gather_meta() -> tuple[str, str]:
-    """(native_version, git_sha) — best-effort, never raises."""
+    """(native_version, git_sha) -- best-effort, never raises."""
     try:
         import goldenmatch_native  # noqa: PLC0415
         native_version = getattr(goldenmatch_native, "__version__", "unknown")
@@ -114,19 +133,71 @@ def _gather_meta() -> tuple[str, str]:
     return native_version, git_sha
 
 
+def _fmt_f1(v: float) -> str:
+    if math.isnan(v):
+        return "   n/a"
+    return f"{v:.4f}"
+
+
+def _fmt_corr(v: float) -> str:
+    if math.isnan(v):
+        return "   n/a"
+    return f"{v:+.3f}"
+
+
+def _fmt_prec(v: float) -> str:
+    return f"{v:.2f}"
+
+
 def _render_report_table(
     results: dict[str, dict], skipped: dict[str, str]
 ) -> str:
-    """Print a simple summary table (no metrics yet — Task 15 adds them)."""
+    """Render the per-dataset metrics table."""
     lines: list[str] = []
+
+    header = (
+        f"  {'dataset':<30} {'kind':<7}  {'rows':<7}  "
+        f"{'gt_pairs':<9}  {'base_f1':<8}  {'n_sugg':<6}  "
+        f"{'rank_corr':<10}  {'sugg_prec':<9}  {'conv_f1':<8}  {'steps':<5}"
+    )
+    sep = "  " + "-" * (len(header) - 2)
+    lines.append(header)
+    lines.append(sep)
+
     for name, rec in results.items():
-        gt = rec["gt_pairs"]
-        rows = rec["rows"]
-        kind = rec["kind"]
-        lines.append(f"  {name:<30} {kind:<7}  rows={rows:<7}  gt_pairs={gt}")
+        if rec.get("error"):
+            lines.append(
+                f"  {name:<30} {'ERROR':<7}  {rec.get('error', '')}"
+            )
+            continue
+
+        lines.append(
+            f"  {name:<30} {rec['kind']:<7}  {rec['rows']:<7}  "
+            f"{rec['gt_pairs']:<9}  {_fmt_f1(rec['baseline_f1']):<8}  "
+            f"{rec['n_suggestions']:<6}  "
+            f"{_fmt_corr(rec['rank_corr']):<10}  "
+            f"{_fmt_prec(rec['suggester_prec']):<9}  "
+            f"{_fmt_f1(rec['convergence_final_f1']):<8}  "
+            f"{rec['convergence_steps']:<5}"
+        )
+
     for name, reason in skipped.items():
         lines.append(f"  {name:<30} SKIPPED: {reason}")
+
     return "\n".join(lines)
+
+
+def _compute_headline(results: dict[str, dict]) -> float:
+    """Mean rank_correlation across datasets that have >= 2 suggestions."""
+    corrs = [
+        rec["rank_corr"]
+        for rec in results.values()
+        if not math.isnan(rec.get("rank_corr", float("nan")))
+        and rec.get("n_suggestions", 0) >= 2
+    ]
+    if not corrs:
+        return float("nan")
+    return sum(corrs) / len(corrs)
 
 
 # ── main ──────────────────────────────────────────────────────────────────────
@@ -162,8 +233,16 @@ def main(argv: list[str] | None = None) -> int:
         print()
         print(_render_report_table(results, skipped))
         print()
+
+        headline = _compute_headline(results)
+        n_with_gt = sum(1 for r in results.values() if r.get("gt_pairs", 0) > 0)
+        native_ok = any(r.get("native_available", False) for r in results.values())
+
         print(f"  {len(results)} dataset(s) loaded, {len(skipped)} skipped")
-        print("  0 metrics yet (Task 15 wires the oracle and delta-F1 measurement)")
+        print(f"  {n_with_gt} dataset(s) with ground truth (F1 applicable)")
+        if not native_ok:
+            print("  native kernel absent -- suggestions not evaluated (install goldenmatch[native])")
+        print(f"  suggester score (mean rank_corr): {_fmt_corr(headline)}")
         return 0
 
     if args.mode == "bless":
@@ -172,8 +251,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.mode == "gate":
-        print("suggest_quality gate: not implemented until Task 15/16")
-        print("(Task 15 wires the oracle; Task 16 adds the CI gate against the bless'd baseline.)")
+        print("suggest_quality gate: not implemented until Task 16")
+        print("(Task 16 adds the CI gate against the bless'd baseline.)")
         # Exit 0 (never fail) until the gate is implemented.
         return 0
 

--- a/scripts/suggest_quality/cli.py
+++ b/scripts/suggest_quality/cli.py
@@ -246,17 +246,219 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.mode == "bless":
-        print("suggest_quality bless: not implemented until Task 16")
-        print("(Task 16 will wire the oracle, build the scorecard, and commit the baseline.)")
-        return 0
+        return _cmd_bless(results, skipped, native_version, git_sha)
 
     if args.mode == "gate":
-        print("suggest_quality gate: not implemented until Task 16")
-        print("(Task 16 adds the CI gate against the bless'd baseline.)")
-        # Exit 0 (never fail) until the gate is implemented.
-        return 0
+        return _cmd_gate(results, skipped, native_version, git_sha, args.tolerance)
 
     return 0  # unreachable
+
+
+# ── bless ─────────────────────────────────────────────────────────────────────
+
+def _build_scorecard(
+    results: dict[str, dict],
+    skipped: dict[str, str],
+    native_version: str,
+    git_sha: str,
+) -> dict:
+    """Assemble a stable, round-floated scorecard dict.
+
+    Per-dataset record shape (mirrors the oracle output):
+        kind, rows, gt_pairs, baseline_f1, n_suggestions,
+        suggested_order_lifts, convergence_final_f1, convergence_steps,
+        rank_corr, suggester_prec
+
+    Floats are rounded to 6 decimal places so byte-stable re-runs produce
+    the same JSON diff.
+    """
+    import json  # noqa: PLC0415
+
+    _PRECISION = 6
+
+    def _round(v):
+        if isinstance(v, float):
+            if math.isnan(v):
+                return None  # JSON has no NaN; None serializes as null
+            return round(v, _PRECISION)
+        if isinstance(v, dict):
+            return {k: _round(vv) for k, vv in v.items()}
+        if isinstance(v, list):
+            return [_round(x) for x in v]
+        return v
+
+    datasets_out: dict[str, dict] = {}
+    for name, rec in results.items():
+        datasets_out[name] = _round(rec)
+
+    return {
+        "meta": {
+            "native_version": native_version,
+            "git_sha": git_sha,
+            "datasets_run": sorted(results.keys()),
+            "datasets_skipped": skipped,
+        },
+        "datasets": datasets_out,
+    }
+
+
+def _dumps(scorecard: dict) -> str:
+    """Serialize scorecard to a stable, human-readable JSON string."""
+    import json  # noqa: PLC0415
+    return json.dumps(scorecard, indent=2, sort_keys=True)
+
+
+def _loads_baseline() -> dict:
+    """Load the blessed baseline from disk, or return an empty baseline."""
+    if not _BASELINE.exists():
+        return {"datasets": {}, "meta": {}}
+    try:
+        import json  # noqa: PLC0415
+        return json.loads(_BASELINE.read_text(encoding="utf-8"))
+    except Exception:
+        return {"datasets": {}, "meta": {}}
+
+
+def _cmd_bless(
+    results: dict[str, dict],
+    skipped: dict[str, str],
+    native_version: str,
+    git_sha: str,
+) -> int:
+    """Write the current oracle results as the new blessed baseline."""
+    scorecard = _build_scorecard(results, skipped, native_version, git_sha)
+    _BASELINE.parent.mkdir(parents=True, exist_ok=True)
+    _BASELINE.write_text(_dumps(scorecard), encoding="utf-8")
+    print(f"suggest_quality bless: wrote {_BASELINE}")
+    print(f"  {len(results)} dataset(s) blessed, {len(skipped)} skipped")
+    for name, rec in results.items():
+        bf = rec.get("baseline_f1")
+        nc = rec.get("convergence_final_f1")
+        print(
+            f"  {name}: baseline_f1={_fmt_f1(bf if bf is not None else float('nan'))}  "
+            f"conv_f1={_fmt_f1(nc if nc is not None else float('nan'))}  "
+            f"n_sugg={rec.get('n_suggestions', 0)}"
+        )
+    return 0
+
+
+# ── gate ──────────────────────────────────────────────────────────────────────
+
+_GATE_TOLERANCES = {
+    "rank_corr": 0.05,        # Spearman rank correlation
+    "suggester_prec": 0.05,   # fraction of non-regressing suggestions
+    "convergence_final_f1": 0.02,  # greedy-convergence final F1
+}
+
+
+def _cmd_gate(
+    results: dict[str, dict],
+    skipped: dict[str, str],
+    native_version: str,
+    git_sha: str,
+    cli_tolerance: float,
+) -> int:
+    """Compare current oracle results against the blessed baseline.
+
+    Exits 1 if any dataset regresses beyond tolerance on:
+      - rank_corr          (drops > 0.05)
+      - suggester_prec     (drops > 0.05)
+      - convergence_final_f1 (drops > 0.02)
+
+    Datasets absent from the baseline are reported as NEW (informational).
+    Datasets in the baseline but absent from the current run are reported
+    as MISSING (informational, not a gate failure — CI skips real datasets).
+    """
+    baseline = _loads_baseline()
+    base_datasets = baseline.get("datasets", {})
+
+    _COL_W = 32
+    _MET_W = 22
+    _VAL_W = 8
+
+    header = (
+        f"  {'dataset':<{_COL_W}} {'metric':<{_MET_W}} "
+        f"{'baseline':>{_VAL_W}}  {'current':>{_VAL_W}}  {'delta':>8}  status"
+    )
+    sep = "  " + "-" * (len(header) - 2)
+
+    rows: list[tuple[str, str, str, str, str, str]] = []  # (ds, metric, base, cur, delta, status)
+
+    for name, rec in results.items():
+        b = base_datasets.get(name)
+        for metric, tol in _GATE_TOLERANCES.items():
+            cur_raw = rec.get(metric)
+            if cur_raw is None or (isinstance(cur_raw, float) and math.isnan(cur_raw)):
+                continue  # not available this run -> skip
+
+            cur = float(cur_raw)
+
+            if b is None:
+                # New dataset not in baseline
+                rows.append((
+                    name, metric,
+                    "n/a", f"{cur:+.4f}", "  n/a", "NEW",
+                ))
+                continue
+
+            base_raw = b.get(metric)
+            if base_raw is None:
+                rows.append((name, metric, "n/a", f"{cur:+.4f}", "  n/a", "NEW"))
+                continue
+
+            base = float(base_raw) if base_raw is not None else float("nan")
+            if math.isnan(base):
+                rows.append((name, metric, "n/a", f"{cur:+.4f}", "  n/a", "NEW"))
+                continue
+
+            delta = cur - base
+            if delta < -tol:
+                status = "FAIL"
+            else:
+                status = "OK"
+
+            rows.append((
+                name, metric,
+                f"{base:+.4f}", f"{cur:+.4f}", f"{delta:+.4f}", status,
+            ))
+
+    # Datasets in baseline but absent from current run
+    for name in base_datasets:
+        if name not in results:
+            rows.append((name, "*", "present", "absent", "  n/a", "MISSING"))
+
+    # Render table
+    print("suggest_quality gate")
+    print(f"  native={native_version}  sha={git_sha[:12] if git_sha != 'unknown' else 'unknown'}")
+    print(f"  baseline={_BASELINE}")
+    print()
+    print(header)
+    print(sep)
+    for ds, met, base_s, cur_s, delta_s, status in rows:
+        mark = {"FAIL": "x", "OK": ".", "NEW": "+", "MISSING": "~"}.get(status, "?")
+        print(
+            f"  {ds:<{_COL_W}} {met:<{_MET_W}} "
+            f"{base_s:>{_VAL_W}}  {cur_s:>{_VAL_W}}  {delta_s:>8}  {mark} ({status})"
+        )
+    if not rows:
+        print("  (no comparable datasets — baseline may be empty)")
+    print()
+
+    n_fail = sum(1 for *_, s in rows if s == "FAIL")
+    n_ok = sum(1 for *_, s in rows if s == "OK")
+    n_new = sum(1 for *_, s in rows if s == "NEW")
+    n_missing = sum(1 for *_, s in rows if s == "MISSING")
+
+    verdict = "FAIL" if n_fail > 0 else "PASS"
+    print(
+        f"  verdict: {verdict}  "
+        f"({n_ok} ok, {n_fail} fail, {n_new} new, {n_missing} missing, "
+        f"{len(skipped)} skipped)"
+    )
+    if skipped:
+        print("  skipped: " + ", ".join(f"{k} ({v})" for k, v in skipped.items()))
+
+    return 0 if verdict == "PASS" else 1
 
 
 if __name__ == "__main__":

--- a/scripts/suggest_quality/cli.py
+++ b/scripts/suggest_quality/cli.py
@@ -272,8 +272,6 @@ def _build_scorecard(
     Floats are rounded to 6 decimal places so byte-stable re-runs produce
     the same JSON diff.
     """
-    import json  # noqa: PLC0415
-
     _PRECISION = 6
 
     def _round(v):
@@ -360,17 +358,33 @@ def _cmd_gate(
 ) -> int:
     """Compare current oracle results against the blessed baseline.
 
-    Exits 1 if any dataset regresses beyond tolerance on:
-      - rank_corr          (drops > 0.05)
-      - suggester_prec     (drops > 0.05)
-      - convergence_final_f1 (drops > 0.02)
+    Exits 1 if ANY of:
+      - zero datasets actually evaluated this run (gate certifies nothing)
+      - a blessed dataset is MISSING from the current run (the dataset no
+        longer evaluates — a regression that hides as "it didn't run")
+      - any metric regressed beyond tolerance:
+          rank_corr            (drops > 0.05)
+          suggester_prec       (drops > 0.05)
+          convergence_final_f1 (drops > 0.02)
 
-    Datasets absent from the baseline are reported as NEW (informational).
-    Datasets in the baseline but absent from the current run are reported
-    as MISSING (informational, not a gate failure — CI skips real datasets).
+    Datasets absent from the baseline are reported as NEW (informational —
+    a brand-new dataset has no baseline to regress against).
     """
     baseline = _loads_baseline()
     base_datasets = baseline.get("datasets", {})
+
+    # A gate that evaluated nothing must NOT be green: it would mask real
+    # regressions. `results` holds only datasets that produced real metrics
+    # this run (skipped/errored ones land in `skipped`).
+    if not results:
+        print("suggest_quality gate")
+        print(f"  native={native_version}  sha={git_sha[:12] if git_sha != 'unknown' else 'unknown'}")
+        print(f"  baseline={_BASELINE}")
+        print()
+        print("  ERROR: gate evaluated 0 datasets; cannot certify.")
+        if skipped:
+            print("  skipped: " + ", ".join(f"{k} ({v})" for k, v in skipped.items()))
+        return 1
 
     _COL_W = 32
     _MET_W = 22
@@ -422,7 +436,7 @@ def _cmd_gate(
                 f"{base:+.4f}", f"{cur:+.4f}", f"{delta:+.4f}", status,
             ))
 
-    # Datasets in baseline but absent from current run
+    # Datasets in baseline but absent from current run -> gate FAIL.
     for name in base_datasets:
         if name not in results:
             rows.append((name, "*", "present", "absent", "  n/a", "MISSING"))
@@ -435,7 +449,7 @@ def _cmd_gate(
     print(header)
     print(sep)
     for ds, met, base_s, cur_s, delta_s, status in rows:
-        mark = {"FAIL": "x", "OK": ".", "NEW": "+", "MISSING": "~"}.get(status, "?")
+        mark = {"FAIL": "x", "OK": ".", "NEW": "+", "MISSING": "x"}.get(status, "?")
         print(
             f"  {ds:<{_COL_W}} {met:<{_MET_W}} "
             f"{base_s:>{_VAL_W}}  {cur_s:>{_VAL_W}}  {delta_s:>8}  {mark} ({status})"
@@ -449,7 +463,10 @@ def _cmd_gate(
     n_new = sum(1 for *_, s in rows if s == "NEW")
     n_missing = sum(1 for *_, s in rows if s == "MISSING")
 
-    verdict = "FAIL" if n_fail > 0 else "PASS"
+    # A blessed dataset that no longer evaluates is a regression too: a real
+    # break can surface as "the dataset stopped running", not just a metric
+    # drop. NEW datasets stay informational (no baseline to regress against).
+    verdict = "FAIL" if (n_fail > 0 or n_missing > 0) else "PASS"
     print(
         f"  verdict: {verdict}  "
         f"({n_ok} ok, {n_fail} fail, {n_new} new, {n_missing} missing, "

--- a/scripts/suggest_quality/datasets.py
+++ b/scripts/suggest_quality/datasets.py
@@ -1,0 +1,197 @@
+"""Dataset registry: synthetic anchors (always available) + real labeled
+datasets (skip-when-absent).
+
+Each Dataset's loader returns (df, gt_pairs) | None, where gt_pairs is a
+set[(i, j)] in ROW-INDEX space (i<j).  A real loader returns None when its
+data isn't present locally; the harness records it as ``skipped``, never
+crashes.
+
+Mirrors ``scripts.autoconfig_quality.datasets`` exactly — same Dataset
+dataclass, same REGISTRY list structure, same loader signatures — so
+someone who knows autoconfig_quality recognises this immediately.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import polars as pl
+
+# Re-use the shared anchor generators from autoconfig_quality rather than
+# re-implementing them.  The anchors are the same labeled ER shapes.
+from scripts.autoconfig_quality.anchors import crm_df, gen_labeled, make_healthcare_df
+
+
+@dataclass(frozen=True)
+class Dataset:
+    name: str
+    kind: Literal["anchor", "real"]
+    loader: Callable[[], tuple[pl.DataFrame, set] | None]
+    full_scan: bool = False  # True -> oracle ignores --row-cap, runs the whole df
+
+
+def effective_row_cap(dataset: Dataset, cli_row_cap: int | None) -> int | None:
+    """A full_scan dataset ignores the CLI cap (None = no truncation)."""
+    return None if dataset.full_scan else cli_row_cap
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _pairs_to_row_index(
+    df: pl.DataFrame, id_col: str, str_pairs: set[tuple[str, str]]
+) -> set[tuple[int, int]]:
+    """Map id-string pairs to canonical (min, max) row-index pairs.
+
+    Drops pairs whose endpoints are missing from the frame or identical.
+    Imported by tests directly.
+    """
+    pos = {str(v): i for i, v in enumerate(df[id_col].to_list())}
+    out: set[tuple[int, int]] = set()
+    for a, b in str_pairs:
+        ia, ib = pos.get(str(a)), pos.get(str(b))
+        if ia is not None and ib is not None and ia != ib:
+            out.add((min(ia, ib), max(ia, ib)))
+    return out
+
+
+# ── anchors (always available, deterministic) ──────────────────────────────────
+
+def _sparse_zip() -> tuple[pl.DataFrame, set]:
+    # n=30k is the scale where the zip5 sampling-artifact + blocking-coupling
+    # regression manifests (zips saturate to ~0.32 cardinality). No true dups
+    # -> blocking-shape anchor, F1 not applicable (gt is empty).
+    df = make_healthcare_df(30_000, seed=715, zip_present=0.5).drop("matching_id")
+    return df, set()
+
+
+def _shared_email() -> tuple[pl.DataFrame, set]:
+    return crm_df(), set()  # config-shape anchor (demote-phone / keep-shared-email)
+
+
+def _person() -> tuple[pl.DataFrame, set]:
+    return gen_labeled(n_entities=400, seed=7)  # has row-index ground truth
+
+
+# ── synthetic (always available) ──────────────────────────────────────────────
+
+def _synthetic() -> tuple[pl.DataFrame, set]:
+    """Small synthetic person dataset (PII-free, committable, runs in CI).
+
+    Uses the same gen_labeled generator as the anchor but with a different
+    seed and entity count so it's a distinct dataset in the registry.
+    """
+    return gen_labeled(n_entities=200, seed=42)
+
+
+# ── real labeled datasets (skip-when-absent) ────────────────────────────────
+
+_DATASETS_ROOT = (
+    Path(__file__).resolve().parents[2]
+    / "packages/python/goldenmatch/tests/benchmarks/datasets"
+)
+
+
+def _febrl3() -> tuple[pl.DataFrame, set] | None:
+    """FEBRL3 (recordlinkage-bundled). rec_id-pair truth -> row-index via df['id'].
+    Returns None when recordlinkage isn't installed (skip-when-absent)."""
+    from scripts.dqbench_adapters.febrl3 import load_febrl3_df_and_gt
+    loaded = load_febrl3_df_and_gt()
+    if loaded is None:
+        return None
+    df, rec_pairs = loaded
+    return df, _pairs_to_row_index(df, "id", rec_pairs)
+
+
+_NCVR_REAL_PATH = _DATASETS_ROOT / "NCVR" / "ncvoter_sample_10k.txt"
+
+
+def _ncvr_synthetic() -> tuple[pl.DataFrame, set]:
+    """PII-free NCVR-shaped corpus (seed 42, committable, runs in CI). Its F1 is its
+    OWN baseline, never the real-data number."""
+    from scripts.dqbench_adapters.ncvr import build_ncvr_synthetic_df_and_gt
+    df, ncid_pairs = build_ncvr_synthetic_df_and_gt(seed=42)
+    return df, _pairs_to_row_index(df, "ncid", ncid_pairs)
+
+
+def _ncvr_real() -> tuple[pl.DataFrame, set] | None:
+    """Real NCVR sample (gitignored PII, local-only). None when the file is absent."""
+    from scripts.dqbench_adapters.ncvr import build_ncvr_df_and_gt
+    loaded = build_ncvr_df_and_gt(_NCVR_REAL_PATH, seed=42)
+    if loaded is None:
+        return None
+    df, ncid_pairs = loaded
+    return df, _pairs_to_row_index(df, "ncid", ncid_pairs)
+
+
+_VENDORED = Path(__file__).resolve().parent / "vendored"
+
+
+def _historical_50k() -> tuple[pl.DataFrame, set] | None:
+    """Splink historical_50k from the committed parquet (vendored from
+    autoconfig_quality's vendored/ dir). Returns None when the parquet is absent."""
+    # Prefer a local copy in suggest_quality/vendored/; fall back to the one
+    # vendored by autoconfig_quality so we don't duplicate the 10 MB file.
+    _aq_vendored = (
+        Path(__file__).resolve().parents[1]
+        / "autoconfig_quality" / "vendored" / "historical_50k.parquet"
+    )
+    p = _VENDORED / "historical_50k.parquet"
+    if not p.exists():
+        p = _aq_vendored
+    if not p.exists():
+        return None
+    df = pl.read_parquet(p)
+    clusters = df["cluster"].to_list()
+    by_cluster: dict[object, list[int]] = {}
+    for row, cid in enumerate(clusters):
+        by_cluster.setdefault(cid, []).append(row)
+    gt: set[tuple[int, int]] = set()
+    for members in by_cluster.values():
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                gt.add((members[i], members[j]))
+    match_df = df.drop([c for c in ("cluster", "unique_id") if c in df.columns])
+    return match_df, gt
+
+
+def _dblp_acm() -> tuple[pl.DataFrame, set] | None:
+    """DBLP-ACM bibliographic record-linkage. Concatenate the two tables, build
+    row-index GT from the perfect mapping. Returns None when the data is absent."""
+    d = _DATASETS_ROOT / "DBLP-ACM"
+    dblp_p, acm_p = d / "DBLP2.csv", d / "ACM.csv"
+    map_p = d / "DBLP-ACM_perfectMapping.csv"
+    if not (dblp_p.exists() and acm_p.exists() and map_p.exists()):
+        return None
+    try:
+        dblp = pl.read_csv(dblp_p, encoding="utf8-lossy", ignore_errors=True)
+        acm = pl.read_csv(acm_p, encoding="utf8-lossy", ignore_errors=True)
+        mapping = pl.read_csv(map_p, encoding="utf8-lossy", ignore_errors=True)
+        df = pl.concat([dblp, acm], how="diagonal_relaxed")
+        cols = mapping.columns  # standard headers: idDBLP, idACM
+        a_col, b_col = cols[0], cols[1]
+        str_pairs = {
+            (str(a), str(b))
+            for a, b in zip(mapping[a_col].to_list(), mapping[b_col].to_list())
+        }
+        return df, _pairs_to_row_index(df, "id", str_pairs)
+    except Exception:
+        return None  # any malformed piece -> skip, never crash the run
+
+
+REGISTRY: list[Dataset] = [
+    # Anchors — always load, deterministic, fast.
+    Dataset("anchor_sparse_zip",   "anchor", _sparse_zip),
+    Dataset("anchor_shared_email", "anchor", _shared_email),
+    Dataset("anchor_person_match", "anchor", _person),
+    # Synthetic — always load, committable, CI-safe.
+    Dataset("synthetic",           "real",   _synthetic),
+    # Real labeled datasets — skip-when-absent.
+    Dataset("dblp_acm",            "real",   _dblp_acm),
+    Dataset("febrl3",              "real",   _febrl3),
+    Dataset("ncvr_synthetic",      "real",   _ncvr_synthetic),
+    Dataset("ncvr_real",           "real",   _ncvr_real),
+    Dataset("historical_50k",      "real",   _historical_50k, full_scan=True),
+    # Future: add new labeled datasets with the same skip-when-absent pattern.
+]

--- a/scripts/suggest_quality/metrics.py
+++ b/scripts/suggest_quality/metrics.py
@@ -1,0 +1,86 @@
+"""Pure-function suggester quality metrics.
+
+Sign convention for rank_correlation
+-------------------------------------
+Spearman correlation between rank position (0-indexed, ascending) and the
+NEGATED lifts, so that "highest-lift suggestion ranked first" = +1.0.
+
+Equivalently: rank position 0 should have the LARGEST lift. If the suggester is
+perfect (lifts descending), rank position 0 has the largest lift, correlation
+between positions and (-lifts) is +1.0. If the suggester ranks worst first
+(lifts ascending), correlation is -1.0. A random suggester gives ~0.
+
+Edge cases:
+- 0 suggestions  -> float('nan')
+- 1 suggestion   -> float('nan')  (Spearman is undefined for n=1)
+- all lifts tied -> float('nan')  (scipy returns nan on zero-variance input)
+"""
+from __future__ import annotations
+
+import math
+
+
+def rank_correlation(suggested_order_lifts: list[float]) -> float:
+    """Spearman rank correlation between suggester rank and measured F1 lift.
+
+    Convention: "best-suggestion-first" => +1.0, "worst-first" => -1.0.
+
+    Args:
+        suggested_order_lifts: Measured F1 lifts in the order the suggester
+            ranked them (index 0 = top-ranked suggestion).
+
+    Returns:
+        Spearman rho in [-1, 1], or float('nan') when undefined (n < 2).
+    """
+    n = len(suggested_order_lifts)
+    if n < 2:
+        return float("nan")
+
+    from scipy.stats import spearmanr  # noqa: PLC0415
+
+    ranks = list(range(n))                        # [0, 1, 2, ...] ascending
+    neg_lifts = [-x for x in suggested_order_lifts]
+
+    result = spearmanr(ranks, neg_lifts)
+    # scipy < 1.9 returns a named tuple; >= 1.9 returns SpearmanrResult
+    rho = float(result.statistic if hasattr(result, "statistic") else result[0])
+    if math.isnan(rho):
+        return float("nan")
+    return rho
+
+
+def suggester_precision(lifts: list[float]) -> float:
+    """Fraction of suggestions with lift >= 0 (i.e. do not regress F1).
+
+    A lift of exactly 0.0 counts as "not harmful" (no regression).
+
+    Args:
+        lifts: Measured F1 lift per suggestion (any order).
+
+    Returns:
+        Value in [0, 1].  Returns 1.0 for an empty list (vacuously true).
+    """
+    if not lifts:
+        return 1.0
+    non_negative = sum(1 for x in lifts if x >= 0.0)
+    return non_negative / len(lifts)
+
+
+def convergence(steps: list[tuple[str, float]]) -> dict:
+    """Summarize a greedy-convergence trail.
+
+    Args:
+        steps: List of (suggestion_id, f1_after_applying_it) in application
+            order.  May be empty (no suggestion had positive lift).
+
+    Returns:
+        dict with keys:
+            final_f1 (float):  F1 after the last step, or 0.0 if empty.
+            steps (int):       Number of greedy steps taken.
+            improved (bool):   True iff at least one step was taken.
+    """
+    return {
+        "final_f1": steps[-1][1] if steps else 0.0,
+        "steps": len(steps),
+        "improved": len(steps) > 0,
+    }

--- a/scripts/suggest_quality/oracle.py
+++ b/scripts/suggest_quality/oracle.py
@@ -1,0 +1,281 @@
+"""Oracle enumeration: measure the true F1 lift of every emitted suggestion.
+
+``evaluate_dataset(name, df, gt_pairs)`` is the core loop:
+
+1. Baseline: auto-configure the df (rerank disabled), run it, expand clusters
+   to predicted pairs, compute baseline F1 via evaluate_pairs.
+2. Suggestions: review_config(df, baseline_config) -> ranked list[Suggestion].
+3. Oracle: for each suggestion, apply it, re-run, compute F1, record lift.
+4. Convergence: greedily apply top suggestion, re-run, repeat up to STEP_CAP
+   or until no suggestion has positive measured lift.
+5. Return a per-dataset record dict.
+
+Predicted pairs derivation
+--------------------------
+Reuses ``evaluate_clusters`` from ``goldenmatch.core.evaluate``, which expands
+each multi-member cluster into all (min, max) member pairs and calls
+``evaluate_pairs`` internally.  This is the canonical approach used by existing
+benchmarks in the codebase.
+"""
+from __future__ import annotations
+
+import copy
+import logging
+import math
+from itertools import combinations
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Greedy convergence step cap
+_CONVERGENCE_STEP_CAP = 5
+
+
+def _auto_configure_no_rerank(df: pl.DataFrame):
+    """Auto-configure df with rerank disabled on all matchkeys.
+
+    Returns a GoldenMatchConfig.  Never raises ControllerNotConfidentError --
+    falls back to allow_red_config=True so CI-scale anchors always produce a
+    config.
+    """
+    from goldenmatch.core.autoconfig import auto_configure_df  # noqa: PLC0415
+
+    try:
+        config = auto_configure_df(df, confidence_required=False)
+    except Exception:
+        # Ultra-fallback: allow any config including RED
+        config = auto_configure_df(df, confidence_required=False, allow_red_config=True)
+
+    # Disable rerank to avoid HuggingFace model downloads in offline/CI env
+    try:
+        for mk in config.get_matchkeys():
+            if getattr(mk, "rerank", False):
+                mk.rerank = False
+    except Exception:
+        logger.debug("_auto_configure_no_rerank: failed to disable rerank", exc_info=True)
+
+    return config
+
+
+def _run_config(df: pl.DataFrame, config) -> tuple[dict, list]:
+    """Run the pipeline for a given config; return (clusters, scored_pairs).
+
+    Uses MatchEngine._run_pipeline (same path as review_config).
+    """
+    import copy as _copy  # noqa: PLC0415
+
+    from goldenmatch.tui.engine import MatchEngine  # noqa: PLC0415
+
+    _config = _copy.deepcopy(config)
+    # Disable rerank to be safe
+    try:
+        for mk in _config.get_matchkeys():
+            if getattr(mk, "rerank", False):
+                mk.rerank = False
+    except Exception:
+        pass
+
+    engine = MatchEngine.from_dataframe(df)
+    result = engine._run_pipeline(df, _config)
+    return result.clusters, result.scored_pairs
+
+
+def _clusters_to_predicted_pairs(
+    clusters: dict,
+    scored_pairs: list[tuple[int, int, float]],
+) -> list[tuple[int, int, float]]:
+    """Expand multi-member clusters to pairwise predicted pairs.
+
+    Reuses the same approach as ``evaluate_clusters``:
+    for each multi-member cluster, emit all (min(a,b), max(a,b), 1.0) pairs.
+
+    We ignore ``scored_pairs`` directly because cluster membership (post-WCC)
+    is the canonical output -- just like the existing evaluate_clusters.
+    """
+    predicted: list[tuple[int, int, float]] = []
+    for _cid, info in clusters.items():
+        members = info.get("members", [])
+        if len(members) < 2:
+            continue
+        for a, b in combinations(sorted(members), 2):
+            predicted.append((a, b, 1.0))
+    return predicted
+
+
+def _compute_f1(
+    clusters: dict,
+    scored_pairs: list,
+    gt_pairs: set,
+) -> float:
+    """Derive F1 from cluster output vs ground truth pairs.
+
+    When gt_pairs is empty the dataset is a blocking-shape anchor (no truth),
+    so F1 is reported as NaN (not applicable).
+    """
+    if not gt_pairs:
+        return float("nan")
+
+    from goldenmatch.core.evaluate import evaluate_pairs  # noqa: PLC0415
+
+    predicted = _clusters_to_predicted_pairs(clusters, scored_pairs)
+    result = evaluate_pairs(predicted, gt_pairs)
+    return result.f1
+
+
+def evaluate_dataset(
+    name: str,
+    df: pl.DataFrame,
+    gt_pairs: set,
+    *,
+    row_cap: int | None = None,
+) -> dict:
+    """Run the oracle loop for one dataset; return a metrics record.
+
+    Args:
+        name: Dataset name (used as a key in the record).
+        df: The labeled DataFrame.
+        gt_pairs: Ground truth as canonical (min, max) row-index pairs.
+        row_cap: If given, truncate df to this many rows before running.
+
+    Returns:
+        dict with keys:
+            name (str)
+            rows (int)
+            gt_pairs (int)
+            baseline_f1 (float)
+            n_suggestions (int)
+            suggested_order_lifts (list[float])
+            convergence_final_f1 (float)
+            convergence_steps (int)
+            native_available (bool)
+            error (str | None)
+    """
+    # Row cap
+    if row_cap is not None and df.height > row_cap:
+        df = df.head(row_cap)
+        # Rebuild gt_pairs to only include pairs within the cap
+        n = df.height
+        gt_pairs = {(a, b) for a, b in gt_pairs if a < n and b < n}
+
+    record: dict = {
+        "name": name,
+        "rows": df.height,
+        "gt_pairs": len(gt_pairs),
+        "baseline_f1": float("nan"),
+        "n_suggestions": 0,
+        "suggested_order_lifts": [],
+        "convergence_final_f1": float("nan"),
+        "convergence_steps": 0,
+        "native_available": False,
+        "error": None,
+    }
+
+    # Ensure __row_id__ is present (needed by collision_rates in review_config)
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
+
+    try:
+        # ── Step 1: Baseline ──────────────────────────────────────────────────
+        baseline_config = _auto_configure_no_rerank(df)
+        baseline_clusters, baseline_scored_pairs = _run_config(df, baseline_config)
+        baseline_f1 = _compute_f1(baseline_clusters, baseline_scored_pairs, gt_pairs)
+        record["baseline_f1"] = baseline_f1
+
+        # ── Step 2: Suggestions ───────────────────────────────────────────────
+        try:
+            from goldenmatch.core.suggest import SuggestionsNativeRequired, review_config  # noqa: PLC0415
+
+            suggestions = review_config(df, baseline_config)
+            record["native_available"] = True
+        except SuggestionsNativeRequired:
+            record["native_available"] = False
+            record["n_suggestions"] = 0
+            record["suggested_order_lifts"] = []
+            record["convergence_final_f1"] = baseline_f1
+            record["convergence_steps"] = 0
+            return record
+        except Exception as e:
+            record["error"] = f"review_config failed: {e}"
+            record["convergence_final_f1"] = baseline_f1
+            return record
+
+        record["n_suggestions"] = len(suggestions)
+
+        # ── Step 3: Oracle (true lift per suggestion) ─────────────────────────
+        lifts: list[float] = []
+        for suggestion in suggestions:
+            try:
+                from goldenmatch.core.suggest import apply_suggestion  # noqa: PLC0415
+
+                cfg2 = apply_suggestion(baseline_config, suggestion)
+                clusters2, scored2 = _run_config(df, cfg2)
+                f1_after = _compute_f1(clusters2, scored2, gt_pairs)
+                lift = (
+                    f1_after - baseline_f1
+                    if not (math.isnan(f1_after) or math.isnan(baseline_f1))
+                    else float("nan")
+                )
+                lifts.append(lift)
+            except Exception as exc:
+                logger.debug(
+                    "oracle: suggestion %r failed: %s", suggestion.id, exc, exc_info=True
+                )
+                lifts.append(float("nan"))
+
+        record["suggested_order_lifts"] = lifts
+
+        # ── Step 4: Convergence ───────────────────────────────────────────────
+        convergence_steps: list[tuple[str, float]] = []
+        current_config = copy.deepcopy(baseline_config)
+        current_f1 = baseline_f1
+
+        for _step in range(_CONVERGENCE_STEP_CAP):
+            # Re-run suggestions on current config
+            try:
+                step_suggestions = review_config(df, current_config)
+            except Exception:
+                break
+
+            if not step_suggestions:
+                break
+
+            # Pick the top suggestion; measure its lift
+            top = step_suggestions[0]
+            try:
+                cfg_next = apply_suggestion(current_config, top)
+                clusters_next, scored_next = _run_config(df, cfg_next)
+                f1_next = _compute_f1(clusters_next, scored_next, gt_pairs)
+            except Exception as exc:
+                logger.debug("convergence step failed: %s", exc, exc_info=True)
+                break
+
+            measured_lift = (
+                f1_next - current_f1
+                if not (math.isnan(f1_next) or math.isnan(current_f1))
+                else float("nan")
+            )
+
+            if math.isnan(measured_lift) or measured_lift <= 0:
+                break  # No positive lift; stop
+
+            convergence_steps.append((top.id, f1_next))
+            current_config = cfg_next
+            current_f1 = f1_next
+
+        record["convergence_steps"] = len(convergence_steps)
+        record["convergence_final_f1"] = (
+            convergence_steps[-1][1] if convergence_steps else baseline_f1
+        )
+
+    except Exception as exc:
+        record["error"] = str(exc)
+        logger.warning("evaluate_dataset(%s) failed: %s", name, exc, exc_info=True)
+
+    return record

--- a/scripts/suggest_quality/oracle.py
+++ b/scripts/suggest_quality/oracle.py
@@ -23,12 +23,8 @@ import copy
 import logging
 import math
 from itertools import combinations
-from typing import TYPE_CHECKING
 
 import polars as pl
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +43,8 @@ def _auto_configure_no_rerank(df: pl.DataFrame):
 
     try:
         config = auto_configure_df(df, confidence_required=False)
-    except Exception:
+    except Exception as exc:
+        logger.debug("auto_configure_df first attempt failed: %s", exc, exc_info=True)
         # Ultra-fallback: allow any config including RED
         config = auto_configure_df(df, confidence_required=False, allow_red_config=True)
 
@@ -67,11 +64,9 @@ def _run_config(df: pl.DataFrame, config) -> tuple[dict, list]:
 
     Uses MatchEngine._run_pipeline (same path as review_config).
     """
-    import copy as _copy  # noqa: PLC0415
-
     from goldenmatch.tui.engine import MatchEngine  # noqa: PLC0415
 
-    _config = _copy.deepcopy(config)
+    _config = copy.deepcopy(config)
     # Disable rerank to be safe
     try:
         for mk in _config.get_matchkeys():
@@ -233,6 +228,7 @@ def evaluate_dataset(
 
         # ── Step 4: Convergence ───────────────────────────────────────────────
         convergence_steps: list[tuple[str, float]] = []
+        applied_ids: set[str] = set()
         current_config = copy.deepcopy(baseline_config)
         current_f1 = baseline_f1
 
@@ -248,6 +244,11 @@ def evaluate_dataset(
 
             # Pick the top suggestion; measure its lift
             top = step_suggestions[0]
+            # Guard against cycling: if the kernel keeps emitting the same
+            # patch (e.g. an idempotent no-op), stop rather than burn steps.
+            if top.id in applied_ids:
+                break
+            applied_ids.add(top.id)
             try:
                 cfg_next = apply_suggestion(current_config, top)
                 clusters_next, scored_next = _run_config(df, cfg_next)

--- a/scripts/suggest_quality/tests/test_datasets.py
+++ b/scripts/suggest_quality/tests/test_datasets.py
@@ -1,0 +1,64 @@
+"""Smoke tests for the suggest_quality dataset registry.
+
+Mirrors ``scripts.autoconfig_quality.tests.test_datasets`` — same assertions,
+adapted for the suggest_quality registry and the extra ``synthetic`` entry.
+"""
+import polars as pl
+import pytest
+
+from scripts.suggest_quality.datasets import REGISTRY, Dataset, _pairs_to_row_index
+
+
+def test_registry_is_non_empty():
+    assert len(REGISTRY) >= 1
+
+
+def test_anchors_always_load():
+    by_name = {d.name: d for d in REGISTRY}
+    for n in ("anchor_sparse_zip", "anchor_shared_email", "anchor_person_match"):
+        d = by_name[n]
+        assert isinstance(d, Dataset)
+        assert d.kind == "anchor"
+        loaded = d.loader()
+        assert loaded is not None
+        df, gt = loaded
+        assert df.height > 0
+
+
+def test_synthetic_always_loads():
+    by_name = {d.name: d for d in REGISTRY}
+    d = by_name["synthetic"]
+    assert d.kind == "real"
+    loaded = d.loader()
+    assert loaded is not None
+    df, gt = loaded
+    assert df.height > 0
+    assert len(gt) > 0  # gen_labeled produces GT
+
+
+def test_person_anchor_has_gt_others_empty():
+    by_name = {d.name: d for d in REGISTRY}
+    _, gt = by_name["anchor_person_match"].loader()
+    assert len(gt) > 0
+    _, gt2 = by_name["anchor_sparse_zip"].loader()
+    assert gt2 == set()
+
+
+def test_real_loader_skips_when_absent():
+    by_name = {d.name: d for d in REGISTRY}
+    dblp = by_name["dblp_acm"]
+    assert dblp.kind == "real"
+    res = dblp.loader()
+    assert res is None or (isinstance(res, tuple) and len(res) == 2)
+
+
+def test_pairs_to_row_index_maps_and_canonicalizes():
+    df = pl.DataFrame({"id": ["a", "b", "c"]})
+    gt = _pairs_to_row_index(df, "id", {("c", "a"), ("b", "b"), ("x", "a")})
+    assert gt == {(0, 2)}
+
+
+def test_historical_50k_registered_full_scan():
+    by_name = {d.name: d for d in REGISTRY}
+    h = by_name["historical_50k"]
+    assert h.full_scan is True


### PR DESCRIPTION
## Summary

A config-suggestion engine for GoldenMatch: zero-config first, then the system reviews a run's results against the config that produced them and proposes **ranked, explainable** config edits. Built as a pyo3-free native kernel so every language surface can share one source of truth.

- **`goldenmatch-suggest-core`** (new Rust crate, pyo3-free, Arrow-in): diagnostics reductions (reuses `analysis-core` histogram) + 3 rules (threshold tune / scorer swap / add negative-evidence) + priors suppression + ranking + in-kernel rationale text. 29 tests + golden vectors.
- **`goldenmatch._native.suggest_config`** pyo3 shim (thin `PyArrowType<RecordBatch>` delegation, mirrors `score.rs`).
- **`goldenmatch.core.suggest`** Python adapter: `review_config(df, config)` (runs the pipeline + kernel), `apply_suggestion`, `SuggestionsNativeRequired` degradation. Suggestions are a `goldenmatch[native]` feature.
- **`scripts/suggest_quality`** oracle benchmark: per-dataset baseline F1 → kernel suggestions → measured per-suggestion F1 lift → Spearman rank-correlation + suggester-precision + convergence metrics; `report` / `bless` / `gate` CLI + `bench-suggest-quality.yml` CI gate (builds native, asserts the symbol, gates vs committed baseline).

## Self-verification (no net-negative suggestions)

The benchmark immediately exposed that emitting kernel suggestions *blind* could lower F1 (on `ncvr_synthetic`, baseline already 0.983, two emitted suggestions both hurt → `suggester_precision = 0.0`). Fix: **`review_config` self-verifies** — it simulates each candidate (apply → re-run) and keeps it only if an **unsupervised** config-health proxy (`matched_rate * avg_confidence − Herfindahl concentration penalty`; no ground truth) doesn't worsen.

Result (`suggester_precision = 1.0` across all benchmark datasets):
- `anchor_person_match`: emits a suggestion that lifts F1 **0.9896 → 1.0**
- `ncvr_synthetic` / `synthetic`: already near-optimal under zero-config → correctly emits **nothing**
- the NCVR address scorer-swap still survives verify

"Don't emit net-negative" is now a structural property, not per-rule tuning.

## Honest posture (what this is / isn't)

- **Default-off / opt-in.** No pipeline path calls `review_config`; it's reached via `from goldenmatch.core.suggest import review_config`. Surfaces (CLI/MCP/TUI), accept/reject persistence, and the default-on flip are **Plan 2**.
- **Finding:** zero-config already applies the noise-aware `token_sort→jaro_winkler` swap (#662), so Rule 2's headline NCVR win is largely *pre-captured* by zero-config — the suggester's value shows on suboptimal/manual configs. The rules are still simple; the benchmark is the tool to iterate them. v1 makes the suggester **safe**, not yet **optimal**.

Spec + addendum: `docs/superpowers/specs/2026-06-24-config-suggestion-kernel-design.md`. Plan: `docs/superpowers/plans/2026-06-24-config-suggestion-kernel-plan-1.md`.

## Test plan

- [x] Rust kernel: `cargo test -p goldenmatch-suggest-core` → 29 passed + golden vectors
- [x] Python suggest suite (adapter/apply/verify/anchors/metrics/oracle): 67 passed, 1 skipped (real-NCVR anchor, dataset gitignored)
- [x] `suggest_quality gate` → PASS (9 ok / 0 fail) vs committed baseline; gate fails on zero-eval / missing-blessed / regression
- [x] ruff clean; native wheel builds + `suggest_config` symbol present
- [ ] CI green on the branch (merge queue runs native + python lanes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wz94wngiSXtkxzBPKzqyUy
