### PR TITLE
Substrate eval v1.1: P/R decomposition — the floor is recall

### DIFF
--- a/docs/superpowers/reports/2026-06-30-substrate-quality-eval.md
+++ b/docs/superpowers/reports/2026-06-30-substrate-quality-eval.md
@@ -33,6 +33,20 @@ The plan set two validation clauses. The discriminating one holds; the other was
 
 **Resolution is not the bottleneck.** Level A stays high across the whole sweep (0.97 → 0.90 → 0.87) — the resolver degrades gracefully with surface variance. The substrate defect lives in **extraction**, which is where the architecture work must land.
 
+## Precision/recall decomposition (v1.1)
+
+The floor is **entirely recall.** Surfacing `P(B)`/`R(B)` on the same corpus:
+
+| ambiguity | ER-F1(B) | P(B) | R(B) | components |
+|---|---|---|---|---|
+| 0.0 | 0.3629 | 0.9333 | 0.2252 | 28 |
+| 0.3 | 0.2020 | 0.9785 | 0.1126 | 64 |
+| 0.6 | 0.1375 | 0.9231 | 0.0743 | 78 |
+
+Precision holds at **0.92–0.98** across the whole sweep while recall collapses **0.23 → 0.11 → 0.07.** When the 7B connects two mentions into a node it is almost always right; the damage is connections it never makes — dropped edges and mentions left as orphan singletons. This is **missed-edges, not over-merge**, and it settles the architecture direction: **recall recovery via cross-document entity resolution** (fold the disconnected mentions back into their entities), not splitting. The high precision is headroom — we can merge far more aggressively before precision is at risk.
+
+(Numbers from a second build; ambiguity=0 drifts trivially from the F1-only run above — F1 0.363 vs 0.371, 28 vs 27 components — LLM nondeterminism, within noise.)
+
 ## What it means for the roadmap
 
 This is the instrument the reframed north star needed. The QA arc's "the graph shatters on real prose" symptom is now a **standing, optimizable metric** with an attribution axis:
@@ -44,13 +58,13 @@ The architecture fix — proper cross-document entity resolution using goldenmat
 
 ## Caveats / v1 scope
 
-- **No precision/recall decomposition in the scoreboard yet.** The `[substrate]` line and table report F1 only; `run_one` computes `er_p_b`/`er_r_b` but they aren't surfaced. At ambiguity=0 the low B is most likely recall-driven (docs whose edge never extracted → orphan gold mentions → singleton fresh-ids), but that needs the P/R split to state. **v1.1: emit P/R columns** and attribute the floor.
+- **Precision/recall decomposition — done (v1.1, above).** The floor is recall (P(B) 0.92–0.98, R(B) 0.23→0.07). Confirmed the prior hypothesis: dropped edges → orphan gold mentions, not over-merge.
 - **Within-doc over-merge is under-counted.** Alignment keys on the doc's `(subj, obj)`; two gold entities merged inside a single doc can't be distinguished. This does not affect the cross-doc, ambiguity-driven fragmentation that dominates here (documented in the spec).
 - **provenance = 1.000 across the board** is expected with a single build engine (every edge that lands carries its `source_refs`); it becomes discriminating only in the multi-engine v2 bake-off.
 - Single seed, N=20 questions' worth of corpus (~139 edge-docs / 278 gold mentions). The monotone gap is robust to that, but the absolute floor should be re-confirmed on a second seed before it drives a specific architecture target.
 
 ## Next
 
-1. **v1.1** — P/R columns + floor attribution (recall-vs-precision) on this same corpus.
-2. **Architecture** — cross-doc entity resolution via the goldenmatch engine; re-run this eval as the pass/fail gate.
+1. **v1.1 — done.** P/R columns landed; the floor is recall (see decomposition above).
+2. **Architecture** — cross-doc entity resolution via the goldenmatch engine to recover the missed edges; re-run this eval as the pass/fail gate. Target: lift R(B) at ambiguity=0 without dropping P(B) below ~0.9.
 3. **v2 bake-off** — reframe the multi-engine comparison around substrate quality (this A/B + coherence + temporal as-of correctness), not factoid QA. `provenance` and cross-engine A−B become the discriminators.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_eval.py
