### PR TITLE
feat(er-kg-bench): stage-2-A MuSiQue fair-metric + lever-ranking verdict

### DIFF
--- a/docs/superpowers/plans/2026-06-29-stage2a-musique-lever-ranking.md
+++ b/docs/superpowers/plans/2026-06-29-stage2a-musique-lever-ranking.md
@@ -1,0 +1,382 @@
+# Stage-2-A: MuSiQue Lever-Ranking Instrument — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add narrow, deterministic answer-string canonicalization (dates, times, standalone number-words) to the bench metrics so `answer_match` is format-fair, then run an N≈50 MuSiQue eval and commit a verdict report ranking the three real failure levers (extraction-recall / retrieval / synthesis).
+
+**Architecture:** One new pure function `_canonicalize_spans(s)` in `metrics.py`, called at the top of the existing `_normalize` so every metric AND the localize buckets (which derive from `answer_match`) get fairer matching from one change point. Then a measurement run + a committed report. No graph/retrieval/synthesis feature work.
+
+**Tech Stack:** Python (pure stdlib `re`), pytest, the existing `scripts/distill/modal_bench.py --corpus musique` Modal harness.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-stage2a-musique-lever-ranking-design.md`
+
+**Branch:** `feat/stage2a-musique-lever-ranking` (already created off `origin/main`).
+
+---
+
+## Environment notes (read before starting)
+
+- **Run tests box-safely** (the box OOMs on the full suite). Use the main venv with the bench dir on the path:
+  ```bash
+  cd packages/python/goldenmatch/benchmarks/er-kg-bench
+  PYTHONPATH="." POLARS_SKIP_CPU_CHECK=1 "D:/show_case/goldenmatch/.venv/Scripts/python.exe" \
+    -m pytest tests/test_qa_answer_normalization.py -q -p no:cacheprovider
+  ```
+- **Do NOT run the whole pytest suite locally.** Targeted file runs only.
+- `ruff check` via the same venv before each commit.
+- GitHub auth for any push: `GH_TOKEN=$(gh auth token --user benzsevern)`.
+- All code goes in `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py` and a new test file `tests/test_qa_answer_normalization.py` under the same bench package.
+
+## Spec-deviation to note (decided here, in the plan)
+
+The spec lists `100 ≡ one hundred` as a positive case, but its own scope says "no compound parsing". `one hundred` is a compound (`one`+`hundred`). **Resolution: support STANDALONE cardinals only.** `hundred`≡`100`, `twenty`≡`20`, `one`≡`1` all canonicalize; `one hundred` falls through unchanged (compound, out of scope). This honors the stricter rule and removes the contradiction. The positive number-word tests use standalone words.
+
+## File structure
+
+- **Modify:** `erkgbench/qa_e2e/metrics.py` — add `_MONTH_NUM`, `_NUMWORD`, span regexes, `_canonicalize_spans(s)`; call it as the first line of `_normalize`.
+- **Create:** `tests/test_qa_answer_normalization.py` — all unit tests (canonicalization + coupling + no-regression).
+- **Create:** `docs/superpowers/reports/2026-06-29-stage2a-musique-lever-ranking.md` — the verdict report (Task 5).
+
+---
+
+### Task 1: Date canonicalization
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/metrics.py`
+- Test: `tests/test_qa_answer_normalization.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/test_qa_answer_normalization.py
+"""Fair-metric answer canonicalization: dates/times/standalone-number-words compare equal across
+formats, WITHOUT making distinct answers collide. Pure, no LLM. Spec: 2026-06-29-stage2a-...-design.md"""
+from __future__ import annotations
+
+from erkgbench.qa_e2e import metrics
+from erkgbench.qa_e2e.metrics import answer_match
+
+
+def test_date_formats_canonicalize_equal():
+    # the three date phrasings all normalize to the same ISO token sequence
+    for a, b in [
+        ("11 February 1929", "February 11, 1929"),
+        ("11 February 1929", "1929-02-11"),
+        ("February 11, 1929", "1929-02-11"),
+    ]:
+        assert metrics._normalize(a) == metrics._normalize(b), (a, b)
+
+
+def test_date_distinct_years_still_differ():
+    assert metrics._normalize("1928") != metrics._normalize("11 February 1929")
+    # same month/day, different year must NOT collide
+    assert metrics._normalize("11 February 1928") != metrics._normalize("11 February 1929")
+
+
+def test_bare_year_not_forced_to_match_full_date():
+    # gold = full date, pred mentions only the year -> incomplete, must NOT match (containment)
+    assert answer_match("the year was 1929", "11 February 1929") == 0.0
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `... -m pytest tests/test_qa_answer_normalization.py -q`
+Expected: FAIL (`_normalize` not yet canonicalizing dates → format strings differ).
+
+- [ ] **Step 3: Implement date canonicalization**
+
+In `metrics.py`, after the `_MONTHS` definition (reuse it), add:
+
+```python
+_MONTH_NUM = {m: i for i, m in enumerate(
+    "january february march april may june july august september october november december".split(),
+    start=1,
+)}
+
+# Non-anchored date spans (input is already lowercased by `_normalize`). Each ->
+# ISO `YYYY-MM-DD`; the later punctuation-strip collapses the dashes so all formats
+# converge. A BARE year is deliberately NOT matched here (left as the 4-digit token),
+# so it never collides with a full date.
+_DATE_DMY = re.compile(rf"\b(\d{{1,2}})\s+({_MONTHS})\s+(\d{{3,4}})\b")          # 11 february 1929
+_DATE_MDY = re.compile(rf"\b({_MONTHS})\s+(\d{{1,2}}),?\s+(\d{{3,4}})\b")        # february 11, 1929
+_DATE_ISO = re.compile(r"\b(\d{4})-(\d{1,2})-(\d{1,2})\b")                       # 1929-02-11
+_DATE_SLASH = re.compile(r"\b(\d{1,2})/(\d{1,2})/(\d{2,4})\b")                   # 02/11/1929 (M/D/Y)
+
+
+def _iso(y: int, m: int, d: int) -> str:
+    return f"{y:04d}-{m:02d}-{d:02d}"
+
+
+def _canon_dates(s: str) -> str:
+    s = _DATE_DMY.sub(lambda m: _iso(int(m.group(3)), _MONTH_NUM[m.group(2)], int(m.group(1))), s)
+    s = _DATE_MDY.sub(lambda m: _iso(int(m.group(3)), _MONTH_NUM[m.group(1)], int(m.group(2))), s)
+    s = _DATE_ISO.sub(lambda m: _iso(int(m.group(1)), int(m.group(2)), int(m.group(3))), s)
+    s = _DATE_SLASH.sub(
+        lambda m: _iso(int(m.group(3)) + (1900 if int(m.group(3)) < 100 else 0),
+                       int(m.group(1)), int(m.group(2))), s)
+    return s
+
+
+def _canonicalize_spans(s: str) -> str:
+    """Canonicalize date/time/standalone-number-word spans in a LOWERCASED string so equivalent
+    answers compare equal after `_normalize`. Narrow + fail-soft: only the recognized span types are
+    touched; everything else (and anything out of scope) passes through unchanged."""
+    return _canon_dates(s)
+```
+
+Then wire it into `_normalize` (change only the first lines):
+
+```python
+def _normalize(s: str) -> str:
+    s = _canonicalize_spans(s.lower())   # NEW: canonicalize while punctuation/structure intact
+    s = s.translate(_PUNCT)
+    s = _ARTICLES.sub(" ", s)
+    return " ".join(s.split())
+```
+
+(Note: `_normalize` previously called `s.lower()` itself; the lowercase now happens in the `_canonicalize_spans(s.lower())` call, so the body no longer needs a separate `.lower()`.)
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `... -m pytest tests/test_qa_answer_normalization.py -q`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add erkgbench/qa_e2e/metrics.py tests/test_qa_answer_normalization.py
+git commit -m "feat(er-kg-bench): date canonicalization in answer normalization (ISO)"
+```
+
+---
+
+### Task 2: Time canonicalization
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/metrics.py`
+- Test: `tests/test_qa_answer_normalization.py`
+
+- [ ] **Step 1: Write failing tests** (append)
+
+```python
+def test_time_formats_canonicalize_equal():
+    for a, b in [("5am", "5 a.m."), ("5am", "5 AM"), ("5pm", "5 p.m.")]:
+        assert metrics._normalize(a) == metrics._normalize(b), (a, b)
+
+
+def test_time_am_pm_distinct():
+    assert metrics._normalize("5am") != metrics._normalize("5pm")
+```
+
+- [ ] **Step 2: Run, verify FAIL** (`5 a.m.` -> punct-strip -> `5 am` two tokens; `5am` one token).
+
+- [ ] **Step 3: Implement** — add the time regex + extend `_canonicalize_spans`:
+
+```python
+# 5am / 5 am / 5 a.m. / 5 AM -> "5am"; 5pm / 5 p.m. -> "5pm". hour (+ optional :minute) only.
+_TIME_RE = re.compile(r"\b(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s*m\.?\b")
+
+
+def _canon_times(s: str) -> str:
+    def repl(m):
+        hh, mm, ap = m.group(1), m.group(2), m.group(3)
+        return f"{int(hh)}{(':' + mm) if mm else ''}{ap}m"
+    return _TIME_RE.sub(repl, s)
+```
+
+Extend `_canonicalize_spans` to `return _canon_times(_canon_dates(s))`.
+
+- [ ] **Step 4: Run, verify PASS** (Task 1 tests still green too).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(er-kg-bench): time canonicalization (5 a.m. == 5am)"
+```
+
+---
+
+### Task 3: Standalone number-word canonicalization
+
+**Files:**
+- Modify: `erkgbench/qa_e2e/metrics.py`
+- Test: `tests/test_qa_answer_normalization.py`
+
+- [ ] **Step 1: Write failing tests** (append)
+
+```python
+def test_standalone_number_words_canonicalize():
+    assert metrics._normalize("hundred") == metrics._normalize("100")
+    assert metrics._normalize("twenty") == metrics._normalize("20")
+    assert metrics._normalize("one") == metrics._normalize("1")
+
+
+def test_number_word_distinct_values_differ():
+    assert metrics._normalize("hundred") != metrics._normalize("1000")
+    assert metrics._normalize("twenty") != metrics._normalize("twelve")
+
+
+def test_compound_and_out_of_scope_number_words_fall_through():
+    # compound / decimal / magnitude / ordinal are NOT parsed (left as-is)
+    for w in ["twenty-one", "1.5 million", "third", "one hundred"]:
+        assert metrics._normalize(w) == metrics._normalize_legacy_for_test(w)
+```
+
+> `_normalize_legacy_for_test` is a tiny test-only helper that applies ONLY the old normalization
+> (lower/punct/articles/whitespace, no span-canon) so the fall-through assertion is precise. Add it
+> in the test file, not in `metrics.py`:
+> ```python
+> import re as _re, string as _string
+> _OLD_PUNCT = str.maketrans("", "", _string.punctuation)
+> _OLD_ART = _re.compile(r"\b(a|an|the)\b")
+> def _legacy(s):
+>     s = s.lower().translate(_OLD_PUNCT); s = _OLD_ART.sub(" ", s); return " ".join(s.split())
+> ```
+> Reference it as `_legacy` (rename the assertion call accordingly).
+
+- [ ] **Step 2: Run, verify FAIL**.
+
+- [ ] **Step 3: Implement** — fixed standalone lookup + word-boundary replace:
+
+```python
+_NUMWORD = {
+    "zero": "0", "one": "1", "two": "2", "three": "3", "four": "4", "five": "5",
+    "six": "6", "seven": "7", "eight": "8", "nine": "9", "ten": "10", "eleven": "11",
+    "twelve": "12", "thirteen": "13", "fourteen": "14", "fifteen": "15", "sixteen": "16",
+    "seventeen": "17", "eighteen": "18", "nineteen": "19", "twenty": "20", "thirty": "30",
+    "forty": "40", "fifty": "50", "sixty": "60", "seventy": "70", "eighty": "80",
+    "ninety": "90", "hundred": "100",
+}
+_NUMWORD_RE = re.compile(r"\b(" + "|".join(_NUMWORD) + r")\b")
+
+
+def _canon_numwords(s: str) -> str:
+    # Replace ONLY standalone cardinal words. Compounds ("one hundred") become two tokens
+    # ("1 100") which won't equal "100", so they effectively fall through as non-matching --
+    # acceptable: we never CLAIM a compound match, and distinct values stay distinct.
+    return _NUMWORD_RE.sub(lambda m: _NUMWORD[m.group(1)], s)
+```
+
+Extend `_canonicalize_spans` to `return _canon_numwords(_canon_times(_canon_dates(s)))`.
+
+> **Order matters:** dates first (consume month-name spans), then times, then number-words (so a
+> bare "one" inside an already-canonicalized date can't be re-touched — dates are now pure digits).
+
+- [ ] **Step 4: Run, verify PASS** (all prior tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(er-kg-bench): standalone number-word canonicalization (fixed lookup)"
+```
+
+---
+
+### Task 4: Bucket-coupling proof + no-regression
+
+**Files:**
+- Test: `tests/test_qa_answer_normalization.py`
+- Verify: existing `tests/test_qa_metrics.py` still green.
+
+- [ ] **Step 1: Write the coupling + regression tests** (append)
+
+```python
+def test_answer_match_date_crossformat_containment():
+    # harness.py:153/155 compute in_graph/in_ball as answer_match(" ".join(names), gold).
+    # A graph node holding the date in a DIFFERENT format must now read as a hit.
+    graph_names = "foo bar February 11, 1929 baz"
+    assert answer_match(graph_names, "11 February 1929") == 1.0
+
+
+def test_entity_answers_unchanged_no_regression():
+    # engineered-style entity answers contain no date/time/number-word spans -> canon is a no-op
+    for name in ["Exeter College", "the Politburo", "Sega Genesis", "Lana Wood"]:
+        assert metrics._normalize(name) == _legacy(name)
+
+
+def test_answer_match_entity_still_works():
+    assert answer_match("the final entity is Acme Corp", "Acme Corp") == 1.0
+    assert answer_match("Acme Corp", "Globex") == 0.0
+```
+
+- [ ] **Step 2: Run the new file, verify PASS.**
+
+- [ ] **Step 3: Run the EXISTING metrics suite for no-regression**
+
+Run: `... -m pytest tests/test_qa_metrics.py tests/test_qa_aggregation_metric.py -q -p no:cacheprovider`
+Expected: PASS. If any test asserts a `_normalize`/`answer_match` value on a date/number that the
+canonicalization now changes, inspect it: a *correct* fairness change may require updating that
+assertion (do so, noting why in the commit); a *wrong* collision means the regex is too greedy — fix
+the regex, not the test.
+
+- [ ] **Step 4: ruff**
+
+Run: `... -m ruff check erkgbench/qa_e2e/metrics.py tests/test_qa_answer_normalization.py`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "test(er-kg-bench): bucket-coupling + no-regression for answer canonicalization"
+```
+
+---
+
+### Task 5: N≈50 MuSiQue ranking run + verdict report
+
+**Files:**
+- Create: `docs/superpowers/reports/2026-06-29-stage2a-musique-lever-ranking.md`
+
+This task is a MEASUREMENT, not code. Use the established detached Modal pattern (the box OOM-reaps the local CLI ~1 min in).
+
+- [ ] **Step 1: Push the branch so the run uses committed code** (Modal uploads the local tree, but push first so the metric change is on the PR)
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) git push -u origin feat/stage2a-musique-lever-ranking
+```
+
+- [ ] **Step 2: Fire the N=50 MuSiQue run (detached + spawn)**
+
+```bash
+P="a99885f0-c5af-4ae1-9dc8-255cc60aa129"
+export MODAL_TOKEN_ID=$(infisical.cmd secrets get MODAL_TOKEN_ID --projectId "$P" --env dev --plain --silent)
+export MODAL_TOKEN_SECRET=$(infisical.cmd secrets get MODAL_TOKEN_SECRET --projectId "$P" --env dev --plain --silent)
+M="D:/show_case/goldenmatch/.venv/Scripts/modal.exe"
+PYTHONIOENCODING=utf-8 "$M" run --detach scripts/distill/modal_bench.py \
+  --engine goldengraph --eval end_to_end --corpus musique --n 50 --spawn \
+  --opts $'GOLDENGRAPH_QA_MODE=auto'
+```
+
+Result lands at `results/end_to_end_50_goldengraph-qwen2.5-7b-instruct-musique.md` on the `gg-bench-cache` volume. Poll with a Monitor (until-loop, `volume get --force`, grep for `support_recall=`). **N=50 of real prose may approach the ~60-min cap; if it times out, re-run at N=40.**
+
+- [ ] **Step 3: Aggregate the buckets from the trace**
+
+```bash
+# pull the result, count buckets
+grep -oE "(EXTRACTION|RETRIEVAL-BROKEN-CHAIN|SYNTHESIS)" /tmp/musique_n50.md | sort | uniq -c | sort -rn
+grep -iE "support_recall=|musique \| 0" /tmp/musique_n50.md | head -2
+```
+
+- [ ] **Step 4: Write the verdict report**
+
+Create `docs/superpowers/reports/2026-06-29-stage2a-musique-lever-ranking.md` with:
+- The run config (N, model, corpus, opts, date) and the headline `answer_match` (fair-metric) + `support_recall`.
+- **A table of ACTUAL per-bucket counts** (raw N per bucket — do not assume an even split).
+- The **ranked recommendation**: which lever dominates → the target of the next sub-project.
+- An explicit **confidence statement** scaled to the per-bucket N (e.g. "EXTRACTION leads at X/50; the retrieval/synthesis split is within sampling noise at this N").
+- A one-line pointer to the spec.
+
+- [ ] **Step 5: Commit the report**
+
+```bash
+git add docs/superpowers/reports/2026-06-29-stage2a-musique-lever-ranking.md
+git commit -m "docs(stage-2a): MuSiQue N=50 lever-ranking verdict report"
+```
+
+---
+
+## Done criterion
+
+- The 4 code tasks merged behind green tests (new file + no-regression on existing metrics suite).
+- A committed verdict report with actual per-bucket counts + a ranked, confidence-qualified recommendation for the next stage-2 sub-project.
+- Open a PR for the branch; arm auto-merge once CI is green.

--- a/docs/superpowers/plans/2026-06-29-stage2a-musique-lever-ranking.md
+++ b/docs/superpowers/plans/2026-06-29-stage2a-musique-lever-ranking.md
@@ -224,6 +224,8 @@ def test_out_of_scope_number_words_fall_through():
     # hyphenated compound / decimal+magnitude / ordinal are NOT parsed (left as the old normalization).
     # NB: `one hundred` is deliberately NOT here -- whitespace compounds split to `1 100` by design
     # (see the spec-deviation note); we assert neither a match nor a fall-through for it.
+    # (`1.5 million`: both legacy and canon strip the decimal point identically; the point is that
+    # canon ADDS nothing -- `million` isn't in the lookup -- not that the string is preserved verbatim.)
     for w in ["twenty-one", "1.5 million", "third"]:
         assert metrics._normalize(w) == _legacy(w)
 ```

--- a/docs/superpowers/plans/2026-06-29-stage2a-musique-lever-ranking.md
+++ b/docs/superpowers/plans/2026-06-29-stage2a-musique-lever-ranking.md
@@ -29,7 +29,11 @@
 
 ## Spec-deviation to note (decided here, in the plan)
 
-The spec lists `100 ≡ one hundred` as a positive case, but its own scope says "no compound parsing". `one hundred` is a compound (`one`+`hundred`). **Resolution: support STANDALONE cardinals only.** `hundred`≡`100`, `twenty`≡`20`, `one`≡`1` all canonicalize; `one hundred` falls through unchanged (compound, out of scope). This honors the stricter rule and removes the contradiction. The positive number-word tests use standalone words.
+The spec lists `100 ≡ one hundred` as a positive case, but its own scope says "no compound parsing". `one hundred` is a compound (`one`+`hundred`). **Resolution: support STANDALONE cardinals only.** `hundred`≡`100`, `twenty`≡`20`, `one`≡`1` all canonicalize. Compound handling is split by separator, and the regex is **hyphen/word-guarded** (lookarounds, not `\b`) so the two cases are consistent and intentional:
+- **Hyphenated** compounds (`twenty-one`) **fall through untouched** — the guard refuses to match a cardinal adjacent to `-` or another word char.
+- **Whitespace-separated** compounds (`one hundred`) split into two tokens (`1 100`). This does NOT equal `100`, so it simply does not match — acceptable, because we never *claim* a compound match and distinct values stay distinct. We do not assert `one hundred` as either a match or a fall-through.
+
+The positive number-word tests use standalone words only.
 
 ## File structure
 
@@ -216,15 +220,17 @@ def test_number_word_distinct_values_differ():
     assert metrics._normalize("twenty") != metrics._normalize("twelve")
 
 
-def test_compound_and_out_of_scope_number_words_fall_through():
-    # compound / decimal / magnitude / ordinal are NOT parsed (left as-is)
-    for w in ["twenty-one", "1.5 million", "third", "one hundred"]:
-        assert metrics._normalize(w) == metrics._normalize_legacy_for_test(w)
+def test_out_of_scope_number_words_fall_through():
+    # hyphenated compound / decimal+magnitude / ordinal are NOT parsed (left as the old normalization).
+    # NB: `one hundred` is deliberately NOT here -- whitespace compounds split to `1 100` by design
+    # (see the spec-deviation note); we assert neither a match nor a fall-through for it.
+    for w in ["twenty-one", "1.5 million", "third"]:
+        assert metrics._normalize(w) == _legacy(w)
 ```
 
-> `_normalize_legacy_for_test` is a tiny test-only helper that applies ONLY the old normalization
-> (lower/punct/articles/whitespace, no span-canon) so the fall-through assertion is precise. Add it
-> in the test file, not in `metrics.py`:
+> `_legacy` is a tiny test-only helper (top of the test file, NOT in `metrics.py`) that applies ONLY
+> the old normalization (lower/punct/articles/whitespace, no span-canon), so the fall-through assertion
+> is precise:
 > ```python
 > import re as _re, string as _string
 > _OLD_PUNCT = str.maketrans("", "", _string.punctuation)
@@ -232,7 +238,8 @@ def test_compound_and_out_of_scope_number_words_fall_through():
 > def _legacy(s):
 >     s = s.lower().translate(_OLD_PUNCT); s = _OLD_ART.sub(" ", s); return " ".join(s.split())
 > ```
-> Reference it as `_legacy` (rename the assertion call accordingly).
+> Trace for `twenty-one` under the guarded regex (Step 3): the lookarounds refuse `twenty` (followed
+> by `-`) and `one` (preceded by `-`), so canon is a no-op → `_normalize` = `twentyone` = `_legacy`. ✓
 
 - [ ] **Step 2: Run, verify FAIL**.
 
@@ -247,13 +254,15 @@ _NUMWORD = {
     "forty": "40", "fifty": "50", "sixty": "60", "seventy": "70", "eighty": "80",
     "ninety": "90", "hundred": "100",
 }
-_NUMWORD_RE = re.compile(r"\b(" + "|".join(_NUMWORD) + r")\b")
+# Hyphen/word-GUARDED (lookarounds, not \b): a cardinal adjacent to `-` or another word char is NOT
+# matched, so hyphenated compounds ("twenty-one") fall through untouched. Whitespace-separated
+# compounds ("one hundred") still split to "1 100" -- non-matching by design (see spec-deviation note).
+_NUMWORD_RE = re.compile(r"(?<![\w-])(" + "|".join(_NUMWORD) + r")(?![\w-])")
 
 
 def _canon_numwords(s: str) -> str:
-    # Replace ONLY standalone cardinal words. Compounds ("one hundred") become two tokens
-    # ("1 100") which won't equal "100", so they effectively fall through as non-matching --
-    # acceptable: we never CLAIM a compound match, and distinct values stay distinct.
+    # Replace ONLY standalone cardinal words (guarded). "one hundred" -> "1 100" (won't equal "100",
+    # so it simply doesn't match); "twenty-one" -> untouched. Distinct values stay distinct.
     return _NUMWORD_RE.sub(lambda m: _NUMWORD[m.group(1)], s)
 ```
 

--- a/docs/superpowers/reports/2026-06-29-stage2a-musique-lever-ranking.md
+++ b/docs/superpowers/reports/2026-06-29-stage2a-musique-lever-ranking.md
@@ -1,0 +1,88 @@
+# Stage-2-A: MuSiQue Lever-Ranking Verdict (N=50)
+
+**Date:** 2026-06-30
+**Spec:** `docs/superpowers/specs/2026-06-29-stage2a-musique-lever-ranking-design.md`
+**Plan:** `docs/superpowers/plans/2026-06-29-stage2a-musique-lever-ranking.md`
+
+## Run config
+
+- Corpus: **MuSiQue-Ans**, seeded subset, **N=50** questions.
+- Engine: goldengraph, open extraction, `GOLDENGRAPH_QA_MODE=auto`, `LITERAL_ATTRS` off (measured-dead).
+- Model: `qwen2.5:7b-instruct` (chat) + `nomic-embed-text` (embed), Modal A10G.
+- **Metric: the stage-2-A fair normalizer** (date/time/number-word canonicalization) — so both the
+  headline `answer_match` AND the localize bucket categorization are format-fair.
+
+## Headline (fair metric)
+
+| metric | value |
+|---|---|
+| `answer_match` (all 50) | **0.12** |
+| `answer_match` (entity-answerable subset, n=30) | **0.20** |
+| `support_recall` | **0.58** |
+| `exact_match` / `token_f1` | 0.08 / 0.13 |
+
+Answer-type mix of the 50 golds: **entity 30, phrase 9, number 7, date 4** — i.e. **20 of 50 (40%)
+are non-entity answers** an entity graph cannot emit as a node.
+
+## Raw failure-stage tally
+
+The harness localize categorizes each question's failing hop. Multi-hop questions can contribute to
+more than one stage, so these are **failure-stage frequencies** (they rank the modes; they do not
+partition the 50 questions):
+
+| stage | count |
+|---|---|
+| EXTRACTION (gold not a graph node) | 21 |
+| SYNTHESIS (retrieved, wrong answer) | 18 |
+| RETRIEVAL-BROKEN-CHAIN (in graph, unreachable) | 14 |
+
+## The refinement that changes the ranking
+
+The lead bucket (EXTRACTION, 21) is **not** primarily an extraction-recall problem. Classifying its
+gold answers:
+
+- **~5 entities actually missed** — `Lana Wood`, `U.S. Marshal Rooster Cogburn`, `Han Chinese
+  emigrants`, `The Australian Ballet`, `Yamanote Line loop`. A real extraction-recall gap on dense
+  prose.
+- **~16 non-entity answers** — dates (`11 February 1929`, `April 28, 1952`, `30 November 1999`),
+  numbers (`1,438,159`, `1599`, `551-600`), descriptive phrases (`built on 16-bit architectures and
+  offered improved graphics and sound`, `northeastern Oklahoma`, `rises in northern Minnesota and
+  meanders slowly southwards`). These are **unanswerable-by-construction** for an entity graph — a
+  representation mismatch, **already measured dead** (literal-attrs: 0.083 → 0.083, support_recall
+  *worse*; see the design doc). NOT a lever we chase.
+
+So ~3/4 of the EXTRACTION bucket is the structural non-entity issue, not extraction recall.
+
+## Ranked FIXABLE levers (the verdict)
+
+Stripping the ~16 structurally-unanswerable non-entity questions from EXTRACTION:
+
+1. **SYNTHESIS — 18 (the dominant fixable lever).** The answer was in the retrieved ball; the model
+   wrote the wrong one. Most tractable: it needs **no graph-structure change** — better answer-reading
+   off the retrieved subgraph (synthesis prompting / answer extraction). `support_recall` 0.58 confirms
+   retrieval surfaces the evidence for well over half the questions.
+2. **RETRIEVAL-BROKEN-CHAIN — 14.** Entity in the graph but unreachable from the seeds (multi-hop
+   chain breaks / under-merge on the denser real graph). Reuses the engineered-corpus chain/bridge work.
+3. **Entity-extraction recall — ~5.** Entities the 7B missed in dense prose. Smallest fixable lever.
+
+**Recommendation for the next sub-project (stage-2-B): target SYNTHESIS.** It is the largest fixable
+failure mode, the most tractable (graph-structure-free), and it sits on top of a retrieval layer that
+already surfaces the evidence (`support_recall` 0.58, and 18 questions where the ball *contained* the
+answer). Retrieval (broken chains) is the clear second.
+
+## Confidence
+
+- At N=50, the raw EXTRACTION (21) and SYNTHESIS (18) tallies are close (~3 stage-lines apart) — but
+  once the ~16 structurally-unanswerable non-entity questions are removed from EXTRACTION, **SYNTHESIS
+  is clearly the top fixable lever** and RETRIEVAL clearly third.
+- Per-bucket N is ~14–21 stage-failures — enough to **rank** the three modes, not to split the
+  EXTRACTION/SYNTHESIS raw tallies before the entity/non-entity decomposition.
+- 7B extraction is non-deterministic run-to-run; the *distribution* is stable enough to rank.
+
+## What stage-2-A delivered
+
+- A **format-fair metric** (date/time/number-word canonicalization in `metrics.py`) that also
+  corrects the localize bucket categorization (the buckets derive from `answer_match`).
+- A trustworthy, decomposed ranking that **redirects stage-2 away from the headline (extraction) toward
+  the real fixable lever (synthesis)** — a result the unfair metric + raw bucket count would have
+  obscured.

--- a/docs/superpowers/specs/2026-06-29-stage2a-musique-lever-ranking-design.md
+++ b/docs/superpowers/specs/2026-06-29-stage2a-musique-lever-ranking-design.md
@@ -1,0 +1,141 @@
+# Stage-2-A: MuSiQue Lever-Ranking Instrument — Design
+
+**Status:** Approved (brainstorm), pending implementation plan.
+**Date:** 2026-06-29
+**Context:** goldengraph real-corpus (stage-2) quality. Follows the stage-1 honest-null
+(open-vocab predicate clustering closed) and the support_recall wiring (#1295).
+
+## Goal
+
+Produce a **trustworthy, meaningful-N ranking** of the three real MuSiQue failure modes —
+entity-extraction recall, multi-hop retrieval, synthesis — so the *next* sub-project targets
+the dominant lever. This sub-project **measures and ranks; it adds no graph/retrieval/synthesis
+capability.**
+
+## Why this, not a feature build
+
+The first real-corpus measurements reframed stage-2 twice, by measurement:
+
+1. **Engineered win does not transfer.** MuSiQue N=12 (7B, open extraction): answer_match
+   **0.083** vs engineered 0.60–0.67; support_recall **0.70**.
+2. **Predicate-vocab discovery is not the lever.** Discovery config = 0.0 / support 0.66 —
+   no help (slightly worse: relabeling noise on real prose's large vocab).
+3. **Answer-representation (literal-attrs) is not the lever — measured-dead.** `LITERAL_ATTRS=1`:
+   answer_match unchanged (0.083), support_recall **worse** (0.70 → 0.65). Per-question it
+   *hurt* the cases it should help: `$72,641` went `in_ball=True` → unreachable; `the Politburo`
+   went `in_graph=True` → `False` (extra attribute extraction perturbed extraction and dropped
+   the entity).
+
+What the N=12 localize trace actually shows: the EXTRACTION bucket is **not** "non-entity answers"
+— it is mostly **entities the 7B never extracted from dense prose** (Lana Wood, Rooster Cogburn,
+the Politburo). The failures spread roughly evenly across three real problems:
+
+- **Entity-extraction recall** on dense real prose (`in_graph=False`).
+- **Multi-hop retrieval / broken chains** (`in_graph=True`, `in_ball=False`).
+- **Synthesis** (`in_ball=True`, wrong answer written).
+
+At N=12 each bucket is 3–5 questions — too small to rank confidently, and the obvious cheap lever
+(literal-attrs) is now measured-dead. So the correct next step is a fair-metric, meaningful-N
+**ranking run**, not a speculative build.
+
+## Architecture
+
+Three small, independently-testable pieces.
+
+### 1. Answer-normalization extension (`metrics.py`)
+
+The existing `metrics._normalize` already lowercases, strips **all** punctuation (so `$` and `,`
+are gone — `$72,641` ≡ `72641` *today*), strips articles, and collapses whitespace. The remaining
+fairness gaps it does **not** handle:
+
+- **Date word-order**: `11 February 1929` vs `February 11, 1929` vs `1929-02-11`.
+- **Times**: `5am` vs `5 a.m.` vs `5 AM`.
+- **Number-words**: `100` vs `one hundred`.
+
+Add a layered canonicalization (dates → a canonical token order; times → canonical form;
+number-words ↔ digits) on top of `_normalize`. **Fail-soft**: an un-parseable string canonicalizes
+exactly as today (the date/number rules only fire when the parse succeeds).
+
+**Load-bearing coupling (the reason this is required, not cosmetic):** the localize buckets are
+computed *via* `metrics.answer_match` (`harness.py:153` `in_graph`, `harness.py:155` `in_ball`).
+Unfair normalization therefore **mis-categorizes the buckets** — a date answer present in the graph
+but format-mismatched falsely reads `in_graph=False` and is counted as EXTRACTION when it is really
+retrieval/synthesis. Fairer normalization is required for the ranking to be correct.
+
+Pure functions, unit-tested, no LLM.
+
+### 2. Bigger-N ranking run
+
+MuSiQue **N≈50**, open extraction, `LITERAL_ATTRS` **off** (measured-dead), auto mode. The harness
+already emits per-question `EXTRACTION / RETRIEVAL-BROKEN-CHAIN / SYNTHESIS`; aggregate into a
+confident distribution. Run via the existing `scripts/distill/modal_bench.py --corpus musique`.
+
+### 3. Verdict report
+
+A committed markdown alongside the other bench reports: the fair-metric `answer_match`, the
+per-bucket counts, and a **ranked recommendation** for the next sub-project. States confidence
+honestly (see Risks).
+
+## Data flow
+
+```
+run_qa_e2e (--corpus musique, N≈50)
+  → harness scores answer_match with the EXTENDED normalizer
+  → localize categorizes each question (now fairly) into a bucket
+  → aggregate bucket counts
+  → verdict report (committed)
+```
+
+## Error handling
+
+- Normalization is **fail-soft**: date/time/number-word rules fire only on a successful parse;
+  any failure falls through to the existing `_normalize` output. No new exceptions on the scoring
+  path.
+- The Modal run uses the established detach + spawn + volume + Monitor pattern (box OOM-reaps the
+  local CLI ~1 min in).
+
+## Testing
+
+- **Normalizer unit tests** (pure, box-safe, the TDD core):
+  - *Should now match*: `11 February 1929` ≡ `February 11, 1929` ≡ `1929-02-11`; `5am` ≡ `5 a.m.`;
+    `100` ≡ `one hundred`.
+  - *Must still NOT match*: `1928` ≠ `1929`; `Lana Wood` ≠ `Natalie Wood`; `100` ≠ `1000`.
+  - *Fall-through*: `"the Politburo"` normalizes exactly as today (regression-locked against
+    the current `_normalize`).
+- **Bucket-coupling test**: a graph containing `February 11, 1929` reads `in_graph=True` for a
+  gold of `11 February 1929` — proving the normalization flows into localize categorization, not
+  just the headline.
+- **Engineered no-regression**: a small engineered e2e must hold its answer_match — the fairness
+  change is additive, not a silent rescore.
+- **Integration validation** = the N≈50 run itself.
+
+## Scope / YAGNI
+
+- **No LLM-judge** (deferred; deterministic normalization first).
+- **No literal-attrs** (measured-dead).
+- **No graph/retrieval/synthesis feature work** — this sub-project only measures and ranks. The
+  lever-fix is the next sub-project, scoped from this verdict.
+- **Normalization stays minimal**: dates, times, number-words only. No general semantic equivalence
+  (`NYC` ≡ `New York City`), no unit conversion — real but rare on MuSiQue; add only if the verdict
+  shows they are material.
+- **N≈50, not 100**: balances signal against the ~60-min Modal cap (the literal-attrs run hit
+  ~36 min at N=12; open extraction is lighter, but N=50 of real prose is the practical ceiling for
+  one job).
+
+## Risks
+
+- **Sample size**: even N≈50 gives ~15–25 questions per bucket — enough to *rank* the levers, not
+  to split hairs between close seconds. The verdict states confidence, does not over-claim.
+- **Normalization over-reach**: an over-eager date/number parser could make wrong answers match
+  (false positives). Mitigated by the explicit non-equivalence guard tests (`1928 ≠ 1929`,
+  `100 ≠ 1000`) and the fail-soft fall-through.
+- **7B non-determinism**: live-7B extraction varies run-to-run (same caveat as every live run);
+  the bucket *distribution* at N≈50 is stable enough to rank even if individual questions flip.
+
+## Files
+
+- Modify: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py`
+  (date/time/number-word canonicalization layered on `_normalize`).
+- Create: a normalizer unit-test file under the bench `tests/`.
+- Create: the verdict report (committed markdown).
+- Validation: existing `scripts/distill/modal_bench.py` (`--corpus musique`, no code change).

--- a/docs/superpowers/specs/2026-06-29-stage2a-musique-lever-ranking-design.md
+++ b/docs/superpowers/specs/2026-06-29-stage2a-musique-lever-ranking-design.md
@@ -52,9 +52,23 @@ fairness gaps it does **not** handle:
 - **Times**: `5am` vs `5 a.m.` vs `5 AM`.
 - **Number-words**: `100` vs `one hundred`.
 
-Add a layered canonicalization (dates → a canonical token order; times → canonical form;
-number-words ↔ digits) on top of `_normalize`. **Fail-soft**: an un-parseable string canonicalizes
-exactly as today (the date/number rules only fire when the parse succeeds).
+Add a layered canonicalization on top of `_normalize`, with **deliberately narrow** parse scope to
+keep the false-positive surface small:
+
+- **Dates → ISO `YYYY-MM-DD`** when a *full* day/month/year parses (so `11 February 1929`,
+  `February 11, 1929`, and `1929-02-11` all canonicalize identically). A **bare year** (`1929`) is
+  left as the year token — *not* expanded — so it is never forced to match a full date; the existing
+  containment in `answer_match` already lets a bare-year gold match the year token inside a full date
+  where that is genuinely correct, and we do not invent the reverse.
+- **Times → a single canonical form** (`5am`, `5 a.m.`, `5 AM` → `5am`); hour[:minute] + am/pm only.
+- **Number-words ↔ digits → small integer cardinals only**, via a **fixed lookup** (zero..twenty,
+  thirty..hundred and the obvious tens). **No** compound parsing (`twenty-one`), **no** decimals
+  (`1.5 million`), **no** large-magnitude words (`million`/`billion`), **no** ordinals. Anything
+  outside the lookup falls through untouched.
+
+**Fail-soft**: the date/time/number rules fire *only* on a successful parse within these narrow
+bounds; any failure (or anything out of scope) falls through to the existing `_normalize` output, so
+an un-parseable string canonicalizes exactly as today.
 
 **Load-bearing coupling (the reason this is required, not cosmetic):** the localize buckets are
 computed *via* `metrics.answer_match` (`harness.py:153` `in_graph`, `harness.py:155` `in_ball`).
@@ -73,8 +87,9 @@ confident distribution. Run via the existing `scripts/distill/modal_bench.py --c
 ### 3. Verdict report
 
 A committed markdown alongside the other bench reports: the fair-metric `answer_match`, the
-per-bucket counts, and a **ranked recommendation** for the next sub-project. States confidence
-honestly (see Risks).
+**actual per-bucket counts** (the raw N per bucket, so the confidence claim is data-backed rather
+than assuming an even three-way split), and a **ranked recommendation** for the next sub-project.
+States confidence honestly (see Risks).
 
 ## Data flow
 
@@ -97,9 +112,13 @@ run_qa_e2e (--corpus musique, N≈50)
 ## Testing
 
 - **Normalizer unit tests** (pure, box-safe, the TDD core):
-  - *Should now match*: `11 February 1929` ≡ `February 11, 1929` ≡ `1929-02-11`; `5am` ≡ `5 a.m.`;
-    `100` ≡ `one hundred`.
-  - *Must still NOT match*: `1928` ≠ `1929`; `Lana Wood` ≠ `Natalie Wood`; `100` ≠ `1000`.
+  - *Should now match*: `11 February 1929` ≡ `February 11, 1929` ≡ `1929-02-11` (all → ISO);
+    `5am` ≡ `5 a.m.`; `100` ≡ `one hundred`.
+  - *Must still NOT match*: `1928` ≠ `1929`; `Lana Wood` ≠ `Natalie Wood`; `100` ≠ `1000`;
+    a bare year `1929` ≠ a full date `11 February 1929` (gold-full direction: answering only the
+    year is incomplete — the narrow rule must not invent this match).
+  - *Out-of-scope falls through untouched*: `twenty-one`, `1.5 million`, `third` are left as-is
+    (no compound/decimal/large-magnitude/ordinal parsing) — locks the narrow number-word boundary.
   - *Fall-through*: `"the Politburo"` normalizes exactly as today (regression-locked against
     the current `_normalize`).
 - **Bucket-coupling test**: a graph containing `February 11, 1929` reads `in_graph=True` for a

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
@@ -167,11 +167,31 @@ def _canon_times(s: str) -> str:
     return _TIME_RE.sub(repl, s)
 
 
+_NUMWORD = {
+    "zero": "0", "one": "1", "two": "2", "three": "3", "four": "4", "five": "5",
+    "six": "6", "seven": "7", "eight": "8", "nine": "9", "ten": "10", "eleven": "11",
+    "twelve": "12", "thirteen": "13", "fourteen": "14", "fifteen": "15", "sixteen": "16",
+    "seventeen": "17", "eighteen": "18", "nineteen": "19", "twenty": "20", "thirty": "30",
+    "forty": "40", "fifty": "50", "sixty": "60", "seventy": "70", "eighty": "80",
+    "ninety": "90", "hundred": "100",
+}
+# Hyphen/word-GUARDED (lookarounds, not \b): a cardinal adjacent to `-` or another word char is NOT
+# matched, so hyphenated compounds ("twenty-one") fall through untouched. Whitespace-separated
+# compounds ("one hundred") still split to "1 100" -- non-matching by design (see spec-deviation note).
+_NUMWORD_RE = re.compile(r"(?<![\w-])(" + "|".join(_NUMWORD) + r")(?![\w-])")
+
+
+def _canon_numwords(s: str) -> str:
+    # Replace ONLY standalone cardinal words (guarded). "one hundred" -> "1 100" (won't equal "100",
+    # so it simply doesn't match); "twenty-one" -> untouched. Distinct values stay distinct.
+    return _NUMWORD_RE.sub(lambda m: _NUMWORD[m.group(1)], s)
+
+
 def _canonicalize_spans(s: str) -> str:
     """Canonicalize date/time/standalone-number-word spans in a LOWERCASED string so equivalent
     answers compare equal after `_normalize`. Narrow + fail-soft: only the recognized span types are
     touched; everything else (and anything out of scope) passes through unchanged."""
-    return _canon_times(_canon_dates(s))
+    return _canon_numwords(_canon_times(_canon_dates(s)))
 
 
 _DATE_RE = re.compile(

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
@@ -13,7 +13,8 @@ _PUNCT = str.maketrans("", "", string.punctuation)
 
 
 def _normalize(s: str) -> str:
-    s = s.lower().translate(_PUNCT)
+    s = _canonicalize_spans(s.lower())   # NEW: canonicalize while punctuation/structure intact
+    s = s.translate(_PUNCT)
     s = _ARTICLES.sub(" ", s)
     return " ".join(s.split())
 
@@ -119,6 +120,49 @@ _MONTHS = (
     "january|february|march|april|may|june|july|august|september|october"
     "|november|december"
 )
+
+# --- fair-metric span canonicalization ----------------------------------------
+#
+# Canonicalize equivalent date/time/number spellings to one form BEFORE the
+# punctuation/article strip in `_normalize`, so equivalent answers compare equal
+# without making distinct answers collide. Reuses `_MONTHS` (above).
+
+_MONTH_NUM = {m: i for i, m in enumerate(
+    "january february march april may june july august september october november december".split(),
+    start=1,
+)}
+
+# Non-anchored date spans (input is already lowercased by `_normalize`). Each ->
+# ISO `YYYY-MM-DD`; the later punctuation-strip collapses the dashes so all formats
+# converge. A BARE year is deliberately NOT matched here (left as the 4-digit token),
+# so it never collides with a full date.
+_DATE_DMY = re.compile(rf"\b(\d{{1,2}})\s+({_MONTHS})\s+(\d{{3,4}})\b")          # 11 february 1929
+_DATE_MDY = re.compile(rf"\b({_MONTHS})\s+(\d{{1,2}}),?\s+(\d{{3,4}})\b")        # february 11, 1929
+_DATE_ISO = re.compile(r"\b(\d{4})-(\d{1,2})-(\d{1,2})\b")                       # 1929-02-11
+_DATE_SLASH = re.compile(r"\b(\d{1,2})/(\d{1,2})/(\d{2,4})\b")                   # 02/11/1929 (M/D/Y)
+
+
+def _iso(y: int, m: int, d: int) -> str:
+    return f"{y:04d}-{m:02d}-{d:02d}"
+
+
+def _canon_dates(s: str) -> str:
+    s = _DATE_DMY.sub(lambda m: _iso(int(m.group(3)), _MONTH_NUM[m.group(2)], int(m.group(1))), s)
+    s = _DATE_MDY.sub(lambda m: _iso(int(m.group(3)), _MONTH_NUM[m.group(1)], int(m.group(2))), s)
+    s = _DATE_ISO.sub(lambda m: _iso(int(m.group(1)), int(m.group(2)), int(m.group(3))), s)
+    s = _DATE_SLASH.sub(
+        lambda m: _iso(int(m.group(3)) + (1900 if int(m.group(3)) < 100 else 0),
+                       int(m.group(1)), int(m.group(2))), s)
+    return s
+
+
+def _canonicalize_spans(s: str) -> str:
+    """Canonicalize date/time/standalone-number-word spans in a LOWERCASED string so equivalent
+    answers compare equal after `_normalize`. Narrow + fail-soft: only the recognized span types are
+    touched; everything else (and anything out of scope) passes through unchanged."""
+    return _canon_dates(s)
+
+
 _DATE_RE = re.compile(
     rf"^\s*(\d{{1,2}}\s+)?({_MONTHS})\s+\d{{3,4}}\s*$"  # 11 February 1929 / March 1929
     rf"|^\s*({_MONTHS})\s+\d{{1,2}}\s*,?\s*\d{{3,4}}\s*$"  # February 11, 1929

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/metrics.py
@@ -156,11 +156,22 @@ def _canon_dates(s: str) -> str:
     return s
 
 
+# 5am / 5 am / 5 a.m. / 5 AM -> "5am"; 5pm / 5 p.m. -> "5pm". hour (+ optional :minute) only.
+_TIME_RE = re.compile(r"\b(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s*m\.?\b")
+
+
+def _canon_times(s: str) -> str:
+    def repl(m):
+        hh, mm, ap = m.group(1), m.group(2), m.group(3)
+        return f"{int(hh)}{(':' + mm) if mm else ''}{ap}m"
+    return _TIME_RE.sub(repl, s)
+
+
 def _canonicalize_spans(s: str) -> str:
     """Canonicalize date/time/standalone-number-word spans in a LOWERCASED string so equivalent
     answers compare equal after `_normalize`. Narrow + fail-soft: only the recognized span types are
     touched; everything else (and anything out of scope) passes through unchanged."""
-    return _canon_dates(s)
+    return _canon_times(_canon_dates(s))
 
 
 _DATE_RE = re.compile(

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_normalization.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_normalization.py
@@ -1,0 +1,27 @@
+"""Fair-metric answer canonicalization: dates/times/standalone-number-words compare equal across
+formats, WITHOUT making distinct answers collide. Pure, no LLM. Spec: 2026-06-29-stage2a-...-design.md"""
+from __future__ import annotations
+
+from erkgbench.qa_e2e import metrics
+from erkgbench.qa_e2e.metrics import answer_match
+
+
+def test_date_formats_canonicalize_equal():
+    # the three date phrasings all normalize to the same ISO token sequence
+    for a, b in [
+        ("11 February 1929", "February 11, 1929"),
+        ("11 February 1929", "1929-02-11"),
+        ("February 11, 1929", "1929-02-11"),
+    ]:
+        assert metrics._normalize(a) == metrics._normalize(b), (a, b)
+
+
+def test_date_distinct_years_still_differ():
+    assert metrics._normalize("1928") != metrics._normalize("11 February 1929")
+    # same month/day, different year must NOT collide
+    assert metrics._normalize("11 February 1928") != metrics._normalize("11 February 1929")
+
+
+def test_bare_year_not_forced_to_match_full_date():
+    # gold = full date, pred mentions only the year -> incomplete, must NOT match (containment)
+    assert answer_match("the year was 1929", "11 February 1929") == 0.0

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_normalization.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_normalization.py
@@ -25,3 +25,12 @@ def test_date_distinct_years_still_differ():
 def test_bare_year_not_forced_to_match_full_date():
     # gold = full date, pred mentions only the year -> incomplete, must NOT match (containment)
     assert answer_match("the year was 1929", "11 February 1929") == 0.0
+
+
+def test_time_formats_canonicalize_equal():
+    for a, b in [("5am", "5 a.m."), ("5am", "5 AM"), ("5pm", "5 p.m.")]:
+        assert metrics._normalize(a) == metrics._normalize(b), (a, b)
+
+
+def test_time_am_pm_distinct():
+    assert metrics._normalize("5am") != metrics._normalize("5pm")

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_normalization.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_normalization.py
@@ -2,8 +2,20 @@
 formats, WITHOUT making distinct answers collide. Pure, no LLM. Spec: 2026-06-29-stage2a-...-design.md"""
 from __future__ import annotations
 
+import re as _re
+import string as _string
+
 from erkgbench.qa_e2e import metrics
 from erkgbench.qa_e2e.metrics import answer_match
+
+_OLD_PUNCT = str.maketrans("", "", _string.punctuation)
+_OLD_ART = _re.compile(r"\b(a|an|the)\b")
+
+
+def _legacy(s):
+    s = s.lower().translate(_OLD_PUNCT)
+    s = _OLD_ART.sub(" ", s)
+    return " ".join(s.split())
 
 
 def test_date_formats_canonicalize_equal():
@@ -34,3 +46,24 @@ def test_time_formats_canonicalize_equal():
 
 def test_time_am_pm_distinct():
     assert metrics._normalize("5am") != metrics._normalize("5pm")
+
+
+def test_standalone_number_words_canonicalize():
+    assert metrics._normalize("hundred") == metrics._normalize("100")
+    assert metrics._normalize("twenty") == metrics._normalize("20")
+    assert metrics._normalize("one") == metrics._normalize("1")
+
+
+def test_number_word_distinct_values_differ():
+    assert metrics._normalize("hundred") != metrics._normalize("1000")
+    assert metrics._normalize("twenty") != metrics._normalize("twelve")
+
+
+def test_out_of_scope_number_words_fall_through():
+    # hyphenated compound / decimal+magnitude / ordinal are NOT parsed (left as the old normalization).
+    # NB: `one hundred` is deliberately NOT here -- whitespace compounds split to `1 100` by design
+    # (see the spec-deviation note); we assert neither a match nor a fall-through for it.
+    # (`1.5 million`: both legacy and canon strip the decimal point identically; the point is that
+    # canon ADDS nothing -- `million` isn't in the lookup -- not that the string is preserved verbatim.)
+    for w in ["twenty-one", "1.5 million", "third"]:
+        assert metrics._normalize(w) == _legacy(w)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_normalization.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_normalization.py
@@ -67,3 +67,21 @@ def test_out_of_scope_number_words_fall_through():
     # canon ADDS nothing -- `million` isn't in the lookup -- not that the string is preserved verbatim.)
     for w in ["twenty-one", "1.5 million", "third"]:
         assert metrics._normalize(w) == _legacy(w)
+
+
+def test_answer_match_date_crossformat_containment():
+    # harness.py:153/155 compute in_graph/in_ball as answer_match(" ".join(names), gold).
+    # A graph node holding the date in a DIFFERENT format must now read as a hit.
+    graph_names = "foo bar February 11, 1929 baz"
+    assert answer_match(graph_names, "11 February 1929") == 1.0
+
+
+def test_entity_answers_unchanged_no_regression():
+    # engineered-style entity answers contain no date/time/number-word spans -> canon is a no-op
+    for name in ["Exeter College", "the Politburo", "Sega Genesis", "Lana Wood"]:
+        assert metrics._normalize(name) == _legacy(name)
+
+
+def test_answer_match_entity_still_works():
+    assert answer_match("the final entity is Acme Corp", "Acme Corp") == 1.0
+    assert answer_match("Acme Corp", "Globex") == 0.0

--- a/scripts/distill/modal_bench.py
+++ b/scripts/distill/modal_bench.py
@@ -181,7 +181,7 @@ def _bench_impl(eval: str, n: int, ambiguity: float, opts: str, chat: str, embed
     return _persist(eval, n, chat, pathlib.Path(out_md).read_text())
 
 
-@app.function(image=image, gpu="A10G", volumes={"/cache": cache}, timeout=3600)
+@app.function(image=image, gpu="A10G", volumes={"/cache": cache}, timeout=5400)
 def run_bench(eval: str, n: int = 20, ambiguity: float = 0.6, opts: str = "",
               chat: str = "qwen2.5:7b-instruct", embed: str = "nomic-embed-text",
               engine: str = "goldengraph", corpus: str = "engineered") -> str:


### PR DESCRIPTION
## What

Stage-2-A of the goldengraph real-corpus (MuSiQue) effort: a **measurement instrument**, not a feature.
Adds a fair answer-matching metric and ranks the real failure levers so the next sub-project is grounded.

**Code (the one change):** narrow, deterministic answer canonicalization in `metrics.py`, called from
`_normalize` so every metric AND the localize buckets (which derive from `answer_match`) get fairer matching:
- dates → ISO (`11 February 1929` ≡ `February 11, 1929` ≡ `1929-02-11`)
- times → canonical (`5 a.m.` ≡ `5am`)
- standalone number-words → digits via a hyphen/word-guarded fixed lookup (`hundred` ≡ `100`; compounds fall through)

11 new tests + the existing metrics suite green (29 passed, no regression). Plus a `run_bench` timeout bump
(3600→5400s) so the heavy real-corpus eval doesn't hit the function cap.

## Verdict (N=50, fair metric)

`answer_match` 0.12 (entity-subset 0.20, n=30), `support_recall` 0.58. Raw buckets EXTRACTION 21 /
SYNTHESIS 18 / RETRIEVAL 14 — **but** EXTRACTION decomposes ~5 entities-missed vs ~16 non-entity answers
(structural representation mismatch, literal-attrs already measured-dead). So the dominant **fixable** lever
is **SYNTHESIS** (retrieved-but-wrong, needs no graph change), retrieval second. Full report in
`docs/superpowers/reports/2026-06-29-stage2a-musique-lever-ranking.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)