### PR TITLE
docs(readme): KG/RAG angle in both heroes + drop all emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <!-- mcp-name: io.github.benseverndev-oss/goldenmatch -->
 <div align="center">
 
-# 🟡 Golden Suite
+# Golden Suite
 
 **Zero-config entity resolution that scales — dedupe & match messy records from a laptop CSV to 100M+ rows. No training data, no tuning.**
 
 *The headline package, **GoldenMatch**, does the matching — fuzzy + exact + probabilistic (Fellegi-Sunter) + LLM — and **beats hand-tuned Splink out of the box** (96.4% F1 on DBLP-ACM), identical in Python, edge-safe TypeScript, and SQL. Around it sits a full data-quality suite: GoldenCheck profiles, GoldenFlow standardizes, GoldenAnalysis reports, GoldenPipe orchestrates, and InferMap maps schemas — with a Rust extension layer for Postgres / DuckDB and optional WebAssembly acceleration behind the TS ports.*
 
-**🕸️ Made for GraphRAG, too** — entity resolution is the stage knowledge-graph pipelines do *worst* (the same entity scatters across documents as duplicate surface forms). GoldenMatch drops into **neo4j-graphrag / LlamaIndex / Graphiti** as the resolution stage ([`goldenmatch-kg`](packages/python/goldenmatch-kg/README.md)), or builds a knowledge graph straight from text with that resolution at its core ([`goldengraph`](packages/python/goldengraph/README.md)). Both in early access. [→ Knowledge graphs](#knowledge-graphs)
+**Made for GraphRAG, too** — entity resolution is the stage knowledge-graph pipelines do *worst* (the same entity scatters across documents as duplicate surface forms). GoldenMatch drops into **neo4j-graphrag / LlamaIndex / Graphiti** as the resolution stage ([`goldenmatch-kg`](packages/python/goldenmatch-kg/README.md)), or builds a knowledge graph straight from text with that resolution at its core ([`goldengraph`](packages/python/goldengraph/README.md)). Both in early access. [→ Knowledge graphs](#knowledge-graphs)
 
-**⚡ Verified at scale: 100,000,000 records deduped in 9.2 min on a Ray cluster — recall-complete across any partitioning, 0.36 GB driver footprint.**
+**Verified at scale: 100,000,000 records deduped in 9.2 min on a Ray cluster — recall-complete across any partitioning, 0.36 GB driver footprint.**
 
 <br>
 
@@ -56,7 +56,7 @@ npm install goldenmatch
 ```
 
 <!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
-> **🆕 v2.4.0 — The healing loop, now default-on across every surface** — every `dedupe_df` run surfaces ranked, self-verified config-suggestions on `result.suggestions` when there's headroom (free on a healthy run, no second pipeline pass). `dedupe_df(suggest=True)` returns verified suggestions; `heal=True` applies them and re-runs, returning the healed `result.config` + `result.heal_trail`. Available across Python, CLI (`--suggest` / `--heal`), MCP, A2A, REST, web, the TUI, and the edge-safe TypeScript port via WebAssembly. Needs `goldenmatch[native]`; degrades gracefully without it. Kill-switch `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`.
+> **v2.4.0 — The healing loop, now default-on across every surface** — every `dedupe_df` run surfaces ranked, self-verified config-suggestions on `result.suggestions` when there's headroom (free on a healthy run, no second pipeline pass). `dedupe_df(suggest=True)` returns verified suggestions; `heal=True` applies them and re-runs, returning the healed `result.config` + `result.heal_trail`. Available across Python, CLI (`--suggest` / `--heal`), MCP, A2A, REST, web, the TUI, and the edge-safe TypeScript port via WebAssembly. Needs `goldenmatch[native]`; degrades gracefully without it. Kill-switch `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`.
 >
 > **v2.3.0 — Auto-enabled semantic blocking, now default-on** — text-heavy data automatically routes to SimHash-over-embeddings blocking when an embedder is reachable (a byte-identical no-op otherwise). Plus pluggable pgvector / DuckDB-HNSW vector-index backends and opt-in Fellegi-Sunter routing for no-strong-identifier datasets (`GOLDENMATCH_AUTOCONFIG_ROUTE_PROBABILISTIC=1`).
 >
@@ -130,7 +130,7 @@ Zero-config gets you most of the way in one pass; the healing loop closes the ga
 
 | Package | Lang | What it does | Install |
 |---|---|---|---|
-| **[GoldenMatch](packages/python/goldenmatch/README.md)** 🟡 | Python · TS | Zero-config entity resolution. Fuzzy + exact + probabilistic + LLM. Headline package. | `pip install goldenmatch` · `npm i goldenmatch` |
+| **[GoldenMatch](packages/python/goldenmatch/README.md)** | Python · TS | Zero-config entity resolution. Fuzzy + exact + probabilistic + LLM. Headline package. | `pip install goldenmatch` · `npm i goldenmatch` |
 | **[GoldenCheck](packages/python/goldencheck/README.md)** | Python · TS | Data-quality scanning: encoding, Unicode, format validation, anomaly detection. | `pip install goldencheck` · `npm i goldencheck` |
 | **[GoldenFlow](packages/python/goldenflow/README.md)** | Python · TS | Transforms & standardizers: phone, date, address, categorical normalization. | `pip install goldenflow` · `npm i goldenflow` |
 | **[GoldenPipe](packages/python/goldenpipe/README.md)** | Python · TS | Orchestrator that wires Check → Flow → Match → Identity → Analysis into one declarative pipeline. | `pip install goldenpipe` · `npm i goldenpipe` |
@@ -246,9 +246,9 @@ result.report.write_html("report.html")
 
 Reproducible end-to-end pipelines running GoldenMatch on public data at scale, each with measured headline numbers vs baselines:
 
-- 🕵️ **[goldenmatch-shell-company-network](https://github.com/benseverndev-oss/goldenmatch-shell-company-network)** — investigative ER across ICIJ Offshore Leaks + OpenSanctions + GLEIF + UK PSC + UK disqualified-directors. Confidence-weighted graph, structure mining, named investigative candidates. **−62.5% analyst-hours to triage** vs single-source baselines; +133% adversarial perturbation recovery.
-- 🛡️ **[goldenmatch-vuln-attribution](https://github.com/benseverndev-oss/goldenmatch-vuln-attribution)** — cross-database ER on 6.1M OSS vulnerability records across 40 sources (OSV, GHSA, PyPA, RustSec, Go vulndb, EPSS, CISA KEV, CVE Project bulk). **6,126,895 records → 847,475 canonical vulns** in ~5 minutes end-to-end on a single 64GB runner via the full Golden Suite (Check + Flow + Match + Pipe).
-- ⚖️ **[goldenmatch-sanctions-reconciliation](https://github.com/benseverndev-oss/goldenmatch-sanctions-reconciliation)** — cross-list coverage analysis on 85 public sanctions lists across 50+ jurisdictions via OpenSanctions, plus 10-year OFAC SDN history and PEP/crypto cross-analysis. Coverage-gap benchmark for any sanctions-screening vendor.
+- **[goldenmatch-shell-company-network](https://github.com/benseverndev-oss/goldenmatch-shell-company-network)** — investigative ER across ICIJ Offshore Leaks + OpenSanctions + GLEIF + UK PSC + UK disqualified-directors. Confidence-weighted graph, structure mining, named investigative candidates. **−62.5% analyst-hours to triage** vs single-source baselines; +133% adversarial perturbation recovery.
+- **[goldenmatch-vuln-attribution](https://github.com/benseverndev-oss/goldenmatch-vuln-attribution)** — cross-database ER on 6.1M OSS vulnerability records across 40 sources (OSV, GHSA, PyPA, RustSec, Go vulndb, EPSS, CISA KEV, CVE Project bulk). **6,126,895 records → 847,475 canonical vulns** in ~5 minutes end-to-end on a single 64GB runner via the full Golden Suite (Check + Flow + Match + Pipe).
+- **[goldenmatch-sanctions-reconciliation](https://github.com/benseverndev-oss/goldenmatch-sanctions-reconciliation)** — cross-list coverage analysis on 85 public sanctions lists across 50+ jurisdictions via OpenSanctions, plus 10-year OFAC SDN history and PEP/crypto cross-analysis. Coverage-gap benchmark for any sanctions-screening vendor.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 *The headline package, **GoldenMatch**, does the matching — fuzzy + exact + probabilistic (Fellegi-Sunter) + LLM — and **beats hand-tuned Splink out of the box** (96.4% F1 on DBLP-ACM), identical in Python, edge-safe TypeScript, and SQL. Around it sits a full data-quality suite: GoldenCheck profiles, GoldenFlow standardizes, GoldenAnalysis reports, GoldenPipe orchestrates, and InferMap maps schemas — with a Rust extension layer for Postgres / DuckDB and optional WebAssembly acceleration behind the TS ports.*
 
+**🕸️ Made for GraphRAG, too** — entity resolution is the stage knowledge-graph pipelines do *worst* (the same entity scatters across documents as duplicate surface forms). GoldenMatch drops into **neo4j-graphrag / LlamaIndex / Graphiti** as the resolution stage ([`goldenmatch-kg`](packages/python/goldenmatch-kg/README.md)), or builds a knowledge graph straight from text with that resolution at its core ([`goldengraph`](packages/python/goldengraph/README.md)). Both in early access. [→ Knowledge graphs](#knowledge-graphs)
+
 **⚡ Verified at scale: 100,000,000 records deduped in 9.2 min on a Ray cluster — recall-complete across any partitioning, 0.36 GB driver footprint.**
 
 <br>

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -1,15 +1,15 @@
 <!-- mcp-name: io.github.benseverndev-oss/goldenmatch -->
 <div align="center">
 
-# 🟡 GoldenMatch
+# GoldenMatch
 
 **Find duplicate records in 30 seconds. No rules to write, no models to train.**
 
 *Zero-config entity resolution for Python & TypeScript — with a self-verifying auto-config that tells you when it's unsure.*
 
-**⚡ Scales from a CSV on your laptop to 100M+ rows on a Ray cluster — verified: 100,000,000 records deduped recall-complete (correct across any partitioning) in 9.2 min, with a 0.36 GB driver footprint.** ([how →](#scaling-to-100m))
+**Scales from a CSV on your laptop to 100M+ rows on a Ray cluster — verified: 100,000,000 records deduped recall-complete (correct across any partitioning) in 9.2 min, with a 0.36 GB driver footprint.** ([how →](#scaling-to-100m))
 
-**🕸️ The resolution stage for knowledge graphs** — ER is the stage GraphRAG does *worst*. [`goldenmatch-kg`](https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/python/goldenmatch-kg/README.md) plugs GoldenMatch into neo4j-graphrag / LlamaIndex / Graphiti; [`goldengraph`](https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/python/goldengraph/README.md) builds a knowledge graph from text with that resolution at its core. Both in early access.
+**The resolution stage for knowledge graphs** — ER is the stage GraphRAG does *worst*. [`goldenmatch-kg`](https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/python/goldenmatch-kg/README.md) plugs GoldenMatch into neo4j-graphrag / LlamaIndex / Graphiti; [`goldengraph`](https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/python/goldengraph/README.md) builds a knowledge graph from text with that resolution at its core. Both in early access.
 
 <br>
 
@@ -57,7 +57,7 @@ npm install goldenmatch
 > core parity. Version map + rationale: [`docs/versioning-policy.md`](docs/versioning-policy.md).
 
 <!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
-> **🆕 v2.4.0 — The healing loop, now default-on across every surface** — every `dedupe_df` run surfaces ranked, self-verified config-suggestions on `result.suggestions` when there's headroom (free on a healthy run, no second pipeline pass). `dedupe_df(suggest=True)` returns verified suggestions; `heal=True` applies them and re-runs, returning the healed `result.config` + `result.heal_trail`. Available across Python, CLI (`--suggest` / `--heal`), MCP, A2A, REST, web, the TUI, and the edge-safe TypeScript port via WebAssembly. Needs `goldenmatch[native]`; degrades gracefully without it. Kill-switch `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`.
+> **v2.4.0 — The healing loop, now default-on across every surface** — every `dedupe_df` run surfaces ranked, self-verified config-suggestions on `result.suggestions` when there's headroom (free on a healthy run, no second pipeline pass). `dedupe_df(suggest=True)` returns verified suggestions; `heal=True` applies them and re-runs, returning the healed `result.config` + `result.heal_trail`. Available across Python, CLI (`--suggest` / `--heal`), MCP, A2A, REST, web, the TUI, and the edge-safe TypeScript port via WebAssembly. Needs `goldenmatch[native]`; degrades gracefully without it. Kill-switch `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`.
 >
 > **v2.3.0 — Auto-enabled semantic blocking, now default-on** — text-heavy data automatically routes to SimHash-over-embeddings blocking when an embedder is reachable (a byte-identical no-op otherwise). Plus pluggable pgvector / DuckDB-HNSW vector-index backends and opt-in Fellegi-Sunter routing for no-strong-identifier datasets (`GOLDENMATCH_AUTOCONFIG_ROUTE_PROBABILISTIC=1`).
 >
@@ -352,19 +352,19 @@ dev server (`pnpm dev`) proxies `/api/v1/*` to `http://localhost:5050`.
 
 Three companion repos run GoldenMatch end-to-end on public data at scale. Each is a reproducible pipeline with measured headline numbers, not a toy demo.
 
-### 🕵️ [`goldenmatch-shell-company-network`](https://github.com/benseverndev-oss/goldenmatch-shell-company-network)
+### [`goldenmatch-shell-company-network`](https://github.com/benseverndev-oss/goldenmatch-shell-company-network)
 
 Investigative entity resolution across **ICIJ Offshore Leaks + OpenSanctions + GLEIF + UK PSC + UK disqualified-directors**. Builds a confidence-weighted graph, runs unsupervised structure mining, and emits named investigative candidates with per-entity novelty proofs vs single-source search baselines.
 
 > **Pipeline matches or beats every operational baseline measured:** +11.2% multi-source anchors surfaced, **−62.5% analyst-hours to triage**, +133% adversarial perturbation recovery, expected calibration error → 0.
 
-### 🛡️ [`goldenmatch-vuln-attribution`](https://github.com/benseverndev-oss/goldenmatch-vuln-attribution)
+### [`goldenmatch-vuln-attribution`](https://github.com/benseverndev-oss/goldenmatch-vuln-attribution)
 
 Cross-database entity resolution on **6.1M public OSS vulnerability records across 40 sources** (33 OSV ecosystems, GHSA reviewed + unreviewed, PyPA, RustSec, Go vulndb, EPSS, CISA KEV, CVE Project bulk). Reconciles `(vuln_id, alias)` graphs into canonical IDs via union-find. The full Golden Suite stack — GoldenCheck DQ + GoldenFlow normalize + GoldenMatch cluster + GoldenPipe orchestrate — runs **end-to-end in ~5 minutes** on a `large-new-64GB` GitHub Actions runner.
 
 > **6,126,895 records → 847,475 canonical vulnerabilities.** Surfaces concrete failure modes in cross-source agreement that consumers shouldn't trust.
 
-### ⚖️ [`goldenmatch-sanctions-reconciliation`](https://github.com/benseverndev-oss/goldenmatch-sanctions-reconciliation)
+### [`goldenmatch-sanctions-reconciliation`](https://github.com/benseverndev-oss/goldenmatch-sanctions-reconciliation)
 
 Cross-list coverage analysis on the **85 distinct public sanctions lists** in the OpenSanctions `sanctions` collection (50+ jurisdictions). Plus 10-year OFAC SDN history and PEP/crypto cross-analysis. Asks the questions a compliance team should have an answer to: how many canonical entities exist across every free public list combined? What fraction does an OFAC-SDN-only screening vendor actually see?
 
@@ -747,7 +747,7 @@ Files/DB → Ingest → Standardize → Block → Score → Cluster → Golden R
 
 ## Config Reference
 
-> 📁 **Copy-paste-ready configs live in [`configs/`](configs/)** — a robust
+> **Copy-paste-ready configs live in [`configs/`](configs/)** — a robust
 > [`customers.yaml`](configs/customers.yaml), a [`distributed-100m.yaml`](configs/distributed-100m.yaml),
 > and a [walkthrough README](configs/README.md) explaining every knob.
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -9,6 +9,8 @@
 
 **⚡ Scales from a CSV on your laptop to 100M+ rows on a Ray cluster — verified: 100,000,000 records deduped recall-complete (correct across any partitioning) in 9.2 min, with a 0.36 GB driver footprint.** ([how →](#scaling-to-100m))
 
+**🕸️ The resolution stage for knowledge graphs** — ER is the stage GraphRAG does *worst*. [`goldenmatch-kg`](https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/python/goldenmatch-kg/README.md) plugs GoldenMatch into neo4j-graphrag / LlamaIndex / Graphiti; [`goldengraph`](https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/python/goldengraph/README.md) builds a knowledge graph from text with that resolution at its core. Both in early access.
+
 <br>
 
 <!-- Packages -->

--- a/scripts/sync_readme_callouts.py
+++ b/scripts/sync_readme_callouts.py
@@ -90,11 +90,11 @@ def _format_callout(version: str, body: str, *, is_first: bool) -> str:
 
     Input body is the raw text from the CHANGELOG marker. If it leads
     with ``**Title** — rest``, fold the version into the bold span so
-    the homepage reads ``**🆕 vX.Y.Z — Title** — rest``. Otherwise just
+    the homepage reads ``**vX.Y.Z — Title** — rest``. Otherwise just
     bold the version.
     """
     body = body.strip()
-    new_badge = "🆕 " if is_first else ""
+    new_badge = ""  # latest callout is already first; no emoji marker
     label = _version_label(version)
     match = _BOLD_TITLE_RE.match(body)
     if match:


### PR DESCRIPTION
## Summary

Surfaces the **GraphRAG / knowledge-graph** angle in both heroes — the growth heroes (#1297) covered ER + the data-quality suite but said nothing about the KG/RAG work, which is a strong, timely hook ("entity resolution is the stage GraphRAG pipelines do worst").

- **Root `README.md` hero** — new line between the suite paragraph and the scale claim: GoldenMatch drops into neo4j-graphrag / LlamaIndex / Graphiti as the resolution stage (`goldenmatch-kg`) or builds a KG from text (`goldengraph`).
- **`packages/python/goldenmatch/README.md` header** — matching KG/RAG line.

Both honestly flagged **"early access"** (goldenmatch-kg + goldengraph are in-repo, PyPI release pending — no install claim). Per-package links use **absolute GitHub URLs** because that README is the PyPI long-description (relative links 404 on PyPI). Roster + callout-sync gates pass.

## Test plan
- [x] `check_docs_consistency.py` green; link targets + `#knowledge-graphs` anchor exist.