@@ -71,12 +71,12 @@ def run_one(seed: int, ambiguity: float) -> dict:
 def _to_markdown(rows: list[tuple[float, dict]]) -> str:
     head = (
         "# Substrate-Quality Scoreboard\n\n"
-        "| ambiguity | ER-F1(A) | ER-F1(B) | A-B gap | components | largest-frac | provenance |\n"
-        "|---|---|---|---|---|---|---|\n"
+        "| ambiguity | ER-F1(A) | ER-F1(B) | P(B) | R(B) | A-B gap | components | largest-frac | provenance |\n"
+        "|---|---|---|---|---|---|---|---|---|\n"
     )
     body = "".join(
-        f"| {amb} | {sb['er_f1_a']:.4f} | {sb['er_f1_b']:.4f} | {sb['ab_gap']:.4f} | "
-        f"{sb['components']} | {sb['largest_fraction']:.4f} | {sb['provenance']:.4f} |\n"
+        f"| {amb} | {sb['er_f1_a']:.4f} | {sb['er_f1_b']:.4f} | {sb['er_p_b']:.4f} | {sb['er_r_b']:.4f} | "
+        f"{sb['ab_gap']:.4f} | {sb['components']} | {sb['largest_fraction']:.4f} | {sb['provenance']:.4f} |\n"
         for amb, sb in rows
     )
     note = (
@@ -100,7 +100,8 @@ def main() -> None:
         rows.append((amb, sb))
         print(
             f"[substrate] ambiguity={amb}: ER-F1(A)={sb['er_f1_a']:.4f} ER-F1(B)={sb['er_f1_b']:.4f} "
-            f"gap={sb['ab_gap']:.4f} components={sb['components']} provenance={sb['provenance']:.3f}",
+            f"P(B)={sb['er_p_b']:.4f} R(B)={sb['er_r_b']:.4f} gap={sb['ab_gap']:.4f} "
+            f"components={sb['components']} provenance={sb['provenance']:.3f}",
             flush=True,
         )
     md = _to_markdown(rows)

--- a/scripts/distill/modal_bench.py
+++ b/scripts/distill/modal_bench.py
@@ -261,10 +261,11 @@ def main(eval: str = "extraction_f1", n: int = 20, ambiguity: float = 0.6, opts:
             merged, eval=eval, n=n, ambiguity=ambiguity, opts=opts, embed=embed))
         return
     fn = run_bench_big if gpu.lower() in ("a100", "a100-80gb", "big") else run_bench
-    # head-to-head: end_to_end tags results by engine (`{eng}-{chat}`), so concurrent engine runs on
-    # the same local model don't collide. Non-default corpora get a `-{corpus}` suffix (matches _persist).
+    # head-to-head: end_to_end + substrate tag results by engine (`{eng}-{chat}`), so concurrent engine
+    # runs on the same local model don't collide. Non-default corpora get a `-{corpus}` suffix. This MUST
+    # mirror the tag `_persist` actually writes, or the printed SPAWNED path points at the wrong file.
     csuf = "" if corpus == "engineered" else f"-{corpus}"
-    tag = (f"{engine}-{chat}{csuf}" if eval == "end_to_end" else chat).replace(":", "-").replace("/", "-")
+    tag = (f"{engine}-{chat}{csuf}" if eval in ("end_to_end", "substrate") else chat).replace(":", "-").replace("/", "-")
     if spawn:
         # fire-and-forget: queue the call SERVER-SIDE and return instantly, so a local-CLI kill can't
         # cancel it. Result lands at results/<eval>_<n>_<model>.md. Pair with `modal run --detach`.


### PR DESCRIPTION
## Summary

Follow-up to #1328. Surfaces **P(B)/R(B)** in the substrate scoreboard and settles the open question from the verdict: at ambiguity=0, is the 0.60 F1 floor recall (missed edges) or precision (over-merge)?

**It's entirely recall.**

| ambiguity | ER-F1(B) | P(B) | R(B) | components |
|---|---|---|---|---|
| 0.0 | 0.3629 | 0.9333 | 0.2252 | 28 |
| 0.3 | 0.2020 | 0.9785 | 0.1126 | 64 |
| 0.6 | 0.1375 | 0.9231 | 0.0743 | 78 |

Precision holds at 0.92–0.98 across the whole sweep while recall collapses 0.23 → 0.11 → 0.07. When the 7B connects two mentions into a node it's almost always right; the damage is connections it never makes — dropped edges, orphan gold mentions. This is **missed-edges, not over-merge**, and it sets the architecture direction: **recall recovery via cross-document entity resolution** (fold the disconnected mentions back into their entities), not splitting. The high precision is headroom — merge more aggressively with little precision risk.

## Also

Fixes the `SPAWNED` path print in `modal_bench` `main()`: the substrate lane persists under the `{engine}-{chat}` tag but `main()` predicted just `{chat}`, so the printed path pointed at the wrong file (`substrate_20_qwen2.5-7b-instruct.md` vs the real `substrate_20_goldengraph-qwen2.5-7b-instruct.md`). Real papercut — it sent a monitor watching a filename that never appears.

## Test Plan
- [x] 10 box-safe pure tests green (`tests/test_substrate_eval.py`)
- [x] ruff clean
- [x] Modal re-run produced the P/R scoreboard (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)