### PR TITLE
Type-agnostic cross-doc merge key: substrate recall 0.23 -> 0.75 at zero precision cost

### DIFF
--- a/docs/superpowers/reports/2026-07-01-substrate-recall-type-jitter.md
+++ b/docs/superpowers/reports/2026-07-01-substrate-recall-type-jitter.md
@@ -1,0 +1,68 @@
+# Substrate Recall: The Floor Was Type Jitter, Not Resolution
+
+**Date:** 2026-07-01
+**Branch:** `feat/xdoc-type-jitter-fix`
+**Follows:** `2026-06-30-substrate-quality-eval.md` (the instrument + the R(B) floor)
+**Harness:** Modal `gg-bench` (A10G, `qwen2.5-7b-instruct`), engineered corpus, `erkgbench.run_substrate_eval`.
+
+## The question
+
+The substrate eval put the recall floor at **R(B)=0.23** (ambiguity=0): the same gold entity's mentions across documents rarely land in the same built node. The obvious fix was cross-document entity resolution. This report is the measure-first arc that **refuted that direction** and found the real cause: a one-line key-construction bug.
+
+## The arc — four refutations to one root cause
+
+Every step is a measured Modal run on the substrate eval; each killed a candidate lever.
+
+| # | Experiment | Result | Verdict |
+|---|---|---|---|
+| 1 | `GOLDENGRAPH_PROFILE_LINK=1` (best cross-doc matcher, fully active — `link calls=139`, fingerprints synthesized) | R(B) 0.23 → 0.23 | **cross-doc ER refuted** |
+| 2 | `edge_recall` metric | **0.93** | **extraction drop refuted** — the edges are there |
+| 3 | `GOLDENGRAPH_SUBSTRATE_RESOLVER=exact` (no fuzzy over-merge) | R(B) flat, edge_recall 0.93→0.96 | **within-doc over-merge refuted** (real but marginal) |
+| 4 | `fragmentation_report` | `type_jitter=0.976`, `name_jitter=0.293`, `identical=0.000` | **root cause: type jitter in the merge key** |
+
+**The root cause.** The durable store unifies entities across documents when their `record_key = record_fingerprint(name, typ)` overlaps. An open-vocab 7B assigns a **different `typ` to the same entity in each document**, so the keys never match and the store never merges:
+
+- `schema matching` → 7 nodes typed `Process` / `Algorithm` / `Algorithm or Technique` / `Data Processing Technique` / `method` / `process`
+- `cluster analysis` → `Algorithm` / `Data Analysis Method` / `Data Analysis Technique` / `Method` / `Process` / `Statistical Method`
+
+Each gold entity shattered into **3.49 nodes** on average (max 7); 41/45 entities fragmented. `identical=0.000` confirms the store itself is correct — every non-merge is explained by name/type variation, not a merge bug.
+
+## The fix
+
+Stop keying cross-document merge on the extractor's per-document type. `resolve._key_payload` gains a gated `GOLDENGRAPH_XDOC_KEY`:
+
+- `name` — key on name only (type-agnostic)
+- `name_ci` — key on the case-folded name (also absorbs case-only name jitter)
+- unset (default) — today's `(name, typ)` behavior, unchanged
+
+This is the entity analog of the predicate `SCHEMA_CANON` that won the QA arc: a deterministic, free, source-side constraint. **Default-off**, gated.
+
+## Validation — full ambiguity sweep (`GOLDENGRAPH_XDOC_KEY=name_ci`)
+
+| ambiguity | R(B) base → name_ci | ER-F1(B) base → name_ci | P(B) name_ci | A−B gap base → name_ci | components base → name_ci |
+|---|---|---|---|---|---|
+| 0.0 | 0.2314 → **0.7475** (3.2×) | 0.371 → **0.832** | 0.9379 | 0.60 → **0.14** | 27 → **1** |
+| 0.3 | 0.1126 → **0.4282** (3.8×) | 0.202 → **0.589** | 0.9454 | 0.70 → **0.31** | 64 → **7** |
+| 0.6 | 0.0743 → **0.3502** (4.7×) | 0.138 → **0.503** | 0.8899 | 0.73 → **0.37** | 78 → **4** |
+
+Recall multiplies at every level. **Precision holds** (0.89–0.95 — no observed cost on this corpus). At ambiguity=0 the graph collapses from 27 fragments into **one connected component** — an actually-coherent knowledge base — and `mean_nodes_per_entity` drops 3.49 → 1.33.
+
+## The two-layer architecture (empirically grounded)
+
+The residual A−B gap **grows with ambiguity** (0.14 → 0.31 → 0.37):
+
+1. **`name_ci` kills the type-jitter floor** — the dominant term, and the *whole* story at ambiguity=0.
+2. **The growing residual at higher ambiguity is genuine surface variance** (the corpus's variant surfaces). This is the one place real cross-doc fuzzy/embedding linking can finally earn its keep — now that `name_ci` cleared the type-jitter noise that was drowning it. The profile-link null (step 1) was measured on the *raw* build; **re-measuring profile-link layered on `name_ci` is the natural follow-on**, not a v1 requirement.
+
+The remaining ambiguity=0 residual (9/45 entities, `name_jitter=1.0`) is pure name-level extraction noise: predicate-bleed into names (`authored string metric`) and garbage predicate-as-entity nodes (`acquired`/`Verb`). A separate extraction-cleanup follow-on.
+
+## Decision & scope
+
+- **v1: ship `name_ci` gated, default-off** (`GOLDENGRAPH_XDOC_KEY`). Proven, zero measured precision cost. Measure across corpora before any default flip.
+- **Type-canonicalization variant** (coarse closed type vocab, keyed `(name_ci, coarse_type)`) is the homograph-safe follow-on before flipping a default — `name_ci` drops type entirely, which risks merging homographs (`Apple` company vs fruit) on general corpora this concept-corpus doesn't exercise.
+- **Eval hardening:** `edge_recall` + `fragmentation_report` are now permanent substrate-eval instruments (they found this; they gate future work).
+- **Gate target:** R(B)@ambiguity=0 ≥ 0.75, P(B) ≥ 0.90.
+
+## Lesson
+
+Task structure / deterministic constraint beats clever methods — a third time (after predicate `SCHEMA_CANON` and the refuted open-vocab clustering). We came one approval away from building a global two-phase resolution engine to fix what turned out to be a 15-line key-construction bug. The measure-first arc — refute, don't assume — is what caught it.

--- a/packages/python/goldengraph/goldengraph/resolve.py
+++ b/packages/python/goldengraph/goldengraph/resolve.py
@@ -27,12 +27,29 @@ class ResolvedEntity:
     member_idx: list[int]  # indices into the extraction's mentions list
 
 
+def _key_payload(name: str, typ: str) -> dict:
+    """The dict fed to `record_fingerprint` for cross-document reconciliation. Default is (name, typ) --
+    but an open-vocab extractor assigns a DIFFERENT `typ` to one entity per document (measured: 97.6% of
+    cross-doc fragmentation is type jitter -- 'schema matching' typed Process/Algorithm/method/... across
+    docs), so its record_keys never overlap and the store never unifies it. `GOLDENGRAPH_XDOC_KEY` relaxes
+    the key: `name` = name only (type-agnostic); `name_ci` = name, case-folded (also absorbs the ~case-only
+    name jitter). Pure + goldenmatch-free so the normalization is unit-tested without the fingerprint."""
+    import os
+
+    mode = os.environ.get("GOLDENGRAPH_XDOC_KEY", "").strip().lower()
+    if mode == "name":
+        return {"name": name}
+    if mode == "name_ci":
+        return {"name": name.strip().lower()}
+    return {"name": name, "typ": typ}
+
+
 def _record_key(name: str, typ: str) -> str:
     import goldenmatch as gm
 
-    # dict arg, fixed keys — the fingerprint must be constructed identically on
-    # every call or cross-document reconciliation drifts.
-    return gm.record_fingerprint({"name": name, "typ": typ})
+    # The fingerprint must be constructed identically on every call or cross-document reconciliation
+    # drifts; `_key_payload` is the single chokepoint (all call sites route through it).
+    return gm.record_fingerprint(_key_payload(name, typ))
 
 
 def _build_entities(mentions: list[Mention], groups_idx: list[list[int]]) -> list[ResolvedEntity]:

--- a/packages/python/goldengraph/tests/test_xdoc_key.py
+++ b/packages/python/goldengraph/tests/test_xdoc_key.py
@@ -1,0 +1,31 @@
+"""GOLDENGRAPH_XDOC_KEY relaxes the cross-doc record_key payload to defeat extractor type/case jitter.
+
+Pure test of the normalization (`_key_payload`) -- no goldenmatch / fingerprint needed."""
+from goldengraph.resolve import _key_payload
+
+
+def test_default_key_uses_name_and_type(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_XDOC_KEY", raising=False)
+    assert _key_payload("Schema Matching", "Process") == {"name": "Schema Matching", "typ": "Process"}
+
+
+def test_name_mode_drops_type(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_XDOC_KEY", "name")
+    # same name, DIFFERENT type -> identical payload (so the store unifies them cross-doc)
+    assert (
+        _key_payload("schema matching", "Process")
+        == _key_payload("schema matching", "Algorithm")
+        == {"name": "schema matching"}
+    )
+    # case still matters in bare name mode
+    assert _key_payload("Schema matching", "X") != _key_payload("schema matching", "X")
+
+
+def test_name_ci_mode_folds_case_and_drops_type(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_XDOC_KEY", "name_ci")
+    # the token_sort/schema-matching real jitter: differing case AND type -> one key
+    assert (
+        _key_payload("Schema Matching", "Process")
+        == _key_payload("schema matching", "Algorithm")
+        == {"name": "schema matching"}
+    )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_eval.py
@@ -45,9 +45,16 @@ def _build_graph(corpus) -> dict:
     store = ggn.PyStore()
     llm = OpenAIClient(model=os.environ.get("OPENAI_MODEL") or "gpt-4o-mini")
     embedder = GoldenmatchEmbedder(provider="openai", model=os.environ.get("OPENAI_EMBED_MODEL") or None)
+    # Diagnostic lever: GOLDENGRAPH_SUBSTRATE_RESOLVER=exact swaps the fuzzy dedupe for exact (name,typ)
+    # resolution -> zero within-doc over-merge. If edge_recall/R(B) jump under exact, fuzzy over-merge was
+    # collapsing src+dst into dropped self-loops; if flat, the loss is pure extraction drop. Default fuzzy.
+    resolver = None
+    if os.environ.get("GOLDENGRAPH_SUBSTRATE_RESOLVER", "").strip().lower() == "exact":
+        from goldengraph.resolve import _exact_resolve
+        resolver = _exact_resolve
     ingest_corpus(
         [d.text for d in corpus.documents], store, llm=llm, embedder=embedder,
-        doc_ids=[d.id for d in corpus.documents],
+        doc_ids=[d.id for d in corpus.documents], resolver=resolver,
     )
     slice_graph = store.as_of(_AS_OF, _AS_OF)
     all_ids = [e["entity_id"] for e in slice_graph.entities()]
@@ -63,6 +70,17 @@ def run_one(seed: int, ambiguity: float) -> dict:
     gold = emit_gold_mentions(corpus.documents)
     resolver_clusters = _resolver_clusters(gold)
     graph = _build_graph(corpus)
+    if os.environ.get("GOLDENGRAPH_SUBSTRATE_FRAG", "") not in ("", "0", "false"):
+        fr = substrate_eval.fragmentation_report(graph, gold)
+        print(
+            f"[frag] ambiguity={ambiguity}: mean_nodes/entity={fr['mean_nodes_per_entity']:.3f} "
+            f"max={fr['max_nodes_per_entity']} fragmented={fr['fragmented_entities']}/{fr['total_entities']} "
+            f"name_jitter={fr['name_jitter_frac']:.3f} type_jitter={fr['type_jitter_frac']:.3f} "
+            f"identical={fr['identical_frac']:.3f}",
+            flush=True,
+        )
+        for eid, k, nts in fr["worst"]:
+            print(f"[frag]   {eid}: {k} nodes -> {nts}", flush=True)
     return substrate_eval.score_substrate(
         gold_mentions=gold, resolver_clusters=resolver_clusters, graph=graph
     )
@@ -71,12 +89,13 @@ def run_one(seed: int, ambiguity: float) -> dict:
 def _to_markdown(rows: list[tuple[float, dict]]) -> str:
     head = (
         "# Substrate-Quality Scoreboard\n\n"
-        "| ambiguity | ER-F1(A) | ER-F1(B) | P(B) | R(B) | A-B gap | components | largest-frac | provenance |\n"
-        "|---|---|---|---|---|---|---|---|---|\n"
+        "| ambiguity | ER-F1(A) | ER-F1(B) | P(B) | R(B) | edge-recall | A-B gap | components | largest-frac | provenance |\n"
+        "|---|---|---|---|---|---|---|---|---|---|\n"
     )
     body = "".join(
         f"| {amb} | {sb['er_f1_a']:.4f} | {sb['er_f1_b']:.4f} | {sb['er_p_b']:.4f} | {sb['er_r_b']:.4f} | "
-        f"{sb['ab_gap']:.4f} | {sb['components']} | {sb['largest_fraction']:.4f} | {sb['provenance']:.4f} |\n"
+        f"{sb['edge_recall']:.4f} | {sb['ab_gap']:.4f} | {sb['components']} | {sb['largest_fraction']:.4f} | "
+        f"{sb['provenance']:.4f} |\n"
         for amb, sb in rows
     )
     note = (
@@ -100,8 +119,8 @@ def main() -> None:
         rows.append((amb, sb))
         print(
             f"[substrate] ambiguity={amb}: ER-F1(A)={sb['er_f1_a']:.4f} ER-F1(B)={sb['er_f1_b']:.4f} "
-            f"P(B)={sb['er_p_b']:.4f} R(B)={sb['er_r_b']:.4f} gap={sb['ab_gap']:.4f} "
-            f"components={sb['components']} provenance={sb['provenance']:.3f}",
+            f"P(B)={sb['er_p_b']:.4f} R(B)={sb['er_r_b']:.4f} edge_recall={sb['edge_recall']:.4f} "
+            f"gap={sb['ab_gap']:.4f} components={sb['components']} provenance={sb['provenance']:.3f}",
             flush=True,
         )
     md = _to_markdown(rows)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_eval.py
@@ -9,6 +9,30 @@ def _base_doc_id(ref: str) -> str:
     return "::".join(parts[:3]) if len(parts) >= 3 else ref
 
 
+def _assign_nodes(graph: dict, gold_mentions: list[tuple[str, str, str]]) -> dict[int, int]:
+    """Per gold-mention index -> the built node it landed in (via the doc's edge endpoints), or a fresh
+    NEGATIVE id when the doc produced no matching edge (extraction miss / dropped self-loop). Shared by
+    `align_mentions_to_nodes` (which groups these) and `fragmentation_report` (which counts them)."""
+    by_doc: dict[str, tuple[int, int]] = {}
+    for e in graph.get("edges", ()):
+        for ref in e.get("source_refs", ()):
+            by_doc.setdefault(_base_doc_id(ref), (e["subj"], e["obj"]))
+    node_of: dict[int, int] = {}
+    fresh = -1
+    for i, (entity_id, _surface, doc_id) in enumerate(gold_mentions):
+        edge = by_doc.get(_base_doc_id(doc_id))
+        if edge is None:
+            node_of[i] = fresh
+            fresh -= 1
+            continue
+        parts = doc_id.split("::")
+        src_id, dst_id = parts[0], parts[2]
+        node_of[i] = edge[0] if entity_id == src_id else edge[1] if entity_id == dst_id else fresh
+        if node_of[i] == fresh:
+            fresh -= 1
+    return node_of
+
+
 def align_mentions_to_nodes(graph: dict, gold_mentions: list[tuple[str, str, str]]) -> list[list[int]]:
     """Cluster gold-mention INDICES by the built node each landed in. Exact, doc-keyed (not surface):
     each engineered doc is ONE edge `src::rel::dst`; the built edge for that doc (matched by base doc id
@@ -19,28 +43,57 @@ def align_mentions_to_nodes(graph: dict, gold_mentions: list[tuple[str, str, str
     entities) into one node, the build drops the self-loop -> no edge -> both mentions become singletons,
     mislabeling a within-doc over-merge as recall misses. Does not affect the ambiguity-driven (cross-doc,
     recall-side) headline."""
-    # doc base id -> the edge (subj, obj). Prefer an exact base-id match.
-    by_doc: dict[str, tuple[int, int]] = {}
-    for e in graph.get("edges", ()):
-        for ref in e.get("source_refs", ()):
-            by_doc.setdefault(_base_doc_id(ref), (e["subj"], e["obj"]))
-    node_of: dict[int, int] = {}   # mention index -> node id ; unmatched -> a fresh negative id
-    fresh = -1
-    for i, (entity_id, _surface, doc_id) in enumerate(gold_mentions):
-        edge = by_doc.get(_base_doc_id(doc_id))
-        if edge is None:
-            node_of[i] = fresh
-            fresh -= 1
-            continue
-        parts = doc_id.split("::")
-        src_id, dst_id = parts[0], parts[2]
-        node_of[i] = edge[0] if entity_id == src_id else edge[1] if entity_id == dst_id else (fresh)
-        if node_of[i] == fresh:   # entity_id matched neither endpoint (shouldn't happen) -> unmatched
-            fresh -= 1
     groups: dict[int, list[int]] = {}
-    for i, node in node_of.items():
+    for i, node in _assign_nodes(graph, gold_mentions).items():
         groups.setdefault(node, []).append(i)
     return [sorted(v) for v in groups.values()]
+
+
+def fragmentation_report(graph: dict, gold_mentions: list[tuple[str, str, str]]) -> dict:
+    """Diagnose WHY cross-doc co-reference is lost: for each GOLD entity, how many distinct built NODES
+    its mentions scattered across, and whether those nodes differ in NAME or in TYPE. `mean_nodes_per_entity`
+    == 1.0 is perfect unification; higher means the same entity became many nodes. Of the fragmented
+    entities, `name_jitter_frac`/`type_jitter_frac` attribute the cause (the extractor rendering one entity
+    under varied names/types across docs -> mismatched `record_key` -> no store merge); `identical_frac` is
+    fragmented-despite-identical-(name,typ) == a store-merge BUG, not modeling. Ignores fresh (<0) miss
+    nodes so this isolates cross-doc NON-MERGE from extraction drop (that is `edge_recall`)."""
+    id2nt: dict[int, tuple[str, str]] = {
+        e["entity_id"]: (e.get("canonical_name", ""), e.get("typ", "")) for e in graph.get("entities", ())
+    }
+    node_of = _assign_nodes(graph, gold_mentions)
+    by_entity: dict[str, set[int]] = {}
+    for i, (eid, _s, _d) in enumerate(gold_mentions):
+        node = node_of[i]
+        if node < 0:  # extraction-miss singleton -> not a cross-doc non-merge; excluded
+            continue
+        by_entity.setdefault(eid, set()).add(node)
+    multi = {eid: nodes for eid, nodes in by_entity.items() if len(nodes) > 1}
+    total = len(by_entity) or 1
+    name_j = type_j = ident = 0
+    worst: list[tuple[str, int, list[tuple[str, str]]]] = []
+    for eid, nodes in multi.items():
+        nts = [id2nt.get(n, ("?", "?")) for n in nodes]
+        names = {nt[0] for nt in nts}
+        types = {nt[1] for nt in nts}
+        if len(names) > 1:
+            name_j += 1
+        if len(types) > 1:
+            type_j += 1
+        if len(names) == 1 and len(types) == 1:
+            ident += 1
+        worst.append((eid, len(nodes), sorted(nts)))
+    worst.sort(key=lambda t: -t[1])
+    nodes_per = [len(nodes) for nodes in by_entity.values()]
+    return {
+        "mean_nodes_per_entity": sum(nodes_per) / total,
+        "max_nodes_per_entity": max(nodes_per, default=0),
+        "fragmented_entities": len(multi),
+        "total_entities": len(by_entity),
+        "name_jitter_frac": name_j / (len(multi) or 1),
+        "type_jitter_frac": type_j / (len(multi) or 1),
+        "identical_frac": ident / (len(multi) or 1),
+        "worst": worst[:12],
+    }
 
 
 def graph_coherence(graph: dict) -> dict:
@@ -65,6 +118,22 @@ def graph_coherence(graph: dict) -> dict:
     from collections import Counter
     sizes = Counter(roots)
     return {"components": len(sizes), "largest_fraction": max(sizes.values()) / len(roots)}
+
+
+def edge_recall(graph: dict, gold_mentions: list[tuple[str, str, str]]) -> float:
+    """Fraction of GOLD edge-docs that produced a surviving built edge (base doc id present in some
+    edge's `source_refs`). This is extraction COMPLETENESS: a doc whose edge was never extracted -- or
+    whose endpoints the resolver collapsed into a self-loop that `build_batch` drops -- contributes no
+    edge, so both its gold mentions orphan. Decomposes the R(B) floor: low edge_recall => the edges
+    aren't in the graph at all (extraction/over-merge), NOT a cross-doc resolution miss. 1.0 if no gold."""
+    gold_docs = {_base_doc_id(doc_id) for (_eid, _surface, doc_id) in gold_mentions}
+    if not gold_docs:
+        return 1.0
+    built_docs: set[str] = set()
+    for e in graph.get("edges", ()):
+        for ref in e.get("source_refs", ()):
+            built_docs.add(_base_doc_id(ref))
+    return len(gold_docs & built_docs) / len(gold_docs)
 
 
 def provenance_coverage(graph: dict) -> float:
@@ -92,4 +161,5 @@ def score_substrate(*, gold_mentions, resolver_clusters, graph) -> dict:
         "ab_gap": a.f1 - b.f1,
         "components": coh["components"], "largest_fraction": coh["largest_fraction"],
         "provenance": provenance_coverage(graph),
+        "edge_recall": edge_recall(graph, gold_mentions),
     }

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_eval.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 
 from erkgbench.substrate_eval import (
     align_mentions_to_nodes,
+    edge_recall,
+    fragmentation_report,
     graph_coherence,
     provenance_coverage,
     score_substrate,
 )
+
+
+def _ent(eid, name, typ="thing"):
+    return {"entity_id": eid, "canonical_name": name, "typ": typ}
 
 
 def _edge(subj, obj, doc, pred="r"):
@@ -37,6 +43,42 @@ def test_align_clean_one_node_per_entity():
     clustering = align_mentions_to_nodes(graph, gm)
     # mention 0 (A) -> node0, 1 (B)->node1, 2 (A)->node0, 3 (C)->node2
     assert sorted(map(sorted, clustering)) == [[0, 2], [1], [3]]   # A's two mentions share node0
+
+
+def test_edge_recall_counts_gold_docs_with_surviving_edge():
+    # 3 gold edge-docs; build produced an edge for only 2 (doc "A::r3::D" dropped -> extraction/self-loop)
+    gm = [
+        ("A", "A", "A::r::B"), ("B", "B", "A::r::B"),
+        ("A", "A", "A::r2::C"), ("C", "C", "A::r2::C"),
+        ("A", "A", "A::r3::D"), ("D", "D", "A::r3::D"),
+    ]
+    graph = {"entities": [], "edges": [_edge(0, 1, "A::r::B"), _edge(0, 2, "A::r2::C", "r2")]}
+    assert edge_recall(graph, gm) == 2 / 3
+    # a ::N co-occurrence suffix on a source_ref still counts its base doc
+    graph2 = {"entities": [], "edges": [_edge(0, 1, "A::r::B::1")]}
+    assert edge_recall(graph2, [("A", "A", "A::r::B"), ("B", "B", "A::r::B")]) == 1.0
+    assert edge_recall({"edges": []}, []) == 1.0  # no gold -> 1.0
+
+
+def test_fragmentation_report_attributes_name_vs_type_jitter():
+    # gold entity "A" appears in two docs; the build put it in two nodes (5 and 6) that differ by NAME
+    gm = [("A", "A", "A::r::B"), ("B", "B", "A::r::B"), ("A", "A", "A::r2::C"), ("C", "C", "A::r2::C")]
+    graph = {
+        "entities": [_ent(5, "A"), _ent(6, "Ay"), _ent(1, "B"), _ent(2, "C")],
+        "edges": [_edge(5, 1, "A::r::B"), _edge(6, 2, "A::r2::C", "r2")],
+    }
+    fr = fragmentation_report(graph, gm)
+    assert fr["fragmented_entities"] == 1 and fr["total_entities"] == 3
+    assert fr["mean_nodes_per_entity"] == (2 + 1 + 1) / 3   # A->2 nodes, B->1, C->1
+    assert fr["name_jitter_frac"] == 1.0 and fr["type_jitter_frac"] == 0.0
+    assert fr["identical_frac"] == 0.0
+    # type jitter: same name, different typ -> attributed to type not name
+    graph_t = {
+        "entities": [_ent(5, "A", "person"), _ent(6, "A", "org"), _ent(1, "B"), _ent(2, "C")],
+        "edges": [_edge(5, 1, "A::r::B"), _edge(6, 2, "A::r2::C", "r2")],
+    }
+    ft = fragmentation_report(graph_t, gm)
+    assert ft["type_jitter_frac"] == 1.0 and ft["name_jitter_frac"] == 0.0
 
 
 def test_align_entity_split_recall_loss():

--- a/scripts/distill/modal_bench.py
+++ b/scripts/distill/modal_bench.py
@@ -177,9 +177,11 @@ def _bench_impl(eval: str, n: int, ambiguity: float, opts: str, chat: str, embed
         # Substrate-quality A/B ambiguity sweep (engineered corpus; the `--ambiguity` list overrides the
         # scalar `ambiguity` arg). Level A resolver-isolation vs Level B end-to-end build; A-B gap = the
         # construction ceiling as a number. goldengraph only (needs the native store + resolver).
+        _amb = (env.get("GOLDENGRAPH_SUBSTRATE_AMBIGUITY", "").split()
+                or ["0.0", "0.3", "0.6"])
         proc = subprocess.run(
             ["python", "-m", "erkgbench.run_substrate_eval",
-             "--ambiguity", "0.0", "0.3", "0.6", "--out-md", out_md],
+             "--ambiguity", *_amb, "--out-md", out_md],
             cwd=_BENCH, env=env, capture_output=True, text=True, check=True,
         )
         results = pathlib.Path(out_md).read_text() if os.path.exists(out_md) else "(no results md)"


### PR DESCRIPTION
## Summary

The substrate recall floor (`R(B)=0.23`) was never a cross-doc entity-resolution problem. It was a **key-construction bug**: an open-vocab 7B assigns a different `typ` to the same entity in each document, so the store's `record_key=(name, typ)` never overlaps and entities shatter into ~3.5 nodes each.

Measure-first arc (full write-up: `docs/superpowers/reports/2026-07-01-substrate-recall-type-jitter.md`) refuted three candidate levers before finding it:

| experiment | result | verdict |
|---|---|---|
| profile-link (best cross-doc matcher, `link calls=139`) | R(B) 0.23→0.23 | cross-doc ER **refuted** |
| `edge_recall` | 0.93 | extraction drop **refuted** |
| exact resolver | R(B) flat | within-doc over-merge **refuted** |
| `fragmentation_report` | `type_jitter=0.976`, `identical=0.000` | **root cause: type jitter** |

## The fix

`resolve._key_payload` gains a gated `GOLDENGRAPH_XDOC_KEY`:
- `name` — key on name only (type-agnostic)
- `name_ci` — case-folded name (also absorbs case-only name jitter)
- unset (default) — `(name, typ)`, **unchanged**

Default-off. The entity analog of the predicate `SCHEMA_CANON` win.

## Validation (`name_ci`, engineered corpus)

| ambiguity | R(B) base → name_ci | ER-F1(B) | P(B) | components |
|---|---|---|---|---|
| 0.0 | 0.2314 → **0.7475** (3.2×) | 0.371 → **0.832** | 0.938 | 27 → **1** |
| 0.3 | 0.1126 → **0.4282** (3.8×) | 0.202 → **0.589** | 0.945 | 64 → **7** |
| 0.6 | 0.0743 → **0.3502** (4.7×) | 0.138 → **0.503** | 0.890 | 78 → **4** |

Recall multiplies at every level, **precision holds** (0.89–0.95), graph collapses to one component at ambiguity=0.

## Also in this PR
- **Diagnostics** (the instruments that found it): `edge_recall` + `fragmentation_report`, now permanent substrate-eval metrics; a `GOLDENGRAPH_SUBSTRATE_RESOLVER=exact` lever; env-overridable ambiguity sweep in `modal_bench`.

## Scope / follow-ons (not in this PR)
- Type-canonicalization variant (`(name_ci, coarse_type)`) for homograph safety before any default flip.
- Re-measure profile-link layered on `name_ci` for the higher-ambiguity surface-variance residual.
- Name-jitter tail cleanup (predicate-bleed, garbage predicate-as-entity nodes).

## Test Plan
- [x] 12 substrate-eval pure tests green (incl. edge_recall + fragmentation)
- [x] 3 `_key_payload` normalization tests green (box-safe, worktree shadow)
- [x] ruff clean
- [x] Modal sweep produced the numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)