### PR TITLE
feat(er-kg-bench): GoldenGraph temporal as_of capability bench (slice B2)

### DIFF
--- a/.github/workflows/bench-er-kg.yml
+++ b/.github/workflows/bench-er-kg.yml
@@ -129,7 +129,7 @@ jobs:
         working-directory: ${{ env.BENCH_DIR }}
         env:
           POLARS_SKIP_CPU_CHECK: "1"
-        run: "$GITHUB_WORKSPACE/.venv/bin/python -m pytest tests/test_qa_metrics.py tests/test_qa_corpora.py tests/test_qa_harness.py tests/test_qa_gold_oracle.py tests/test_qa_dials.py tests/test_qa_bridge_recall.py tests/test_qa_engineered_surfaces.py tests/test_qa_ablation.py tests/test_qa_extraction_f1.py tests/test_qa_synthesis_given_gold.py tests/test_qa_answer_match_ablation.py tests/test_qa_scorecard_orchestrator.py tests/test_qa_scorecard_cli.py tests/test_qa_aggregation_corpus.py tests/test_qa_aggregation_metric.py tests/test_qa_aggregation_floor.py tests/test_qa_aggregation_cli.py -v"
+        run: "$GITHUB_WORKSPACE/.venv/bin/python -m pytest tests/test_qa_metrics.py tests/test_qa_corpora.py tests/test_qa_harness.py tests/test_qa_gold_oracle.py tests/test_qa_dials.py tests/test_qa_bridge_recall.py tests/test_qa_engineered_surfaces.py tests/test_qa_ablation.py tests/test_qa_extraction_f1.py tests/test_qa_synthesis_given_gold.py tests/test_qa_answer_match_ablation.py tests/test_qa_scorecard_orchestrator.py tests/test_qa_scorecard_cli.py tests/test_qa_aggregation_corpus.py tests/test_qa_aggregation_metric.py tests/test_qa_aggregation_floor.py tests/test_qa_aggregation_cli.py tests/test_qa_temporal_corpus.py tests/test_qa_temporal_floor.py tests/test_qa_temporal_cli.py tests/test_qa_temporal_llm.py -v"
 
       - name: Regenerate demo DEMO.md (Tier 1)
         working-directory: ${{ env.BENCH_DIR }}

--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -28,6 +28,9 @@ on:
       run_aggregation_llm:
         description: "run the slice-B1 real-LLM RAG aggregation floor (realistic confirmation of the deterministic gate)"
         default: "false"
+      run_temporal_llm:
+        description: "run the slice-B2 real-LLM RAG temporal floor (realistic confirmation of the deterministic gate)"
+        default: "false"
       engine:
         description: "all | goldengraph | lightrag | ms_graphrag | graphiti | text_rag | goldenmatch_rag | goldenmatch_entity_rag"
         default: "all"
@@ -477,7 +480,7 @@ jobs:
   scorecard:
     # Opt-in real-LLM confirmation rows (NON-gating): Phase-2 scorecard
     # (run_scorecard) and/or the slice-B1 RAG aggregation floor (run_aggregation_llm).
-    if: ${{ inputs.run_scorecard == 'true' || inputs.run_aggregation_llm == 'true' }}
+    if: ${{ inputs.run_scorecard == 'true' || inputs.run_aggregation_llm == 'true' || inputs.run_temporal_llm == 'true' }}
     runs-on: large-new-64GB
     timeout-minutes: 120
     steps:
