### PR TITLE
feat(goldengraph): goldenprofile -> goldengraph composition adapter

### DIFF
--- a/packages/typescript/goldengraph/README.md
+++ b/packages/typescript/goldengraph/README.md
@@ -40,6 +40,33 @@ communities(graph);           // [{ id: 0, members: [0, 1] }]
 
 The query functions throw until the wasm backend is enabled.
 
+## Composing with goldenprofile
+
+GoldenProfile resolves mentions into a cluster partition; GoldenGraph builds a
+graph from a `{ mentionIndex: entityId }` resolution. The zero-dep bridge
+helpers (`resolutionFromClusters`, `mentionsFromProfiles`) pipeline the two —
+`goldengraph` does not depend on `goldenprofile`; you bring both:
+
+```ts
+import { resolveProfiles } from "goldenprofile";
+import { enableGoldenprofileWasm } from "goldenprofile/wasm";
+import { buildGraph, resolutionFromClusters, mentionsFromProfiles } from "goldengraph";
+import { enableGoldengraphWasm } from "goldengraph/wasm";
+
+enableGoldenprofileWasm();
+enableGoldengraphWasm();
+
+const { clusters } = resolveProfiles({ profiles });
+const graph = buildGraph(
+  mentionsFromProfiles(profiles),     // same order you resolved
+  edges,                              // your mention-level relationships
+  resolutionFromClusters(clusters),   // the bridge
+);
+```
+
+The conversion is exact and order-preserving (profile index `i` == mention index
+`i`), as long as you build the mentions from the SAME profile list you resolved.
+
 > **Scope:** v1 surfaces the 4 graph + query ops. The kernel's bitemporal store (`store_append/as_of/history`) is not yet wired into this package.
 
 ## Regenerating the wasm artifact

--- a/packages/typescript/goldengraph/src/compose.ts
+++ b/packages/typescript/goldengraph/src/compose.ts
@@ -1,0 +1,64 @@
+/**
+ * compose.ts — the goldenprofile → goldengraph bridge.
+ *
+ * GoldenProfile resolves mentions into a cluster PARTITION
+ * (`Resolution.clusters`: `number[][]`, where `clusters[c]` lists the profile
+ * indices in entity `c`). GoldenGraph's `buildGraph` wants the same information
+ * the OTHER way round — a `{ mentionIndex: entityId }` map. These helpers convert
+ * between the two so the two engines pipeline cleanly:
+ *
+ *   import { resolveProfiles } from "goldenprofile";
+ *   import { enableGoldenprofileWasm } from "goldenprofile/wasm";
+ *   import { buildGraph, resolutionFromClusters, mentionsFromProfiles } from "goldengraph";
+ *   import { enableGoldengraphWasm } from "goldengraph/wasm";
+ *
+ *   enableGoldenprofileWasm(); enableGoldengraphWasm();
+ *   const { clusters } = resolveProfiles({ profiles });
+ *   const graph = buildGraph(
+ *     mentionsFromProfiles(profiles),     // same order you resolved
+ *     edges,                              // your mention-level edges
+ *     resolutionFromClusters(clusters),   // the bridge
+ *   );
+ *
+ * Zero-dep: these operate on plain shapes, so `goldengraph` does NOT depend on
+ * `goldenprofile` — the caller already has both. The conversion is exact and
+ * order-preserving (profile index i == mention index i), provided you build the
+ * mentions list from the SAME profile list you resolved.
+ */
+import type { Mention, Resolution } from "./index.js";
+
+/**
+ * Convert a GoldenProfile cluster partition (`Resolution.clusters`) into a
+ * GoldenGraph resolution map: each profile index -> its cluster index (the
+ * entity id). The cluster's positional index becomes the `EntityId`.
+ */
+export function resolutionFromClusters(clusters: readonly number[][]): Resolution {
+  const res: Record<number, number> = {};
+  clusters.forEach((members, entityId) => {
+    for (const idx of members) res[idx] = entityId;
+  });
+  return res;
+}
+
+/** The minimal profile shape this bridge reads (structurally GoldenProfile's `Profile`). */
+export interface ProfileLike {
+  name: string;
+  category: string;
+}
+
+/**
+ * Build the GoldenGraph `Mention[]` from GoldenProfile-style profiles, in the
+ * SAME order (so indices line up with `resolutionFromClusters`). By default the
+ * mention `typ` is the profile `category`; pass `typeOf` to override (e.g. to
+ * derive the type from a different field).
+ *
+ * Note: this maps node-style entity mentions. GoldenProfile `edge`-kind profiles
+ * are a separate concern — supply your graph's relationships as `buildGraph`'s
+ * `edges` argument, not through this helper.
+ */
+export function mentionsFromProfiles<T extends ProfileLike>(
+  profiles: readonly T[],
+  typeOf: (profile: T) => string = (p) => p.category,
+): Mention[] {
+  return profiles.map((p) => ({ name: p.name, typ: typeOf(p) }));
+}

