### PR TITLE
feat(er-kg-bench): GoldenGraph per-stage scorecard + ER-quality ablation (deterministic core)

### DIFF
--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -129,7 +129,7 @@ jobs:
         working-directory: ${{ env.BENCH_DIR }}
         env:
           POLARS_SKIP_CPU_CHECK: "1"
-        run: "$GITHUB_WORKSPACE/.venv/bin/python -m pytest tests/test_qa_metrics.py tests/test_qa_corpora.py tests/test_qa_harness.py -v"
+        run: "$GITHUB_WORKSPACE/.venv/bin/python -m pytest tests/test_qa_metrics.py tests/test_qa_corpora.py tests/test_qa_harness.py tests/test_qa_gold_oracle.py tests/test_qa_dials.py tests/test_qa_bridge_recall.py tests/test_qa_engineered_surfaces.py tests/test_qa_ablation.py -v"
 
       - name: Regenerate demo DEMO.md (Tier 1)
         working-directory: ${{ env.BENCH_DIR }}

--- a/.github/workflows/goldengraph-pipeline.yml
+++ b/.github/workflows/goldengraph-pipeline.yml
@@ -53,3 +53,25 @@ jobs:
         env:
           POLARS_SKIP_CPU_CHECK: "1"
         run: python -m pytest tests/test_qa_goldengraph_smoke.py -v
+
+      - name: ER-quality ablation gate (deterministic, key-free, builds bridge-recall)
+        # The (ER_accuracy)^hops thesis at the retrieval layer: build the store per
+        # resolution dial from gold triples (no LLM extraction), measure bridge-recall
+        # by hop. Gates HARD on monotonic decay + a widening oracle-none gap;
+        # goldengraph>=name_only is a soft WARN (offline fuzzy only separates on
+        # string-close variants). No API key, no network.
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: |
+          python -m pytest tests/test_qa_ablation.py -v
+          python -m erkgbench.qa_e2e.run_ablation \
+            --seed 7 --n-questions 80 --ambiguity 0.6 --out-md ABLATION.md
+
+      - name: Upload ABLATION.md
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: goldengraph-er-ablation
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/ABLATION.md
+          if-no-files-found: ignore

--- a/docs/superpowers/plans/2026-06-26-goldengraph-er-ablation-scorecard.md
+++ b/docs/superpowers/plans/2026-06-26-goldengraph-er-ablation-scorecard.md
@@ -25,8 +25,8 @@
   - `ResolvedEntity(local_id, canonical_name, typ, surface_names: list[str], record_keys: list[str], member_idx: list[int])`
   - `build_batch(extraction, entities, *, at, valid_from=None) -> dict`
   - store: `from goldengraph_native import _native as ggn; store = ggn.PyStore(); store.append(json.dumps(batch))`
-  - **The store merges entities across appends when they share a `record_key`** (the cross-doc-link mechanism injects record_keys precisely so "the store's overlap-merge" connects them).
-- **Retrieval:** `slice_graph = store.as_of(valid_t, tx_t)`; `slice_graph.query(seed_ids, hops) -> {"entities":[{entity_id,canonical_name,typ,surface_names,record_keys,...}], "edges":[{subj,obj,predicate}]}`. Seeds are explicit ids — no embedder needed for oracle-seeding. `_AS_OF` in the engine adapter is the as-of coordinate (read it; reuse the same value).
+  - **The store merges entities across appends when they share a `record_key`** (build-side: `record_keys` go INTO the batch and drive the store's overlap-merge). **But `record_keys` are NOT marshaled back out** — the pyo3 read layer (`goldengraph-native/src/lib.rs`) emits entity dicts with only `entity_id, canonical_name, typ, members, surface_names`. So the dial controls merge via `record_keys` at build time, and the **read-side coverage map is built from `surface_names`** (a merged entity's `surface_names` accumulates every merged surface — confirmed in `store.rs` and `store_golden.json`).
+- **Retrieval:** `slice_graph = store.as_of(valid_t, tx_t)`; `slice_graph.query(seed_ids, hops) -> {"entities":[{entity_id,canonical_name,typ,members,surface_names}], "edges":[{subj,obj,predicate}]}` (NO `record_keys` on the read side). Seeds are explicit ids — no embedder needed for oracle-seeding. `_AS_OF = 10**12` in the engine adapter (reuse the same value).
 
 ## Test environment
 
@@ -80,10 +80,14 @@ def test_gold_chain_walks_to_gold_answer():
 
 
 def test_gold_graph_ignores_non_edge_documents():
-    # MuSiQue-style docs (no `::`) must not crash / pollute the graph.
-    corpus = generate_engineered(seed=1, n_questions=5, ambiguity=0.0, max_hops=2)
+    # A non-edge (MuSiQue-style, not 3-part) doc id must be skipped, not crash.
+    from erkgbench.qa_e2e.corpora import Document, QACorpus
+
+    edge = Document(id="gm:a::works_at::gm:b", text="A works at B.")
+    musique = Document(id="q1::p0", text="unrelated paragraph")  # 2-part id
+    corpus = QACorpus(name="mix", documents=(edge, musique), questions=())
     g = GoldGraph.from_corpus(corpus)
-    assert g.edge_count() > 0
+    assert g.edge_count() == 1 and g.has_edge("gm:a", "works_at", "gm:b")
 ```
 
 - [ ] **Step 2: Run to verify they fail** — `... test_qa_gold_oracle.py -q` → `ModuleNotFoundError: ... qa_e2e.gold`.
@@ -263,11 +267,17 @@ def goldengraph_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], st
     # rerank OFF: name+type is two fields, under the 3-field cross-encoder trigger;
     # this keeps the gate network-free (no HuggingFace download).
     result = gm.dedupe_df(df)  # zero-config; 2 fields => no rerank
-    cluster_of = result.cluster_ids()  # row index -> cluster id  (CONFIRM exact accessor)
-    return {(rows[i][0], rows[i][1]): f"c{cluster_of[i]}" for i in range(len(rows))}
+    # DedupeResult.clusters is dict[cluster_id, {"members":[row_idx,...], "size":n}].
+    # It may only surface multi-member clusters -> default every other row to its
+    # own singleton id (mirrors resolve.py::resolve / ingest.py::_gm_cluster).
+    cluster_of = {i: f"s{i}" for i in range(len(rows))}  # singleton fallback
+    for cid, info in result.clusters.items():
+        for ri in info["members"]:
+            cluster_of[ri] = f"c{cid}"
+    return {(rows[i][0], rows[i][1]): cluster_of[i] for i in range(len(rows))}
 ```
 
