### PR TITLE
feat(goldengraph): stage-2-C surface-bridged retrieval (+ construction-ceiling null)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-stage2c-surface-bridged-retrieval.md
+++ b/docs/superpowers/plans/2026-06-30-stage2c-surface-bridged-retrieval.md
@@ -1,0 +1,269 @@
+# Stage-2-C: Surface-Bridged Retrieval Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in (default-off) `_retrieve_local_bridged` that bridges same-name under-merged siblings as the retrieval ball expands, so multi-hop answers stranded behind a split bridge-entity enter the subgraph — then validate on MuSiQue (ship-or-construction-ceiling-null).
+
+**Architecture:** New iterative-frontier function in `goldengraph/answer.py` reusing the existing `_bridge_surfaces`; a one-line env gate at the single `_retrieve_local` call site in `ask`. Default off = byte-identical to today.
+
+**Tech Stack:** Python (stdlib), pytest, the existing `scripts/distill/modal_bench.py --corpus musique` Modal harness.
+
+**Spec:** `docs/superpowers/specs/2026-06-30-stage2c-surface-bridged-retrieval-design.md`
+**Branch:** `feat/stage2c-retrieval-connectivity` (already created off `origin/main`).
+
+---
+
+## Environment notes (read before starting)
+
+- **Box-safe pure tests** (no native, no LLM, no polars):
+  ```bash
+  cd packages/python/goldengraph
+  PYTHONPATH="." GOLDENGRAPH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 "D:/show_case/goldenmatch/.venv/Scripts/python.exe" \
+    -m pytest tests/test_retrieval_bridge.py tests/test_chain_retrieval.py -q -p no:cacheprovider
+  ```
+- **Do NOT run the whole suite locally** (OOM). `test_retrieval.py` needs `goldengraph_native` (absent on the box) — it is a CI/Modal check, NOT a local one. `ruff check` + `py_compile` before each commit. GitHub auth: `GH_TOKEN=$(gh auth token --user benzsevern)`.
+- **Critical test-stub fact (do NOT "fix"):** `_StubGraph.query(ids, hops)` in `test_chain_retrieval.py` **ignores `hops`** and only ever does a 1-hop expansion from `ids`. That is intentional — it is what makes the plain ball strand at the sink-copy (assert-1). The fixture proves the BRIDGING mechanism (via the bridged function's own iteration), not the depth-growth of the real native `query`. Leave the stub alone.
+
+## File structure
+
+- **Modify:** `goldengraph/answer.py` — add `_retrieve_local_bridged` (after `_retrieve_local`) and `_bridge_enabled()` (near `_hybrid_filter_mode`); wire the gate into the one `_retrieve_local` call site in `ask` (line 287).
+- **Create:** `tests/test_retrieval_bridge.py` — coupling + no-strand + budget + empty-seeds + gate tests.
+- **Create (Task 3):** `docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md`.
+
+---
+
+### Task 1: `_retrieve_local_bridged`
+
+**Files:**
+- Modify: `goldengraph/answer.py`
+- Test: `tests/test_retrieval_bridge.py`
+
+- [ ] **Step 1: Write failing tests** (create the file)
+
+```python
+# tests/test_retrieval_bridge.py
+"""Surface-bridged retrieval (stage-2-C): the ball unions same-name under-merged siblings as it
+expands, so an answer stranded behind a split bridge-entity becomes reachable. Pure (stub graph)."""
+from __future__ import annotations
+
+from goldengraph.answer import _retrieve_local, _retrieve_local_bridged
+# Reuse the under-merge fixture + stub from the chain-retrieval tests (no tests/__init__.py, so the
+# sibling module is importable on the pytest path -- same pattern as `from conftest import ...`).
+from test_chain_retrieval import _StubGraph, _split_graph
+
+
+def _names(ball):
+    return {e["canonical_name"] for e in ball["entities"]}
+
+
+def test_plain_ball_strands_at_under_merge():
+    # plain retrieval seeded at A cannot reach C: id1 is a sink, id4 (same name 'B') is a different node
+    ball = _retrieve_local(_split_graph(), [0], max_hops=4, node_budget=64)
+    assert "C" not in _names(ball)
+
+
+def test_bridged_ball_crosses_under_merge():
+    # per-hop surface bridging unions B(id1)<->B(id4), so part_of->C enters the ball
+    ball = _retrieve_local_bridged(_split_graph(), [0], max_hops=4, node_budget=64)
+    assert "C" in _names(ball)
+
+
+def _connected_graph():
+    # A -acquired-> B -part_of-> C with a SINGLE 'B' node (no under-merge)
+    ents = [{"entity_id": i, "canonical_name": n} for i, n in [(0, "A"), (1, "B"), (2, "C")]]
+    edges = [{"subj": 0, "predicate": "acquired", "obj": 1},
+             {"subj": 1, "predicate": "part_of", "obj": 2}]
+    return _StubGraph(ents, edges)
+
+
+def test_bridged_reaches_answer_on_connected_graph():
+    # no under-merge to bridge -> bridging is a no-op for siblings, but the iteration still reaches C
+    # (proves bridging doesn't break / loop on the easy case)
+    ball = _retrieve_local_bridged(_connected_graph(), [0], max_hops=4, node_budget=64)
+    assert "C" in _names(ball)
+
+
+def test_node_budget_bounds_expansion():
+    # budget=1 breaks AFTER the first hop, BEFORE the bridge hop -> C never enters
+    ball = _retrieve_local_bridged(_split_graph(), [0], max_hops=4, node_budget=1)
+    assert "C" not in _names(ball)
+
+
+def test_empty_seeds_falls_back():
+    ball = _retrieve_local_bridged(_split_graph(), [], max_hops=4, node_budget=64)
+    assert ball["entities"] == [] and ball["edges"] == []
+```
+
+- [ ] **Step 2: Run, verify FAIL** (`_retrieve_local_bridged` undefined).
+
+- [ ] **Step 3: Implement** — in `goldengraph/answer.py`, immediately after `_retrieve_local`:
+
+```python
+def _retrieve_local_bridged(slice_graph, seeds, *, max_hops: int, node_budget: int) -> dict:
+    """Like `_retrieve_local`, but at each hop bridges the reached frontier across same-NAME
+    under-merged siblings (the proven `trace_chain` mechanism), so an answer stranded behind a split
+    bridge-entity (a sink-copy with no out-edge whose source-copy owns the next hop) enters the ball
+    connected to the seeds. Opt-in via the `GOLDENGRAPH_RETRIEVAL_BRIDGE` gate; `node_budget` bounds the
+    accumulation so a popular-name frontier cannot blow up the ball."""
+    if not seeds:
+        return slice_graph.query(seeds, max_hops)
+    frontier = set(seeds)
+    ents: dict = {}            # dedup by entity_id
+    edges: list = []
+    seen: set = set()          # dedup edges by (subj, predicate, obj)
+    for _hop in range(max(max_hops, 1)):
+        sub = slice_graph.query(list(frontier), 1)
+        id_to_name = {e["entity_id"]: e["canonical_name"] for e in sub.get("entities", ())}
+        for e in sub.get("entities", ()):
+            ents.setdefault(e["entity_id"], e)
+        for ed in sub.get("edges", ()):
+            k = (ed["subj"], ed["predicate"], ed["obj"])
+            if k not in seen:
+                seen.add(k)
+                edges.append(ed)
+        if len(ents) >= node_budget:
+            break
+        # next frontier: the reached ids, BRIDGED across same-name siblings
+        frontier = _bridge_surfaces(slice_graph, set(id_to_name), id_to_name)
+    return {"entities": list(ents.values()), "edges": edges}
+```
+
+- [ ] **Step 4: Run, verify PASS** (5 tests).
+
+```bash
+PYTHONPATH="." GOLDENGRAPH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 "D:/show_case/goldenmatch/.venv/Scripts/python.exe" \
+  -m pytest tests/test_retrieval_bridge.py -q -p no:cacheprovider
+```
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add goldengraph/answer.py tests/test_retrieval_bridge.py
+git commit -m "feat(goldengraph): _retrieve_local_bridged (surface-bridged retrieval ball)"
+```
+
+---
+
+### Task 2: gate it into `ask`
+
+**Files:**
+- Modify: `goldengraph/answer.py`
+- Test: `tests/test_retrieval_bridge.py`
+
+- [ ] **Step 1: Write failing test** (append)
+
+```python
+def test_bridge_gate_env(monkeypatch):
+    from goldengraph.answer import _bridge_enabled
+    monkeypatch.delenv("GOLDENGRAPH_RETRIEVAL_BRIDGE", raising=False)
+    assert _bridge_enabled() is False
+    for on in ("1", "true", "yes"):
+        monkeypatch.setenv("GOLDENGRAPH_RETRIEVAL_BRIDGE", on)
+        assert _bridge_enabled() is True
+    for off in ("0", "false", ""):
+        monkeypatch.setenv("GOLDENGRAPH_RETRIEVAL_BRIDGE", off)
+        assert _bridge_enabled() is False
+```
+
+- [ ] **Step 2: Run, verify FAIL** (`_bridge_enabled` undefined).
+
+- [ ] **Step 3: Implement** — add the gate helper near `_hybrid_filter_mode` in `answer.py`:
+
+```python
+def _bridge_enabled() -> bool:
+    """`GOLDENGRAPH_RETRIEVAL_BRIDGE` gate (default off). On -> the local/hybrid retrieval ball is
+    built with `_retrieve_local_bridged` (same-name under-merge bridging) instead of `_retrieve_local`."""
+    import os
+
+    return os.environ.get("GOLDENGRAPH_RETRIEVAL_BRIDGE", "0") not in ("0", "false", "")
+```
+
+Wire the gate at the single call site (`answer.py` line 287). Replace:
+```python
+    subgraph = _retrieve_local(slice_graph, seeds, max_hops=hops, node_budget=node_budget)
+```
+with:
+```python
+    _retrieve = _retrieve_local_bridged if _bridge_enabled() else _retrieve_local
+    subgraph = _retrieve(slice_graph, seeds, max_hops=hops, node_budget=node_budget)
+```
+
+(Both `mode="local"` and `mode="hybrid"` flow through this one line, so the gate covers both — matching the spec. No other call site changes.)
+
+- [ ] **Step 4: Run, verify PASS** + the chain tests for no-regression:
+
+```bash
+PYTHONPATH="." GOLDENGRAPH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 "D:/show_case/goldenmatch/.venv/Scripts/python.exe" \
+  -m pytest tests/test_retrieval_bridge.py tests/test_chain_retrieval.py -q -p no:cacheprovider
+```
+Expected: all pass (gate default-off → `ask`'s retrieval is the unchanged `_retrieve_local`).
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+"D:/show_case/goldenmatch/.venv/Scripts/python.exe" -m ruff check goldengraph/answer.py tests/test_retrieval_bridge.py
+git commit -am "feat(goldengraph): GOLDENGRAPH_RETRIEVAL_BRIDGE gate in ask (default off)"
+```
+
+---
+
+### Task 3: N=20 MuSiQue validation → ship-or-null report
+
+**Files:**
+- Create: `docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md`
+
+A MEASUREMENT, not code. Detached Modal pattern.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) git push -u origin feat/stage2c-retrieval-connectivity
+```
+
+- [ ] **Step 2: Fire the N=20 run (RETRIEVAL_BRIDGE=1)**
+
+```bash
+P="a99885f0-c5af-4ae1-9dc8-255cc60aa129"
+export MODAL_TOKEN_ID=$(infisical.cmd secrets get MODAL_TOKEN_ID --projectId "$P" --env dev --plain --silent)
+export MODAL_TOKEN_SECRET=$(infisical.cmd secrets get MODAL_TOKEN_SECRET --projectId "$P" --env dev --plain --silent)
+M="D:/show_case/goldenmatch/.venv/Scripts/modal.exe"
+PYTHONIOENCODING=utf-8 "$M" run --detach scripts/distill/modal_bench.py \
+  --engine goldengraph --eval end_to_end --corpus musique --n 20 --spawn \
+  --opts $'GOLDENGRAPH_QA_MODE=auto\nGOLDENGRAPH_RETRIEVAL_BRIDGE=1'
+```
+Result: `results/end_to_end_20_goldengraph-qwen2.5-7b-instruct-musique.md`. Poll with a Monitor. Bridging is retrieval-time + cheap, so this completes well under the cap (unlike cross-doc-link).
+
+**Comparison baseline:** the bridge-OFF N=20 run is the matched control. The cross-doc-link N=20 run is NOT a clean control (different opts). If a clean bridge-OFF N=20 baseline isn't already on the volume, fire one (`--opts GOLDENGRAPH_QA_MODE=auto`, same seed/subset) so the A/B is on the identical N=20 questions.
+
+- [ ] **Step 3: Aggregate** (same-component is the primary signal)
+
+```bash
+grep -iE "support_recall=|musique \| 0" /tmp/s2c.md | head -2
+grep -oE "(EXTRACTION|RETRIEVAL-BROKEN-CHAIN|SYNTHESIS)" /tmp/s2c.md | sort | uniq -c | sort -rn
+# SYNTHESIS same_component split (islands should DROP if bridging connects them)
+awk '/SYNTHESIS \(retrieved/{i=1;next} i&&/same_component=/{if(/=True/)t++;else f++;i=0} END{print "True:",t+0," False:",f+0}' /tmp/s2c.md
+```
+
+- [ ] **Step 4: Write the verdict report** — `docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md`:
+  - Run config (N=20, model, RETRIEVAL_BRIDGE=1, date) + the matched bridge-OFF N=20 baseline.
+  - Before/after: `same_component=False` count (the primary signal), `answer_match`, SYNTHESIS/RETRIEVAL buckets, `support_recall`.
+  - **Verdict per the pre-committed gate:**
+    - *islands drop + answer_match rises* → SUCCESS: ship default-off (opt-in lever); record the win; note a follow-up N=50 confirm (bridging is cheap enough to complete N=50).
+    - *flat* → CONSTRUCTION-CEILING NULL: the disconnection is genuine (not name-based under-merge); real-corpus multi-hop is 7B-construction-bound; cheap levers (voting, linking, bridging) exhausted; the remaining fix is a bigger program (stronger extractor / hybrid-passage). State plainly, no tuning.
+  - Confidence statement scaled to N=20.
+
+- [ ] **Step 5: Commit the report**
+
+```bash
+git add docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md
+git commit -m "docs(stage-2c): surface-bridged retrieval validation verdict"
+```
+
+---
+
+## Done criterion
+
+- Tasks 1-2 merged behind green tests (new file + chain tests, no regression; default path byte-identical).
+- A committed verdict report with the matched bridge-OFF vs bridge-ON N=20 comparison and a ship-or-construction-ceiling verdict per the pre-committed gate.
+- Open a PR; arm auto-merge once CI is green. (Code lands regardless of the verdict — default-off; the report records whether the lever is worth enabling and, if null, closes the cheap-lever line for real-corpus multi-hop.)

--- a/docs/superpowers/plans/2026-06-30-stage2c-surface-bridged-retrieval.md
+++ b/docs/superpowers/plans/2026-06-30-stage2c-surface-bridged-retrieval.md
@@ -102,9 +102,9 @@ def test_empty_seeds_falls_back():
 def _retrieve_local_bridged(slice_graph, seeds, *, max_hops: int, node_budget: int) -> dict:
     """Like `_retrieve_local`, but at each hop bridges the reached frontier across same-NAME
     under-merged siblings (the proven `trace_chain` mechanism), so an answer stranded behind a split
-    bridge-entity (a sink-copy with no out-edge whose source-copy owns the next hop) enters the ball
-    connected to the seeds. Opt-in via the `GOLDENGRAPH_RETRIEVAL_BRIDGE` gate; `node_budget` bounds the
-    accumulation so a popular-name frontier cannot blow up the ball."""
+    bridge-entity (a sink-copy with no out-edge whose source-copy owns the next hop) enters the ball.
+    The ball is a connectivity-SUPERSET (not pruned to the seed-connected component); `node_budget` is
+    the only bound on its growth. Opt-in via the `GOLDENGRAPH_RETRIEVAL_BRIDGE` gate."""
     if not seeds:
         return slice_graph.query(seeds, max_hops)
     frontier = set(seeds)
@@ -238,12 +238,14 @@ Result: `results/end_to_end_20_goldengraph-qwen2.5-7b-instruct-musique.md`. Poll
 
 - [ ] **Step 3: Aggregate** (same-component is the primary signal)
 
+First `volume get --force` the result file to a local path (e.g. `/tmp/s2c.md`), then:
 ```bash
 grep -iE "support_recall=|musique \| 0" /tmp/s2c.md | head -2
 grep -oE "(EXTRACTION|RETRIEVAL-BROKEN-CHAIN|SYNTHESIS)" /tmp/s2c.md | sort | uniq -c | sort -rn
 # SYNTHESIS same_component split (islands should DROP if bridging connects them)
 awk '/SYNTHESIS \(retrieved/{i=1;next} i&&/same_component=/{if(/=True/)t++;else f++;i=0} END{print "True:",t+0," False:",f+0}' /tmp/s2c.md
 ```
+(The Modal result lands as `results/end_to_end_20_...musique.md` on the volume; `volume get` it to `/tmp/s2c.md` first — the grep path and the results path are otherwise different.)
 
 - [ ] **Step 4: Write the verdict report** — `docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md`:
   - Run config (N=20, model, RETRIEVAL_BRIDGE=1, date) + the matched bridge-OFF N=20 baseline.

--- a/docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md
+++ b/docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md
@@ -1,0 +1,64 @@
+# Stage-2-C: Surface-Bridged Retrieval — Validation Verdict (CONSTRUCTION-CEILING NULL)
+
+**Date:** 2026-06-30
+**Spec:** `docs/superpowers/specs/2026-06-30-stage2c-surface-bridged-retrieval-design.md`
+**Plan:** `docs/superpowers/plans/2026-06-30-stage2c-surface-bridged-retrieval.md`
+
+## Run config
+
+- Corpus: MuSiQue-Ans, seeded subset, **N=20** (matched A/B on the identical questions).
+- Engine: goldengraph, open extraction, `qwen2.5:7b-instruct` + `nomic-embed-text`, Modal A10G, fair metric.
+- A: `GOLDENGRAPH_QA_MODE=auto` (bridge OFF = the `local` baseline).
+- B: `+ GOLDENGRAPH_RETRIEVAL_BRIDGE=1` (bridge ON).
+
+## Result (matched N=20 A/B)
+
+| metric | bridge-OFF (local) | bridge-ON |
+|---|---|---|
+| `answer_match` | **0.15** | **0.00** (worse) |
+| `support_recall` | 0.65 | 0.725 |
+| SYNTHESIS `same_component=False` (islands) | 6-of-7 | 6-of-7 (unchanged) |
+
+**Verdict: CONSTRUCTION-CEILING NULL.** Surface-bridging did NOT reconnect the disconnected components
+and it tanked `answer_match` (0.15 → 0.00).
+
+## Why (both failure modes, both pointing the same way)
+
+1. **Islands persist 6-of-7 in BOTH arms.** Bridging unions same-NAME siblings; the components stayed
+   disconnected, so the disconnection is NOT name-based under-merge. On real prose the bridge entity is
+   phrased differently across paragraphs (coref/alias), so `seeds_by_name` cannot unify it. The graph is
+   **genuinely** fragmented.
+2. **answer_match → 0.00.** The bridged ball is a connectivity-SUPERSET — it pulls in same-name siblings'
+   unrelated neighborhoods (on a ~2-4k-entity graph, generic names collide), adding noise that degrades
+   synthesis to zero.
+
+The A/B rules out a bug: bridge-OFF scores a normal **0.15** (the best real-corpus number to date), so
+the bridge-ON 0.0 is genuinely caused by bridging, not a hard subset.
+
+## Disposition
+
+- **The code ships, default-off.** `_retrieve_local_bridged` + the `GOLDENGRAPH_RETRIEVAL_BRIDGE` gate
+  are merged behind the default-off flag (16 tests green; default path byte-identical). It is a clean,
+  tested capability that does not help on this stack. **Do NOT enable.**
+- **Cheap connectivity levers are exhausted.** Across stage-2 we have now measured out THREE in a row:
+  self-consistency (2-B, null), cross-doc-link (2-C diag, ineffective + too expensive), surface-bridge
+  (2-C, null + harmful). All fail for the same reason: **the 7B builds a fragmented graph on real
+  prose, and no cheap post-hoc lever can manufacture a connection the extraction never created.**
+
+## The earned finding
+
+Real-corpus multi-hop QA is bottlenecked by **7B graph-construction quality** (entity consistency across
+paragraphs), not by retrieval or synthesis post-processing. `support_recall ≈ 0.65–0.72` confirms the
+evidence is retrieved; the graph wiring it together is the ceiling. The remaining real fixes are bigger
+programs, not cheap levers:
+- **Hand synthesis the raw passages (hybrid mode)** — sidesteps the fragmented graph by reading the
+  answer from text. (Stage-2-D: unblock hybrid on the local stack via the nomic passage embedder.)
+- **A stronger extractor** (frontier model or fine-tuned distill) — fixes construction at the source
+  (costs API spend / training).
+
+## Lesson
+
+`in_ball=True` is not `reachable`. The localize `same_component` field revealed that a chunk of the
+"SYNTHESIS" bucket was really connectivity failure. When a retrieval lever is proposed, check whether the
+disconnection is *bridgeable* (name-based under-merge) or *genuine* before building — here it was genuine,
+and bridging both failed to help AND added noise. Measured in one matched A/B, recorded, moved on.

--- a/docs/superpowers/specs/2026-06-30-stage2c-surface-bridged-retrieval-design.md
+++ b/docs/superpowers/specs/2026-06-30-stage2c-surface-bridged-retrieval-design.md
@@ -1,0 +1,129 @@
+# Stage-2-C: Surface-Bridged Retrieval — Design
+
+**Status:** Approved (brainstorm), pending implementation plan.
+**Date:** 2026-06-30
+**Context:** goldengraph real-corpus (stage-2) quality. Follows two diagnostics that redirected the
+lever twice:
+1. Stage-2-A verdict named SYNTHESIS the top fixable bucket (18 retrieved-but-wrong).
+2. Stage-2-B self-consistency = HONEST-NULL (7B errors systematic, not variance).
+3. Stage-2-C diagnostic #1: the SYNTHESIS bucket is **contaminated by connectivity failures** —
+   6-of-15 traced cases have `same_component=False` (gold answer in the ball but in a DIFFERENT
+   connected component from the seeds → unreachable, not a reasoning miss).
+4. Stage-2-C diagnostic #2: turning on the cross-doc-link flag (`GOLDENGRAPH_CROSS_DOC_LINK=1`) did
+   NOT fix it (N=20: islands persist 4-of-7, fragmentation ~5.6 ent/component, answer_match 0.10 — no
+   lift) and **did not complete N=50 under the 90-min cap** (O(N) per-doc store matching). Ruled out:
+   ineffective + too expensive.
+
+## Goal
+
+Connect under-merged graph components **at retrieval time** by unioning same-NAME siblings as the ball
+grows, so a multi-hop answer stranded behind a split bridge-entity enters the retrieved subgraph
+connected to the seeds. **Opt-in, measure-first**; default off = today's `_retrieve_local`, byte-for-byte.
+
+## Why this lever (and why it differs from the ruled-out one)
+
+The graph the 7B builds on real prose is fragmented: the same entity mentioned across paragraphs gets
+SEPARATE nodes (under-merge), so the bridge entity that should connect seed→answer is split into a
+sink-copy (no out-edge) and a source-copy (owns the next hop) — different ids, not connected. The
+embedding-based cross-doc-link flag (diagnostic #2) tries to fix this at BUILD time and failed
+(ineffective + too expensive). This lever attacks a DIFFERENT mechanism — **name-based** under-merge at
+RETRIEVAL time, zero build cost — reusing `_bridge_surfaces`, the proven `trace_chain` mechanism
+(measured: 27-of-29 multi-hop walk deaths landed on an under-merge sink-copy).
+
+## Architecture
+
+Two pieces, both in `goldengraph/answer.py`.
+
+### 1. `_retrieve_local_bridged(slice_graph, seeds, *, max_hops, node_budget)` (new)
+
+An iterative-frontier variant of `_retrieve_local`. The current `_retrieve_local` re-expands
+`query(seeds, h)` from the FIXED seed set, so a split bridge-entity strands the walk. The bridged
+variant instead accumulates a ball hop-by-hop and, **at each hop, bridges the reached frontier across
+same-name siblings** via the existing `_bridge_surfaces`:
+
+```
+frontier = seeds
+for hop in range(max_hops):
+    sub = slice_graph.query(list(frontier), 1)
+    accumulate sub's entities + edges into the ball (dedup)
+    if ball entity count >= node_budget: break
+    reached = the entity ids in sub
+    frontier = _bridge_surfaces(slice_graph, reached, id_to_name(sub))  # union same-name siblings
+return {entities, edges}   # the accumulated, connectivity-closed ball
+```
+
+So the source-copy of a split bridge-entity joins the next expansion, its out-edge becomes reachable,
+and the answer enters the ball connected. `node_budget` bounds the accumulation (early-exit), so a
+popular-name frontier cannot blow the ball up.
+
+### 2. Gate in `ask`
+
+`GOLDENGRAPH_RETRIEVAL_BRIDGE` (default off, read at call time). When set, `ask` routes BOTH the local
+and hybrid paths through `_retrieve_local_bridged` instead of `_retrieve_local`. One env check at the
+call site (`answer.py` ~line 287, `subgraph = _retrieve_local(...)`); everything downstream (synthesis,
+seed-name handoff, provenance collection) is unchanged.
+
+## Data flow
+
+```
+ask -> seed_by_query -> (RETRIEVAL_BRIDGE? _retrieve_local_bridged : _retrieve_local) -> synthesis
+```
+
+The bridged ball is a connectivity-superset of the plain ball: it contains the same seed neighborhood
+plus the same-name siblings' neighborhoods that close the under-merge gaps.
+
+## Error handling
+
+- Empty seeds → same fallback as `_retrieve_local` (`slice_graph.query(seeds, max_hops)`).
+- Default-off path is byte-identical to today (the gate selects the unchanged `_retrieve_local`).
+- `_bridge_surfaces` already handles missing names (`id_to_name.get(i)`), so a nameless id just
+  contributes itself.
+
+## Testing
+
+Pure, box-safe (stub graph; no LLM, no native).
+
+- **Coupling proof (the mechanism):** reuse the existing `_split_graph` fixture from
+  `test_chain_retrieval.py` — `A -acquired-> B(id1, sink)`, `B(id4) -part_of-> C`, same name "B",
+  different ids, NOT connected. Two asserts:
+  - the **plain** `_retrieve_local` ball seeded at A does NOT contain `C` (strands at the sink-copy);
+  - the **bridged** `_retrieve_local_bridged` ball seeded at A DOES contain `C` (per-hop bridging unions
+    `B(id1)`↔`B(id4)`, so `part_of→C` enters the ball).
+- **No-strand baseline:** on a CONNECTED graph (no under-merge), bridged and plain balls both contain
+  the answer entity (bridging doesn't break the easy case).
+- **Budget bound:** a graph with a popular name (many same-name siblings) still respects `node_budget`
+  (early-exit fires; the ball does not explode).
+- **Empty seeds:** falls back identically to `_retrieve_local`.
+- **Integration validation** = the N=20 MuSiQue run.
+
+## Scope / YAGNI
+
+- **Default off** — opt-in `GOLDENGRAPH_RETRIEVAL_BRIDGE`; the plain path stays the shipped default,
+  byte-identical.
+- **No extraction / synthesis / cross-doc-link changes** — purely a retrieval-ball variant.
+- **No frontier re-ranking or relation-focusing** (relation-focusing was already measured WORSE — see
+  the `_retrieve_local` docstring). Just bridge + expand + budget.
+
+## Validation gate + honest-null readiness
+
+- **Run:** N=20 MuSiQue, `GOLDENGRAPH_RETRIEVAL_BRIDGE=1` (cheap — retrieval-time, so it completes under
+  the cap, unlike cross-doc-link).
+- **Falsifiable, two outcomes:**
+  - **`same_component=False` islands drop AND answer_match rises** → SUCCESS: the disconnection was
+    name-based under-merge; bridging fixes it. Ship as the opt-in lever, record the win.
+  - **Flat** → the disconnection is GENUINE (not name-based under-merge), and the **construction-ceiling
+    finding is earned**: real-corpus multi-hop is bottlenecked by 7B graph-construction quality, and the
+    cheap post-hoc levers (voting, linking, bridging) are exhausted. Record it plainly; the remaining fix
+    is a bigger program (stronger extractor / hybrid-passage). **No tuning to force a number.**
+
+This is the last cheap connectivity lever; the gate makes either outcome a clean result.
+
+## Files
+
+- Modify: `packages/python/goldengraph/goldengraph/answer.py` (`_retrieve_local_bridged` + the
+  `RETRIEVAL_BRIDGE` gate at the `_retrieve_local` call site in `ask`).
+- Create: `packages/python/goldengraph/tests/test_retrieval_bridge.py` (coupling + baseline + budget +
+  empty-seeds tests).
+- Validation: existing `scripts/distill/modal_bench.py --corpus musique` (env opt; no bench change).
+- Report: `docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md` (win or
+  construction-ceiling null).

--- a/docs/superpowers/specs/2026-06-30-stage2c-surface-bridged-retrieval-design.md
+++ b/docs/superpowers/specs/2026-06-30-stage2c-surface-bridged-retrieval-design.md
@@ -43,14 +43,23 @@ same-name siblings** via the existing `_bridge_surfaces`:
 
 ```
 frontier = seeds
