### PR TITLE
Fix config_critique blocking-blindness (#1261, #1263)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/config_critique.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_critique.py
@@ -581,7 +581,7 @@ def _detect_distributed_over_merge(
             f"merge across many medium clusters"
             + (f"; the run merged {pct} of records" if pct else "")
             + ". This is precision collapse spread thin enough that no single "
-            f"cluster looks oversized."
+            "cluster looks oversized."
         )
     else:
         title = "Records are grouped using a column with very few values"

--- a/packages/python/goldenmatch/goldenmatch/core/config_critique.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_critique.py
@@ -70,6 +70,23 @@ _IDENTITY_COL_TYPES = frozenset(
 _BLOCK_P99_WARN = 5000
 _BLOCK_P99_HIGH = 50_000
 
+# Distributed-over-merge detector (#1261). A precision collapse that is spread
+# across many MEDIUM clusters (no single mega-cluster) is invisible to the
+# oversized-cluster smell, so this looks at the BLOCKING side instead: blocking
+# that leans entirely on low-cardinality columns lets unrelated records collide.
+# A blocking field at/above this distinct-ratio is a real anchor (near-unique
+# keys don't distributed-over-merge); below it the field is "low-signal" for
+# blocking and a handful of values group large swaths of the data.
+_DIST_STRONG_BLOCK_CARD = 0.5
+_DIST_LOW_BLOCK_CARD = 0.1
+# Col types that are strong blocking anchors regardless of the sampled ratio.
+_DIST_STRONG_BLOCK_TYPES = frozenset({"email", "phone", "identifier"})
+# Merge evidence floors: fire only when the run actually merged a lot. From real
+# clusters, the fraction of records that landed in a multi-member cluster; from
+# preliminary signals alone, the p95 cluster size (medium clusters forming).
+_DIST_MERGE_RATE = 0.10
+_DIST_CLUSTER_P95 = 3
+
 # severity → rank for stable high→low ordering.
 _SEVERITY_RANK = {"high": 0, "medium": 1, "low": 2}
 
@@ -313,7 +330,16 @@ def _detect_low_signal_key(
                     "column": col,
                     "cardinality_ratio": round(prof.cardinality_ratio, 4),
                 },
-                fix_config_hint={"action": "demote_to_blocking", "column": col},
+                # #1263: the remedy is ``exclude_column`` (drop it from scoring),
+                # NOT ``demote_to_blocking``. A column that trips this detector is
+                # near-constant by definition (cardinality_ratio < 0.01) — exactly
+                # the property that makes it a catastrophic STANDALONE blocking
+                # key (a handful of values group the whole dataset). Demoting it
+                # to its own blocking pass collapsed candidate generation into a
+                # few mega-blocks and tanked precision. ``exclude_column``'s
+                # collapse guard preserves the column where it's load-bearing for
+                # blocking and only removes its (useless) scoring role.
+                fix_config_hint={"action": "exclude_column", "column": col},
                 title_plain=title,
                 detail_plain=detail,
                 fix_plain=(
@@ -427,6 +453,159 @@ def _detect_over_merge(
             fix_plain=(
                 "Raise the match threshold (or tighten the rules) so only "
                 "strong evidence merges records."
+            ),
+        )
+    ]
+
+
+def _merge_signal(
+    signals: dict | None, clusters: dict | None, n_rows: int
+) -> tuple[float | None, int, bool]:
+    """Summarize how much the run merged.
+
+    Returns ``(merge_rate, p95, mega)``:
+    - ``merge_rate`` — fraction of input records that landed in a multi-member
+      cluster, from the REAL clusters when present, else ``None``.
+    - ``p95`` — 95th-percentile preliminary cluster size (medium clusters
+      forming), from postflight signals; ``0`` if unavailable.
+    - ``mega`` — a >100-member cluster exists; the oversized-cluster smell
+      (:func:`_detect_over_merge`) already owns that case, so the distributed
+      detector defers to it.
+    """
+    mega = False
+    p95 = 0
+    if signals:
+        if signals.get("oversized_clusters"):
+            mega = True
+        prelim = signals.get("preliminary_cluster_sizes") or {}
+        pv = prelim.get("p95")
+        if isinstance(pv, (int, float)):
+            p95 = int(pv)
+        pmax = prelim.get("max")
+        if isinstance(pmax, (int, float)) and pmax > 100:
+            mega = True
+    merge_rate: float | None = None
+    if clusters and n_rows > 0:
+        try:
+            merged = 0
+            for info in clusters.values():
+                if not isinstance(info, dict):
+                    continue
+                members = info.get("members")
+                size = len(members) if members is not None else info.get("size", 0)
+                if isinstance(size, int) and size > 1:
+                    merged += size
+                    if size > 100:
+                        mega = True
+            merge_rate = merged / n_rows
+        except Exception:
+            merge_rate = None
+    return merge_rate, p95, mega
+
+
+def _detect_distributed_over_merge(
+    config: GoldenMatchConfig,
+    signals: dict | None,
+    clusters: dict | None,
+    profiles_by_name: dict[str, ColumnProfile],
+    n_rows: int,
+    phrasing: str,
+) -> list[dict]:
+    """Flag precision collapse driven by low-cardinality blocking (#1261).
+
+    The oversized-cluster detector only fires on a single mega-cluster (>100
+    members). When the over-merge is DISTRIBUTED across many medium clusters —
+    the textbook failure when blocking leans on a few low-cardinality columns
+    (e.g. ~30 surnames / 12 companies across 416 rows, so unrelated people
+    collide on name+company+city) — no cluster is individually huge and the
+    smell stays silent at precision 0.22. This detector looks at the BLOCKING
+    side: blocking that has NO strong anchor (every key is a low-cardinality
+    column) plus real merging is the distributed-over-merge signature.
+    """
+    blocking = getattr(config, "blocking", None)
+    if blocking is None:
+        return []
+    try:
+        from goldenmatch.core.blocker import collect_blocking_fields
+
+        block_fields = collect_blocking_fields(blocking)
+    except Exception:
+        return []
+    if not block_fields:
+        return []
+
+    # Resolve each blocking field's cardinality. A field with no profile is
+    # treated as unknown (can't assess) — skip it for the anchor check.
+    low_card: list[tuple[str, int]] = []  # (column, distinct_value_count)
+    for col in block_fields:
+        prof = profiles_by_name.get(col)
+        if prof is None:
+            continue
+        if (
+            prof.cardinality_ratio >= _DIST_STRONG_BLOCK_CARD
+            or prof.col_type in _DIST_STRONG_BLOCK_TYPES
+        ):
+            return []  # a strong anchor key — distributed over-merge unlikely.
+        if prof.cardinality_ratio < _DIST_LOW_BLOCK_CARD:
+            distinct = max(1, round(prof.cardinality_ratio * n_rows))
+            low_card.append((col, distinct))
+    if not low_card:
+        return []
+
+    merge_rate, p95, mega = _merge_signal(signals, clusters, n_rows)
+    if mega:
+        return []  # the oversized-cluster detector owns the mega-cluster case.
+    has_merge = (
+        merge_rate is not None and merge_rate >= _DIST_MERGE_RATE
+    ) or (merge_rate is None and p95 >= _DIST_CLUSTER_P95)
+    if not has_merge:
+        return []
+
+    # Report the weakest (fewest-distinct) blocking key as the culprit.
+    col, distinct = min(low_card, key=lambda t: t[1])
+    evidence: dict = {"blocking_key": col, "distinct_values": distinct}
+    if merge_rate is not None:
+        evidence["merge_rate"] = round(merge_rate, 3)
+    else:
+        evidence["cluster_p95"] = p95
+    pct = f"{round((merge_rate or 0) * 100)}%" if merge_rate is not None else None
+    if phrasing == "technical":
+        title = (
+            f"Blocking key '{col}' has only {distinct} distinct values "
+            f"(distributed over-merge risk)"
+        )
+        detail = (
+            f"Blocking relies on low-cardinality column '{col}' "
+            f"(~{distinct} distinct values) with no near-unique anchor key, so "
+            f"unrelated records that merely share '{col}' are compared and can "
+            f"merge across many medium clusters"
+            + (f"; the run merged {pct} of records" if pct else "")
+            + ". This is precision collapse spread thin enough that no single "
+            f"cluster looks oversized."
+        )
+    else:
+        title = "Records are grouped using a column with very few values"
+        detail = (
+            f"The matching groups records by '{col}', which only has about "
+            f"{distinct} different values, and there's no more specific key to "
+            f"separate them. So unrelated records that happen to share '{col}' "
+            f"get compared and merged"
+            + (f" (about {pct} of records ended up merged)" if pct else "")
+            + ". The over-merging is spread across many groups, so no single "
+            "group looks too big — but precision still suffers."
+        )
+    return [
+        _finding(
+            id="distributed_over_merge",
+            severity="high",
+            evidence=evidence,
+            fix_config_hint={"action": "compound_blocking"},
+            title_plain=title,
+            detail_plain=detail,
+            fix_plain=(
+                f"Add a more specific blocking key — combine '{col}' with "
+                "another field (or add a stronger key) so records that only "
+                f"share '{col}' aren't compared."
             ),
         )
     ]
@@ -609,6 +788,10 @@ def diagnose_config(
     profiles_by_name = _profiles_by_name(df)
     signals = _signals_of(result)
     clusters = _clusters_of(result)
+    try:
+        n_rows = df.height
+    except Exception:
+        n_rows = 0
 
     findings: list[dict] = []
     findings += _safe(_detect_source_admitted, referenced, excluded, phrasing)
@@ -617,6 +800,15 @@ def diagnose_config(
     )
     findings += _safe(_detect_oversized_block, signals, phrasing)
     findings += _safe(_detect_over_merge, signals, clusters, phrasing)
+    findings += _safe(
+        _detect_distributed_over_merge,
+        config,
+        signals,
+        clusters,
+        profiles_by_name,
+        n_rows,
+        phrasing,
+    )
     findings += _safe(_detect_null_sink, matchkey_cols, profiles_by_name, phrasing)
     findings += _safe(
         _detect_low_signal_key, matchkey_cols, profiles_by_name, phrasing
@@ -729,18 +921,41 @@ def _set_matchkeys(config: Any, matchkeys: list) -> None:
         config.matchkeys = matchkeys
 
 
+def _is_blocking_field(blocking: Any, column: str) -> bool:
+    """Whether ``column`` appears in any blocking key/pass/sub-block."""
+    if blocking is None:
+        return False
+    for attr in ("keys", "passes", "sub_block_keys"):
+        for kc in getattr(blocking, attr, None) or []:
+            if column in kc.fields:
+                return True
+    return False
+
+
 def _strip_column_from_blocking(blocking: Any, column: str) -> bool:
     """Remove ``column`` from blocking keys/passes/sub_block_keys (in place).
 
     A key/pass whose only field was ``column`` is dropped. Returns whether
     anything changed.
+
+    **Collapse guard (#1263):** if removing the column would leave blocking with
+    NO keys/passes/sub-blocks at all (it was the sole partition key), the strip
+    is refused and blocking is left untouched — dropping the only blocking key
+    turns candidate generation into a full cross-product. The column's
+    (load-bearing) blocking role is preserved; its scoring role is still removed
+    by the matchkey strip, and the caller skips ``exclude_columns`` so the two
+    don't contradict.
     """
     if blocking is None:
         return False
+    # Compute the post-removal groups WITHOUT committing, so a total collapse
+    # can be detected before any mutation.
+    proposed: dict[str, list] = {}
     changed = False
     for attr in ("keys", "passes", "sub_block_keys"):
         kcs = getattr(blocking, attr, None)
         if not kcs:
+            proposed[attr] = list(kcs or [])
             continue
         new_kcs: list = []
         for kc in kcs:
@@ -752,8 +967,14 @@ def _strip_column_from_blocking(blocking: Any, column: str) -> bool:
                 # else: single-field block on the column -> drop it
             else:
                 new_kcs.append(kc)
+        proposed[attr] = new_kcs
+    if not changed:
+        return False
+    if sum(len(v) for v in proposed.values()) == 0:
+        return False  # sole partition key — preserve blocking, refuse the strip.
+    for attr, new_kcs in proposed.items():
         setattr(blocking, attr, new_kcs)
-    return changed
+    return True
 
 
 def _add_blocking_pass(config: Any, column: str) -> bool:
@@ -818,10 +1039,16 @@ def _apply_exclude_column(config: Any, hint: dict) -> tuple[Any, bool]:
     if mk_changed:
         _set_matchkeys(new, mks)
     block_changed = _strip_column_from_blocking(new.blocking, column)
-    excl = list(new.exclude_columns or [])
-    excl_changed = column not in excl
-    if excl_changed:
-        new.exclude_columns = excl + [column]
+    # If the column is STILL a blocking field (the collapse guard kept it as the
+    # sole partition key), don't also add it to exclude_columns — that would
+    # neutralize the blocking key we just preserved. Strip it from scoring only.
+    still_blocking = _is_blocking_field(new.blocking, column)
+    excl_changed = False
+    if not still_blocking:
+        excl = list(new.exclude_columns or [])
+        if column not in excl:
+            new.exclude_columns = excl + [column]
+            excl_changed = True
     if not (mk_changed or block_changed or excl_changed):
         return new, False
     return _revalidated(config, new)
@@ -885,7 +1112,10 @@ def apply_hint(config: GoldenMatchConfig, fix_config_hint: dict) -> tuple[Any, b
     side). Supported actions:
 
     - ``exclude_column``: strip the column from every matchkey field and every
-      blocking key/pass, and add it to ``exclude_columns``.
+      blocking key/pass, and add it to ``exclude_columns``. If the column is the
+      SOLE blocking key, its blocking role is preserved (the strip + exclude are
+      skipped) so removal can't collapse candidate generation into a
+      cross-product (#1263).
     - ``demote_to_blocking``: strip the column from every matchkey field and add
       a single-field blocking pass on it (converting ``static``/``adaptive``
       blocking to an explicit ``multi_pass`` union when needed).

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -286,13 +286,18 @@ def _ensure_global_row_id(ds: Dataset) -> Dataset:
     if "__row_id__" in _row_columns(ds):
         return ds
 
-    # Only a real Ray Dataset supports the row-id assignment below. Stub-based
-    # wiring tests pass a bare object() whose only exercised method is the
-    # patched scorer -- leave anything without the Dataset API untouched.
-    if not (hasattr(ds, "count") and hasattr(ds, "zip")):
+    # Only a real Ray Dataset gets the row-id assignment below. In the ray-less
+    # python lane ``ds`` cannot be a real Dataset, and the mock/stub wiring tests
+    # pass a MagicMock or bare object(); a MagicMock satisfies ``hasattr`` for any
+    # attribute, so guard on the concrete type (not duck-typing) and import ray
+    # defensively -- both cases fall through to a no-op.
+    try:
+        import ray
+        from ray.data import Dataset as _RayDataset
+    except Exception:
         return ds
-
-    import ray
+    if not isinstance(ds, _RayDataset):
+        return ds
 
     logger.warning(
         "phase5: input rows carry no __row_id__; assigning a global row id "

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -168,6 +168,18 @@ def _run_phase5_pipeline(
         "distributed streaming pipeline (GOLDENMATCH_DISTRIBUTED_PIPELINE=2)",
     )
 
+    # 1c. Guarantee a GLOBAL __row_id__ on the input rows. Phase 5 scoring keys
+    #     pairs on __row_id__ and step 4 joins rows.__row_id__ == member_id, so
+    #     BOTH require a globally-unique id. Production inputs (the bench parquet
+    #     generator) already carry it -- a no-op that leaves the streaming path
+    #     untouched. When absent (a caller passing a raw frame, e.g. the wiring
+    #     tests) the prior code let each partition synthesize colliding local ids
+    #     AND left the join referencing a __row_id__ column that wasn't on the
+    #     rows: on older Ray the join silently produced nothing; newer Ray's
+    #     hash-shuffle eagerly projects the key and raises KeyError. Adding the id
+    #     here fixes the crash and the latent cross-partition id collision.
+    ds = _ensure_global_row_id(ds)
+
     # 2. Distributed scoring -> Ray Dataset of pairs (RAW: per-partition, so each
     #    component's edges are co-located in one block -- required by local_cc).
     raw_pairs_ds = score_blocks_distributed(ds, cfg)
@@ -258,6 +270,43 @@ def _row_columns(ds: Dataset) -> list[str]:
         return list(ds.schema().names)
     except Exception:  # pragma: no cover - schema() shape varies by Ray version
         return []
+
+
+def _ensure_global_row_id(ds: Dataset) -> Dataset:
+    """Return ``ds`` guaranteed to carry a globally-unique ``__row_id__``.
+
+    No-op when the column already exists (the production contract -- the input
+    parquet carries ``__row_id__``, so the streaming path is unchanged). When it
+    is absent, attach a deterministic global index via ``zip(range(n))`` and
+    materialize so distributed scoring (step 2) and the cluster join (step 4)
+    observe the SAME ids. ``zip``/``count`` execute the input once; that cost is
+    only paid on the fallback (callers that didn't supply ``__row_id__``), which
+    is why we also warn -- supplying it upstream keeps the pipeline streaming.
+    """
+    if "__row_id__" in _row_columns(ds):
+        return ds
+
+    # Only a real Ray Dataset supports the row-id assignment below. Stub-based
+    # wiring tests pass a bare object() whose only exercised method is the
+    # patched scorer -- leave anything without the Dataset API untouched.
+    if not (hasattr(ds, "count") and hasattr(ds, "zip")):
+        return ds
+
+    import ray
+
+    logger.warning(
+        "phase5: input rows carry no __row_id__; assigning a global row id "
+        "(this materializes the input). Provide a global __row_id__ upstream to "
+        "keep the pipeline fully streaming."
+    )
+    n = ds.count()
+    indexed = ds.zip(ray.data.range(n))
+
+    def _rename_id(batch: Any) -> Any:  # pa.Table -> pa.Table
+        names = ["__row_id__" if c == "id" else c for c in batch.column_names]
+        return batch.rename_columns(names)
+
+    return indexed.map_batches(_rename_id, batch_format="pyarrow").materialize()
 
 
 def _join_assignments_distributed(

--- a/packages/python/goldenmatch/tests/test_config_critique.py
+++ b/packages/python/goldenmatch/tests/test_config_critique.py
@@ -265,6 +265,160 @@ def test_over_merge_fires_on_oversized_clusters():
     assert finding["evidence"]["max_cluster_size"] == 4200
 
 
+# ── distributed_over_merge (#1261) ─────────────────────────────────────────────
+
+
+def _low_card_df(n=416):
+    """A no-strong-key frame: name/company/city are all low-cardinality, so
+    blocking on them distributes over-merge across many medium clusters."""
+    surnames = [f"sur{i % 30}" for i in range(n)]
+    companies = [f"co{i % 12}" for i in range(n)]
+    cities = [f"city{i % 20}" for i in range(n)]
+    return pl.DataFrame({"name": surnames, "company": companies, "city": cities})
+
+
+def test_distributed_over_merge_fires_on_low_card_blocking_with_merging():
+    df = _low_card_df()
+    cfg = _exact_config(
+        fields=["name", "company", "city"],
+        blocking_fields=["name", "company", "city"],
+    )
+    # Many MEDIUM clusters, none oversized (>100): a distributed over-merge that
+    # the mega-cluster smell can't see. ~40% of records merged.
+    clusters = {
+        i: {"members": [2 * i, 2 * i + 1], "size": 2} for i in range(80)
+    }
+    signals = {
+        "oversized_clusters": [],
+        "preliminary_cluster_sizes": {"p50": 1, "p95": 4, "p99": 8, "max": 9, "count": 80},
+    }
+    out = diagnose_config(df, cfg, _result(signals=signals, clusters=clusters))
+
+    ids = [f["id"] for f in out["findings"]]
+    assert "distributed_over_merge" in ids
+    finding = next(f for f in out["findings"] if f["id"] == "distributed_over_merge")
+    assert finding["severity"] == "high"
+    # The weakest (fewest-distinct) blocking key is reported.
+    assert finding["evidence"]["blocking_key"] == "company"
+    assert finding["evidence"]["distinct_values"] == 12
+    assert finding["fix_config_hint"]["action"] == "compound_blocking"
+
+
+def test_distributed_over_merge_silent_with_strong_blocking_key():
+    # A near-unique anchor (email) means blocking has a strong key -> no
+    # distributed over-merge, even though name is low-cardinality.
+    df = pl.DataFrame({
+        "name": [f"sur{i % 5}" for i in range(50)],
+        "email": [f"user{i}@x.com" for i in range(50)],
+    })
+    cfg = _exact_config(fields=["name", "email"], blocking_fields=["email", "name"])
+    clusters = {i: {"members": [2 * i, 2 * i + 1], "size": 2} for i in range(20)}
+    signals = {
+        "oversized_clusters": [],
+        "preliminary_cluster_sizes": {"p50": 1, "p95": 4, "p99": 6, "max": 6, "count": 20},
+    }
+    out = diagnose_config(df, cfg, _result(signals=signals, clusters=clusters))
+    assert all(f["id"] != "distributed_over_merge" for f in out["findings"])
+
+
+def test_distributed_over_merge_silent_without_merge_evidence():
+    # Low-cardinality blocking but the run barely merged (all singletons) ->
+    # nothing to warn about yet.
+    df = _low_card_df(60)
+    cfg = _exact_config(
+        fields=["name", "company"], blocking_fields=["name", "company"]
+    )
+    clusters = {i: {"members": [i], "size": 1} for i in range(60)}
+    signals = {
+        "oversized_clusters": [],
+        "preliminary_cluster_sizes": {"p50": 1, "p95": 1, "p99": 1, "max": 1, "count": 60},
+    }
+    out = diagnose_config(df, cfg, _result(signals=signals, clusters=clusters))
+    assert all(f["id"] != "distributed_over_merge" for f in out["findings"])
+
+
+def test_distributed_over_merge_defers_to_mega_cluster_detector():
+    # A genuine mega-cluster (>100) is the oversized-cluster detector's job;
+    # the distributed detector stays quiet so the two don't double-report.
+    df = _low_card_df()
+    cfg = _exact_config(fields=["name"], blocking_fields=["name", "company"])
+    signals = {
+        "oversized_clusters": [{"cluster_id": 1, "size": 300}],
+        "preliminary_cluster_sizes": {"p50": 2, "p95": 9, "p99": 50, "max": 300, "count": 50},
+    }
+    out = diagnose_config(df, cfg, _result(signals=signals))
+    assert all(f["id"] != "distributed_over_merge" for f in out["findings"])
+
+
+# ── low_signal_key remedy is exclude_column, not demote_to_blocking (#1263) ─────
+
+
+def test_low_signal_key_emits_exclude_column_not_demote():
+    # The #1263 regression: low_signal_key used to emit demote_to_blocking, which
+    # turned a near-constant column into a standalone blocking pass and collapsed
+    # candidate generation. The remedy must be exclude_column.
+    df = pl.DataFrame({
+        "name": [f"n{i}" for i in range(400)],
+        "gender_code": [("M", "F", "U")[i % 3] for i in range(400)],  # 3/400 < 0.01
+    })
+    cfg = _exact_config(fields=["name", "gender_code"])
+    out = diagnose_config(df, cfg, _result())
+    finding = next(f for f in out["findings"] if f["id"] == "low_signal_key")
+    assert finding["fix_config_hint"] == {
+        "action": "exclude_column",
+        "column": "gender_code",
+    }
+
+
+def test_low_signal_key_roundtrip_does_not_add_blocking_pass():
+    # Applying the low_signal_key hint must NOT create a single-field blocking
+    # pass on the near-constant column (the #1263 over-block).
+    df = pl.DataFrame({
+        "name": [f"n{i}" for i in range(400)],
+        "gender_code": [("M", "F", "U")[i % 3] for i in range(400)],
+    })
+    cfg = _exact_config(
+        fields=["name", "gender_code"], blocking_fields=["name", "gender_code"]
+    )
+    finding = next(
+        f for f in diagnose_config(df, cfg, _result())["findings"]
+        if f["id"] == "low_signal_key"
+    )
+    new, applied = apply_hint(cfg, finding["fix_config_hint"])
+    assert applied
+    # gender_code is gone from matching AND there is no standalone gender pass.
+    assert "gender_code" not in _mk_field_names(new)
+    all_block_fields = [
+        f
+        for attr in ("keys", "passes", "sub_block_keys")
+        for kc in (getattr(new.blocking, attr, None) or [])
+        for f in kc.fields
+    ]
+    assert ["gender_code"] not in [
+        kc.fields
+        for attr in ("keys", "passes", "sub_block_keys")
+        for kc in (getattr(new.blocking, attr, None) or [])
+    ], "must not create a standalone single-field block on the near-constant column"
+    # name survives as a blocking key, so candidate generation isn't collapsed.
+    assert "name" in all_block_fields
+
+
+def test_apply_exclude_column_preserves_sole_blocking_key():
+    # If the excluded column is the ONLY blocking key, removing it would empty
+    # blocking (full cross-product). The collapse guard preserves the blocking
+    # role and skips exclude_columns.
+    cfg = _exact_config(fields=["name", "gender_code"], blocking_fields=["gender_code"])
+    new, applied = apply_hint(
+        cfg, {"action": "exclude_column", "column": "gender_code"}
+    )
+    assert applied  # the matchkey strip still applied
+    assert "gender_code" not in _mk_field_names(new)
+    # blocking is preserved (not collapsed) and the column is NOT excluded.
+    block_fields = [f for kc in (new.blocking.keys or []) for f in kc.fields]
+    assert "gender_code" in block_fields
+    assert "gender_code" not in (new.exclude_columns or [])
+
+
 # ── phrasing="plain" renders the plain fields, no LLM ──────────────────────────
 
 


### PR DESCRIPTION
## What and why

`diagnose_config` / `apply_hint` reasoned about per-field MATCH signal and mega-cluster smells, but were blind to (a) a column's BLOCKING role/cardinality and (b) distributed (non-mega) over-merge. That caused two dogfooding failures. Fixes #1263 and #1261.

**#1263 -- config-feedback loop regressed F1 ~4x.** `low_signal_key` fires only on near-constant columns (`cardinality_ratio < 0.01`), yet it emitted `demote_to_blocking`, which turned that near-constant column into a STANDALONE single-field blocking pass. A handful of distinct values then grouped the whole dataset into a few mega-blocks (649 -> 9,097 candidate pairs in the report), and precision cratered 0.61 -> 0.11. A near-constant column is exactly the wrong thing to make a blocking key.

**#1261 -- `diagnose_config` reported "looks solid" at precision 0.22** (1,130 false-positive pairs). The `over_merge` detector only fires on a single >100-member cluster; here the over-merge was DISTRIBUTED across many medium clusters driven by low-cardinality blocking (~30 surnames / 12 companies across 416 rows), so no single cluster looked oversized.

## Changes

- **`low_signal_key` remedy is now `exclude_column`, not `demote_to_blocking`** -- drop a near-constant column from scoring instead of promoting it to a standalone (catastrophic) blocking pass.
- **Collapse guard in `_strip_column_from_blocking`** -- if the column is the SOLE blocking key, its blocking role is preserved (strip + `exclude_columns` skipped) so removal can't turn candidate generation into a cross-product. `_apply_exclude_column` skips `exclude_columns` for a still-load-bearing blocking field.
- **New result-aware detector `_detect_distributed_over_merge` (#1261)** -- flags blocking that has no strong anchor key (every blocking field is low-cardinality) plus real merging, reporting the weakest blocking key + merge rate. Defers to the existing `over_merge` detector when a genuine mega-cluster exists; stays silent when a strong (near-unique) blocking key is present (so the good-config "no findings" path is unchanged).
- New helper `_is_blocking_field`; tunables for the distributed detector; docstring updates.

> **Note on scope:** this branch is the session's rolling working branch, so the PR also carries two earlier already-green commits that touch `distributed/pipeline.py` (`_ensure_global_row_id` in the Phase 5 Ray pipeline, fixing a hash-shuffle `KeyError` on inputs with no global `__row_id__`). They're independent of the config_critique change above and were verified separately; can be split out if you'd prefer this PR be config_critique-only.

## Testing

- `.venv/bin/python -m pytest packages/python/goldenmatch/tests/test_config_critique.py` -- 34 passed (8 new).
- `... tests/test_config_lint.py tests/test_autoconfig_regressions.py` -- 62 passed.
- `ruff check --select E9,F63,F7,F82` on the changed files -- clean.
- End-to-end repro confirmed: #1263 hint now strips `gender_code` from matching + the compound block key (leaving `name`), no standalone gender pass; #1261 detector fires `high` on the no-strong-key low-cardinality config that previously got "looks solid."
- (`tests/test_mcp_new_tools.py` fails locally only because the optional `mcp` dep is absent -- pre-existing, in CI's ignore list, unrelated.)

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ran targeted ruff instead)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / inline rationale updated where a gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmYnMS7Njc9e7mdz47FpdJ