### PR TITLE
ci(suggest-quality): trim PR/push to the fast gate; nightly the heavy gym-gate

### DIFF
--- a/.github/workflows/bench-suggest-quality.yml
+++ b/.github/workflows/bench-suggest-quality.yml
@@ -4,13 +4,17 @@
 # datasets (synthetic + ncvr_synthetic + anchor_*) and gates on regression
 # vs the committed scorecard.json baseline.
 #
-# Three ways to trigger:
-#   1. Automatically on push when relevant paths change.
-#   2. workflow_dispatch (for a manual re-check or one-shot bless).
+# Two-tier cost split (the gym-gate / FULL_DIST catalog recovery check overruns
+# ~70-120min, so it does NOT belong on every suggest-touching push):
+#   - PUSH (PR signal): runs ONLY the fast `gate` step (deterministic subset,
+#     FULL_DIST=0, ~minutes). This is the per-PR suggester-quality regression
+#     guard -- it's the step that catches suggester_prec / convergence drops.
+#   - SCHEDULE (nightly) + workflow_dispatch: ALSO run the heavy `gym-gate`
+#     (FULL_DIST over the whole catalog). The comprehensive recovery check runs
+#     daily on main instead of taxing each PR with a 2h tail.
 #
-# The gate step exits nonzero on a regression; the job fails and blocks
-# the PR.  The bench runner matches the repo default for bench workloads
-# (large-new-64GB, 16c/64GB).
+# The gate step exits nonzero on a regression; the job fails. The bench runner
+# matches the repo default for bench workloads (large-new-64GB, 16c/64GB).
 #
 # To bless a new baseline after an intentional kernel change:
 #   gh workflow run bench-suggest-quality.yml --ref <branch> -f mode=bless
@@ -31,6 +35,10 @@ on:
         description: "Runner label"
         required: false
         default: "large-new-64GB"
+  schedule:
+    # Nightly full run (fast gate + heavy gym-gate FULL_DIST) on main, off-peak
+    # off-minute so it doesn't pile onto the top-of-hour scheduler.
+    - cron: "37 7 * * *"
   push:
     paths:
       - "packages/rust/extensions/suggest-core/**"
@@ -105,6 +113,10 @@ jobs:
           uv run python -m scripts.suggest_quality "$MODE" $FILTER
 
       - name: Run gym-gate (catalog recovery non-regression)
+        # Heavy FULL_DIST catalog recovery check (~70-120min). Skipped on push so
+        # PRs get only the fast `gate`; runs on the nightly schedule + manual
+        # workflow_dispatch.
+        if: ${{ github.event_name != 'push' }}
         env:
           GOLDENMATCH_SUGGEST_FULL_DIST: "1"
         run: |


### PR DESCRIPTION
## What and why

`bench-suggest-quality` ran **both** gates on every suggest-touching push:

| Step | Cost | Per-PR value |
|------|------|--------------|
| `gate` (deterministic subset: `synthetic` + `ncvr_synthetic` + `anchor_*`, `FULL_DIST=0`) | ~minutes | high — catches `suggester_prec` / convergence regressions (this is the step that caught the ncvr_synthetic drop) |
| `gym-gate` (`FULL_DIST=1`, whole catalog incl. `historical_50k`) | ~70–120 min | low per-PR — catalog-wide recovery non-regression |

The `gym-gate` is what forced the 120-min job timeout and produced cancelled / perpetual-red `suggest-quality` checks on PRs (e.g. #1277), while adding little per-PR signal. The workflow also triggers on `push` (not `merge_group`), so it never actually gated the merge queue — it was advisory-only regardless.

## Changes

- **Add a nightly `schedule:` trigger** (`37 7 * * *`) alongside the existing `push` + `workflow_dispatch`.
- **Gate the `gym-gate` step with `if: github.event_name != 'push'`** so it runs on the nightly schedule + manual dispatch, but **not** on PR/push.
- Net: PRs touching suggest get only the fast `gate` (~minutes); the comprehensive FULL_DIST catalog-recovery check runs daily on `main`.
- The fast `gate`, the `bless` / `gym-bless` paths, the runner, and the 120-min timeout (still needed for the scheduled/dispatch FULL_DIST run) are unchanged.

## Testing

- `python -c "import yaml; yaml.safe_load(...)"` — valid; triggers resolve to `workflow_dispatch` + `schedule` + `push`, schedule cron `37 7 * * *`.
- This very push exercises the change: the workflow's own file is in its `push` paths, so it runs on this branch and should execute **only** the fast `gate` (gym-gate skipped on push).

## Checklist

- [x] YAML validated
- [x] No secrets, tokens, or `.env` files committed
- [ ] Package `CHANGELOG.md` — n/a (CI-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmYnMS7Njc9e7mdz47FpdJ)_