### PR TITLE
ci(suggest-quality): bump timeout 60 to 120 (fix perpetual red main)

### DIFF
--- a/.github/workflows/bench-suggest-quality.yml
+++ b/.github/workflows/bench-suggest-quality.yml
@@ -45,7 +45,11 @@ permissions:
 jobs:
   suggest-quality:
     runs-on: ${{ inputs.runner || 'large-new-64GB' }}
-    timeout-minutes: 60
+    # The gym-gate step (FULL_DIST over the whole catalog) + native build + the
+    # regular gate overrun 60min on every push, cancelling the job at "Complete
+    # job" -> a perpetual red `suggest-quality` check on main. 120 gives the
+    # FULL_DIST work headroom (a one-shot gym-bless completed in ~70min under it).
+    timeout-minutes: 120
     env:
       GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
       GOLDENMATCH_NATIVE: "1"


### PR DESCRIPTION
## Summary

Fixes **main showing red**: the `suggest-quality` check has been CANCELLED on every recent push.

**Root cause:** the job has `timeout-minutes: 60`, but each push runs the regular gate (FULL_DIST=0) PLUS the `gym-gate` (FULL_DIST=1 over the whole catalog) PLUS the native build. Latest run: 06:22 to 07:23 = **61 min** — the regular gate passed, gym-gate was mid-flight when the 60-min cap killed the job, conclusion `cancelled`, red. It is non-required (never blocked a merge), but the cancelled check renders red on main.

Same fix I made earlier on the #1271 branch, which was closed/superseded and never merged — so main still had 60.

**Fix:** `timeout-minutes: 60 -> 120`. A one-shot gym-bless completed in ~70 min under a 120 cap, so there is ample headroom. Editing the workflow (in its own push-paths) re-triggers a fresh, now-passing `suggest-quality` run on the new main HEAD, clearing the red.

## Test plan
- [x] YAML parses.
- [ ] After merge: the `suggest-quality` run on the new main HEAD completes (not cancelled), main green.
