### PR TITLE
fix(distributed): ensure global __row_id__ in Phase 5 pipeline (Ray hash-shuffle)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -286,13 +286,18 @@ def _ensure_global_row_id(ds: Dataset) -> Dataset:
     if "__row_id__" in _row_columns(ds):
         return ds
 
-    # Only a real Ray Dataset supports the row-id assignment below. Stub-based
-    # wiring tests pass a bare object() whose only exercised method is the
-    # patched scorer -- leave anything without the Dataset API untouched.
-    if not (hasattr(ds, "count") and hasattr(ds, "zip")):
+    # Only a real Ray Dataset gets the row-id assignment below. In the ray-less
+    # python lane ``ds`` cannot be a real Dataset, and the mock/stub wiring tests
+    # pass a MagicMock or bare object(); a MagicMock satisfies ``hasattr`` for any
+    # attribute, so guard on the concrete type (not duck-typing) and import ray
+    # defensively -- both cases fall through to a no-op.
+    try:
+        import ray
+        from ray.data import Dataset as _RayDataset
+    except Exception:
         return ds
-
-    import ray
+    if not isinstance(ds, _RayDataset):
+        return ds
 
     logger.warning(
         "phase5: input rows carry no __row_id__; assigning a global row id "

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -168,6 +168,18 @@ def _run_phase5_pipeline(
         "distributed streaming pipeline (GOLDENMATCH_DISTRIBUTED_PIPELINE=2)",
     )
 
+    # 1c. Guarantee a GLOBAL __row_id__ on the input rows. Phase 5 scoring keys
+    #     pairs on __row_id__ and step 4 joins rows.__row_id__ == member_id, so
+    #     BOTH require a globally-unique id. Production inputs (the bench parquet
+    #     generator) already carry it -- a no-op that leaves the streaming path
+    #     untouched. When absent (a caller passing a raw frame, e.g. the wiring
+    #     tests) the prior code let each partition synthesize colliding local ids
+    #     AND left the join referencing a __row_id__ column that wasn't on the
+    #     rows: on older Ray the join silently produced nothing; newer Ray's
+    #     hash-shuffle eagerly projects the key and raises KeyError. Adding the id
+    #     here fixes the crash and the latent cross-partition id collision.
+    ds = _ensure_global_row_id(ds)
+
     # 2. Distributed scoring -> Ray Dataset of pairs (RAW: per-partition, so each
     #    component's edges are co-located in one block -- required by local_cc).
     raw_pairs_ds = score_blocks_distributed(ds, cfg)
@@ -258,6 +270,43 @@ def _row_columns(ds: Dataset) -> list[str]:
         return list(ds.schema().names)
     except Exception:  # pragma: no cover - schema() shape varies by Ray version
         return []
+
+
+def _ensure_global_row_id(ds: Dataset) -> Dataset:
+    """Return ``ds`` guaranteed to carry a globally-unique ``__row_id__``.
+
+    No-op when the column already exists (the production contract -- the input
+    parquet carries ``__row_id__``, so the streaming path is unchanged). When it
+    is absent, attach a deterministic global index via ``zip(range(n))`` and
+    materialize so distributed scoring (step 2) and the cluster join (step 4)
+    observe the SAME ids. ``zip``/``count`` execute the input once; that cost is
+    only paid on the fallback (callers that didn't supply ``__row_id__``), which
+    is why we also warn -- supplying it upstream keeps the pipeline streaming.
+    """
+    if "__row_id__" in _row_columns(ds):
+        return ds
+
+    # Only a real Ray Dataset supports the row-id assignment below. Stub-based
+    # wiring tests pass a bare object() whose only exercised method is the
+    # patched scorer -- leave anything without the Dataset API untouched.
+    if not (hasattr(ds, "count") and hasattr(ds, "zip")):
+        return ds
+
+    import ray
+
+    logger.warning(
+        "phase5: input rows carry no __row_id__; assigning a global row id "
+        "(this materializes the input). Provide a global __row_id__ upstream to "
+        "keep the pipeline fully streaming."
+    )
+    n = ds.count()
+    indexed = ds.zip(ray.data.range(n))
+
+    def _rename_id(batch: Any) -> Any:  # pa.Table -> pa.Table
+        names = ["__row_id__" if c == "id" else c for c in batch.column_names]
+        return batch.rename_columns(names)
+
+    return indexed.map_batches(_rename_id, batch_format="pyarrow").materialize()
 
 
 def _join_assignments_distributed(


### PR DESCRIPTION
## What and why

The merge-queue `distributed_broad` lane fails on current Ray (`ray>=2.0` is unpinned; CI now pulls 2.55.x) with `KeyError: 'Field "__row_id__" does not exist in schema'`, taking down `test_phase5_pipeline_end_to_end_correctness` and `test_phase5_pipeline_runs_without_take_all`. This is dependency drift, not a code bug in any one PR — it surfaced because #1275 edits `ci.yml`, which forces the full matrix in the merge queue and runs this lane that PR path-filters normally skip. The fix lands on `main` so the lane is green for everyone.

## Changes

- `goldenmatch/distributed/pipeline.py`: `_run_phase5_pipeline` now calls a new `_ensure_global_row_id(ds)` before distributed scoring.
  - The Phase 5 streaming path keys scored pairs on `__row_id__` and joins `rows.__row_id__ == assignments.member_id`; both require a globally-unique row id. When the input lacks one, the old code let each partition synthesize colliding local ids and left the join referencing a `__row_id__` column that was never on the rows.
  - On older Ray the join silently produced nothing (the wiring tests passed vacuously); newer Ray's hash-shuffle eagerly projects the join key and raises.
  - `_ensure_global_row_id` is a no-op when the column is present (the production contract — the bench parquet generator supplies it, so the streaming path is untouched). Otherwise it attaches a deterministic global index via `zip(range(n))` and materializes so scoring and the join observe the same ids. This also fixes the latent cross-partition id collision the docstring already warned about.
  - A guard skips stub datasets so the materialize-once wiring test (which passes a bare `object()`) is unaffected.

## Testing

Reproduced and verified against Ray 2.55.1 locally via `uv run --with "ray[data]>=2.0" --with scipy ...`:

- Before: both Phase 5 tests fail with the documented `__row_id__` KeyError.
- After: `test_phase5_pipeline_runs_without_take_all`, `test_phase5_pipeline_end_to_end_correctness`, and `test_phase5_materializes_pairs_once_before_clustering` all pass.
- Full distributed suite: 157 passed, 4 skipped. The one remaining failure (`test_bucket_mode_equivalence_with_df_mode`) is a pre-existing polars driver/worker deserialization artifact of the local sandbox — it fails identically on clean `main` and passes in CI — unrelated to this change.
- `ruff check` clean on the changed file.

## Checklist

- [x] Tests passing locally for the changed package (distributed lane)
- [x] `ruff check` clean on the changed file
- [ ] Package `CHANGELOG.md` updated if behavior changed (internal distributed fix; no user-facing API change)
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmYnMS7Njc9e7mdz47FpdJ)_