### PR TITLE
feat(er-kg-bench): synthesis-model override (test the SYNTHESIS-is-the-bottleneck hypothesis)

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -66,6 +66,9 @@ on:
       literal_attrs:
         description: "goldengraph only: capture literal attribute values (dates/quantities/amounts) as typed leaf nodes so the graph can answer non-entity questions"
         default: "false"
+      synth_model:
+        description: "goldengraph only: model for the answer-time synthesis call ONLY (build stays on --model); blank = same as build. Tests the SYNTHESIS-is-the-bottleneck hypothesis, e.g. gpt-4o"
+        default: ""
       judge:
         description: "ALL engines: also score a format-fair LLM-judge answer-equivalence metric (fixed gpt-4o-mini judge) so terse vs verbose answers compare fairly"
         default: "true"
@@ -137,6 +140,7 @@ jobs:
           GOLDENGRAPH_BUILD_DEBUG: ${{ inputs.build_debug }}
           GOLDENGRAPH_EXTRACTOR: ${{ inputs.extractor }}
           GOLDENGRAPH_LITERAL_ATTRS: ${{ inputs.literal_attrs }}
+          GOLDENGRAPH_SYNTH_MODEL: ${{ inputs.synth_model }}
           GOLDENGRAPH_QA_RETRIEVAL_HOPS: ${{ inputs.retrieval_hops }}
           GOLDENGRAPH_QA_NODE_BUDGET: ${{ inputs.retrieval_node_budget }}
           GOLDENGRAPH_DISTILL_LOG: ${{ inputs.distill_log == 'true' && format('results/distill_goldengraph_amb{0}.jsonl', matrix.ambiguity) || '' }}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -140,6 +140,20 @@ class GoldenGraphQAEngine:
             node_budget if node_budget is not None
             else int(os.environ.get("GOLDENGRAPH_QA_NODE_BUDGET", "256"))
         )
+        # Synthesis-model override (GOLDENGRAPH_SYNTH_MODEL): the trace shows the
+        # answer edge is usually IN the retrieved ball (SYNTHESIS is the dominant
+        # loss) -- i.e. the bottleneck is the multi-hop REASONING at answer time, not
+        # retrieval. This lets a run use a STRONGER model for the answer-time `ask()`
+        # call ONLY, while the build stays on the (cheap, high-volume) base model.
+        # Empty -> reuse the base llm (byte-identical to before). The synth model's
+        # tokens are charged to the engine (returned as the answer's token usage).
+        synth_model = os.environ.get("GOLDENGRAPH_SYNTH_MODEL", "").strip()
+        if synth_model:
+            from goldengraph.llm import OpenAIClient
+
+            self._synth_llm = _CountingLLM(OpenAIClient(model=synth_model))
+        else:
+            self._synth_llm = self._llm
 
     def build_kg(self, corpus) -> BuildResult:
         from goldengraph.ingest import ingest_corpus
@@ -172,11 +186,13 @@ class GoldenGraphQAEngine:
         from goldengraph.answer import ask
 
         t0 = time.perf_counter()
-        before_in, before_out = self._llm.input_tokens, self._llm.output_tokens
+        # Meter the SYNTH llm (== base llm unless GOLDENGRAPH_SYNTH_MODEL is set), so
+        # the answer's reported token usage reflects whichever model did the reasoning.
+        before_in, before_out = self._synth_llm.input_tokens, self._synth_llm.output_tokens
         text = ask(
             question,
             handle["store"],
-            llm=self._llm,
+            llm=self._synth_llm,
             embedder=self._embedder,
             valid_t=handle["valid_t"],
             tx_t=handle["tx_t"],
@@ -196,8 +212,8 @@ class GoldenGraphQAEngine:
             # to corpus ids (MuSiQue '<qid>::p<idx>'); that is a goldengraph API
             # change, tracked as a follow-up rather than forced here.
             retrieved_fact_ids=(),
-            input_tokens=self._llm.input_tokens - before_in,
-            output_tokens=self._llm.output_tokens - before_out,
+            input_tokens=self._synth_llm.input_tokens - before_in,
+            output_tokens=self._synth_llm.output_tokens - before_out,
             latency_s=time.perf_counter() - t0,
         )
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_synth_model.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_synth_model.py
@@ -1,0 +1,59 @@
+"""Synthesis-model override (GOLDENGRAPH_SYNTH_MODEL) on the QA engine adapter.
+
+The trace shows SYNTHESIS is the dominant loss bucket -- the answer edge is in the
+retrieved ball but the answer-time reasoning fails. This override lets a run use a
+stronger model for the `ask()` synthesis call ONLY while the build stays on the
+base model. These tests pin the wiring (no native, no real LLM)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+pytest.importorskip("goldengraph")
+
+from erkgbench.qa_e2e.engines.goldengraph import GoldenGraphQAEngine  # noqa: E402
+
+
+class _StubLLM:
+    def complete(self, prompt):  # pragma: no cover - never called in __init__
+        return ""
+
+
+class _StubEmbedder:
+    def embed(self, texts):  # pragma: no cover - never called in __init__
+        return []
+
+
+def test_synth_llm_reuses_base_when_unset(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_MODEL", raising=False)
+    eng = GoldenGraphQAEngine(llm=_StubLLM(), embedder=_StubEmbedder())
+    # byte-identical to before: the synthesis call uses the very same wrapped llm.
+    assert eng._synth_llm is eng._llm
+
+
+def test_synth_llm_builds_separate_client_when_set(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_MODEL", "gpt-4o")
+    captured = {}
+
+    class _FakeOpenAIClient:
+        def __init__(self, *, model):
+            captured["model"] = model
+
+        def complete(self, prompt):  # pragma: no cover
+            return ""
+
+    # Patch the symbol the adapter imports inside __init__.
+    import goldengraph.llm as gllm
+
+    monkeypatch.setattr(gllm, "OpenAIClient", _FakeOpenAIClient, raising=False)
+
+    eng = GoldenGraphQAEngine(llm=_StubLLM(), embedder=_StubEmbedder())
+    assert eng._synth_llm is not eng._llm  # a distinct client
+    assert captured["model"] == "gpt-4o"  # built with the override model


### PR DESCRIPTION
## Why

Four levers measured (literals, synthesis-prompt A+B, cross-doc linking, budget) — **none moved the headline judge off ~0.26–0.34.** The trace says why: **SYNTHESIS is ~50% of the loss and the answer edge is usually already in the retrieved ball.** Every graph-quality lever puts more answers *into* the ball and synthesis fails to use them; the A+B prompt levers regressed. The bottleneck is the answer-time multi-hop **reasoning**, and the one untested variable is the **synthesis model** — everything runs on `gpt-4o-mini`.

## What

`GOLDENGRAPH_SYNTH_MODEL` override (bench adapter): a run can use a stronger model for the `ask()` synthesis call **only**, while the high-volume build stays on the base model. Blank = reuse the base llm (byte-identical). The synth model's tokens are metered + charged to the engine's answer usage. Exposed as a `bench-graphrag-qa` workflow input.

## Validation
- 2 offline tests (reuse base when unset; build a separate client at the override model when set). Green.

## The experiment (dispatched)
`synth_model=gpt-4o`, `literal_attrs=true`, traced, N=50 — vs the `gpt-4o-mini` baseline (`28121496629`, judge 0.34). **If reasoning is the ceiling, judge moves; if not, the ceiling is retrieval precision** and we'll know to stop chasing it. This is a bench-experiment vehicle; a clean win would graft `synth_model` into goldengraph's `ask()` as a product param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_