### PR TITLE
docs(readme): healing loop is shipped on every surface, not "in progress"

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ GoldenMatch's core workflow is a loop, not a one-shot:
 
 1. **Zero-config first pass** — `dedupe_df(df)` runs with no rules and no training data. Auto-config picks a defensible config and you get good results immediately.
 2. **You get the config it chose** — the chosen config comes back on `result.config`: inspectable, diffable, versionable. Never a black box.
-3. **The healer suggests tweaks** — `review_config(df, config)` reviews the results against the config and emits ranked, explainable, self-verified edits. Each suggestion is kept only if it doesn't worsen an unsupervised health proxy, so a tweak never makes results worse.
-4. **You apply the tweaks** — `apply_suggestion` turns a suggestion into an improved config.
-5. **Results improve. Repeat** — re-run and loop until the healer goes quiet.
+3. **The healer suggests tweaks** — every `dedupe_df(df)` run checks a free signal and, when there's headroom, attaches ranked, explainable, self-verified edits to `result.suggestions` (no extra cost on a healthy result). Each suggestion is kept only if it doesn't worsen an unsupervised health proxy, so a tweak never makes results worse.
+4. **You apply the tweaks** — `dedupe_df(df, heal=True)` applies them and re-runs in one call (returning the healed `result.config` + a `result.heal_trail`); or take the wheel with `apply_suggestion`.
+5. **Results improve. Repeat** — loop until the healer goes quiet.
 
 Zero-config gets you most of the way in one pass; the healing loop closes the gap to an expert-tuned config without you having to be the expert.
 
-> **Status:** the healer is opt-in via the Python API (`from goldenmatch.core.suggest import review_config`) and needs `goldenmatch[native]`. It is not yet wired into the default `dedupe_df` pipeline; CLI/MCP surfaces are in progress. Full details: [config-suggestions](https://docs.bensevern.dev/goldenmatch/config-suggestions).
+> **Status:** the healer is **wired into the default pipeline** on every surface — Python (`dedupe_df(df, suggest=True)` for verified suggestions, `heal=True` for the full apply-and-re-run loop, or `review_config` for direct control), CLI (`--suggest` / `--heal`), MCP & A2A (`review_config`), REST, web, and the TUI — plus the edge-safe TypeScript port via WebAssembly (`enableSuggestWasm()`). It needs `goldenmatch[native]` and degrades gracefully without it (attaches nothing, never errors). Kill-switch: `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`. Full details: [config-suggestions](https://docs.bensevern.dev/goldenmatch/config-suggestions).
 
 ---
 


### PR DESCRIPTION
## Summary

The root README's **"The healing loop"** section was stale — its `Status` blockquote still claimed the healer was opt-in-only and **"not yet wired into the default `dedupe_df` pipeline; CLI/MCP surfaces in progress."** That's been false since the default-pipeline (#1275) and WASM/TS (#1277) work merged.

Updated to reflect reality:
- **Status blockquote:** the healer is wired into the default pipeline on every surface — Python (`dedupe_df(suggest=True)` / `heal=True` / `review_config`), CLI (`--suggest`/`--heal`), MCP & A2A (`review_config`), REST, web, TUI — plus the TS/WASM port via `enableSuggestWasm()`. Needs `goldenmatch[native]`, degrades gracefully without it, kill-switch `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`.
- **Steps 3–4:** now show the default-on `dedupe_df(suggest=/heal=)` surface (suggestions ride along on every run; `heal=True` applies + re-runs), not just the manual `review_config`/`apply_suggestion` path.

Docs-only. Auto-synced README-callout block untouched (`readme_callouts --check` passes).

## Test plan
- [x] `scripts/check_docs_consistency.py` — all gates pass (callout-sync, version, nav, roster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)