### PR TITLE
feat(er-kg-bench): text-RAG no-KG baseline + full 5-engine head-to-head

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -66,6 +66,12 @@ on:
       retrieval_node_budget:
         description: "goldengraph only: max entities in the answer ball (RETRIEVAL-BUDGET sweep; bigger = more reach + cost)"
         default: "256"
+      goldengraph_qa_mode:
+        description: "goldengraph only: answer retrieval mode -- local (entity-graph BFS) | hybrid (BFS + goldenmatch passage retrieval fed to synthesis)"
+        default: "local"
+      goldengraph_passage_k:
+        description: "goldengraph hybrid only: raw passages retrieved per question (matches text_rag/goldenmatch_rag context budget)"
+        default: "10"
       distill_log:
         description: "goldengraph only: capture (text->extraction)+(entity->fingerprint) pairs to a JSONL artifact for in-house distillation"
         default: "false"
@@ -145,6 +151,8 @@ jobs:
           GOLDENGRAPH_LITERAL_ATTRS: ${{ inputs.literal_attrs }}
           GOLDENGRAPH_QA_RETRIEVAL_HOPS: ${{ inputs.retrieval_hops }}
           GOLDENGRAPH_QA_NODE_BUDGET: ${{ inputs.retrieval_node_budget }}
+          GOLDENGRAPH_QA_MODE: ${{ inputs.goldengraph_qa_mode }}
+          GOLDENGRAPH_QA_PASSAGE_K: ${{ inputs.goldengraph_passage_k }}
           GOLDENGRAPH_DISTILL_LOG: ${{ inputs.distill_log == 'true' && format('results/distill_goldengraph_amb{0}.jsonl', matrix.ambiguity) || '' }}
         run: |
           mkdir -p results

--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -20,8 +20,11 @@ on:
         description: "hard cost cap per (engine, ambiguity) run"
         default: "25"
       engine:
-        description: "all | goldengraph | lightrag | ms_graphrag | graphiti"
+        description: "all | goldengraph | lightrag | ms_graphrag | graphiti | text_rag"
         default: "all"
+      text_rag_top_k:
+        description: "text_rag only: passages retrieved per question (the naive-RAG no-KG baseline's context budget)"
+        default: "10"
       trace:
         description: "goldengraph only: localize where each answer is lost (extraction/retrieval/synthesis)"
         default: "false"
@@ -205,6 +208,46 @@ jobs:
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_lightrag_amb${{ matrix.ambiguity }}*.*
           if-no-files-found: ignore
 
