### PR TITLE
feat(goldengraph): query-router slice 2 (temporal as-of mode + routing)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-goldengraph-temporal-mode.md
+++ b/docs/superpowers/plans/2026-06-27-goldengraph-temporal-mode.md
@@ -1,0 +1,521 @@
+# GoldenGraph query-router slice 2 (temporal as-of mode) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote temporal as-of into a first-class LLM-free `ask` mode, flip the router's `temporal_asof` plan to a real `as_of` lever (date = slice time), and extend the slice-1 router gate to prove routed as-of-accuracy == 1.0 in both regimes.
+
+**Architecture:** Extend `goldengraph/route.py` (temporal slot extraction + `as_of` plan rule), add `asof_object` + an `as_of` branch to `ask(mode="auto")` in `goldengraph/answer.py` (parses the query's integer date and slices `store.as_of(D)`, overriding the caller's valid_t; a CLAMP routes any non-returning specialized plan to a valid mode). The gate (`erkgbench/qa_e2e/router_eval.py`) builds a concept-surface-named windowed store (B2's is QID-named) and adds temporal classifier + routed-accuracy assertions.
+
+**Tech Stack:** Python 3.12, pytest, ruff. STACKED on slice 1 (`feat/goldengraph-query-router`, PR #1283). `asof_object` + routed gate need the `goldengraph_native` wheel (goldengraph-pipeline CI); `route.py` + temporal classifier-accuracy are wheel-free.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-goldengraph-temporal-mode-design.md`
+
+---
+
+## Conventions for every task
+
+- Worktree: `D:\show_case\gg-temporal-mode`, branch `feat/goldengraph-temporal-mode` (stacked on slice 1).
+- `PYEXE="D:/show_case/goldenmatch/.venv/Scripts/python.exe"`.
+- `route.py` tests wheel-free: `cd D:/show_case/gg-temporal-mode && POLARS_SKIP_CPU_CHECK=1 PYTHONPATH="packages/python/goldengraph" "$PYEXE" -m pytest packages/python/goldengraph/tests/test_route.py -v`.
+- er-kg-bench wheel-free tests: from the bench dir, `PYTHONPATH="$(pwd);D:/show_case/gg-temporal-mode/packages/python/goldengraph"` (use `;` separator on Windows).
+- `asof_object` + routed-correctness need the wheel -> CI only; guard wheel tests with `pytest.importorskip("goldengraph_native")`.
+- Ruff-clean per commit. Commit footer:
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01Sc5aGSaVBTWBWpytNH99QE
+  ```
+- Reuse from B2 `erkgbench/qa_e2e/temporal.py` (verified): `generate_temporal(*, seed, n_facts, ambiguity) -> (docs, facts, qs)`; `TemporalFact(anchor_id, relation, a_id, b_id, tc)` (frozen); `TemporalQuestion(id, question, anchor_id, relation, D, regime, gold_obj)`; question text `f"As of {D}, what does {by_id[src_id].canonical} {rel_words}?"`; `T1 = 1`; `goldengraph_asof(store, anchor_id, relation, D)`; `as_of_accuracy(pred, gold)`. `engineered.RELATION_SCHEMA`, `engineered._load_entities()` (`.id` QID, `.canonical` surface).
+
+## File structure
+
+- Modify `packages/python/goldengraph/goldengraph/route.py` -- temporal slot extraction + `as_of` plan.
+- Modify `packages/python/goldengraph/goldengraph/answer.py` -- `asof_object`, `as_of` branch + clamp.
+- Modify `packages/python/goldengraph/tests/test_route.py` -- temporal intent/slot/plan tests.
+- Create `packages/python/goldengraph/tests/test_asof_mode.py` -- `asof_object` + auto dispatch (wheel).
+- Modify `erkgbench/qa_e2e/router_eval.py` -- concept-named store + temporal gate + RouterResult ext.
+- Modify `erkgbench/qa_e2e/.../tests/test_qa_router.py` -- temporal classifier-accuracy + gate shape.
+- No CI-wiring changes: the slice-1 router gate step (goldengraph-pipeline), the bench-er-kg
+  `test_qa_router.py` entry, and the `run_router_capability` lane already exist and now cover
+  temporal automatically.
+
+---
+
+## Task 1: route.py temporal slots + `as_of` plan (wheel-free)
+
+**Files:**
+- Modify: `packages/python/goldengraph/goldengraph/route.py`
+- Test: `packages/python/goldengraph/tests/test_route.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_route.py
+
+def test_temporal_slots_extracted():
+    p = route.classify_query("As of 42, what does Metaphone works at?", predicates=_PREDS)
+    assert p.intent is route.QueryIntent.TEMPORAL_ASOF
+    assert p.anchor_surface == "Metaphone"
+    assert p.relation == "works_at"
+    assert p.as_of == "42"
+    assert p.confidence >= 0.8
+
+
+def test_temporal_multiword_anchor():
+    p = route.classify_query(
+        "As of 7, what does Levenshtein distance located in?", predicates=_PREDS
+    )
+    assert p.anchor_surface == "Levenshtein distance"
+    assert p.relation == "located_in"
+    assert p.as_of == "7"
+
+
+def test_plan_temporal_routes_to_as_of():
+    p = route.classify_query("As of 42, what does Metaphone works at?", predicates=_PREDS)
+    plan = route.plan_query(p)
+    assert plan.mode == "as_of" and plan.note is None
+
+
+def test_plan_temporal_low_confidence_falls_back():
+    # no predicates -> relation None -> not routed to as_of
+    p = route.classify_query("As of 42, what does Metaphone works at?")
+    assert route.plan_query(p).mode == "local"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `... pytest packages/python/goldengraph/tests/test_route.py -k temporal -v`
+Expected: FAIL (anchor_surface/as_of None; plan still `not_yet_promoted`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# in route.py: add the temporal lead-in regex + extend classify_query's TEMPORAL_ASOF branch
+
+_TEMPORAL_LEADIN_RE = re.compile(
+    r"^\s*as of\s+(?P<d>\d+)\s*,\s*what does\s+(?P<rest>.+?)\s*[.?]?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _extract_temporal_slots(query: str, predicates):
+    """(anchor, relation, as_of) from 'As of <D>, what does <anchor> <relation words>?'.
+    Reuses the predicate-suffix split. Returns (None, None, None) when the lead-in misses."""
+    m = _TEMPORAL_LEADIN_RE.match(query)
+    if not m:
+        return None, None, None
+    rest = m.group("rest").strip()
+    anchor, relation = _split_anchor_relation(rest, predicates)  # see NOTE
+    return anchor, relation, m.group("d")
+```
+
+NOTE: factor the predicate-suffix split out of the existing `_extract_agg_slots` into a shared
+`_split_anchor_relation(rest, predicates) -> (anchor|None, relation|None)` (the body that does the
+longest-suffix predicate match), and call it from BOTH `_extract_agg_slots` and
+`_extract_temporal_slots`. DRY; keep `_extract_agg_slots`'s behavior identical.
+
+Then in `classify_query`, add the TEMPORAL_ASOF slot branch:
+
+```python
+    if intent is QueryIntent.TEMPORAL_ASOF:
+        anchor, relation, as_of = _extract_temporal_slots(query, predicates)
+        conf = 0.9 if (anchor and relation and as_of) else 0.5
+        return QueryProfile(intent=intent, anchor_surface=anchor, relation=relation,
+                            as_of=as_of, confidence=conf)
+```
+
+And in `plan_query`, replace the temporal rule:
+
+```python
+    if profile.intent is QueryIntent.TEMPORAL_ASOF:
+        if profile.confidence >= MIN_CONF and profile.anchor_surface and profile.relation and profile.as_of:
+            return RetrievalPlan(mode="as_of")
+        return RetrievalPlan(mode="local")  # low-confidence temporal -> safe general mode
+```
+
+(Delete the old `RetrievalPlan(mode="local", note="not_yet_promoted")` line. Update the slice-1
+test `test_plan_temporal_marked_not_yet_promoted` -> assert `mode == "as_of"` for a well-formed
+temporal query, or delete it -- it's superseded by `test_plan_temporal_routes_to_as_of`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `... pytest packages/python/goldengraph/tests/test_route.py -v`
+Expected: PASS (all, including the updated slice-1 temporal test). `ruff check route.py` -> clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldengraph/goldengraph/route.py packages/python/goldengraph/tests/test_route.py
+git commit -m "feat(goldengraph): query-router temporal slot extraction + as_of plan"
+```
+
+---
+
+## Task 2: asof_object + as_of branch + clamp (wheel-bound)
+
+**Files:**
+- Modify: `packages/python/goldengraph/goldengraph/answer.py`
+- Test: `packages/python/goldengraph/tests/test_asof_mode.py`
+
+- [ ] **Step 1: Write the failing test** (mirror `test_aggregate_mode.py`; build a 2-window store)
+
+```python
+# packages/python/goldengraph/tests/test_asof_mode.py
+"""asof_object + ask(mode='auto') temporal dispatch -- needs goldengraph_native (CI lane)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("goldengraph_native")
+
+from conftest import StubEmbedder, StubLLM  # noqa: E402
+from goldengraph.answer import asof_object, ask  # noqa: E402
+
+
+def _windowed_store():
+    # X works_at A for [1,5); X works_at B for [5, inf). Hand-built (build_batch can't set valid_to).
+    from goldengraph_native import _native as ggn
+
+    store = ggn.PyStore()
+    batch = {
+        "entities": [
+            {"local_id": 0, "canonical_name": "X", "typ": "concept", "surface_names": ["X"], "record_keys": ["kx"]},
+            {"local_id": 1, "canonical_name": "Apple", "typ": "concept", "surface_names": ["Apple"], "record_keys": ["ka"]},
+            {"local_id": 2, "canonical_name": "Banana", "typ": "concept", "surface_names": ["Banana"], "record_keys": ["kb"]},
+        ],
+        "edges": [
+            {"subj_local": 0, "predicate": "works_at", "obj_local": 1, "valid_from": 1, "valid_to": 5, "source_refs": []},
+            {"subj_local": 0, "predicate": "works_at", "obj_local": 2, "valid_from": 5, "valid_to": None, "source_refs": []},
+        ],
+        "ingested_at": 1,
+    }
+    store.append(json.dumps(batch))
+    return store
+
+
+def test_asof_object_flips_across_the_correction():
+    store = _windowed_store()
+    assert asof_object(store.as_of(3, 10**12), "X", "works_at") == "Apple"   # past window
+    assert asof_object(store.as_of(7, 10**12), "X", "works_at") == "Banana"  # current window
+
+
+def test_ask_auto_routes_temporal_past():
+    store = _windowed_store()
+    out = ask("As of 3, what does X works_at?", store, llm=StubLLM("UNUSED"),
+              embedder=StubEmbedder({}), valid_t=10**12, tx_t=10**12, mode="auto")
+    assert out == "Apple"
+
+
+def test_ask_auto_unparseable_date_falls_back_to_local(monkeypatch):
+    # a temporal-looking query whose date can't int() must NOT raise (clamp -> local synthesis)
+    store = _windowed_store()
+    # StubLLM returns a canned synthesis string; the point is it does not raise ValueError
+    out = ask("As of 2020, what does X works_at?", store, llm=StubLLM("some answer"),
+              embedder=StubEmbedder({"X": 0}), valid_t=10**12, tx_t=10**12, mode="auto")
+    assert isinstance(out, str)  # "2020" parses fine; this asserts the path is exercised w/o raise
+```
+
+NOTE: "2020" parses as an int, so the third test mostly asserts no-raise on the temporal path. To
+test the TRUE unparseable branch, the date regex requires `\d+`, so a non-digit date won't even
+classify TEMPORAL_ASOF. The clamp's real value is defensive (a future date format); the test that
+matters is `test_asof_object_flips_across_the_correction` + `test_ask_auto_routes_temporal_past`.
+Keep the third test as a smoke that the temporal `ask` path returns a string without raising.
+
+- [ ] **Step 2: Run to verify it fails** (CI lane / skips locally without the wheel)
+
+Run: `... pytest packages/python/goldengraph/tests/test_asof_mode.py -v`
+Expected: FAIL (`ImportError: cannot import name 'asof_object'`) in CI, SKIP locally.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to answer.py (near aggregate_members)
+
+def asof_object(slice_graph, anchor_surface: str, relation: str) -> str | None:
+    """The object on a (subj==seed, predicate==relation) edge present IN THIS SLICE (the slice
+    already encodes the as-of window). LLM-free."""
+    seeds = slice_graph.seeds_by_name(anchor_surface)
+    if not seeds:
+        return None
+    sub = slice_graph.query(seeds, 1)
+    id_to_name = {e["entity_id"]: e["canonical_name"] for e in sub.get("entities", ())}
+    seedset = set(seeds)
+    objs = {
+        id_to_name[e["obj"]]
+        for e in sub.get("edges", ())
+        if e["subj"] in seedset and e["predicate"] == relation and e["obj"] in id_to_name
+    }
+    objs.discard(anchor_surface)
+    return next(iter(sorted(objs)), None)
+```
+
+Then update the `mode == "auto"` block (add the as_of branch + the CLAMP, per the spec):
+
+```python
+        if plan.mode == "as_of" and profile.anchor_surface and profile.relation and profile.as_of:
+            try:
+                d = int(profile.as_of)
+            except ValueError:
+                d = None
+            if d is not None:
+                obj = asof_object(store.as_of(d, tx_t), profile.anchor_surface, profile.relation)
+                return obj if obj is not None else "(unknown)"
+        # clamp: a specialized plan that did not return must not carry an invalid mode downstream
+        mode = plan.mode if plan.mode in ("local", "hybrid", "global") else "local"
+```
+
+(Replace the slice-1 `mode = plan.mode  # fall through ...` line with this clamp.)
+
+- [ ] **Step 4: Run to verify it passes** (CI lane). `ruff check answer.py` -> clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldengraph/goldengraph/answer.py packages/python/goldengraph/tests/test_asof_mode.py
+git commit -m "feat(goldengraph): asof_object + ask(mode=auto) temporal dispatch + mode clamp"
+```
+
+---
+
+## Task 3: router gate temporal extension (er-kg-bench)
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/router_eval.py`
+- Test: `tests/test_qa_router.py`
+
+- [ ] **Step 1: Write the failing wheel-free test**
+
+```python
+# add to tests/test_qa_router.py
+
+def test_temporal_classifier_accuracy_on_b2_questions():
+    acc = re_.temporal_classifier_accuracy(seed=7, n_facts=20, ambiguity=0.6)
+    assert acc["temporal_recall"] == 1.0
+    assert acc["temporal_slot_acc"] == 1.0
+
+
+def test_gate_shape_includes_temporal():
+    res = re_.RouterResult(
+        aggregate_recall=1.0, slot_accuracy=1.0, routed_setf1=1.0,
+        temporal_recall=1.0, temporal_slot_acc=1.0, temporal_past_acc=1.0, temporal_current_acc=1.0,
+    )
+    assert re_.gate_exit_code(res) == 0
+
+
+def test_gate_fails_when_temporal_past_low():
+    res = re_.RouterResult(
+        aggregate_recall=1.0, slot_accuracy=1.0, routed_setf1=1.0,
+        temporal_recall=1.0, temporal_slot_acc=1.0, temporal_past_acc=0.0, temporal_current_acc=1.0,
+    )
+    assert re_.gate_exit_code(res) == 1
+```
+
+NOTE: extending `RouterResult` with required fields breaks slice-1's `RouterResult(...)` test
+constructions (they pass only the 3 aggregate fields). Give the 4 new temporal fields DEFAULTS
+(`= 1.0`) so slice-1 tests still construct a passing result, OR update those test constructors. Use
+defaults -- less churn, and a default-1.0 means "not measured -> not failing".
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd <bench dir> && PYTHONPATH="$(pwd);<goldengraph>" "$PYEXE" -m pytest tests/test_qa_router.py -k temporal -v`
+Expected: FAIL (`AttributeError: temporal_classifier_accuracy`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# in router_eval.py
+
+# extend the dataclass (defaults keep slice-1 constructions valid)
+@dataclass
+class RouterResult:
+    aggregate_recall: float
+    slot_accuracy: float
+    routed_setf1: float
+    temporal_recall: float = 1.0
+    temporal_slot_acc: float = 1.0
+    temporal_past_acc: float = 1.0
+    temporal_current_acc: float = 1.0
+
+
+def temporal_classifier_accuracy(*, seed: int, n_facts: int, ambiguity: float) -> dict:
+    from goldengraph.route import QueryIntent, classify_query
+
+    from .engineered import RELATION_SCHEMA, _load_entities
+    from .temporal import generate_temporal
+
+    _docs, _facts, qs = generate_temporal(seed=seed, n_facts=n_facts, ambiguity=ambiguity)
+    by_id = {e.id: e for e in _load_entities()}
+    preds = set(RELATION_SCHEMA)
+    rec = slot = 0
+    for q in qs:
+        p = classify_query(q.question, predicates=preds)
+        if p.intent is QueryIntent.TEMPORAL_ASOF:
+            rec += 1
+        ok_date = p.as_of is not None and p.as_of.isdigit() and int(p.as_of) == q.D
+        if p.anchor_surface == by_id[q.anchor_id].canonical and p.relation == q.relation and ok_date:
+            slot += 1
+    n = len(qs) or 1
+    return {"temporal_recall": rec / n, "temporal_slot_acc": slot / n}
+
+
+def _build_concept_named_temporal_store(facts, by_id):
+    """Mirror temporal.build_temporal_store but name nodes by CONCEPT SURFACE (so question-text
+    seeds_by_name resolves) while keeping oracle merge on the QID record_keys. Needs the wheel."""
+    import json
+
+    from goldengraph_native import _native as ggn
+
+    from .temporal import T1
+
+    store = ggn.PyStore()
+    for f in facts:
+        def ent(local, _id):
+            return {"local_id": local, "canonical_name": by_id[_id].canonical, "typ": "concept",
+                    "surface_names": [by_id[_id].canonical], "record_keys": [_id]}
+        batch = {
+            "entities": [ent(0, f.anchor_id), ent(1, f.a_id), ent(2, f.b_id)],
+            "edges": [
+                {"subj_local": 0, "predicate": f.relation, "obj_local": 1,
+                 "valid_from": T1, "valid_to": f.tc, "source_refs": []},
+                {"subj_local": 0, "predicate": f.relation, "obj_local": 2,
+                 "valid_from": f.tc, "valid_to": None, "source_refs": []},
+            ],
+            "ingested_at": 1,
+        }
+        store.append(json.dumps(batch))
+    return store
+
+
+def run_temporal_routed_accuracy(*, seed: int, n_facts: int, ambiguity: float) -> dict:
+    """Route each B2 question through classify_query -> store.as_of(D) -> asof_object; as-of-accuracy
+    by regime vs name-projected gold. Needs the wheel."""
+    from goldengraph.answer import asof_object
+    from goldengraph.route import classify_query
+
+    from .engineered import RELATION_SCHEMA, _load_entities
+    from .temporal import _BIG_TX, as_of_accuracy, generate_temporal
+
+    _docs, facts, qs = generate_temporal(seed=seed, n_facts=n_facts, ambiguity=ambiguity)
+    by_id = {e.id: e for e in _load_entities()}
+    store = _build_concept_named_temporal_store(facts, by_id)
+    preds = set(RELATION_SCHEMA)
+    acc: dict = {"past": [], "current": []}
+    for q in qs:
+        p = classify_query(q.question, predicates=preds)
+        got = None
+        if p.anchor_surface and p.relation and p.as_of and p.as_of.isdigit():
+            got = asof_object(store.as_of(int(p.as_of), _BIG_TX), p.anchor_surface, p.relation)
+        gold_name = by_id[q.gold_obj].canonical
+        acc[q.regime].append(as_of_accuracy(got, gold_name))
+    return {r: (sum(v) / len(v) if v else 0.0) for r, v in acc.items()}
+```
+
+Then extend the slice-1 freeze constants + `evaluate_assertions` + `run_router_deterministic` +
+`render_router_md`:
+
+```python
+# new frozen thresholds
+TEMPORAL_RECALL_MIN = 0.99
+TEMPORAL_SLOT_MIN = 0.99
+TEMPORAL_ACC_MIN = 0.99
+
+# in evaluate_assertions: APPEND these HARD rows
+        (f"classifier routes temporal questions to TEMPORAL_ASOF (recall {res.temporal_recall:.3f} >= {TEMPORAL_RECALL_MIN})",
+         res.temporal_recall >= TEMPORAL_RECALL_MIN, True),
+        (f"temporal slots (anchor/relation/date) correct (acc {res.temporal_slot_acc:.3f} >= {TEMPORAL_SLOT_MIN})",
+         res.temporal_slot_acc >= TEMPORAL_SLOT_MIN, True),
+        (f"routed as-of-accuracy past=={res.temporal_past_acc:.3f} current=={res.temporal_current_acc:.3f} (both >= {TEMPORAL_ACC_MIN})",
+         res.temporal_past_acc >= TEMPORAL_ACC_MIN and res.temporal_current_acc >= TEMPORAL_ACC_MIN, True),
+```
+
+```python
+def run_router_deterministic(*, seed: int, n_anchors: int) -> RouterResult:
+    acc = classifier_accuracy(seed=seed, n_anchors=n_anchors, ambiguity=0.0)
+    routed = run_routed_correctness(seed=seed, n_anchors=n_anchors)
+    tacc = temporal_classifier_accuracy(seed=seed, n_facts=n_anchors, ambiguity=0.6)
+    tr = run_temporal_routed_accuracy(seed=seed, n_facts=n_anchors, ambiguity=0.6)
+    return RouterResult(
+        aggregate_recall=acc["aggregate_recall"], slot_accuracy=acc["slot_accuracy"],
+        routed_setf1=routed,
+        temporal_recall=tacc["temporal_recall"], temporal_slot_acc=tacc["temporal_slot_acc"],
+        temporal_past_acc=tr.get("past", 0.0), temporal_current_acc=tr.get("current", 0.0),
+    )
+```
+
+Add temporal lines to `render_router_md` (the `- temporal_*:` rows). NOTE the B2 temporal store is
+ER-perfect by construction (oracle record_keys), so `ambiguity=0.6` is fine for temporal (the
+ambiguity only affects rendered doc surfaces, which the gate does not read -- it routes from the
+question text and builds the store from facts). Aggregation stays pinned at `ambiguity=0.0` (slice 1).
+
+- [ ] **Step 4: Run the wheel-free test + ruff**
+
+Run: `... pytest tests/test_qa_router.py -v` (the temporal-classifier + gate-shape tests; routed
+accuracy runs in CI). `ruff check router_eval.py` -> clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add erkgbench/qa_e2e/router_eval.py tests/test_qa_router.py
+git commit -m "feat(er-kg-bench): router gate temporal extension (concept-named windowed store)"
+```
+
+---
+
+## Task 4: opt-in temporal auto-vs-local row
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/router_eval.py`
+- Test: `tests/test_qa_router.py`
+
+Extend `run_router_llm` (slice 1) to ALSO compare `ask(mode="auto")` vs `ask(mode="local")` on the
+PAST-regime temporal questions, building the concept-named WINDOWED store (NOT engine.build_kg --
+spec). The pure scoring is `as_of_accuracy` (already in temporal.py) over the answer text mapped to a
+name; reuse the slice-1 `answer_setf1`-style parse for a single object. Heavy/billing-blocked/guarded.
+
+- [ ] **Step 1: Write the failing test (pure helper)**
+
+```python
+# add to tests/test_qa_router.py
+def test_first_known_name_in_text():
+    assert re_.first_known_name("It is Banana.", {"Apple", "Banana"}) == "Banana"
+    assert re_.first_known_name("nothing", {"Apple"}) is None
+```
+
+- [ ] **Step 2-4:** implement `first_known_name(text, universe) -> str|None` (the single-object
+  analog of slice-1 `parse_entity_set`: first universe name appearing in the text). Extend
+  `RouterLLMResult` with `temporal_auto_acc`/`temporal_local_acc` (defaults None) and extend
+  `run_router_llm` to: build the concept-named windowed store, iterate PAST-regime questions, call
+  `ask(..., mode="auto")` and `ask(..., mode="local")` with the engine's real llm/embedder (from
+  `_build_engine("goldengraph")` for the llm+embedder only; the STORE is the windowed one), map each
+  answer via `first_known_name` to a name, score `as_of_accuracy` vs `by_id[q.gold_obj].canonical`,
+  mean per arm. Guard the whole thing in try/except -> None on failure. Add the rows to
+  `render_router_llm_md`. Run the pure test (PASS), ruff clean, commit.
+
+```bash
+git add erkgbench/qa_e2e/router_eval.py tests/test_qa_router.py
+git commit -m "feat(er-kg-bench): opt-in temporal auto-vs-local row (windowed store)"
+```
+
+---
+
+## Final verification (before finishing the branch)
+
+- [ ] `... pytest packages/python/goldengraph/tests/test_route.py -v` -> PASS.
+- [ ] er-kg-bench `tests/test_qa_router.py` -> PASS (wheel-free part: aggregate + temporal classifier + gate shape + pure helpers).
+- [ ] `ruff check` on all modified .py -> clean.
+- [ ] Use superpowers:finishing-a-development-branch: push (benzsevern account), open PR vs `feat/goldengraph-query-router` (STACKED -- base is slice 1, not main, until #1283 merges; if #1283 merges first, rebase `--onto origin/main` + retarget to main). Watch the `goldengraph-pipeline` router gate go green BEFORE arming `gh pr merge --auto`. Freeze `TEMPORAL_*` thresholds from the measured `ROUTER.md` if needed; record memory.
+- [ ] If routed as-of-accuracy is NOT 1.0 in BOTH regimes, surface to Ben (the as-of traversal or the date->slice wiring is wrong) -- do not loosen the gate.
+
+## Known unknowns to resolve during implementation (call out, don't guess)
+
+- Confirm `_split_anchor_relation` factoring keeps `_extract_agg_slots` byte-identical (run the
+  slice-1 aggregate route tests after refactoring).
+- Confirm the slice-1 `RouterResult(...)` test constructors still pass after adding defaulted
+  temporal fields (or update them).
+- Confirm the slice-1 `test_plan_temporal_marked_not_yet_promoted` is updated/removed (it now routes
+  to `as_of`).
+- The opt-in `run_router_llm` temporal arm uses the engine's `_llm`/`_embedder` over the WINDOWED
+  store -- confirm `_build_engine("goldengraph")` exposes those (it does: `engine._llm`,
+  `engine._embedder`) and that `ask(mode="local")` over the windowed store doesn't need a passage
+  retriever (local mode doesn't; hybrid does).

--- a/docs/superpowers/specs/2026-06-27-goldengraph-temporal-mode-design.md
+++ b/docs/superpowers/specs/2026-06-27-goldengraph-temporal-mode-design.md
@@ -90,8 +90,21 @@ slice-1 aggregate branch, right after the existing `slice_graph = store.as_of(va
             if d is not None:
                 obj = asof_object(store.as_of(d, tx_t), profile.anchor_surface, profile.relation)
                 return obj if obj is not None else "(unknown)"
-        mode = plan.mode  # fall through to local/hybrid/global
+        # Any specialized plan that did NOT return (unparseable date, missing slots) must clamp to a
+        # VALID downstream synthesis mode -- letting `plan.mode` carry "aggregate"/"as_of" forward
+        # would hit the existing `if mode not in ("local","hybrid"): raise ValueError` guard. (This
+        # also retro-hardens slice 1's aggregate path.)
+        mode = plan.mode if plan.mode in ("local", "hybrid", "global") else "local"
 ```
+
+NOTE (predicate vocab source): `_slice_predicates` reads the relation vocabulary from the
+caller's-`valid_t` slice. For a temporal query whose answer lives in a LATER window, the relation
+predicate still exists in that caller slice as long as the caller passes a non-empty "now"-ish
+`valid_t` (the predicate appears on at least one edge somewhere in `[valid_t]`); if the caller passes
+an empty/early slice the relation won't resolve and the query safely routes to `local`. The
+deterministic gate calls `classify_query` directly with `RELATION_SCHEMA` (not via `ask`), so this
+caveat is not load-bearing for the gate; it is a documented edge for direct `ask(mode="auto")`
+callers.
 
 ### 3. Gate (free, deterministic, key-free; extends the slice-1 router gate)
 
@@ -125,10 +138,15 @@ date->slice-time wiring is wrong).
 
 ### Opt-in real-LLM confirmation (`bench-graphrag-qa`, ungated)
 
-Extend slice-1's `run_router_capability` lane: on the past-regime questions, compare answer-match of
-`ask(mode="auto")` (routes to as-of, slices at D) vs `ask(mode="local")` (general, no temporal
-slice). Shows routing to the as-of lever WINS on a corrected-away past value. Non-gating, `|| true`,
-billing-blocked.
+Extend slice-1's `run_router_capability` lane with a temporal comparison: on the past-regime
+questions, `ask(mode="auto")` (routes to as-of, slices at D) vs `ask(mode="local")` (general, no
+temporal slice). **Store choice (load-bearing):** this lane MUST build the concept-surface-named
+WINDOWED store via `_build_concept_named_temporal_store` (the same gate builder) -- NOT
+`engine.build_kg` real-ingest, because the real extraction pipeline does not parse the engineered
+`"As of {T1}, ..."` / `"From {tc}, ..."` document phrasing into edge `valid_from`/`valid_to` windows,
+so as-of slicing could not distinguish A from B and the demonstration would be vacuous. A real
+LLM/embedder is still used for the synthesis side of `local` mode. Shows routing to the as-of lever
+WINS on a corrected-away past value. Non-gating, `|| true`, billing-blocked.
 
 ## Components / file structure
 
@@ -152,7 +170,9 @@ billing-blocked.
 ## Error handling
 
 - `classify_query` never raises; a temporal query with an unparseable date -> `as_of` set but the
-  `ask` branch's `int()` guard falls through to `local`.
+  `ask` branch's `int()` guard fails, the as-of branch does not return, and the final `mode = ... else
+  "local"` CLAMP routes it to the safe general mode (it must NOT let `mode="as_of"` reach the
+  `if mode not in ("local","hybrid"): raise` guard). The clamp covers the aggregate path too.
 - `asof_object` returns `None` (anchor not found / no edge in slice) -> the `ask` branch returns
   `"(unknown)"`; the gate scores it as a miss.
 - `ask(mode="auto")` temporal branch never raises (parse-guarded) -> no regression vs slice 1.

--- a/docs/superpowers/specs/2026-06-27-goldengraph-temporal-mode-design.md
+++ b/docs/superpowers/specs/2026-06-27-goldengraph-temporal-mode-design.md
@@ -1,0 +1,178 @@
+# GoldenGraph query-router slice 2 -- temporal as-of mode + routing
+
+**Status:** design
+**Date:** 2026-06-27
+**Owner:** Ben Severn
+**Worktree:** `gg-temporal-mode` (branch `feat/goldengraph-temporal-mode`, STACKED on
+`feat/goldengraph-query-router` / slice 1 / PR #1283)
+
+## Problem
+
+Slice 1 built the query-routing kernel and promoted aggregation to a first-class LLM-free `ask`
+mode. It also *classifies* temporal "as of <date>" queries (`QueryIntent.TEMPORAL_ASOF`) but routes
+them to the general `local` mode with a `not_yet_promoted` marker, because no as-of answer mode
+exists in the engine. The capability is proven (slice B2: `goldengraph_asof` answers past-date
+queries 1.0 vs a temporal-blind floor 0.0) but lives only as a bench function. Slice 2 promotes it.
+
+## Goal
+
+Promote temporal as-of from the B2 bench traversal into a first-class `ask` mode and flip the
+router's `temporal_asof` plan from `not_yet_promoted` to a real `as_of` lever. Same two-tier shape
+as slice 1: a free deterministic gate (classifier + routed as-of-accuracy) + an opt-in real-LLM row.
+
+This is slice 2 of the 4-slice router program (1: kernel + aggregate [shipped, #1283]; 2: temporal
+[this]; 3: LLM classifier tier + confidence hardening; 4: meta-kernel unifying ER + query
+controllers).
+
+## Non-goals
+
+- **Bare-integer dates only.** The engineered B2 question is `"As of {D}, what does {anchor}
+  {rel_words}?"` with `D` an integer (1-100). Slice 2 parses that integer. Real calendar-date
+  parsing (years / ISO / relative) is OUT -- it pairs naturally with the slice-3 LLM tier (or a
+  dedicated date-util); stated honestly, not faked.
+- **No change to the existing B2 bench** (`temporal.py` stays QID-named for its id-space parity).
+  The gate builds its own concept-surface-named store (below).
+- No LLM in the deterministic gate. No change to slice-1's aggregate path or to `local`/`hybrid`/
+  `global`.
+
+## Architecture
+
+### 1. Router kernel (`goldengraph/route.py`, MODIFY)
+
+- Extend `classify_query`'s `TEMPORAL_ASOF` branch to extract slots. New `_TEMPORAL_LEADIN_RE`
+  matches `"As of <D>, what does <rest>"`; `D` -> `as_of` (the raw integer string), and `<rest>` is
+  split into `anchor_surface` + `relation` by the SAME predicate-suffix match the aggregate path
+  uses (`_extract_agg_slots` is generalized / reused). Confidence high when anchor+relation+as_of
+  all resolve.
+- `plan_query`: `TEMPORAL_ASOF` with anchor+relation+as_of and confidence >= MIN_CONF ->
+  `RetrievalPlan(mode="as_of")`; below threshold or missing slots -> the existing safe `local`
+  fallback (DROP the `not_yet_promoted` note).
+
+### 2. As-of as a first-class `ask` mode (`goldengraph/answer.py`, MODIFY)
+
+```
+def asof_object(slice_graph, anchor_surface: str, relation: str) -> str | None:
+    """The object on a (subj==seed, predicate==relation) edge present IN THIS SLICE.
+    The slice already encodes the as-of window, so this is the aggregate traversal
+    returning ONE object. LLM-free."""
+    seeds = slice_graph.seeds_by_name(anchor_surface)
+    if not seeds:
+        return None
+    sub = slice_graph.query(seeds, 1)
+    id_to_name = {e["entity_id"]: e["canonical_name"] for e in sub.get("entities", ())}
+    seedset = set(seeds)
+    objs = {
+        id_to_name[e["obj"]]
+        for e in sub.get("edges", ())
+        if e["subj"] in seedset and e["predicate"] == relation and e["obj"] in id_to_name
+    }
+    objs.discard(anchor_surface)
+    return next(iter(sorted(objs)), None)
+```
+
+**The genuinely-new bit -- the date is the slice time.** In `ask(mode="auto")`, the temporal branch
+parses `profile.as_of -> D = int(...)` and slices `store.as_of(D, tx_t)`, **overriding the caller's
+`valid_t`** (a temporal query carries its own time). A non-integer/missing `as_of` (or any parse
+failure) falls through to the safe general mode -- never raises. Add the branch alongside the
+slice-1 aggregate branch, right after the existing `slice_graph = store.as_of(valid_t, tx_t)` line:
+
+```
+    if mode == "auto":
+        profile = classify_query(query, predicates=_slice_predicates(slice_graph))
+        plan = plan_query(profile)
+        if plan.mode == "aggregate" and profile.anchor_surface and profile.relation:
+            return _format_aggregate(aggregate_members(slice_graph, profile.anchor_surface, profile.relation))
+        if plan.mode == "as_of" and profile.anchor_surface and profile.relation and profile.as_of:
+            try:
+                d = int(profile.as_of)
+            except ValueError:
+                d = None
+            if d is not None:
+                obj = asof_object(store.as_of(d, tx_t), profile.anchor_surface, profile.relation)
+                return obj if obj is not None else "(unknown)"
+        mode = plan.mode  # fall through to local/hybrid/global
+```
+
+### 3. Gate (free, deterministic, key-free; extends the slice-1 router gate)
+
+The slice-1 `router_eval.py` gate is extended to cover BOTH levers (one `ROUTER.md`, one
+`RouterResult`). Reuses the B2 corpus (`generate_temporal`) + `goldengraph_asof` as the parity
+reference.
+
+**The representation fix (the design's load-bearing point):** B2's `build_temporal_store` names
+nodes by **QID** (`surface_names=[anchor_id]`), but the question text uses the concept *surface*
+(`by_id[src_id].canonical`). So question-text `seeds_by_name(concept)` cannot find a QID-named
+anchor. The gate builds a **concept-surface-named** bi-temporal store: a gate-local
+`_build_concept_named_temporal_store(facts, by_id)` mirroring `build_temporal_store`'s valid_to
+windows but with `surface_names=[by_id[id].canonical]` and `canonical_name=[concept]` (record_keys
+stay the QID so oracle merge is unchanged). Then `canonical_name == concept surface`,
+`seeds_by_name(concept)` resolves, and the returned object name is the object's concept surface,
+compared to the name-projected gold `by_id[q.gold_obj].canonical`. This is both necessary for
+name-seeding AND more realistic than the QID-named bench store (a real ingest produces
+concept-named nodes). B2's own bench is untouched.
+
+Gate assertions (all HARD, added to slice-1's three):
+4. **Temporal classifier** (wheel-free): every B2 question classifies `TEMPORAL_ASOF` with correct
+   `anchor_surface == by_id[q.anchor_id].canonical`, `relation == q.relation`, `int(as_of) == q.D`.
+5. **Routed as-of-accuracy** (wheel): route each question through `classify_query -> store.as_of(D)
+   -> asof_object`; as-of-accuracy (vs `by_id[q.gold_obj].canonical`) == 1.0 in BOTH regimes (past +
+   current). The capability is the PAST regime (a temporal-blind reader returns the corrected-away
+   value; B2 floor = 0.0 there).
+
+Thresholds frozen from the first measured run (verify-then-freeze). STOP-and-surface if routed
+as-of-accuracy is not 1.0 in either regime (the engine-native as-of traversal or the
+date->slice-time wiring is wrong).
+
+### Opt-in real-LLM confirmation (`bench-graphrag-qa`, ungated)
+
+Extend slice-1's `run_router_capability` lane: on the past-regime questions, compare answer-match of
+`ask(mode="auto")` (routes to as-of, slices at D) vs `ask(mode="local")` (general, no temporal
+slice). Shows routing to the as-of lever WINS on a corrected-away past value. Non-gating, `|| true`,
+billing-blocked.
+
+## Components / file structure
+
+- `packages/python/goldengraph/goldengraph/route.py` (MODIFY): `_TEMPORAL_LEADIN_RE`, temporal slot
+  extraction in `classify_query`, `plan_query` `as_of` rule (drop `not_yet_promoted`).
+- `packages/python/goldengraph/goldengraph/answer.py` (MODIFY): `asof_object`, the `as_of` branch in
+  `ask(mode="auto")`.
+- `packages/python/goldengraph/tests/test_route.py` (MODIFY): temporal intent + slot tests.
+- `packages/python/goldengraph/tests/test_aggregate_mode.py` (MODIFY) or a new
+  `tests/test_asof_mode.py` (CREATE): `asof_object` + `ask(mode="auto")` temporal dispatch (wheel;
+  importorskip). Build a tiny 2-window store (X-rel-A [1,5), X-rel-B [5,inf)) and assert the answer
+  flips across D.
+- `erkgbench/qa_e2e/router_eval.py` (MODIFY): `_build_concept_named_temporal_store`,
+  `temporal_classifier_accuracy`, `run_temporal_routed_accuracy`, extend `RouterResult` +
+  `run_router_deterministic` + `evaluate_assertions` + `render_router_md`.
+- `tests/test_qa_router.py` (MODIFY): temporal classifier-accuracy + gate-shape for the new
+  assertions.
+- `.github/workflows/bench-graphrag-qa.yml` (MODIFY): the `run_router_capability` step already runs
+  `--with-llm`; extend `run_router_llm` to add the temporal auto-vs-local comparison (no new input).
+
+## Error handling
+
+- `classify_query` never raises; a temporal query with an unparseable date -> `as_of` set but the
+  `ask` branch's `int()` guard falls through to `local`.
+- `asof_object` returns `None` (anchor not found / no edge in slice) -> the `ask` branch returns
+  `"(unknown)"`; the gate scores it as a miss.
+- `ask(mode="auto")` temporal branch never raises (parse-guarded) -> no regression vs slice 1.
+
+## Testing strategy (TDD)
+
+Per-task failing-test-first, ruff-clean per commit. `route.py` temporal tests + temporal
+classifier-accuracy run wheel-free; `asof_object` + routed correctness need the wheel
+(`goldengraph-pipeline`). Verify routed as-of-accuracy == 1.0 in both regimes on the real B2 corpus
+before freezing thresholds.
+
+## Open risks
+
+- **Concept-name collisions / multi-object windows.** At a given D exactly one of (A,B) is valid per
+  fact by construction (windows `[T1,tc)` and `[tc,inf)` partition time), so `asof_object` sees one
+  object; `sorted(...)[0]` is a deterministic tie-break guard if a corpus ever violates that.
+- **The date-overrides-`valid_t` semantics.** Documented and intentional: a temporal-routed query
+  determines its own slice. Non-temporal modes still honor the caller's `valid_t`. Stated in the
+  `ask` docstring.
+- **If routed as-of-accuracy is not 1.0** in either regime, STOP and surface -- the as-of traversal
+  or the date wiring is wrong; do not loosen the gate.
+- **Bare-int scope.** Real dates are S3; the gate's claim is scoped to the engineered integer-time
+  corpus, said in the render.

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -29,6 +29,24 @@ def aggregate_members(slice_graph, anchor_surface: str, relation: str) -> set[st
     }
 
 
+def asof_object(slice_graph, anchor_surface: str, relation: str) -> str | None:
+    """The object on a (subj==seed, predicate==relation) edge present IN THIS SLICE (the slice
+    already encodes the as-of window). The aggregate traversal returning ONE object. LLM-free."""
+    seeds = slice_graph.seeds_by_name(anchor_surface)
+    if not seeds:
+        return None
+    sub = slice_graph.query(seeds, 1)
+    id_to_name = {e["entity_id"]: e["canonical_name"] for e in sub.get("entities", ())}
+    seedset = set(seeds)
+    objs = {
+        id_to_name[e["obj"]]
+        for e in sub.get("edges", ())
+        if e["subj"] in seedset and e["predicate"] == relation and e["obj"] in id_to_name
+    }
+    objs.discard(anchor_surface)
+    return next(iter(sorted(objs)), None)
+
+
 def _format_aggregate(members: set[str]) -> str:
     return ", ".join(sorted(members)) if members else "(none found)"
 
@@ -113,7 +131,18 @@ def ask(
             return _format_aggregate(
                 aggregate_members(slice_graph, profile.anchor_surface, profile.relation)
             )
-        mode = plan.mode  # fall through to the existing local/hybrid/global handling
+        if plan.mode == "as_of" and profile.anchor_surface and profile.relation and profile.as_of:
+            # the date IS the slice time -> override the caller's valid_t for this temporal query
+            try:
+                d = int(profile.as_of)
+            except ValueError:
+                d = None
+            if d is not None:
+                obj = asof_object(store.as_of(d, tx_t), profile.anchor_surface, profile.relation)
+                return obj if obj is not None else "(unknown)"
+        # clamp: a specialized plan that did NOT return must not carry an invalid mode into the
+        # `if mode not in ("local","hybrid"): raise` guard below
+        mode = plan.mode if plan.mode in ("local", "hybrid", "global") else "local"
     if mode == "global":
         communities = slice_graph.communities()[:max_communities]
         views = [slice_graph.query(c["members"], 1) for c in communities]

--- a/packages/python/goldengraph/goldengraph/route.py
+++ b/packages/python/goldengraph/goldengraph/route.py
@@ -47,24 +47,44 @@ _LEADIN_RE = re.compile(
 )
 
 
-def _extract_agg_slots(query: str, predicates) -> tuple[str | None, str | None]:
-    m = _LEADIN_RE.match(query)
-    if not m:
-        return None, None
-    rest = m.group("rest").strip()
+def _split_anchor_relation(rest: str, predicates) -> tuple[str | None, str | None]:
+    """Split '<anchor> <relation words>' by matching the LONGEST predicate phrase that is a suffix
+    of `rest`; the prefix is the anchor. Without `predicates` the relation can't be split out."""
+    rest = rest.strip()
     if not predicates:
-        return rest, None  # can't split anchor from relation without the vocab
-    # longest predicate-phrase that is a suffix of `rest` -> that's the relation; prefix is anchor.
+        return (rest or None), None
     best = None
     for pred in predicates:
         phrase = pred.replace("_", " ")
         if rest.lower().endswith(phrase.lower()) and (best is None or len(phrase) > len(best[1])):
             best = (pred, phrase)
     if best is None:
-        return rest, None
+        return (rest or None), None
     pred, phrase = best
     anchor = rest[: len(rest) - len(phrase)].strip()
     return (anchor or None), pred
+
+
+def _extract_agg_slots(query: str, predicates) -> tuple[str | None, str | None]:
+    m = _LEADIN_RE.match(query)
+    if not m:
+        return None, None
+    return _split_anchor_relation(m.group("rest"), predicates)
+
+
+_TEMPORAL_LEADIN_RE = re.compile(
+    r"^\s*as of\s+(?P<d>\d+)\s*,\s*what does\s+(?P<rest>.+?)\s*[.?]?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _extract_temporal_slots(query: str, predicates):
+    """(anchor, relation, as_of) from 'As of <D>, what does <anchor> <relation words>?'."""
+    m = _TEMPORAL_LEADIN_RE.match(query)
+    if not m:
+        return None, None, None
+    anchor, relation = _split_anchor_relation(m.group("rest"), predicates)
+    return anchor, relation, m.group("d")
 
 
 def classify_query(query: str, *, predicates=None) -> QueryProfile:
@@ -76,6 +96,11 @@ def classify_query(query: str, *, predicates=None) -> QueryProfile:
         anchor, relation = _extract_agg_slots(query, predicates)
         conf = 0.9 if (anchor and relation) else 0.5
         return QueryProfile(intent=intent, anchor_surface=anchor, relation=relation, confidence=conf)
+    if intent is QueryIntent.TEMPORAL_ASOF:
+        anchor, relation, as_of = _extract_temporal_slots(query, predicates)
+        conf = 0.9 if (anchor and relation and as_of) else 0.5
+        return QueryProfile(intent=intent, anchor_surface=anchor, relation=relation,
+                            as_of=as_of, confidence=conf)
     conf = 0.5 if intent is not QueryIntent.MULTI_HOP else 0.3
     return QueryProfile(intent=intent, confidence=conf)
 
@@ -99,8 +124,14 @@ def plan_query(profile: QueryProfile) -> RetrievalPlan:
     ):
         return RetrievalPlan(mode="aggregate")
     if profile.intent is QueryIntent.TEMPORAL_ASOF:
-        # the as-of mode lands in slice 2; route to general for now but mark it honestly
-        return RetrievalPlan(mode="local", note="not_yet_promoted")
+        if (
+            profile.confidence >= MIN_CONF
+            and profile.anchor_surface
+            and profile.relation
+            and profile.as_of
+        ):
+            return RetrievalPlan(mode="as_of")
+        return RetrievalPlan(mode="local")  # low-confidence temporal -> safe general mode
     if profile.intent is QueryIntent.MULTI_HOP:
         return RetrievalPlan(mode="hybrid")
     return RetrievalPlan(mode="local")  # LOOKUP + low-confidence fallbacks

--- a/packages/python/goldengraph/tests/test_asof_mode.py
+++ b/packages/python/goldengraph/tests/test_asof_mode.py
@@ -1,0 +1,59 @@
+"""asof_object + ask(mode='auto') temporal dispatch -- needs goldengraph_native (CI lane)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("goldengraph_native")
+
+from conftest import StubEmbedder, StubLLM  # noqa: E402
+from goldengraph.answer import ask, asof_object  # noqa: E402
+
+_BIG = 10**12
+
+
+def _windowed_store():
+    # X works_at Apple for [1,5); X works_at Banana for [5, inf).
+    from goldengraph_native import _native as ggn
+
+    store = ggn.PyStore()
+    batch = {
+        "entities": [
+            {"local_id": 0, "canonical_name": "X", "typ": "concept", "surface_names": ["X"], "record_keys": ["kx"]},
+            {"local_id": 1, "canonical_name": "Apple", "typ": "concept", "surface_names": ["Apple"], "record_keys": ["ka"]},
+            {"local_id": 2, "canonical_name": "Banana", "typ": "concept", "surface_names": ["Banana"], "record_keys": ["kb"]},
+        ],
+        "edges": [
+            {"subj_local": 0, "predicate": "works_at", "obj_local": 1, "valid_from": 1, "valid_to": 5, "source_refs": []},
+            {"subj_local": 0, "predicate": "works_at", "obj_local": 2, "valid_from": 5, "valid_to": None, "source_refs": []},
+        ],
+        "ingested_at": 1,
+    }
+    store.append(json.dumps(batch))
+    return store
+
+
+def test_asof_object_flips_across_the_correction():
+    store = _windowed_store()
+    assert asof_object(store.as_of(3, _BIG), "X", "works_at") == "Apple"
+    assert asof_object(store.as_of(7, _BIG), "X", "works_at") == "Banana"
+
+
+def test_asof_object_none_when_anchor_missing():
+    store = _windowed_store()
+    assert asof_object(store.as_of(3, _BIG), "Nonexistent", "works_at") is None
+
+
+def test_ask_auto_routes_temporal_past():
+    store = _windowed_store()
+    out = ask("As of 3, what does X works_at?", store, llm=StubLLM("UNUSED"),
+              embedder=StubEmbedder({}), valid_t=_BIG, tx_t=_BIG, mode="auto")
+    assert out == "Apple"
+
+
+def test_ask_auto_routes_temporal_current():
+    store = _windowed_store()
+    out = ask("As of 7, what does X works_at?", store, llm=StubLLM("UNUSED"),
+              embedder=StubEmbedder({}), valid_t=_BIG, tx_t=_BIG, mode="auto")
+    assert out == "Banana"

--- a/packages/python/goldengraph/tests/test_asof_mode.py
+++ b/packages/python/goldengraph/tests/test_asof_mode.py
@@ -47,13 +47,15 @@ def test_asof_object_none_when_anchor_missing():
 
 def test_ask_auto_routes_temporal_past():
     store = _windowed_store()
-    out = ask("As of 3, what does X works_at?", store, llm=StubLLM("UNUSED"),
+    # NL question uses the SPACED relation phrase ("works at"), like the real B2 corpus
+    # (rel.replace("_"," ")); the slot-splitter suffix-matches the spaced predicate phrase.
+    out = ask("As of 3, what does X works at?", store, llm=StubLLM("UNUSED"),
               embedder=StubEmbedder({}), valid_t=_BIG, tx_t=_BIG, mode="auto")
     assert out == "Apple"
 
 
 def test_ask_auto_routes_temporal_current():
     store = _windowed_store()
-    out = ask("As of 7, what does X works_at?", store, llm=StubLLM("UNUSED"),
+    out = ask("As of 7, what does X works at?", store, llm=StubLLM("UNUSED"),
               embedder=StubEmbedder({}), valid_t=_BIG, tx_t=_BIG, mode="auto")
     assert out == "Banana"

--- a/packages/python/goldengraph/tests/test_route.py
+++ b/packages/python/goldengraph/tests/test_route.py
@@ -57,10 +57,33 @@ def test_plan_low_confidence_aggregate_falls_back():
     assert route.plan_query(p).mode in ("local", "hybrid")
 
 
-def test_plan_temporal_marked_not_yet_promoted():
-    p = route.classify_query("Who did X work for as of 2019?")
+def test_temporal_slots_extracted():
+    p = route.classify_query("As of 42, what does Metaphone works at?", predicates=_PREDS)
+    assert p.intent is route.QueryIntent.TEMPORAL_ASOF
+    assert p.anchor_surface == "Metaphone"
+    assert p.relation == "works_at"
+    assert p.as_of == "42"
+    assert p.confidence >= 0.8
+
+
+def test_temporal_multiword_anchor():
+    p = route.classify_query(
+        "As of 7, what does Levenshtein distance located in?", predicates=_PREDS
+    )
+    assert p.anchor_surface == "Levenshtein distance"
+    assert p.relation == "located_in"
+    assert p.as_of == "7"
+
+
+def test_plan_temporal_routes_to_as_of():
+    p = route.classify_query("As of 42, what does Metaphone works at?", predicates=_PREDS)
     plan = route.plan_query(p)
-    assert plan.mode == "local" and plan.note == "not_yet_promoted"
+    assert plan.mode == "as_of" and plan.note is None
+
+
+def test_plan_temporal_low_confidence_falls_back():
+    p = route.classify_query("As of 42, what does Metaphone works at?")
+    assert route.plan_query(p).mode == "local"
 
 
 def test_plan_multihop_routes_hybrid():

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/router_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/router_eval.py
@@ -233,6 +233,8 @@ class RouterLLMResult:
     auto_setf1: float | None
     local_setf1: float | None
     budget_exhausted: bool
+    temporal_auto_acc: float | None = None
+    temporal_local_acc: float | None = None
 
 
 def answer_setf1(answer_text: str, gold_names: set, universe: set) -> float:
@@ -278,13 +280,48 @@ def run_router_llm(*, seed: int, n_anchors: int, tracker) -> RouterLLMResult:
                      valid_t=_BIG, tx_t=_BIG, mode="local")
             auto_vals.append(answer_setf1(a, gold, universe))
             local_vals.append(answer_setf1(ln, gold, universe))
+        t_auto, t_local = _temporal_auto_vs_local(seed, n_anchors, engine, tracker, _BIG)
         return RouterLLMResult(
             auto_setf1=(sum(auto_vals) / len(auto_vals)) if auto_vals else None,
             local_setf1=(sum(local_vals) / len(local_vals)) if local_vals else None,
             budget_exhausted=tracker.budget_exhausted,
+            temporal_auto_acc=t_auto,
+            temporal_local_acc=t_local,
         )
     except Exception:
         return RouterLLMResult(auto_setf1=None, local_setf1=None, budget_exhausted=tracker.budget_exhausted)
+
+
+def _temporal_auto_vs_local(seed, n_anchors, engine, tracker, big):
+    """Past-regime temporal auto-vs-local over the concept-named WINDOWED store (NOT engine.build_kg:
+    real ingest doesn't parse the engineered date phrasing into valid_to windows). Returns
+    (auto_acc, local_acc) or (None, None) on failure. Uses the engine's real llm/embedder."""
+    try:
+        from goldengraph.answer import ask
+
+        from .temporal import as_of_accuracy, generate_temporal
+
+        _docs, facts, qs = generate_temporal(seed=seed, n_facts=n_anchors, ambiguity=0.6)
+        by_id = {e.id: e for e in _load_entities()}
+        universe = {e.canonical for e in _load_entities()}
+        store = _build_concept_named_temporal_store(facts, by_id)
+        a_vals, l_vals = [], []
+        for q in (q for q in qs if q.regime == "past"):
+            if tracker.budget_exhausted:
+                break
+            gold = by_id[q.gold_obj].canonical
+            a = ask(q.question, store, llm=engine._llm, embedder=engine._embedder,
+                    valid_t=big, tx_t=big, mode="auto")
+            ln = ask(q.question, store, llm=engine._llm, embedder=engine._embedder,
+                     valid_t=big, tx_t=big, mode="local")
+            a_vals.append(as_of_accuracy(first_known_name(a, universe), gold))
+            l_vals.append(as_of_accuracy(first_known_name(ln, universe), gold))
+        return (
+            (sum(a_vals) / len(a_vals)) if a_vals else None,
+            (sum(l_vals) / len(l_vals)) if l_vals else None,
+        )
+    except Exception:
+        return None, None
 
 
 def render_router_llm_md(res: RouterLLMResult) -> str:
@@ -298,5 +335,9 @@ def render_router_llm_md(res: RouterLLMResult) -> str:
         f"budget_exhausted: {res.budget_exhausted}\n\n"
         "| mode | answer_setF1 |\n|---|---|\n"
         f"| auto (routed->aggregate) | {_f(res.auto_setf1)} |\n"
-        f"| local (general) | {_f(res.local_setf1)} |\n"
+        f"| local (general) | {_f(res.local_setf1)} |\n\n"
+        "## temporal past-regime (as-of-accuracy on a corrected-away value)\n\n"
+        "| mode | as_of_accuracy |\n|---|---|\n"
+        f"| auto (routed->as_of, slices at D) | {_f(res.temporal_auto_acc)} |\n"
+        f"| local (general, no temporal slice) | {_f(res.temporal_local_acc)} |\n"
     )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/router_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/router_eval.py
@@ -34,12 +34,20 @@ class RouterResult:
     aggregate_recall: float
     slot_accuracy: float
     routed_setf1: float
+    # temporal (slice 2); defaults keep slice-1 constructions valid (1.0 == not-failing)
+    temporal_recall: float = 1.0
+    temporal_slot_acc: float = 1.0
+    temporal_past_acc: float = 1.0
+    temporal_current_acc: float = 1.0
 
 
 # frozen from the first measured run (verify-then-freeze)
 AGG_RECALL_MIN = 0.99
 SLOT_ACC_MIN = 0.99
 ROUTED_SETF1_MIN = 0.99
+TEMPORAL_RECALL_MIN = 0.99
+TEMPORAL_SLOT_MIN = 0.99
+TEMPORAL_ACC_MIN = 0.99
 
 
 def evaluate_assertions(res: RouterResult):
@@ -50,6 +58,12 @@ def evaluate_assertions(res: RouterResult):
          res.slot_accuracy >= SLOT_ACC_MIN, True),
         (f"routed aggregate set-F1 at ambiguity=0.0 (got {res.routed_setf1:.3f} >= {ROUTED_SETF1_MIN})",
          res.routed_setf1 >= ROUTED_SETF1_MIN, True),
+        (f"classifier routes temporal questions to TEMPORAL_ASOF (recall {res.temporal_recall:.3f} >= {TEMPORAL_RECALL_MIN})",
+         res.temporal_recall >= TEMPORAL_RECALL_MIN, True),
+        (f"temporal slots (anchor/relation/date) correct (acc {res.temporal_slot_acc:.3f} >= {TEMPORAL_SLOT_MIN})",
+         res.temporal_slot_acc >= TEMPORAL_SLOT_MIN, True),
+        (f"routed as-of-accuracy past={res.temporal_past_acc:.3f} current={res.temporal_current_acc:.3f} (both >= {TEMPORAL_ACC_MIN})",
+         res.temporal_past_acc >= TEMPORAL_ACC_MIN and res.temporal_current_acc >= TEMPORAL_ACC_MIN, True),
     ]
 
 
@@ -87,26 +101,121 @@ def run_routed_correctness(*, seed: int, n_anchors: int) -> float:
     return (sum(vals) / len(vals)) if vals else 0.0
 
 
+# --- temporal as-of routing (slice 2) ---
+
+
+def temporal_classifier_accuracy(*, seed: int, n_facts: int, ambiguity: float) -> dict:
+    from goldengraph.route import QueryIntent
+
+    from .temporal import generate_temporal
+
+    _docs, _facts, qs = generate_temporal(seed=seed, n_facts=n_facts, ambiguity=ambiguity)
+    by_id = {e.id: e for e in _load_entities()}
+    preds = set(RELATION_SCHEMA)
+    rec = slot = 0
+    for q in qs:
+        p = classify_query(q.question, predicates=preds)
+        if p.intent is QueryIntent.TEMPORAL_ASOF:
+            rec += 1
+        ok_date = p.as_of is not None and p.as_of.isdigit() and int(p.as_of) == q.D
+        if p.anchor_surface == by_id[q.anchor_id].canonical and p.relation == q.relation and ok_date:
+            slot += 1
+    n = len(qs) or 1
+    return {"temporal_recall": rec / n, "temporal_slot_acc": slot / n}
+
+
+def _build_concept_named_temporal_store(facts, by_id):
+    """Mirror temporal.build_temporal_store but name nodes by CONCEPT SURFACE (so question-text
+    seeds_by_name resolves) while keeping oracle merge on the QID record_keys. Needs the wheel."""
+    import json
+
+    from goldengraph_native import _native as ggn
+
+    from .temporal import T1
+
+    def ent(local, _id):
+        return {"local_id": local, "canonical_name": by_id[_id].canonical, "typ": "concept",
+                "surface_names": [by_id[_id].canonical], "record_keys": [_id]}
+
+    store = ggn.PyStore()
+    for f in facts:
+        batch = {
+            "entities": [ent(0, f.anchor_id), ent(1, f.a_id), ent(2, f.b_id)],
+            "edges": [
+                {"subj_local": 0, "predicate": f.relation, "obj_local": 1,
+                 "valid_from": T1, "valid_to": f.tc, "source_refs": []},
+                {"subj_local": 0, "predicate": f.relation, "obj_local": 2,
+                 "valid_from": f.tc, "valid_to": None, "source_refs": []},
+            ],
+            "ingested_at": 1,
+        }
+        store.append(json.dumps(batch))
+    return store
+
+
+def run_temporal_routed_accuracy(*, seed: int, n_facts: int, ambiguity: float) -> dict:
+    """Route each B2 question through classify_query -> store.as_of(D) -> asof_object; as-of-accuracy
+    by regime vs name-projected gold. Needs the wheel."""
+    from goldengraph.answer import asof_object
+
+    from .temporal import _BIG_TX, as_of_accuracy, generate_temporal
+
+    _docs, facts, qs = generate_temporal(seed=seed, n_facts=n_facts, ambiguity=ambiguity)
+    by_id = {e.id: e for e in _load_entities()}
+    store = _build_concept_named_temporal_store(facts, by_id)
+    preds = set(RELATION_SCHEMA)
+    acc: dict = {"past": [], "current": []}
+    for q in qs:
+        p = classify_query(q.question, predicates=preds)
+        got = None
+        if p.anchor_surface and p.relation and p.as_of and p.as_of.isdigit():
+            got = asof_object(store.as_of(int(p.as_of), _BIG_TX), p.anchor_surface, p.relation)
+        gold_name = by_id[q.gold_obj].canonical
+        acc[q.regime].append(as_of_accuracy(got, gold_name))
+    return {r: (sum(v) / len(v) if v else 0.0) for r, v in acc.items()}
+
+
+def first_known_name(text: str, universe: set) -> str | None:
+    """First universe name appearing in `text` (the single-object analog of parse_entity_set)."""
+    low = text.lower()
+    hits = [(low.index(n.lower()), n) for n in universe if n.lower() in low]
+    return min(hits)[1] if hits else None
+
+
 def run_router_deterministic(*, seed: int, n_anchors: int) -> RouterResult:
     acc = classifier_accuracy(seed=seed, n_anchors=n_anchors, ambiguity=0.0)
     routed = run_routed_correctness(seed=seed, n_anchors=n_anchors)
+    # Temporal: B2 store is oracle-keyed so ER is perfect regardless of ambiguity (it only affects
+    # rendered doc surfaces, which the gate does not read). NOTE: at n_facts==_N_ANCHORS the
+    # generator uses a single RELATION_SCHEMA[0] relation -- lower relation diversity, exact by
+    # construction.
+    tacc = temporal_classifier_accuracy(seed=seed, n_facts=n_anchors, ambiguity=0.6)
+    tr = run_temporal_routed_accuracy(seed=seed, n_facts=n_anchors, ambiguity=0.6)
     return RouterResult(
         aggregate_recall=acc["aggregate_recall"],
         slot_accuracy=acc["slot_accuracy"],
         routed_setf1=routed,
+        temporal_recall=tacc["temporal_recall"],
+        temporal_slot_acc=tacc["temporal_slot_acc"],
+        temporal_past_acc=tr.get("past", 0.0),
+        temporal_current_acc=tr.get("current", 0.0),
     )
 
 
 def render_router_md(res: RouterResult) -> str:
     lines = [
-        "# GoldenGraph query-router gate (slice 1, no LLM)",
+        "# GoldenGraph query-router gate (slices 1-2, no LLM)",
         "",
-        "Heuristic classify_query routes B1 list-questions to the aggregate lever; the engine-native",
-        "aggregate_members traversal returns the exact member set (name space, ambiguity=0.0).",
+        "Heuristic classify_query routes B1 list-questions to the aggregate lever and B2 temporal",
+        "questions to the as-of lever; the engine-native traversals return the exact answer.",
         "",
-        f"- aggregate_recall: {res.aggregate_recall:.3f}",
-        f"- slot_accuracy:    {res.slot_accuracy:.3f}",
-        f"- routed_setF1:     {res.routed_setf1:.3f}",
+        f"- aggregate_recall:     {res.aggregate_recall:.3f}",
+        f"- slot_accuracy:        {res.slot_accuracy:.3f}",
+        f"- routed_setF1:         {res.routed_setf1:.3f}",
+        f"- temporal_recall:      {res.temporal_recall:.3f}",
+        f"- temporal_slot_acc:    {res.temporal_slot_acc:.3f}",
+        f"- temporal_past_acc:    {res.temporal_past_acc:.3f}",
+        f"- temporal_current_acc: {res.temporal_current_acc:.3f}",
         "",
         "## verdicts",
         "",

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_router.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_router.py
@@ -33,3 +33,30 @@ def test_answer_setf1_pure():
 def test_answer_setf1_partial():
     got = re_.answer_setf1("Only Banana here.", {"Banana", "Cherry"}, {"Banana", "Cherry"})
     assert 0.0 < got < 1.0
+
+
+def test_temporal_classifier_accuracy_on_b2_questions():
+    acc = re_.temporal_classifier_accuracy(seed=7, n_facts=20, ambiguity=0.6)
+    assert acc["temporal_recall"] == 1.0
+    assert acc["temporal_slot_acc"] == 1.0
+
+
+def test_gate_shape_includes_temporal():
+    res = re_.RouterResult(
+        aggregate_recall=1.0, slot_accuracy=1.0, routed_setf1=1.0,
+        temporal_recall=1.0, temporal_slot_acc=1.0, temporal_past_acc=1.0, temporal_current_acc=1.0,
+    )
+    assert re_.gate_exit_code(res) == 0
+
+
+def test_gate_fails_when_temporal_past_low():
+    res = re_.RouterResult(
+        aggregate_recall=1.0, slot_accuracy=1.0, routed_setf1=1.0,
+        temporal_recall=1.0, temporal_slot_acc=1.0, temporal_past_acc=0.0, temporal_current_acc=1.0,
+    )
+    assert re_.gate_exit_code(res) == 1
+
+
+def test_first_known_name_in_text():
+    assert re_.first_known_name("It is Banana.", {"Apple", "Banana"}) == "Banana"
+    assert re_.first_known_name("nothing", {"Apple"}) is None


### PR DESCRIPTION
## Summary
Slice 2 of the KG/RAG query-routing controller (slice 1 = #1283, merged). Promotes temporal as-of from a bench function into a first-class LLM-free `ask` mode and flips the router's `temporal_asof` plan from `not_yet_promoted` to a real `as_of` lever.

- **Router kernel** (`route.py`): temporal slot extraction (`_TEMPORAL_LEADIN_RE` -> anchor/relation/`as_of` integer, via a shared `_split_anchor_relation` factored from the aggregate path); `plan_query` routes `TEMPORAL_ASOF` -> `as_of`.
- **As-of as a first-class `ask` mode** (`answer.py`): `asof_object` = the aggregate traversal returning one object on the as-of slice. **The date is the slice time** — `ask(mode="auto")` parses the query's integer and slices `store.as_of(D)`, overriding the caller's `valid_t`. A **clamp** routes any non-returning specialized plan to a valid mode (fixes a latent `raise` the spec review caught; also retro-hardens slice 1's aggregate path).
- **Gate** (extends the slice-1 router gate, key-free): temporal classifier accuracy + routed as-of-accuracy in both regimes. Load-bearing fix — B2's bench store is **QID-named**, so the gate builds a **concept-surface-named windowed store** so question-text `seeds_by_name` resolves and comparison is name-space.
- Opt-in real-LLM temporal `auto`-vs-`local` row over the windowed store (`run_router_capability` lane).
- Honest scope: bare-integer dates (corpus-shaped); real calendar dates are slice 3.

Spec: `docs/superpowers/specs/2026-06-27-goldengraph-temporal-mode-design.md`
Plan: `docs/superpowers/plans/2026-06-27-goldengraph-temporal-mode.md`

## Test Plan
- [x] 14 route-kernel + 10 router-gate tests pass locally (wheel-free, post-rebase); ruff clean.
- [x] Temporal classifier validated on REAL B2 questions: temporal_recall 1.0 + slot_acc 1.0.
- [ ] `goldengraph-pipeline` green (builds the wheel, runs `asof_object` + routed as-of-accuracy in both regimes). Thresholds are placeholders pending the first measured `ROUTER.md`; will freeze (and surface if routed accuracy != 1.0 in either regime) before arming auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)