+ents: dict[entity_id -> entity]   # dedup by entity_id
+edges: list ; seen: set            # dedup edges by the (subj, predicate, obj) tuple
 for hop in range(max_hops):
     sub = slice_graph.query(list(frontier), 1)
-    accumulate sub's entities + edges into the ball (dedup)
-    if ball entity count >= node_budget: break
-    reached = the entity ids in sub
-    frontier = _bridge_surfaces(slice_graph, reached, id_to_name(sub))  # union same-name siblings
-return {entities, edges}   # the accumulated, connectivity-closed ball
+    id_to_name = {e["entity_id"]: e["canonical_name"] for e in sub["entities"]}
+    for e in sub["entities"]: ents.setdefault(e["entity_id"], e)
+    for ed in sub["edges"]:
+        k = (ed["subj"], ed["predicate"], ed["obj"])
+        if k not in seen: seen.add(k); edges.append(ed)
+    if len(ents) >= node_budget: break
+    reached = set(id_to_name)                                   # the entity ids in sub
+    frontier = _bridge_surfaces(slice_graph, reached, id_to_name)  # union same-name siblings
+return {"entities": list(ents.values()), "edges": edges}        # accumulated, connectivity-closed ball
 ```
+
+Edge dedup uses the `(subj, predicate, obj)` tuple (edges are plain dicts with no natural id);
+entity dedup uses `entity_id`.
 
 So the source-copy of a split bridge-entity joins the next expansion, its out-edge becomes reachable,
 and the answer enters the ball connected. `node_budget` bounds the accumulation (early-exit), so a
@@ -89,6 +98,10 @@ Pure, box-safe (stub graph; no LLM, no native).
   - the **plain** `_retrieve_local` ball seeded at A does NOT contain `C` (strands at the sink-copy);
   - the **bridged** `_retrieve_local_bridged` ball seeded at A DOES contain `C` (per-hop bridging unions
     `B(id1)`↔`B(id4)`, so `part_of→C` enters the ball).
+  - **Plan note:** assert-1 (plain ball lacks C) holds *because the test stub's `query` ignores `hops`
+    and re-expands the fixed seed* — that is exactly what makes the sink-copy strand reproduce in the
+    fixture. Do NOT "fix" the stub to honor `hops`; the fixture proves the BRIDGING mechanism, not the
+    depth-growth of the real `query`.
 - **No-strand baseline:** on a CONNECTED graph (no under-merge), bridged and plain balls both contain
   the answer entity (bridging doesn't break the easy case).
 - **Budget bound:** a graph with a popular name (many same-name siblings) still respects `node_budget`

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -177,6 +177,14 @@ def _hybrid_filter_mode() -> str:
     return os.environ.get("GOLDENGRAPH_HYBRID_FILTER", "").strip().lower()
 
 
+def _bridge_enabled() -> bool:
+    """`GOLDENGRAPH_RETRIEVAL_BRIDGE` gate (default off). On -> the local/hybrid retrieval ball is
+    built with `_retrieve_local_bridged` (same-name under-merge bridging) instead of `_retrieve_local`."""
+    import os
+
+    return os.environ.get("GOLDENGRAPH_RETRIEVAL_BRIDGE", "0") not in ("0", "false", "")
+
+
 def _retrieve_local(slice_graph, seeds, *, max_hops: int, node_budget: int) -> dict:
     """Expand the seed neighborhood depth-by-depth up to ``max_hops``, stopping early
     once the subgraph reaches ``node_budget`` entities.
@@ -313,7 +321,8 @@ def ask(
     if mode not in ("local", "hybrid"):
         raise ValueError(f"mode must be 'local', 'hybrid', or 'global', got {mode!r}")
     seeds = seed_by_query(slice_graph, query, embedder, k=k)
-    subgraph = _retrieve_local(slice_graph, seeds, max_hops=hops, node_budget=node_budget)
+    _retrieve = _retrieve_local_bridged if _bridge_enabled() else _retrieve_local
+    subgraph = _retrieve(slice_graph, seeds, max_hops=hops, node_budget=node_budget)
     # Hand the synthesis the seed entity NAMES (the query-relevant anchors) so the
     # multi-hop walk starts at the right place instead of guessing among the ball.
     id_to_name = {

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -202,6 +202,35 @@ def _retrieve_local(slice_graph, seeds, *, max_hops: int, node_budget: int) -> d
     return sub
 
 
+def _retrieve_local_bridged(slice_graph, seeds, *, max_hops: int, node_budget: int) -> dict:
+    """Like `_retrieve_local`, but at each hop bridges the reached frontier across same-NAME
+    under-merged siblings (the proven `trace_chain` mechanism), so an answer stranded behind a split
+    bridge-entity (a sink-copy with no out-edge whose source-copy owns the next hop) enters the ball.
+    The ball is a connectivity-SUPERSET (not pruned to the seed-connected component); `node_budget` is
+    the only bound on its growth. Opt-in via the `GOLDENGRAPH_RETRIEVAL_BRIDGE` gate."""
+    if not seeds:
+        return slice_graph.query(seeds, max_hops)
+    frontier = set(seeds)
+    ents: dict = {}            # dedup by entity_id
+    edges: list = []
+    seen: set = set()          # dedup edges by (subj, predicate, obj)
+    for _hop in range(max(max_hops, 1)):
+        sub = slice_graph.query(list(frontier), 1)
+        id_to_name = {e["entity_id"]: e["canonical_name"] for e in sub.get("entities", ())}
+        for e in sub.get("entities", ()):
+            ents.setdefault(e["entity_id"], e)
+        for ed in sub.get("edges", ()):
+            k = (ed["subj"], ed["predicate"], ed["obj"])
+            if k not in seen:
+                seen.add(k)
+                edges.append(ed)
+        if len(ents) >= node_budget:
+            break
+        # next frontier: the reached ids, BRIDGED across same-name siblings
+        frontier = _bridge_surfaces(slice_graph, set(id_to_name), id_to_name)
+    return {"entities": list(ents.values()), "edges": edges}
+
+
 def ask(
     query: str,
     store,

--- a/packages/python/goldengraph/tests/test_retrieval_bridge.py
+++ b/packages/python/goldengraph/tests/test_retrieval_bridge.py
@@ -1,0 +1,50 @@
+"""Surface-bridged retrieval (stage-2-C): the ball unions same-name under-merged siblings as it
+expands, so an answer stranded behind a split bridge-entity becomes reachable. Pure (stub graph)."""
+from __future__ import annotations
+
+# Reuse the under-merge fixture + stub from the chain-retrieval tests (no tests/__init__.py, so the
+# sibling module is importable on the pytest path -- same pattern as `from conftest import ...`).
+from goldengraph.answer import _retrieve_local, _retrieve_local_bridged
+from test_chain_retrieval import _split_graph, _StubGraph
+
+
+def _names(ball):
+    return {e["canonical_name"] for e in ball["entities"]}
+
+
+def test_plain_ball_strands_at_under_merge():
+    # plain retrieval seeded at A cannot reach C: id1 is a sink, id4 (same name 'B') is a different node
+    ball = _retrieve_local(_split_graph(), [0], max_hops=4, node_budget=64)
+    assert "C" not in _names(ball)
+
+
+def test_bridged_ball_crosses_under_merge():
+    # per-hop surface bridging unions B(id1)<->B(id4), so part_of->C enters the ball
+    ball = _retrieve_local_bridged(_split_graph(), [0], max_hops=4, node_budget=64)
+    assert "C" in _names(ball)
+
+
+def _connected_graph():
+    # A -acquired-> B -part_of-> C with a SINGLE 'B' node (no under-merge)
+    ents = [{"entity_id": i, "canonical_name": n} for i, n in [(0, "A"), (1, "B"), (2, "C")]]
+    edges = [{"subj": 0, "predicate": "acquired", "obj": 1},
+             {"subj": 1, "predicate": "part_of", "obj": 2}]
+    return _StubGraph(ents, edges)
+
+
+def test_bridged_reaches_answer_on_connected_graph():
+    # no under-merge to bridge -> bridging is a no-op for siblings, but the iteration still reaches C
+    # (proves bridging doesn't break / loop on the easy case)
+    ball = _retrieve_local_bridged(_connected_graph(), [0], max_hops=4, node_budget=64)
+    assert "C" in _names(ball)
+
+
+def test_node_budget_bounds_expansion():
+    # budget=1 breaks AFTER the first hop, BEFORE the bridge hop -> C never enters
+    ball = _retrieve_local_bridged(_split_graph(), [0], max_hops=4, node_budget=1)
+    assert "C" not in _names(ball)
+
+
+def test_empty_seeds_falls_back():
+    ball = _retrieve_local_bridged(_split_graph(), [], max_hops=4, node_budget=64)
+    assert ball["entities"] == [] and ball["edges"] == []

--- a/packages/python/goldengraph/tests/test_retrieval_bridge.py
+++ b/packages/python/goldengraph/tests/test_retrieval_bridge.py
@@ -48,3 +48,15 @@ def test_node_budget_bounds_expansion():
 def test_empty_seeds_falls_back():
     ball = _retrieve_local_bridged(_split_graph(), [], max_hops=4, node_budget=64)
     assert ball["entities"] == [] and ball["edges"] == []
+
+
+def test_bridge_gate_env(monkeypatch):
+    from goldengraph.answer import _bridge_enabled
+    monkeypatch.delenv("GOLDENGRAPH_RETRIEVAL_BRIDGE", raising=False)
+    assert _bridge_enabled() is False
+    for on in ("1", "true", "yes"):
+        monkeypatch.setenv("GOLDENGRAPH_RETRIEVAL_BRIDGE", on)
+        assert _bridge_enabled() is True
+    for off in ("0", "false", ""):
+        monkeypatch.setenv("GOLDENGRAPH_RETRIEVAL_BRIDGE", off)
+        assert _bridge_enabled() is False


### PR DESCRIPTION
## What

Opt-in (default-off) `_retrieve_local_bridged` + `GOLDENGRAPH_RETRIEVAL_BRIDGE` gate: an iterative-frontier
retrieval ball that bridges same-name under-merged siblings per hop (reuses `trace_chain`'s `_bridge_surfaces`).
16 tests green; default path byte-identical.

## Verdict: CONSTRUCTION-CEILING NULL (code ships default-off anyway)

Matched N=20 A/B: bridge-OFF (local) **0.15** vs bridge-ON **0.00** — bridging hurt; SYNTHESIS islands
**6/7 unchanged in both arms**. The disconnection is *genuine* (not name-based under-merge — bridging
can't unify a bridge entity phrased differently across paragraphs), and the connectivity-superset ball
adds noise. This is the THIRD cheap-connectivity null (self-consistency, cross-doc-link, surface-bridge):
real-corpus multi-hop is bottlenecked by 7B graph-construction quality. Do NOT enable. Next: hybrid
passages (stage-2-D) / stronger extractor. Full report:
`docs/superpowers/reports/2026-06-30-stage2c-surface-bridged-retrieval.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)