### PR TITLE
feat(goldengraph): stage-2-B opt-in synthesis self-consistency (+ honest-null verdict)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-stage2b-synthesis-self-consistency.md
+++ b/docs/superpowers/plans/2026-06-30-stage2b-synthesis-self-consistency.md
@@ -1,0 +1,418 @@
+# Stage-2-B: Synthesis Self-Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in (default-off) self-consistency to `synthesize_local` — sample the LLM N times at temperature and majority-vote the parsed answer — to recover the synthesis answers that are already in the retrieved ball (the stage-2-A SYNTHESIS lever: 18 retrieved-but-wrong on MuSiQue N=50).
+
+**Architecture:** `OpenAIClient` gains `complete_many` (N-loop at temperature, token-tracked). `synthesize_local` samples via `complete_many` when `GOLDENGRAPH_SYNTH_SAMPLES > 1`, parses each with the existing `_extract_answer`, and votes via a small goldengraph-local normalizer (returning the most-common RAW form). Default off = byte-identical single-call behavior. Then an N=50 MuSiQue validation → ship-or-honest-null report.
+
+**Tech Stack:** Python (stdlib), pytest, the existing `scripts/distill/modal_bench.py --corpus musique` Modal harness.
+
+**Spec:** `docs/superpowers/specs/2026-06-30-stage2b-synthesis-self-consistency-design.md`
+**Branch:** `feat/stage2b-synthesis-self-consistency` (already created off `origin/main`).
+
+---
+
+## Environment notes (read before starting)
+
+- **Run tests box-safely** (the box OOMs on the full suite + on native imports). These tests are pure (no native, no LLM, no polars):
+  ```bash
+  cd packages/python/goldengraph
+  PYTHONPATH="." GOLDENGRAPH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 "D:/show_case/goldenmatch/.venv/Scripts/python.exe" \
+    -m pytest tests/test_synthesis_self_consistency.py tests/test_synthesize_format.py tests/test_budget.py -q -p no:cacheprovider
+  ```
+- **Do NOT run the whole pytest suite locally.** Targeted file runs only. `ruff check` + `py_compile` before each commit.
+- GitHub auth for push: `GH_TOKEN=$(gh auth token --user benzsevern)`.
+- Existing stub LLMs in `tests/conftest.py`: `StubLLM(response)` and `RecordingLLM(response="ANSWER")` — both implement ONLY `complete` (no `complete_many`), which is exactly what the fallback-parity test needs. The self-consistency test defines its own `_ManyStub` in the new test file.
+
+## File structure
+
+- **Modify:** `goldengraph/llm.py` — thread `temperature` through `_chat` (default 0; `complete()` unchanged); add `complete_many(prompt, *, n, temperature)`; document `complete_many` in the `LLMClient` Protocol as an optional capability.
+- **Modify:** `goldengraph/synthesize.py` — `_synth_samples()` / `_synth_temperature()` env parsers, `_vote_answer()` helper, and the self-consistency branch in `synthesize_local`.
+- **Create:** `tests/test_synthesis_self_consistency.py` — vote-logic, stub-LLM, fallback-parity, and `complete_many` tests.
+- **Create (Task 4):** `docs/superpowers/reports/2026-06-30-stage2b-synthesis-self-consistency.md` — validation verdict.
+
+---
+
+### Task 1: `complete_many` on the LLM client
+
+**Files:**
+- Modify: `goldengraph/llm.py`
+- Test: `tests/test_synthesis_self_consistency.py`
+
+- [ ] **Step 1: Write the failing test** (create the file)
+
+```python
+# tests/test_synthesis_self_consistency.py
+"""Synthesis self-consistency: sample N times + majority-vote (stage-2-B). Pure, no live LLM."""
+from __future__ import annotations
+
+from goldengraph.llm import OpenAIClient
+
+
+class _FakeChat:
+    """Minimal stand-in for openai's client: records every create() call's kwargs and
+    returns a canned completion with a usage object (so budget accounting doesn't crash)."""
+    def __init__(self):
+        self.calls = []
+
+        class _Msg:  # resp.choices[0].message.content
+            content = "hello"
+
+        class _Choice:
+            message = _Msg()
+
+        class _Usage:
+            prompt_tokens = 1
+            completion_tokens = 1
+
+        class _Resp:
+            choices = [_Choice()]
+            usage = _Usage()
+
+        self._resp = _Resp()
+
+    # mimic client.chat.completions.create(**kwargs)
+    class _Completions:
+        def __init__(self, outer):
+            self._outer = outer
+
+        def create(self, **kwargs):
+            self._outer.calls.append(kwargs)
+            return self._outer._resp
+
+    @property
+    def chat(self):
+        outer = self
+
+        class _Chat:
+            completions = _FakeChat._Completions(outer)
+
+        return _Chat()
+
+
+def test_complete_many_issues_n_calls_at_temperature():
+    fake = _FakeChat()
+    client = OpenAIClient(model="m", client=fake)
+    out = client.complete_many("p", n=3, temperature=0.7)
+    assert out == ["hello", "hello", "hello"]
+    assert len(fake.calls) == 3
+    assert all(c["temperature"] == 0.7 for c in fake.calls)
+
+
+def test_complete_unchanged_temperature_zero():
+    fake = _FakeChat()
+    client = OpenAIClient(model="m", client=fake)
+    client.complete("p")
+    assert fake.calls[-1]["temperature"] == 0
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run the box-safe command above (just this file). Expected: FAIL (`complete_many` undefined; `_FakeChat` ok).
+
+- [ ] **Step 3: Implement** — in `goldengraph/llm.py`, thread temperature + add `complete_many`:
+
+Change `_chat` signature + the kwargs line:
+```python
+    def _chat(self, prompt: str, *, json_mode: bool = False, temperature: float = 0) -> str:
+        client = self._ensure_client()
+        kwargs = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": temperature,
+        }
+        # ... (rest unchanged: json_mode, create, usage/budget) ...
+```
+(`complete` / `complete_json` call `_chat` without `temperature`, so they stay `temperature=0` — unchanged.)
+
+Add the method (after `complete_json`):
+```python
+    def complete_many(self, prompt: str, *, n: int, temperature: float) -> list[str]:
+        """N independent completions at `temperature` (for synthesis self-consistency).
+        A LOOP of single calls -- Ollama's OpenAI-compatible endpoint does not reliably
+        honor the `n=` param -- each token-tracked through `_chat`'s budget path."""
+        return [self._chat(prompt, temperature=temperature) for _ in range(max(1, n))]
+```
+
+Document it in the Protocol (after the `complete_json` comment block):
+```python
+    # Optional: N independent samples at a temperature, for synthesis self-consistency.
+    # Callers feature-detect with `hasattr(llm, "complete_many")` and fall back to `complete`.
+    # def complete_many(self, prompt: str, *, n: int, temperature: float) -> list[str]: ...
+```
+
+- [ ] **Step 4: Run, verify PASS** (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add goldengraph/llm.py tests/test_synthesis_self_consistency.py
+git commit -m "feat(goldengraph): complete_many on OpenAIClient (N samples at temperature)"
+```
+
+---
+
+### Task 2: vote helper + env parsers
+
+**Files:**
+- Modify: `goldengraph/synthesize.py`
+- Test: `tests/test_synthesis_self_consistency.py`
+
+- [ ] **Step 1: Write failing tests** (append)
+
+```python
+from goldengraph.synthesize import _vote_answer, _synth_samples, _synth_temperature
+
+
+def test_vote_majority_returns_raw_form():
+    # 'Firefox' and 'firefox.' share a normalized key -> 2 votes; raw winner keeps casing
+    assert _vote_answer(["Firefox", "firefox.", "Chrome"]) == "Firefox"
+
+
+def test_vote_skips_empty_and_handles_single():
+    assert _vote_answer(["", "Acme", ""]) == "Acme"
+    assert _vote_answer(["Solo"]) == "Solo"
+    assert _vote_answer([]) == ""
+    assert _vote_answer(["", "  "]) == ""
+
+
+def test_vote_tie_breaks_first_seen():
+    # one each -> the key seen first wins
+    assert _vote_answer(["Beta", "Alpha"]) == "Beta"
+
+
+def test_synth_env_parsers_defensive(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_SAMPLES", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_TEMPERATURE", raising=False)
+    assert _synth_samples() == 1 and _synth_temperature() == 0.7
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", "5")
+    assert _synth_samples() == 5
+    for bad in ("abc", "0", "-3", "1"):  # non-int / <=1 -> single call
+        monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", bad)
+        assert _synth_samples() == 1
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_TEMPERATURE", "xyz")
+    assert _synth_temperature() == 0.7
+```
+
+- [ ] **Step 2: Run, verify FAIL** (`_vote_answer`/`_synth_*` undefined).
+
+- [ ] **Step 3: Implement** — in `goldengraph/synthesize.py`, add near the top (after imports):
+
+```python
+import os
+import string
+from collections import Counter
+
+
+def _synth_samples() -> int:
+    """`GOLDENGRAPH_SYNTH_SAMPLES` (default 1 = single call). Non-int / <=1 -> 1 (fail-safe)."""
+    try:
+        n = int(os.environ.get("GOLDENGRAPH_SYNTH_SAMPLES", "1"))
+    except ValueError:
+        return 1
+    return n if n > 1 else 1
+
+
+def _synth_temperature() -> float:
+    """`GOLDENGRAPH_SYNTH_TEMPERATURE` (default 0.7). Non-float -> 0.7."""
+    try:
+        return float(os.environ.get("GOLDENGRAPH_SYNTH_TEMPERATURE", "0.7"))
+    except ValueError:
+        return 0.7
+
+
+def _vote_key(s: str) -> str:
+    """Group-key for voting: lowercase, collapse whitespace, strip surrounding punctuation.
+    goldengraph-LOCAL + minimal (cannot import the bench's metrics._normalize); its only job is
+    to make 'Firefox' and 'firefox.' vote together."""
+    return " ".join(s.lower().split()).strip(string.punctuation + " ")
+
+
+def _vote_answer(answers: list[str]) -> str:
+    """Majority vote over parsed answers. Group by `_vote_key`, pick the key with the most votes
+    (tie -> first-seen key), return the FIRST raw answer carrying that key (preserves real casing).
+    Empty/blank answers are skipped; no candidates -> ''."""
+    cand = [a for a in answers if a and a.strip()]
+    if not cand:
+        return ""
+    keys = [_vote_key(a) for a in cand]
+    counts = Counter(keys)
+    # max() is stable -> first-seen order breaks ties; iterate keys in first-seen order
+    best_key = max(dict.fromkeys(keys), key=lambda k: counts[k])
+    return next(a for a, k in zip(cand, keys) if k == best_key)
+```
+
+(If `os` is already imported at module level, do not duplicate; `_literals_enabled` currently imports `os` locally, so a module-level `import os` is a safe addition — remove the local import inside `_literals_enabled` only if it becomes redundant and tests still pass.)
+
+- [ ] **Step 4: Run, verify PASS** (Task 1 tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(goldengraph): synthesis vote helper + defensive env parsers"
+```
+
+---
+
+### Task 3: wire self-consistency into `synthesize_local`
+
+**Files:**
+- Modify: `goldengraph/synthesize.py`
+- Test: `tests/test_synthesis_self_consistency.py`
+
+- [ ] **Step 1: Write failing tests** (append)
+
+```python
+from goldengraph.synthesize import synthesize_local
+
+_SUB = {
+    "entities": [{"entity_id": 0, "canonical_name": "Acme", "typ": "org"}],
+    "edges": [],
+}
+
+
+class _ManyStub:
+    """LLM stub with complete_many returning a CANNED list of completions (already in the
+    'show hops then Answer: X' shape). Records whether complete_many vs complete was used."""
+    def __init__(self, samples: list[str], single: str = "Answer: SingleFallback"):
+        self._samples = samples
+        self._single = single
+        self.many_calls = 0
+        self.single_calls = 0
+
+    def complete(self, prompt: str) -> str:
+        self.single_calls += 1
+        return self._single
+
+    def complete_many(self, prompt: str, *, n: int, temperature: float) -> list[str]:
+        self.many_calls += 1
+        return list(self._samples)
+
+
+def test_self_consistency_votes_when_enabled(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", "3")
+    llm = _ManyStub(["Answer: Firefox", "Answer: Firefox", "Answer: Chrome"])
+    assert synthesize_local("q?", _SUB, llm) == "Firefox"
+    assert llm.many_calls == 1 and llm.single_calls == 0
+
+
+def test_default_off_uses_single_complete(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_SAMPLES", raising=False)
+    llm = _ManyStub(["Answer: X"])
+    out = synthesize_local("q?", _SUB, llm)
+    assert out == "SingleFallback"           # the single-call path
+    assert llm.single_calls == 1 and llm.many_calls == 0
+
+
+def test_stub_without_complete_many_falls_back(monkeypatch):
+    from conftest import RecordingLLM
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", "3")   # enabled, but stub lacks complete_many
+    llm = RecordingLLM("Answer: Y")
+    assert synthesize_local("q?", _SUB, llm) == "Y"
+    assert len(llm.prompts) == 1                            # single call, no crash
+
+
+def test_all_samples_empty_falls_back(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", "3")
+    llm = _ManyStub(["", "   ", ""], single="Answer: Recovered")
+    assert synthesize_local("q?", _SUB, llm) == "Recovered"
+    assert llm.many_calls == 1 and llm.single_calls == 1   # sampled, all empty -> one fallback
+```
+
+- [ ] **Step 2: Run, verify FAIL** (synthesize_local has no sampling branch yet → `test_self_consistency_votes_when_enabled` fails).
+
+- [ ] **Step 3: Implement** — replace the body of `synthesize_local` (keep signature + docstring; the seeds/prompt build is unchanged):
+
+```python
+def synthesize_local(query, subgraph, llm, *, seed_names=None):
+    # ... (unchanged) build `seeds` and select `prompt` (LITERALS variant or not) ...
+    filled = prompt.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
+    n = _synth_samples()
+    if n > 1 and hasattr(llm, "complete_many"):
+        try:
+            samples = llm.complete_many(filled, n=n, temperature=_synth_temperature())
+        except Exception:
+            samples = []
+        voted = _vote_answer([_extract_answer(s) for s in samples])
+        if voted:
+            return voted
+        # all samples empty/failed -> single-call fallback below
+    return _extract_answer(llm.complete(filled))
+```
+
+Note: `filled` is built ONCE; the single-call fallback reuses it. The `samples=1` / no-`complete_many` / all-empty paths all reach the final `return _extract_answer(llm.complete(filled))` — byte-identical to today when off.
+
+- [ ] **Step 4: Run, verify PASS** — the new file + the existing synthesis tests for no-regression:
+
+```bash
+PYTHONPATH="." GOLDENGRAPH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 "D:/show_case/goldenmatch/.venv/Scripts/python.exe" \
+  -m pytest tests/test_synthesis_self_consistency.py tests/test_synthesize_format.py tests/test_hybrid_synthesis.py -q -p no:cacheprovider
+```
+Expected: all PASS (self-consistency tests + the existing synthesis tests unchanged — `synthesize_local`'s default path is byte-identical).
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+"D:/show_case/goldenmatch/.venv/Scripts/python.exe" -m ruff check goldengraph/llm.py goldengraph/synthesize.py tests/test_synthesis_self_consistency.py
+git commit -am "feat(goldengraph): opt-in synthesis self-consistency in synthesize_local"
+```
+
+---
+
+### Task 4: N=50 MuSiQue validation → ship-or-honest-null report
+
+**Files:**
+- Create: `docs/superpowers/reports/2026-06-30-stage2b-synthesis-self-consistency.md`
+
+A MEASUREMENT, not code. Detached Modal pattern (box OOM-reaps the local CLI ~1 min in).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) git push -u origin feat/stage2b-synthesis-self-consistency
+```
+
+- [ ] **Step 2: Fire the validation run (SAMPLES=5)**
+
+```bash
+P="a99885f0-c5af-4ae1-9dc8-255cc60aa129"
+export MODAL_TOKEN_ID=$(infisical.cmd secrets get MODAL_TOKEN_ID --projectId "$P" --env dev --plain --silent)
+export MODAL_TOKEN_SECRET=$(infisical.cmd secrets get MODAL_TOKEN_SECRET --projectId "$P" --env dev --plain --silent)
+M="D:/show_case/goldenmatch/.venv/Scripts/modal.exe"
+PYTHONIOENCODING=utf-8 "$M" run --detach scripts/distill/modal_bench.py \
+  --engine goldengraph --eval end_to_end --corpus musique --n 50 --spawn \
+  --opts $'GOLDENGRAPH_QA_MODE=auto\nGOLDENGRAPH_SYNTH_SAMPLES=5'
+```
+Result: `results/end_to_end_50_goldengraph-qwen2.5-7b-instruct-musique.md` on `gg-bench-cache`. Poll with a Monitor (until-loop, `volume get --force`, grep `support_recall=`). **5× synthesis calls + real prose → this is heavier than the stage-2-A baseline; the run_bench timeout is already 5400s (90 min). If it still caps, drop to N=40.**
+
+- [ ] **Step 3: Aggregate vs the stage-2-A baseline**
+
+```bash
+grep -iE "support_recall=|musique \| 0" /tmp/s2b.md | head -2
+grep -oE "(EXTRACTION|RETRIEVAL-BROKEN-CHAIN|SYNTHESIS)" /tmp/s2b.md | sort | uniq -c | sort -rn
+```
+Baseline to beat: `answer_match` 0.12, SYNTHESIS bucket 18.
+
+- [ ] **Step 4: Write the verdict report** — `docs/superpowers/reports/2026-06-30-stage2b-synthesis-self-consistency.md`:
+  - Run config (N, model, SAMPLES=5, temperature, date).
+  - Before/after: `answer_match` (0.12 → ?), SYNTHESIS bucket (18 → ?), `support_recall`.
+  - **Verdict, per the pre-committed gate:**
+    - *Rises + SYNTHESIS drops* → SUCCESS: keep default-off (opt-in lever); note the win; optional 3/5/8 sample mini-sweep as a follow-up.
+    - *Flat* → HONEST-NULL: 7B synthesis errors are systematic not variance; keep the code default-off; next lever = constrained-selection or retrieval. State it plainly, no tuning.
+  - Confidence statement scaled to N.
+
+- [ ] **Step 5: Commit the report**
+
+```bash
+git add docs/superpowers/reports/2026-06-30-stage2b-synthesis-self-consistency.md
+git commit -m "docs(stage-2b): synthesis self-consistency validation verdict"
+```
+
+---
+
+## Done criterion
+
+- Tasks 1-3 merged behind green tests (new file + existing synthesis suites, no regression; default path byte-identical).
+- A committed validation report with the before/after and a ship-or-honest-null verdict per the pre-committed gate.
+- Open a PR; arm auto-merge once CI is green. (The code lands regardless of the verdict — it is default-off; the report records whether the lever is worth enabling.)

--- a/docs/superpowers/reports/2026-06-30-stage2b-synthesis-self-consistency.md
+++ b/docs/superpowers/reports/2026-06-30-stage2b-synthesis-self-consistency.md
@@ -1,0 +1,67 @@
+# Stage-2-B: Synthesis Self-Consistency — Validation Verdict (HONEST-NULL)
+
+**Date:** 2026-06-30
+**Spec:** `docs/superpowers/specs/2026-06-30-stage2b-synthesis-self-consistency-design.md`
+**Plan:** `docs/superpowers/plans/2026-06-30-stage2b-synthesis-self-consistency.md`
+
+## Run config
+
+- Corpus: MuSiQue-Ans, seeded subset, **N=50**.
+- Engine: goldengraph, open extraction, `GOLDENGRAPH_QA_MODE=auto`, **`GOLDENGRAPH_SYNTH_SAMPLES=5`**,
+  `GOLDENGRAPH_SYNTH_TEMPERATURE=0.7` (default).
+- Model: `qwen2.5:7b-instruct` + `nomic-embed-text`, Modal A10G, fair metric (stage-2-A, on main).
+
+## Result vs the stage-2-A baseline
+
+| metric | baseline (single-call) | self-consistency (SAMPLES=5) |
+|---|---|---|
+| `answer_match` (all 50) | 0.12 | **0.08** (worse) |
+| `answer_match` (entity-subset, n=30) | 0.20 | **0.13** (worse) |
+| SYNTHESIS bucket | 18 | 16 (−2, within noise) |
+| EXTRACTION bucket | 21 | 25 |
+| RETRIEVAL bucket | 14 | 12 |
+| `support_recall` | 0.58 | 0.63 |
+
+**Verdict: HONEST-NULL.** Self-consistency did not recover the synthesis misses — `answer_match`
+dropped (0.12 → 0.08), and the SYNTHESIS bucket barely moved (−2).
+
+## Why it failed (the mechanism)
+
+Self-consistency only helps when the **correct** answer is the **modal** sample across the N draws. At
+**12% base accuracy** on hard multi-hop reasoning, the correct answer is *not* the plurality — most of
+the 5 samples are wrong, so majority-voting reinforces a wrong answer rather than surfacing the right
+one. The temperature-0.7 diversity adds more *wrong* variants, making it marginally worse, not better.
+This is a known failure mode of self-consistency: it amplifies a model that is right-more-often-than-any-
+single-wrong-answer; it cannot manufacture correctness a low-accuracy base model doesn't have.
+
+The stage-2-A diagnosis ("the answer is IN the ball; the model reads the wrong one") was correct, but
+the corrective assumption — that the error is **variance** (so voting recovers it) — is refuted. The 7B's
+synthesis errors are **systematic**: it reasons to the same (wrong) answer, or to a spread of wrong
+answers that out-vote the right one.
+
+## Confound (flagged for honesty)
+
+The baseline and this run are SEPARATE live-7B builds, and 7B extraction is non-deterministic run-to-run
+(EXTRACTION drifted 21 → 25 with no extraction-side change). So the small bucket movements partly reflect
+extraction variance, not synthesis. The verdict is robust regardless: `answer_match` went **down**, and
+the mechanism above explains why. A confirmatory re-run could separate the variance, but a
+mechanistically-explained null does not warrant another ~70-min run.
+
+## Disposition
+
+- **The code ships, default-off.** `complete_many` + opt-in self-consistency in `synthesize_local` are
+  merged behind `GOLDENGRAPH_SYNTH_SAMPLES` (default 1 = byte-identical single call), 31 tests green. It
+  is a clean, tested capability that simply does not help on *this* stack at *this* base accuracy.
+- **Do NOT enable by default** (it lowers answer-match).
+- **Next lever:** because synthesis errors are systematic not variance, the productive directions are the
+  ones that *constrain* or *raise* the base reasoning rather than average over it:
+  1. **Constrained-ball selection** — force the final answer to be one of the retrieved ball entities
+     (the stage-2-A YAGNI'd alternative), removing off-ball/free-form wrong answers.
+  2. **Retrieval (broken chains)** — the clear second lever from stage-2-A (14), which also lifts the
+     base subgraph quality synthesis reasons over.
+
+## Lesson
+
+Self-consistency is not a free win on a low-accuracy base model. It requires the correct answer to be
+modal; verify the base accuracy clears that bar before assuming variance-reduction will help. Measured
+in one falsifiable run, recorded, moved on — no tuning to force a number.

--- a/docs/superpowers/specs/2026-06-30-stage2b-synthesis-self-consistency-design.md
+++ b/docs/superpowers/specs/2026-06-30-stage2b-synthesis-self-consistency-design.md
@@ -34,14 +34,18 @@ feature; the bench exercises it via env).
 Add `complete_many(prompt, *, n, temperature) -> list[str]` to `OpenAIClient`: a **loop of N calls** at
 the given temperature (NOT the OpenAI `n=` param — Ollama's OpenAI-compatible endpoint does not reliably
 support `n`), each token-tracked through the existing budget path. `complete()` stays `temperature=0`,
-untouched. The `LLMClient` Protocol gains `complete_many` as an OPTIONAL capability; `synthesize_local`
-falls back to single-call when a stub lacks it (back-compat for test stubs).
+untouched. **Implementation note for the plan:** `_chat` currently hardcodes `temperature: 0` and takes
+no temperature argument; the plan must thread a `temperature` param through `_chat` (default 0, so
+`complete()` is unchanged) rather than reuse `complete()` verbatim. The `LLMClient` Protocol gains
+`complete_many` as an OPTIONAL capability — mirroring the existing `complete_json` feature-detect
+pattern; `synthesize_local` falls back to single-call (via `hasattr`) when a stub lacks it.
 
 ### 2. Self-consistency in `synthesize_local` (`goldengraph/synthesize.py`)
 
-Gated by two env vars:
+Gated by two env vars (parsed defensively, mirroring the repo's `_literals_enabled` house style — a
+non-int / `<= 1` / negative `SAMPLES` resolves to single-call, never crashes synthesis):
 - `GOLDENGRAPH_SYNTH_SAMPLES` (default `1` = current single call; opt-in).
-- `GOLDENGRAPH_SYNTH_TEMPERATURE` (default `0.7`).
+- `GOLDENGRAPH_SYNTH_TEMPERATURE` (default `0.7`; non-float falls back to the default).
 
 When `samples > 1`: draw N completions via `complete_many`, parse each with the existing
 `_extract_answer`, then **vote**:
@@ -58,6 +62,10 @@ The prompt text, `_extract_answer`, and the `samples=1` path are unchanged.
 
 MuSiQue N=50 with self-consistency on (`GOLDENGRAPH_SYNTH_SAMPLES=5`), compared to the stage-2-A
 baseline (`answer_match` 0.12, SYNTHESIS bucket 18). The fair metric (now on main) scores it.
+**Lever/metric alignment:** the bench runs goldengraph in `mode=auto`, which routes MuSiQue's
+natural-language questions to the LOCAL synthesis path (`synthesize_local`) — the exact path this lever
+modifies and the one the stage-2-A SYNTHESIS bucket was measured on. (`synthesize_hybrid`/`global` share
+the single-call shape but are explicitly OUT of scope here.)
 
 ## Data flow
 

--- a/docs/superpowers/specs/2026-06-30-stage2b-synthesis-self-consistency-design.md
+++ b/docs/superpowers/specs/2026-06-30-stage2b-synthesis-self-consistency-design.md
@@ -1,0 +1,121 @@
+# Stage-2-B: Synthesis Self-Consistency — Design
+
+**Status:** Approved (brainstorm), pending implementation plan.
+**Date:** 2026-06-30
+**Context:** goldengraph real-corpus (stage-2) quality. Follows stage-2-A's verdict
+(`docs/superpowers/reports/2026-06-29-stage2a-musique-lever-ranking.md`): on MuSiQue N=50, **SYNTHESIS
+is the dominant fixable lever** — 18 questions had the gold answer IN the retrieved ball
+(`in_ball=True`) but the 7B wrote the wrong answer. `support_recall` 0.58: the evidence is retrieved;
+the model mis-reads it.
+
+## Goal
+
+Reduce the 7B's synthesis reasoning-variance by **sampling the answer N times and majority-voting**,
+recovering the answer that is already in the retrieved ball. **Opt-in, measure-first**; default off =
+today's single-call behavior, byte-for-byte.
+
+## Why self-consistency
+
+The current `synthesize_local` is already a heavily-engineered SINGLE 7B call (multi-hop decomposition,
+direction-awareness, commit-to-single-entity, `Answer:` parsing). The 18 failures are genuine
+reasoning/selection errors on a weak model — the right entity is in the ball, the model reasons to the
+wrong one. The prompt is already elaborate and format is already fixed (stage-2-A). Self-consistency
+(sample + majority vote) is the classic variance-reduction fix for weak-model reasoning, and it fits
+the measured situation: the answer is retrievable, so multiple reasoning attempts plus a vote should
+surface it.
+
+## Architecture
+
+Three small, independently-testable pieces. All in the goldengraph engine package (a real engine
+feature; the bench exercises it via env).
+
+### 1. LLM sampling (`goldengraph/llm.py`)
+
+Add `complete_many(prompt, *, n, temperature) -> list[str]` to `OpenAIClient`: a **loop of N calls** at
+the given temperature (NOT the OpenAI `n=` param — Ollama's OpenAI-compatible endpoint does not reliably
+support `n`), each token-tracked through the existing budget path. `complete()` stays `temperature=0`,
+untouched. The `LLMClient` Protocol gains `complete_many` as an OPTIONAL capability; `synthesize_local`
+falls back to single-call when a stub lacks it (back-compat for test stubs).
+
+### 2. Self-consistency in `synthesize_local` (`goldengraph/synthesize.py`)
+
+Gated by two env vars:
+- `GOLDENGRAPH_SYNTH_SAMPLES` (default `1` = current single call; opt-in).
+- `GOLDENGRAPH_SYNTH_TEMPERATURE` (default `0.7`).
+
+When `samples > 1`: draw N completions via `complete_many`, parse each with the existing
+`_extract_answer`, then **vote**:
+- Group answers by a small goldengraph-LOCAL normalizer (lowercase + collapse whitespace + strip
+  surrounding punctuation). goldengraph cannot import the bench's `metrics._normalize`, so the
+  vote-grouping normalizer is local and minimal — its only job is to make `Firefox` / `firefox.` vote
+  together.
+- **Return the most common RAW form** (not the normalized key), so the answer keeps its real casing.
+- **Deterministic tie-break**: highest count, then first-seen order.
+
+The prompt text, `_extract_answer`, and the `samples=1` path are unchanged.
+
+### 3. Validation run
+
+MuSiQue N=50 with self-consistency on (`GOLDENGRAPH_SYNTH_SAMPLES=5`), compared to the stage-2-A
+baseline (`answer_match` 0.12, SYNTHESIS bucket 18). The fair metric (now on main) scores it.
+
+## Data flow
+
+```
+ask -> synthesize_local
+  -> samples>1 ? complete_many(prompt, n=N, temperature=T)  : complete(prompt)   [default]
+  -> _extract_answer on each sample
+  -> normalized-group vote -> plurality RAW answer
+```
+
+## Error handling
+
+- A failed/empty sample is skipped; if ALL samples fail, fall back to a single `complete`.
+- `samples=1` is byte-identical to today: one `complete` call, no temperature change, no vote path.
+- A stub LLM without `complete_many` -> single-call fallback (no crash).
+
+## Testing
+
+- **Vote logic** (pure): `["Firefox","firefox.","Chrome"]` -> `Firefox` (normalized grouping collapses
+  the first two; raw form returned); tie -> first-seen (`["A","B"]` -> `A`); single element -> itself;
+  empty input -> empty.
+- **Self-consistency via stub LLM**: a stub `complete_many` returning
+  `["Answer: Firefox","Answer: Firefox","Answer: Chrome"]` -> `synthesize_local` returns `Firefox`; a
+  stub returning one empty/error entry proves skip-and-continue.
+- **Fallback parity**: `samples=1` (default) makes exactly one `complete` call (not `complete_many`); a
+  stub lacking `complete_many` still works -> locks the "byte-identical when off" guarantee.
+- **`complete_many` shape**: on a fake OpenAI client, asserts N calls at the requested temperature and
+  N returned strings (no live network).
+- **Integration validation** = the N=50 MuSiQue run.
+
+## Scope / YAGNI
+
+- **No constrained-ball selection** (vote over parsed answers only) — add only if validation shows
+  off-ball hallucination dominates.
+- **No `n=` API optimization** — robust N-loop; revisit only if cost matters.
+- **No change to retrieval / extraction / the prompt text** — purely the sampling + vote wrapper.
+- **Default off** — the single-call baseline stays the shipped default; self-consistency is the opt-in
+  measured lane.
+
+## Validation gate + honest-null readiness
+
+**Known risk:** if the 7B fails SYSTEMATICALLY (reasons to the *same* wrong answer every time), voting
+cannot help — all samples agree on wrong. The design is therefore explicitly falsifiable. The N=50
+validation decides:
+
+- **`answer_match` rises meaningfully AND the SYNTHESIS bucket drops** -> success. Keep it default-off
+  (the measured opt-in lever), record the before/after in a report. Optionally a small sample-count
+  sweep (3 / 5 / 8) if the first N shows life.
+- **Flat** -> **honest-null it** (like the argctx and literal-attrs closures): record that 7B synthesis
+  errors are systematic, not variance; keep the code behind the default-off flag; the next lever
+  becomes constrained-selection or retrieval. **No tuning to force a number.**
+
+## Files
+
+- Modify: `packages/python/goldengraph/goldengraph/llm.py` (`complete_many` on `OpenAIClient`; Protocol
+  optional method).
+- Modify: `packages/python/goldengraph/goldengraph/synthesize.py` (env-gated self-consistency +
+  vote helper in `synthesize_local`).
+- Create: `packages/python/goldengraph/tests/test_synthesis_self_consistency.py` (vote + stub-LLM tests).
+- Validation: existing `scripts/distill/modal_bench.py --corpus musique` (env opts; no bench code change).
+- Report (on success or null): `docs/superpowers/reports/2026-06-30-stage2b-synthesis-self-consistency.md`.

--- a/packages/python/goldengraph/goldengraph/llm.py
+++ b/packages/python/goldengraph/goldengraph/llm.py
@@ -21,6 +21,10 @@ class LLMClient(Protocol):
     # -- test stubs and the pure protocol need not implement it.
     # def complete_json(self, prompt: str) -> str: ...
 
+    # Optional: N independent samples at a temperature, for synthesis self-consistency.
+    # Callers feature-detect with `hasattr(llm, "complete_many")` and fall back to `complete`.
+    # def complete_many(self, prompt: str, *, n: int, temperature: float) -> list[str]: ...
+
 
 class OpenAIClient:
     """Minimal OpenAI adapter (optional `[openai]` extra). Reuses goldenmatch's
@@ -48,12 +52,18 @@ class OpenAIClient:
         failure mode). Honored by OpenAI + Ollama's OpenAI-compatible endpoint."""
         return self._chat(prompt, json_mode=True)
 
-    def _chat(self, prompt: str, *, json_mode: bool) -> str:
+    def complete_many(self, prompt: str, *, n: int, temperature: float) -> list[str]:
+        """N independent completions at `temperature` (for synthesis self-consistency).
+        A LOOP of single calls -- Ollama's OpenAI-compatible endpoint does not reliably
+        honor the `n=` param -- each token-tracked through `_chat`'s budget path."""
+        return [self._chat(prompt, temperature=temperature) for _ in range(max(1, n))]
+
+    def _chat(self, prompt: str, *, json_mode: bool = False, temperature: float = 0) -> str:
         client = self._ensure_client()
         kwargs = {
             "model": self.model,
             "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0,
+            "temperature": temperature,
         }
         if json_mode:
             kwargs["response_format"] = {"type": "json_object"}

--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -190,11 +190,18 @@ def synthesize_local(
         "(none identified -- choose the most relevant entities yourself)"
     )
     prompt = _LOCAL_PROMPT_LITERALS if _literals_enabled() else _LOCAL_PROMPT
-    return _extract_answer(
-        llm.complete(
-            prompt.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
-        )
-    )
+    filled = prompt.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
+    n = _synth_samples()
+    if n > 1 and hasattr(llm, "complete_many"):
+        try:
+            samples = llm.complete_many(filled, n=n, temperature=_synth_temperature())
+        except Exception:
+            samples = []
+        voted = _vote_answer([_extract_answer(s) for s in samples])
+        if voted:
+            return voted
+        # all samples empty/failed -> single-call fallback below
+    return _extract_answer(llm.complete(filled))
 
 
 _HYBRID_HEAD = (

--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -8,7 +8,49 @@ the caller (`ask`) pre-emptively caps community count.
 
 from __future__ import annotations
 
+import os
+import string
+from collections import Counter
+
 from .llm import LLMClient
+
+
+def _synth_samples() -> int:
+    """`GOLDENGRAPH_SYNTH_SAMPLES` (default 1 = single call). Non-int / <=1 -> 1 (fail-safe)."""
+    try:
+        n = int(os.environ.get("GOLDENGRAPH_SYNTH_SAMPLES", "1"))
+    except ValueError:
+        return 1
+    return n if n > 1 else 1
+
+
+def _synth_temperature() -> float:
+    """`GOLDENGRAPH_SYNTH_TEMPERATURE` (default 0.7). Non-float -> 0.7."""
+    try:
+        return float(os.environ.get("GOLDENGRAPH_SYNTH_TEMPERATURE", "0.7"))
+    except ValueError:
+        return 0.7
+
+
+def _vote_key(s: str) -> str:
+    """Group-key for voting: lowercase, collapse whitespace, strip surrounding punctuation.
+    goldengraph-LOCAL + minimal (cannot import the bench's metrics._normalize); its only job is
+    to make 'Firefox' and 'firefox.' vote together."""
+    return " ".join(s.lower().split()).strip(string.punctuation + " ")
+
+
+def _vote_answer(answers: list[str]) -> str:
+    """Majority vote over parsed answers. Group by `_vote_key`, pick the key with the most votes
+    (tie -> first-seen key), return the FIRST raw answer carrying that key (preserves real casing).
+    Empty/blank answers are skipped; no candidates -> ''."""
+    cand = [a for a in answers if a and a.strip()]
+    if not cand:
+        return ""
+    keys = [_vote_key(a) for a in cand]
+    counts = Counter(keys)
+    # max() is stable -> first-seen order breaks ties; iterate keys in first-seen order
+    best_key = max(dict.fromkeys(keys), key=lambda k: counts[k])
+    return next(a for a, k in zip(cand, keys) if k == best_key)
 
 
 def _format_subgraph(view: dict) -> str:

--- a/packages/python/goldengraph/tests/test_synthesis_self_consistency.py
+++ b/packages/python/goldengraph/tests/test_synthesis_self_consistency.py
@@ -61,7 +61,12 @@ def test_complete_unchanged_temperature_zero():
     assert fake.calls[-1]["temperature"] == 0
 
 
-from goldengraph.synthesize import _synth_samples, _synth_temperature, _vote_answer
+from goldengraph.synthesize import (
+    _synth_samples,
+    _synth_temperature,
+    _vote_answer,
+    synthesize_local,
+)
 
 
 def test_vote_majority_returns_raw_form():
@@ -92,3 +97,57 @@ def test_synth_env_parsers_defensive(monkeypatch):
         assert _synth_samples() == 1
     monkeypatch.setenv("GOLDENGRAPH_SYNTH_TEMPERATURE", "xyz")
     assert _synth_temperature() == 0.7
+
+
+_SUB = {
+    "entities": [{"entity_id": 0, "canonical_name": "Acme", "typ": "org"}],
+    "edges": [],
+}
+
+
+class _ManyStub:
+    """LLM stub with complete_many returning a CANNED list of completions (already in the
+    'show hops then Answer: X' shape). Records whether complete_many vs complete was used."""
+    def __init__(self, samples: list[str], single: str = "Answer: SingleFallback"):
+        self._samples = samples
+        self._single = single
+        self.many_calls = 0
+        self.single_calls = 0
+
+    def complete(self, prompt: str) -> str:
+        self.single_calls += 1
+        return self._single
+
+    def complete_many(self, prompt: str, *, n: int, temperature: float) -> list[str]:
+        self.many_calls += 1
+        return list(self._samples)
+
+
+def test_self_consistency_votes_when_enabled(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", "3")
+    llm = _ManyStub(["Answer: Firefox", "Answer: Firefox", "Answer: Chrome"])
+    assert synthesize_local("q?", _SUB, llm) == "Firefox"
+    assert llm.many_calls == 1 and llm.single_calls == 0
+
+
+def test_default_off_uses_single_complete(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_SAMPLES", raising=False)
+    llm = _ManyStub(["Answer: X"])
+    out = synthesize_local("q?", _SUB, llm)
+    assert out == "SingleFallback"           # the single-call path
+    assert llm.single_calls == 1 and llm.many_calls == 0
+
+
+def test_stub_without_complete_many_falls_back(monkeypatch):
+    from conftest import RecordingLLM
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", "3")   # enabled, but stub lacks complete_many
+    llm = RecordingLLM("Answer: Y")
+    assert synthesize_local("q?", _SUB, llm) == "Y"
+    assert len(llm.prompts) == 1                            # single call, no crash
+
+
+def test_all_samples_empty_falls_back(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", "3")
+    llm = _ManyStub(["", "   ", ""], single="Answer: Recovered")
+    assert synthesize_local("q?", _SUB, llm) == "Recovered"
+    assert llm.many_calls == 1 and llm.single_calls == 1   # sampled, all empty -> one fallback

--- a/packages/python/goldengraph/tests/test_synthesis_self_consistency.py
+++ b/packages/python/goldengraph/tests/test_synthesis_self_consistency.py
@@ -59,3 +59,36 @@ def test_complete_unchanged_temperature_zero():
     client = OpenAIClient(model="m", client=fake)
     client.complete("p")
     assert fake.calls[-1]["temperature"] == 0
+
+
+from goldengraph.synthesize import _synth_samples, _synth_temperature, _vote_answer
+
+
+def test_vote_majority_returns_raw_form():
+    # 'Firefox' and 'firefox.' share a normalized key -> 2 votes; raw winner keeps casing
+    assert _vote_answer(["Firefox", "firefox.", "Chrome"]) == "Firefox"
+
+
+def test_vote_skips_empty_and_handles_single():
+    assert _vote_answer(["", "Acme", ""]) == "Acme"
+    assert _vote_answer(["Solo"]) == "Solo"
+    assert _vote_answer([]) == ""
+    assert _vote_answer(["", "  "]) == ""
+
+
+def test_vote_tie_breaks_first_seen():
+    # one each -> the key seen first wins
+    assert _vote_answer(["Beta", "Alpha"]) == "Beta"
+
+
+def test_synth_env_parsers_defensive(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_SAMPLES", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_TEMPERATURE", raising=False)
+    assert _synth_samples() == 1 and _synth_temperature() == 0.7
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", "5")
+    assert _synth_samples() == 5
+    for bad in ("abc", "0", "-3", "1"):  # non-int / <=1 -> single call
+        monkeypatch.setenv("GOLDENGRAPH_SYNTH_SAMPLES", bad)
+        assert _synth_samples() == 1
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_TEMPERATURE", "xyz")
+    assert _synth_temperature() == 0.7

--- a/packages/python/goldengraph/tests/test_synthesis_self_consistency.py
+++ b/packages/python/goldengraph/tests/test_synthesis_self_consistency.py
@@ -1,0 +1,61 @@
+"""Synthesis self-consistency: sample N times + majority-vote (stage-2-B). Pure, no live LLM."""
+from __future__ import annotations
+
+from goldengraph.llm import OpenAIClient
+
+
+class _FakeChat:
+    """Minimal stand-in for openai's client: records every create() call's kwargs and
+    returns a canned completion with a usage object (so budget accounting doesn't crash)."""
+    def __init__(self):
+        self.calls = []
+
+        class _Msg:  # resp.choices[0].message.content
+            content = "hello"
+
+        class _Choice:
+            message = _Msg()
+
+        class _Usage:
+            prompt_tokens = 1
+            completion_tokens = 1
+
+        class _Resp:
+            choices = [_Choice()]
+            usage = _Usage()
+
+        self._resp = _Resp()
+
+    # mimic client.chat.completions.create(**kwargs)
+    class _Completions:
+        def __init__(self, outer):
+            self._outer = outer
+
+        def create(self, **kwargs):
+            self._outer.calls.append(kwargs)
+            return self._outer._resp
+
+    @property
+    def chat(self):
+        outer = self
+
+        class _Chat:
+            completions = _FakeChat._Completions(outer)
+
+        return _Chat()
+
+
+def test_complete_many_issues_n_calls_at_temperature():
+    fake = _FakeChat()
+    client = OpenAIClient(model="m", client=fake)
+    out = client.complete_many("p", n=3, temperature=0.7)
+    assert out == ["hello", "hello", "hello"]
+    assert len(fake.calls) == 3
+    assert all(c["temperature"] == 0.7 for c in fake.calls)
+
+
+def test_complete_unchanged_temperature_zero():
+    fake = _FakeChat()
+    client = OpenAIClient(model="m", client=fake)
+    client.complete("p")
+    assert fake.calls[-1]["temperature"] == 0


### PR DESCRIPTION
## What

Opt-in (default-off) synthesis self-consistency for goldengraph: `complete_many` on the LLM client
(N samples at temperature, token-tracked) + an env-gated vote in `synthesize_local`
(`GOLDENGRAPH_SYNTH_SAMPLES`, default 1 = byte-identical single call). 31 tests green; default path
unchanged.

## Verdict: HONEST-NULL (code ships default-off anyway)

N=50 MuSiQue, SAMPLES=5: `answer_match` 0.12 -> 0.08 (worse), SYNTHESIS bucket 18 -> 16 (noise).
Self-consistency only helps when the correct answer is the MODAL sample; at 12% base accuracy on hard
multi-hop it isn't, so majority-voting reinforces wrong answers. The errors are systematic, not
variance. The capability is merged behind the default-off flag; do NOT enable by default. Next lever =
constrained-ball selection or retrieval. Full report:
`docs/superpowers/reports/2026-06-30-stage2b-synthesis-self-consistency.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)