### PR TITLE
fix(suggest): run domain extraction in MatchEngine._run_pipeline (#1300)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -199,6 +199,15 @@ class MatchEngine:
         if config.standardization and config.standardization.rules:
             combined_lf = apply_standardization(combined_lf, config.standardization.rules)
 
+        # ── Domain feature extraction ──
+        # Materializes derived columns (e.g. ``__title_key__``) that auto-config
+        # may reference from matchkeys / blocking keys. Must run BEFORE
+        # compute_matchkeys, mirroring ``_run_dedupe_pipeline`` -- without it this
+        # path crashes with ColumnNotFoundError whenever auto-config detects a
+        # domain (bibliographic / product shapes, e.g. DBLP-ACM). See issue #1300.
+        from goldenmatch.core.pipeline import _apply_domain_extraction
+        combined_lf = _apply_domain_extraction(combined_lf, config)
+
         # ── Compute matchkeys ──
         matchkeys = config.get_matchkeys()
         combined_lf = compute_matchkeys(combined_lf, matchkeys)

--- a/packages/python/goldenmatch/tests/test_engine.py
+++ b/packages/python/goldenmatch/tests/test_engine.py
@@ -163,3 +163,69 @@ class TestMatchEngineRunFull:
         engine = MatchEngine([sample_csv])
         result = engine.run_full(exact_email_config)
         assert result.stats.total_records == 5
+
+
+class TestEngineDomainExtraction:
+    """Regression for #1300.
+
+    ``MatchEngine._run_pipeline`` must materialize domain-derived columns (e.g.
+    ``__title_key__``) that the config references from a matchkey, the same way
+    ``core.pipeline._run_dedupe_pipeline`` does. Without the domain-extraction
+    step, any MatchEngine run on a bibliographic/product config -- including the
+    healer's ``review_config(verify=True)`` baseline + per-candidate re-runs --
+    crashed with ``ColumnNotFoundError: __title_key__``.
+    """
+
+    @staticmethod
+    def _biblio_config(tmp_path):
+        from goldenmatch.config.schemas import DomainConfig
+
+        return GoldenMatchConfig(
+            domain=DomainConfig(enabled=True, mode="bibliographic", llm_validation=False),
+            matchkeys=[
+                MatchkeyConfig(
+                    name="title_key",
+                    fields=[MatchkeyField(column="__title_key__")],
+                    comparison="exact",
+                )
+            ],
+            output=OutputConfig(format="csv", directory=str(tmp_path), run_name="biblio"),
+            golden_rules=GoldenRulesConfig(
+                default=GoldenFieldRule(strategy="most_complete"),
+            ),
+        )
+
+    @staticmethod
+    def _biblio_df():
+        return pl.DataFrame(
+            {
+                "title": [
+                    "A Survey of Entity Resolution",
+                    "A Survey of Entity Resolution",
+                    "Deep Learning for Record Linkage",
+                    "Scalable Blocking Techniques",
+                ],
+                "authors": ["Smith, J", "J. Smith", "Lee, K", "Brown, A"],
+                "venue": ["VLDB", "VLDB", "SIGMOD", "ICDE"],
+                "year": ["2020", "2020", "2021", "2019"],
+            }
+        )
+
+    def test_run_pipeline_materializes_domain_derived_matchkey_column(self, tmp_path):
+        from goldenmatch.tui.engine import MatchEngine
+
+        # _run_pipeline expects __row_id__ on the frame (callers add it upstream;
+        # the healer does df.with_row_index("__row_id__") before calling in).
+        df = self._biblio_df().with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
+        config = self._biblio_config(tmp_path)
+        engine = MatchEngine.from_dataframe(df)
+
+        # Pre-fix this raised ColumnNotFoundError("__title_key__") because the
+        # domain-extraction step that creates __title_key__ never ran.
+        result = engine._run_pipeline(df, config)
+
+        assert result is not None
+        # The two identical-title rows share a __title_key__ -> exact match.
+        assert result.clusters, "expected the duplicate-title rows to cluster"


### PR DESCRIPTION
Fixes #1300.

## Problem

`MatchEngine._run_pipeline` (`tui/engine.py`) goes standardization -> compute_matchkeys, skipping the **domain-feature-extraction** step that `core.pipeline._run_dedupe_pipeline` runs between them. So any config carrying a domain-derived matchkey column -- e.g. an `exact` matchkey on `__title_key__`, which `auto_configure_df` emits for bibliographic / product data -- crashes the engine path:

```
ColumnNotFoundError: unable to find column "__title_key__"
```

The healer's `review_config(verify=True)` runs its baseline + per-candidate re-runs through `MatchEngine._run_pipeline`, so it crashed on exactly the over-merging configs it exists to fix. (The default `dedupe_df` healer uses the artifacts-in `suggest_from_result` -- no re-run -- so it was unaffected.)

## Fix

Call the existing shared `_apply_domain_extraction(combined_lf, config)` helper in `_run_pipeline`, in the same slot the dedupe/match pipelines use (after standardization, before `compute_matchkeys`). No new logic -- the helper already exists and is shared by `_run_dedupe_pipeline` / `_run_match_pipeline`; the engine path just wasn't wired to it. Its docstring already noted this exact crash for the match pipeline.

## Verification

- `review_config(verify=True)` now completes on real Leipzig DBLP-ACM (the repro from #1300) -- returns its suggestion, no crash.
- 31 `test_suggest_adapter` + `test_suggest_verify` tests still pass (native kernel present locally).
- New regression test `TestEngineDomainExtraction::test_run_pipeline_materializes_domain_derived_matchkey_column` asserts `_run_pipeline` materializes a domain-derived matchkey column instead of raising. Native-independent (covers the engine bug directly).

Surfaced alongside #1299 (the separate healer-lever gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)