### PR TITLE
feat(er-kg-bench): GoldenGraph scorecard real-LLM rows (Phase 2 of slice A)

### DIFF
--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -129,7 +129,7 @@ jobs:
         working-directory: ${{ env.BENCH_DIR }}
         env:
           POLARS_SKIP_CPU_CHECK: "1"
-        run: "$GITHUB_WORKSPACE/.venv/bin/python -m pytest tests/test_qa_metrics.py tests/test_qa_corpora.py tests/test_qa_harness.py tests/test_qa_gold_oracle.py tests/test_qa_dials.py tests/test_qa_bridge_recall.py tests/test_qa_engineered_surfaces.py tests/test_qa_ablation.py -v"
+        run: "$GITHUB_WORKSPACE/.venv/bin/python -m pytest tests/test_qa_metrics.py tests/test_qa_corpora.py tests/test_qa_harness.py tests/test_qa_gold_oracle.py tests/test_qa_dials.py tests/test_qa_bridge_recall.py tests/test_qa_engineered_surfaces.py tests/test_qa_ablation.py tests/test_qa_extraction_f1.py tests/test_qa_synthesis_given_gold.py tests/test_qa_answer_match_ablation.py tests/test_qa_scorecard_orchestrator.py tests/test_qa_scorecard_cli.py -v"
 
       - name: Regenerate demo DEMO.md (Tier 1)
         working-directory: ${{ env.BENCH_DIR }}

--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -19,6 +19,12 @@ on:
       budget_usd:
         description: "hard cost cap per (engine, ambiguity) run"
         default: "25"
+      run_scorecard:
+        description: "run the Phase-2 real-LLM scorecard (extraction-F1 + synthesis-given-gold + answer-match ablation) instead of the head-to-head"
+        default: "false"
+      scorecard_budget_usd:
+        description: "scorecard only: hard USD cap for the whole scorecard run"
+        default: "2"
       engine:
         description: "all | goldengraph | lightrag | ms_graphrag | graphiti"
         default: "all"
