### PR TITLE
feat(goldengraph): bitemporal store surface (appendBatch / asOf / history)

### DIFF
--- a/context-network/decisions/0029-goldengraph-wasm-ts.md
+++ b/context-network/decisions/0029-goldengraph-wasm-ts.md
@@ -16,9 +16,12 @@ missing. Bigger surface — 7 kernel ops — and it composes goldenprofile (its
    (throw) when the backend isn't enabled — never a fake result.
 2. **v1 = the 4 graph+query ops** (`buildGraph` / `neighborhood` / `seedsByName`
    / `communities`). **The bitemporal store** (`store_append` / `store_as_of` /
-   `store_history`) is **deferred** — it is roughly double the type + fixture
-   surface (`StableId`, `StoredEntity/Edge`, `HistoryEvent`, snapshot format,
-   bitemporal `as_of`) and cleanly separable. A fast-follow.
+   `store_history`) was deferred as a separable fast-follow. **UPDATE (0.2.0,
+   2026-06-28): the store shipped** — `appendBatch` / `asOf` / `history` over a
+   portable JSON `Snapshot`, with parity fixtures for the append→as_of→history
+   flow. Gotcha: the kernel's i64/u64 params (`valid_t`/`tx_t`/`id`) map to
+   wasm-bindgen **BigInt**; the public API takes `number` and converts at the
+   wasm boundary.
 3. **Zero runtime deps.** The resolution input is a `{mentionIndex: entityId}`
    map or `["native", scorerId, threshold]` — NOT goldenprofile's `Resolution`
    shape — so no hard goldenprofile dependency. Composition (`resolveProfiles →

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,15 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-28 — GoldenGraph TS: bitemporal store shipped (0.2.0)
+- The store deferred in [0029](../decisions/0029-goldengraph-wasm-ts.md) now ships:
+  `appendBatch` / `asOf` / `history` over a portable JSON `Snapshot` (the kernel's
+  `store_*` ops). Parity fixtures cover the append → as_of → history flow; 9 total
+  goldengraph parity cases. Also: the `goldenprofile → goldengraph` composition
+  helpers (`resolutionFromClusters` / `mentionsFromProfiles`) landed (#1306).
+- Gotcha recorded in 0029: wasm-bindgen maps the kernel's i64/u64 params to BigInt;
+  the public API takes `number` and converts at the boundary.
+
 ## 2026-06-28 — GoldenGraph (KG engine) on the TS/WASM surface (v1: graph+query)
 - New ADR [../decisions/0029-goldengraph-wasm-ts.md](../decisions/0029-goldengraph-wasm-ts.md):
   the GoldenGraph knowledge-graph engine gets a TS/JS surface via `goldengraph-wasm`

--- a/packages/rust/extensions/goldengraph-wasm/Cargo.lock
+++ b/packages/rust/extensions/goldengraph-wasm/Cargo.lock
@@ -3,340 +3,16 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "const-random",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "arrow"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffaaa3e009861fd829d0a24dd6f115aa8e4634324bb092147d43baafe69ca4a7"
-dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac95125e1d71c4a252b5a9c729aef111e80418f08aaa6dbabd1ba66918247fc"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-array"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
-dependencies = [
- "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "hashbrown",
- "num-complex",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
-dependencies = [
- "bytes",
- "half",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82c236c3caf8df5664284f3f1fbe89938852163998c3fdbf37e84ac220445e9"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "atoi",
- "base64",
- "chrono",
- "half",
- "lexical-core",
- "num-traits",
- "ryu",
-]
-
-[[package]]
-name = "arrow-data"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
-dependencies = [
- "arrow-buffer",
- "arrow-schema",
- "half",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79cf73ad2eba8686ec2aa9bbf8671208e509025f166afc040cedbd94ffe4983"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
-]
-
-[[package]]
-name = "arrow-row"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea0f7d8ed6182f14952761e2c0f989852d5aa334fcbc49f73a9f2247c25b879"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "half",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
-
-[[package]]
-name = "arrow-select"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067a67e0361f6c31f4a7248759f36ca4ca71b187a941ed4d49da1c7d3d4db624"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-string"
-version = "59.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bc95847f3ff62a2b03d6f8ce2e3e78f01362060549a2a311898dd442f6256d"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "memchr",
- "num-traits",
- "regex",
- "regex-syntax",
-]
-
-[[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "bytes"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
-
-[[package]]
-name = "cc"
-version = "1.2.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
 
 [[package]]
 name = "goldengraph-core"
@@ -360,9 +36,6 @@ dependencies = [
 [[package]]
 name = "goldenmatch-graph-core"
 version = "0.1.0"
-dependencies = [
- "arrow",
-]
 
 [[package]]
 name = "goldenmatch-score-core"
@@ -372,138 +45,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "js-sys"
-version = "0.3.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
-dependencies = [
- "cfg-if",
- "futures-util",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "lexical-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.186"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "log"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
@@ -512,54 +57,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -580,57 +81,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
 name = "rapidfuzz"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "270e04e5ea61d40841942bb15e451c29ee1618637bcf97fc7ede5dd4a9b1601b"
 
 [[package]]
-name = "regex"
-version = "1.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
@@ -676,18 +136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,40 +147,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -777,91 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/packages/rust/extensions/goldengraph-wasm/examples/gen_parity_fixtures.rs
+++ b/packages/rust/extensions/goldengraph-wasm/examples/gen_parity_fixtures.rs
@@ -158,6 +158,77 @@ fn main() {
         "expected": serde_json::from_str::<Value>(&comms2).unwrap(),
     }));
 
+    // ---- Bitemporal store: append -> append(merge via record_key) -> as_of / history.
+    let be = |local_id: u32, name: &str, typ: &str, surf: Value, keys: Value| {
+        json!({"local_id": local_id, "canonical_name": name, "typ": typ,
+               "surface_names": surf, "record_keys": keys})
+    };
+    let bed = |s: u32, p: &str, o: u32, vf: i64, refs: Value| {
+        json!({"subj_local": s, "predicate": p, "obj_local": o,
+               "valid_from": vf, "valid_to": Value::Null, "source_refs": refs})
+    };
+    // Batch 1 @ t=100: Apple Inc + Tim Cook, one ceo_of edge.
+    let batch1 = json!({
+        "entities": [
+            be(0, "Apple Inc", "Company", json!(["Apple Inc"]), json!(["k_apple"])),
+            be(1, "Tim Cook", "Person", json!(["Tim Cook"]), json!(["k_tim"])),
+        ],
+        "edges": [bed(1, "ceo_of", 0, 100, json!(["doc1"]))],
+        "ingested_at": 100,
+    });
+    // Batch 2 @ t=200: same record_key k_apple, new surface "Apple".
+    let batch2 = json!({
+        "entities": [be(0, "Apple", "Company", json!(["Apple"]), json!(["k_apple"]))],
+        "edges": [],
+        "ingested_at": 200,
+    });
+
+    let snap1 = goldengraph_wasm::store_append_impl("", &serde_json::to_string(&batch1).unwrap())
+        .expect("append1");
+    let snap2 =
+        goldengraph_wasm::store_append_impl(&snap1, &serde_json::to_string(&batch2).unwrap())
+            .expect("append2");
+
+    cases.push(json!({
+        "name": "store_append_fresh",
+        "fn": "store_append",
+        "args": { "snapshot": "", "batch": batch1 },
+        "expected": serde_json::from_str::<Value>(&snap1).unwrap(),
+    }));
+    cases.push(json!({
+        "name": "store_append_merge",
+        "fn": "store_append",
+        "args": { "snapshot": serde_json::from_str::<Value>(&snap1).unwrap(), "batch": batch2 },
+        "expected": serde_json::from_str::<Value>(&snap2).unwrap(),
+    }));
+
+    // as_of the current view (valid + tx both after the last ingest).
+    let g_asof = goldengraph_wasm::store_as_of_impl(&snap2, 250, 250).expect("as_of");
+    cases.push(json!({
+        "name": "store_as_of_current",
+        "fn": "store_as_of",
+        "args": { "snapshot": serde_json::from_str::<Value>(&snap2).unwrap(), "valid_t": 250, "tx_t": 250 },
+        "expected": canon_graph(serde_json::from_str(&g_asof).unwrap()),
+    }));
+
+    // history of the first entity id in the snapshot.
+    let snap2v: Value = serde_json::from_str(&snap2).unwrap();
+    let first_id: u64 = snap2v["entities"]
+        .as_object()
+        .unwrap()
+        .keys()
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let hist = goldengraph_wasm::store_history_impl(&snap2, first_id).expect("history");
+    cases.push(json!({
+        "name": "store_history_first",
+        "fn": "store_history",
+        "args": { "snapshot": snap2v, "id": first_id },
+        "expected": serde_json::from_str::<Value>(&hist).unwrap(),
+    }));
+
     println!(
         "{}",
         serde_json::to_string_pretty(&json!({ "cases": cases })).unwrap()

--- a/packages/typescript/goldengraph/CHANGELOG.md
+++ b/packages/typescript/goldengraph/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `goldengraph` are documented here.
 
+## [0.2.0] - 2026-06-28
+
+### Added
+- **Bitemporal store** surface: `appendBatch(snapshot, batch)`, `asOf(snapshot,
+  validT, txT)`, `history(snapshot, id)` — the kernel's `store_*` ops, over a
+  portable JSON snapshot. Types: `StoreBatch` / `BatchEntity` / `BatchEdge` /
+  `Snapshot` / `StoredEntity` / `StoredEdge` / `HistoryEvent`.
+- `goldenprofile -> goldengraph` composition helpers (`resolutionFromClusters`,
+  `mentionsFromProfiles`).
+
 ## [0.1.0] - 2026-06-28
 
 Initial release: edge-safe TypeScript surface for the GoldenGraph knowledge-graph engine (v1 — the 4 graph + query ops).

--- a/packages/typescript/goldengraph/README.md
+++ b/packages/typescript/goldengraph/README.md
@@ -67,7 +67,28 @@ const graph = buildGraph(
 The conversion is exact and order-preserving (profile index `i` == mention index
 `i`), as long as you build the mentions from the SAME profile list you resolved.
 
-> **Scope:** v1 surfaces the 4 graph + query ops. The kernel's bitemporal store (`store_append/as_of/history`) is not yet wired into this package.
+## Bitemporal store
+
+Ingest entities + edges over time, then read the graph "as of" a (valid-time,
+transaction-time) point, or an entity's merge/split history. The snapshot is a
+portable JSON value — the store ops are stateless over it (no handles cross the
+boundary), so you hold and pass it back.
+
+```ts
+import { appendBatch, asOf, history } from "goldengraph";
+import { enableGoldengraphWasm } from "goldengraph/wasm";
+
+enableGoldengraphWasm();
+
+let snap = appendBatch(null, batch1);   // null opens a fresh store
+snap = appendBatch(snap, batch2);       // entities sharing a record_key merge
+
+const graph = asOf(snap, validTime, txTime);  // bitemporal slice
+const events = history(snap, entityId);        // [{ Merge: {...} } | { Split: {...} }]
+```
+
+`record_keys` (e.g. `:h1:` fingerprints) match entities across batches; a match
+merges them and records a `Merge` history event.
 
 ## Regenerating the wasm artifact
 

--- a/packages/typescript/goldengraph/README.md
+++ b/packages/typescript/goldengraph/README.md
@@ -81,14 +81,16 @@ import { enableGoldengraphWasm } from "goldengraph/wasm";
 enableGoldengraphWasm();
 
 let snap = appendBatch(null, batch1);   // null opens a fresh store
-snap = appendBatch(snap, batch2);       // entities sharing a record_key merge
+snap = appendBatch(snap, batch2);       // entities sharing a record_key dedup
 
 const graph = asOf(snap, validTime, txTime);  // bitemporal slice
 const events = history(snap, entityId);        // [{ Merge: {...} } | { Split: {...} }]
 ```
 
-`record_keys` (e.g. `:h1:` fingerprints) match entities across batches; a match
-merges them and records a `Merge` history event.
+`record_keys` (e.g. `:h1:` fingerprints) match entities across batches: a match
+updates the existing entity in place (latest-wins on its attributes — no
+duplicate entity is created). `history(id)` returns an entity's merge/split
+events, which come from distinct-entity merges/splits, not from record_key dedup.
 
 ## Regenerating the wasm artifact
 

--- a/packages/typescript/goldengraph/package.json
+++ b/packages/typescript/goldengraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldengraph",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "GoldenGraph knowledge-graph engine — build / query / community over resolved entities. Edge-safe TypeScript surface over the same pyo3-free Rust kernel as the Python/C bindings, via opt-in WebAssembly.",
   "keywords": [
     "knowledge-graph",

--- a/packages/typescript/goldengraph/scripts/build_goldengraph_wasm.mjs
+++ b/packages/typescript/goldengraph/scripts/build_goldengraph_wasm.mjs
@@ -75,6 +75,9 @@ export function build_graph(mentions_json: string, edges_json: string, resolutio
 export function neighborhood(graph_json: string, seeds_json: string, hops: number): string;
 export function seeds_by_name(graph_json: string, name: string): string;
 export function communities(graph_json: string): string;
+export function store_append(snapshot_json: string, batch_json: string): string;
+export function store_as_of(snapshot_json: string, valid_t: bigint, tx_t: bigint): string;
+export function store_history(snapshot_json: string, id: bigint): string;
 export type SyncInitInput = BufferSource | WebAssembly.Module;
 export function initSync(
   module: { module: SyncInitInput } | SyncInitInput,

--- a/packages/typescript/goldengraph/src/core/_wasm/goldengraphWasmBindings.d.ts
+++ b/packages/typescript/goldengraph/src/core/_wasm/goldengraphWasmBindings.d.ts
@@ -3,6 +3,9 @@ export function build_graph(mentions_json: string, edges_json: string, resolutio
 export function neighborhood(graph_json: string, seeds_json: string, hops: number): string;
 export function seeds_by_name(graph_json: string, name: string): string;
 export function communities(graph_json: string): string;
+export function store_append(snapshot_json: string, batch_json: string): string;
+export function store_as_of(snapshot_json: string, valid_t: bigint, tx_t: bigint): string;
+export function store_history(snapshot_json: string, id: bigint): string;
 export type SyncInitInput = BufferSource | WebAssembly.Module;
 export function initSync(
   module: { module: SyncInitInput } | SyncInitInput,

--- a/packages/typescript/goldengraph/src/core/goldengraphWasm.ts
+++ b/packages/typescript/goldengraph/src/core/goldengraphWasm.ts
@@ -14,6 +14,9 @@ import {
   neighborhood,
   seeds_by_name,
   communities,
+  store_append,
+  store_as_of,
+  store_history,
   initSync,
 } from "./_wasm/goldengraphWasmBindings.js";
 import { GOLDENGRAPH_WASM_BASE64 } from "./_wasm/goldengraphWasmBytes.js";
@@ -44,5 +47,9 @@ export function enableGoldengraphWasm(): void {
     neighborhood: (g, s, h) => neighborhood(g, s, h),
     seedsByName: (g, n) => seeds_by_name(g, n),
     communities: (g) => communities(g),
+    storeAppend: (s, b) => store_append(s, b),
+    // valid_t/tx_t/id are i64/u64 in the kernel -> wasm-bindgen wants BigInt.
+    storeAsOf: (s, v, t) => store_as_of(s, BigInt(v), BigInt(t)),
+    storeHistory: (s, id) => store_history(s, BigInt(id)),
   });
 }

--- a/packages/typescript/goldengraph/src/core/goldengraphWasmBackend.ts
+++ b/packages/typescript/goldengraph/src/core/goldengraphWasmBackend.ts
@@ -9,7 +9,7 @@
  * an actionable error (mirrors goldenprofile + Python's native-wheel requirement).
  */
 
-/** The 4 graph+query JSON boundaries the wasm kernel implements (one core). */
+/** The JSON boundaries the wasm kernel implements (one core). */
 export interface GoldengraphWasmBackend {
   /** `(mentions, edges, resolution) -> graph` JSON. */
   buildGraph(mentionsJson: string, edgesJson: string, resolutionJson: string): string;
@@ -19,6 +19,12 @@ export interface GoldengraphWasmBackend {
   seedsByName(graphJson: string, name: string): string;
   /** `(graph) -> communities` JSON. */
   communities(graphJson: string): string;
+  /** `(snapshot|"" , batch) -> snapshot` JSON (bitemporal store append). */
+  storeAppend(snapshotJson: string, batchJson: string): string;
+  /** `(snapshot, valid_t, tx_t) -> graph` JSON (bitemporal slice). */
+  storeAsOf(snapshotJson: string, validT: number, txT: number): string;
+  /** `(snapshot, id) -> history-events` JSON. */
+  storeHistory(snapshotJson: string, id: number): string;
 }
 
 let _backend: GoldengraphWasmBackend | null = null;
@@ -41,4 +47,16 @@ export function disableGoldengraphWasm(): void {
 /** True when the opt-in wasm backend is currently registered. */
 export function isGoldengraphWasmEnabled(): boolean {
   return _backend !== null;
+}
+
+/** The registered backend, or throw the actionable "enable wasm" error. */
+export function requireGoldengraphWasmBackend(): GoldengraphWasmBackend {
+  if (_backend === null) {
+    throw new Error(
+      "GoldenGraph requires the wasm backend. " +
+        'Import { enableGoldengraphWasm } from "goldengraph/wasm" and call it ' +
+        "once before any query.",
+    );
+  }
+  return _backend;
 }

--- a/packages/typescript/goldengraph/src/index.ts
+++ b/packages/typescript/goldengraph/src/index.ts
@@ -14,8 +14,8 @@
  * The engine is the SAME pyo3-free Rust kernel (`goldengraph-core`) the Python
  * (`goldengraph_native`) and C bindings use — byte-identical by construction.
  *
- * v1 surfaces the 4 graph+query ops. The bitemporal store
- * (`store_append/as_of/history`) is in the kernel but not yet wired here.
+ * Surfaces the 4 graph+query ops plus the bitemporal store (`appendBatch` /
+ * `asOf` / `history`, re-exported from `./store.js`).
  */
 export {
   setGoldengraphWasmBackend,
@@ -31,6 +31,20 @@ export {
   mentionsFromProfiles,
   type ProfileLike,
 } from "./compose.js";
+
+// The bitemporal store surface (append / as-of / history).
+export {
+  appendBatch,
+  asOf,
+  history,
+  type BatchEntity,
+  type BatchEdge,
+  type StoreBatch,
+  type StoredEntity,
+  type StoredEdge,
+  type HistoryEvent,
+  type Snapshot,
+} from "./store.js";
 
 import { getGoldengraphWasmBackend } from "./core/goldengraphWasmBackend.js";
 

--- a/packages/typescript/goldengraph/src/store.ts
+++ b/packages/typescript/goldengraph/src/store.ts
@@ -1,0 +1,107 @@
+/**
+ * store.ts — the GoldenGraph bitemporal store surface.
+ *
+ * Stateless ops over a portable JSON snapshot (the snapshot IS the state — no
+ * handles cross the boundary). Append batches over time, then read the graph
+ * "as of" a (valid-time, transaction-time) point, or an entity's merge/split
+ * history. The kernel is the same `goldengraph-core` the Python/C bindings use.
+ *
+ *   import { appendBatch, asOf, history } from "goldengraph";
+ *   import { enableGoldengraphWasm } from "goldengraph/wasm";
+ *   enableGoldengraphWasm();
+ *   let snap = appendBatch(null, batch1);   // null opens a fresh store
+ *   snap = appendBatch(snap, batch2);       // chain
+ *   const graph = asOf(snap, Date.now(), Date.now());
+ */
+import { requireGoldengraphWasmBackend } from "./core/goldengraphWasmBackend.js";
+import type { Graph } from "./index.js";
+
+/** An entity in an append batch (local id is batch-scoped). Mirrors `BatchEntity`. */
+export interface BatchEntity {
+  local_id: number;
+  canonical_name: string;
+  typ: string;
+  surface_names: string[];
+  /** Host-supplied stable keys (e.g. `:h1:` fingerprints) used to match across batches. */
+  record_keys: string[];
+}
+
+/** A relationship in an append batch, over batch-local ids. Mirrors `BatchEdge`. */
+export interface BatchEdge {
+  subj_local: number;
+  predicate: string;
+  obj_local: number;
+  valid_from: number;
+  valid_to: number | null;
+  source_refs: string[];
+}
+
+/** A batch of entities + edges ingested at `ingested_at` (transaction time). */
+export interface StoreBatch {
+  entities: BatchEntity[];
+  edges: BatchEdge[];
+  ingested_at: number;
+}
+
+/** A stored entity with bitemporal supersession metadata. Mirrors `StoredEntity`. */
+export interface StoredEntity {
+  id: number;
+  canonical_name: string;
+  typ: string;
+  surface_names: string[];
+  record_keys: string[];
+  created_at: number;
+  superseded_by: number | null;
+  superseded_at: number | null;
+}
+
+/** A stored edge with a validity interval. Mirrors `StoredEdge`. */
+export interface StoredEdge {
+  subj: number;
+  predicate: string;
+  obj: number;
+  valid_from: number;
+  valid_to: number | null;
+  ingested_at: number;
+  source_refs: string[];
+}
+
+/** A merge/split event in an entity's history (externally-tagged, mirrors `HistoryEvent`). */
+export type HistoryEvent =
+  | { Merge: { kept: number; absorbed: number[]; at: number } }
+  | { Split: { from: number; into: number[]; at: number } };
+
+/** The portable bitemporal store snapshot (the serialized kernel `GraphStore`). */
+export interface Snapshot {
+  /** Keyed by stable id (stringified, since it's a JSON object). */
+  entities: Record<string, StoredEntity>;
+  edges: StoredEdge[];
+  history: HistoryEvent[];
+  next_id: number;
+}
+
+/**
+ * Append a batch. Pass `null` (or an empty snapshot) to open a fresh store;
+ * otherwise the batch is merged into `snapshot`. Returns the new snapshot —
+ * chain calls to ingest over time.
+ */
+export function appendBatch(snapshot: Snapshot | null, batch: StoreBatch): Snapshot {
+  const snapJson = snapshot === null ? "" : JSON.stringify(snapshot);
+  return JSON.parse(
+    requireGoldengraphWasmBackend().storeAppend(snapJson, JSON.stringify(batch)),
+  ) as Snapshot;
+}
+
+/** The resolved graph as of `(validT, txT)` — a bitemporal slice of the snapshot. */
+export function asOf(snapshot: Snapshot, validT: number, txT: number): Graph {
+  return JSON.parse(
+    requireGoldengraphWasmBackend().storeAsOf(JSON.stringify(snapshot), validT, txT),
+  ) as Graph;
+}
+
+/** The merge/split history of entity `id` in the snapshot. */
+export function history(snapshot: Snapshot, id: number): HistoryEvent[] {
+  return JSON.parse(
+    requireGoldengraphWasmBackend().storeHistory(JSON.stringify(snapshot), id),
+  ) as HistoryEvent[];
+}

--- a/packages/typescript/goldengraph/tests/parity/fixtures/goldengraph/queries.json
+++ b/packages/typescript/goldengraph/tests/parity/fixtures/goldengraph/queries.json
@@ -304,6 +304,358 @@
       ],
       "fn": "communities",
       "name": "communities_disconnected"
+    },
+    {
+      "args": {
+        "batch": {
+          "edges": [
+            {
+              "obj_local": 0,
+              "predicate": "ceo_of",
+              "source_refs": [
+                "doc1"
+              ],
+              "subj_local": 1,
+              "valid_from": 100,
+              "valid_to": null
+            }
+          ],
+          "entities": [
+            {
+              "canonical_name": "Apple Inc",
+              "local_id": 0,
+              "record_keys": [
+                "k_apple"
+              ],
+              "surface_names": [
+                "Apple Inc"
+              ],
+              "typ": "Company"
+            },
+            {
+              "canonical_name": "Tim Cook",
+              "local_id": 1,
+              "record_keys": [
+                "k_tim"
+              ],
+              "surface_names": [
+                "Tim Cook"
+              ],
+              "typ": "Person"
+            }
+          ],
+          "ingested_at": 100
+        },
+        "snapshot": ""
+      },
+      "expected": {
+        "edges": [
+          {
+            "ingested_at": 100,
+            "obj": 0,
+            "predicate": "ceo_of",
+            "source_refs": [
+              "doc1"
+            ],
+            "subj": 1,
+            "valid_from": 100,
+            "valid_to": null
+          }
+        ],
+        "entities": {
+          "0": {
+            "canonical_name": "Apple Inc",
+            "created_at": 100,
+            "id": 0,
+            "record_keys": [
+              "k_apple"
+            ],
+            "superseded_at": null,
+            "superseded_by": null,
+            "surface_names": [
+              "Apple Inc"
+            ],
+            "typ": "Company"
+          },
+          "1": {
+            "canonical_name": "Tim Cook",
+            "created_at": 100,
+            "id": 1,
+            "record_keys": [
+              "k_tim"
+            ],
+            "superseded_at": null,
+            "superseded_by": null,
+            "surface_names": [
+              "Tim Cook"
+            ],
+            "typ": "Person"
+          }
+        },
+        "history": [],
+        "next_id": 2
+      },
+      "fn": "store_append",
+      "name": "store_append_fresh"
+    },
+    {
+      "args": {
+        "batch": {
+          "edges": [],
+          "entities": [
+            {
+              "canonical_name": "Apple",
+              "local_id": 0,
+              "record_keys": [
+                "k_apple"
+              ],
+              "surface_names": [
+                "Apple"
+              ],
+              "typ": "Company"
+            }
+          ],
+          "ingested_at": 200
+        },
+        "snapshot": {
+          "edges": [
+            {
+              "ingested_at": 100,
+              "obj": 0,
+              "predicate": "ceo_of",
+              "source_refs": [
+                "doc1"
+              ],
+              "subj": 1,
+              "valid_from": 100,
+              "valid_to": null
+            }
+          ],
+          "entities": {
+            "0": {
+              "canonical_name": "Apple Inc",
+              "created_at": 100,
+              "id": 0,
+              "record_keys": [
+                "k_apple"
+              ],
+              "superseded_at": null,
+              "superseded_by": null,
+              "surface_names": [
+                "Apple Inc"
+              ],
+              "typ": "Company"
+            },
+            "1": {
+              "canonical_name": "Tim Cook",
+              "created_at": 100,
+              "id": 1,
+              "record_keys": [
+                "k_tim"
+              ],
+              "superseded_at": null,
+              "superseded_by": null,
+              "surface_names": [
+                "Tim Cook"
+              ],
+              "typ": "Person"
+            }
+          },
+          "history": [],
+          "next_id": 2
+        }
+      },
+      "expected": {
+        "edges": [
+          {
+            "ingested_at": 100,
+            "obj": 0,
+            "predicate": "ceo_of",
+            "source_refs": [
+              "doc1"
+            ],
+            "subj": 1,
+            "valid_from": 100,
+            "valid_to": null
+          }
+        ],
+        "entities": {
+          "0": {
+            "canonical_name": "Apple",
+            "created_at": 100,
+            "id": 0,
+            "record_keys": [
+              "k_apple"
+            ],
+            "superseded_at": null,
+            "superseded_by": null,
+            "surface_names": [
+              "Apple"
+            ],
+            "typ": "Company"
+          },
+          "1": {
+            "canonical_name": "Tim Cook",
+            "created_at": 100,
+            "id": 1,
+            "record_keys": [
+              "k_tim"
+            ],
+            "superseded_at": null,
+            "superseded_by": null,
+            "surface_names": [
+              "Tim Cook"
+            ],
+            "typ": "Person"
+          }
+        },
+        "history": [],
+        "next_id": 2
+      },
+      "fn": "store_append",
+      "name": "store_append_merge"
+    },
+    {
+      "args": {
+        "snapshot": {
+          "edges": [
+            {
+              "ingested_at": 100,
+              "obj": 0,
+              "predicate": "ceo_of",
+              "source_refs": [
+                "doc1"
+              ],
+              "subj": 1,
+              "valid_from": 100,
+              "valid_to": null
+            }
+          ],
+          "entities": {
+            "0": {
+              "canonical_name": "Apple",
+              "created_at": 100,
+              "id": 0,
+              "record_keys": [
+                "k_apple"
+              ],
+              "superseded_at": null,
+              "superseded_by": null,
+              "surface_names": [
+                "Apple"
+              ],
+              "typ": "Company"
+            },
+            "1": {
+              "canonical_name": "Tim Cook",
+              "created_at": 100,
+              "id": 1,
+              "record_keys": [
+                "k_tim"
+              ],
+              "superseded_at": null,
+              "superseded_by": null,
+              "surface_names": [
+                "Tim Cook"
+              ],
+              "typ": "Person"
+            }
+          },
+          "history": [],
+          "next_id": 2
+        },
+        "tx_t": 250,
+        "valid_t": 250
+      },
+      "expected": {
+        "edges": [
+          {
+            "obj": 0,
+            "predicate": "ceo_of",
+            "source_refs": [
+              "doc1"
+            ],
+            "subj": 1
+          }
+        ],
+        "entities": [
+          {
+            "canonical_name": "Apple",
+            "entity_id": 0,
+            "members": [],
+            "surface_names": [
+              "Apple"
+            ],
+            "typ": "Company"
+          },
+          {
+            "canonical_name": "Tim Cook",
+            "entity_id": 1,
+            "members": [],
+            "surface_names": [
+              "Tim Cook"
+            ],
+            "typ": "Person"
+          }
+        ]
+      },
+      "fn": "store_as_of",
+      "name": "store_as_of_current"
+    },
+    {
+      "args": {
+        "id": 0,
+        "snapshot": {
+          "edges": [
+            {
+              "ingested_at": 100,
+              "obj": 0,
+              "predicate": "ceo_of",
+              "source_refs": [
+                "doc1"
+              ],
+              "subj": 1,
+              "valid_from": 100,
+              "valid_to": null
+            }
+          ],
+          "entities": {
+            "0": {
+              "canonical_name": "Apple",
+              "created_at": 100,
+              "id": 0,
+              "record_keys": [
+                "k_apple"
+              ],
+              "superseded_at": null,
+              "superseded_by": null,
+              "surface_names": [
+                "Apple"
+              ],
+              "typ": "Company"
+            },
+            "1": {
+              "canonical_name": "Tim Cook",
+              "created_at": 100,
+              "id": 1,
+              "record_keys": [
+                "k_tim"
+              ],
+              "superseded_at": null,
+              "superseded_by": null,
+              "surface_names": [
+                "Tim Cook"
+              ],
+              "typ": "Person"
+            }
+          },
+          "history": [],
+          "next_id": 2
+        }
+      },
+      "expected": [],
+      "fn": "store_history",
+      "name": "store_history_first"
     }
   ]
 }

--- a/packages/typescript/goldengraph/tests/parity/goldengraph-wasm.parity.test.ts
+++ b/packages/typescript/goldengraph/tests/parity/goldengraph-wasm.parity.test.ts
@@ -17,14 +17,27 @@ import {
   neighborhood,
   seedsByName,
   communities,
+  appendBatch,
+  asOf,
+  history,
   type Graph,
   type Community,
+  type Snapshot,
+  type StoreBatch,
+  type HistoryEvent,
 } from "../../src/index.js";
 import { enableGoldengraphWasm } from "../../src/core/goldengraphWasm.js";
 
 interface Case {
   name: string;
-  fn: "build_graph" | "neighborhood" | "seeds_by_name" | "communities";
+  fn:
+    | "build_graph"
+    | "neighborhood"
+    | "seeds_by_name"
+    | "communities"
+    | "store_append"
+    | "store_as_of"
+    | "store_history";
   args: Record<string, unknown>;
   expected: unknown;
 }
@@ -85,6 +98,22 @@ describe("goldengraph wasm <-> host parity", () => {
         case "communities": {
           const got = communities(c.args.graph as Graph);
           expect(got).toEqual(c.expected as Community[]);
+          break;
+        }
+        case "store_append": {
+          const snap = c.args.snapshot === "" ? null : (c.args.snapshot as Snapshot);
+          const got = appendBatch(snap, c.args.batch as StoreBatch);
+          expect(got).toEqual(c.expected as Snapshot); // snapshot is deterministic
+          break;
+        }
+        case "store_as_of": {
+          const got = asOf(c.args.snapshot as Snapshot, c.args.valid_t as number, c.args.tx_t as number);
+          expect(canonGraph(got)).toEqual(canonGraph(c.expected as Graph));
+          break;
+        }
+        case "store_history": {
+          const got = history(c.args.snapshot as Snapshot, c.args.id as number);
+          expect(got).toEqual(c.expected as HistoryEvent[]);
           break;
         }
       }

--- a/packages/typescript/goldengraph/tests/unit/store.test.ts
+++ b/packages/typescript/goldengraph/tests/unit/store.test.ts
@@ -37,16 +37,20 @@ describe("goldengraph bitemporal store", () => {
     expect(snap.next_id).toBeGreaterThan(0);
   });
 
-  it("chained append + as-of reflects the merged record_key entity", () => {
+  it("chained append + as-of dedups by record_key (no duplicate entity)", () => {
     enableGoldengraphWasm();
     let snap = appendBatch(null, batch1);
-    snap = appendBatch(snap, batch2); // same k_apple -> merges into Apple Inc
+    snap = appendBatch(snap, batch2); // same k_apple -> updates entity 0, no new entity
 
     const graph = asOf(snap, 250, 250);
-    const apple = graph.entities.find((e) => e.surface_names.includes("Apple Inc"));
-    // the merge brought the "Apple" surface onto the same entity
-    expect(apple?.surface_names).toEqual(expect.arrayContaining(["Apple", "Apple Inc"]));
-    // Tim Cook + the CEO edge survive
+    // Still 2 entities: batch2's k_apple matched entity 0 (no duplicate added).
+    expect(graph.entities.length).toBe(2);
+    // The matched entity is updated to the latest batch (canonical "Apple",
+    // surfaces ["Apple"]) — the kernel is latest-wins, not a surface union.
+    const apple = graph.entities.find((e) => e.canonical_name === "Apple");
+    expect(apple).toBeDefined();
+    expect(apple?.surface_names).toEqual(["Apple"]);
+    // Tim Cook + the CEO edge survive.
     expect(graph.entities.some((e) => e.canonical_name === "Tim Cook")).toBe(true);
     expect(graph.edges.some((e) => e.predicate === "ceo_of")).toBe(true);
   });

--- a/packages/typescript/goldengraph/tests/unit/store.test.ts
+++ b/packages/typescript/goldengraph/tests/unit/store.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Bitemporal store: append (fresh + chained), as-of slice, history, and the
+ * unregistered-throw contract.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { appendBatch, asOf, disableGoldengraphWasm, type StoreBatch } from "../../src/index.js";
+import { enableGoldengraphWasm } from "../../src/core/goldengraphWasm.js";
+
+const batch1: StoreBatch = {
+  entities: [
+    { local_id: 0, canonical_name: "Apple Inc", typ: "Company", surface_names: ["Apple Inc"], record_keys: ["k_apple"] },
+    { local_id: 1, canonical_name: "Tim Cook", typ: "Person", surface_names: ["Tim Cook"], record_keys: ["k_tim"] },
+  ],
+  edges: [{ subj_local: 1, predicate: "ceo_of", obj_local: 0, valid_from: 100, valid_to: null, source_refs: ["doc1"] }],
+  ingested_at: 100,
+};
+const batch2: StoreBatch = {
+  entities: [{ local_id: 0, canonical_name: "Apple", typ: "Company", surface_names: ["Apple"], record_keys: ["k_apple"] }],
+  edges: [],
+  ingested_at: 200,
+};
+
+describe("goldengraph bitemporal store", () => {
+  afterEach(() => {
+    disableGoldengraphWasm();
+  });
+
+  it("throws when wasm is not enabled", () => {
+    disableGoldengraphWasm();
+    expect(() => appendBatch(null, batch1)).toThrowError(/requires the wasm backend/i);
+  });
+
+  it("append (fresh) opens a store with the batch's entities", () => {
+    enableGoldengraphWasm();
+    const snap = appendBatch(null, batch1);
+    expect(Object.keys(snap.entities).length).toBe(2);
+    expect(snap.next_id).toBeGreaterThan(0);
+  });
+
+  it("chained append + as-of reflects the merged record_key entity", () => {
+    enableGoldengraphWasm();
+    let snap = appendBatch(null, batch1);
+    snap = appendBatch(snap, batch2); // same k_apple -> merges into Apple Inc
+
+    const graph = asOf(snap, 250, 250);
+    const apple = graph.entities.find((e) => e.surface_names.includes("Apple Inc"));
+    // the merge brought the "Apple" surface onto the same entity
+    expect(apple?.surface_names).toEqual(expect.arrayContaining(["Apple", "Apple Inc"]));
+    // Tim Cook + the CEO edge survive
+    expect(graph.entities.some((e) => e.canonical_name === "Tim Cook")).toBe(true);
+    expect(graph.edges.some((e) => e.predicate === "ceo_of")).toBe(true);
+  });
+});


### PR DESCRIPTION
Ships the GoldenGraph kernel's bitemporal store ops, deferred from v1 (#1305, ADR 0029).

## What's here
- `appendBatch(snapshot | null, batch)` → snapshot; `asOf(snapshot, validT, txT)` → graph; `history(snapshot, id)` → merge/split events. Stateless over a portable JSON `Snapshot` (no handles cross the boundary — hold it and pass it back).
- Types: `StoreBatch` / `BatchEntity` / `BatchEdge` / `Snapshot` / `StoredEntity` / `StoredEdge` / `HistoryEvent` (the externally-tagged `Merge | Split` enum).
- Parity fixtures extended to the append → as_of → history flow (9 total goldengraph cases, idempotent) + unit tests for the bitemporal flow and the refusing contract.
- README store section, CHANGELOG, ADR 0029 update, context-network log. Bumped 0.1.0 → 0.2.0 (also covers the composition helpers from #1306).

## Gotcha (in ADR 0029)
The kernel's i64/u64 params (`valid_t`/`tx_t`/`id`) map to wasm-bindgen **BigInt**, not number. The public API takes `number` and converts at the wasm boundary — caught by "Cannot convert N to a BigInt" in the parity check.

## Verified locally
All 9 parity cases pass vs the committed wasm — including append-fresh, a `record_key` merge across batches, an `as_of` slice, and `history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)