@@ -531,4 +534,24 @@ jobs:
         with:
           name: graphrag-qa-aggregation-llm
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/AGGREGATION_LLM.md
+          if-no-files-found: ignore
+      - name: Run the real-LLM RAG temporal floor (slice B2, opt-in)
+        if: ${{ inputs.run_temporal_llm == 'true' }}
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          POLARS_SKIP_CPU_CHECK: "1"
+        # --with-llm adds the realistic RAG row; NON-gating (`|| true`; the
+        # deterministic gate is goldengraph-pipeline's job).
+        run: |
+          python -m erkgbench.qa_e2e.run_temporal \
+            --seed 7 --n-facts 40 --ambiguity 0.6 \
+            --with-llm --budget-usd "${{ inputs.scorecard_budget_usd }}" \
+            --out-md TEMPORAL_LLM.md || true
+      - name: Upload TEMPORAL_LLM.md
+        if: ${{ always() && inputs.run_temporal_llm == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-qa-temporal-llm
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/TEMPORAL_LLM.md
           if-no-files-found: ignore

--- a/.github/workflows/goldengraph-pipeline.yml
+++ b/.github/workflows/goldengraph-pipeline.yml
@@ -96,3 +96,25 @@ jobs:
           name: goldengraph-aggregation
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/AGGREGATION.md
           if-no-files-found: ignore
+
+      - name: Temporal as_of capability gate (deterministic, key-free)
+        # The second capability RAG structurally can't do: as-of a PAST date after a
+        # correction. goldengraph store.as_of(D) returns the edge true at D; a
+        # temporal-blind floor returns the latest -> wrong on past. Runs the valid_to
+        # round-trip + as_of e2e first, then gates HARD on gg accuracy in both regimes
+        # + gg >> floor on PAST queries. No key.
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: |
+          python -m pytest tests/test_qa_temporal_store.py -v
+          python -m erkgbench.qa_e2e.run_temporal \
+            --seed 7 --n-facts 40 --ambiguity 0.6 --out-md TEMPORAL.md
+
+      - name: Upload TEMPORAL.md
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: goldengraph-temporal
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/TEMPORAL.md
+          if-no-files-found: ignore

--- a/docs/superpowers/plans/2026-06-27-goldengraph-temporal-asof-bench.md
+++ b/docs/superpowers/plans/2026-06-27-goldengraph-temporal-asof-bench.md
@@ -1,0 +1,490 @@
+# GoldenGraph Temporal `as_of` Bench (slice B2) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure the temporal `as_of` capability — answer "what was true about X as of date D" exactly via the bi-temporal store, where a passage retriever structurally can't — with a free, deterministic CI gate.
+
+**Architecture:** A new corpus emits, per fact, two edges with explicit valid windows (`X-rel-A [T1,Tc)`, `X-rel-B [Tc,∞)`) hand-built into the store JSON. goldengraph answers by `store.as_of(valid_t=D)` traversal (the edge true at D); a deterministic temporal-blind floor returns the latest-mentioned object (wrong on past-date queries). The gate asserts goldengraph is accurate in both regimes and ≫ the floor on past-date queries. An opt-in real-LLM RAG row confirms.
+
+**Tech Stack:** Python 3.11, pytest (wheel-free except the `as_of` traversal + the valid_to round-trip, which `importorskip` `goldengraph_native`), GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-goldengraph-temporal-asof-bench-design.md`
+
+---
+
+## Key code facts (verified against main)
+
+- **Store JSON shape** (`build_batch` in `goldengraph/ingest.py`): `{"entities":[{local_id, canonical_name, typ, surface_names, record_keys}], "edges":[{subj_local, predicate, obj_local, valid_from, valid_to, source_refs}], "ingested_at": at}`. `build_batch` always emits `valid_to=None` — B2 hand-builds this dict with explicit `valid_to`.
+- **valid_to is honored end-to-end** (reviewer-confirmed): `PyStore.append(json)` → serde `StoreBatch` (no rename, no validation) → `append` copies `e.valid_to` → `as_of` window filter `valid_from <= valid_t && valid_to.is_none_or(|vt| valid_t < vt)`. The regime boundary is half-open: `D=Tc → B`.
+- **Store API:** `from goldengraph_native import _native as ggn; store = ggn.PyStore(); store.append(json.dumps(batch)); slice = store.as_of(valid_t, tx_t)`. `slice.query([node_id], 1) -> {"entities":[{entity_id, canonical_name, typ, surface_names}], "edges":[{subj, predicate, obj, source_refs}]}` (edges in slice-view id space). `slice.entities()` enumerates.
+- **Reused:** `engineered._load_entities() -> [_Entity(id, canonical, variants)]`, `engineered._render_mention(ent, rng, ambiguity)`, `engineered.RELATION_SCHEMA` (5); `dials.surface_to_canon(g) -> {surface: set(canonical_id)}` (concept-universe, edge-independent — call with any `GoldGraph`); `gold.GoldGraph.from_corpus`; `scorecard_llm._BudgetedLLM` (#1276); `from . import metrics`.
+- `goldengraph` is a STANDALONE package (PYTHONPATH for local runs; CI installs editable).
+
+### Reviewer notes (carry these)
+1. goldengraph is right-BY-CONSTRUCTION in both regimes → expected as_of-accuracy is **1.0**. The gate's `>=0.9` is defensive slack; a real ~0.9 is a signal to investigate, not "passing".
+2. A fact's **two edges go in ONE batch** (single `ingested_at`); valid-time is the only discriminator — NOT two batches at different tx-times. "Corrections appended after originals" refers to **doc list order** (consumed by the wheel-free `temporal_blind_floor`, which reads docs), NOT edge/batch ingest order.
+3. **Floor cleanliness:** sample the A/B objects from a pool DISJOINT from the anchor pool, so an anchor never appears as another fact's object (which would contaminate the floor's "docs mentioning the anchor"). The floor also filters by the relation phrase, so anchor-reuse-across-relations stays clean.
+
+## Test environment
+
+```
+PY="/d/show_case/goldenmatch/.venv/Scripts/python.exe"
+GG="D:/show_case/goldenmatch/.worktrees/gg-temporal/packages/python/goldengraph"
+cd packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$(pwd -W);$GG" POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 GOLDENMATCH_NATIVE=0 "$PY" -m pytest <path> -q
+```
+Wheel-free for Tasks 1, 2, 4(partial), 6; Tasks 3 (valid_to round-trip + as_of traversal) `importorskip` `goldengraph_native`. Run only named files.
+
+---
+
+## Task 1: Temporal corpus generator + gold (wheel-free)
+
+**Files:**
+- Create: `erkgbench/qa_e2e/temporal.py`
+- Test: `tests/test_qa_temporal_corpus.py`
+
+Use @superpowers:test-driven-development.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Temporal as_of corpus: per fact a value corrected at valid-time Tc
+(X-rel-A [1,Tc), X-rel-B [Tc,inf)), with past (D<Tc -> A) and current (D>=Tc -> B)
+questions. Deterministic for a seed."""
+from __future__ import annotations
+
+from erkgbench.qa_e2e.temporal import T1, generate_temporal
+
+
+def test_facts_have_two_windows_and_both_regime_questions():
+    docs, facts, qs = generate_temporal(seed=7, n_facts=20, ambiguity=0.5)
+    assert any(q.regime == "past" for q in qs) and any(q.regime == "current" for q in qs)
+    fbyk = {(f.anchor_id, f.relation): f for f in facts}
+    for q in qs:
+        f = fbyk[(q.anchor_id, q.relation)]
+        if q.regime == "past":
+            assert T1 <= q.D < f.tc and q.gold_obj == f.a_id
+        else:
+            assert q.D >= f.tc and q.gold_obj == f.b_id
+        assert q.relation.replace("_", " ") in q.question
+
+
+def test_objects_disjoint_from_anchors():
+    # floor cleanliness: an anchor never appears as another fact's A/B object
+    docs, facts, qs = generate_temporal(seed=7, n_facts=30, ambiguity=0.4)
+    anchors = {f.anchor_id for f in facts}
+    objects = {f.a_id for f in facts} | {f.b_id for f in facts}
+    assert not (anchors & objects)
+
+
+def test_each_regime_has_enough_questions():
+    docs, facts, qs = generate_temporal(seed=7, n_facts=40, ambiguity=0.3)
+    past = sum(1 for q in qs if q.regime == "past")
+    current = sum(1 for q in qs if q.regime == "current")
+    assert past >= 20 and current >= 20
+```
+
+- [ ] **Step 2: Run -> fail** (`ModuleNotFoundError ... temporal`).
+
+- [ ] **Step 3: Implement** `temporal.py` (corpus half):
+
+```python
+"""Temporal as_of capability bench (slice B2). A bi-temporal corpus + goldengraph
+store.as_of(D) traversal vs a temporal-blind passage floor. The KG does what RAG
+can't: answer 'as of a PAST date' correctly when a fact was later corrected."""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from .corpora import Document
+from .engineered import RELATION_SCHEMA, _load_entities, _render_mention
+
+T1 = 1            # valid_from of every original edge
+_TMAX = 100       # query/date horizon
+_N_ANCHORS = 20   # first N entities are anchors; the rest are objects (disjoint)
+
+
+@dataclass(frozen=True)
+class TemporalFact:
+    anchor_id: str
+    relation: str
+    a_id: str     # original object (valid [T1, tc))
+    b_id: str     # corrected object (valid [tc, inf))
+    tc: int       # correction valid-time
+
+
+@dataclass(frozen=True)
+class TemporalQuestion:
+    id: str
+    question: str
+    anchor_id: str
+    relation: str
+    D: int
+    regime: str    # "past" | "current"
+    gold_obj: str  # canonical id of the object true at D
+
+
+def generate_temporal(*, seed: int, n_facts: int, ambiguity: float):
+    rng = random.Random(seed)
+    ents = _load_entities()
+    by_id = {e.id: e for e in ents}
+    ids = [e.id for e in ents]
+    anchors = ids[:_N_ANCHORS]
+    objects = ids[_N_ANCHORS:]
+    docs: list[Document] = []
+    facts: list[TemporalFact] = []
+    qs: list[TemporalQuestion] = []
+    for i in range(n_facts):
+        src_id = anchors[i % len(anchors)]
+        rel = RELATION_SCHEMA[(i // len(anchors)) % len(RELATION_SCHEMA)]  # B1 outer cycle
+        a_id, b_id = rng.sample(objects, 2)
+        tc = rng.randint(20, 80)
+        facts.append(TemporalFact(src_id, rel, a_id, b_id, tc))
+        rel_words = rel.replace("_", " ")
+        # two source passages (real RAG reads these; nothing enforces a slice)
+        xs = _render_mention(by_id[src_id], rng, ambiguity)
+        docs.append(Document(id=f"{src_id}::{rel}::{a_id}::t{T1}",
+                             text=f"As of {T1}, {xs} {rel_words} {_render_mention(by_id[a_id], rng, ambiguity)}.",
+                             src_surface=xs, dst_surface=by_id[a_id].canonical))
+        xs2 = _render_mention(by_id[src_id], rng, ambiguity)
+        docs.append(Document(id=f"{src_id}::{rel}::{b_id}::t{tc}",
+                             text=f"From {tc}, {xs2} {rel_words} {_render_mention(by_id[b_id], rng, ambiguity)}.",
+                             src_surface=xs2, dst_surface=by_id[b_id].canonical))
+        # one past + one current question per fact
+        d_past = rng.randint(T1, tc - 1)
+        d_cur = rng.randint(tc, _TMAX)
+        for tag, D, regime, gold in (("p", d_past, "past", a_id), ("c", d_cur, "current", b_id)):
+            qs.append(TemporalQuestion(
+                id=f"tmp-{i}-{tag}",
+                question=f"As of {D}, what does {by_id[src_id].canonical} {rel_words}?",
+                anchor_id=src_id, relation=rel, D=D, regime=regime, gold_obj=gold))
+    return tuple(docs), facts, qs
+```
+
+> Note: doc ids are 4-part (`src::rel::dst::t`) so they never collide with the 3-part engineered convention and `gold.GoldGraph.from_corpus` skips them (the store is built from FACTS, not doc-id parsing). The `tc >= 20` floor + `d_past in [T1, tc-1]` guarantees a non-empty past window.
+
+- [ ] **Step 4: Run -> pass.** (`n_facts=40` over 20 anchors × outer-cycle relations → 40 distinct facts, 40 past + 40 current questions.)
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): temporal as_of corpus + gold`.
+
+---
+
+## Task 2: temporal-blind floor + as_of-accuracy + gate + render (wheel-free)
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/temporal.py`
+- Test: `tests/test_qa_temporal_floor.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+from erkgbench.qa_e2e.corpora import Document
+from erkgbench.qa_e2e.temporal import (
+    TemporalResult, as_of_accuracy, gate_verdicts, render_temporal_md, temporal_blind_floor,
+)
+
+
+def _docs():
+    # X works_at A (early), then X works_at B (correction, appended LATER)
+    return (
+        Document(id="x::works_at::a::t1", text="As of 1, X works at Apple.", src_surface="X", dst_surface="Apple"),
+        Document(id="x::works_at::b::t5", text="From 5, X works at Google.", src_surface="X", dst_surface="Google"),
+    )
+
+
+def test_floor_returns_latest_object_ignoring_D():
+    docs = _docs()
+    s2c = {"X": "x", "Apple": "a", "Google": "b"}
+    # asked about a PAST date (D=3, before the correction) -> floor STILL returns latest (b)
+    got = temporal_blind_floor(docs, {"X"}, "works_at", D=3, surface_to_canon=s2c)
+    assert got == "b"  # wrong for the past regime (gold would be 'a')
+
+
+def test_as_of_accuracy():
+    assert as_of_accuracy("a", "a") == 1.0
+    assert as_of_accuracy("b", "a") == 0.0
+    assert as_of_accuracy(None, "a") == 0.0
+
+
+def test_gate_verdicts_pass_when_gg_high_and_beats_floor_on_past():
+    gg = {"past": 1.0, "current": 1.0}
+    floor = {"past": 0.0, "current": 1.0}
+    v = gate_verdicts(gg, floor)
+    assert all(p for _l, p, _h in v)
+
+
+def test_gate_verdicts_fail_when_floor_matches_gg_on_past():
+    gg = {"past": 1.0, "current": 1.0}
+    floor = {"past": 1.0, "current": 1.0}  # floor somehow right on past -> no capability gap
+    v = gate_verdicts(gg, floor)
+    gap = next(p for label, p, _h in v if "PAST" in label)
+    assert gap is False
+
+
+def test_render_has_regimes_and_verdicts():
+    res = TemporalResult(gg_acc={"past": 1.0, "current": 1.0},
+                         floor_acc={"past": 0.0, "current": 1.0}, llm_acc=None)
+    md = render_temporal_md(res)
+    assert "past" in md and "current" in md and ("PASS" in md or "FAIL" in md)
+```
+
+- [ ] **Step 2: Run -> fail.**
+
+- [ ] **Step 3: Implement** (append to `temporal.py`):
+
+```python
+import re
+from dataclasses import dataclass  # already imported; keep one
+
+
+def _mentions(text: str, surface: str) -> bool:
+    return re.search(r"\b" + re.escape(surface) + r"\b", text) is not None
+
+
+def temporal_blind_floor(docs, anchor_surfaces: set, relation: str, D: int, *,
+                         surface_to_canon: dict) -> str | None:
+    """RAG-without-a-temporal-axis: among docs mentioning the anchor AND the relation
+    phrase, take the LAST in doc order (corrections are appended after originals) and
+    return its non-anchor object. Ignores D -> wrong on past-date queries. Deterministic."""
+    rel_words = relation.replace("_", " ")
+    hits = [d for d in docs
+            if any(_mentions(d.text, a) for a in anchor_surfaces) and rel_words in d.text]
+    if not hits:
+        return None
+    d = hits[-1]  # latest-mentioned (temporal-blind)
+    for surf, canon in surface_to_canon.items():
+        if canon not in {surface_to_canon.get(a) for a in anchor_surfaces} and _mentions(d.text, surf):
+            return canon
+    return None
+
+
+def as_of_accuracy(predicted_obj, gold_obj) -> float:
+    return 1.0 if predicted_obj == gold_obj else 0.0
+
+
+@dataclass
+class TemporalResult:
+    gg_acc: dict        # regime -> mean goldengraph as_of-accuracy
+    floor_acc: dict     # regime -> mean temporal-blind floor accuracy
+    llm_acc: dict | None = None
+
+
+def gate_verdicts(gg_acc: dict, floor_acc: dict, *, gg_threshold: float = 0.9,
+                  past_gap_margin: float = 0.5) -> list[tuple[str, bool, bool]]:
+    """[(label, passed, is_hard), ...]. Expected gg = 1.0 both regimes (right by
+    construction); >=0.9 is slack. The capability is the PAST-regime gap (the floor
+    returns the corrected value -> ~0 on past)."""
+    both = all(gg_acc.get(r, 0.0) >= gg_threshold for r in ("past", "current"))
+    past_gap = (gg_acc.get("past", 0.0) - floor_acc.get("past", 0.0)) >= past_gap_margin
+    floor_current_ok = floor_acc.get("current", 0.0) >= 0.5
+    return [
+        (f"goldengraph as_of-accuracy >= {gg_threshold} in BOTH regimes (respects "
+         "valid-time)", both, True),
+        (f"goldengraph beats the temporal-blind floor by >= {past_gap_margin} on PAST "
+         "queries (RAG can't answer 'as of a past date')", past_gap, True),
+        ("floor is OK on the current regime (it's temporal-blind, not broken) (soft)",
+         floor_current_ok, False),
+    ]
+
+
+def gate_exit_code(res: TemporalResult) -> int:
+    return 1 if any(not p for _l, p, h in gate_verdicts(res.gg_acc, res.floor_acc) if h) else 0
+
+
+def render_temporal_md(res: TemporalResult) -> str:
+    lines = ["# GoldenGraph temporal as_of -- KG vs temporal-blind floor", "",
+             "as_of-accuracy by regime (past = ask about a corrected-away value).", "",
+             "| regime | goldengraph | floor |", "|---|---|---|"]
+    for r in ("past", "current"):
+        la = f" | {res.llm_acc[r]:.3f}" if res.llm_acc else ""
+        lines.append(f"| {r} | {res.gg_acc.get(r, 0.0):.3f} | {res.floor_acc.get(r, 0.0):.3f}{la} |")
+    if res.llm_acc:
+        lines[lines.index("| regime | goldengraph | floor |")] = "| regime | goldengraph | floor | llm-rag |"
+        lines[lines.index("|---|---|---|")] = "|---|---|---|---|"
+    lines += ["", "## verdicts", ""]
+    for label, passed, is_hard in gate_verdicts(res.gg_acc, res.floor_acc):
+        tag = "PASS" if passed else ("FAIL" if is_hard else "WARN")
+        lines.append(f"- [{tag}] {label}")
+    return "\n".join(lines) + "\n"
+```
+
+> The render's llm-column header swap is fiddly — the implementer may instead build the header row conditionally up front. Keep the asserted strings (`past`, `current`, `PASS`/`FAIL`) intact.
+
+- [ ] **Step 4: Run -> pass.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): temporal-blind floor + as_of metric + gate + render`.
+
+---
+
+## Task 3: valid_to round-trip + store build + goldengraph as_of (needs the wheel)
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/temporal.py`
+- Test: `tests/test_qa_temporal_store.py` (`importorskip`)
+
+- [ ] **Step 1: Write the failing tests** (the valid_to round-trip is FIRST — it pins the load-bearing path)
+
+```python
+import json
+
+import pytest
+
+pytest.importorskip("goldengraph_native")
+
+
+def test_valid_to_round_trips_through_pystore_append_and_as_of():
+    from goldengraph_native import _native as ggn
+
+    store = ggn.PyStore()
+    # X(0) -rel-> A(1) valid [1,5); X(0) -rel-> B(2) valid [5,inf). ONE batch.
+    batch = {
+        "entities": [
+            {"local_id": 0, "canonical_name": "X", "typ": "c", "surface_names": ["X"], "record_keys": ["x"]},
+            {"local_id": 1, "canonical_name": "A", "typ": "c", "surface_names": ["A"], "record_keys": ["a"]},
+            {"local_id": 2, "canonical_name": "B", "typ": "c", "surface_names": ["B"], "record_keys": ["b"]},
+        ],
+        "edges": [
+            {"subj_local": 0, "predicate": "rel", "obj_local": 1, "valid_from": 1, "valid_to": 5, "source_refs": []},
+            {"subj_local": 0, "predicate": "rel", "obj_local": 2, "valid_from": 5, "valid_to": None, "source_refs": []},
+        ],
+        "ingested_at": 1,
+    }
+    store.append(json.dumps(batch))
+    BIG = 10**12
+    past = store.as_of(3, BIG)
+    cur = store.as_of(7, BIG)
+    past_names = {e["canonical_name"] for e in past.entities()}
+    cur_names = {e["canonical_name"] for e in cur.entities()}
+    assert "A" in past_names and "B" not in past_names   # D=3 -> only A's window
+    assert "B" in cur_names and "A" not in cur_names      # D=7 -> only B's window
+
+
+def test_goldengraph_asof_returns_the_gold_object_in_both_regimes():
+    from erkgbench.qa_e2e.temporal import (
+        build_temporal_store, generate_temporal, goldengraph_asof,
+    )
+
+    docs, facts, qs = generate_temporal(seed=7, n_facts=20, ambiguity=0.6)
+    store = build_temporal_store(facts)
+    for q in qs:
+        got = goldengraph_asof(store, q.anchor_id, q.relation, q.D)
+        assert got == q.gold_obj  # exact, in both regimes
+```
+
+- [ ] **Step 2: Run -> fail/skip** (skips locally without the wheel; the round-trip test is the first thing the gate lane runs).
+
+- [ ] **Step 3: Implement** (append to `temporal.py`):
+
+```python
+import json
+from pathlib import Path  # if needed
+
+
+_BIG_TX = 10**12
+
+
+def build_temporal_store(facts):
+    """Build a bi-temporal store from the facts: per fact ONE batch with X-rel-A
+    [T1,tc) and X-rel-B [tc,inf). Oracle record_keys (= canonical id) so X merges
+    across facts/relations. Hand-built JSON (build_batch can't set valid_to)."""
+    from goldengraph_native import _native as ggn
+
+    store = ggn.PyStore()
+    for i, f in enumerate(facts):
+        batch = {
+            "entities": [
+                {"local_id": 0, "canonical_name": f.anchor_id, "typ": "concept",
+                 "surface_names": [f.anchor_id], "record_keys": [f.anchor_id]},
+                {"local_id": 1, "canonical_name": f.a_id, "typ": "concept",
+                 "surface_names": [f.a_id], "record_keys": [f.a_id]},
+                {"local_id": 2, "canonical_name": f.b_id, "typ": "concept",
+                 "surface_names": [f.b_id], "record_keys": [f.b_id]},
+            ],
+            "edges": [
+                {"subj_local": 0, "predicate": f.relation, "obj_local": 1,
+                 "valid_from": T1, "valid_to": f.tc, "source_refs": []},
+                {"subj_local": 0, "predicate": f.relation, "obj_local": 2,
+                 "valid_from": f.tc, "valid_to": None, "source_refs": []},
+            ],
+            "ingested_at": 1,
+        }
+        store.append(json.dumps(batch))
+    return store
+
+
+def goldengraph_asof(store, anchor_id: str, relation: str, D: int) -> str | None:
+    """Exact as_of traversal: slice the store at valid_t=D, seed the anchor, 1-hop,
+    filter edges by predicate -> the single object whose valid window contains D."""
+    slice_g = store.as_of(D, _BIG_TX)
+    # canonical-name IS the record_key/canonical id here (build_temporal_store sets
+    # canonical_name = the id), so map view-entity-id -> canonical_name directly.
+    id_to_canon = {e["entity_id"]: e["canonical_name"] for e in slice_g.entities()}
+    seed = next((eid for eid, c in id_to_canon.items() if c == anchor_id), None)
+    if seed is None:
+        return None
+    ball = slice_g.query([seed], 1)
+    objs = {id_to_canon.get(e["obj"]) for e in ball.get("edges", ())
+            if e["subj"] == seed and e["predicate"] == relation}
+    objs.discard(None)
+    objs.discard(anchor_id)
+    return next(iter(objs)) if len(objs) == 1 else (next(iter(objs), None) if objs else None)
+```
+
+> Because `build_temporal_store` sets `canonical_name == the canonical id` and uses oracle record_keys, the slice's `canonical_name` IS the gold id — no `surface_to_canon` needed on the goldengraph side (the corpus uses canonical ids as names in the store). The DOC text (for the floor) still uses rendered surfaces; the two paths are independent.
+
+- [ ] **Step 4: Run in the gate lane (Task 5) -> both pass.**
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): temporal store build + goldengraph as_of traversal`.
+
+---
+
+## Task 4: deterministic runner + CLI
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/temporal.py` (`run_temporal_deterministic`)
+- Create: `erkgbench/qa_e2e/run_temporal.py`
+- Test: `tests/test_qa_temporal_cli.py` (argparse + `gate_exit_code` wheel-free)
+
+- [ ] **Step 1:** `run_temporal_deterministic(*, seed, n_facts, ambiguity, llm=None) -> TemporalResult`: build the corpus + temporal store, for each question score `goldengraph_asof` vs `gold_obj` and `temporal_blind_floor` vs `gold_obj`, mean by regime. The floor's `surface_to_canon` = invert `dials.surface_to_canon(GoldGraph.from_corpus(... a QACorpus of the docs ...))` to `{surface: canonical_id}` (first-wins); `anchor_surfaces[anchor_id]` = the anchor's concept surfaces. If `llm` given, also score `llm_temporal_rag` (Task 6) into `llm_acc`. Needs the wheel (`build_temporal_store`).
+- [ ] **Step 2:** `run_temporal.py` CLI: `--seed/--n-facts/--ambiguity/--out-md`, writes `TEMPORAL.md`, exits `gate_exit_code`; `--with-llm --budget-usd` builds `_BudgetedLLM(OpenAIClient...)` when `OPENAI_API_KEY` set.
+- [ ] **Step 3:** wheel-free CLI test: `_parser().parse_args([])` defaults; `gate_exit_code` over a synthetic pass (gg 1.0/1.0, floor 0.0/1.0 -> 0) and fail (floor 1.0/1.0 -> 1).
+- [ ] **Step 4:** Run -> pass.
+- [ ] **Step 5: Commit** — `feat(er-kg-bench): temporal deterministic runner + CLI`.
+
+---
+
+## Task 5: key-free CI gate
+
+**Files:**
+- Modify: `.github/workflows/goldengraph-pipeline.yml` (a step after the B1 aggregation gate)
+- Modify: `.github/workflows/bench-er-kg.yml` (add the wheel-free temporal test files)
+
+- [ ] **Step 1:** In `goldengraph-pipeline.yml`, after the aggregation gate step, add a `temporal` gate step (same wheel): `python -m pytest tests/test_qa_temporal_store.py -v` (the valid_to round-trip + as_of e2e) then `python -m erkgbench.qa_e2e.run_temporal --seed 7 --n-facts 40 --ambiguity 0.6 --out-md TEMPORAL.md`; no key; upload `TEMPORAL.md`. Exit code gates.
+- [ ] **Step 2:** In `bench-er-kg.yml` pure-Python step, append `tests/test_qa_temporal_corpus.py tests/test_qa_temporal_floor.py tests/test_qa_temporal_cli.py` (wheel-free; the store test `importorskip`s).
+- [ ] **Step 3:** Validate both YAMLs parse.
+- [ ] **Step 4: Commit** — `ci(goldengraph): key-free temporal as_of capability gate`.
+- [ ] **Step 5:** Push, open PR, confirm the `pipeline` lane runs the temporal gate green (the real validator: the valid_to round-trip + as_of traversal + the 3 verdicts).
+
+---
+
+## Task 6: opt-in real-LLM RAG confirmation (non-gating)
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/temporal.py` (`llm_temporal_rag`)
+- Modify: `.github/workflows/bench-graphrag-qa.yml` (extend the opt-in lane, gated on a new input)
+- Test: `tests/test_qa_temporal_llm.py` (stub-LLM, wheel-free)
+
+- [ ] **Step 1:** `llm_temporal_rag(docs, anchor_surfaces, relation, D, llm, *, surface_to_canon) -> str|None`: pass BOTH dated passages (anchor+relation docs) + "As of {D}, what does X {relation}? Answer with one entity name." -> map the answer name to a canonical id. The LLM has the dated text but no enforced slice -> past-regime accuracy collapses. Stub-LLM test: returns a known name -> mapped to canonical; assert mapping + that both passages were in the prompt.
+- [ ] **Step 2:** Wire a `run_temporal_llm` input into `bench-graphrag-qa.yml` (mirror B1's `run_aggregation_llm`): a step (gated on the input) runs `run_temporal --with-llm` -> `TEMPORAL_LLM.md`, NON-gating (`|| true`).
+- [ ] **Step 3:** Run the stub test -> pass.
+- [ ] **Step 4: Commit** — `feat(er-kg-bench): opt-in real-LLM RAG temporal confirmation`.
+
+---
+
+## Done criteria
+
+- Wheel-free tests green (corpus, floor, metric, gate verdicts, render, CLI, LLM-stub).
+- `pipeline` lane: the valid_to round-trip passes, `goldengraph_asof` returns the gold object in both regimes, and `TEMPORAL.md` shows goldengraph as_of-accuracy ~1.0 in both regimes with the floor ~0 on past (HARD PASS).
+- No existing gate touched; the new gate is additive; the real-LLM RAG row is opt-in/non-gating.
+
+## Not in scope (YAGNI)
+
+Transaction-time audit (Model B), attribute history, multi-correction chains, the ER-dial tie-in, NL date parsing, new entity universe.

--- a/docs/superpowers/plans/2026-06-27-goldengraph-temporal-asof-bench.md
+++ b/docs/superpowers/plans/2026-06-27-goldengraph-temporal-asof-bench.md
@@ -17,6 +17,7 @@
 - **Store JSON shape** (`build_batch` in `goldengraph/ingest.py`): `{"entities":[{local_id, canonical_name, typ, surface_names, record_keys}], "edges":[{subj_local, predicate, obj_local, valid_from, valid_to, source_refs}], "ingested_at": at}`. `build_batch` always emits `valid_to=None` — B2 hand-builds this dict with explicit `valid_to`.
 - **valid_to is honored end-to-end** (reviewer-confirmed): `PyStore.append(json)` → serde `StoreBatch` (no rename, no validation) → `append` copies `e.valid_to` → `as_of` window filter `valid_from <= valid_t && valid_to.is_none_or(|vt| valid_t < vt)`. The regime boundary is half-open: `D=Tc → B`.
 - **Store API:** `from goldengraph_native import _native as ggn; store = ggn.PyStore(); store.append(json.dumps(batch)); slice = store.as_of(valid_t, tx_t)`. `slice.query([node_id], 1) -> {"entities":[{entity_id, canonical_name, typ, surface_names}], "edges":[{subj, predicate, obj, source_refs}]}` (edges in slice-view id space). `slice.entities()` enumerates.
+- **LOAD-BEARING (reviewer):** the store does NOT keep the batch's `canonical_name` field — `append` RECOMPUTES it as the longest `surface_names` entry (tie → lex-smallest, `canonical_of`). The `canonical_name == id` shortcut in `build_temporal_store`/`goldengraph_asof` works ONLY because `surface_names=[anchor_id]` (so `canonical_of([id]) == id`). Do NOT drop `surface_names=[id]` (e.g. to `[]`) — `canonical_name` would go empty and the entire `id_to_canon`/seed lookup silently breaks. Re-appending X with `record_keys=[anchor_id]` reconciles to one StableId, and surfaces stay `[id]` across re-appends.
 - **Reused:** `engineered._load_entities() -> [_Entity(id, canonical, variants)]`, `engineered._render_mention(ent, rng, ambiguity)`, `engineered.RELATION_SCHEMA` (5); `dials.surface_to_canon(g) -> {surface: set(canonical_id)}` (concept-universe, edge-independent — call with any `GoldGraph`); `gold.GoldGraph.from_corpus`; `scorecard_llm._BudgetedLLM` (#1276); `from . import metrics`.
 - `goldengraph` is a STANDALONE package (PYTHONPATH for local runs; CI installs editable).
 
@@ -94,7 +95,9 @@ store.as_of(D) traversal vs a temporal-blind passage floor. The KG does what RAG
 can't: answer 'as of a PAST date' correctly when a fact was later corrected."""
 from __future__ import annotations
 
+import json
 import random
+import re
 from dataclasses import dataclass
 
 from .corpora import Document
@@ -230,13 +233,9 @@ def test_render_has_regimes_and_verdicts():
 
 - [ ] **Step 2: Run -> fail.**
 
-- [ ] **Step 3: Implement** (append to `temporal.py`):
+- [ ] **Step 3: Implement** (append to `temporal.py`; `re`/`dataclass` are already imported at the top):
 
 ```python