+  text_rag:
+    needs: setup
+    if: ${{ inputs.engine == 'all' || inputs.engine == 'text_rag' }}
+    runs-on: ubuntu-latest  # no KG build -- just embeddings + chat; the light lane
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        ambiguity: ${{ fromJSON(needs.setup.outputs.ambiguities) }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install text-RAG baseline deps (isolated)
+        run: python -m pip install --upgrade pip pytest numpy goldenmatch datasets openai
+      - name: Run text-RAG baseline end-to-end (real LLM, budget-capped)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          POLARS_SKIP_CPU_CHECK: "1"
+          TEXT_RAG_TOP_K: ${{ inputs.text_rag_top_k }}
+        run: |
+          python -m erkgbench.qa_e2e.run_qa_e2e \
+            --engine text_rag \
+            --corpus "${{ inputs.corpus }}" \
+            --max-questions "${{ inputs.max_questions }}" \
+            --ambiguity "${{ matrix.ambiguity }}" \
+            --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
+            --out-md "results/RESULTS_QA_E2E_text_rag_amb${{ matrix.ambiguity }}.md" \
+            --out-json "results/results_qa_e2e_text_rag_amb${{ matrix.ambiguity }}.json"
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-qa-results-text_rag-amb${{ matrix.ambiguity }}
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_text_rag_amb${{ matrix.ambiguity }}*.*
+          if-no-files-found: ignore
+
   ms_graphrag:
     needs: setup
     if: ${{ inputs.engine == 'all' || inputs.engine == 'ms_graphrag' }}
@@ -292,7 +335,7 @@ jobs:
           if-no-files-found: ignore
 
   aggregate:
-    needs: [goldengraph, lightrag, ms_graphrag, graphiti]
+    needs: [goldengraph, lightrag, ms_graphrag, graphiti, text_rag]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -20,10 +20,13 @@ on:
         description: "hard cost cap per (engine, ambiguity) run"
         default: "25"
       engine:
-        description: "all | goldengraph | lightrag | ms_graphrag | graphiti | text_rag"
+        description: "all | goldengraph | lightrag | ms_graphrag | graphiti | text_rag | goldenmatch_rag | goldenmatch_entity_rag"
         default: "all"
       text_rag_top_k:
         description: "text_rag only: passages retrieved per question (the naive-RAG no-KG baseline's context budget)"
+        default: "10"
+      goldenmatch_rag_top_k:
+        description: "goldenmatch_rag / goldenmatch_entity_rag only: records retrieved per question via goldenmatch's own retrieval surface"
         default: "10"
       trace:
         description: "goldengraph only: localize where each answer is lost (extraction/retrieval/synthesis)"
@@ -248,6 +251,86 @@ jobs:
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_text_rag_amb${{ matrix.ambiguity }}*.*
           if-no-files-found: ignore
 
+  goldenmatch_rag:
+    needs: setup
+    if: ${{ inputs.engine == 'all' || inputs.engine == 'goldenmatch_rag' }}
+    runs-on: ubuntu-latest  # goldenmatch retrieval (embed + ANN), no KG build -- light lane
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        ambiguity: ${{ fromJSON(needs.setup.outputs.ambiguities) }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install goldenmatch + datasets (isolated)
+        run: python -m pip install --upgrade pip pytest numpy goldenmatch datasets openai
+      - name: Run goldenmatch-RAG end-to-end (real LLM, budget-capped)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          POLARS_SKIP_CPU_CHECK: "1"
+          GOLDENMATCH_RAG_TOP_K: ${{ inputs.goldenmatch_rag_top_k }}
+        run: |
+          python -m erkgbench.qa_e2e.run_qa_e2e \
+            --engine goldenmatch_rag \
+            --corpus "${{ inputs.corpus }}" \
+            --max-questions "${{ inputs.max_questions }}" \
+            --ambiguity "${{ matrix.ambiguity }}" \
+            --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
+            --out-md "results/RESULTS_QA_E2E_goldenmatch_rag_amb${{ matrix.ambiguity }}.md" \
+            --out-json "results/results_qa_e2e_goldenmatch_rag_amb${{ matrix.ambiguity }}.json"
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-qa-results-goldenmatch_rag-amb${{ matrix.ambiguity }}
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_goldenmatch_rag_amb${{ matrix.ambiguity }}*.*
+          if-no-files-found: ignore
+
+  goldenmatch_entity_rag:
+    needs: setup
+    if: ${{ inputs.engine == 'all' || inputs.engine == 'goldenmatch_entity_rag' }}
+    runs-on: ubuntu-latest  # goldenmatch entity-aware retrieval (retrieve -> dedupe -> canonicalize)
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        ambiguity: ${{ fromJSON(needs.setup.outputs.ambiguities) }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install goldenmatch + datasets (isolated)
+        run: python -m pip install --upgrade pip pytest numpy goldenmatch datasets openai
+      - name: Run goldenmatch entity-aware RAG end-to-end (real LLM, budget-capped)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          POLARS_SKIP_CPU_CHECK: "1"
+          GOLDENMATCH_RAG_TOP_K: ${{ inputs.goldenmatch_rag_top_k }}
+        run: |
+          python -m erkgbench.qa_e2e.run_qa_e2e \
+            --engine goldenmatch_entity_rag \
+            --corpus "${{ inputs.corpus }}" \
+            --max-questions "${{ inputs.max_questions }}" \
+            --ambiguity "${{ matrix.ambiguity }}" \
+            --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
+            --out-md "results/RESULTS_QA_E2E_goldenmatch_entity_rag_amb${{ matrix.ambiguity }}.md" \
+            --out-json "results/results_qa_e2e_goldenmatch_entity_rag_amb${{ matrix.ambiguity }}.json"
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-qa-results-goldenmatch_entity_rag-amb${{ matrix.ambiguity }}
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_e2e_goldenmatch_entity_rag_amb${{ matrix.ambiguity }}*.*
+          if-no-files-found: ignore
+
   ms_graphrag:
     needs: setup
     if: ${{ inputs.engine == 'all' || inputs.engine == 'ms_graphrag' }}
@@ -335,7 +418,7 @@ jobs:
           if-no-files-found: ignore
 
   aggregate:
-    needs: [goldengraph, lightrag, ms_graphrag, graphiti, text_rag]
+    needs: [goldengraph, lightrag, ms_graphrag, graphiti, text_rag, goldenmatch_rag, goldenmatch_entity_rag]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from .embed import Embedder, seed_by_query
 from .llm import LLMClient
-from .synthesize import synthesize_global, synthesize_local
+from .synthesize import synthesize_global, synthesize_hybrid, synthesize_local
 
 
 def _retrieve_local(slice_graph, seeds, *, max_hops: int, node_budget: int) -> dict:
@@ -50,13 +50,20 @@ def ask(
     hops: int = 4,
     max_communities: int = 10,
     node_budget: int = 64,
+    passages: object | None = None,
+    passage_k: int = 10,
 ) -> str:
     """Answer `query` against `store` as-of `(valid_t, tx_t)`.
 
     `mode="local"`: embedding-seeded neighborhood, expanded adaptively up to `hops`
     (bounded by `node_budget` entities) so multi-hop answers are reachable, then
-    synthesized with explicit step-by-step relation tracing. `mode="global"`: community
-    map-reduce (capped at `max_communities` --
+    synthesized with explicit step-by-step relation tracing. `mode="hybrid"`: the same
+    seeded ball PLUS raw source passages retrieved by `passages.retrieve(query,
+    passage_k)` -> `list[str]`, handed to synthesis as the ground-truth context with
+    the graph as a cross-passage multi-hop map (recovers the source-text fidelity the
+    extracted triples drop; the answer is freed from the entity-only constraint). With
+    no `passages` retriever it degrades to passages-empty (graph-only, free-form
+    answer). `mode="global"`: community map-reduce (capped at `max_communities` --
     the pre-emptive guard on the N+1 LLM fan-out; per-call budget is the `LLMClient`'s
     job). Each community is contextualized with its immediate (1-hop) neighborhood.
     """
@@ -65,8 +72,8 @@ def ask(
         communities = slice_graph.communities()[:max_communities]
         views = [slice_graph.query(c["members"], 1) for c in communities]
         return synthesize_global(query, views, llm)
-    if mode != "local":
-        raise ValueError(f"mode must be 'local' or 'global', got {mode!r}")
+    if mode not in ("local", "hybrid"):
+        raise ValueError(f"mode must be 'local', 'hybrid', or 'global', got {mode!r}")
     seeds = seed_by_query(slice_graph, query, embedder, k=k)
     subgraph = _retrieve_local(slice_graph, seeds, max_hops=hops, node_budget=node_budget)
     # Hand the synthesis the seed entity NAMES (the query-relevant anchors) so the
@@ -75,6 +82,13 @@ def ask(
         e["entity_id"]: e["canonical_name"] for e in subgraph.get("entities", ())
     }
     seed_names = [id_to_name[s] for s in seeds if s in id_to_name]
+    if mode == "hybrid":
+        passage_texts = (
+            list(passages.retrieve(query, passage_k)) if passages is not None else []
+        )
+        return synthesize_hybrid(
+            query, subgraph, passage_texts, llm, seed_names=seed_names
+        )
     return synthesize_local(query, subgraph, llm, seed_names=seed_names)
 
 

--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -155,6 +155,67 @@ def synthesize_local(
     )
 
 
+_HYBRID_HEAD = (
+    "Answer the question using the PASSAGES below as the primary source of truth.\n"
+    "These questions are usually MULTI-HOP: the answer is reached by chaining facts "
+    "that may be split across several passages, and the bridge entity in the middle is "
+    "often NOT named in the question. Use the RELATIONSHIP GRAPH (entities joined by "
+    "directed, labelled relationships) as a MAP to connect facts across passages -- it "
+    "shows how entities mentioned in different passages link up, so you can carry a "
+    "bridge entity from one passage to the next. The PASSAGES are AUTHORITATIVE on the "
+    "actual facts and values; the graph is only a navigation aid -- never answer with a "
+    "graph entity that the passages contradict.\n"
+    "Work it out step by step: decompose the question into an ordered chain of "
+    "sub-questions, resolve each against the passages (using the graph to find the next "
+    "bridge entity when a passage doesn't state it directly), and carry the result "
+    "forward until you reach the answer.\n"
+    "Anchor entities (most query-relevant): {seeds}\n"
+)
+# Free-form answer instruction (UNLIKE synthesize_local's entity-only clause): the
+# passages can carry the non-entity answers (dates/numbers/phrases) the extracted
+# triples drop, so the hybrid path must not force the answer to be a graph node.
+_HYBRID_ANSWER = (
+    "Give the SHORTEST exact answer (an entity, name, date, number, or short phrase) "
+    "and nothing else on the last line, prefixed 'Answer: '. Show brief reasoning "
+    "first if helpful.\n"
+)
+_HYBRID_TAIL = "Question: {q}\n\nPassages:\n{passages}\n\nRelationship graph:\n{sub}"
+_HYBRID_PROMPT = _HYBRID_HEAD + _HYBRID_ANSWER + _HYBRID_TAIL
+
+
+def synthesize_hybrid(
+    query: str,
+    subgraph: dict,
+    passages: list[str],
+    llm: LLMClient,
+    *,
+    seed_names: list[str] | None = None,
+) -> str:
+    """Hybrid synthesis: raw retrieved PASSAGES (ground truth) + the graph subgraph
+    (a multi-hop navigation scaffold).
+
+    The bench's structural finding was that the KG is a LOSSY intermediate -- the
+    extracted triples drop the source-text fidelity that plain text-RAG keeps, which
+    is why goldengraph lost to a naive paragraph retriever. This path layers the
+    passages back in (recovering fidelity) while keeping the graph as a cross-passage
+    multi-hop map. It also FREES the answer from `synthesize_local`'s entity-only
+    constraint -- the passages can carry the date/number/phrase answers the triples
+    can't. Returns the parsed ``Answer:`` line (see `_extract_answer`)."""
+    seeds = ", ".join(dict.fromkeys(s for s in (seed_names or []) if s)) or (
+        "(none identified -- choose the most relevant entities yourself)"
+    )
+    ctx = "\n\n".join(f"[{i + 1}] {p}" for i, p in enumerate(passages)) or (
+        "(no passages retrieved)"
+    )
+    return _extract_answer(
+        llm.complete(
+            _HYBRID_PROMPT.format(
+                q=query, seeds=seeds, passages=ctx, sub=_format_subgraph(subgraph)
+            )
+        )
+    )
+
+
 def synthesize_global(query: str, community_views: list[dict], llm: LLMClient) -> str:
     summaries = [
         llm.complete(_MAP_PROMPT.format(q=query, sub=_format_subgraph(v)))

--- a/packages/python/goldengraph/tests/test_hybrid_synthesis.py
+++ b/packages/python/goldengraph/tests/test_hybrid_synthesis.py
@@ -1,0 +1,169 @@
+"""Hybrid retrieval: passages (ground truth) + graph subgraph (multi-hop map).
+
+The bench showed the triple-only KG is a LOSSY intermediate -- it lost to plain
+paragraph RAG. `mode="hybrid"` layers the raw passages back into synthesis while
+keeping the graph for cross-passage bridging, and frees the answer from the
+entity-only constraint. These pure tests (no native, no LLM, no network) pin the
+contract: synthesis sees BOTH passages and the name-keyed graph, the passages
+retriever is consulted with `passage_k`, and the answer instruction is free-form.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from goldengraph.answer import ask
+from goldengraph.synthesize import synthesize_hybrid
+from conftest import RecordingLLM, StubEmbedder
+
+_SUB = {
+    "entities": [
+        {"entity_id": 0, "canonical_name": "Acme", "typ": "org"},
+        {"entity_id": 1, "canonical_name": "Rocket", "typ": "product"},
+    ],
+    "edges": [{"subj": 0, "predicate": "made", "obj": 1}],
+}
+
+
+def test_hybrid_prompt_carries_both_passages_and_graph():
+    llm = RecordingLLM()
+    synthesize_hybrid(
+        "who made the rocket?",
+        _SUB,
+        ["Acme built the famous Rocket in 1958.", "Unrelated sky passage."],
+        llm,
+        seed_names=["Acme"],
+    )
+    prompt = llm.prompts[-1]
+    # passages present (ground-truth context)...
+    assert "Acme built the famous Rocket in 1958." in prompt
+    assert "Passages:" in prompt
+    # ...AND the name-keyed graph edge (the cross-passage multi-hop map)
+    assert "Acme -[made]-> Rocket" in prompt
+    assert "Anchor entities (most query-relevant): Acme" in prompt
+    assert "Answer:" in prompt
+
+
+def test_hybrid_answer_is_free_form_not_entity_only():
+    # The hybrid path must NOT inherit synthesize_local's entity-only clause -- the
+    # passages can carry date/number/phrase answers the triples drop.
+    llm = RecordingLLM()
+    synthesize_hybrid("q?", _SUB, ["p"], llm)
+    prompt = llm.prompts[-1]
+    assert "date, number, or short phrase" in prompt
+    assert "ALWAYS a single entity" not in prompt  # the local-mode constraint is absent
+
+
+def test_hybrid_parses_answer_line():
+    llm = RecordingLLM("hop one\nhop two\nAnswer: Acme")
+    assert synthesize_hybrid("q?", _SUB, ["p"], llm) == "Acme"
+
+
+def test_hybrid_empty_passages_is_safe():
+    llm = RecordingLLM()
+    synthesize_hybrid("q?", _SUB, [], llm)
+    assert "(no passages retrieved)" in llm.prompts[-1]
+
+
+# --- ask(mode="hybrid") integration over a fake store ---
+
+_NAMES = ["Start", "A", "Zeta"]
+_EDGES = [(0, "works_at", 1), (1, "acquired", 2)]
+
+
+class _FakeGraph:
+    def __init__(self, names, edges):
+        self._names = names
+        self._edges = edges
+        self._adj: dict[int, set[int]] = {i: set() for i in range(len(names))}
+        for s, _p, o in edges:
+            self._adj[s].add(o)
+            self._adj[o].add(s)
+
+    def _ent(self, i):
+        return {"entity_id": i, "canonical_name": self._names[i], "typ": "concept"}
+
+    def entities(self):
+        return [self._ent(i) for i in range(len(self._names))]
+
+    def query(self, seeds, hops):
+        seen, frontier = set(seeds), set(seeds)
+        for _ in range(hops):
+            nxt: set[int] = set()
+            for u in frontier:
+                nxt |= self._adj[u]
+            frontier = nxt - seen
+            seen |= nxt
+        ents = [self._ent(i) for i in sorted(seen)]
+        edges = [
+            {"subj": s, "predicate": p, "obj": o}
+            for (s, p, o) in self._edges
+            if s in seen and o in seen
+        ]
+        return {"entities": ents, "edges": edges}
+
+
+class _FakeStore:
+    def __init__(self, graph):
+        self._graph = graph
+
+    def as_of(self, valid_t, tx_t):  # noqa: ARG002 - single static slice
+        return self._graph
+
+
+class _FakePassages:
+    def __init__(self, texts):
+        self._texts = texts
+        self.calls: list[tuple[str, int]] = []
+
+    def retrieve(self, query: str, k: int) -> list[str]:
+        self.calls.append((query, k))
+        return list(self._texts)[:k]
+
+
+def test_ask_hybrid_feeds_passages_and_graph_to_synthesis():
+    llm = RecordingLLM()
+    store = _FakeStore(_FakeGraph(_NAMES, _EDGES))
+    embedder = StubEmbedder({"Start": 0, "A": 1, "Zeta": 2})
+    passages = _FakePassages(["Start works at A.", "A acquired Zeta in 1990."])
+    ask(
+        "Start",
+        store,
+        llm=llm,
+        embedder=embedder,
+        valid_t=1,
+        tx_t=1,
+        mode="hybrid",
+        k=1,
+        hops=4,
+        node_budget=64,
+        passages=passages,
+        passage_k=7,
+    )
+    prompt = llm.prompts[-1]
+    # the passage retriever was consulted with passage_k (not the graph hops/k)
+    assert passages.calls == [("Start", 7)]
+    # both halves reach synthesis
+    assert "A acquired Zeta in 1990." in prompt
+    assert "Start -[works_at]-> A" in prompt
+    assert "acquired" in prompt
+
+
+def test_ask_hybrid_without_retriever_degrades_to_graph_only():
+    llm = RecordingLLM()
+    store = _FakeStore(_FakeGraph(_NAMES, _EDGES))
+    embedder = StubEmbedder({"Start": 0, "A": 1, "Zeta": 2})
+    ask(
+        "Start", store, llm=llm, embedder=embedder, valid_t=1, tx_t=1,
+        mode="hybrid", k=1, hops=4, node_budget=64, passages=None,
+    )
+    assert "(no passages retrieved)" in llm.prompts[-1]
+
+
+def test_ask_rejects_unknown_mode():
+    store = _FakeStore(_FakeGraph(_NAMES, _EDGES))
+    with pytest.raises(ValueError, match="local"):
+        ask(
+            "Start", store, llm=RecordingLLM(), embedder=StubEmbedder({"Start": 0}),
+            valid_t=1, tx_t=1, mode="bogus",
+        )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -61,6 +61,41 @@ _NODE_BUDGET = int(os.environ.get("GOLDENGRAPH_QA_NODE_BUDGET", "256"))
 #: the graph but disconnected from the seeds within any reasonable depth).
 _WIDE_HOPS = 8
 
+#: Answer-time retrieval mode. "local" (default) = the entity-graph BFS over extracted
+#: triples (the historical goldengraph path). "hybrid" = that ball PLUS raw source
+#: passages retrieved by goldenmatch's own retrieval surface, fed to synthesis as the
+#: ground truth with the graph as a multi-hop map. The bench's structural finding was
+#: that the triple-only graph is a LOSSY intermediate (it lost to plain paragraph RAG);
+#: hybrid tests whether layering the passages back in -- while keeping the graph for
+#: cross-passage bridging -- closes that gap. Env-tunable for the A/B.
+_QA_MODE = os.environ.get("GOLDENGRAPH_QA_MODE", "local")
+
+#: Passages retrieved per question in hybrid mode (matches the goldenmatch_rag /
+#: text_rag context budget so the comparison is apples-to-apples).
+_QA_PASSAGE_K = int(os.environ.get("GOLDENGRAPH_QA_PASSAGE_K", "10"))
+
+
+class _PassageRetriever:
+    """goldenmatch paragraph retrieval over the corpus -- literally the goldenmatch_rag
+    retriever (`retrieve_similar_records` + the SAME OpenAI embedder), reused as the
+    passage source for goldengraph's hybrid `ask`. The injected embedder caches by
+    cache_key, so the corpus embeds once across all questions; each query embeds once.
+    Holds NO graph state -- the graph half stays the store's job."""
+
+    def __init__(self, ids, texts, embedder):
+        from .goldenmatch_rag import _make_frame
+
+        self._frame = _make_frame(ids, texts)
+        self._embedder = embedder
+
+    def retrieve(self, query: str, k: int) -> list[str]:
+        from goldenmatch.core.retrieval import retrieve_similar_records
+
+        hits = retrieve_similar_records(
+            self._frame, query, "text", k=k, embedder=self._embedder
+        )
+        return [str(h.record.get("text", "")) for h in hits]
+
 
 class _CachingEmbedder:
     """Memoizes embeddings by text across the WHOLE run. Two callers re-embed the
@@ -123,6 +158,8 @@ class GoldenGraphQAEngine:
         resolver: Any | None = None,
         retrieval_hops: int | None = None,
         node_budget: int | None = None,
+        retrieval_mode: str | None = None,
+        passage_k: int | None = None,
     ):
         self._llm = _CountingLLM(llm)
         # Cache embeddings across the whole run: the build's cross-doc linking and
@@ -139,6 +176,16 @@ class GoldenGraphQAEngine:
         self._node_budget = (
             node_budget if node_budget is not None
             else int(os.environ.get("GOLDENGRAPH_QA_NODE_BUDGET", "256"))
+        )
+        # "local" (entity-graph BFS, default) vs "hybrid" (BFS + goldenmatch passage
+        # retrieval fed to synthesis). hybrid builds a passage index at build time.
+        self._retrieval_mode = (
+            retrieval_mode if retrieval_mode is not None
+            else os.environ.get("GOLDENGRAPH_QA_MODE", "local")
+        )
+        self._passage_k = (
+            passage_k if passage_k is not None
+            else int(os.environ.get("GOLDENGRAPH_QA_PASSAGE_K", "10"))
         )
 
     def build_kg(self, corpus) -> BuildResult:
@@ -160,7 +207,27 @@ class GoldenGraphQAEngine:
             [doc.text for doc in corpus.documents], store, llm=self._llm,
             resolver=self._resolver, embedder=self._embedder, fp_index=fp_index,
         )
-        handle = {"store": store, "valid_t": _AS_OF, "tx_t": _AS_OF}
+        # Hybrid mode also indexes the raw paragraphs for answer-time passage
+        # retrieval. Built with a SEPARATE OpenAI embedder (text-embedding-3-large,
+        # matching goldenmatch_rag/text_rag) so the passage half is identical to the
+        # standalone goldenmatch_rag engine -- the graph half stays the store's job.
+        # Embedding calls here are NOT charged to the engine token budget (parity with
+        # text_rag/goldenmatch_rag, which meter only synthesis chat tokens).
+        passages = None
+        if self._retrieval_mode == "hybrid":
+            from openai import OpenAI
+
+            from .goldenmatch_rag import _OpenAIEmbedderAdapter
+
+            adapter = _OpenAIEmbedderAdapter(OpenAI(), "text-embedding-3-large")
+            passages = _PassageRetriever(
+                [d.id for d in corpus.documents],
+                [d.text for d in corpus.documents],
+                adapter,
+            )
+        handle = {
+            "store": store, "valid_t": _AS_OF, "tx_t": _AS_OF, "passages": passages,
+        }
         return BuildResult(
             handle=handle,
             input_tokens=self._llm.input_tokens - before_in,
@@ -180,9 +247,11 @@ class GoldenGraphQAEngine:
             embedder=self._embedder,
             valid_t=handle["valid_t"],
             tx_t=handle["tx_t"],
-            mode="local",
+            mode=self._retrieval_mode,
             hops=self._retrieval_hops,
             node_budget=self._node_budget,
+            passages=handle.get("passages"),
+            passage_k=self._passage_k,
         )
         return AnswerResult(
             text=text,

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldenmatch_rag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldenmatch_rag.py
@@ -1,0 +1,187 @@
+"""GoldenMatch-native RAG engines -- does goldenmatch's OWN retrieval surface beat
+naive text-RAG, and does its entity-resolution layer add anything?
+
+The head-to-head had a no-KG control (`text_rag`) that reimplements naive retrieval
+with the raw `openai` SDK -- but goldenmatch SHIPS a first-class retrieval surface
+(`retrieve_similar_records`, `entity_aware_retrieve`) that nothing in the bench used.
+These two engines close that gap:
+
+  - `goldenmatch_rag`     -> goldenmatch's `retrieve_similar_records` + the SAME
+                            synthesis text_rag uses. Isolates goldenmatch's retrieval
+                            MECHANICS (embed -> ANNBlocker top-k) vs OpenAI's.
+  - `goldenmatch_entity_rag` -> `entity_aware_retrieve` (retrieve -> dedupe ->
+                            canonicalize) + the same synthesis. Isolates what the
+                            entity-resolution layer ADDS on top of plain retrieval.
+
+Both hold the EMBEDDER constant -- OpenAI `text-embedding-3-large`, the same model
+text_rag and ms_graphrag use -- via an injected adapter, so any delta vs text_rag is
+attributable to goldenmatch's retrieval/resolution layer, NOT a different embedder.
+The adapter caches by `cache_key` so the corpus is embedded once across all questions
+(matching text_rag's build-once cost), and the resolve step is pinned to a
+deterministic fuzzy token_sort (no auto-config embedding scorer -> no torch in the
+light lane). The OpenAI client is injectable so the wiring is testable offline."""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import numpy as np
+
+from ..harness import AnswerResult, BuildResult
+from .text_rag import _PROMPT, _extract_answer
+
+_EMBED_BATCH = 256
+# Force the resolve step onto a deterministic fuzzy token_sort match on the passage
+# text. Passing `fuzzy=` makes dedupe_df build an EXPLICIT config (skips auto-config),
+# so it never routes the long text column to an embedding scorer (which would need
+# torch / sentence-transformers, absent in the light lane).
+_RESOLVE_FUZZY = {"text": 0.85}
+
+
+class _OpenAIEmbedderAdapter:
+    """Wraps the OpenAI embeddings API in the `embed_column(values, cache_key)`
+    shape goldenmatch's retrieval surface expects. Caches by `cache_key` so the
+    corpus (same values, same key every question) is embedded exactly once."""
+
+    def __init__(self, client: Any, model: str, *, batch: int = _EMBED_BATCH):
+        self._client = client
+        self._model = model
+        self._batch = batch
+        self._cache: dict[str, np.ndarray] = {}
+
+    def embed_column(self, values, cache_key=None) -> np.ndarray:
+        if cache_key is not None and cache_key in self._cache:
+            return self._cache[cache_key]
+        texts = [v if (v and str(v).strip()) else " " for v in values]
+        out: list[list[float]] = []
+        for i in range(0, len(texts), self._batch):
+            chunk = [str(t) for t in texts[i : i + self._batch]]
+            resp = self._client.embeddings.create(model=self._model, input=chunk)
+            out.extend(d.embedding for d in resp.data)
+        arr = np.asarray(out, dtype=float)
+        arr = arr / (np.linalg.norm(arr, axis=1, keepdims=True) + 1e-12)
+        if cache_key is not None:
+            self._cache[cache_key] = arr
+        return arr
+
+
+def _make_frame(ids: list[str], texts: list[str]):
+    import polars as pl
+
+    return pl.DataFrame({"id": ids, "text": texts})
+
+
+def _synthesize(client: Any, model: str, ctx: str, question: str):
+    """Run the SAME synthesis prompt the other engines use; return
+    (answer_text, prompt_tokens, completion_tokens)."""
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": _PROMPT.format(ctx=ctx, q=question)}],
+    )
+    raw = resp.choices[0].message.content or ""
+    usage = getattr(resp, "usage", None)
+    return (
+        _extract_answer(raw),
+        int(getattr(usage, "prompt_tokens", 0) or 0),
+        int(getattr(usage, "completion_tokens", 0) or 0),
+    )
+
+
+class _BaseGoldenmatchRAGEngine:
+    fidelity = "real-e2e"
+
+    def __init__(
+        self,
+        *,
+        model: str = "gpt-4o-mini",
+        embedding_model: str = "text-embedding-3-large",
+        top_k: int | None = None,
+        client: Any | None = None,
+    ):
+        if client is None:
+            from openai import OpenAI
+
+            client = OpenAI()
+        self._client = client
+        self._model = model
+        self._embedder = _OpenAIEmbedderAdapter(client, embedding_model)
+        self._top_k = (
+            top_k
+            if top_k is not None
+            else int(os.environ.get("GOLDENMATCH_RAG_TOP_K", "10"))
+        )
+
+    def build_kg(self, corpus) -> BuildResult:
+        t0 = time.perf_counter()
+        ids = [d.id for d in corpus.documents]
+        texts = [d.text for d in corpus.documents]
+        handle = {"frame": _make_frame(ids, texts), "n": len(ids)}
+        return BuildResult(handle=handle, latency_s=time.perf_counter() - t0)
+
+
+class GoldenmatchRAGQAEngine(_BaseGoldenmatchRAGEngine):
+    """goldenmatch `retrieve_similar_records` + shared synthesis."""
+
+    name = "goldenmatch_rag"
+
+    def answer(self, handle, question: str) -> AnswerResult:
+        t0 = time.perf_counter()
+        if not handle or not handle.get("n"):
+            return AnswerResult(text="", latency_s=time.perf_counter() - t0)
+        from goldenmatch.core.retrieval import retrieve_similar_records
+
+        hits = retrieve_similar_records(
+            handle["frame"], question, "text", k=self._top_k, embedder=self._embedder
+        )
+        if not hits:
+            return AnswerResult(text="", latency_s=time.perf_counter() - t0)
+        ctx = "\n\n".join(f"[{i + 1}] {h.record.get('text', '')}" for i, h in enumerate(hits))
+        text, in_tok, out_tok = _synthesize(self._client, self._model, ctx, question)
+        return AnswerResult(
+            text=text,
+            retrieved_fact_ids=tuple(str(h.record.get("id")) for h in hits),
+            input_tokens=in_tok,
+            output_tokens=out_tok,
+            latency_s=time.perf_counter() - t0,
+        )
+
+
+class GoldenmatchEntityRAGQAEngine(_BaseGoldenmatchRAGEngine):
+    """goldenmatch `entity_aware_retrieve` (retrieve -> dedupe -> canonicalize) +
+    shared synthesis. Deterministic canonicalization (no `llm_call`), deterministic
+    fuzzy resolve -- so the ONLY new variable vs `goldenmatch_rag` is the
+    entity-resolution layer."""
+
+    name = "goldenmatch_entity_rag"
+
+    def answer(self, handle, question: str) -> AnswerResult:
+        t0 = time.perf_counter()
+        if not handle or not handle.get("n"):
+            return AnswerResult(text="", latency_s=time.perf_counter() - t0)
+        from goldenmatch.core.rag_surface import entity_aware_retrieve
+
+        result = entity_aware_retrieve(
+            handle["frame"],
+            question,
+            "text",
+            k=self._top_k,
+            embedder=self._embedder,
+            fuzzy=_RESOLVE_FUZZY,
+        )
+        if not result.entities:
+            return AnswerResult(text="", latency_s=time.perf_counter() - t0)
+        ctx = "\n\n".join(
+            f"[{i + 1}] {e.record.get('text', '')}" for i, e in enumerate(result.entities)
+        )
+        text, in_tok, out_tok = _synthesize(self._client, self._model, ctx, question)
+        ids = tuple(
+            str(m.record.get("id")) for e in result.entities for m in e.members
+        )
+        return AnswerResult(
+            text=text,
+            retrieved_fact_ids=ids,
+            input_tokens=in_tok,
+            output_tokens=out_tok,
+            latency_s=time.perf_counter() - t0,
+        )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/text_rag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/text_rag.py
@@ -1,0 +1,115 @@
+"""Naive text-RAG baseline -- the no-knowledge-graph CONTROL for the head-to-head.
+
+The honest yardstick the program was missing: chunk = paragraph, embed every doc,
+retrieve top-K by query-embedding cosine, hand the passages to the SAME model the KG
+engines use, and answer. NO extraction, NO resolution, NO graph traversal -- so the
+gap (positive OR negative) between this and goldengraph / lightrag / ms_graphrag /
+graphiti is exactly what the KG structure buys (or costs) on multi-hop QA. Without
+it, every KG judge score is unanchored.
+
+Neutral by construction: uses the `openai` SDK directly (text-embedding-3-large +
+gpt-4o-mini, matching ms_graphrag's models), not any engine's own stack. The client
+is injectable so the wiring is testable without a network."""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import numpy as np
+
+from ..harness import AnswerResult, BuildResult
+
+_EMBED_BATCH = 256
+
+_PROMPT = (
+    "Answer the question using ONLY the passages below. These questions are often "
+    "MULTI-HOP -- you may need to combine facts from several passages. Give the "
+    "SHORTEST exact answer (an entity, name, date, or short phrase) and nothing "
+    "else on the last line, prefixed 'Answer: '. Show brief reasoning first if "
+    "helpful.\n\nPassages:\n{ctx}\n\nQuestion: {q}\n"
+)
+
+
+def _extract_answer(text: str) -> str:
+    """Pull the final answer (the last `Answer:` line); fall back to the last
+    non-empty line. Mirrors the goldengraph adapter so the metric sees the same
+    answer SHAPE across engines (the format-fair judge handles the rest)."""
+    if not text or not text.strip():
+        return text
+    idx = text.lower().rfind("answer:")
+    if idx != -1:
+        tail = text[idx + len("answer:"):].lstrip()
+        return tail.splitlines()[0].strip() if tail else ""
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    return lines[-1] if lines else text.strip()
+
+
+class TextRAGQAEngine:
+    name = "text_rag"
+    fidelity = "real-e2e"
+
+    def __init__(
+        self,
+        *,
+        model: str = "gpt-4o-mini",
+        embedding_model: str = "text-embedding-3-large",
+        top_k: int | None = None,
+        client: Any | None = None,
+    ):
+        # Lazy client construction so importing this module for the registry never
+        # needs an API key; tests inject a stub.
+        if client is None:
+            from openai import OpenAI
+
+            client = OpenAI()
+        self._client = client
+        self._model = model
+        self._embedding_model = embedding_model
+        self._top_k = (
+            top_k if top_k is not None else int(os.environ.get("TEXT_RAG_TOP_K", "10"))
+        )
+
+    def _embed(self, texts: list[str]) -> np.ndarray:
+        out: list[list[float]] = []
+        for i in range(0, len(texts), _EMBED_BATCH):
+            chunk = [t if (t and t.strip()) else " " for t in texts[i : i + _EMBED_BATCH]]
+            resp = self._client.embeddings.create(model=self._embedding_model, input=chunk)
+            out.extend(d.embedding for d in resp.data)
+        arr = np.asarray(out, dtype=float)
+        return arr / (np.linalg.norm(arr, axis=1, keepdims=True) + 1e-12)
+
+    def build_kg(self, corpus) -> BuildResult:
+        t0 = time.perf_counter()
+        ids = [d.id for d in corpus.documents]
+        texts = [d.text for d in corpus.documents]
+        unit = self._embed(texts) if texts else np.zeros((0, 1))
+        handle = {"ids": ids, "texts": texts, "unit": unit}
+        return BuildResult(handle=handle, latency_s=time.perf_counter() - t0)
+
+    def answer(self, handle, question: str) -> AnswerResult:
+        t0 = time.perf_counter()
+        texts = handle["texts"]
+        unit = handle["unit"]
+        if not texts:
+            return AnswerResult(text="", latency_s=time.perf_counter() - t0)
+        qn = self._embed([question])[0]
+        sims = unit @ qn
+        k = min(self._top_k, len(texts))
+        top = list(np.argsort(-sims)[:k])
+        ctx = "\n\n".join(f"[{i + 1}] {texts[j]}" for i, j in enumerate(top))
+        resp = self._client.chat.completions.create(
+            model=self._model,
+            messages=[{"role": "user", "content": _PROMPT.format(ctx=ctx, q=question)}],
+        )
+        raw = resp.choices[0].message.content or ""
+        usage = getattr(resp, "usage", None)
+        return AnswerResult(
+            text=_extract_answer(raw),
+            # text-RAG CAN surface its retrieved ids -> support_recall is real here
+            # (unlike the KG engines, whose ball-source-ids aren't wired through).
+            retrieved_fact_ids=tuple(handle["ids"][j] for j in top),
+            input_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+            output_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
+            latency_s=time.perf_counter() - t0,
+        )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -97,6 +97,14 @@ def _build_engine(name: str):
             falkordb_host=os.environ.get("FALKORDB_HOST", "localhost"),
             falkordb_port=int(os.environ.get("FALKORDB_PORT", "6379")),
         )
+    if name == "text_rag":
+        # The no-KG control: naive paragraph-retrieval RAG on the SAME models the KG
+        # engines use, so the gap is exactly what the graph buys (or costs).
+        from .engines.text_rag import TextRAGQAEngine
+
+        return TextRAGQAEngine(
+            model="gpt-4o-mini", embedding_model="text-embedding-3-large"
+        )
     raise SystemExit(f"unknown engine: {name}")
 
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_qa_e2e.py
@@ -105,6 +105,23 @@ def _build_engine(name: str):
         return TextRAGQAEngine(
             model="gpt-4o-mini", embedding_model="text-embedding-3-large"
         )
+    if name == "goldenmatch_rag":
+        # goldenmatch's OWN retrieval surface (retrieve_similar_records) with the SAME
+        # OpenAI embedder text_rag uses -- isolates our retrieval mechanics vs naive
+        # cosine, embedder held constant.
+        from .engines.goldenmatch_rag import GoldenmatchRAGQAEngine
+
+        return GoldenmatchRAGQAEngine(
+            model="gpt-4o-mini", embedding_model="text-embedding-3-large"
+        )
+    if name == "goldenmatch_entity_rag":
+        # goldenmatch's entity-aware RAG (retrieve -> dedupe -> canonicalize) -- the
+        # product's differentiated claim, measured for the first time.
+        from .engines.goldenmatch_rag import GoldenmatchEntityRAGQAEngine
+
+        return GoldenmatchEntityRAGQAEngine(
+            model="gpt-4o-mini", embedding_model="text-embedding-3-large"
+        )
     raise SystemExit(f"unknown engine: {name}")
 
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_goldenmatch_rag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_goldenmatch_rag.py
@@ -1,0 +1,153 @@
+"""GoldenMatch-native RAG engines -- retrieval ordering, answer parsing, token + id
+surfacing, and the entity-resolution path. The OpenAI client is a fake (no network);
+goldenmatch's REAL retrieval surface (retrieve_similar_records / entity_aware_retrieve)
+runs over the fake embeddings."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+pytest.importorskip("numpy")
+pytest.importorskip("polars")
+pytest.importorskip("goldenmatch")
+
+from erkgbench.qa_e2e.engines.goldenmatch_rag import (  # noqa: E402
+    GoldenmatchEntityRAGQAEngine,
+    GoldenmatchRAGQAEngine,
+)
+
+
+def _vec(t: str):
+    # 2-D toy embedding: aligned with the query iff the text mentions "rocket".
+    return [1.0, 0.0] if "rocket" in t.lower() else [0.0, 1.0]
+
+
+class _Emb:
+    def __init__(self, e):
+        self.embedding = e
+
+
+class _EmbResp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeEmbeddings:
+    def create(self, *, model, input):
+        return _EmbResp([_Emb(_vec(t)) for t in input])
+
+
+class _ChatResp:
+    def __init__(self, content, pt=11, ct=3):
+        self.choices = [
+            type("C", (), {"message": type("M", (), {"content": content})()})()
+        ]
+        self.usage = type("U", (), {"prompt_tokens": pt, "completion_tokens": ct})()
+
+
+class _FakeChatCompletions:
+    def __init__(self):
+        self.last_messages = None
+
+    def create(self, *, model, messages):
+        self.last_messages = messages
+        return _ChatResp("hop one\nAnswer: Acme")
+
+
+class _FakeChat:
+    def __init__(self):
+        self.completions = _FakeChatCompletions()
+
+
+class _FakeClient:
+    def __init__(self):
+        self.embeddings = _FakeEmbeddings()
+        self.chat = _FakeChat()
+
+
+class _Doc:
+    def __init__(self, id, text):
+        self.id = id
+        self.text = text
+
+
+class _Corpus:
+    def __init__(self, docs):
+        self.documents = docs
+
+
+def _corpus():
+    return _Corpus([
+        _Doc("d0::p0", "The sky is blue and unrelated."),
+        _Doc("d0::p1", "Acme built the famous Rocket in 1958."),
+    ])
+
+
+def test_goldenmatch_rag_retrieves_relevant_first_and_parses_answer():
+    client = _FakeClient()
+    eng = GoldenmatchRAGQAEngine(client=client, top_k=2)
+    handle = eng.build_kg(_corpus()).handle
+    res = eng.answer(handle, "who made the rocket?")
+
+    assert res.text == "Acme"
+    # the rocket passage is retrieved FIRST (goldenmatch's ANN ranks it top)
+    assert res.retrieved_fact_ids[0] == "d0::p1"
+    assert res.input_tokens == 11 and res.output_tokens == 3
+    # the prompt actually carried the retrieved passage text
+    assert "Rocket" in client.chat.completions.last_messages[0]["content"]
+
+
+def test_goldenmatch_rag_caches_corpus_embedding_across_questions():
+    # The adapter must embed the corpus once (cache_key hit), not per question.
+    client = _FakeClient()
+    eng = GoldenmatchRAGQAEngine(client=client, top_k=2)
+    handle = eng.build_kg(_corpus()).handle
+    eng.answer(handle, "who made the rocket?")
+    cached_keys = set(eng._embedder._cache)
+    eng.answer(handle, "who made the rocket?")
+    # second question reused the same corpus cache key (still present, not regrown)
+    assert any(k.startswith("retrieve:text:") for k in cached_keys)
+
+
+def test_goldenmatch_entity_rag_resolves_and_answers():
+    client = _FakeClient()
+    eng = GoldenmatchEntityRAGQAEngine(client=client, top_k=2)
+    handle = eng.build_kg(_corpus()).handle
+    res = eng.answer(handle, "who made the rocket?")
+
+    assert res.text == "Acme"
+    # distinct paragraphs -> each is its own entity -> both ids surface
+    assert "d0::p1" in res.retrieved_fact_ids
+    assert res.input_tokens == 11 and res.output_tokens == 3
+
+
+def test_both_empty_corpus_is_safe():
+    for cls in (GoldenmatchRAGQAEngine, GoldenmatchEntityRAGQAEngine):
+        eng = cls(client=_FakeClient())
+        handle = eng.build_kg(_Corpus([])).handle
+        assert eng.answer(handle, "q?").text == ""
+
+
+def test_build_engine_constructs_goldenmatch_rag_engines(monkeypatch):
+    import erkgbench.qa_e2e.engines.goldenmatch_rag as gr
+
+    monkeypatch.setattr(
+        gr, "GoldenmatchRAGQAEngine",
+        lambda **kw: ("goldenmatch_rag", kw.get("model")), raising=True
+    )
+    monkeypatch.setattr(
+        gr, "GoldenmatchEntityRAGQAEngine",
+        lambda **kw: ("goldenmatch_entity_rag", kw.get("model")), raising=True
+    )
+    from erkgbench.qa_e2e.run_qa_e2e import _build_engine
+
+    assert _build_engine("goldenmatch_rag") == ("goldenmatch_rag", "gpt-4o-mini")
+    assert _build_engine("goldenmatch_entity_rag") == (
+        "goldenmatch_entity_rag", "gpt-4o-mini"
+    )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_text_rag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_text_rag.py
@@ -1,0 +1,115 @@
+"""Text-RAG baseline engine -- retrieval ordering, answer parsing, token + id
+surfacing. Pure (injected fake openai client; no network)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+pytest.importorskip("numpy")
+
+from erkgbench.qa_e2e.engines.text_rag import TextRAGQAEngine  # noqa: E402
+
+
+def _vec(t: str):
+    # 2-D toy embedding: aligned with the query iff the text mentions "rocket".
+    return [1.0, 0.0] if "rocket" in t.lower() else [0.0, 1.0]
+
+
+class _Emb:
+    def __init__(self, e):
+        self.embedding = e
+
+
+class _EmbResp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeEmbeddings:
+    def create(self, *, model, input):
+        return _EmbResp([_Emb(_vec(t)) for t in input])
+
+
+class _ChatResp:
+    def __init__(self, content, pt=11, ct=3):
+        self.choices = [
+            type("C", (), {"message": type("M", (), {"content": content})()})()
+        ]
+        self.usage = type("U", (), {"prompt_tokens": pt, "completion_tokens": ct})()
+
+
+class _FakeChatCompletions:
+    def __init__(self):
+        self.last_messages = None
+
+    def create(self, *, model, messages):
+        self.last_messages = messages
+        return _ChatResp("hop one\nAnswer: Acme")
+
+
+class _FakeChat:
+    def __init__(self):
+        self.completions = _FakeChatCompletions()
+
+
+class _FakeClient:
+    def __init__(self):
+        self.embeddings = _FakeEmbeddings()
+        self.chat = _FakeChat()
+
+
+class _Doc:
+    def __init__(self, id, text):
+        self.id = id
+        self.text = text
+
+
+class _Corpus:
+    def __init__(self, docs):
+        self.documents = docs
+
+
+def test_text_rag_retrieves_relevant_first_and_parses_answer():
+    client = _FakeClient()
+    eng = TextRAGQAEngine(client=client, top_k=2)
+    corpus = _Corpus([
+        _Doc("d0::p0", "The sky is blue and unrelated."),
+        _Doc("d0::p1", "Acme built the famous Rocket in 1958."),
+    ])
+    handle = eng.build_kg(corpus).handle
+    res = eng.answer(handle, "who made the rocket?")
+
+    # answer parsed from the last `Answer:` line
+    assert res.text == "Acme"
+    # the rocket passage is retrieved FIRST (the support_recall signal text-RAG has)
+    assert res.retrieved_fact_ids[0] == "d0::p1"
+    assert len(res.retrieved_fact_ids) == 2
+    # chat usage is metered onto the answer
+    assert res.input_tokens == 11 and res.output_tokens == 3
+    # the prompt actually contained the retrieved passages
+    assert "Rocket" in client.chat.completions.last_messages[0]["content"]
+
+
+def test_text_rag_empty_corpus_is_safe():
+    eng = TextRAGQAEngine(client=_FakeClient())
+    res = eng.answer(_Corpus([]).__dict__ | {"ids": [], "texts": [], "unit": []}, "q?")
+    assert res.text == ""
+
+
+def test_build_engine_constructs_text_rag(monkeypatch):
+    # _build_engine must not need a network/key to construct the engine -> patch the
+    # OpenAI client the engine would otherwise build.
+    import erkgbench.qa_e2e.engines.text_rag as tr
+
+    monkeypatch.setattr(tr, "TextRAGQAEngine",
+                        lambda **kw: ("text_rag", kw.get("model")), raising=True)
+    from erkgbench.qa_e2e.run_qa_e2e import _build_engine
+
+    got = _build_engine("text_rag")
+    assert got == ("text_rag", "gpt-4o-mini")


### PR DESCRIPTION
## Why

Four graph-quality levers (literals, synthesis-prompt A+B, cross-doc linking, budget) measured — **none moved the headline judge off ~0.26–0.34**, and a stronger synth model (gpt-4o) bought only ~0.34→0.38. The structural worry: **a KG is a lossy intermediate** vs. text-RAG, which keeps the raw paragraphs. Until we measure the no-KG control on the *same* questions and judge, "0.38" is unanchored — we can't say whether the graph helps or hurts on MuSiQue QA.

This adds the missing anchor: a naive paragraph-retrieval RAG baseline, on the **same** models the KG engines use (gpt-4o-mini + text-embedding-3-large), wired into the same harness/judge so all five engines compete on the identical 50 MuSiQue questions.

## What

- **`engines/text_rag.py`** — `TextRAGQAEngine`: embed every doc paragraph, cosine top-k retrieve per question (`TEXT_RAG_TOP_K`, default 10), multi-hop synthesis prompt, `Answer:`-line parsing mirroring goldengraph. `retrieved_fact_ids` are the retrieved paragraph ids → real `support_recall`.
- **`run_qa_e2e.py`** — `_build_engine("text_rag")` branch.
- **`bench-graphrag-qa.yml`** — new `text_rag` job (no FalkorDB/index dependency), `text_rag_top_k` input, `engine=all` now spans goldengraph + lightrag + ms_graphrag + graphiti + text_rag, aggregate `needs:` it.
- **3 offline tests** (injected fake OpenAI client): retrieves the relevant passage first + parses the answer + meters tokens + surfaces ids; empty-corpus safe; `_build_engine` constructs it. Green.

## The experiment (dispatched)
`engine=all`, corpus=musique, N=50, judged — text_rag vs the four KGs side-by-side. **If text_rag ≥ the KGs, the graph is not earning its place on this task and we re-scope; if the KGs clear it, the structure is paying and the levers are worth chasing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2QxUGxP1Mp1rmcdrGMAxb)_