-> **CONFIRM during impl:** the exact `dedupe_df` result accessor that yields a per-row cluster/group id (`.cluster_ids()` is a placeholder — check `goldenmatch.dedupe_df`'s return type; it may be a frame with a `cluster_id` column). Use whatever maps row index → group. This is the only API-shape unknown; everything else is verified.
+> Reference implementations of the `result.clusters` → row-group map: `resolve.py::resolve` and `ingest.py::_gm_cluster`. Confirm `DedupeResult.clusters` shape (`_api.py`) during impl — `{cluster_id: {"members":[...], "size":n}}`.
 
 - [ ] **Step 4: Run → pass.**
 - [ ] **Step 5: Commit** — `feat(er-kg-bench): ER-quality dial key-policies`.
@@ -376,6 +386,16 @@ def bridge_recall(gold_chain, subgraph: dict, coverage: dict) -> dict:
 
 `ablation.py` ties it together: for each dial, build a store directly from gold triples (record_keys from the dial), retrieve per question (oracle-seeded), compute bridge-recall by hop.
 
+### Task 4a (prerequisite, shared-file change): expose per-document rendered surfaces
+
+The rendered surface (canonical or variant, chosen by the ambiguity dial) is currently embedded ONLY in `Document.text` (`f"{s} {rel_words} {o}."`), and parsing it back is ambiguous (surfaces and relation phrases both contain spaces). It's load-bearing: for `name_only`/`goldengraph` the rendered variant surface is what differentiates those dials from `oracle`. Extend the generator (small, backward-compatible):
+
+- Modify `erkgbench/qa_e2e/corpora.py`: add `src_surface: str = ""` and `dst_surface: str = ""` to the frozen `Document` dataclass (defaults keep MuSiQue + all existing callers working).
+- Modify `erkgbench/qa_e2e/engineered.py` (the edge-doc render loop, ~lines 102–114): pass the already-computed `s` / `o` rendered surfaces into the `Document(...)` constructor as `src_surface=s, dst_surface=o`.
+- Test (wheel-free, `tests/test_qa_engineered_surfaces.py`): `generate_engineered(...)` edge docs carry non-empty `src_surface`/`dst_surface`, each ∈ {canonical, a variant} of the doc-id's src/dst entity; commit as its own step.
+
+Keyspace consistency: every rendered surface is canonical-or-variant, and `dials._entity_surfaces` enumerates exactly canonical+variants, so `km[(entity_id, rendered_surface)]` always hits.
+
 - [ ] **Step 1: Write the failing test**
 
 ```python
@@ -405,15 +425,14 @@ def test_ablation_monotonic_and_hop_widening():
 - [ ] **Step 3: Implement `ablation.py`**
 
 Build path per dial (bypass `ingest_corpus`/`_extract`):
-1. `g = GoldGraph.from_corpus(corpus)`; `km = dials.<dial>_keys(corpus, g)`.
-2. For each edge document, derive the two mention surfaces actually rendered in `Document.text` (parse the doc text, OR — simpler & exact — re-derive from the doc id's canonical ids + the gold, choosing the surface deterministically the SAME way the generator did). **CONFIRM the cleanest source of the rendered surface** (the doc text contains it; `engineered.py` renders `src`/`dst` mentions). Pragmatic: extract the two surfaces from `Document.text` via the known render template, or extend `generate_engineered` to also emit per-document `(src_surface, dst_surface)` gold metadata (preferred — a tiny, backward-compatible addition to the generator). Use the metadata route if parsing is fragile.
-3. Build one `Extraction(mentions=[Mention(src_surface, src_typ), Mention(dst_surface, dst_typ)], relationships=[Relationship(0, rel, 1)])`.
-4. Build `ResolvedEntity`s with `record_keys=[km[(entity_id, surface)]]`, `member_idx=[i]`, `surface_names=[surface]`. (Each mention its own ResolvedEntity; the STORE merges across docs by record_key.)
-5. Maintain `record_key -> canonical_id` side map as you go.
-6. `store.append(json.dumps(build_batch(extraction, entities, at=i+1)))`.
-7. After all docs: `slice_graph = store.as_of(_AS_OF, _AS_OF)`. Build `coverage`: enumerate `slice_graph.entities()`, map each `entity_id` → `{canonical for rk in entity["record_keys"] for canonical in side_map[rk]}`.
-8. Per question: oracle-seed = the store entity id covering `qa.start_entity_id`; `subgraph = _retrieve_local(slice_graph, [seed], max_hops, node_budget)`; `bridge_recall(gold_chain(g, qa), subgraph, coverage)`; bucket by `qa.hop_count`.
-9. Aggregate per dial: `mean` whole-chain + `by_hop[k]` mean.
+1. `g = GoldGraph.from_corpus(corpus)`; `km = dials.<dial>_keys(corpus, g)`. Build the read-side side map `surface_to_canon: dict[str, set[str]]` by inverting `dials._entity_surfaces(g)` (one surface may map to multiple canonicals — the `name_only` collision case).
+2. For each edge document, read the rendered surfaces directly from `doc.src_surface` / `doc.dst_surface` (Task 4a) and the entity ids + relation from `doc.id.split("::")`.
+3. Build one `Extraction(mentions=[Mention(src_surface, src_typ), Mention(dst_surface, dst_typ)], relationships=[Relationship(0, rel, 1)])` (types from the concept universe).
+4. Build two `ResolvedEntity`s (one per mention): `record_keys=[km[(entity_id, surface)]]`, `member_idx=[i]`, `surface_names=[surface]`, `local_id=i`. The STORE merges across docs by record_key overlap.
+5. `store.append(json.dumps(build_batch(extraction, entities, at=i+1)))`.
+6. After all docs: `slice_graph = store.as_of(_AS_OF, _AS_OF)`. Build `coverage: dict[entity_id, set[canonical]]` from the READABLE `surface_names` (record_keys aren't exposed): `coverage[e["entity_id"]] = { c for s in e["surface_names"] for c in surface_to_canon.get(s, ()) }` over `slice_graph.entities()`.
+7. Per question: oracle-seed = the store entity id whose coverage contains `qa.start_entity_id` (invert `coverage`; if several, pick the smallest entity_id deterministically); `subgraph = _retrieve_local(slice_graph, [seed], max_hops=self_hops, node_budget=self_budget)`; `bridge_recall(gold_chain(g, qa), subgraph, coverage)`; bucket by `qa.hop_count`. (Use the engine adapter's default hops/node_budget — read them from `engines/goldengraph.py`.)
+8. Aggregate per dial: `mean` whole-chain + `by_hop[k]` mean.
 
 Return a small dataclass `AblationResult(recall: dict[str, dict])`.
 

--- a/docs/superpowers/plans/2026-06-26-goldengraph-er-ablation-scorecard.md
+++ b/docs/superpowers/plans/2026-06-26-goldengraph-er-ablation-scorecard.md
@@ -1,0 +1,466 @@
+# GoldenGraph ER-Ablation Scorecard Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the deterministic, $0, CI-gateable bridge-recall ER-ablation that proves/refutes goldengraph's `(ER_accuracy)^hops` thesis at the retrieval layer, plus the per-stage scorecard scaffold.
+
+**Architecture:** A pure-Python oracle reconstructs the engineered corpus's gold graph + per-question chain from doc-id parsing. Four ER-quality "dials" assign cross-document identity by controlling the `record_key`s each mention emits (the store merges mentions across documents iff they share a record_key). For each dial we build a goldengraph native store directly from gold triples (bypassing the LLM extractor), oracle-seed retrieval at the gold start entity, expand the ball, and measure bridge-recall (is the gold chain walkable) bucketed by hop. The gate asserts monotonic decay in ER quality + a widening oracle−none gap with hops.
+
+**Tech Stack:** Python 3.11, pytest (wheel-free for the metric core; `goldengraph_native` wheel for the end-to-end ablation), GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-goldengraph-er-ablation-scorecard-design.md`
+
+**Scope of THIS plan:** the deterministic core (Tasks 1–6) — oracle, dial key-policies, bridge-recall metric, store-build + ablation runner, CLI/`ABLATION.md`, CI gate. The real-LLM scorecard rows (extraction-F1, synthesis-given-gold-subgraph, answer-match confirmation) are **Phase 2 of slice A, a follow-up PR** wired into the existing opt-in `bench-graphrag-qa` lane — they need real-LLM budget and don't gate. Noted in §"Phase 2".
+
+---
+
+## Key code facts (verified against the branch)
+
+- **Corpus:** `erkgbench.qa_e2e.engineered.generate_engineered(*, seed, n_questions, ambiguity, max_hops=4) -> QACorpus`. One `Document` per edge, `Document.id = f"{src_id}::{rel}::{dst_id}"` (canonical ids; `::` separator; ids contain at most a single `:`). `QAItem(question, gold_answer, gold_supporting_fact_ids, hop_count, ambiguity_level, start_entity_id, relation_chain)`. Each `(entity, relation)` has a unique edge → `relation_chain` walks deterministically.
+- **Concepts:** `dataset.concepts_loader.load_concepts(path) -> list[Concept]`; `Concept(concept, canonical_id, entity_type, variants: tuple[Variant])`, `Variant(surface)`. Gives the `surface → canonical_id` map for the `oracle` dial.
+- **Ingest seams** (`goldengraph.ingest` / `.extract` / `.resolve`):
+  - `Mention(name: str, typ: str, context: str = "")`
+  - `Relationship(subj: int, predicate: str, obj: int)` (subj/obj index `Extraction.mentions`)
+  - `Extraction(mentions: list[Mention], relationships: list[Relationship])`
+  - `ResolvedEntity(local_id, canonical_name, typ, surface_names: list[str], record_keys: list[str], member_idx: list[int])`
+  - `build_batch(extraction, entities, *, at, valid_from=None) -> dict`
+  - store: `from goldengraph_native import _native as ggn; store = ggn.PyStore(); store.append(json.dumps(batch))`
+  - **The store merges entities across appends when they share a `record_key`** (the cross-doc-link mechanism injects record_keys precisely so "the store's overlap-merge" connects them).
+- **Retrieval:** `slice_graph = store.as_of(valid_t, tx_t)`; `slice_graph.query(seed_ids, hops) -> {"entities":[{entity_id,canonical_name,typ,surface_names,record_keys,...}], "edges":[{subj,obj,predicate}]}`. Seeds are explicit ids — no embedder needed for oracle-seeding. `_AS_OF` in the engine adapter is the as-of coordinate (read it; reuse the same value).
+
+## Test environment
+
+Wheel-free tests (Tasks 1–3) run via the main venv with a path shadow + polars guard, from the er-kg-bench dir:
+```
+PY="/d/show_case/goldenmatch/.venv/Scripts/python.exe"
+cd packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$(pwd -W)" POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 "$PY" -m pytest <path> -q
+```
+End-to-end ablation tests (Task 4+) need the `goldengraph_native` wheel — guard with `pytest.importorskip("goldengraph_native")` so they skip locally and run in the wheel-building CI gate. Do NOT run the full suite (OOMs the box) — run only the named files.
+
+---
+
+## Task 1: Gold oracle (wheel-free)
+
+**Files:**
+- Create: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/gold.py`
+- Test: `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_gold_oracle.py`
+
+Use @superpowers:test-driven-development.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Pure oracle: reconstruct the engineered gold graph + walk a question's chain.
+No native, no LLM, no network."""
+from __future__ import annotations
+
+from erkgbench.qa_e2e.engineered import generate_engineered
+from erkgbench.qa_e2e.gold import GoldGraph, gold_chain
+
+
+def test_gold_graph_rebuilds_edges_from_doc_ids():
+    corpus = generate_engineered(seed=7, n_questions=20, ambiguity=0.5, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    # every traversed-edge document id `src::rel::dst` is an edge in the gold graph
+    for d in corpus.documents:
+        src, rel, dst = d.id.split("::")
+        assert g.has_edge(src, rel, dst)
+
+
+def test_gold_chain_walks_to_gold_answer():
+    corpus = generate_engineered(seed=7, n_questions=20, ambiguity=0.5, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    for qa in corpus.questions:
+        chain = gold_chain(g, qa)  # ordered [(src_id, rel, dst_id), ...]
+        assert len(chain) == qa.hop_count
+        assert chain[0][0] == qa.start_entity_id
+        # the chain's terminal entity's canonical name == gold_answer
+        assert g.canonical_name(chain[-1][2]) == qa.gold_answer
+
+
+def test_gold_graph_ignores_non_edge_documents():
+    # MuSiQue-style docs (no `::`) must not crash / pollute the graph.
+    corpus = generate_engineered(seed=1, n_questions=5, ambiguity=0.0, max_hops=2)
+    g = GoldGraph.from_corpus(corpus)
+    assert g.edge_count() > 0
+```
+
+- [ ] **Step 2: Run to verify they fail** — `... test_qa_gold_oracle.py -q` → `ModuleNotFoundError: ... qa_e2e.gold`.
+
+- [ ] **Step 3: Implement `gold.py`**
+
+```python
+"""Pure-Python oracle over the engineered corpus: rebuild the gold graph from
+edge-document ids and walk each question's relation_chain. No native/LLM/network.
+
+Engineered `Document.id` is `src_id::rel::dst_id` with CANONICAL ids; each
+(entity, relation) has a unique edge, so a relation_chain walk is deterministic."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .corpora import QACorpus, QAItem
+
+
+@dataclass
+class GoldGraph:
+    # src_id -> {relation -> dst_id}
+    _edges: dict[str, dict[str, str]] = field(default_factory=dict)
+    _names: dict[str, str] = field(default_factory=dict)  # canonical_id -> canonical name
+
+    @classmethod
+    def from_corpus(cls, corpus: QACorpus) -> "GoldGraph":
+        g = cls()
+        # canonical names from the concept universe (ids -> concept string)
+        from dataset.concepts_loader import load_concepts  # type: ignore
+
+        bench_root = Path(__file__).resolve().parents[2]
+        for c in load_concepts(bench_root / "dataset" / "concepts.jsonl"):
+            g._names[c.canonical_id] = c.concept
+        for d in corpus.documents:
+            parts = d.id.split("::")
+            if len(parts) != 3:  # non-edge doc (MuSiQue) -> skip
+                continue
+            src, rel, dst = parts
+            g._edges.setdefault(src, {})[rel] = dst
+        return g
+
+    def has_edge(self, src: str, rel: str, dst: str) -> bool:
+        return self._edges.get(src, {}).get(rel) == dst
+
+    def edge_count(self) -> int:
+        return sum(len(v) for v in self._edges.values())
+
+    def canonical_name(self, entity_id: str) -> str:
+        return self._names.get(entity_id, entity_id)
+
+
+def gold_chain(g: GoldGraph, qa: QAItem) -> list[tuple[str, str, str]]:
+    """Walk `qa.relation_chain` from `qa.start_entity_id` over the gold graph.
+    Returns the ordered edge list [(src_id, rel, dst_id), ...]. Raises KeyError
+    if the chain is broken (should never happen for a generated question)."""
+    chain: list[tuple[str, str, str]] = []
+    cur = qa.start_entity_id
+    for rel in qa.relation_chain:
+        dst = g._edges[cur][rel]
+        chain.append((cur, rel, dst))
+        cur = dst
+    return chain
+```
+
+- [ ] **Step 4: Run to verify pass** — expect 3 passed.
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): gold oracle for the engineered corpus`.
+
+---
+
+## Task 2: ER-quality dial key-policies (wheel-free)
+
+**Files:**
+- Create: `.../erkgbench/qa_e2e/dials.py`
+- Test: `.../tests/test_qa_dials.py`
+
+The dial controls cross-document identity via the `record_key` assigned to each mention. A dial is a function `record_key_map(corpus, gold) -> dict[(entity_id, surface) -> str]`: the key two mentions must SHARE to merge in the store.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+from erkgbench.qa_e2e.engineered import generate_engineered
+from erkgbench.qa_e2e.gold import GoldGraph
+from erkgbench.qa_e2e import dials
+
+
+def _setup():
+    corpus = generate_engineered(seed=7, n_questions=20, ambiguity=0.6, max_hops=4)
+    return corpus, GoldGraph.from_corpus(corpus)
+
+
+def test_oracle_merges_all_surfaces_of_an_entity():
+    corpus, g = _setup()
+    km = dials.oracle_keys(corpus, g)
+    # every (entity_id, surface) pair for one entity maps to ONE key
+    keys_by_entity: dict[str, set] = {}
+    for (eid, _surface), key in km.items():
+        keys_by_entity.setdefault(eid, set()).add(key)
+    assert all(len(s) == 1 for s in keys_by_entity.values())
+
+
+def test_none_gives_every_mention_a_unique_key():
+    corpus, g = _setup()
+    km = dials.none_keys(corpus, g)
+    assert len(set(km.values())) == len(km)  # all distinct
+
+
+def test_name_only_keys_by_exact_surface():
+    corpus, g = _setup()
+    km = dials.name_only_keys(corpus, g)
+    # two different surfaces of the same entity get DIFFERENT keys
+    by_entity: dict[str, set] = {}
+    for (eid, surface), key in km.items():
+        by_entity.setdefault(eid, set()).add(key)
+    multi = [s for s in by_entity.values() if len(s) > 1]
+    assert multi, "ambiguity>0 should give some entity >1 surface-key"
+
+
+def test_goldengraph_merges_at_least_exact_and_no_more_than_oracle():
+    corpus, g = _setup()
+    o, gg, nm = dials.oracle_keys(corpus, g), dials.goldengraph_keys(corpus, g), dials.name_only_keys(corpus, g)
+    # distinct-key count: oracle <= goldengraph <= name_only  (more merging = fewer keys)
+    assert len(set(o.values())) <= len(set(gg.values())) <= len(set(nm.values()))
+```
+
+- [ ] **Step 2: Run → fail** (`ModuleNotFoundError ... dials`).
+
+- [ ] **Step 3: Implement `dials.py`**
+
+Build the `(entity_id, surface)` universe from the corpus: re-derive each document's two mentions (src/dst canonical ids + the rendered surface). Because the renderer is seed-deterministic, re-run the same surface choice is unavailable — instead enumerate from the gold graph + concepts: every entity's surfaces = its canonical name + its variant surfaces. Keys:
+- `oracle_keys`: `key = entity_id` (canonical id) for every `(entity_id, surface)`.
+- `none_keys`: `key = f"{entity_id}::{surface}::{i}"` unique per pair (use enumerate order; deterministic).
+- `name_only_keys`: `key = surface` (exact string — same surface across entities collides, which is the honest behaviour of exact-name resolution).
+- `goldengraph_keys`: run `goldenmatch.dedupe_df` over the distinct `(surface, typ)` rows **with rerank forced off** (name+type only — two fields stay under the 3-field cross-encoder trigger; see spec §footgun), assign each cluster a shared synthetic key. Deterministic, offline.
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from .corpora import QACorpus
+from .gold import GoldGraph
+
+
+def _entity_surfaces(g: GoldGraph) -> list[tuple[str, str, str]]:
+    """[(entity_id, surface, typ), ...] over the concept universe (canonical + variants)."""
+    from dataset.concepts_loader import load_concepts  # type: ignore
+
+    bench_root = Path(__file__).resolve().parents[2]
+    out: list[tuple[str, str, str]] = []
+    for c in load_concepts(bench_root / "dataset" / "concepts.jsonl"):
+        surfaces = [c.concept] + [v.surface for v in c.variants]
+        for s in dict.fromkeys(surfaces):
+            out.append((c.canonical_id, s, c.entity_type))
+    return out
+
+
+def oracle_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
+    return {(eid, s): eid for (eid, s, _t) in _entity_surfaces(g)}
+
+
+def none_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
+    return {(eid, s): f"{eid}::{s}::{i}" for i, (eid, s, _t) in enumerate(_entity_surfaces(g))}
+
+
+def name_only_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
+    return {(eid, s): s for (eid, s, _t) in _entity_surfaces(g)}
+
+
+def goldengraph_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
+    rows = _entity_surfaces(g)
+    import polars as pl  # noqa: F401  (guarded by POLARS_SKIP_CPU_CHECK in tests/CI)
+    import goldenmatch as gm
+
+    df = pl.DataFrame({"name": [s for (_e, s, _t) in rows], "type": [t for (_e, _s, t) in rows]})
+    # rerank OFF: name+type is two fields, under the 3-field cross-encoder trigger;
+    # this keeps the gate network-free (no HuggingFace download).
+    result = gm.dedupe_df(df)  # zero-config; 2 fields => no rerank
+    cluster_of = result.cluster_ids()  # row index -> cluster id  (CONFIRM exact accessor)
+    return {(rows[i][0], rows[i][1]): f"c{cluster_of[i]}" for i in range(len(rows))}
+```
+
+> **CONFIRM during impl:** the exact `dedupe_df` result accessor that yields a per-row cluster/group id (`.cluster_ids()` is a placeholder — check `goldenmatch.dedupe_df`'s return type; it may be a frame with a `cluster_id` column). Use whatever maps row index → group. This is the only API-shape unknown; everything else is verified.
+
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): ER-quality dial key-policies`.
+
+---
+
+## Task 3: Bridge-recall metric (wheel-free)
+
+**Files:**
+- Create: `.../erkgbench/qa_e2e/scorecard.py`
+- Test: `.../tests/test_qa_bridge_recall.py`
+
+Bridge-recall operates on a **resolved subgraph dict** + a **canonical-coverage map** (`entity_id -> set(canonical_ids)` derived from the build's `record_key -> canonical` side map). It does NOT touch the store — fully wheel-free and unit-testable.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+from erkgbench.qa_e2e.scorecard import bridge_recall
+
+# resolved subgraph: store-entity ids -> edges; coverage maps store id -> canonical ids
+_CHAIN = [("c0", "works_at", "c1"), ("c1", "acquired", "c2")]  # 2-hop gold chain
+
+
+def _sub(edges):
+    ents = sorted({e for pair in edges for e in (pair[0], pair[2])})
+    return {"entities": [{"entity_id": e} for e in ents],
+            "edges": [{"subj": s, "predicate": p, "obj": o} for (s, p, o) in edges]}
+
+
+def test_full_chain_present_recall_one():
+    # store ids 0,1,2 each carry exactly canonical c0,c1,c2; both edges present
+    sub = _sub([(0, "works_at", 1), (1, "acquired", 2)])
+    cov = {0: {"c0"}, 1: {"c1"}, 2: {"c2"}}
+    r = bridge_recall(_CHAIN, sub, cov)
+    assert r["whole_chain"] == 1.0 and r["edge_recall"] == 1.0
+
+
+def test_undermerged_bridge_breaks_walk():
+    # c1's mentions are SPLIT: node 1 carries c1 (reached from c0) but the c1->c2
+    # edge was authored from node 3 (the other c1 surface). Walk cannot continue.
+    sub = _sub([(0, "works_at", 1), (3, "acquired", 2)])
+    cov = {0: {"c0"}, 1: {"c1"}, 3: {"c1"}, 2: {"c2"}}
+    r = bridge_recall(_CHAIN, sub, cov)
+    assert r["whole_chain"] == 0.0
+    assert r["edge_recall"] == 0.5  # first edge reachable, second not from the carried node
+
+
+def test_missing_from_ball_zero():
+    sub = _sub([(0, "works_at", 1)])  # second edge absent entirely
+    cov = {0: {"c0"}, 1: {"c1"}}
+    r = bridge_recall(_CHAIN, sub, cov)
+    assert r["whole_chain"] == 0.0
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement `bridge_recall`**
+
+```python
+"""Per-stage scorecard metrics. bridge_recall = does the resolved+retrieved
+subgraph let you WALK the gold chain end to end (the (ER)^hops thesis at the
+retrieval layer; no LLM)."""
+from __future__ import annotations
+
+
+def _nodes_covering(coverage: dict, canon: str) -> set:
+    return {nid for nid, cset in coverage.items() if canon in cset}
+
+
+def bridge_recall(gold_chain, subgraph: dict, coverage: dict) -> dict:
+    """gold_chain: [(src_canon, rel, dst_canon), ...]. coverage: store entity_id ->
+    set(canonical_ids it carries). Returns {"whole_chain": 0/1, "edge_recall": frac}.
+
+    Walk: start from the set of store nodes covering the first src canonical; for
+    each gold edge, can we step (via a subgraph edge, predicate ignored -- gold
+    predicates come from the same triples) from a carried node to a node covering
+    the next canonical? Carry that node set forward. An edge that strands (no such
+    step) ends the walk; remaining edges are unreachable."""
+    adj: dict = {}
+    for e in subgraph.get("edges", ()):
+        adj.setdefault(e["subj"], set()).add(e["obj"])
+        adj.setdefault(e["obj"], set()).add(e["subj"])  # undirected: synthesis walks either way
+    carried = _nodes_covering(coverage, gold_chain[0][0])
+    edges_hit = 0
+    for (_src, _rel, dst) in gold_chain:
+        targets = _nodes_covering(coverage, dst)
+        reachable = {t for c in carried for t in adj.get(c, ()) if t in targets}
+        if not reachable:
+            break
+        edges_hit += 1
+        carried = reachable
+    return {"whole_chain": 1.0 if edges_hit == len(gold_chain) else 0.0,
+            "edge_recall": edges_hit / len(gold_chain) if gold_chain else 0.0}
+```
+
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): bridge-recall metric`.
+
+---
+
+## Task 4: Store-build + ablation runner (needs the wheel)
+
+**Files:**
+- Create: `.../erkgbench/qa_e2e/ablation.py`
+- Test: `.../tests/test_qa_ablation.py` (guarded `importorskip("goldengraph_native")`)
+
+`ablation.py` ties it together: for each dial, build a store directly from gold triples (record_keys from the dial), retrieve per question (oracle-seeded), compute bridge-recall by hop.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+pytest.importorskip("goldengraph_native")
+from erkgbench.qa_e2e.ablation import run_ablation
+
+
+def test_ablation_monotonic_and_hop_widening():
+    res = run_ablation(seed=7, n_questions=60, ambiguity=0.6, max_hops=4)
+    oracle, gg, name_only, none = (
+        res.recall[d] for d in ("oracle", "goldengraph", "name_only", "none")
+    )
+    # 1. monotone in ER quality (mean whole-chain recall)
+    assert oracle["mean"] >= gg["mean"] >= name_only["mean"] - 1e-9 >= none["mean"] - 1e-9
+    # 2. oracle-none gap widens with hops
+    gap_lo = oracle["by_hop"][2] - none["by_hop"][2]
+    gap_hi = oracle["by_hop"][4] - none["by_hop"][4]
+    assert gap_hi > gap_lo
+    # 3. resolver earns its keep (SOFT: >= within a small margin)
+    assert gg["mean"] >= name_only["mean"]
+```
+
+- [ ] **Step 2: Run → fail** (skips if no wheel locally; in CI gate it fails on missing `run_ablation`).
+
+- [ ] **Step 3: Implement `ablation.py`**
+
+Build path per dial (bypass `ingest_corpus`/`_extract`):
+1. `g = GoldGraph.from_corpus(corpus)`; `km = dials.<dial>_keys(corpus, g)`.
+2. For each edge document, derive the two mention surfaces actually rendered in `Document.text` (parse the doc text, OR — simpler & exact — re-derive from the doc id's canonical ids + the gold, choosing the surface deterministically the SAME way the generator did). **CONFIRM the cleanest source of the rendered surface** (the doc text contains it; `engineered.py` renders `src`/`dst` mentions). Pragmatic: extract the two surfaces from `Document.text` via the known render template, or extend `generate_engineered` to also emit per-document `(src_surface, dst_surface)` gold metadata (preferred — a tiny, backward-compatible addition to the generator). Use the metadata route if parsing is fragile.
+3. Build one `Extraction(mentions=[Mention(src_surface, src_typ), Mention(dst_surface, dst_typ)], relationships=[Relationship(0, rel, 1)])`.
+4. Build `ResolvedEntity`s with `record_keys=[km[(entity_id, surface)]]`, `member_idx=[i]`, `surface_names=[surface]`. (Each mention its own ResolvedEntity; the STORE merges across docs by record_key.)
+5. Maintain `record_key -> canonical_id` side map as you go.
+6. `store.append(json.dumps(build_batch(extraction, entities, at=i+1)))`.
+7. After all docs: `slice_graph = store.as_of(_AS_OF, _AS_OF)`. Build `coverage`: enumerate `slice_graph.entities()`, map each `entity_id` → `{canonical for rk in entity["record_keys"] for canonical in side_map[rk]}`.
+8. Per question: oracle-seed = the store entity id covering `qa.start_entity_id`; `subgraph = _retrieve_local(slice_graph, [seed], max_hops, node_budget)`; `bridge_recall(gold_chain(g, qa), subgraph, coverage)`; bucket by `qa.hop_count`.
+9. Aggregate per dial: `mean` whole-chain + `by_hop[k]` mean.
+
+Return a small dataclass `AblationResult(recall: dict[str, dict])`.
+
+- [ ] **Step 4: Run in CI gate (Task 6) / locally if wheel present → pass.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): ER-ablation runner (store build + bridge-recall by hop)`.
+
+---
+
+## Task 5: CLI + ABLATION.md
+
+**Files:**
+- Create: `.../erkgbench/qa_e2e/run_ablation.py`
+- Test: extend `test_qa_ablation.py` with a markdown-render unit test (wheel-free: feed a fake `AblationResult`).
+
+- [ ] **Step 1: Failing test** — `render_ablation_md(result)` returns a string containing the 4 dial rows, the by-hop columns, and a PASS/FAIL line per assertion.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** `run_ablation.py`: argparse (`--seed --n-questions --ambiguity --max-hops --out-md`), call `run_ablation`, evaluate the 3 assertions, write `ABLATION.md`, exit non-zero if a HARD assertion fails (soft assertion 3 prints a WARN line, never fails the process — the gate's hard failures are assertions 1+2).
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): run_ablation CLI + ABLATION.md`.
+
+---
+
+## Task 6: CI gate (key-free, builds the wheel)
+
+**Files:**
+- Modify: `.github/workflows/bench-er-kg.yml` (add a `qa-ablation` job mirroring the existing SP6 `gate` job's wheel-build + key-free pattern).
+
+- [ ] **Step 1:** Add a `qa-ablation` job: checkout → install goldenmatch + maturin → build the goldengraph native wheel (same steps as the `goldengraph-pipeline`/SP6 gate; reuse the `CARGO_TARGET_DIR` off-exFAT only applies locally, CI is clean Linux) → run `python -m erkgbench.qa_e2e.run_ablation --seed 7 --n-questions 80 --ambiguity 0.6 --out-md ABLATION.md` with **no API key in env** → upload `ABLATION.md` as an artifact. The process exit code (hard assertions 1+2) gates the job.
+- [ ] **Step 2:** Validate YAML parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/bench-er-kg.yml'))"`.
+- [ ] **Step 3: Commit** — `ci(er-kg-bench): key-free qa-ablation gate`.
+- [ ] **Step 4:** Push branch, open PR, confirm the `qa-ablation` lane goes green (it's the real validator — the wheel build + offline run can't be checked locally on the exFAT box). Iterate on the `dedupe_df` accessor / surface-source CONFIRM items if the lane reveals them.
+
+---
+
+## Phase 2 (follow-up PR, slice A part 2 — NOT in this plan)
+
+Wired into the opt-in `bench-graphrag-qa` lane (real LLM, budget-capped):
+- **extraction-F1** — capture extracted triples during a real build, score entity-F1/relation-F1 vs the gold triples (`gold.py` already has them).
+- **synthesis-given-gold-subgraph** — feed `synthesize_local`/`_hybrid` the gold chain subgraph, measure answer-match (synthesis ceiling).
+- **answer-match confirmation** — the same 4-dial ablation measuring real-LLM answer-match; assert it tracks bridge-recall.
+
+## Done criteria (this plan)
+
+- Tasks 1–3 wheel-free tests green via the shadow+polars-guard command.
+- `qa-ablation` CI lane green: `ABLATION.md` artifact shows oracle ≥ goldengraph ≥ name_only ≥ none, the oracle−none gap widens 2-hop→4-hop (hard), and the goldengraph≥name_only soft line.
+- No API key / network needed for the gate; the full suite is never run locally.
+
+## Not in scope (YAGNI)
+
+Real-LLM scorecard rows (Phase 2), aggregation/temporal corpora (slice B), crossover sweep (slice C), KG-vs-KG (slice D), embedding seed-recall, ANN/persisted embeddings, any `mode="local"`/engine behavior change.

--- a/docs/superpowers/specs/2026-06-26-goldengraph-er-ablation-scorecard-design.md
+++ b/docs/superpowers/specs/2026-06-26-goldengraph-er-ablation-scorecard-design.md
@@ -1,0 +1,176 @@
+# GoldenGraph per-stage scorecard + ER-quality ablation
+
+## Context
+
+The QA-e2e head-to-head measured goldengraph's hybrid mode at **0.420** answer-match
+on musique, below pure passage RAG (**0.520**), and two retrieval/synthesis levers
+(free-form synthesis, path-filter) couldn't move it — because the binding
+constraint is upstream (graph-only = **0.22**; the extracted triples are a lossy
+compression of the source text). The deeper problem is **measurement**: a single
+end-to-end answer-match number conflates four stages (extraction → resolution →
+retrieval → synthesis), so when it reads 0.420 you cannot tell which stage cost the
+points, and you cannot tell whether improving the resolver (goldengraph's actual
+differentiator, **+13pp ER F1** over the best framework) makes downstream answers
+better. QA-over-prose is also RAG's home turf — the answer is in the text — so
+"beat RAG end-to-end" is the wrong target for iterating a KG/ER engine.
+
+This spec builds the instrument that makes goldengraph **measurable per-stage and
+iterable**: a per-stage scorecard plus an **ER-quality ablation** that proves or
+refutes the engine's core thesis — `(ER_accuracy)^hops`: better entity resolution
+strands fewer multi-hop chains, so downstream answers decay slower as hops grow.
+
+This is **slice A** of a four-part benchmark program. Out of scope (each its own
+spec): **B** capability tasks RAG can't do (aggregation/set/count, temporal
+`as_of`); **C** ambiguity × `passage_k` crossover sweep; **D** KG-vs-KG competitive
+(reuse the LightRAG/MS-GraphRAG/Graphiti adapters). This slice targets the
+**engineered** corpus only.
+
+## The key enabler
+
+The engineered corpus (`erkgbench/qa_e2e/engineered.py`) already encodes the gold
+graph with **no new annotation**:
+
+- Each traversed-edge `Document.id` is `src_id::rel::dst_id` with **canonical**
+  entity ids (never variant surfaces) — so a pure-Python oracle rebuilds the full
+  typed gold graph by parsing document ids.
+- Each `QAItem` carries `start_entity_id`, `relation_chain` (ordered relation
+  names), `hop_count`, `ambiguity_level`, and `gold_answer`. Because each
+  `(entity, relation)` pair has a unique edge, walking `relation_chain` from
+  `start_entity_id` over the gold graph deterministically yields the gold bridge
+  entities and the gold answer entity.
+- Concepts (`dataset/concepts.jsonl` via `concepts_loader.load_concepts`) provide
+  `canonical_id`, `entity_type`, and `variants[].surface` — the surface-form
+  universe the resolution dial operates over.
+
+## Design
+
+### Two measurement layers
+
+The thesis is measurable at two layers, and the split is what makes the instrument
+iterable:
+
+- **Retrieval layer — bridge-recall.** Does the retrieved subgraph *contain* the
+  gold answer-chain? A pure graph operation: **no LLM, deterministic, free,
+  CI-gateable.** This is the primary iteration metric.
+- **Answer layer — answer-match.** Does the LLM produce the right answer? Needs a
+  real LLM: costs money, non-deterministic, cannot gate. This is a **periodic
+  confirmation** that the free proxy is faithful, not the iteration loop.
+
+### The ER-quality ablation (deterministic core)
+
+Hold **extraction fixed at oracle** (build the store from the gold triples, no LLM
+extraction) so the resolution stage is isolated, and sweep a resolution-quality
+dial at ingest:
+
+| dial setting | resolver behaviour |
+|---|---|
+| `oracle` | every mention → its true canonical entity (perfect ER) |
+| `goldengraph` | the real resolver (`goldenmatch.dedupe_df` on name + type + context, mirroring `goldengraph.resolve`) |
+| `name_only` | merge only mentions whose surface strings are exactly equal |
+| `none` | every mention is its own entity (no merge — maximal under-merge) |
+
+Each resolver is an injectable `resolver=` callable matching goldengraph's ingest
+contract (returns, per mention group, a resolved entity with member mentions); the
+four are deterministic (no embeddings, no network — `dedupe_df` is fuzzy string
+scoring, not embedding-based).
+
+**Bridge-recall metric (no LLM):** for each question,
+
+1. **Oracle-seed** at the resolved node containing `start_entity_id`'s mentions
+   (bypass the embedding seeder — that isolates resolution from seed quality, which
+   is a separate retrieval axis deferred to slice C's seed-recall).
+2. Expand the ball (`PyGraph.query`) under the engine's normal retrieval.
+3. Test whether `relation_chain` is **walkable end-to-end** in the resolved +
+   retrieved subgraph, from the seed to a node carrying the `gold_answer` mention.
+
+Report **whole-chain hit** (binary: full chain reachable) and **per-edge recall**
+(fraction of gold chain edges present), each **bucketed by `hop_count`**.
+Under-merge (`none`) splits a bridge entity across mention-nodes and breaks the
+walk → low recall; `oracle` keeps it whole → high recall. That mechanic *is* the
+thesis.
+
+### The gate (deterministic, key-free, builds the wheel)
+
+Mirrors the existing SP6 `qa_eval` gate (`bench-er-kg.yml`): builds the native
+goldengraph wheel (maturin), runs the ablation on a small engineered corpus with no
+API key, and asserts:
+
+1. **Monotonic in ER quality:** bridge-recall `oracle ≥ goldengraph ≥ name_only ≥
+   none` (within a small tolerance).
+2. **`^hops` signature:** the `oracle − none` bridge-recall gap **widens with
+   hops** — assert `gap(max_hop) − gap(min_hop) ≥ margin`.
+3. **Resolver earns its keep:** `goldengraph` bridge-recall is materially above
+   `name_only` by a margin. **This is the number that moves when the resolver
+   improves — the iteration signal.**
+
+Margins are chosen from an observed run with slack (the SP6 lesson: 0.10 not 0.20).
+
+### The full scorecard (one page)
+
+| stage | metric | lane | isolates |
+|---|---|---|---|
+| extraction | entity-F1, relation-F1 of extracted vs gold triples | real-LLM (build) | the 0.22 ceiling |
+| resolution | ER-F1 (reuse `er-kg-bench` metrics) | deterministic | the +13pp moat |
+| retrieval | **bridge-recall × ER-dial × hop** | **deterministic (gate)** | does ER flow to reachability |
+| synthesis | answer-match given the **gold** subgraph | real-LLM | can the LLM read a correct graph (synthesis ceiling) |
+
+The two real-LLM rows run in the existing opt-in `bench-graphrag-qa` lane:
+
+- **extraction-F1** — during a real build, capture extracted triples, score against
+  the gold triples (localizes where the 0.22 is lost).
+- **synthesis-given-gold-subgraph** — feed the synthesizer the gold chain subgraph
+  and measure answer-match (the upper bound retrieval+resolution work toward).
+
+### Real-LLM confirmation of the ablation
+
+Same ER dial, measuring **answer-match** instead of bridge-recall, run periodically
+(opt-in, ~$0.3/setting). Assertion: answer-match **tracks** bridge-recall across the
+dial (monotone in the same order). Divergence is itself a finding — synthesis isn't
+using what retrieval surfaced.
+
+## Components / files
+
+New, under `erkgbench/qa_e2e/`:
+
+- **`gold.py`** — the oracle: parse engineered `Document.id`s → typed gold graph;
+  `gold_chain(qa_item)` walks `relation_chain` from `start_entity_id` → ordered
+  (entity, relation, entity) edges + gold answer entity. Pure stdlib.
+- **`resolvers.py`** — the four ablation resolvers as injectable `resolver=`
+  callables (`oracle`, `goldengraph`, `name_only`, `none`).
+- **`scorecard.py`** — the metrics: `bridge_recall(gold_chain, resolved_subgraph)`
+  (whole-chain + per-edge), `extraction_f1(extracted, gold)`,
+  `synthesis_given_gold(...)`, and reuse of `er-kg-bench` ER-F1.
+- **`ablation.py`** — the runner: sweep resolvers × questions → bridge-recall matrix
+  (by hop), the 3 gate assertions, optional `--with-llm` answer-match confirmation.
+- **`run_ablation.py`** — CLI → writes `ABLATION.md` (matrix + assertions) always;
+  `--with-llm` adds answer-match + the extraction/synthesis scorecard rows when an
+  API key is present.
+
+CI: a new **key-free `qa-ablation` gate job** (builds the wheel, runs the
+deterministic ablation on a small engineered corpus, asserts the 3 properties). The
+real-LLM rows wire into the existing opt-in `bench-graphrag-qa` lane.
+
+## Testing
+
+Pure offline tests (no LLM, no network; wheel-free where possible — the metric math
+operates on dicts, only the end-to-end gate job builds the wheel):
+
+1. **Oracle** — tiny engineered corpus → assert reconstructed gold triples; walk a
+   known 3-hop `relation_chain` and assert it lands on `gold_answer`.
+2. **Resolvers** — `oracle` merges all variant surfaces of one entity into one
+   node; `none` merges nothing; `name_only` merges only exact-string dups;
+   `goldengraph` runs `dedupe_df` deterministically.
+3. **Bridge-recall** — synthetic resolved ball *containing* the gold chain →
+   recall 1.0; with a stranded (under-merged) bridge entity → recall < 1.0; per-edge
+   vs whole-chain both asserted.
+4. **Ablation** — on a small fixture: monotonic `oracle ≥ goldengraph ≥ name_only ≥
+   none` and the `oracle − none` gap widens from low-hop to high-hop.
+5. **Determinism** — repeated ablation runs produce identical matrices.
+
+## Scope guard (YAGNI)
+
+In: scorecard + ER ablation on the **engineered** corpus. Out (separate specs):
+aggregation/temporal capability corpora (B), ambiguity × `passage_k` crossover (C),
+KG-vs-KG competitive (D), and the embedding **seed-recall** sub-metric (here we
+oracle-seed to isolate resolution; real seed quality is a distinct retrieval axis).
+No new corpus generator, no ANN index, no persisted embeddings.

--- a/docs/superpowers/specs/2026-06-26-goldengraph-er-ablation-scorecard-design.md
+++ b/docs/superpowers/specs/2026-06-26-goldengraph-er-ablation-scorecard-design.md
@@ -69,10 +69,30 @@ dial at ingest:
 | `name_only` | merge only mentions whose surface strings are exactly equal |
 | `none` | every mention is its own entity (no merge — maximal under-merge) |
 
-Each resolver is an injectable `resolver=` callable matching goldengraph's ingest
-contract (returns, per mention group, a resolved entity with member mentions); the
-four are deterministic (no embeddings, no network — `dedupe_df` is fuzzy string
-scoring, not embedding-based).
+Each resolver is a `Callable[[list[Mention]], list[ResolvedEntity]]` — exactly
+goldengraph's existing `ingest.Resolver` seam (`ResolvedEntity` = `local_id,
+canonical_name, typ, surface_names, record_keys, member_idx`). `oracle` uses the
+concept `variants[].surface → canonical_id` map from `concepts_loader`; `name_only`
+groups by exact surface string; `none` returns one entity per mention; `goldengraph`
+runs `goldenmatch.dedupe_df` (fuzzy string scoring, not embedding-based).
+
+**Store-build path (do NOT route the dial through `ingest_corpus`).** `ingest_corpus`
+/ `_prepare_doc` unconditionally call `_extract(text, llm)`, so they cannot hold
+extraction at oracle offline (extraction needs an LLM or a downloaded local model).
+The ablation builds the store **directly** from the gold edges: construct an
+`Extraction(mentions, relationships)` per document from the oracle's parsed gold
+triples, call `resolver(mentions)`, then `build_batch(...)` → `store.append(...)`
+(all real `ingest.py` functions). This bypasses `_extract` entirely — no LLM, no
+model download — and is the only path that isolates resolution.
+
+**Offline-gate footgun — force rerank off.** `dedupe_df` on a 3-field weighted
+matchkey (name + type + context) triggers auto-config's cross-encoder **rerank**,
+which downloads a HuggingFace model and **fails in the network-free gate** (package
+CLAUDE.md footgun). The deterministic gate therefore runs the `goldengraph` resolver
+on **name + type only** (two fields — stays under the rerank trigger; still a real
+ER edge over `name_only`'s exact match). The full **name + type + context** resolver
+is exercised only in the network-available real-LLM lane. (The plan pins the exact
+mechanism; name+type-only is the robust default that needs no flag.)
 
 **Bridge-recall metric (no LLM):** for each question,
 
@@ -82,6 +102,13 @@ scoring, not embedding-based).
 2. Expand the ball (`PyGraph.query`) under the engine's normal retrieval.
 3. Test whether `relation_chain` is **walkable end-to-end** in the resolved +
    retrieved subgraph, from the seed to a node carrying the `gold_answer` mention.
+
+The gold chain lives in **canonical-id space** (parsed from doc ids); the resolved
+subgraph lives in **resolved-entity-id space**. Bridge-recall maps each gold
+canonical edge to the resolved node(s) *carrying that entity's mentions* and checks
+reachability there — never comparing ids across the two spaces directly. This
+mapping is the crux: under `none`, a bridge entity's mentions scatter across
+distinct resolved nodes, so no single walk connects them and the chain breaks.
 
 Report **whole-chain hit** (binary: full chain reachable) and **per-edge recall**
 (fraction of gold chain edges present), each **bucketed by `hop_count`**.
@@ -104,6 +131,10 @@ API key, and asserts:
    improves — the iteration signal.**
 
 Margins are chosen from an observed run with slack (the SP6 lesson: 0.10 not 0.20).
+The gate's small engineered corpus is generated at **`ambiguity > 0`**: at
+`ambiguity = 0` there are no variant surfaces, so `name_only ≡ none` and the dial
+collapses — the gate corpus must inject variants for the ER quality levels to
+separate.
 
 ### The full scorecard (one page)
 
@@ -140,8 +171,11 @@ New, under `erkgbench/qa_e2e/`:
 - **`scorecard.py`** — the metrics: `bridge_recall(gold_chain, resolved_subgraph)`
   (whole-chain + per-edge), `extraction_f1(extracted, gold)`,
   `synthesis_given_gold(...)`, and reuse of `er-kg-bench` ER-F1.
-- **`ablation.py`** — the runner: sweep resolvers × questions → bridge-recall matrix
-  (by hop), the 3 gate assertions, optional `--with-llm` answer-match confirmation.
+- **`ablation.py`** — the runner: for each dial setting, build the store **directly**
+  from the oracle's gold triples (per-doc `Extraction` → `resolver(mentions)` →
+  `build_batch` → `store.append`, bypassing `ingest_corpus`/`_extract`), then sweep
+  questions → bridge-recall matrix (by hop), the 3 gate assertions, optional
+  `--with-llm` answer-match confirmation.
 - **`run_ablation.py`** — CLI → writes `ABLATION.md` (matrix + assertions) always;
   `--with-llm` adds answer-match + the extraction/synthesis scorecard rows when an
   API key is present.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/ablation.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/ablation.py
@@ -1,0 +1,195 @@
+"""ER-quality ablation: build a goldengraph store directly from the engineered
+gold triples under each resolution dial, oracle-seed retrieval, and measure
+bridge-recall by hop. The deterministic, $0, CI-gateable proof of (ER)^hops.
+
+Store-build bypasses ingest_corpus/_extract (which always call the LLM): per edge
+document we synthesize an Extraction from the gold triple, attach the dial's
+record_key to each mention, build_batch -> store.append. The store merges across
+documents by record_key overlap; the dial therefore controls cross-doc identity.
+
+run_ablation needs the goldengraph_native wheel; AblationResult + render_ablation_md
+are wheel-free.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import dials
+from .engineered import generate_engineered
+from .gold import GoldGraph, gold_chain
+from .scorecard import bridge_recall
+
+_DIALS = ("oracle", "goldengraph", "name_only", "none")
+_KEYFN = {
+    "oracle": dials.oracle_keys,
+    "goldengraph": dials.goldengraph_keys,
+    "name_only": dials.name_only_keys,
+    "none": dials.none_keys,
+}
+
+
+@dataclass
+class AblationResult:
+    # dial -> {"mean": float, "by_hop": {hop:int -> float}}
+    recall: dict[str, dict]
+
+
+def _typ_of(g: GoldGraph) -> dict[str, str]:
+    """entity_id -> entity_type, from the concept universe."""
+    from dataset.concepts_loader import load_concepts  # type: ignore
+
+    bench_root = Path(__file__).resolve().parents[2]
+    return {
+        c.canonical_id: c.entity_type
+        for c in load_concepts(bench_root / "dataset" / "concepts.jsonl")
+    }
+
+
+def _build_store(corpus, g, km, typ_of):
+    """Build a native store from gold triples under a dial's record_key map.
+    Returns (slice_graph, coverage: entity_id -> set(canonical_id))."""
+    from goldengraph.extract import Extraction, Mention, Relationship
+    from goldengraph.ingest import build_batch
+    from goldengraph.resolve import ResolvedEntity
+    from goldengraph_native import _native as ggn
+
+    from .engines.goldengraph import _AS_OF
+
+    store = ggn.PyStore()
+    at = 0
+    for d in corpus.documents:
+        parts = d.id.split("::")
+        if len(parts) != 3:
+            continue
+        src_id, rel, dst_id = parts
+        at += 1
+        s_surf, o_surf = d.src_surface, d.dst_surface
+        extraction = Extraction(
+            mentions=[
+                Mention(name=s_surf, typ=typ_of.get(src_id, "concept")),
+                Mention(name=o_surf, typ=typ_of.get(dst_id, "concept")),
+            ],
+            relationships=[Relationship(subj=0, predicate=rel, obj=1)],
+        )
+        entities = [
+            ResolvedEntity(
+                local_id=0,
+                canonical_name=s_surf,
+                typ=typ_of.get(src_id, "concept"),
+                surface_names=[s_surf],
+                record_keys=[km[(src_id, s_surf)]],
+                member_idx=[0],
+            ),
+            ResolvedEntity(
+                local_id=1,
+                canonical_name=o_surf,
+                typ=typ_of.get(dst_id, "concept"),
+                surface_names=[o_surf],
+                record_keys=[km[(dst_id, o_surf)]],
+                member_idx=[1],
+            ),
+        ]
+        store.append(json.dumps(build_batch(extraction, entities, at=at)))
+
+    slice_graph = store.as_of(_AS_OF, _AS_OF)
+    s2c = dials.surface_to_canon(g)
+    coverage: dict[int, set] = {}
+    for e in slice_graph.entities():
+        cov: set = set()
+        for s in e.get("surface_names", ()):
+            cov |= s2c.get(s, set())
+        coverage[e["entity_id"]] = cov
+    return slice_graph, coverage
+
+
+def run_ablation(*, seed: int, n_questions: int, ambiguity: float, max_hops: int = 4) -> AblationResult:
+    from goldengraph.answer import _retrieve_local
+
+    from .engines.goldengraph import _NODE_BUDGET, _RETRIEVAL_HOPS
+
+    corpus = generate_engineered(
+        seed=seed, n_questions=n_questions, ambiguity=ambiguity, max_hops=max_hops
+    )
+    g = GoldGraph.from_corpus(corpus)
+    typ_of = _typ_of(g)
+    chains = {qa.id: gold_chain(g, qa) for qa in corpus.questions}
+
+    recall: dict[str, dict] = {}
+    for dial in _DIALS:
+        km = _KEYFN[dial](corpus, g)
+        slice_graph, coverage = _build_store(corpus, g, km, typ_of)
+        # invert coverage: canonical -> the (deterministic) store node to seed from
+        seed_of: dict[str, int] = {}
+        for nid in sorted(coverage):  # ascending id => deterministic tie-break
+            for c in coverage[nid]:
+                seed_of.setdefault(c, nid)
+
+        whole: list[float] = []
+        by_hop: dict[int, list[float]] = {}
+        for qa in corpus.questions:
+            seed_node = seed_of.get(qa.start_entity_id)
+            if seed_node is None:
+                br = {"whole_chain": 0.0, "edge_recall": 0.0}
+            else:
+                subgraph = _retrieve_local(
+                    slice_graph, [seed_node], max_hops=_RETRIEVAL_HOPS, node_budget=_NODE_BUDGET
+                )
+                br = bridge_recall(chains[qa.id], subgraph, coverage)
+            whole.append(br["whole_chain"])
+            by_hop.setdefault(qa.hop_count, []).append(br["whole_chain"])
+
+        recall[dial] = {
+            "mean": (sum(whole) / len(whole)) if whole else 0.0,
+            "by_hop": {h: (sum(v) / len(v)) for h, v in sorted(by_hop.items())},
+        }
+    return AblationResult(recall=recall)
+
+
+# --- assertions + markdown (wheel-free) ---
+
+
+def evaluate_assertions(res: AblationResult) -> list[tuple[str, bool, bool]]:
+    """[(label, passed, is_hard), ...]. Hard failures gate; soft only warn."""
+    r = res.recall
+    means = {d: r[d]["mean"] for d in _DIALS}
+    tol = 1e-9
+    monotonic = (
+        means["oracle"] + tol >= means["goldengraph"] >= means["name_only"] - tol
+        and means["name_only"] + tol >= means["none"]
+    )
+
+    def gap(h):
+        return r["oracle"]["by_hop"].get(h, 0.0) - r["none"]["by_hop"].get(h, 0.0)
+
+    hops = sorted(r["oracle"]["by_hop"])
+    widen = bool(hops) and gap(hops[-1]) > gap(hops[0])
+    resolver_edge = means["goldengraph"] + tol >= means["name_only"]
+    return [
+        ("monotonic in ER quality (oracle>=goldengraph>=name_only>=none)", monotonic, True),
+        ("oracle-none gap widens with hops", widen, True),
+        ("resolver earns its keep (goldengraph>=name_only)", resolver_edge, False),
+    ]
+
+
+def render_ablation_md(res: AblationResult) -> str:
+    r = res.recall
+    hops = sorted(r["oracle"]["by_hop"])
+    lines = [
+        "# GoldenGraph ER-quality ablation -- bridge-recall (no LLM)",
+        "",
+        "Whole-chain bridge-recall: can the resolved+retrieved subgraph WALK the gold",
+        "answer chain? The (ER_accuracy)^hops thesis at the retrieval layer.",
+        "",
+        "| dial | mean | " + " | ".join(f"{h}-hop" for h in hops) + " |",
+        "|---|---|" + "---|" * len(hops),
+    ]
+    for d in _DIALS:
+        cells = " | ".join(f"{r[d]['by_hop'].get(h, 0.0):.3f}" for h in hops)
+        lines.append(f"| {d} | {r[d]['mean']:.3f} | {cells} |")
+    lines += ["", "## verdicts", ""]
+    for label, passed, is_hard in evaluate_assertions(res):
+        tag = "PASS" if passed else ("FAIL" if is_hard else "WARN")
+        lines.append(f"- [{tag}] {label}{'' if is_hard else ' (soft)'}")
+    return "\n".join(lines) + "\n"

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/ablation.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/ablation.py
@@ -173,6 +173,14 @@ def evaluate_assertions(res: AblationResult) -> list[tuple[str, bool, bool]]:
     ]
 
 
+def gate_exit_code(res: AblationResult) -> int:
+    """0 if every HARD assertion passes, 1 otherwise. Soft assertions never gate."""
+    hard_failed = any(
+        is_hard and not passed for _label, passed, is_hard in evaluate_assertions(res)
+    )
+    return 1 if hard_failed else 0
+
+
 def render_ablation_md(res: AblationResult) -> str:
     r = res.recall
     hops = sorted(r["oracle"]["by_hop"])

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/corpora.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/corpora.py
@@ -23,6 +23,11 @@ MUSIQUE_SUBSET_SEED = 20260620
 class Document:
     id: str
     text: str
+    #: Engineered edge docs only: the rendered (ambiguity-dialed) surface forms of
+    #: the src/dst mentions, so the ER-ablation can assign per-mention record_keys
+    #: without re-parsing `text`. Empty for MuSiQue / non-edge docs.
+    src_surface: str = ""
+    dst_surface: str = ""
 
 
 @dataclass(frozen=True)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/dials.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/dials.py
@@ -1,0 +1,75 @@
+"""ER-quality dial key-policies.
+
+The dial controls cross-document identity by choosing the `record_key` each
+`(entity_id, surface)` mention emits; the store merges two mentions across
+documents iff they share a record_key. Four levels:
+
+  oracle      -> key = canonical id   (all surfaces of an entity merge: perfect ER)
+  goldengraph -> key = dedupe_df fuzzy cluster (merges string-close variants)
+  name_only   -> key = exact surface  (only identical surfaces merge)
+  none        -> unique key per pair  (nothing merges: maximal under-merge)
+
+`dedupe_df` runs on name+type only (two fields) so it stays under the 3-field
+cross-encoder rerank trigger -- no HuggingFace download, fully offline.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .corpora import QACorpus
+from .gold import GoldGraph
+
+
+def _entity_surfaces(g: GoldGraph) -> list[tuple[str, str, str]]:
+    """[(entity_id, surface, typ), ...] over the concept universe (canonical +
+    variants). The keyspace the build looks up: every rendered surface is one of
+    these, so `km[(entity_id, rendered_surface)]` always hits."""
+    from dataset.concepts_loader import load_concepts  # type: ignore
+
+    bench_root = Path(__file__).resolve().parents[2]
+    out: list[tuple[str, str, str]] = []
+    for c in load_concepts(bench_root / "dataset" / "concepts.jsonl"):
+        surfaces = [c.concept] + [v.surface for v in c.variants]
+        for s in dict.fromkeys(surfaces):
+            out.append((c.canonical_id, s, c.entity_type))
+    return out
+
+
+def surface_to_canon(g: GoldGraph) -> dict[str, set[str]]:
+    """Read-side side map: surface string -> set of canonical ids that use it.
+    A set because a surface can collide across entities (the name_only case)."""
+    m: dict[str, set[str]] = {}
+    for eid, surface, _typ in _entity_surfaces(g):
+        m.setdefault(surface, set()).add(eid)
+    return m
+
+
+def oracle_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
+    return {(eid, s): eid for (eid, s, _t) in _entity_surfaces(g)}
+
+
+def none_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
+    return {(eid, s): f"{eid}::{s}::{i}" for i, (eid, s, _t) in enumerate(_entity_surfaces(g))}
+
+
+def name_only_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
+    return {(eid, s): s for (eid, s, _t) in _entity_surfaces(g)}
+
+
+def goldengraph_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
+    rows = _entity_surfaces(g)
+    import goldenmatch as gm
+    import polars as pl
+
+    df = pl.DataFrame(
+        {"name": [s for (_e, s, _t) in rows], "type": [t for (_e, _s, t) in rows]}
+    )
+    # rerank OFF: name+type is two fields, under the 3-field cross-encoder trigger.
+    result = gm.dedupe_df(df)
+    # DedupeResult.clusters: {cluster_id: {"members":[row_idx,...], "size":n}}. It may
+    # only surface multi-member clusters -> default every row to its own singleton.
+    cluster_of: dict[int, str] = {i: f"s{i}" for i in range(len(rows))}
+    for cid, info in result.clusters.items():
+        for ri in info["members"]:
+            cluster_of[int(ri)] = f"c{cid}"
+    return {(rows[i][0], rows[i][1]): cluster_of[i] for i in range(len(rows))}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engineered.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engineered.py
@@ -110,6 +110,8 @@ def generate_engineered(
                 Document(
                     id=_edge_doc_id(src_id, rel, dst_id),
                     text=f"{s} {rel.replace('_', ' ')} {o}.",
+                    src_surface=s,
+                    dst_surface=o,
                 )
             )
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/gold.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/gold.py
@@ -1,0 +1,57 @@
+"""Pure-Python oracle over the engineered corpus: rebuild the gold graph from
+edge-document ids and walk each question's relation_chain. No native/LLM/network.
+
+Engineered `Document.id` is `src_id::rel::dst_id` with CANONICAL ids; each
+(entity, relation) has a unique edge, so a relation_chain walk is deterministic."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .corpora import QACorpus, QAItem
+
+
+@dataclass
+class GoldGraph:
+    # src_id -> {relation -> dst_id}
+    _edges: dict[str, dict[str, str]] = field(default_factory=dict)
+    _names: dict[str, str] = field(default_factory=dict)  # canonical_id -> canonical name
+
+    @classmethod
+    def from_corpus(cls, corpus: QACorpus) -> GoldGraph:
+        g = cls()
+        # canonical names from the concept universe (ids -> concept string)
+        from dataset.concepts_loader import load_concepts  # type: ignore
+
+        bench_root = Path(__file__).resolve().parents[2]
+        for c in load_concepts(bench_root / "dataset" / "concepts.jsonl"):
+            g._names[c.canonical_id] = c.concept
+        for d in corpus.documents:
+            parts = d.id.split("::")
+            if len(parts) != 3:  # non-edge doc (MuSiQue) -> skip
+                continue
+            src, rel, dst = parts
+            g._edges.setdefault(src, {})[rel] = dst
+        return g
+
+    def has_edge(self, src: str, rel: str, dst: str) -> bool:
+        return self._edges.get(src, {}).get(rel) == dst
+
+    def edge_count(self) -> int:
+        return sum(len(v) for v in self._edges.values())
+
+    def canonical_name(self, entity_id: str) -> str:
+        return self._names.get(entity_id, entity_id)
+
+
+def gold_chain(g: GoldGraph, qa: QAItem) -> list[tuple[str, str, str]]:
+    """Walk `qa.relation_chain` from `qa.start_entity_id` over the gold graph.
+    Returns the ordered edge list [(src_id, rel, dst_id), ...]. Raises KeyError
+    if the chain is broken (should never happen for a generated question)."""
+    chain: list[tuple[str, str, str]] = []
+    cur = qa.start_entity_id
+    for rel in qa.relation_chain:
+        dst = g._edges[cur][rel]
+        chain.append((cur, rel, dst))
+        cur = dst
+    return chain

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_ablation.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_ablation.py
@@ -1,0 +1,40 @@
+"""CLI: run the ER-quality ablation, write ABLATION.md, exit non-zero on a HARD
+assertion failure (monotonic decay + hop-widening). The soft assertion
+(goldengraph>=name_only) prints WARN, never gates.
+
+Needs the goldengraph_native wheel. Example:
+    python -m erkgbench.qa_e2e.run_ablation --seed 7 --n-questions 80 \
+        --ambiguity 0.6 --out-md ABLATION.md
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .ablation import gate_exit_code, render_ablation_md, run_ablation
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--seed", type=int, default=7)
+    p.add_argument("--n-questions", type=int, default=80)
+    p.add_argument("--ambiguity", type=float, default=0.6)
+    p.add_argument("--max-hops", type=int, default=4)
+    p.add_argument("--out-md", default="ABLATION.md")
+    args = p.parse_args(argv)
+
+    res = run_ablation(
+        seed=args.seed,
+        n_questions=args.n_questions,
+        ambiguity=args.ambiguity,
+        max_hops=args.max_hops,
+    )
+    md = render_ablation_md(res)
+    with open(args.out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    sys.stdout.write(md)
+    return gate_exit_code(res)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard.py
@@ -1,0 +1,43 @@
+"""Per-stage scorecard metrics.
+
+bridge_recall = does the resolved + retrieved subgraph let you WALK the gold chain
+end to end? This is the `(ER_accuracy)^hops` thesis measured at the RETRIEVAL layer
+-- no LLM. Under-merge (a bridge entity split across resolved nodes) strands the
+walk; perfect resolution keeps it whole.
+"""
+from __future__ import annotations
+
+
+def _nodes_covering(coverage: dict, canon: str) -> set:
+    return {nid for nid, cset in coverage.items() if canon in cset}
+
+
+def bridge_recall(gold_chain, subgraph: dict, coverage: dict) -> dict:
+    """gold_chain: [(src_canon, rel, dst_canon), ...]. coverage: store entity_id ->
+    set(canonical_ids it carries). Returns {"whole_chain": 0/1, "edge_recall": frac}.
+
+    Walk: start from the store nodes covering the first src canonical; for each gold
+    edge, can we step (via a subgraph edge -- predicate ignored, gold predicates come
+    from the same triples) from a carried node to a node covering the next canonical?
+    Carry that node set forward. An edge that strands (no such step) ends the walk;
+    remaining edges are unreachable. Edges are undirected (synthesis walks either
+    way)."""
+    if not gold_chain:
+        return {"whole_chain": 1.0, "edge_recall": 0.0}
+    adj: dict = {}
+    for e in subgraph.get("edges", ()):
+        adj.setdefault(e["subj"], set()).add(e["obj"])
+        adj.setdefault(e["obj"], set()).add(e["subj"])
+    carried = _nodes_covering(coverage, gold_chain[0][0])
+    edges_hit = 0
+    for (_src, _rel, dst) in gold_chain:
+        targets = _nodes_covering(coverage, dst)
+        reachable = {t for c in carried for t in adj.get(c, ()) if t in targets}
+        if not reachable:
+            break
+        edges_hit += 1
+        carried = reachable
+    return {
+        "whole_chain": 1.0 if edges_hit == len(gold_chain) else 0.0,
+        "edge_recall": edges_hit / len(gold_chain),
+    }

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_ablation.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_ablation.py
@@ -1,0 +1,54 @@
+"""End-to-end ER-ablation: build the store per dial, bridge-recall by hop.
+
+Needs the goldengraph_native wheel -> skips locally, validates in the wheel-building
+qa-ablation CI gate. The markdown render test (bottom) is wheel-free."""
+from __future__ import annotations
+
+import pytest
+from erkgbench.qa_e2e.ablation import AblationResult, render_ablation_md
+
+
+def test_ablation_monotonic_and_hop_widening():
+    pytest.importorskip("goldengraph_native")
+    from erkgbench.qa_e2e.ablation import run_ablation
+
+    res = run_ablation(seed=7, n_questions=80, ambiguity=0.6, max_hops=4)
+    oracle, gg, name_only, none = (
+        res.recall[d] for d in ("oracle", "goldengraph", "name_only", "none")
+    )
+    # 1. monotone in ER quality (mean whole-chain recall)
+    assert oracle["mean"] >= gg["mean"] >= name_only["mean"] - 1e-9 >= none["mean"] - 1e-9
+    # 2. oracle-none gap widens with hops
+    gap_lo = oracle["by_hop"][2] - none["by_hop"][2]
+    gap_hi = oracle["by_hop"][4] - none["by_hop"][4]
+    assert gap_hi > gap_lo
+    # 3. resolver earns its keep (SOFT)
+    assert gg["mean"] >= name_only["mean"]
+
+
+# --- wheel-free: markdown rendering over a synthetic result ---
+
+
+def _fake_result() -> AblationResult:
+    def dial(mean, h2, h3, h4):
+        return {"mean": mean, "by_hop": {2: h2, 3: h3, 4: h4}}
+
+    return AblationResult(
+        recall={
+            "oracle": dial(0.90, 0.95, 0.90, 0.85),
+            "goldengraph": dial(0.70, 0.85, 0.70, 0.55),
+            "name_only": dial(0.65, 0.82, 0.66, 0.50),
+            "none": dial(0.30, 0.60, 0.25, 0.10),
+        }
+    )
+
+
+def test_render_ablation_md_has_dials_hops_and_verdicts():
+    md = render_ablation_md(_fake_result())
+    for dial in ("oracle", "goldengraph", "name_only", "none"):
+        assert dial in md
+    assert "2-hop" in md and "4-hop" in md
+    # the three assertion verdict lines render
+    assert "monotonic" in md.lower()
+    assert "widen" in md.lower()
+    assert "PASS" in md or "FAIL" in md

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_ablation.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_ablation.py
@@ -52,3 +52,28 @@ def test_render_ablation_md_has_dials_hops_and_verdicts():
     assert "monotonic" in md.lower()
     assert "widen" in md.lower()
     assert "PASS" in md or "FAIL" in md
+
+
+def test_gate_exit_code_zero_when_hard_assertions_pass():
+    from erkgbench.qa_e2e.ablation import gate_exit_code
+
+    # _fake_result is monotone + widens (gaps 0.60->0.75); soft may vary -> exit 0
+    assert gate_exit_code(_fake_result()) == 0
+
+
+def test_gate_exit_code_one_when_a_hard_assertion_fails():
+    from erkgbench.qa_e2e.ablation import gate_exit_code
+
+    def dial(mean, h2, h3, h4):
+        return {"mean": mean, "by_hop": {2: h2, 3: h3, 4: h4}}
+
+    # non-monotone: none > name_only -> a HARD failure -> exit 1
+    bad = AblationResult(
+        recall={
+            "oracle": dial(0.9, 0.9, 0.9, 0.9),
+            "goldengraph": dial(0.5, 0.5, 0.5, 0.5),
+            "name_only": dial(0.2, 0.2, 0.2, 0.2),
+            "none": dial(0.6, 0.6, 0.6, 0.6),
+        }
+    )
+    assert gate_exit_code(bad) == 1

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_bridge_recall.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_bridge_recall.py
@@ -1,0 +1,41 @@
+"""bridge_recall: does the resolved+retrieved subgraph let you WALK the gold chain
+end to end. Pure -- operates on a subgraph dict + a store-entity coverage map, no
+store/LLM/network."""
+from __future__ import annotations
+
+from erkgbench.qa_e2e.scorecard import bridge_recall
+
+_CHAIN = [("c0", "works_at", "c1"), ("c1", "acquired", "c2")]  # 2-hop gold chain
+
+
+def _sub(edges):
+    ents = sorted({e for pair in edges for e in (pair[0], pair[2])})
+    return {
+        "entities": [{"entity_id": e} for e in ents],
+        "edges": [{"subj": s, "predicate": p, "obj": o} for (s, p, o) in edges],
+    }
+
+
+def test_full_chain_present_recall_one():
+    sub = _sub([(0, "works_at", 1), (1, "acquired", 2)])
+    cov = {0: {"c0"}, 1: {"c1"}, 2: {"c2"}}
+    r = bridge_recall(_CHAIN, sub, cov)
+    assert r["whole_chain"] == 1.0 and r["edge_recall"] == 1.0
+
+
+def test_undermerged_bridge_breaks_walk():
+    # c1's mentions split: node 1 carries c1 (reached from c0) but the c1->c2 edge
+    # was authored from node 3 (the other c1 surface). Walk cannot continue.
+    sub = _sub([(0, "works_at", 1), (3, "acquired", 2)])
+    cov = {0: {"c0"}, 1: {"c1"}, 3: {"c1"}, 2: {"c2"}}
+    r = bridge_recall(_CHAIN, sub, cov)
+    assert r["whole_chain"] == 0.0
+    assert r["edge_recall"] == 0.5  # first edge reachable, second not from carried node
+
+
+def test_missing_from_ball_zero():
+    sub = _sub([(0, "works_at", 1)])  # second edge absent entirely
+    cov = {0: {"c0"}, 1: {"c1"}}
+    r = bridge_recall(_CHAIN, sub, cov)
+    assert r["whole_chain"] == 0.0
+    assert r["edge_recall"] == 0.5

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_dials.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_dials.py
@@ -1,0 +1,47 @@
+"""ER-quality dial key-policies: the record_key each (entity, surface) emits, which
+controls cross-document merge in the store. Wheel-free (dedupe_df is fuzzy string,
+no embeddings/network with rerank off)."""
+from __future__ import annotations
+
+from erkgbench.qa_e2e import dials
+from erkgbench.qa_e2e.engineered import generate_engineered
+from erkgbench.qa_e2e.gold import GoldGraph
+
+
+def _setup():
+    corpus = generate_engineered(seed=7, n_questions=20, ambiguity=0.6, max_hops=4)
+    return corpus, GoldGraph.from_corpus(corpus)
+
+
+def test_oracle_merges_all_surfaces_of_an_entity():
+    corpus, g = _setup()
+    km = dials.oracle_keys(corpus, g)
+    keys_by_entity: dict[str, set] = {}
+    for (eid, _surface), key in km.items():
+        keys_by_entity.setdefault(eid, set()).add(key)
+    assert all(len(s) == 1 for s in keys_by_entity.values())
+
+
+def test_none_gives_every_mention_a_unique_key():
+    corpus, g = _setup()
+    km = dials.none_keys(corpus, g)
+    assert len(set(km.values())) == len(km)  # all distinct
+
+
+def test_name_only_keys_by_exact_surface():
+    corpus, g = _setup()
+    km = dials.name_only_keys(corpus, g)
+    by_entity: dict[str, set] = {}
+    for (eid, _surface), key in km.items():
+        by_entity.setdefault(eid, set()).add(key)
+    multi = [s for s in by_entity.values() if len(s) > 1]
+    assert multi, "ambiguity>0 should give some entity >1 surface-key"
+
+
+def test_goldengraph_merges_at_least_exact_and_no_more_than_oracle():
+    corpus, g = _setup()
+    o = dials.oracle_keys(corpus, g)
+    gg = dials.goldengraph_keys(corpus, g)
+    nm = dials.name_only_keys(corpus, g)
+    # distinct-key count: more merging = fewer keys. oracle <= goldengraph <= name_only
+    assert len(set(o.values())) <= len(set(gg.values())) <= len(set(nm.values()))

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_engineered_surfaces.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_engineered_surfaces.py
@@ -1,0 +1,34 @@
+"""Engineered edge documents expose their rendered surfaces (Task 4a) so the
+ablation can assign per-mention record_keys without re-parsing Document.text."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from erkgbench.qa_e2e.engineered import generate_engineered
+from erkgbench.qa_e2e.gold import GoldGraph
+
+
+def _surfaces_of(g: GoldGraph) -> dict[str, set[str]]:
+    from dataset.concepts_loader import load_concepts  # type: ignore
+
+    bench_root = Path(__file__).resolve().parents[1]
+    out: dict[str, set[str]] = {}
+    for c in load_concepts(bench_root / "dataset" / "concepts.jsonl"):
+        out[c.canonical_id] = {c.concept, *(v.surface for v in c.variants)}
+    return out
+
+
+def test_edge_docs_carry_rendered_surfaces_within_the_entity_universe():
+    corpus = generate_engineered(seed=7, n_questions=20, ambiguity=0.6, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    surf = _surfaces_of(g)
+    saw_variant = False
+    for d in corpus.documents:
+        src, _rel, dst = d.id.split("::")
+        assert d.src_surface and d.dst_surface  # non-empty
+        assert d.src_surface in surf[src]
+        assert d.dst_surface in surf[dst]
+        # at ambiguity 0.6 at least some doc should render a non-canonical surface
+        if d.src_surface != g.canonical_name(src):
+            saw_variant = True
+    assert saw_variant, "ambiguity>0 should produce some variant surface"

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_gold_oracle.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_gold_oracle.py
@@ -1,0 +1,37 @@
+"""Pure oracle: reconstruct the engineered gold graph + walk a question's chain.
+No native, no LLM, no network."""
+from __future__ import annotations
+
+from erkgbench.qa_e2e.engineered import generate_engineered
+from erkgbench.qa_e2e.gold import GoldGraph, gold_chain
+
+
+def test_gold_graph_rebuilds_edges_from_doc_ids():
+    corpus = generate_engineered(seed=7, n_questions=20, ambiguity=0.5, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    # every traversed-edge document id `src::rel::dst` is an edge in the gold graph
+    for d in corpus.documents:
+        src, rel, dst = d.id.split("::")
+        assert g.has_edge(src, rel, dst)
+
+
+def test_gold_chain_walks_to_gold_answer():
+    corpus = generate_engineered(seed=7, n_questions=20, ambiguity=0.5, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    for qa in corpus.questions:
+        chain = gold_chain(g, qa)  # ordered [(src_id, rel, dst_id), ...]
+        assert len(chain) == qa.hop_count
+        assert chain[0][0] == qa.start_entity_id
+        # the chain's terminal entity's canonical name == gold_answer
+        assert g.canonical_name(chain[-1][2]) == qa.gold_answer
+
+
+def test_gold_graph_ignores_non_edge_documents():
+    # A non-edge (MuSiQue-style, not 3-part) doc id must be skipped, not crash.
+    from erkgbench.qa_e2e.corpora import Document, QACorpus
+
+    edge = Document(id="gm:a::works_at::gm:b", text="A works at B.")
+    musique = Document(id="q1::p0", text="unrelated paragraph")  # 2-part id
+    corpus = QACorpus(name="mix", documents=(edge, musique), questions=())
+    g = GoldGraph.from_corpus(corpus)
+    assert g.edge_count() == 1 and g.has_edge("gm:a", "works_at", "gm:b")


### PR DESCRIPTION
Builds the instrument that makes goldengraph **measurable per-stage and iterable** — the answer to "the KG loses to RAG on QA and I can't tell why." A single end-to-end answer-match number conflates extraction → resolution → retrieval → synthesis; this decomposes it and proves/refutes the engine's core thesis `(ER_accuracy)^hops` at the **retrieval layer**, deterministically and for $0.

## What this is
**Slice A** of a 4-part benchmark program (B = aggregation/temporal capability tasks RAG can't do; C = ambiguity×passage_k crossover; D = KG-vs-KG — each its own spec). This PR is the deterministic core + gate.

## How it works (no LLM, no network, CI-gateable)
The engineered corpus already encodes the gold graph (canonical IDs in `src::rel::dst` doc IDs + per-question `start_entity_id`/`relation_chain`), so gold triples and chains are free.

- **`gold.py`** — oracle: rebuild the gold graph + walk each question's chain to its answer.
- **`dials.py`** — 4 ER-quality levels controlling cross-doc identity via the `record_key` each mention emits: `oracle` (canonical id) / `goldengraph` (`dedupe_df` fuzzy, name+type only so it stays offline) / `name_only` (exact surface) / `none` (unique). The store merges across documents by record_key overlap.
- **`scorecard.py::bridge_recall`** — does the resolved+retrieved subgraph let you WALK the gold chain? Under-merge strands the walk; perfect ER keeps it whole. That mechanic *is* the thesis.
- **`ablation.py`** — build the store directly from gold triples per dial (bypassing the LLM extractor), oracle-seed retrieval, bridge-recall by hop. Coverage built from the readable `surface_names` (record_keys aren't marshaled back out) + a `surface→canonical` map.
- **`run_ablation.py`** — CLI → `ABLATION.md`; exits non-zero only on a HARD assertion fail.

## The gate (key-free, in `goldengraph-pipeline.yml`)
- **HARD:** bridge-recall monotonic `oracle ≥ goldengraph ≥ name_only ≥ none`; the `oracle−none` gap **widens with hops** (the `^hops` signature).
- **SOFT (WARN):** `goldengraph ≥ name_only` — offline fuzzy only separates on string-close variants (typo/suffix); synonym/brand have no string signal (the known SP6 0.33 floor).

## Honest status
The **end-to-end ablation has not run locally** — it `importorskip`s the `goldengraph_native` wheel, which builds in CI. The 20 wheel-free tests (oracle/dials/bridge-recall/render/gate) pass + lint clean, but **the real bridge-recall curve validates for the first time in the `goldengraph-pipeline` lane here.** If the small gate corpus turns out too dense to separate the dials (ball contains everything), the hop-widening assertion will catch it and I'll tune the corpus size — that's the gate doing its job.

## Test plan
- [x] 20 wheel-free tests pass (`gold_oracle`, `dials`, `bridge_recall`, `engineered_surfaces`, render + `gate_exit_code`)
- [x] existing `test_qa_corpora` unaffected (backward-compatible `Document` fields)
- [ ] **`goldengraph-pipeline` lane green — the real validator** (builds the wheel + runs the ablation gate)
- [ ] `bench-er-kg` pure-Python step picks up the new wheel-free tests

Spec + plan: `docs/superpowers/specs/2026-06-26-goldengraph-er-ablation-scorecard-design.md`, `docs/superpowers/plans/2026-06-26-goldengraph-er-ablation-scorecard.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)