@@ -325,4 +331,41 @@ jobs:
         with:
           name: graphrag-qa-results-AGGREGATE
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/RESULTS_QA_E2E.md
+          if-no-files-found: ignore
+
+  scorecard:
+    # Opt-in Phase-2 real-LLM scorecard (extraction-F1 + synthesis-given-gold +
+    # 4-dial answer-match ablation). Standalone; NON-gating; gated on run_scorecard.
+    if: ${{ inputs.run_scorecard == 'true' }}
+    runs-on: large-new-64GB
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install goldenmatch + native engine wheel + goldengraph + datasets
+        run: |
+          python -m pip install --upgrade pip maturin pytest goldenmatch datasets openai
+          maturin build --release \
+            -m packages/rust/extensions/goldengraph-native/Cargo.toml --out dist
+          python -m pip install dist/*.whl
+          python -m pip install --no-deps -e packages/python/goldengraph
+      - name: Run the real-LLM scorecard (budget-capped, opt-in)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: |
+          python -m erkgbench.qa_e2e.run_scorecard \
+            --seed 7 --n-questions 60 --ambiguity 0.6 \
+            --budget-usd "${{ inputs.scorecard_budget_usd }}" \
+            --out-md SCORECARD.md
+      - name: Upload SCORECARD.md
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-qa-scorecard
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/SCORECARD.md
           if-no-files-found: ignore

--- a/docs/superpowers/plans/2026-06-27-goldengraph-scorecard-llm-rows.md
+++ b/docs/superpowers/plans/2026-06-27-goldengraph-scorecard-llm-rows.md
@@ -1,0 +1,602 @@
+# GoldenGraph Scorecard Real-LLM Rows Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the three real-LLM scorecard rows (extraction-F1, synthesis-given-gold, 4-dial answer-match ablation matched to bridge-recall) as an opt-in, budget-capped, non-gating bench lane that produces `SCORECARD.md`.
+
+**Architecture:** Pure metric functions (extraction-F1, gold-subgraph build, synthesis scoring, tracking verdict) are wheel-free and unit-tested with stub LLMs. An orchestrator (`run_scorecard`) runs all three rows under one `BudgetTracker`, wrapping the real LLM so every call records usage and the run stops cleanly at the cap. The answer-match ablation reuses #1274's `ablation._build_store` + `scorecard.bridge_recall` so both curves come from the identical store/ball. A thin CLI writes `SCORECARD.md`; a new opt-in `workflow_dispatch` lane runs it with `OPENAI_API_KEY`.
+
+**Tech Stack:** Python 3.11, pytest (wheel-free except the e2e ablation row, which `importorskip`s `goldengraph_native`), GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-goldengraph-scorecard-llm-rows-design.md`
+
+---
+
+## Key code facts (verified against main, post-#1274)
+
+- **Reused from #1274** (`erkgbench/qa_e2e/`): `gold.GoldGraph` (`from_corpus`, `canonical_name`, `gold_chain(g, qa) -> [(src_id, rel, dst_id), ...]`); `dials.{oracle,goldengraph,name_only,none}_keys`, `dials.surface_to_canon`; `ablation._build_store(corpus, g, km, typ_of) -> (slice_graph, coverage)`, `ablation._typ_of(g) -> {entity_id: entity_type}`; `scorecard.bridge_recall(gold_chain, subgraph, coverage) -> {"whole_chain","edge_recall"}`.
+- **`run_ablation`'s seed pattern** (replicate): `seed_of = {}; for nid in sorted(coverage): for c in coverage[nid]: seed_of.setdefault(c, nid)`; then `_retrieve_local(slice_graph, [seed_of[start_entity_id]], max_hops=_RETRIEVAL_HOPS, node_budget=_NODE_BUDGET)`. Constants in `engines/goldengraph.py`: `_RETRIEVAL_HOPS` (6), `_NODE_BUDGET` (256), `_AS_OF` (10**12).
+- **Synthesis:** `from goldengraph.synthesize import synthesize_local`; `synthesize_local(query, subgraph, llm, *, seed_names=None) -> str`. Subgraph shape: `{"entities":[{"entity_id","canonical_name","typ"}], "edges":[{"subj","predicate","obj"}]}` (`_format_subgraph` reads exactly these). `seed_names` is a list of NAMES (not ids).
+- **Extraction:** `from goldengraph.extract import extract as _extract` (or `from goldengraph.ingest import _extract`); `_extract(text, llm) -> Extraction`. `Extraction.mentions: list[Mention]` (`Mention.name`, `.typ`); `Extraction.relationships: list[Relationship]` (`Relationship.subj`/`obj` are INT indices into `mentions`, `.predicate` free-form).
+- **Answer-match:** `from . import metrics`; `metrics.answer_match(pred, gold) -> float` (1.0 if normalized gold is a contiguous token run in pred); `metrics._normalize(s)`.
+- **Budget:** `from goldenmatch.config.schemas import BudgetConfig`; `from goldenmatch.core.llm_budget import BudgetTracker`. `t = BudgetTracker(BudgetConfig(max_cost_usd=X))`; `t.record_usage(in_tokens, out_tokens, model)`; `t.budget_exhausted`; `t.can_send(n_tokens)`; `t.total_cost_usd`.
+- **Real LLM + token counter:** `from goldengraph.llm import OpenAIClient` → `OpenAIClient(model="gpt-4o-mini")`. `from .engines.goldengraph import _CountingLLM` wraps an LLMClient, exposes `.complete`, `.input_tokens`, `.output_tokens` (estimate = `len(prompt)//4`; the bench's existing approximation — reuse it, don't invent real token counts).
+
+### Plan-review precision notes (carry these)
+- `build_gold_subgraph` needs `GoldGraph` (for canonical names) AND a typ map (`ablation._typ_of`) — `gold_chain` alone yields only ids. `typ` is non-load-bearing for synthesis but use `_typ_of` to match the stated shape.
+- The answer-match ablation must build `{entity_id: canonical_name}` from `slice_graph.entities()` to pass `seed_names=[name]` (the `seed_of` inversion yields an id).
+
+## Test environment
+
+```
+PY="/d/show_case/goldenmatch/.venv/Scripts/python.exe"
+cd packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$(pwd -W)" POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 GOLDENMATCH_NATIVE=0 "$PY" -m pytest <path> -q
+```
+Wheel-free for Tasks 1, 2, 4, 5; the Task 3 e2e ablation `importorskip`s `goldengraph_native` (skips locally, validates in the opt-in lane). Run only named files — never the full suite.
+
+---
+
+## Task 1: extraction-F1 metric (wheel-free)
+
+**Files:**
+- Create: `erkgbench/qa_e2e/scorecard_llm.py`
+- Test: `tests/test_qa_extraction_f1.py`
+
+Use @superpowers:test-driven-development.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""extraction-F1: did real extraction recover the gold entities + edge per doc.
+Pure -- operates on a gold (src,dst) surface pair + a goldengraph Extraction."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from erkgbench.qa_e2e.scorecard_llm import extraction_counts, f1_from_counts
+
+
+@dataclass
+class _M:
+    name: str
+    typ: str = "concept"
+
+
+@dataclass
+class _R:
+    subj: int
+    predicate: str
+    obj: int
+
+
+@dataclass
+class _Ex:
+    mentions: list
+    relationships: list
+
+
+def test_perfect_extraction_is_f1_one():
+    ex = _Ex([_M("Acme"), _M("Rocket")], [_R(0, "made", 1)])
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["ent_tp"] == 2 and c["ent_fp"] == 0 and c["ent_fn"] == 0
+    assert c["rel_tp"] == 1 and c["rel_fp"] == 0 and c["rel_fn"] == 0
+
+
+def test_missing_entity_drops_recall_and_loses_the_edge():
+    ex = _Ex([_M("Acme")], [])  # dst entity + the edge both missing
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["ent_tp"] == 1 and c["ent_fn"] == 1
+    assert c["rel_tp"] == 0 and c["rel_fn"] == 1
+
+
+def test_spurious_entity_drops_precision():
+    ex = _Ex([_M("Acme"), _M("Rocket"), _M("Noise")], [_R(0, "made", 1)])
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["ent_tp"] == 2 and c["ent_fp"] == 1
+
+
+def test_relation_matches_either_direction_ignoring_predicate():
+    # edge authored dst->src with a different predicate word still counts
+    ex = _Ex([_M("Rocket"), _M("Acme")], [_R(0, "built by", 1)])
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["rel_tp"] == 1 and c["rel_fp"] == 0
+
+
+def test_normalization_case_insensitive():
+    ex = _Ex([_M("ACME"), _M(" rocket ")], [_R(0, "made", 1)])
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["ent_tp"] == 2 and c["rel_tp"] == 1
+
+
+def test_f1_from_counts():
+    assert f1_from_counts(2, 0, 0) == {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+    r = f1_from_counts(1, 1, 1)
+    assert r["precision"] == 0.5 and r["recall"] == 0.5 and r["f1"] == 0.5
+    assert f1_from_counts(0, 0, 0)["f1"] == 0.0  # empty -> 0, no ZeroDivision
+```
+
+- [ ] **Step 2: Run -> fail** (`ModuleNotFoundError ... scorecard_llm`).
+
+- [ ] **Step 3: Implement** in `scorecard_llm.py`:
+
+```python
+"""Real-LLM scorecard rows (Phase 2 of slice A): extraction-F1, synthesis-given-gold,
+and the 4-dial answer-match ablation matched to bridge-recall. Opt-in, budget-capped,
+NON-gating -- the deterministic bridge-recall gate (#1274) stays the blocking signal."""
+from __future__ import annotations
+
+from . import metrics
+
+
+def _norm(s: str) -> str:
+    return metrics._normalize(s)
+
+
+def extraction_counts(gold_src: str, gold_dst: str, extraction) -> dict:
+    """Per-doc entity + (existence-based) relation TP/FP/FN of `extraction` vs the
+    one gold edge {gold_src, gold_dst}. Predicate label ignored; edge counted in
+    either direction."""
+    gold_ents = {_norm(gold_src), _norm(gold_dst)}
+    got_ents = {_norm(m.name) for m in extraction.mentions}
+    ent_tp = len(gold_ents & got_ents)
+    ent_fp = len(got_ents - gold_ents)
+    ent_fn = len(gold_ents - got_ents)
+
+    gold_edge = frozenset(gold_ents)
+    got_edges = [
+        frozenset({_norm(extraction.mentions[r.subj].name), _norm(extraction.mentions[r.obj].name)})
+        for r in extraction.relationships
+        if r.subj < len(extraction.mentions) and r.obj < len(extraction.mentions)
+    ]
+    rel_tp = 1 if gold_edge in got_edges else 0
+    rel_fp = sum(1 for e in got_edges if e != gold_edge)
+    rel_fn = 1 - rel_tp
+    return {
+        "ent_tp": ent_tp, "ent_fp": ent_fp, "ent_fn": ent_fn,
+        "rel_tp": rel_tp, "rel_fp": rel_fp, "rel_fn": rel_fn,
+    }
+
+
+def f1_from_counts(tp: int, fp: int, fn: int) -> dict:
+    p = tp / (tp + fp) if (tp + fp) else 0.0
+    r = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return {"precision": p, "recall": r, "f1": f1}
+```
+
+- [ ] **Step 4: Run -> pass.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): extraction-F1 metric (Phase 2 scorecard)`.
+
+---
+
+## Task 2: gold subgraph + synthesis-given-gold (wheel-free, stub LLM)
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/scorecard_llm.py`
+- Test: `tests/test_qa_synthesis_given_gold.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from __future__ import annotations
+
+from erkgbench.qa_e2e.engineered import generate_engineered
+from erkgbench.qa_e2e.gold import GoldGraph, gold_chain
+from erkgbench.qa_e2e import ablation
+from erkgbench.qa_e2e.scorecard_llm import build_gold_subgraph, synthesis_given_gold
+
+
+class _StubLLM:
+    def __init__(self, response):
+        self.response = response
+        self.prompts = []
+
+    def complete(self, prompt):
+        self.prompts.append(prompt)
+        return self.response
+
+
+def _setup():
+    corpus = generate_engineered(seed=7, n_questions=10, ambiguity=0.3, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    return corpus, g, ablation._typ_of(g)
+
+
+def test_build_gold_subgraph_carries_the_chain():
+    corpus, g, typ_of = _setup()
+    qa = corpus.questions[0]
+    chain = gold_chain(g, qa)
+    sub = build_gold_subgraph(chain, g, typ_of)
+    ids = {e["entity_id"] for e in sub["entities"]}
+    # every chain entity present; every chain edge present
+    for (s, rel, o) in chain:
+        assert s in ids and o in ids
+        assert any(e["subj"] == s and e["obj"] == o and e["predicate"] == rel for e in sub["edges"])
+    # canonical names attached (not bare ids)
+    assert all(e["canonical_name"] for e in sub["entities"])
+
+
+def test_synthesis_given_gold_scores_answer_match():
+    corpus, g, typ_of = _setup()
+    qa = corpus.questions[0]
+    chain = gold_chain(g, qa)
+    llm = _StubLLM(f"reasoning...\nAnswer: {qa.gold_answer}")
+    score = synthesis_given_gold(qa.question, chain, g, typ_of, qa.gold_answer, llm)
+    assert score == 1.0
+    # the synthesis prompt was handed the gold chain (a chain entity name appears)
+    assert g.canonical_name(chain[-1][2]) in llm.prompts[-1]
+
+
+def test_synthesis_given_gold_wrong_answer_scores_zero():
+    corpus, g, typ_of = _setup()
+    qa = corpus.questions[0]
+    chain = gold_chain(g, qa)
+    llm = _StubLLM("Answer: definitely-not-the-gold-xyzzy")
+    assert synthesis_given_gold(qa.question, chain, g, typ_of, qa.gold_answer, llm) == 0.0
+```
+
+- [ ] **Step 2: Run -> fail.**
+
+- [ ] **Step 3: Implement** (append to `scorecard_llm.py`):
+
+```python
+def build_gold_subgraph(gold_chain, g, typ_of: dict) -> dict:
+    """{entities, edges} over the chain's canonical entities -- the shape
+    synthesize_local's _format_subgraph reads. entity_id = canonical id."""
+    ids: list = []
+    for (s, _rel, o) in gold_chain:
+        for x in (s, o):
+            if x not in ids:
+                ids.append(x)
+    entities = [
+        {"entity_id": x, "canonical_name": g.canonical_name(x), "typ": typ_of.get(x, "concept")}
+        for x in ids
+    ]
+    edges = [{"subj": s, "predicate": rel, "obj": o} for (s, rel, o) in gold_chain]
+    return {"entities": entities, "edges": edges}
+
+
+def synthesis_given_gold(question, gold_chain, g, typ_of, gold_answer, llm) -> float:
+    from goldengraph.synthesize import synthesize_local
+
+    sub = build_gold_subgraph(gold_chain, g, typ_of)
+    start_name = g.canonical_name(gold_chain[0][0])
+    pred = synthesize_local(question, sub, llm, seed_names=[start_name])
+    return metrics.answer_match(pred, gold_answer)
+```
+
+- [ ] **Step 4: Run -> pass.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): synthesis-given-gold-subgraph row`.
+
+---
+
+## Task 3: 4-dial answer-match ablation + tracking verdict (e2e wheel; verdict wheel-free)
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/scorecard_llm.py`
+- Test: `tests/test_qa_answer_match_ablation.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from erkgbench.qa_e2e.scorecard_llm import tracking_verdict
+
+
+def test_tracking_verdict_pass_when_orders_match():
+    am = {"oracle": 0.9, "goldengraph": 0.6, "name_only": 0.3, "none": 0.2}
+    br = {"oracle": 1.0, "goldengraph": 0.55, "name_only": 0.23, "none": 0.23}
+    label, passed = tracking_verdict(am, br)
+    assert passed is True
+
+
+def test_tracking_verdict_warn_on_divergence():
+    # answer-match HIGH for none but bridge-recall says none is worst -> divergence
+    am = {"oracle": 0.5, "goldengraph": 0.5, "name_only": 0.5, "none": 0.9}
+    br = {"oracle": 1.0, "goldengraph": 0.55, "name_only": 0.23, "none": 0.23}
+    label, passed = tracking_verdict(am, br)
+    assert passed is False
+
+
+def test_answer_match_ablation_e2e():
+    pytest.importorskip("goldengraph_native")
+    from erkgbench.qa_e2e.engineered import generate_engineered
+    from erkgbench.qa_e2e.gold import GoldGraph
+    from erkgbench.qa_e2e import ablation
+    from erkgbench.qa_e2e.scorecard_llm import answer_match_ablation
+
+    corpus = generate_engineered(seed=7, n_questions=40, ambiguity=0.6, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    typ_of = ablation._typ_of(g)
+
+    class _FixedLLM:  # deterministic, no network -- always answers "Answer: X"
+        def complete(self, prompt):
+            return "Answer: X"
+
+    res = answer_match_ablation(corpus, g, typ_of, _FixedLLM())
+    # both curves present per dial; bridge-recall mirrors the deterministic ablation
+    for d in ("oracle", "goldengraph", "name_only", "none"):
+        assert "answer_match" in res[d] and "bridge_recall" in res[d]
+    assert res["oracle"]["bridge_recall"]["mean"] >= res["none"]["bridge_recall"]["mean"]
+```
+
+- [ ] **Step 2: Run -> fail** (verdict import; e2e skips locally).
+
+- [ ] **Step 3: Implement** (append to `scorecard_llm.py`):
+
+```python
+_DIAL_ORDER = ("oracle", "goldengraph", "name_only", "none")
+
+
+def tracking_verdict(answer_match_by_dial: dict, bridge_recall_by_dial: dict) -> tuple[str, bool]:
+    """PASS if the answer-match dial ranking matches the bridge-recall ranking
+    (both should descend oracle..none). A faithful proxy tracks."""
+    def _rank(d):
+        return [k for k in sorted(d, key=lambda k: -d[k])]
+    same = _rank(answer_match_by_dial) == _rank(bridge_recall_by_dial)
+    return ("answer-match tracks bridge-recall", same)
+
+
+def answer_match_ablation(corpus, g, typ_of, llm, *, max_hops_unused=None) -> dict:
+    """Per dial: reuse ablation._build_store (oracle extraction, dial record_keys),
+    oracle-seed + _retrieve_local ball (IDENTICAL to bridge-recall), then real
+    synthesize_local over that ball. Returns per-dial answer-match + bridge-recall
+    (mean + by_hop)."""
+    from goldengraph.answer import _retrieve_local
+    from goldengraph.synthesize import synthesize_local
+
+    from . import dials
+    from .ablation import _DIALS, _KEYFN, _build_store
+    from .engines.goldengraph import _NODE_BUDGET, _RETRIEVAL_HOPS
+    from .gold import gold_chain
+    from .scorecard import bridge_recall
+
+    chains = {qa.id: gold_chain(g, qa) for qa in corpus.questions}
+    out: dict = {}
+    for dial in _DIALS:
+        km = _KEYFN[dial](corpus, g)
+        slice_graph, coverage = _build_store(corpus, g, km, typ_of)
+        seed_of: dict = {}
+        for nid in sorted(coverage):
+            for c in coverage[nid]:
+                seed_of.setdefault(c, nid)
+        id_to_name = {e["entity_id"]: e["canonical_name"] for e in slice_graph.entities()}
+
+        am, br = [], []
+        am_hop, br_hop = {}, {}
+        for qa in corpus.questions:
+            seed_node = seed_of.get(qa.start_entity_id)
+            if seed_node is None:
+                a, b = 0.0, 0.0
+            else:
+                ball = _retrieve_local(slice_graph, [seed_node], max_hops=_RETRIEVAL_HOPS, node_budget=_NODE_BUDGET)
+                pred = synthesize_local(qa.question, ball, llm, seed_names=[id_to_name.get(seed_node, "")])
+                a = metrics.answer_match(pred, qa.gold_answer)
+                b = bridge_recall(chains[qa.id], ball, coverage)["whole_chain"]
+            am.append(a); br.append(b)
+            am_hop.setdefault(qa.hop_count, []).append(a)
+            br_hop.setdefault(qa.hop_count, []).append(b)
+        out[dial] = {
+            "answer_match": {"mean": sum(am) / len(am) if am else 0.0,
+                             "by_hop": {h: sum(v) / len(v) for h, v in sorted(am_hop.items())}},
+            "bridge_recall": {"mean": sum(br) / len(br) if br else 0.0,
+                              "by_hop": {h: sum(v) / len(v) for h, v in sorted(br_hop.items())}},
+        }
+    return out
+```
+
+> Note: `ablation._DIALS` and `_KEYFN` are module-level in #1274's `ablation.py` — import them (don't re-list the dial names).
+
+- [ ] **Step 4: Run -> verdict tests pass; e2e validates in CI.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): 4-dial answer-match ablation + tracking verdict`.
+
+---
+
+## Task 4: orchestrator + budget + render (wheel-free except the ablation call)
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/scorecard_llm.py`
+- Test: `tests/test_qa_scorecard_orchestrator.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from __future__ import annotations
+
+from erkgbench.qa_e2e.scorecard_llm import (
+    ScorecardResult, _BudgetedLLM, render_scorecard_md,
+)
+from goldenmatch.config.schemas import BudgetConfig
+from goldenmatch.core.llm_budget import BudgetTracker
+
+
+class _CostLLM:
+    def complete(self, prompt):
+        return "x" * 4000  # big output -> burns budget fast
+
+
+def test_budgeted_llm_stops_at_cap():
+    tracker = BudgetTracker(BudgetConfig(max_cost_usd=0.0))  # zero budget
+    llm = _BudgetedLLM(_CostLLM(), tracker, model="gpt-4o-mini")
+    # one call records usage; with a zero cap the tracker reports exhausted
+    llm.complete("a prompt that costs tokens")
+    assert llm.exhausted is True
+
+
+def test_render_scorecard_md_has_all_three_stages():
+    res = ScorecardResult(
+        extraction={"entity": {"f1": 0.8}, "relation": {"f1": 0.6}},
+        synthesis_ceiling={"mean": 0.9, "by_hop": {2: 0.95, 4: 0.85}},
+        answer_match_ablation={
+            "oracle": {"answer_match": {"mean": 0.9, "by_hop": {}}, "bridge_recall": {"mean": 1.0, "by_hop": {}}},
+            "goldengraph": {"answer_match": {"mean": 0.6, "by_hop": {}}, "bridge_recall": {"mean": 0.55, "by_hop": {}}},
+            "name_only": {"answer_match": {"mean": 0.3, "by_hop": {}}, "bridge_recall": {"mean": 0.23, "by_hop": {}}},
+            "none": {"answer_match": {"mean": 0.2, "by_hop": {}}, "bridge_recall": {"mean": 0.23, "by_hop": {}}},
+        },
+        tracking=("answer-match tracks bridge-recall", True),
+        budget_exhausted=False,
+    )
+    md = render_scorecard_md(res)
+    assert "extraction" in md.lower() and "entity-F1" in md
+    assert "synthesis" in md.lower()
+    assert "answer-match" in md.lower() and "bridge-recall" in md.lower()
+    assert "PASS" in md or "WARN" in md
+```
+
+- [ ] **Step 2: Run -> fail.**
+
+- [ ] **Step 3: Implement** (append to `scorecard_llm.py`):
+
+```python
+from dataclasses import dataclass
+
+from .engines.goldengraph import _CountingLLM
+
+
+@dataclass
+class ScorecardResult:
+    extraction: dict          # {"entity": f1dict, "relation": f1dict}
+    synthesis_ceiling: dict   # {"mean", "by_hop"}
+    answer_match_ablation: dict
+    tracking: tuple
+    budget_exhausted: bool
+
+
+class _BudgetedLLM:
+    """Wrap the real LLM: count tokens (the bench's len//4 estimate) and record each
+    call to the BudgetTracker so `exhausted` gates further calls."""
+
+    def __init__(self, inner, tracker, *, model: str = "gpt-4o-mini"):
+        self._c = _CountingLLM(inner)
+        self._t = tracker
+        self._model = model
+
+    @property
+    def exhausted(self) -> bool:
+        return self._t.budget_exhausted
+
+    def complete(self, prompt: str) -> str:
+        bi, bo = self._c.input_tokens, self._c.output_tokens
+        out = self._c.complete(prompt)
+        self._t.record_usage(self._c.input_tokens - bi, self._c.output_tokens - bo, self._model)
+        return out
+
+
+def render_scorecard_md(res: ScorecardResult) -> str:
+    lines = ["# GoldenGraph scorecard -- real-LLM rows (Phase 2)", ""]
+    lines += ["## extraction (vs gold triples)",
+              f"- entity-F1: {res.extraction['entity']['f1']:.3f}",
+              f"- relation-F1: {res.extraction['relation']['f1']:.3f}", ""]
+    sc = res.synthesis_ceiling
+    lines += ["## synthesis ceiling (answer-match given the GOLD subgraph)",
+              f"- mean: {sc['mean']:.3f}"
+              + (" | by-hop " + ", ".join(f"{h}:{v:.3f}" for h, v in sc["by_hop"].items())
+                 if sc["by_hop"] else ""), ""]
+    lines += ["## answer-match ablation (matched to bridge-recall)", "",
+              "| dial | answer-match | bridge-recall |", "|---|---|---|"]
+    for d in _DIAL_ORDER:
+        a = res.answer_match_ablation[d]["answer_match"]["mean"]
+        b = res.answer_match_ablation[d]["bridge_recall"]["mean"]
+        lines.append(f"| {d} | {a:.3f} | {b:.3f} |")
+    label, passed = res.tracking
+    lines += ["", f"- [{'PASS' if passed else 'WARN'}] {label}"]
+    if res.budget_exhausted:
+        lines += ["", "> BUDGET-EXHAUSTED: results are partial."]
+    return "\n".join(lines) + "\n"
+
+
+def run_scorecard(*, seed, n_questions, ambiguity, max_hops, inner_llm, budget_usd) -> ScorecardResult:
+    """Orchestrate the three rows under one budget. Each row checks `llm.exhausted`
+    before a call and stops cleanly. Needs the wheel for the ablation row."""
+    from .ablation import _typ_of
+    from .engineered import generate_engineered
+    from .gold import GoldGraph, gold_chain
+
+    tracker = BudgetTracker(BudgetConfig(max_cost_usd=budget_usd))
+    llm = _BudgetedLLM(inner_llm, tracker)
+    corpus = generate_engineered(seed=seed, n_questions=n_questions, ambiguity=ambiguity, max_hops=max_hops)
+    g = GoldGraph.from_corpus(corpus)
+    typ_of = _typ_of(g)
+
+    # row 1: extraction-F1 (real _extract per edge doc)
+    from goldengraph.extract import extract as _extract
+    et = {"ent_tp": 0, "ent_fp": 0, "ent_fn": 0, "rel_tp": 0, "rel_fp": 0, "rel_fn": 0}
+    for d in corpus.documents:
+        if llm.exhausted or len(d.id.split("::")) != 3:
+            continue
+        ex = _extract(d.text, llm)
+        c = extraction_counts(d.src_surface, d.dst_surface, ex)
+        for k in et:
+            et[k] += c[k]
+    extraction = {"entity": f1_from_counts(et["ent_tp"], et["ent_fp"], et["ent_fn"]),
+                  "relation": f1_from_counts(et["rel_tp"], et["rel_fp"], et["rel_fn"])}
+
+    # row 2: synthesis-given-gold
+    s_all, s_hop = [], {}
+    for qa in corpus.questions:
+        if llm.exhausted:
+            continue
+        chain = gold_chain(g, qa)
+        sc = synthesis_given_gold(qa.question, chain, g, typ_of, qa.gold_answer, llm)
+        s_all.append(sc); s_hop.setdefault(qa.hop_count, []).append(sc)
+    synthesis_ceiling = {"mean": sum(s_all) / len(s_all) if s_all else 0.0,
+                         "by_hop": {h: sum(v) / len(v) for h, v in sorted(s_hop.items())}}
+
+    # row 3: answer-match ablation (matched). Honors the budget INSIDE via llm.exhausted
+    # short-circuit -- synthesize_local calls go through the budgeted llm.
+    ama = answer_match_ablation(corpus, g, typ_of, llm)
+    am_means = {d: ama[d]["answer_match"]["mean"] for d in ama}
+    br_means = {d: ama[d]["bridge_recall"]["mean"] for d in ama}
+    return ScorecardResult(
+        extraction=extraction,
+        synthesis_ceiling=synthesis_ceiling,
+        answer_match_ablation=ama,
+        tracking=tracking_verdict(am_means, br_means),
+        budget_exhausted=tracker.budget_exhausted,
+    )
+```
+
+> The `answer_match_ablation` synthesize calls must also short-circuit on `llm.exhausted` — add a guard in its per-question loop (`if llm has exhausted attr and llm.exhausted: pred=""`) so a mid-ablation cap stops cleanly. Keep it duck-typed (the e2e test's `_FixedLLM` has no `exhausted` — guard with `getattr(llm, "exhausted", False)`).
+
+- [ ] **Step 4: Run -> pass** (budget + render wheel-free; full `run_scorecard` validates in CI).
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): scorecard orchestrator + budget + render`.
+
+---
+
+## Task 5: CLI
+
+**Files:**
+- Create: `erkgbench/qa_e2e/run_scorecard.py`
+
+- [ ] **Step 1:** Implement a thin argparse CLI: `--seed/--n-questions/--ambiguity/--max-hops/--budget-usd/--out-md`. Build the real LLM (`from goldengraph.llm import OpenAIClient; OpenAIClient(model="gpt-4o-mini")`), call `run_scorecard(..., inner_llm=client, budget_usd=...)`, write `render_scorecard_md(res)` to `--out-md`, print it. Always exit 0 (non-gating). If no `OPENAI_API_KEY` in env, print a notice + exit 0 (the lane is opt-in).
+- [ ] **Step 2:** Smoke: `python -c "import erkgbench.qa_e2e.run_scorecard"` imports clean (no exec). Add `tests/test_qa_scorecard_cli.py` asserting `run_scorecard.main(["--help"])`-style argparse builds (use `parser`-only or `pytest.raises(SystemExit)` on `--help`).
+- [ ] **Step 3: Commit** — `feat(er-kg-bench): run_scorecard CLI`.
+
+---
+
+## Task 6: opt-in CI lane
+
+**Files:**
+- Modify: `.github/workflows/bench-graphrag-qa.yml`
+
+- [ ] **Step 1:** Add a `scorecard` job (workflow_dispatch only) mirroring the existing goldengraph job's setup (build the `goldengraph_native` wheel via maturin + install goldenmatch + goldengraph; the existing bench-graphrag-qa already does this for the goldengraph engine — copy that setup). Add a `scorecard_budget_usd` input (default e.g. `"2"`). Run `python -m erkgbench.qa_e2e.run_scorecard --seed 7 --n-questions 60 --ambiguity 0.6 --budget-usd "${{ inputs.scorecard_budget_usd }}" --out-md SCORECARD.md` with `OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}`; upload `SCORECARD.md`. Non-gating (the job's success is the CLI exit 0; the metrics are reported, not asserted).
+- [ ] **Step 2:** Add the new wheel-free test files to the bench-er-kg.yml pure-Python step (alongside #1274's): `tests/test_qa_extraction_f1.py tests/test_qa_synthesis_given_gold.py tests/test_qa_answer_match_ablation.py tests/test_qa_scorecard_orchestrator.py tests/test_qa_scorecard_cli.py`.
+- [ ] **Step 3:** Validate YAML: `python -c "import yaml; yaml.safe_load(open('.github/workflows/bench-graphrag-qa.yml'))"`.
+- [ ] **Step 4: Commit** — `ci(bench): opt-in scorecard real-LLM lane`.
+- [ ] **Step 5:** Push, open PR. The wheel-free tests gate via bench-er-kg; the real-LLM `scorecard` lane is `workflow_dispatch` (dispatch it manually once merged to produce the first `SCORECARD.md`). Confirm the wheel-free lanes green before arming.
+
+---
+
+## Done criteria
+
+- Wheel-free tests green (extraction-F1, synthesis-given-gold, tracking verdict, budget cap, render, CLI argparse).
+- `run_scorecard` produces a `SCORECARD.md` with all three stages + the tracking line (validated by a manual dispatch of the opt-in lane post-merge).
+- No hard gate added; #1274's deterministic gate untouched; the lane never blocks merge.
+
+## Not in scope (YAGNI)
+
+musique extraction-F1 (no gold triples), LLM-judge variant, hybrid synthesis, any new corpus, slices B/C/D.

--- a/docs/superpowers/plans/2026-06-27-goldengraph-scorecard-llm-rows.md
+++ b/docs/superpowers/plans/2026-06-27-goldengraph-scorecard-llm-rows.md
@@ -420,11 +420,14 @@ class _CostLLM:
 
 
 def test_budgeted_llm_stops_at_cap():
-    tracker = BudgetTracker(BudgetConfig(max_cost_usd=0.0))  # zero budget
+    # tiny POSITIVE cap (not 0.0 -- 0.0 is exhausted at construction, which wouldn't
+    # exercise the record->exhaust transition). One big-output call records enough
+    # usage to flip the flag, proving _BudgetedLLM.complete -> record_usage works.
+    tracker = BudgetTracker(BudgetConfig(max_cost_usd=1e-9))
     llm = _BudgetedLLM(_CostLLM(), tracker, model="gpt-4o-mini")
-    # one call records usage; with a zero cap the tracker reports exhausted
+    assert llm.exhausted is False  # not yet -- nothing recorded
     llm.complete("a prompt that costs tokens")
-    assert llm.exhausted is True
+    assert llm.exhausted is True   # the recorded usage crossed the cap
 
 
 def test_render_scorecard_md_has_all_three_stages():
@@ -560,7 +563,7 @@ def run_scorecard(*, seed, n_questions, ambiguity, max_hops, inner_llm, budget_u
     )
 ```
 
-> The `answer_match_ablation` synthesize calls must also short-circuit on `llm.exhausted` — add a guard in its per-question loop (`if llm has exhausted attr and llm.exhausted: pred=""`) so a mid-ablation cap stops cleanly. Keep it duck-typed (the e2e test's `_FixedLLM` has no `exhausted` — guard with `getattr(llm, "exhausted", False)`).
+> **This EDITS the Task 3 `answer_match_ablation` function in the same `scorecard_llm.py`** (not a new definition). Add a budget short-circuit in its per-question loop: before the `synthesize_local` call, `if getattr(llm, "exhausted", False): pred = ""` (then `a = answer_match("", gold) = 0.0`), so a mid-ablation cap stops cleanly. Duck-typed: the Task 3 e2e `_FixedLLM` has no `exhausted` attr, so `getattr(..., False)` leaves it unaffected — the Task 3 test stays green after this edit.
 
 - [ ] **Step 4: Run -> pass** (budget + render wheel-free; full `run_scorecard` validates in CI).
 - [ ] **Step 5: Commit** — `feat(er-kg-bench): scorecard orchestrator + budget + render`.

--- a/docs/superpowers/specs/2026-06-27-goldengraph-scorecard-llm-rows-design.md
+++ b/docs/superpowers/specs/2026-06-27-goldengraph-scorecard-llm-rows-design.md
@@ -1,0 +1,134 @@
+# GoldenGraph scorecard — real-LLM rows (Phase 2 of slice A)
+
+## Context
+
+Slice A's deterministic core (PR #1274) shipped two scorecard stages — **resolution**
+(ER-F1, reused from er-kg-bench) and **retrieval** (bridge-recall under the 4-dial ER
+ablation, the `(ER)^hops` proof, deterministic + CI-gated). The measured curve
+confirmed the thesis (oracle 1.00 → goldengraph 0.56 → name_only/none 0.23, gap
+widening 0.44→0.91 across hops).
+
+Two scorecard stages remain, both needing a real LLM, plus a validation of the
+free bridge-recall proxy:
+
+- **extraction** (entity-F1 / relation-F1 of extracted vs gold triples) — localizes
+  *where* the graph-only 0.22 ceiling loses facts (the binding constraint the whole
+  program is pointed at).
+- **synthesis** (answer-match given the *gold* subgraph) — the synthesis ceiling:
+  can the LLM read a correct graph.
+- **answer-match confirmation** (the 4-dial ablation measuring real-LLM answer-match
+  instead of bridge-recall) — validates that bridge-recall is a faithful proxy for
+  answer quality.
+
+This spec is **Phase 2 of slice A**. It does not touch the deterministic gate. The
+remaining slices (B aggregation/temporal, C crossover, D KG-vs-KG) stay separate.
+
+## Gating posture
+
+Real-LLM → costs money, non-deterministic → **never a hard gate**. This is an
+**opt-in `workflow_dispatch` lane**, budget-capped via the bench's existing
+`BudgetTracker(BudgetConfig(max_cost_usd=...))` + `record_usage`, producing a
+`SCORECARD.md` artifact. Assertions render as PASS/WARN in the report; they do not
+fail the process. The #1274 bridge-recall gate stays the blocking signal.
+
+All three rows run on the **engineered** corpus (the only corpus with gold triples +
+gold chains) and reuse #1274: `gold.py` (`GoldGraph`, `gold_chain`), `dials.py` (the
+four `*_keys` + `surface_to_canon`), `ablation.py` (`_build_store`), `scorecard.py`
+(`bridge_recall`), `metrics.py` (`answer_match`), and the engine adapter's
+`_CountingLLM` + real `OpenAIClient`.
+
+## Metric definitions
+
+### extraction-F1 (real `_extract`, no store)
+
+For each engineered edge document, gold = `{src_surface, dst_surface}` (from #1274's
+`Document.src_surface`/`dst_surface`) + the relation between them. Run real
+`_extract(doc.text, llm)` → `Extraction(mentions, relationships)` and score, micro
+across the corpus:
+
+- **entity-F1:** extracted mention surfaces vs the gold surface pair, normalized
+  (lowercase / strip via `metrics._normalize`). Micro TP/FP/FN.
+- **relation-F1 (existence-based):** a relationship is correct if its subj/obj
+  mention surfaces match the gold src/dst pair (either direction — edges are walked
+  both ways), **ignoring the predicate label**. The LLM emits free-form predicates
+  ("works at" vs gold `works_at`) and synthesis treats labels as hints, so "did it
+  recover the *edge*" is the honest signal. Micro TP/FP/FN.
+
+Low entity-F1 → the LLM misses entities; low relation-F1 → misses edges. This is the
+localizer for the 0.22 ceiling. Cost: N extraction calls.
+
+### synthesis-given-gold (real `synthesize_local`, no store, no retrieval)
+
+Build the gold chain subgraph from `gold.py`:
+`{entities:[{entity_id, canonical_name, typ}], edges:[{subj, predicate, obj}]}` over
+the chain's canonical entities + gold edges. Call
+`synthesize_local(question, gold_subgraph, llm, seed_names=[start_canonical])` and
+score `answer_match(pred, gold_answer)`. Mean by hop = the synthesis ceiling given a
+perfect graph. `synthesize_local` is entity-only, which fits: engineered gold answers
+*are* canonical entity names. Cost: N synthesis calls.
+
+### answer-match ablation — 4-dial, matched to bridge-recall
+
+Per dial (`oracle`/`goldengraph`/`name_only`/`none`), reuse `ablation._build_store`
+(oracle extraction, dial record_keys) + the coverage map + oracle-seed +
+`_retrieve_local` ball — **identical to the bridge-recall measurement**. The only new
+step: real `synthesize_local` over that ball (seed_names = the seed node's
+canonical_name), scored with `answer_match` vs `gold_answer`. Recompute `bridge_recall`
+on the same ball so the report carries both curves side by side. Cost: 4×N synthesis
+calls (builds are LLM-free — oracle extraction).
+
+**Tracking verdict (PASS/WARN, not gating):** the answer-match dial ordering matches
+the bridge-recall ordering (`oracle ≥ goldengraph ≥ name_only ≥ none`, tolerance). A
+faithful proxy means they track. *Expected honest effect:* under the weak dials the
+answer entity is reached under a variant surface, so the model may output the variant
+rather than the canonical gold → answer-match drops further, tracking bridge-recall
+*more* strongly. That is a real ER→answer effect (bad resolution costs you the
+canonical name), not a metric artifact — noted in the report. A genuine **divergence**
+(bridge-recall high for a dial but answer-match low) is the finding the row exists to
+surface: synthesis failing to read a ball that contains the answer.
+
+Total LLM cost ≈ **6N calls** (N extract + N synth + 4N synth), budget-capped.
+
+## Components / files
+
+New, under `erkgbench/qa_e2e/`:
+
+- **`scorecard_llm.py`** — `extraction_f1(gold_triples, extraction)`,
+  `build_gold_subgraph(gold_chain)`, `synthesis_given_gold(question, gold_chain, llm)`,
+  `answer_match_ablation(corpus, llm, ...)` (reuses `ablation._build_store` +
+  `bridge_recall`), `tracking_verdict(answer_match_by_dial, bridge_recall_by_dial)`,
+  a `ScorecardResult` dataclass, and `render_scorecard_md`.
+- **`run_scorecard.py`** — CLI (real LLM, `--budget-usd`, `--seed`/`--n-questions`/
+  `--ambiguity`), writes `SCORECARD.md`. Stops cleanly when the budget cap is hit
+  (records partial results + a BUDGET-EXHAUSTED note).
+
+CI: a new opt-in `workflow_dispatch` lane (a job in `bench-graphrag-qa.yml` or a
+sibling) with a `budget_usd` input + `OPENAI_API_KEY`; uploads `SCORECARD.md`. Never
+`ci-required`.
+
+## Testing
+
+Pure offline (no LLM/network; the ablation store-build row `importorskip`s the wheel):
+
+1. **`extraction_f1`** — synthetic gold + synthetic `Extraction`: perfect match → 1.0;
+   a missing entity drops recall; a spurious entity drops precision; an edge in either
+   direction between the right surfaces counts as a relation TP regardless of predicate
+   label.
+2. **`synthesis_given_gold`** — `StubLLM` returning `"...\nAnswer: X"`: assert the gold
+   subgraph is constructed (the synthesis prompt carries the chain entities/edges) and
+   `answer_match` is scored against the parsed answer.
+3. **`tracking_verdict`** — synthetic per-dial answer-match + bridge-recall dicts: PASS
+   when the orders match, WARN on a divergence.
+4. **Budget cap** — a fake LLM + a tiny `max_cost_usd`: the runner stops and records
+   `budget_exhausted` rather than running all 6N calls.
+5. **Report render** — `render_scorecard_md(ScorecardResult)` carries the three stage
+   sections + both ablation curves + the verdict line.
+6. **e2e ablation row** — `importorskip("goldengraph_native")`; validates in the opt-in
+   lane.
+
+## Scope guard (YAGNI)
+
+Engineered corpus only. No new corpus, no musique extraction-F1 (no gold triples
+there), no LLM-judge variant (use the deterministic `answer_match`; `judge_prompt`
+exists but is out of scope here). The #1274 deterministic gate is untouched; this lane
+never blocks merge. Slices B/C/D remain separate specs.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_scorecard.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_scorecard.py
@@ -1,0 +1,54 @@
+"""CLI: run the real-LLM scorecard rows (extraction-F1, synthesis-given-gold,
+4-dial answer-match ablation), write SCORECARD.md. Opt-in, budget-capped, NON-gating
+-- always exits 0. Needs OPENAI_API_KEY + the goldengraph_native wheel.
+
+Example:
+    python -m erkgbench.qa_e2e.run_scorecard --seed 7 --n-questions 60 \
+        --ambiguity 0.6 --budget-usd 2 --out-md SCORECARD.md
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="GoldenGraph real-LLM scorecard")
+    p.add_argument("--seed", type=int, default=7)
+    p.add_argument("--n-questions", type=int, default=60)
+    p.add_argument("--ambiguity", type=float, default=0.6)
+    p.add_argument("--max-hops", type=int, default=4)
+    p.add_argument("--budget-usd", type=float, default=2.0)
+    p.add_argument("--out-md", default="SCORECARD.md")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        sys.stderr.write("No OPENAI_API_KEY; skipping the scorecard (opt-in lane).\n")
+        return 0
+
+    from goldengraph.llm import OpenAIClient
+
+    from .scorecard_llm import render_scorecard_md, run_scorecard
+
+    res = run_scorecard(
+        seed=args.seed,
+        n_questions=args.n_questions,
+        ambiguity=args.ambiguity,
+        max_hops=args.max_hops,
+        inner_llm=OpenAIClient(model="gpt-4o-mini"),
+        budget_usd=args.budget_usd,
+    )
+    md = render_scorecard_md(res)
+    with open(args.out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    sys.stdout.write(md)
+    return 0  # non-gating
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard_llm.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard_llm.py
@@ -1,0 +1,44 @@
+"""Real-LLM scorecard rows (Phase 2 of slice A): extraction-F1, synthesis-given-gold,
+and the 4-dial answer-match ablation matched to bridge-recall. Opt-in, budget-capped,
+NON-gating -- the deterministic bridge-recall gate (#1274) stays the blocking signal."""
+from __future__ import annotations
+
+from . import metrics
+
+
+def _norm(s: str) -> str:
+    return metrics._normalize(s)
+
+
+def extraction_counts(gold_src: str, gold_dst: str, extraction) -> dict:
+    """Per-doc entity + (existence-based) relation TP/FP/FN of `extraction` vs the
+    one gold edge {gold_src, gold_dst}. Predicate label ignored; edge counted in
+    either direction."""
+    gold_ents = {_norm(gold_src), _norm(gold_dst)}
+    got_ents = {_norm(m.name) for m in extraction.mentions}
+    ent_tp = len(gold_ents & got_ents)
+    ent_fp = len(got_ents - gold_ents)
+    ent_fn = len(gold_ents - got_ents)
+
+    gold_edge = frozenset(gold_ents)
+    got_edges = [
+        frozenset(
+            {_norm(extraction.mentions[r.subj].name), _norm(extraction.mentions[r.obj].name)}
+        )
+        for r in extraction.relationships
+        if r.subj < len(extraction.mentions) and r.obj < len(extraction.mentions)
+    ]
+    rel_tp = 1 if gold_edge in got_edges else 0
+    rel_fp = sum(1 for e in got_edges if e != gold_edge)
+    rel_fn = 1 - rel_tp
+    return {
+        "ent_tp": ent_tp, "ent_fp": ent_fp, "ent_fn": ent_fn,
+        "rel_tp": rel_tp, "rel_fp": rel_fp, "rel_fn": rel_fn,
+    }
+
+
+def f1_from_counts(tp: int, fp: int, fn: int) -> dict:
+    p = tp / (tp + fp) if (tp + fp) else 0.0
+    r = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return {"precision": p, "recall": r, "f1": f1}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard_llm.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard_llm.py
@@ -3,6 +3,11 @@ and the 4-dial answer-match ablation matched to bridge-recall. Opt-in, budget-ca
 NON-gating -- the deterministic bridge-recall gate (#1274) stays the blocking signal."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from goldenmatch.config.schemas import BudgetConfig
+from goldenmatch.core.llm_budget import BudgetTracker
+
 from . import metrics
 
 
@@ -142,3 +147,134 @@ def answer_match_ablation(corpus, g, typ_of, llm) -> dict:
             },
         }
     return out
+
+
+# --- orchestrator: the three rows under one budget ---
+
+
+@dataclass
+class ScorecardResult:
+    extraction: dict          # {"entity": f1dict, "relation": f1dict}
+    synthesis_ceiling: dict   # {"mean", "by_hop"}
+    answer_match_ablation: dict
+    tracking: tuple
+    budget_exhausted: bool
+
+
+class _BudgetedLLM:
+    """Wrap the real LLM: count tokens (the bench's len//4 estimate) and record each
+    call to the BudgetTracker so `exhausted` gates further calls."""
+
+    def __init__(self, inner, tracker, *, model: str = "gpt-4o-mini"):
+        from .engines.goldengraph import _CountingLLM
+
+        self._c = _CountingLLM(inner)
+        self._t = tracker
+        self._model = model
+
+    @property
+    def exhausted(self) -> bool:
+        return self._t.budget_exhausted
+
+    def complete(self, prompt: str) -> str:
+        bi, bo = self._c.input_tokens, self._c.output_tokens
+        out = self._c.complete(prompt)
+        self._t.record_usage(
+            self._c.input_tokens - bi, self._c.output_tokens - bo, self._model
+        )
+        return out
+
+
+def render_scorecard_md(res: ScorecardResult) -> str:
+    lines = ["# GoldenGraph scorecard -- real-LLM rows (Phase 2)", ""]
+    lines += [
+        "## extraction (vs gold triples)",
+        f"- entity-F1: {res.extraction['entity']['f1']:.3f}",
+        f"- relation-F1: {res.extraction['relation']['f1']:.3f}",
+        "",
+    ]
+    sc = res.synthesis_ceiling
+    by_hop = (
+        " | by-hop " + ", ".join(f"{h}:{v:.3f}" for h, v in sc["by_hop"].items())
+        if sc["by_hop"]
+        else ""
+    )
+    lines += [
+        "## synthesis ceiling (answer-match given the GOLD subgraph)",
+        f"- mean: {sc['mean']:.3f}{by_hop}",
+        "",
+    ]
+    lines += [
+        "## answer-match ablation (matched to bridge-recall)",
+        "",
+        "| dial | answer-match | bridge-recall |",
+        "|---|---|---|",
+    ]
+    for d in _DIAL_ORDER:
+        a = res.answer_match_ablation[d]["answer_match"]["mean"]
+        b = res.answer_match_ablation[d]["bridge_recall"]["mean"]
+        lines.append(f"| {d} | {a:.3f} | {b:.3f} |")
+    label, passed = res.tracking
+    lines += ["", f"- [{'PASS' if passed else 'WARN'}] {label}"]
+    if res.budget_exhausted:
+        lines += ["", "> BUDGET-EXHAUSTED: results are partial."]
+    return "\n".join(lines) + "\n"
+
+
+def run_scorecard(*, seed, n_questions, ambiguity, max_hops, inner_llm, budget_usd) -> ScorecardResult:
+    """Orchestrate the three rows under one budget. Each row checks `llm.exhausted`
+    before a call and stops cleanly. Needs the wheel for the ablation row."""
+    from goldengraph.extract import extract as _extract
+
+    from .ablation import _typ_of
+    from .engineered import generate_engineered
+    from .gold import GoldGraph, gold_chain
+
+    tracker = BudgetTracker(BudgetConfig(max_cost_usd=budget_usd))
+    llm = _BudgetedLLM(inner_llm, tracker)
+    corpus = generate_engineered(
+        seed=seed, n_questions=n_questions, ambiguity=ambiguity, max_hops=max_hops
+    )
+    g = GoldGraph.from_corpus(corpus)
+    typ_of = _typ_of(g)
+
+    # row 1: extraction-F1 (real _extract per edge doc)
+    et = {"ent_tp": 0, "ent_fp": 0, "ent_fn": 0, "rel_tp": 0, "rel_fp": 0, "rel_fn": 0}
+    for d in corpus.documents:
+        if llm.exhausted or len(d.id.split("::")) != 3:
+            continue
+        ex = _extract(d.text, llm)
+        c = extraction_counts(d.src_surface, d.dst_surface, ex)
+        for k in et:
+            et[k] += c[k]
+    extraction = {
+        "entity": f1_from_counts(et["ent_tp"], et["ent_fp"], et["ent_fn"]),
+        "relation": f1_from_counts(et["rel_tp"], et["rel_fp"], et["rel_fn"]),
+    }
+
+    # row 2: synthesis-given-gold
+    s_all, s_hop = [], {}
+    for qa in corpus.questions:
+        if llm.exhausted:
+            continue
+        chain = gold_chain(g, qa)
+        sc = synthesis_given_gold(qa.question, chain, g, typ_of, qa.gold_answer, llm)
+        s_all.append(sc)
+        s_hop.setdefault(qa.hop_count, []).append(sc)
+    synthesis_ceiling = {
+        "mean": sum(s_all) / len(s_all) if s_all else 0.0,
+        "by_hop": {h: sum(v) / len(v) for h, v in sorted(s_hop.items())},
+    }
+
+    # row 3: answer-match ablation (matched). Honors the budget INSIDE via the
+    # llm.exhausted short-circuit in answer_match_ablation's per-question loop.
+    ama = answer_match_ablation(corpus, g, typ_of, llm)
+    am_means = {d: ama[d]["answer_match"]["mean"] for d in ama}
+    br_means = {d: ama[d]["bridge_recall"]["mean"] for d in ama}
+    return ScorecardResult(
+        extraction=extraction,
+        synthesis_ceiling=synthesis_ceiling,
+        answer_match_ablation=ama,
+        tracking=tracking_verdict(am_means, br_means),
+        budget_exhausted=tracker.budget_exhausted,
+    )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard_llm.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard_llm.py
@@ -67,3 +67,78 @@ def synthesis_given_gold(question, gold_chain, g, typ_of, gold_answer, llm) -> f
     start_name = g.canonical_name(gold_chain[0][0])
     pred = synthesize_local(question, sub, llm, seed_names=[start_name])
     return metrics.answer_match(pred, gold_answer)
+
+
+_DIAL_ORDER = ("oracle", "goldengraph", "name_only", "none")
+
+
+def tracking_verdict(answer_match_by_dial: dict, bridge_recall_by_dial: dict) -> tuple[str, bool]:
+    """PASS if the answer-match dial ranking matches the bridge-recall ranking
+    (both should descend oracle..none). A faithful proxy tracks."""
+
+    def _rank(d):
+        return sorted(d, key=lambda k: -d[k])
+
+    same = _rank(answer_match_by_dial) == _rank(bridge_recall_by_dial)
+    return ("answer-match tracks bridge-recall", same)
+
+
+def answer_match_ablation(corpus, g, typ_of, llm) -> dict:
+    """Per dial: reuse ablation._build_store (oracle extraction, dial record_keys),
+    oracle-seed + _retrieve_local ball (IDENTICAL to bridge-recall), then real
+    synthesize_local over that ball. Returns per-dial answer-match + bridge-recall
+    (mean + by_hop)."""
+    from goldengraph.answer import _retrieve_local
+    from goldengraph.synthesize import synthesize_local
+
+    from .ablation import _DIALS, _KEYFN, _build_store
+    from .engines.goldengraph import _NODE_BUDGET, _RETRIEVAL_HOPS
+    from .gold import gold_chain
+    from .scorecard import bridge_recall
+
+    chains = {qa.id: gold_chain(g, qa) for qa in corpus.questions}
+    out: dict = {}
+    for dial in _DIALS:
+        km = _KEYFN[dial](corpus, g)
+        slice_graph, coverage = _build_store(corpus, g, km, typ_of)
+        seed_of: dict = {}
+        for nid in sorted(coverage):
+            for c in coverage[nid]:
+                seed_of.setdefault(c, nid)
+        id_to_name = {e["entity_id"]: e["canonical_name"] for e in slice_graph.entities()}
+
+        am, br = [], []
+        am_hop: dict = {}
+        br_hop: dict = {}
+        for qa in corpus.questions:
+            seed_node = seed_of.get(qa.start_entity_id)
+            if seed_node is None:
+                a, b = 0.0, 0.0
+            else:
+                ball = _retrieve_local(
+                    slice_graph, [seed_node], max_hops=_RETRIEVAL_HOPS, node_budget=_NODE_BUDGET
+                )
+                # mid-ablation budget short-circuit (duck-typed: no-op for a plain LLM)
+                if getattr(llm, "exhausted", False):
+                    pred = ""
+                else:
+                    pred = synthesize_local(
+                        qa.question, ball, llm, seed_names=[id_to_name.get(seed_node, "")]
+                    )
+                a = metrics.answer_match(pred, qa.gold_answer)
+                b = bridge_recall(chains[qa.id], ball, coverage)["whole_chain"]
+            am.append(a)
+            br.append(b)
+            am_hop.setdefault(qa.hop_count, []).append(a)
+            br_hop.setdefault(qa.hop_count, []).append(b)
+        out[dial] = {
+            "answer_match": {
+                "mean": sum(am) / len(am) if am else 0.0,
+                "by_hop": {h: sum(v) / len(v) for h, v in sorted(am_hop.items())},
+            },
+            "bridge_recall": {
+                "mean": sum(br) / len(br) if br else 0.0,
+                "by_hop": {h: sum(v) / len(v) for h, v in sorted(br_hop.items())},
+            },
+        }
+    return out

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard_llm.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/scorecard_llm.py
@@ -42,3 +42,28 @@ def f1_from_counts(tp: int, fp: int, fn: int) -> dict:
     r = tp / (tp + fn) if (tp + fn) else 0.0
     f1 = 2 * p * r / (p + r) if (p + r) else 0.0
     return {"precision": p, "recall": r, "f1": f1}
+
+
+def build_gold_subgraph(gold_chain, g, typ_of: dict) -> dict:
+    """{entities, edges} over the chain's canonical entities -- the shape
+    synthesize_local's _format_subgraph reads. entity_id = canonical id."""
+    ids: list = []
+    for (s, _rel, o) in gold_chain:
+        for x in (s, o):
+            if x not in ids:
+                ids.append(x)
+    entities = [
+        {"entity_id": x, "canonical_name": g.canonical_name(x), "typ": typ_of.get(x, "concept")}
+        for x in ids
+    ]
+    edges = [{"subj": s, "predicate": rel, "obj": o} for (s, rel, o) in gold_chain]
+    return {"entities": entities, "edges": edges}
+
+
+def synthesis_given_gold(question, gold_chain, g, typ_of, gold_answer, llm) -> float:
+    from goldengraph.synthesize import synthesize_local
+
+    sub = build_gold_subgraph(gold_chain, g, typ_of)
+    start_name = g.canonical_name(gold_chain[0][0])
+    pred = synthesize_local(question, sub, llm, seed_names=[start_name])
+    return metrics.answer_match(pred, gold_answer)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_match_ablation.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_match_ablation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+from erkgbench.qa_e2e.scorecard_llm import tracking_verdict
+
+
+def test_tracking_verdict_pass_when_orders_match():
+    am = {"oracle": 0.9, "goldengraph": 0.6, "name_only": 0.3, "none": 0.2}
+    br = {"oracle": 1.0, "goldengraph": 0.55, "name_only": 0.23, "none": 0.23}
+    _label, passed = tracking_verdict(am, br)
+    assert passed is True
+
+
+def test_tracking_verdict_warn_on_divergence():
+    # answer-match HIGH for none but bridge-recall says none is worst -> divergence
+    am = {"oracle": 0.5, "goldengraph": 0.5, "name_only": 0.5, "none": 0.9}
+    br = {"oracle": 1.0, "goldengraph": 0.55, "name_only": 0.23, "none": 0.23}
+    _label, passed = tracking_verdict(am, br)
+    assert passed is False
+
+
+def test_answer_match_ablation_e2e():
+    pytest.importorskip("goldengraph_native")
+    from erkgbench.qa_e2e import ablation
+    from erkgbench.qa_e2e.engineered import generate_engineered
+    from erkgbench.qa_e2e.gold import GoldGraph
+    from erkgbench.qa_e2e.scorecard_llm import answer_match_ablation
+
+    corpus = generate_engineered(seed=7, n_questions=40, ambiguity=0.6, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    typ_of = ablation._typ_of(g)
+
+    class _FixedLLM:  # deterministic, no network -- always answers "Answer: X"
+        def complete(self, prompt):
+            return "Answer: X"
+
+    res = answer_match_ablation(corpus, g, typ_of, _FixedLLM())
+    for d in ("oracle", "goldengraph", "name_only", "none"):
+        assert "answer_match" in res[d] and "bridge_recall" in res[d]
+    assert res["oracle"]["bridge_recall"]["mean"] >= res["none"]["bridge_recall"]["mean"]

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_extraction_f1.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_extraction_f1.py
@@ -1,0 +1,66 @@
+"""extraction-F1: did real extraction recover the gold entities + edge per doc.
+Pure -- operates on a gold (src,dst) surface pair + a goldengraph Extraction."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from erkgbench.qa_e2e.scorecard_llm import extraction_counts, f1_from_counts
+
+
+@dataclass
+class _M:
+    name: str
+    typ: str = "concept"
+
+
+@dataclass
+class _R:
+    subj: int
+    predicate: str
+    obj: int
+
+
+@dataclass
+class _Ex:
+    mentions: list
+    relationships: list
+
+
+def test_perfect_extraction_is_f1_one():
+    ex = _Ex([_M("Acme"), _M("Rocket")], [_R(0, "made", 1)])
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["ent_tp"] == 2 and c["ent_fp"] == 0 and c["ent_fn"] == 0
+    assert c["rel_tp"] == 1 and c["rel_fp"] == 0 and c["rel_fn"] == 0
+
+
+def test_missing_entity_drops_recall_and_loses_the_edge():
+    ex = _Ex([_M("Acme")], [])  # dst entity + the edge both missing
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["ent_tp"] == 1 and c["ent_fn"] == 1
+    assert c["rel_tp"] == 0 and c["rel_fn"] == 1
+
+
+def test_spurious_entity_drops_precision():
+    ex = _Ex([_M("Acme"), _M("Rocket"), _M("Noise")], [_R(0, "made", 1)])
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["ent_tp"] == 2 and c["ent_fp"] == 1
+
+
+def test_relation_matches_either_direction_ignoring_predicate():
+    # edge authored dst->src with a different predicate word still counts
+    ex = _Ex([_M("Rocket"), _M("Acme")], [_R(0, "built by", 1)])
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["rel_tp"] == 1 and c["rel_fp"] == 0
+
+
+def test_normalization_case_insensitive():
+    ex = _Ex([_M("ACME"), _M(" rocket ")], [_R(0, "made", 1)])
+    c = extraction_counts("Acme", "Rocket", ex)
+    assert c["ent_tp"] == 2 and c["rel_tp"] == 1
+
+
+def test_f1_from_counts():
+    assert f1_from_counts(2, 0, 0) == {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+    r = f1_from_counts(1, 1, 1)
+    assert r["precision"] == 0.5 and r["recall"] == 0.5 and r["f1"] == 0.5
+    assert f1_from_counts(0, 0, 0)["f1"] == 0.0  # empty -> 0, no ZeroDivision

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_scorecard_cli.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_scorecard_cli.py
@@ -1,0 +1,21 @@
+"""The scorecard CLI parses + is import-clean. No real run (needs key + wheel)."""
+from __future__ import annotations
+
+import pytest
+from erkgbench.qa_e2e import run_scorecard
+
+
+def test_parser_defaults():
+    args = run_scorecard._parser().parse_args([])
+    assert args.seed == 7 and args.budget_usd == 2.0 and args.out_md == "SCORECARD.md"
+
+
+def test_help_exits_clean():
+    with pytest.raises(SystemExit) as e:
+        run_scorecard.main(["--help"])
+    assert e.value.code == 0
+
+
+def test_main_no_key_is_noop(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert run_scorecard.main(["--n-questions", "1"]) == 0  # opt-in: exits 0, no run

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_scorecard_orchestrator.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_scorecard_orchestrator.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from erkgbench.qa_e2e.scorecard_llm import (
+    ScorecardResult,
+    _BudgetedLLM,
+    render_scorecard_md,
+)
+from goldenmatch.config.schemas import BudgetConfig
+from goldenmatch.core.llm_budget import BudgetTracker
+
+
+class _CostLLM:
+    def complete(self, prompt):
+        return "x" * 4000  # big output -> burns budget fast
+
+
+def test_budgeted_llm_stops_at_cap():
+    # tiny POSITIVE cap (not 0.0 -- 0.0 is exhausted at construction, which wouldn't
+    # exercise the record->exhaust transition). One big-output call records enough
+    # usage to flip the flag, proving _BudgetedLLM.complete -> record_usage works.
+    tracker = BudgetTracker(BudgetConfig(max_cost_usd=1e-9))
+    llm = _BudgetedLLM(_CostLLM(), tracker, model="gpt-4o-mini")
+    assert llm.exhausted is False  # not yet -- nothing recorded
+    llm.complete("a prompt that costs tokens")
+    assert llm.exhausted is True   # the recorded usage crossed the cap
+
+
+def test_render_scorecard_md_has_all_three_stages():
+    res = ScorecardResult(
+        extraction={"entity": {"f1": 0.8}, "relation": {"f1": 0.6}},
+        synthesis_ceiling={"mean": 0.9, "by_hop": {2: 0.95, 4: 0.85}},
+        answer_match_ablation={
+            "oracle": {"answer_match": {"mean": 0.9, "by_hop": {}}, "bridge_recall": {"mean": 1.0, "by_hop": {}}},
+            "goldengraph": {"answer_match": {"mean": 0.6, "by_hop": {}}, "bridge_recall": {"mean": 0.55, "by_hop": {}}},
+            "name_only": {"answer_match": {"mean": 0.3, "by_hop": {}}, "bridge_recall": {"mean": 0.23, "by_hop": {}}},
+            "none": {"answer_match": {"mean": 0.2, "by_hop": {}}, "bridge_recall": {"mean": 0.23, "by_hop": {}}},
+        },
+        tracking=("answer-match tracks bridge-recall", True),
+        budget_exhausted=False,
+    )
+    md = render_scorecard_md(res)
+    assert "extraction" in md.lower() and "entity-F1" in md
+    assert "synthesis" in md.lower()
+    assert "answer-match" in md.lower() and "bridge-recall" in md.lower()
+    assert "PASS" in md or "WARN" in md

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_synthesis_given_gold.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_synthesis_given_gold.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from erkgbench.qa_e2e import ablation
+from erkgbench.qa_e2e.engineered import generate_engineered
+from erkgbench.qa_e2e.gold import GoldGraph, gold_chain
+from erkgbench.qa_e2e.scorecard_llm import build_gold_subgraph, synthesis_given_gold
+
+
+class _StubLLM:
+    def __init__(self, response):
+        self.response = response
+        self.prompts = []
+
+    def complete(self, prompt):
+        self.prompts.append(prompt)
+        return self.response
+
+
+def _setup():
+    corpus = generate_engineered(seed=7, n_questions=10, ambiguity=0.3, max_hops=4)
+    g = GoldGraph.from_corpus(corpus)
+    return corpus, g, ablation._typ_of(g)
+
+
+def test_build_gold_subgraph_carries_the_chain():
+    corpus, g, typ_of = _setup()
+    qa = corpus.questions[0]
+    chain = gold_chain(g, qa)
+    sub = build_gold_subgraph(chain, g, typ_of)
+    ids = {e["entity_id"] for e in sub["entities"]}
+    for (s, rel, o) in chain:
+        assert s in ids and o in ids
+        assert any(
+            e["subj"] == s and e["obj"] == o and e["predicate"] == rel for e in sub["edges"]
+        )
+    assert all(e["canonical_name"] for e in sub["entities"])
+
+
+def test_synthesis_given_gold_scores_answer_match():
+    corpus, g, typ_of = _setup()
+    qa = corpus.questions[0]
+    chain = gold_chain(g, qa)
+    llm = _StubLLM(f"reasoning...\nAnswer: {qa.gold_answer}")
+    score = synthesis_given_gold(qa.question, chain, g, typ_of, qa.gold_answer, llm)
+    assert score == 1.0
+    # the synthesis prompt was handed the gold chain (a chain entity name appears)
+    assert g.canonical_name(chain[-1][2]) in llm.prompts[-1]
+
+
+def test_synthesis_given_gold_wrong_answer_scores_zero():
+    corpus, g, typ_of = _setup()
+    qa = corpus.questions[0]
+    chain = gold_chain(g, qa)
+    llm = _StubLLM("Answer: definitely-not-the-gold-xyzzy")
+    assert synthesis_given_gold(qa.question, chain, g, typ_of, qa.gold_answer, llm) == 0.0


### PR DESCRIPTION
Completes the per-stage scorecard. #1274 shipped the deterministic core (resolution ER-F1 + retrieval bridge-recall, the `(ER)^hops` proof). This adds the three rows that need a real LLM, as an **opt-in, budget-capped, non-gating** lane.

## What this adds (`erkgbench/qa_e2e/scorecard_llm.py` + `run_scorecard.py`)
- **extraction-F1** — real `_extract` per engineered edge doc vs the gold triple (existence-based entity + relation TP/FP/FN, predicate-ignored, either direction). **Localizes the 0.22 graph-only ceiling** — the binding constraint the whole program is pointed at.
- **synthesis-given-gold** — `synthesize_local` over the *gold* chain subgraph, scored with `answer_match`. The synthesis ceiling: can the LLM read a correct graph.
- **4-dial answer-match ablation, matched to bridge-recall** — reuses #1274's `ablation._build_store` + `bridge_recall` so both curves come from the identical store/ball; only the final step (real `synthesize_local`) differs. **Tracking verdict** checks the answer-match dial ranking matches bridge-recall's — validating the free deterministic proxy. Divergence (bridge-recall high, answer-match low) is the finding the row exists to surface.
- Orchestrated under one `BudgetTracker`; `_BudgetedLLM` records each call's token estimate so the run stops cleanly at the cap. `render_scorecard_md` → `SCORECARD.md`.

## Gating
**Never a hard gate.** New `scorecard` job in `bench-graphrag-qa.yml` (`run_scorecard=true`, `scorecard_budget_usd`) builds the native wheel + runs `run_scorecard`, uploads `SCORECARD.md`, always exits 0. The #1274 deterministic bridge-recall gate stays the blocking signal.

## Honest status
The real-LLM numbers have **not** run — they validate only in the opt-in `scorecard` lane (needs key + budget; won't auto-run on this PR). The 16 wheel-free tests (extraction-F1, gold-subgraph build, synthesis stub, tracking verdict, budget record→exhaust transition against the real `BudgetTracker`, render, CLI) pass + lint clean; the e2e ablation `importorskip`s the wheel.

## Test plan
- [x] 16 wheel-free tests pass; `test_qa_corpora` unaffected
- [x] both workflow YAMLs parse; `scorecard` job present (gated on `run_scorecard`)
- [ ] `bench-er-kg` pure-Python step green on the 5 new test files (the real validator for these)
- [ ] manual dispatch of `bench-graphrag-qa` with `run_scorecard=true` post-merge → first `SCORECARD.md`

Spec + plan: `docs/superpowers/specs/2026-06-27-goldengraph-scorecard-llm-rows-design.md`, `docs/superpowers/plans/2026-06-27-goldengraph-scorecard-llm-rows.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)