-import re
-from dataclasses import dataclass  # already imported; keep one
-
-
 def _mentions(text: str, surface: str) -> bool:
     return re.search(r"\b" + re.escape(surface) + r"\b", text) is not None
 
@@ -372,20 +371,21 @@ def test_goldengraph_asof_returns_the_gold_object_in_both_regimes():
 
 - [ ] **Step 2: Run -> fail/skip** (skips locally without the wheel; the round-trip test is the first thing the gate lane runs).
 
-- [ ] **Step 3: Implement** (append to `temporal.py`):
+- [ ] **Step 3: Implement** (append to `temporal.py`; `json` is already imported at the top):
 
 ```python
-import json
-from pathlib import Path  # if needed
-
-
 _BIG_TX = 10**12
 
 
 def build_temporal_store(facts):
     """Build a bi-temporal store from the facts: per fact ONE batch with X-rel-A
     [T1,tc) and X-rel-B [tc,inf). Oracle record_keys (= canonical id) so X merges
-    across facts/relations. Hand-built JSON (build_batch can't set valid_to)."""
+    across facts/relations. Hand-built JSON (build_batch can't set valid_to).
+
+    LOAD-BEARING: surface_names=[<id>] is REQUIRED -- the store recomputes
+    canonical_name as the longest surface (ignoring the batch canonical_name field),
+    so surface_names=[id] makes canonical_name==id, which goldengraph_asof relies on
+    to map view-entity-id -> the gold canonical id. Do not drop it."""
     from goldengraph_native import _native as ggn
 
     store = ggn.PyStore()

--- a/docs/superpowers/specs/2026-06-27-goldengraph-temporal-asof-bench-design.md
+++ b/docs/superpowers/specs/2026-06-27-goldengraph-temporal-asof-bench-design.md
@@ -1,0 +1,153 @@
+# GoldenGraph temporal `as_of` capability bench (slice B2)
+
+## Context
+
+Slice B1 (#1278) measured the first capability RAG structurally can't do --
+set/count aggregation -- with a free, deterministic gate (goldengraph exact
+traversal set-F1 1.000 at every size; the structure-blind passage floor 0.3-0.5).
+
+This slice measures the second, and the starkest: **temporal `as_of`** -- "what
+was true about X *as of date D*". A graph with a bi-temporal store can answer it
+exactly; a passage retriever **has no respected temporal axis at all**, so when a
+fact is later corrected it cannot tell which version was current as of a *past*
+date. This is a capability gap, not a quality gap -- RAG literally cannot attempt
+the past-date query correctly.
+
+This is **slice B2** of the capability program. C (ambiguity x passage_k crossover)
+and D (KG-vs-KG) remain separate.
+
+## The capability mechanic + the store constraint
+
+`goldengraph-core`'s store is bi-temporal on EDGES (and identity), NOT on entity
+attributes (canonical_name is latest-state -- SP2 scope line). So a temporal change
+is modeled as an **edge whose object changes over valid-time**. From `store.rs`:
+`as_of(valid_t, tx_t)` keeps the latest edge version per `(subj, predicate, obj)`
+known by `tx_t`, then filters to those whose valid window contains `valid_t`
+(`valid_from <= valid_t < valid_to`, open `valid_to` = current). The JSON batch
+edge honors a set `valid_to`; `build_batch` only ever emits `None`, so the
+Python->JSON->`PyStore.append`->`as_of` valid-time path is UNEXERCISED -- the
+load-bearing risk this spec calls out (see Testing).
+
+## Design
+
+### The corpus (`qa_e2e/temporal.py`)
+
+A set of `(anchor X, relation)` facts, each **corrected once** at a random
+valid-time `Tc`. Reuses the entity universe (`engineered._load_entities`) + the
+ambiguity dial (`_render_mention`). Per fact, two edges go into the store with
+explicit valid windows:
+
+- `X -rel-> A` : `valid_from = T1, valid_to = Tc`
+- `X -rel-> B` : `valid_from = Tc, valid_to = None` (current)
+
+…plus source passages for a real RAG to read (`"As of <T1>, X rel A."` /
+`"From <Tc>, X rel B."` -- the text *states* the dates, but nothing enforces a
+temporal slice). The anchor renders under variant surfaces across its docs (ER
+still matters); an oracle resolver merges X. Anchors cycle the universe with the
+B1 outer-cycle relation assignment so `(X, rel)` is unique per fact. Deterministic
+for a seed.
+
+Questions: per fact, sample query dates `D` in BOTH regimes --
+**past** (`T1 <= D < Tc` -> gold = A) and **current** (`D >= Tc` -> gold = B):
+*"As of `<D>`, what does X `<relation>`?"* (D is passed as the integer `valid_t`;
+no NL date parsing.)
+
+### Store build (B2-specific -- NOT `ablation._build_store`)
+
+`_build_temporal_store(facts)` hand-builds the `StoreBatch` JSON directly (the shape
+`build_batch` emits: `entities=[{local_id, canonical_name, typ, surface_names,
+record_keys}]`, `edges=[{subj_local, predicate, obj_local, valid_from, valid_to,
+source_refs}]`, `ingested_at`), setting **explicit `valid_to`** per edge. Oracle
+record_keys (= canonical id) so X merges across its edge-docs. One batch per fact;
+`store.append(json.dumps(batch))`.
+
+### goldengraph answer -- exact `as_of` traversal (free, no LLM)
+
+`goldengraph_asof(store, anchor_id, relation, D)`: `slice = store.as_of(valid_t=D,
+tx_t=BIG)`; build coverage (`entity_id -> canonical` from the slice's
+`surface_names` + `dials.surface_to_canon`); oracle-seed the anchor (invert
+coverage); `slice.query([seed], 1)`; filter edges to `predicate == relation` with
+`subj == seed` -> the single object whose valid window contains `D`. Right in BOTH
+regimes by construction. No LLM, no embedder.
+
+### Deterministic temporal-blind floor (free, no LLM)
+
+`temporal_blind_floor(docs, anchor_surfaces, relation, D)`: return the object of the
+**latest-appended** doc for `(X, rel)` (doc order; corrections appended after
+originals), ignoring `D`. Correct on **current** queries, **wrong on past** queries
+(returns B when asked about the pre-`Tc` state). Passages have no respected
+valid-time -- that is the structural gap.
+
+### Metric
+
+`as_of_accuracy(predicted_obj_canonical, gold_obj_canonical) -> 1.0|0.0`, bucketed by
+**regime** (`past` / `current`).
+
+### The gate (free, deterministic, key-free, builds the wheel)
+
+In `goldengraph-pipeline.yml`, mirroring B1:
+1. **goldengraph as_of-accuracy >= 0.9 in BOTH regimes (HARD)** -- it respects
+   valid-time.
+2. **goldengraph beats the temporal-blind floor by >= margin on PAST-regime queries
+   (HARD)** -- the floor is ~0 there; the starkest "RAG can't": it cannot answer
+   "as of a past date" correctly.
+3. **floor is fine on the current regime (SOFT)** -- shows the floor is specifically
+   *temporal-blind*, not just broken.
+
+Margins chosen from an observed run with slack.
+
+### Opt-in real-LLM RAG confirmation (non-gating)
+
+In `bench-graphrag-qa`, budget-capped: retrieve both dated passages + "As of <D>,
+what does X <relation>?" -> the LLM has the valid-time TEXT but no enforced slice;
+measure past-regime accuracy (confirmation it collapses). Reuses #1276's
+`scorecard_llm._BudgetedLLM`. Renders into `TEMPORAL.md`.
+
+## Components / files
+
+New, under `erkgbench/qa_e2e/`:
+- **`temporal.py`** -- `generate_temporal`, `_build_temporal_store`,
+  `goldengraph_asof`, `temporal_blind_floor`, `as_of_accuracy`, the gate-assertion
+  helper, `TemporalResult`, `render_temporal_md`, `run_temporal_deterministic`.
+- **`run_temporal.py`** -- CLI -> `TEMPORAL.md`, exits non-zero on a HARD gate
+  failure; `--with-llm` adds the real-LLM RAG row when a key is present.
+
+CI: a new key-free `temporal` gate step in `goldengraph-pipeline.yml` (wheel +
+deterministic run + the 3 assertions); the opt-in real-LLM RAG row in
+`bench-graphrag-qa.yml`.
+
+## Testing
+
+Pure offline (the `as_of` traversal + the valid_to round-trip `importorskip` the
+wheel; gold/floor/metric/gate logic is wheel-free):
+
+1. **valid_to round-trip (wheel, FIRST)** -- append `X-rel-A [vf=1, vt=5]` +
+   `X-rel-B [vf=5, vt=None]`; assert `as_of(valid_t=3)` returns ONLY A and
+   `as_of(valid_t=7)` returns ONLY B. This pins the unexercised Python->store
+   valid-time path; if the store ignores JSON `valid_to`, this fails first and
+   localizes it.
+2. **Corpus/gold** -- each fact has A-edge `[T1,Tc]` + B-edge `[Tc,None]`; a
+   past-regime Q has gold=A, a current-regime Q gold=B; dates sampled in both
+   regimes; the relation is stated in the question.
+3. **Temporal-blind floor** -- deterministic: returns the latest doc's object in
+   BOTH regimes (so it is wrong on past). Wheel-free.
+4. **as_of-accuracy + regime bucketing** -- `pred==gold` -> 1.0 else 0.0.
+5. **Gate verdicts** -- synthetic past/current accuracy dicts: PASS when goldengraph
+   is high in both regimes and >> floor on past; FAIL when the floor matches
+   goldengraph on past.
+6. **goldengraph `as_of` traversal (wheel)** -- build the temporal store, `as_of(D)`
+   per question, assert the gold object in both regimes.
+
+Note: goldengraph's whole answer path is wheel-gated (it needs the store), so the
+*real* numbers validate only in the gate lane -- the wheel-free tests cover the
+gold/floor/metric/gate logic, and the valid_to round-trip (1) is the critical
+early wheel check.
+
+## Scope guard (YAGNI)
+
+In: valid-time **single** correction per fact + the deterministic gate + opt-in
+real-LLM RAG. Out (separate/deferred): transaction-time audit semantics (the
+rejected Model B), attribute history (SP2 doesn't support it), multi-correction
+chains, the ER-dial tie-in, NL date parsing (D is the integer `valid_t`), no new
+entity universe. The #1274 / #1276 / B1 gates are untouched; the new gate is
+additive.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_temporal.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_temporal.py
@@ -1,0 +1,55 @@
+"""CLI: run the deterministic temporal as_of capability bench (goldengraph
+store.as_of vs a temporal-blind floor), write TEMPORAL.md, exit non-zero on a HARD
+gate failure. Key-free; needs the goldengraph_native wheel.
+
+Example:
+    python -m erkgbench.qa_e2e.run_temporal --seed 7 --n-facts 40 \
+        --ambiguity 0.6 --out-md TEMPORAL.md
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from .temporal import gate_exit_code, render_temporal_md, run_temporal_deterministic
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="GoldenGraph temporal as_of capability bench")
+    p.add_argument("--seed", type=int, default=7)
+    p.add_argument("--n-facts", type=int, default=40)
+    p.add_argument("--ambiguity", type=float, default=0.6)
+    p.add_argument("--out-md", default="TEMPORAL.md")
+    p.add_argument("--with-llm", action="store_true",
+                   help="also score the realistic real-LLM RAG floor (needs OPENAI_API_KEY)")
+    p.add_argument("--budget-usd", type=float, default=2.0)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    llm = None
+    if args.with_llm and os.environ.get("OPENAI_API_KEY"):
+        from goldengraph.llm import OpenAIClient
+        from goldenmatch.config.schemas import BudgetConfig
+        from goldenmatch.core.llm_budget import BudgetTracker
+
+        from .scorecard_llm import _BudgetedLLM
+
+        llm = _BudgetedLLM(
+            OpenAIClient(model="gpt-4o-mini"),
+            BudgetTracker(BudgetConfig(max_cost_usd=args.budget_usd)),
+        )
+    res = run_temporal_deterministic(
+        seed=args.seed, n_facts=args.n_facts, ambiguity=args.ambiguity, llm=llm,
+    )
+    md = render_temporal_md(res)
+    with open(args.out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    sys.stdout.write(md)
+    return gate_exit_code(res)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/temporal.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/temporal.py
@@ -3,6 +3,7 @@ store.as_of(D) traversal vs a temporal-blind passage floor. The KG does what RAG
 can't: answer 'as of a PAST date' correctly when a fact was later corrected."""
 from __future__ import annotations
 
+import json
 import random
 import re
 from dataclasses import dataclass
@@ -148,3 +149,60 @@ def render_temporal_md(res: TemporalResult) -> str:
         tag = "PASS" if passed else ("FAIL" if is_hard else "WARN")
         lines.append(f"- [{tag}] {label}")
     return "\n".join(lines) + "\n"
+
+
+# --- store build + goldengraph as_of traversal (needs the native wheel) ---
+
+_BIG_TX = 10**12
+
+
+def build_temporal_store(facts):
+    """Build a bi-temporal store from the facts: per fact ONE batch with X-rel-A
+    [T1,tc) and X-rel-B [tc,inf). Oracle record_keys (= canonical id) so X merges
+    across facts/relations. Hand-built JSON (build_batch can't set valid_to).
+
+    LOAD-BEARING: surface_names=[<id>] is REQUIRED -- the store recomputes
+    canonical_name as the longest surface (ignoring the batch canonical_name field),
+    so surface_names=[id] makes canonical_name==id, which goldengraph_asof relies on
+    to map view-entity-id -> the gold canonical id. Do not drop it."""
+    from goldengraph_native import _native as ggn
+
+    store = ggn.PyStore()
+    for f in facts:
+        batch = {
+            "entities": [
+                {"local_id": 0, "canonical_name": f.anchor_id, "typ": "concept",
+                 "surface_names": [f.anchor_id], "record_keys": [f.anchor_id]},
+                {"local_id": 1, "canonical_name": f.a_id, "typ": "concept",
+                 "surface_names": [f.a_id], "record_keys": [f.a_id]},
+                {"local_id": 2, "canonical_name": f.b_id, "typ": "concept",
+                 "surface_names": [f.b_id], "record_keys": [f.b_id]},
+            ],
+            "edges": [
+                {"subj_local": 0, "predicate": f.relation, "obj_local": 1,
+                 "valid_from": T1, "valid_to": f.tc, "source_refs": []},
+                {"subj_local": 0, "predicate": f.relation, "obj_local": 2,
+                 "valid_from": f.tc, "valid_to": None, "source_refs": []},
+            ],
+            "ingested_at": 1,
+        }
+        store.append(json.dumps(batch))
+    return store
+
+
+def goldengraph_asof(store, anchor_id: str, relation: str, D: int) -> str | None:
+    """Exact as_of traversal: slice the store at valid_t=D, seed the anchor, 1-hop,
+    filter edges by predicate -> the single object whose valid window contains D."""
+    slice_g = store.as_of(D, _BIG_TX)
+    # canonical_name == the canonical id here (build_temporal_store sets
+    # surface_names=[id] -> store recomputes canonical_name = id), so map directly.
+    id_to_canon = {e["entity_id"]: e["canonical_name"] for e in slice_g.entities()}
+    seed = next((eid for eid, c in id_to_canon.items() if c == anchor_id), None)
+    if seed is None:
+        return None
+    ball = slice_g.query([seed], 1)
+    objs = {id_to_canon.get(e["obj"]) for e in ball.get("edges", ())
+            if e["subj"] == seed and e["predicate"] == relation}
+    objs.discard(None)
+    objs.discard(anchor_id)
+    return next(iter(objs), None) if len(objs) <= 1 else next(iter(objs))

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/temporal.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/temporal.py
@@ -4,6 +4,7 @@ can't: answer 'as of a PAST date' correctly when a fact was later corrected."""
 from __future__ import annotations
 
 import random
+import re
 from dataclasses import dataclass
 
 from .corpora import Document
@@ -71,3 +72,79 @@ def generate_temporal(*, seed: int, n_facts: int, ambiguity: float):
                 question=f"As of {D}, what does {by_id[src_id].canonical} {rel_words}?",
                 anchor_id=src_id, relation=rel, D=D, regime=regime, gold_obj=gold))
     return tuple(docs), facts, qs
+
+
+# --- temporal-blind floor + metric + gate + render (wheel-free) ---
+
+
+def _mentions(text: str, surface: str) -> bool:
+    return re.search(r"\b" + re.escape(surface) + r"\b", text) is not None
+
+
+def temporal_blind_floor(docs, anchor_surfaces: set, relation: str, D: int, *,
+                         surface_to_canon: dict) -> str | None:
+    """RAG-without-a-temporal-axis: among docs mentioning the anchor AND the relation
+    phrase, take the LAST in doc order (corrections appended after originals) and
+    return its non-anchor object. Ignores D -> wrong on past-date queries."""
+    rel_words = relation.replace("_", " ")
+    hits = [d for d in docs
+            if any(_mentions(d.text, a) for a in anchor_surfaces) and rel_words in d.text]
+    if not hits:
+        return None
+    d = hits[-1]  # latest-mentioned (temporal-blind)
+    anchor_canons = {surface_to_canon.get(a) for a in anchor_surfaces}
+    for surf, canon in surface_to_canon.items():
+        if canon not in anchor_canons and _mentions(d.text, surf):
+            return canon
+    return None
+
+
+def as_of_accuracy(predicted_obj, gold_obj) -> float:
+    return 1.0 if predicted_obj == gold_obj else 0.0
+
+
+@dataclass
+class TemporalResult:
+    gg_acc: dict        # regime -> mean goldengraph as_of-accuracy
+    floor_acc: dict     # regime -> mean temporal-blind floor accuracy
+    llm_acc: dict | None = None
+
+
+def gate_verdicts(gg_acc: dict, floor_acc: dict, *, gg_threshold: float = 0.9,
+                  past_gap_margin: float = 0.5) -> list[tuple[str, bool, bool]]:
+    """[(label, passed, is_hard), ...]. Expected gg = 1.0 both regimes (right by
+    construction); >=0.9 is slack. The capability is the PAST-regime gap (the floor
+    returns the corrected value -> ~0 on past)."""
+    both = all(gg_acc.get(r, 0.0) >= gg_threshold for r in ("past", "current"))
+    past_gap = (gg_acc.get("past", 0.0) - floor_acc.get("past", 0.0)) >= past_gap_margin
+    floor_current_ok = floor_acc.get("current", 0.0) >= 0.5
+    return [
+        (f"goldengraph as_of-accuracy >= {gg_threshold} in BOTH regimes (respects "
+         "valid-time)", both, True),
+        (f"goldengraph beats the temporal-blind floor by >= {past_gap_margin} on PAST "
+         "queries (RAG can't answer 'as of a past date')", past_gap, True),
+        ("floor is OK on the current regime (it's temporal-blind, not broken) (soft)",
+         floor_current_ok, False),
+    ]
+
+
+def gate_exit_code(res: TemporalResult) -> int:
+    return 1 if any(not p for _l, p, h in gate_verdicts(res.gg_acc, res.floor_acc) if h) else 0
+
+
+def render_temporal_md(res: TemporalResult) -> str:
+    has_llm = res.llm_acc is not None
+    header = ("| regime | goldengraph | floor | llm-rag |" if has_llm
+              else "| regime | goldengraph | floor |")
+    sep = ("|---|---|---|---|" if has_llm else "|---|---|---|")
+    lines = ["# GoldenGraph temporal as_of -- KG vs temporal-blind floor", "",
+             "as_of-accuracy by regime (past = ask about a corrected-away value).", "",
+             header, sep]
+    for r in ("past", "current"):
+        la = f" {res.llm_acc.get(r, 0.0):.3f} |" if has_llm else ""
+        lines.append(f"| {r} | {res.gg_acc.get(r, 0.0):.3f} | {res.floor_acc.get(r, 0.0):.3f} |{la}")
+    lines += ["", "## verdicts", ""]
+    for label, passed, is_hard in gate_verdicts(res.gg_acc, res.floor_acc):
+        tag = "PASS" if passed else ("FAIL" if is_hard else "WARN")
+        lines.append(f"- [{tag}] {label}")
+    return "\n".join(lines) + "\n"

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/temporal.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/temporal.py
@@ -206,3 +206,67 @@ def goldengraph_asof(store, anchor_id: str, relation: str, D: int) -> str | None
     objs.discard(None)
     objs.discard(anchor_id)
     return next(iter(objs), None) if len(objs) <= 1 else next(iter(objs))
+
+
+def _mean_by_regime(pairs) -> dict:
+    agg: dict = {}
+    for r, v in pairs:
+        agg.setdefault(r, []).append(v)
+    return {r: sum(v) / len(v) for r, v in agg.items()}
+
+
+def run_temporal_deterministic(*, seed: int, n_facts: int, ambiguity: float,
+                               llm=None) -> TemporalResult:
+    """Build the corpus + bi-temporal store; per question score goldengraph as_of
+    vs the temporal-blind floor, mean by regime. Needs the wheel (build_temporal_store).
+    If `llm` is given, also score the realistic real-LLM RAG row."""
+    from . import dials
+    from .corpora import QACorpus
+    from .gold import GoldGraph
+
+    docs, facts, qs = generate_temporal(seed=seed, n_facts=n_facts, ambiguity=ambiguity)
+    store = build_temporal_store(facts)
+    g = GoldGraph.from_corpus(QACorpus(name="temporal", documents=docs, questions=()))
+    s2c: dict = {}
+    anchor_surf: dict = {}
+    for eid, surf, _typ in dials._entity_surfaces(g):
+        s2c.setdefault(surf, eid)
+        anchor_surf.setdefault(eid, set()).add(surf)
+
+    gg, floor, llm_acc = [], [], []
+    for q in qs:
+        a_surfs = anchor_surf.get(q.anchor_id, set())
+        gg.append((q.regime, as_of_accuracy(
+            goldengraph_asof(store, q.anchor_id, q.relation, q.D), q.gold_obj)))
+        floor.append((q.regime, as_of_accuracy(
+            temporal_blind_floor(docs, a_surfs, q.relation, q.D, surface_to_canon=s2c),
+            q.gold_obj)))
+        if llm is not None and not getattr(llm, "exhausted", False):
+            llm_acc.append((q.regime, as_of_accuracy(
+                llm_temporal_rag(docs, a_surfs, q.relation, q.D, llm, surface_to_canon=s2c),
+                q.gold_obj)))
+    return TemporalResult(
+        gg_acc=_mean_by_regime(gg),
+        floor_acc=_mean_by_regime(floor),
+        llm_acc=_mean_by_regime(llm_acc) if llm_acc else None,
+    )
+
+
+def llm_temporal_rag(docs, anchor_surfaces: set, relation: str, D: int, llm, *,
+                     surface_to_canon: dict) -> str | None:
+    """Realistic RAG floor (opt-in, real LLM): hand the LLM BOTH dated passages +
+    'As of D, what does X <relation>?'. The text states the dates but nothing
+    enforces a slice, so past-regime accuracy collapses. Maps the answer name back
+    to a canonical id (unknown -> None)."""
+    rel_words = relation.replace("_", " ")
+    hits = [d for d in docs
+            if any(_mentions(d.text, a) for a in anchor_surfaces) and rel_words in d.text]
+    passages = "\n".join(f"- {d.text}" for d in hits) or "(no passages)"
+    prompt = (
+        f"As of time {D}, what does the subject {rel_words}? Use ONLY the passages "
+        "below; answer with one entity name and nothing else.\n\n" + passages
+    )
+    out = llm.complete(prompt) or ""
+    lines = out.strip().splitlines()
+    name = lines[0].strip().lstrip("-* ").strip() if lines else ""
+    return surface_to_canon.get(name)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/temporal.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/temporal.py
@@ -1,0 +1,73 @@
+"""Temporal as_of capability bench (slice B2). A bi-temporal corpus + goldengraph
+store.as_of(D) traversal vs a temporal-blind passage floor. The KG does what RAG
+can't: answer 'as of a PAST date' correctly when a fact was later corrected."""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from .corpora import Document
+from .engineered import RELATION_SCHEMA, _load_entities, _render_mention
+
+T1 = 1            # valid_from of every original edge
+_TMAX = 100       # query/date horizon
+_N_ANCHORS = 20   # first N entities are anchors; the rest are objects (disjoint)
+
+
+@dataclass(frozen=True)
+class TemporalFact:
+    anchor_id: str
+    relation: str
+    a_id: str     # original object (valid [T1, tc))
+    b_id: str     # corrected object (valid [tc, inf))
+    tc: int       # correction valid-time
+
+
+@dataclass(frozen=True)
+class TemporalQuestion:
+    id: str
+    question: str
+    anchor_id: str
+    relation: str
+    D: int
+    regime: str    # "past" | "current"
+    gold_obj: str  # canonical id of the object true at D
+
+
+def generate_temporal(*, seed: int, n_facts: int, ambiguity: float):
+    rng = random.Random(seed)
+    ents = _load_entities()
+    by_id = {e.id: e for e in ents}
+    ids = [e.id for e in ents]
+    anchors = ids[:_N_ANCHORS]
+    objects = ids[_N_ANCHORS:]
+    docs: list[Document] = []
+    facts: list[TemporalFact] = []
+    qs: list[TemporalQuestion] = []
+    for i in range(n_facts):
+        src_id = anchors[i % len(anchors)]
+        rel = RELATION_SCHEMA[(i // len(anchors)) % len(RELATION_SCHEMA)]  # B1 outer cycle
+        a_id, b_id = rng.sample(objects, 2)
+        tc = rng.randint(20, 80)
+        facts.append(TemporalFact(src_id, rel, a_id, b_id, tc))
+        rel_words = rel.replace("_", " ")
+        # two source passages (a real RAG reads these; nothing enforces a slice)
+        xs = _render_mention(by_id[src_id], rng, ambiguity)
+        docs.append(Document(
+            id=f"{src_id}::{rel}::{a_id}::t{T1}",
+            text=f"As of {T1}, {xs} {rel_words} {_render_mention(by_id[a_id], rng, ambiguity)}.",
+            src_surface=xs, dst_surface=by_id[a_id].canonical))
+        xs2 = _render_mention(by_id[src_id], rng, ambiguity)
+        docs.append(Document(
+            id=f"{src_id}::{rel}::{b_id}::t{tc}",
+            text=f"From {tc}, {xs2} {rel_words} {_render_mention(by_id[b_id], rng, ambiguity)}.",
+            src_surface=xs2, dst_surface=by_id[b_id].canonical))
+        # one past + one current question per fact
+        d_past = rng.randint(T1, tc - 1)
+        d_cur = rng.randint(tc, _TMAX)
+        for tag, D, regime, gold in (("p", d_past, "past", a_id), ("c", d_cur, "current", b_id)):
+            qs.append(TemporalQuestion(
+                id=f"tmp-{i}-{tag}",
+                question=f"As of {D}, what does {by_id[src_id].canonical} {rel_words}?",
+                anchor_id=src_id, relation=rel, D=D, regime=regime, gold_obj=gold))
+    return tuple(docs), facts, qs

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_cli.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_cli.py
@@ -1,0 +1,23 @@
+"""The temporal CLI parses; gate_exit_code reflects the hard verdicts. The full
+run_temporal_deterministic needs the wheel (covered by the gate lane)."""
+from __future__ import annotations
+
+from erkgbench.qa_e2e import run_temporal
+from erkgbench.qa_e2e.temporal import TemporalResult, gate_exit_code
+
+
+def test_parser_defaults():
+    args = run_temporal._parser().parse_args([])
+    assert args.seed == 7 and args.n_facts == 40 and args.ambiguity == 0.6
+
+
+def test_gate_exit_code_zero_when_gg_beats_floor_on_past():
+    res = TemporalResult(gg_acc={"past": 1.0, "current": 1.0},
+                         floor_acc={"past": 0.0, "current": 1.0})
+    assert gate_exit_code(res) == 0
+
+
+def test_gate_exit_code_one_when_floor_right_on_past():
+    res = TemporalResult(gg_acc={"past": 1.0, "current": 1.0},
+                         floor_acc={"past": 1.0, "current": 1.0})  # no past gap
+    assert gate_exit_code(res) == 1

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_corpus.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_corpus.py
@@ -1,0 +1,33 @@
+"""Temporal as_of corpus: per fact a value corrected at valid-time Tc
+(X-rel-A [1,Tc), X-rel-B [Tc,inf)), with past (D<Tc -> A) and current (D>=Tc -> B)
+questions. Deterministic for a seed."""
+from __future__ import annotations
+
+from erkgbench.qa_e2e.temporal import T1, generate_temporal
+
+
+def test_facts_have_two_windows_and_both_regime_questions():
+    docs, facts, qs = generate_temporal(seed=7, n_facts=20, ambiguity=0.5)
+    assert any(q.regime == "past" for q in qs) and any(q.regime == "current" for q in qs)
+    fbyk = {(f.anchor_id, f.relation): f for f in facts}
+    for q in qs:
+        f = fbyk[(q.anchor_id, q.relation)]
+        if q.regime == "past":
+            assert T1 <= q.D < f.tc and q.gold_obj == f.a_id
+        else:
+            assert q.D >= f.tc and q.gold_obj == f.b_id
+        assert q.relation.replace("_", " ") in q.question
+
+
+def test_objects_disjoint_from_anchors():
+    docs, facts, qs = generate_temporal(seed=7, n_facts=30, ambiguity=0.4)
+    anchors = {f.anchor_id for f in facts}
+    objects = {f.a_id for f in facts} | {f.b_id for f in facts}
+    assert not (anchors & objects)
+
+
+def test_each_regime_has_enough_questions():
+    docs, facts, qs = generate_temporal(seed=7, n_facts=40, ambiguity=0.3)
+    past = sum(1 for q in qs if q.regime == "past")
+    current = sum(1 for q in qs if q.regime == "current")
+    assert past >= 20 and current >= 20

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_floor.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_floor.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from erkgbench.qa_e2e.corpora import Document
+from erkgbench.qa_e2e.temporal import (
+    TemporalResult,
+    as_of_accuracy,
+    gate_verdicts,
+    render_temporal_md,
+    temporal_blind_floor,
+)
+
+
+def _docs():
+    return (
+        Document(id="x::works_at::a::t1", text="As of 1, X works at Apple.",
+                 src_surface="X", dst_surface="Apple"),
+        Document(id="x::works_at::b::t5", text="From 5, X works at Google.",
+                 src_surface="X", dst_surface="Google"),
+    )
+
+
+def test_floor_returns_latest_object_ignoring_D():
+    docs = _docs()
+    s2c = {"X": "x", "Apple": "a", "Google": "b"}
+    # asked about a PAST date (D=3, before the correction) -> floor STILL returns latest (b)
+    got = temporal_blind_floor(docs, {"X"}, "works_at", D=3, surface_to_canon=s2c)
+    assert got == "b"  # wrong for the past regime (gold would be 'a')
+
+
+def test_as_of_accuracy():
+    assert as_of_accuracy("a", "a") == 1.0
+    assert as_of_accuracy("b", "a") == 0.0
+    assert as_of_accuracy(None, "a") == 0.0
+
+
+def test_gate_verdicts_pass_when_gg_high_and_beats_floor_on_past():
+    gg = {"past": 1.0, "current": 1.0}
+    floor = {"past": 0.0, "current": 1.0}
+    v = gate_verdicts(gg, floor)
+    assert all(p for _l, p, _h in v)
+
+
+def test_gate_verdicts_fail_when_floor_matches_gg_on_past():
+    gg = {"past": 1.0, "current": 1.0}
+    floor = {"past": 1.0, "current": 1.0}  # floor somehow right on past -> no capability gap
+    v = gate_verdicts(gg, floor)
+    gap = next(p for label, p, _h in v if "PAST" in label)
+    assert gap is False
+
+
+def test_render_has_regimes_and_verdicts():
+    res = TemporalResult(gg_acc={"past": 1.0, "current": 1.0},
+                         floor_acc={"past": 0.0, "current": 1.0}, llm_acc=None)
+    md = render_temporal_md(res)
+    assert "past" in md and "current" in md and ("PASS" in md or "FAIL" in md)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_llm.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_llm.py
@@ -1,0 +1,39 @@
+"""Opt-in real-LLM RAG temporal row -- stub-LLM, wheel-free (no real key)."""
+from __future__ import annotations
+
+from erkgbench.qa_e2e.corpora import Document
+from erkgbench.qa_e2e.temporal import llm_temporal_rag
+
+
+class _StubLLM:
+    def __init__(self, response):
+        self.response = response
+        self.prompts = []
+
+    def complete(self, prompt):
+        self.prompts.append(prompt)
+        return self.response
+
+
+def _docs():
+    return (
+        Document(id="x::works_at::a::t1", text="As of 1, X works at Apple.",
+                 src_surface="X", dst_surface="Apple"),
+        Document(id="x::works_at::b::t5", text="From 5, X works at Google.",
+                 src_surface="X", dst_surface="Google"),
+    )
+
+
+def test_llm_rag_maps_answer_to_canonical_and_sees_both_passages():
+    s2c = {"X": "x", "Apple": "a", "Google": "b"}
+    llm = _StubLLM("Apple")  # model answers the pre-correction value
+    got = llm_temporal_rag(_docs(), {"X"}, "works_at", 3, llm, surface_to_canon=s2c)
+    assert got == "a"
+    # both dated passages were in the prompt (no enforced temporal slice)
+    assert "Apple" in llm.prompts[-1] and "Google" in llm.prompts[-1]
+
+
+def test_llm_rag_unknown_answer_is_none():
+    s2c = {"X": "x", "Apple": "a"}
+    llm = _StubLLM("- Some Bogus Entity")
+    assert llm_temporal_rag(_docs(), {"X"}, "works_at", 3, llm, surface_to_canon=s2c) is None

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_store.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_temporal_store.py
@@ -1,0 +1,49 @@
+"""goldengraph store.as_of over the bi-temporal store. Needs the native wheel ->
+skips locally, validates in the gate lane. The valid_to round-trip is FIRST: it
+pins the previously-unexercised Python->JSON->store valid-time path."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("goldengraph_native")
+
+
+def test_valid_to_round_trips_through_pystore_append_and_as_of():
+    from goldengraph_native import _native as ggn
+
+    store = ggn.PyStore()
+    # X(0) -rel-> A(1) valid [1,5); X(0) -rel-> B(2) valid [5,inf). ONE batch.
+    batch = {
+        "entities": [
+            {"local_id": 0, "canonical_name": "X", "typ": "c", "surface_names": ["X"], "record_keys": ["x"]},
+            {"local_id": 1, "canonical_name": "A", "typ": "c", "surface_names": ["A"], "record_keys": ["a"]},
+            {"local_id": 2, "canonical_name": "B", "typ": "c", "surface_names": ["B"], "record_keys": ["b"]},
+        ],
+        "edges": [
+            {"subj_local": 0, "predicate": "rel", "obj_local": 1, "valid_from": 1, "valid_to": 5, "source_refs": []},
+            {"subj_local": 0, "predicate": "rel", "obj_local": 2, "valid_from": 5, "valid_to": None, "source_refs": []},
+        ],
+        "ingested_at": 1,
+    }
+    store.append(json.dumps(batch))
+    BIG = 10**12
+    past_names = {e["canonical_name"] for e in store.as_of(3, BIG).entities()}
+    cur_names = {e["canonical_name"] for e in store.as_of(7, BIG).entities()}
+    assert "A" in past_names and "B" not in past_names   # D=3 -> only A's window
+    assert "B" in cur_names and "A" not in cur_names      # D=7 -> only B's window
+
+
+def test_goldengraph_asof_returns_the_gold_object_in_both_regimes():
+    from erkgbench.qa_e2e.temporal import (
+        build_temporal_store,
+        generate_temporal,
+        goldengraph_asof,
+    )
+
+    docs, facts, qs = generate_temporal(seed=7, n_facts=20, ambiguity=0.6)
+    store = build_temporal_store(facts)
+    for q in qs:
+        got = goldengraph_asof(store, q.anchor_id, q.relation, q.D)
+        assert got == q.gold_obj  # exact, in both regimes


### PR DESCRIPTION
The second capability RAG structurally **cannot** do, and the starkest: answer "what was true about X *as of a past date D*" after the fact was corrected. A bi-temporal graph slices to the version valid at D; a passage retriever has no respected temporal axis, so it returns the corrected (latest) value and is **wrong on every past-date query**.

**Slice B2** of the capability program (B1 aggregation shipped in #1278).

## What this adds (`erkgbench/qa_e2e/temporal.py` + `run_temporal.py`)
- **Bi-temporal corpus** — per fact a value corrected at valid-time `Tc`: `X-rel-A` valid `[T1,Tc)`, `X-rel-B` valid `[Tc,∞)`, plus dated source passages. Past (`D<Tc`→A) + current (`D≥Tc`→B) questions. Anchors/objects disjoint (floor cleanliness).
- **goldengraph answer = exact `store.as_of(D)` traversal** (free, no LLM): slice at valid-time `D`, seed the anchor, filter by predicate → the single object whose valid window contains `D`. Right in **both** regimes by construction.
- **Deterministic temporal-blind floor** (free, no LLM): return the latest-mentioned object, ignoring `D` → **wrong on past** queries. "RAG without a temporal axis."
- **as_of-accuracy** by regime + opt-in real-LLM RAG row (reuses #1276's `_BudgetedLLM`).

## The gate (free, deterministic, key-free, in `goldengraph-pipeline.yml`)
First runs the **`valid_to` round-trip** (the previously-unexercised Python→JSON→store valid-time path) + the as_of e2e, then asserts: (1) goldengraph as_of-accuracy ≥ 0.9 in **both** regimes; (2) goldengraph beats the temporal-blind floor by ≥ 0.5 on **past** queries — the starkest "RAG can't answer as-of-a-past-date". (3, soft) the floor is fine on the current regime (it's temporal-blind, not broken).

## Honest status
goldengraph's whole answer path is wheel-gated (it needs the store), so the **real numbers + the `valid_to` round-trip validate only in the `pipeline` lane**. 13 wheel-free tests pass + lint clean (corpus, floor, metric, gate, CLI, LLM-stub); the as_of traversal + round-trip `importorskip` the wheel. I'll watch the lane and report `TEMPORAL.md`.

## Test plan
- [x] 13 wheel-free tests pass; both workflow YAMLs parse
- [ ] `pipeline` lane: `valid_to` round-trip passes, `goldengraph_asof` returns the gold object in both regimes, `TEMPORAL.md` shows gg ~1.0 both regimes + floor ~0 on past (HARD PASS)
- [ ] `bench-er-kg` pure-Python step green on the 4 new wheel-free files

Spec + plan: `docs/superpowers/specs/2026-06-27-goldengraph-temporal-asof-bench-design.md`, `docs/superpowers/plans/2026-06-27-goldengraph-temporal-asof-bench.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)