--- a/packages/typescript/goldengraph/src/index.ts
+++ b/packages/typescript/goldengraph/src/index.ts
@@ -25,6 +25,13 @@ export {
   type GoldengraphWasmBackend,
 } from "./core/goldengraphWasmBackend.js";
 
+// The goldenprofile -> goldengraph bridge (zero-dep; operates on plain shapes).
+export {
+  resolutionFromClusters,
+  mentionsFromProfiles,
+  type ProfileLike,
+} from "./compose.js";
+
 import { getGoldengraphWasmBackend } from "./core/goldengraphWasmBackend.js";
 
 /** A raw mention to be resolved. Mirrors the Rust `Mention` serde shape. */

--- a/packages/typescript/goldengraph/tests/unit/compose.test.ts
+++ b/packages/typescript/goldengraph/tests/unit/compose.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The goldenprofile -> goldengraph bridge: cluster partition -> resolution map,
+ * profiles -> mentions, and the full pipeline producing the expected graph.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  buildGraph,
+  communities,
+  resolutionFromClusters,
+  mentionsFromProfiles,
+  disableGoldengraphWasm,
+} from "../../src/index.js";
+import { enableGoldengraphWasm } from "../../src/core/goldengraphWasm.js";
+
+describe("goldenprofile -> goldengraph compose", () => {
+  afterEach(() => {
+    disableGoldengraphWasm();
+  });
+
+  it("resolutionFromClusters maps each profile index to its cluster id", () => {
+    // clusters: entity 0 = profiles {0,1}; entity 1 = profile {2}
+    expect(resolutionFromClusters([[0, 1], [2]])).toEqual({ 0: 0, 1: 0, 2: 1 });
+  });
+
+  it("mentionsFromProfiles preserves order and maps typ from category", () => {
+    const profiles = [
+      { name: "Apple Inc", category: "Company", kind: "node" },
+      { name: "Tim Cook", category: "Person", kind: "node" },
+    ];
+    expect(mentionsFromProfiles(profiles)).toEqual([
+      { name: "Apple Inc", typ: "Company" },
+      { name: "Tim Cook", typ: "Person" },
+    ]);
+  });
+
+  it("mentionsFromProfiles honors a custom typeOf", () => {
+    const profiles = [{ name: "X", category: "Company" }];
+    expect(mentionsFromProfiles(profiles, () => "Org")).toEqual([{ name: "X", typ: "Org" }]);
+  });
+
+  it("full pipeline: a goldenprofile-shaped resolution builds the expected graph", () => {
+    enableGoldengraphWasm();
+    // Simulate goldenprofile output: 3 profiles, clusters merge 0+1 into one entity.
+    const profiles = [
+      { name: "Apple Inc", category: "Company" },
+      { name: "Apple", category: "Company" },
+      { name: "Tim Cook", category: "Person" },
+    ];
+    const clusters = [[0, 1], [2]]; // what resolveProfiles(...).clusters would give
+    const edges = [{ subj: 2, predicate: "ceo_of", obj: 0, source_ref: "doc1" }];
+
+    const graph = buildGraph(
+      mentionsFromProfiles(profiles),
+      edges,
+      resolutionFromClusters(clusters),
+    );
+
+    expect(graph.entities.length).toBe(2);
+    const apple = graph.entities.find((e) => e.surface_names.includes("Apple Inc"));
+    expect(apple?.surface_names).toEqual(expect.arrayContaining(["Apple", "Apple Inc"]));
+    // connected by the ceo_of edge -> one community
+    expect(communities(graph)).toEqual([{ id: 0, members: [0, 1] }]);
+  });
+});


### PR DESCRIPTION
Follow-up to #1305. The composition adapter that pipelines the two engines.

GoldenProfile emits a cluster PARTITION (`Resolution.clusters: number[][]`); GoldenGraph's `buildGraph` wants a `{ mentionIndex: entityId }` map. Two zero-dep bridge helpers (base export of `goldengraph`):

- `resolutionFromClusters(clusters)` — partition → resolution map (cluster index = entity id).
- `mentionsFromProfiles(profiles, typeOf?)` — goldenprofile-shaped `{name, category}` → `Mention[]` (`typ` from `category` by default), order-preserving.

`goldengraph` stays **zero-dep** — these operate on plain shapes; the caller brings both packages. README documents the full `resolveProfiles → buildGraph` pipeline. Edge-kind goldenprofile profiles are out of scope (supply graph edges directly).

Verified locally (Node + committed wasm): `resolutionFromClusters([[0,1],[2]])` → `{0:0,1:0,2:1}`; the full pipeline yields the expected 2 merged entities (`surface_names ["Apple","Apple Inc"]`) and one community. Unit tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)