### PR TITLE
feat(memory): Postgres backend for MemoryStore (dataset-isolated Learning Memory)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-postgres-memory-store.md
+++ b/docs/superpowers/plans/2026-07-01-postgres-memory-store.md
@@ -1,0 +1,354 @@
+# Postgres MemoryStore Backend — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `backend='postgres'` path to `MemoryStore` so Learning Memory corrections + adjustments persist in a shared multi-tenant Postgres, isolated by `dataset`, with `learn()` scoped per-tenant.
+
+**Architecture:** Keep one `MemoryStore` class. Introduce a thin execution seam (`_execute`/`_executescript`/`_commit` + a placeholder/upsert/DDL that dispatch on `self._backend`) so existing method bodies keep their `?`-style SQL and only the genuinely dialect-specific bits (DDL, the two upserts, `IS NULL`→`COALESCE`) branch. Thread `dataset` through the learner + pipeline and `table_prefix` through config + pipeline.
+
+**Tech Stack:** Python, `psycopg` v3 (existing optional `postgres` extra), SQLite (stdlib), Pydantic config, pytest (DB-gated via `tests/_pg_helpers.py`).
+
+**Spec:** `docs/superpowers/specs/2026-07-01-postgres-memory-store-design.md`
+
+## How to run tests (this monorepo)
+
+From the repo root `D:\ER\gm-pg-memory`:
+- Sync once: `uv sync --extra dev --extra postgres` (workspace `uv.lock` at root).
+- Non-DB tests: `uv run pytest packages/python/goldenmatch/tests/<path> -q`
+- DB-gated tests need `GOLDENMATCH_TEST_DATABASE_URL` set to an admin Postgres URL; without it, `HAS_POSTGRES` is False and those tests **skip** cleanly. (Set it during execution; the fixture provisions a throwaway `gm_test_<uuid>` DB per test.)
+
+Locate the existing memory-store tests first (`grep -rl "MemoryStore" packages/python/goldenmatch/tests`) and co-locate new tests beside them.
+
+---
+
+## File Structure
+
+- `packages/python/goldenmatch/goldenmatch/core/memory/store.py` — `LearnedAdjustment.dataset`; `dataset` params; execution seam; postgres branch; `table_prefix`.
+- `packages/python/goldenmatch/goldenmatch/core/memory/learner.py` — `MemoryLearner(dataset=…)` threading.
+- `packages/python/goldenmatch/goldenmatch/config/schemas.py` — `MemoryConfig.table_prefix`.
+- `packages/python/goldenmatch/goldenmatch/core/pipeline.py` — `_open_memory_store` (table_prefix), `_apply_memory_pre` (dataset).
+- `packages/python/goldenmatch/tests/…/test_memory_store_postgres.py` — new DB-gated tests.
+- Existing SQLite memory-store tests — extended for the new params (back-compat).
+
+---
+
+## Task 1: `LearnedAdjustment.dataset` field
+
+**Files:** Modify `core/memory/store.py` (dataclass ~114; `_row_to_adjustment` ~479). Test: existing memory-store test file.
+
+- [ ] **Step 1: Failing test** — a `LearnedAdjustment` accepts `dataset` and defaults to None.
+
+```python
+def test_learned_adjustment_has_dataset_field():
+    from goldenmatch.core.memory.store import LearnedAdjustment
+    adj = LearnedAdjustment(matchkey_name="mk", threshold=0.9)
+    assert adj.dataset is None
+    adj2 = LearnedAdjustment(matchkey_name="mk", threshold=0.9, dataset="org_1")
+    assert adj2.dataset == "org_1"
+```
+
+- [ ] **Step 2: Run → fail** (`TypeError: unexpected keyword argument 'dataset'`).
+- [ ] **Step 3: Implement** — add to the dataclass (after `learned_at`):
+
+```python
+    dataset: str | None = None
+```
+
+And make `_row_to_adjustment` populate it defensively (SQLite rows won't have the column):
+
+```python
+    @staticmethod
+    def _row_to_adjustment(row: Any) -> LearnedAdjustment:
+        weights = json.loads(row["field_weights"]) if row["field_weights"] else None
+        keys = row.keys() if hasattr(row, "keys") else ()
+        return LearnedAdjustment(
+            matchkey_name=row["matchkey_name"],
+            threshold=row["threshold"],
+            field_weights=weights,
+            sample_size=row["sample_size"],
+            learned_at=(row["learned_at"] if isinstance(row["learned_at"], datetime)
+                        else datetime.fromisoformat(row["learned_at"])),
+            dataset=row["dataset"] if "dataset" in keys else None,
+        )
+```
+
+> Note the `learned_at` guard: psycopg returns `datetime`, sqlite returns an ISO string. Apply the same `isinstance(...)` guard to `created_at` in `_row_to_correction` (Step: update that converter identically).
+
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** — `feat(memory): LearnedAdjustment.dataset + dialect-safe timestamp parsing`
+
+---
+
+## Task 2: `dataset` params on store read/write methods (SQLite, back-compat)
+
+**Files:** Modify `core/memory/store.py` (`corrections_since` ~415, `save_adjustment` ~424, `get_adjustment` ~436, `get_all_adjustments` ~445). Test: existing memory-store test file.
+
+`get_corrections`/`count_corrections` already accept `dataset` — leave them.
+
+- [ ] **Step 1: Failing tests** (SQLite):
+
+```python
+def test_corrections_since_dataset_filter(tmp_path):
+    from datetime import datetime, timedelta
+    from goldenmatch.core.memory.store import MemoryStore, Correction
+    s = MemoryStore(path=str(tmp_path / "m.db"))
+    old = datetime.now() - timedelta(hours=1)
+    def mk(a, b, ds):
+        return Correction(id=f"{a}-{b}-{ds}", id_a=a, id_b=b, decision="reject",
+                          source="steward", trust=1.0, field_hash="", record_hash="",
+                          original_score=0.5, dataset=ds)
+    s.add_correction(mk(1, 2, "A")); s.add_correction(mk(3, 4, "B"))
+    assert len(s.corrections_since(old, dataset="A")) == 1
+    assert len(s.corrections_since(old)) == 2          # back-compat: unfiltered
+
+def test_adjustment_roundtrip_ignores_dataset_on_sqlite(tmp_path):
+    from goldenmatch.core.memory.store import MemoryStore, LearnedAdjustment
+    from datetime import datetime
+    s = MemoryStore(path=str(tmp_path / "m.db"))
+    s.save_adjustment(LearnedAdjustment("mk", threshold=0.9, sample_size=12,
+                                        learned_at=datetime.now()), dataset="A")
+    got = s.get_adjustment("mk", dataset="A")
+    assert got is not None and got.threshold == 0.9
+```
+
+- [ ] **Step 2: Run → fail** (`corrections_since()`/`save_adjustment()` reject `dataset`).
+- [ ] **Step 3: Implement (SQLite bodies).** Add `dataset: str | None = None` to each signature.
+  - `corrections_since(since, dataset=None)`: when `dataset` is set, add `AND dataset = ?` to the WHERE.
+  - `save_adjustment(adj, dataset=None)`: SQLite keeps `INSERT OR REPLACE` keyed by `matchkey_name` (its schema has no dataset column). The `dataset` param is accepted + ignored on SQLite (documented) — it is honored on Postgres (Task 6). If `adj.dataset` is None and `dataset` is set, set `adj.dataset = dataset` before saving so the returned object is tagged.
+  - `get_adjustment(matchkey_name, dataset=None)`: SQLite ignores `dataset` (matchkey-only lookup); tag the returned adjustment's `.dataset` with the passed value for caller consistency.
+  - `get_all_adjustments(dataset=None)`: SQLite ignores the filter (returns all).
+
+  (These keep SQLite behavior identical while making the multi-tenant signature available; Postgres implements the real filtering in Task 6.)
+
+- [ ] **Step 4: Run → pass** (new + all existing SQLite memory tests).
+- [ ] **Step 5: Commit** — `feat(memory): dataset params on store methods (sqlite back-compat)`
+
+---
+
+## Task 3: Thread `dataset` into `MemoryLearner`
+
+**Files:** Modify `core/memory/learner.py`. Test: existing learner test file.
+
+- [ ] **Step 1: Failing test** — a learner with a dataset only learns over that dataset and tags the adjustment.
+
+```python
+def test_learner_scopes_to_dataset(tmp_path):
+    from goldenmatch.core.memory.store import MemoryStore, Correction
+    from goldenmatch.core.memory.learner import MemoryLearner
+    s = MemoryStore(path=str(tmp_path / "m.db"))
+    def mk(a, b, ds, dec, score):
+        return Correction(id=f"{a}-{b}-{ds}", id_a=a, id_b=b, decision=dec,
+                          source="steward", trust=1.0, field_hash="", record_hash="",
+                          original_score=score, matchkey_name="mk", dataset=ds)
+    # 10 approves high, 10 rejects low in dataset A; noise in B
+    for i in range(10): s.add_correction(mk(i, 100+i, "A", "approve", 0.9))
+    for i in range(10): s.add_correction(mk(200+i, 300+i, "A", "reject", 0.2))
+    s.add_correction(mk(999, 1000, "B", "approve", 0.1))
+    learner = MemoryLearner(s, dataset="A")
+    adjustments = learner.learn()
+    assert adjustments and adjustments[0].dataset == "A"
+    assert 0.2 <= adjustments[0].threshold <= 0.9
+```
+
+- [ ] **Step 2: Run → fail** (`MemoryLearner()` rejects `dataset`).
+- [ ] **Step 3: Implement.** Add `dataset: str | None = None` to `__init__`, store `self._dataset = dataset`. In `has_new_corrections`, pass it: `self._store.count_corrections(dataset=self._dataset)` and `self._store.corrections_since(last, dataset=self._dataset)`. In `learn`, read `self._store.get_corrections(dataset=self._dataset)` and set `adj = LearnedAdjustment(..., dataset=self._dataset)` and `self._store.save_adjustment(adj, dataset=self._dataset)`.
+
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** — `feat(memory): MemoryLearner dataset scoping`
+
+---
+
+## Task 4: `MemoryConfig.table_prefix` + pipeline threading
+
+**Files:** Modify `config/schemas.py` (`MemoryConfig` ~894), `core/pipeline.py` (`_open_memory_store` ~292, `_apply_memory_pre` ~509). Test: a config test + a pipeline unit test (or grounding assertion).
+
+- [ ] **Step 1: Failing test** — config accepts `table_prefix`; invalid prefix rejected.
+
+```python
+def test_memory_config_table_prefix():
+    from goldenmatch.config.schemas import MemoryConfig
+    assert MemoryConfig().table_prefix == ""
+    assert MemoryConfig(table_prefix="goldenmatch_").table_prefix == "goldenmatch_"
+    import pytest
+    with pytest.raises(Exception):
+        MemoryConfig(table_prefix="bad-prefix; DROP")
+```
+
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement.** Add to `MemoryConfig`:
+
+```python
+    table_prefix: str = ""
+
+    @field_validator("table_prefix")
+    @classmethod
+    def _validate_table_prefix(cls, v: str) -> str:
+        import re
+        if v and not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", v):
+            raise ValueError("table_prefix must match ^[A-Za-z_][A-Za-z0-9_]*$")
+        return v
+```
+
+Thread through the pipeline:
+- `_open_memory_store`: add `table_prefix=config.memory.table_prefix,` to the `MemoryStore(...)` call.
+- `_apply_memory_pre`: build the learner with the dataset:
+
+```python
+        learner = MemoryLearner(
+            memory_store,
+            threshold_min=config.memory.learning.threshold_min_corrections,
+            weights_min=config.memory.learning.weights_min_corrections,
+            dataset=config.memory.dataset,
+        )
+```
+
+- [ ] **Step 4: Run → pass** (config test; and existing pipeline tests still green — `MemoryStore` must accept `table_prefix` now, so do Task 5's signature add first if needed, or add the `table_prefix=""` param in this task's store change and wire the real behavior in Task 6). Add `table_prefix: str = ""` to `MemoryStore.__init__` here (accepted, regex-guarded, unused by SQLite) so the pipeline call type-checks.
+- [ ] **Step 5: Commit** — `feat(memory): table_prefix config + pipeline dataset/prefix threading`
+
+---
+
+## Task 5: Execution seam (route SQLite through a dialect-aware executor)
+
+**Files:** Modify `core/memory/store.py`. Test: existing SQLite memory tests are the guard (pure refactor — no behavior change).
+
+- [ ] **Step 1: Confirm the SQLite suite is green** (baseline): `uv run pytest packages/python/goldenmatch/tests/<memory tests> -q` → PASS.
+- [ ] **Step 2: Introduce the seam.** Add helpers on `MemoryStore` and route every `self._conn.execute(...)` / `executescript` / `with self._conn:` through them:
+
+```python
+    def _ph(self, sql: str) -> str:
+        """Translate '?' placeholders to the backend's style."""
+        return sql if self._backend == "sqlite" else sql.replace("?", "%s")
+
+    def _execute(self, sql: str, params: tuple = ()):  # returns a cursor/iterable of rows
+        return self._conn.execute(self._ph(sql), params)
+
+    def _commit(self):
+        self._conn.commit()
+```
+
+Mechanically replace `self._conn.execute(<sql>, <params>)` → `self._execute(<sql>, <params>)` in every method, and replace the `with self._conn:` transaction blocks with explicit `self._execute(...); self._commit()` (psycopg has no `with connection:` auto-commit semantics identical to sqlite). Keep the SQL text (with `?`) unchanged — `_ph` handles the dialect.
+
+- [ ] **Step 3: Run → the full SQLite memory suite still passes** (proves the refactor is behavior-preserving on sqlite).
+- [ ] **Step 4: Commit** — `refactor(memory): route store SQL through a dialect-aware executor`
+
+---
+
+## Task 6: Postgres backend branch + DDL + upserts + DB-gated tests
+
+**Files:** Modify `core/memory/store.py` (`__init__` ~164, `_SCHEMA`, `add_correction` upsert, `save_adjustment`, the `IS NULL` reads). Create `tests/…/test_memory_store_postgres.py`.
+
+- [ ] **Step 1: Failing DB-gated test** (skips without `GOLDENMATCH_TEST_DATABASE_URL`). Co-locate with existing memory tests; mirror `tests/identity/test_postgres_bulk.py` for the fixture usage.
+
+```python
+import pytest
+from tests._pg_helpers import HAS_POSTGRES, pg_url_fixture
+
+pytestmark = pytest.mark.skipif(not HAS_POSTGRES, reason="no test postgres")
+
+@pytest.fixture
+def pg_url():
+    with pg_url_fixture() as holder:
+        yield holder.url()
+
+def _mk(a, b, ds, dec="reject", score=0.5, trust=1.0, src="steward"):
+    from goldenmatch.core.memory.store import Correction
+    return Correction(id=f"{a}-{b}-{ds}", id_a=a, id_b=b, decision=dec, source=src,
+                      trust=trust, field_hash="", record_hash="", original_score=score,
+                      matchkey_name="mk", dataset=ds)
+
+def test_pg_correction_roundtrip_and_trust_wins(pg_url):
+    from goldenmatch.core.memory.store import MemoryStore
+    s = MemoryStore(backend="postgres", connection=pg_url, table_prefix="goldenmatch_")
+    s.add_correction(_mk(1, 2, "A"))
+    assert s.count_corrections(dataset="A") == 1
+    # lower-trust does not overwrite higher-trust
+    s.add_correction(_mk(1, 2, "A", dec="approve", trust=0.5, src="agent"))
+    got = s.get_pair_correction(1, 2, dataset="A")
+    assert got.decision == "reject"           # steward (1.0) kept
+    s.close()
+
+def test_pg_null_dataset_upsert(pg_url):
+    from goldenmatch.core.memory.store import MemoryStore
+    s = MemoryStore(backend="postgres", connection=pg_url, table_prefix="goldenmatch_")
+    s.add_correction(_mk(1, 2, None)); s.add_correction(_mk(1, 2, None, dec="approve"))
+    assert s.count_corrections() == 1          # upsert, not duplicate
+    s.close()
+
+def test_pg_adjustments_tenant_isolation(pg_url):
+    from goldenmatch.core.memory.store import MemoryStore, LearnedAdjustment
+    from datetime import datetime
+    s = MemoryStore(backend="postgres", connection=pg_url, table_prefix="goldenmatch_")
+    s.save_adjustment(LearnedAdjustment("mk", threshold=0.8, learned_at=datetime.now()), dataset="A")
+    s.save_adjustment(LearnedAdjustment("mk", threshold=0.6, learned_at=datetime.now()), dataset="B")
+    assert s.get_adjustment("mk", dataset="A").threshold == 0.8
+    assert s.get_adjustment("mk", dataset="B").threshold == 0.6
+    got = s.get_all_adjustments(dataset="A")
+    assert len(got) == 1 and got[0].dataset == "A"
+    s.close()
+
+def test_pg_missing_extra_message(monkeypatch):
+    # Simulate psycopg missing → actionable ImportError (only meaningful if importable)
+    ...
+
+def test_pg_learn_per_dataset_isolation(pg_url):
+    from goldenmatch.core.memory.store import MemoryStore
+    from goldenmatch.core.memory.learner import MemoryLearner
+    s = MemoryStore(backend="postgres", connection=pg_url, table_prefix="goldenmatch_")
+    for i in range(10): s.add_correction(_mk(i, 100+i, "A", "approve", 0.9))
+    for i in range(10): s.add_correction(_mk(200+i, 300+i, "A", "reject", 0.2))
+    for i in range(10): s.add_correction(_mk(i, 100+i, "B", "approve", 0.3))
+    for i in range(10): s.add_correction(_mk(200+i, 300+i, "B", "reject", 0.25))
+    MemoryLearner(s, dataset="A").learn()
+    MemoryLearner(s, dataset="B").learn()
+    a, b = s.get_adjustment("mk", dataset="A"), s.get_adjustment("mk", dataset="B")
+    assert a and b and a.threshold != b.threshold   # not pooled
+    s.close()
+```
+
+- [ ] **Step 2: Run → fail** (`NotImplementedError: Backend 'postgres'`).
+- [ ] **Step 3: Implement the postgres branch.** In `__init__`, add the regex-guarded `table_prefix` (store as `self._p = f"{table_prefix}" or ""`, applied to table names) and:
+
+```python
+        elif backend == "postgres":
+            try:
+                import psycopg  # noqa: PLC0415 — lazy, optional extra
+            except ImportError as e:
+                raise ImportError(
+                    "backend='postgres' requires: pip install goldenmatch[postgres]"
+                ) from e
+            if not connection:
+                raise ValueError("backend='postgres' requires a connection DSN")
+            self._conn = psycopg.connect(connection, row_factory=psycopg.rows.dict_row)
+            for stmt in self._pg_schema():   # split DDL; execute individually
+                self._conn.execute(stmt)
+            self._conn.commit()
+```
+
+  - `_pg_schema()` returns the two `CREATE TABLE IF NOT EXISTS` statements (+ the corrections unique index) with Postgres types and `self._p` prefixing the table names:
+    - corrections: `id TEXT PRIMARY KEY, id_a BIGINT, id_b BIGINT, decision TEXT, source TEXT, trust DOUBLE PRECISION, field_hash TEXT, record_hash TEXT, original_score DOUBLE PRECISION, matchkey_name TEXT, reason TEXT, dataset TEXT, created_at TIMESTAMPTZ DEFAULT now(), field_name TEXT, original_value TEXT, corrected_value TEXT, cluster_score DOUBLE PRECISION, cluster_outcome TEXT`
+    - `CREATE UNIQUE INDEX IF NOT EXISTS <prefix>corrections_pair ON <prefix>corrections (id_a, id_b, COALESCE(dataset, ''))`
+    - adjustments: `dataset TEXT NOT NULL DEFAULT '', matchkey_name TEXT, threshold DOUBLE PRECISION, field_weights TEXT, sample_size INTEGER, learned_at TIMESTAMPTZ, PRIMARY KEY (dataset, matchkey_name)`
+  - **Table names:** parameterize the hard-coded `corrections`/`adjustments` in every method's SQL through `self._p` — simplest is a small `self._t("corrections")` returning `f"{self._p}corrections"` and building SQL with it, OR keep sqlite bare names and prefix only in the postgres DDL + queries. Given both backends run the same method bodies, introduce `self._corrections` / `self._adjustments` table-name attributes set in `__init__` (sqlite → bare, postgres → prefixed) and interpolate them in the (already dialect-neutral) SQL strings. Validate the prefix with the regex before interpolation (never raw input).
+  - **`add_correction` upsert (postgres):** branch on `self._backend`. Postgres uses:
+    `INSERT INTO <corrections> (...) VALUES (...) ON CONFLICT (id_a, id_b, COALESCE(dataset, '')) DO UPDATE SET decision=EXCLUDED.decision, ... WHERE EXCLUDED.trust >= <corrections>.trust`. This replaces the trust-check-then-DELETE+INSERT for postgres (keep the existing sqlite path). Timestamps: pass `correction.created_at` (a `datetime`) directly for postgres (not `.isoformat()`).
+  - **`save_adjustment` (postgres):** `INSERT INTO <adjustments> (dataset, matchkey_name, threshold, field_weights, sample_size, learned_at) VALUES (%s,...) ON CONFLICT (dataset, matchkey_name) DO UPDATE SET ...`. Use `dataset or ''`.
+  - **`get_adjustment`/`get_all_adjustments` (postgres):** filter by `dataset` (`WHERE dataset = %s`, using `dataset or ''`); `get_all_adjustments(None)` → all rows.
+  - **`IS NULL` reads:** `get_pair_correction`/`get_corrections`/`count_corrections`/`corrections_since` with `dataset=None` on postgres must match rows where dataset is NULL via `COALESCE(dataset,'') = ''` (the sqlite `dataset IS NULL` stays for sqlite). Add a `_dataset_pred(alias)` helper returning the right predicate per backend, or branch inline.
+  - **Row conversion:** `psycopg` dict_row returns a `dict` (has `.keys()`, `row["x"]`), so `_row_to_correction`/`_row_to_adjustment` already work — the timestamp guard from Task 1 handles `datetime` vs str.
+  - **`_commit`:** `self._conn.commit()` for both (psycopg needs explicit commit; sqlite connection.commit() is fine).
+
+- [ ] **Step 4: Run → pass** with `GOLDENMATCH_TEST_DATABASE_URL` set; and confirm the tests **skip** cleanly when it's unset.
+- [ ] **Step 5: Full memory suite green on SQLite** (no regression): `uv run pytest packages/python/goldenmatch/tests/<memory> -q`.
+- [ ] **Step 6: Commit** — `feat(memory): postgres MemoryStore backend (dataset-isolated corrections + adjustments)`
+
+---
+
+## Final verification
+
+- [ ] SQLite memory suite green; ruff/lint clean on changed files (`uv run ruff check packages/python/goldenmatch/goldenmatch/core/memory packages/python/goldenmatch/goldenmatch/core/pipeline.py packages/python/goldenmatch/goldenmatch/config/schemas.py`).
+- [ ] Postgres tests green with a test DSN; skip cleanly without.
+- [ ] Open PR against `main` from `feat/postgres-memory-store`.
+
+## Out of scope (per spec)
+
+- golden-truth integration (Spec 2). Connection pooling / injected-connection constructor. Alembic migrations. Adding a `dataset` column to the SQLite `adjustments` schema.

--- a/docs/superpowers/plans/2026-07-01-postgres-memory-store.md
+++ b/docs/superpowers/plans/2026-07-01-postgres-memory-store.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a `backend='postgres'` path to `MemoryStore` so Learning Memory corrections + adjustments persist in a shared multi-tenant Postgres, isolated by `dataset`, with `learn()` scoped per-tenant.
 
-**Architecture:** Keep one `MemoryStore` class. Introduce a thin execution seam (`_execute`/`_executescript`/`_commit` + a placeholder/upsert/DDL that dispatch on `self._backend`) so existing method bodies keep their `?`-style SQL and only the genuinely dialect-specific bits (DDL, the two upserts, `IS NULL`→`COALESCE`) branch. Thread `dataset` through the learner + pipeline and `table_prefix` through config + pipeline.
+**Architecture:** Keep one `MemoryStore` class. Introduce a thin execution seam (`_execute`/`_commit` + a placeholder helper that dispatch on `self._backend`) so existing method bodies keep their `?`-style SQL and only the genuinely dialect-specific bits (DDL, the two upserts, `IS NULL`→`COALESCE`) branch. Thread `dataset` through the learner + pipeline and `table_prefix` through config + pipeline.
 
 **Tech Stack:** Python, `psycopg` v3 (existing optional `postgres` extra), SQLite (stdlib), Pydantic config, pytest (DB-gated via `tests/_pg_helpers.py`).
 
@@ -72,7 +72,14 @@ And make `_row_to_adjustment` populate it defensively (SQLite rows won't have th
         )
 ```
 
-> Note the `learned_at` guard: psycopg returns `datetime`, sqlite returns an ISO string. Apply the same `isinstance(...)` guard to `created_at` in `_row_to_correction` (Step: update that converter identically).
+- [ ] **Step 3b: Apply the same timestamp guard to `_row_to_correction`** (load-bearing for Postgres reads in Task 6: psycopg returns a `datetime`, sqlite an ISO string). Change its `created_at=datetime.fromisoformat(row["created_at"])` to:
+
+```python
+            created_at=(row["created_at"] if isinstance(row["created_at"], datetime)
+                        else datetime.fromisoformat(row["created_at"])),
+```
+
+Add a focused test that a `Correction` round-trips through the SQLite store with a parseable `created_at` (guards the refactor).
 
 - [ ] **Step 4: Run → pass.**
 - [ ] **Step 5: Commit** — `feat(memory): LearnedAdjustment.dataset + dialect-safe timestamp parsing`
@@ -212,7 +219,7 @@ Thread through the pipeline:
 **Files:** Modify `core/memory/store.py`. Test: existing SQLite memory tests are the guard (pure refactor — no behavior change).
 
 - [ ] **Step 1: Confirm the SQLite suite is green** (baseline): `uv run pytest packages/python/goldenmatch/tests/<memory tests> -q` → PASS.
-- [ ] **Step 2: Introduce the seam.** Add helpers on `MemoryStore` and route every `self._conn.execute(...)` / `executescript` / `with self._conn:` through them:
+- [ ] **Step 2: Introduce the seam.** Add helpers on `MemoryStore` and route every `self._conn.execute(...)` / `with self._conn:` through them. (`executescript` stays inside the SQLite-only `__init__` branch — it needs no seam.)
 
 ```python
     def _ph(self, sql: str) -> str:
@@ -246,9 +253,10 @@ from tests._pg_helpers import HAS_POSTGRES, pg_url_fixture
 pytestmark = pytest.mark.skipif(not HAS_POSTGRES, reason="no test postgres")
 
 @pytest.fixture
-def pg_url():
-    with pg_url_fixture() as holder:
-        yield holder.url()
+def pg():
+    # pg_url_fixture is a generator (NOT a context manager) — mirror the existing
+    # pattern in tests/test_db.py: `yield from`. The yielded holder exposes .url().
+    yield from pg_url_fixture()
 
 def _mk(a, b, ds, dec="reject", score=0.5, trust=1.0, src="steward"):
     from goldenmatch.core.memory.store import Correction
@@ -256,9 +264,9 @@ def _mk(a, b, ds, dec="reject", score=0.5, trust=1.0, src="steward"):
                       trust=trust, field_hash="", record_hash="", original_score=score,
                       matchkey_name="mk", dataset=ds)
 
-def test_pg_correction_roundtrip_and_trust_wins(pg_url):
+def test_pg_correction_roundtrip_and_trust_wins(pg):
     from goldenmatch.core.memory.store import MemoryStore
-    s = MemoryStore(backend="postgres", connection=pg_url, table_prefix="goldenmatch_")
+    s = MemoryStore(backend="postgres", connection=pg.url(), table_prefix="goldenmatch_")
     s.add_correction(_mk(1, 2, "A"))
     assert s.count_corrections(dataset="A") == 1
     # lower-trust does not overwrite higher-trust
@@ -267,17 +275,17 @@ def test_pg_correction_roundtrip_and_trust_wins(pg_url):
     assert got.decision == "reject"           # steward (1.0) kept
     s.close()
 
-def test_pg_null_dataset_upsert(pg_url):
+def test_pg_null_dataset_upsert(pg):
     from goldenmatch.core.memory.store import MemoryStore
-    s = MemoryStore(backend="postgres", connection=pg_url, table_prefix="goldenmatch_")
+    s = MemoryStore(backend="postgres", connection=pg.url(), table_prefix="goldenmatch_")
     s.add_correction(_mk(1, 2, None)); s.add_correction(_mk(1, 2, None, dec="approve"))
     assert s.count_corrections() == 1          # upsert, not duplicate
     s.close()
 
-def test_pg_adjustments_tenant_isolation(pg_url):
+def test_pg_adjustments_tenant_isolation(pg):
     from goldenmatch.core.memory.store import MemoryStore, LearnedAdjustment
     from datetime import datetime
-    s = MemoryStore(backend="postgres", connection=pg_url, table_prefix="goldenmatch_")
+    s = MemoryStore(backend="postgres", connection=pg.url(), table_prefix="goldenmatch_")
     s.save_adjustment(LearnedAdjustment("mk", threshold=0.8, learned_at=datetime.now()), dataset="A")
     s.save_adjustment(LearnedAdjustment("mk", threshold=0.6, learned_at=datetime.now()), dataset="B")
     assert s.get_adjustment("mk", dataset="A").threshold == 0.8
@@ -287,13 +295,17 @@ def test_pg_adjustments_tenant_isolation(pg_url):
     s.close()
 
 def test_pg_missing_extra_message(monkeypatch):
-    # Simulate psycopg missing → actionable ImportError (only meaningful if importable)
-    ...
+    # Force `import psycopg` to fail → the actionable ImportError, without a DB.
+    import sys
+    monkeypatch.setitem(sys.modules, "psycopg", None)
+    from goldenmatch.core.memory.store import MemoryStore
+    with pytest.raises(ImportError, match=r"goldenmatch\[postgres\]"):
+        MemoryStore(backend="postgres", connection="postgresql://unused")
 
-def test_pg_learn_per_dataset_isolation(pg_url):
+def test_pg_learn_per_dataset_isolation(pg):
     from goldenmatch.core.memory.store import MemoryStore
     from goldenmatch.core.memory.learner import MemoryLearner
-    s = MemoryStore(backend="postgres", connection=pg_url, table_prefix="goldenmatch_")
+    s = MemoryStore(backend="postgres", connection=pg.url(), table_prefix="goldenmatch_")
     for i in range(10): s.add_correction(_mk(i, 100+i, "A", "approve", 0.9))
     for i in range(10): s.add_correction(_mk(200+i, 300+i, "A", "reject", 0.2))
     for i in range(10): s.add_correction(_mk(i, 100+i, "B", "approve", 0.3))
@@ -328,7 +340,7 @@ def test_pg_learn_per_dataset_isolation(pg_url):
     - corrections: `id TEXT PRIMARY KEY, id_a BIGINT, id_b BIGINT, decision TEXT, source TEXT, trust DOUBLE PRECISION, field_hash TEXT, record_hash TEXT, original_score DOUBLE PRECISION, matchkey_name TEXT, reason TEXT, dataset TEXT, created_at TIMESTAMPTZ DEFAULT now(), field_name TEXT, original_value TEXT, corrected_value TEXT, cluster_score DOUBLE PRECISION, cluster_outcome TEXT`
     - `CREATE UNIQUE INDEX IF NOT EXISTS <prefix>corrections_pair ON <prefix>corrections (id_a, id_b, COALESCE(dataset, ''))`
     - adjustments: `dataset TEXT NOT NULL DEFAULT '', matchkey_name TEXT, threshold DOUBLE PRECISION, field_weights TEXT, sample_size INTEGER, learned_at TIMESTAMPTZ, PRIMARY KEY (dataset, matchkey_name)`
-  - **Table names:** parameterize the hard-coded `corrections`/`adjustments` in every method's SQL through `self._p` — simplest is a small `self._t("corrections")` returning `f"{self._p}corrections"` and building SQL with it, OR keep sqlite bare names and prefix only in the postgres DDL + queries. Given both backends run the same method bodies, introduce `self._corrections` / `self._adjustments` table-name attributes set in `__init__` (sqlite → bare, postgres → prefixed) and interpolate them in the (already dialect-neutral) SQL strings. Validate the prefix with the regex before interpolation (never raw input).
+  - **Table names (pick ONE approach — this one).** In `__init__`, after validating `table_prefix` against `^[A-Za-z_][A-Za-z0-9_]*$` (reuse the same guard as the config validator; empty string allowed), set two attributes: `self._corrections = f"{table_prefix}corrections"` and `self._adjustments = f"{table_prefix}adjustments"` (sqlite → `table_prefix=""` → bare `corrections`/`adjustments`, unchanged). Then f-string-interpolate these attributes into the SQL of **every method that hard-codes a table name** — sweep all nine: `add_correction`, `get_pair_correction`, `get_corrections`, `count_corrections`, `corrections_since`, `save_adjustment`, `get_adjustment`, `get_all_adjustments`, `last_learn_time` (plus the DDL). The names come from validated config, never raw user input, so interpolation is safe. Do NOT introduce a `self._t()` helper — the two attributes are enough.
   - **`add_correction` upsert (postgres):** branch on `self._backend`. Postgres uses:
     `INSERT INTO <corrections> (...) VALUES (...) ON CONFLICT (id_a, id_b, COALESCE(dataset, '')) DO UPDATE SET decision=EXCLUDED.decision, ... WHERE EXCLUDED.trust >= <corrections>.trust`. This replaces the trust-check-then-DELETE+INSERT for postgres (keep the existing sqlite path). Timestamps: pass `correction.created_at` (a `datetime`) directly for postgres (not `.isoformat()`).
   - **`save_adjustment` (postgres):** `INSERT INTO <adjustments> (dataset, matchkey_name, threshold, field_weights, sample_size, learned_at) VALUES (%s,...) ON CONFLICT (dataset, matchkey_name) DO UPDATE SET ...`. Use `dataset or ''`.

--- a/docs/superpowers/specs/2026-07-01-postgres-memory-store-design.md
+++ b/docs/superpowers/specs/2026-07-01-postgres-memory-store-design.md
@@ -31,7 +31,13 @@ spec that depends on the contract at the bottom of this doc.
   - `adjustments (matchkey_name TEXT PRIMARY KEY, threshold, field_weights, sample_size, learned_at)` — **keyed by matchkey_name alone**.
 - ~15 methods, all `self._conn.execute(...)` with `?` placeholders. `add_correction` upserts via DELETE+INSERT in a transaction (trust-wins).
 - `core/pipeline.py` already constructs the store as
-  `MemoryStore(backend=config.memory.backend, path=config.memory.path, connection=config.memory.connection)` — **so the run path needs no change** once the backend exists.
+  `MemoryStore(backend=config.memory.backend, path=config.memory.path, connection=config.memory.connection)` — so the **existing** `backend`/`path`/`connection`
+  plumbing needs no change. (The two new params this spec adds — `table_prefix`
+  and threading `dataset` into the learner — do require small pipeline edits; see
+  §4/§5 + Files touched.)
+- `get_corrections` and `count_corrections` **already** accept a `dataset`
+  argument; `corrections_since` does not. The real gap is that `MemoryLearner`
+  never passes a dataset to any of them (§4).
 - `MemoryConfig` fields already present: `enabled, backend, path, connection, trust, learning, reanchor, dataset`.
 
 ## Design
@@ -120,9 +126,10 @@ dataset filter** and groups by `matchkey_name`; `has_new_corrections()` calls
 `pipeline._apply_memory_pre` builds `MemoryLearner(...)` + calls `learn()`
 **without** threading `config.memory.dataset` (only `_apply_memory_post` →
 `apply_corrections` gets `dataset=config.memory.dataset`). Required changes:
-- `get_corrections`, `count_corrections`, `corrections_since` gain an optional
-  `dataset: str | None = None` filter (Postgres: `WHERE COALESCE(dataset,'')=…`;
-  SQLite: `dataset=None` → today's unfiltered behavior, back-compat).
+- `corrections_since` gains an optional `dataset: str | None = None` filter
+  (`get_corrections` and `count_corrections` already have one). Postgres:
+  `WHERE COALESCE(dataset,'')=…`; SQLite: `dataset=None` → today's unfiltered
+  behavior, back-compat.
 - `MemoryLearner.__init__` gains an optional `dataset: str | None = None`;
   `learn()` and `has_new_corrections()` pass it to the store reads and
   `save_adjustment(..., dataset=self._dataset)`. Default None → today's pooled
@@ -208,9 +215,9 @@ store + pgvector tests use it. Skip cleanly when unset.
 ## Files touched
 
 - `core/memory/store.py` — dialect driver + postgres branch; `dataset` param on
-  `get_corrections`/`count_corrections`/`corrections_since`/`save_adjustment`/
-  `get_adjustment`/`get_all_adjustments`; `table_prefix` (+ regex guard);
-  `dataset` field on `LearnedAdjustment`.
+  `corrections_since` (new) + `save_adjustment`/`get_adjustment`/
+  `get_all_adjustments` (`get_corrections`/`count_corrections` already have it);
+  `table_prefix` (+ regex guard); `dataset` field on `LearnedAdjustment`.
 - `core/memory/learner.py` — `MemoryLearner.__init__(dataset=…)`; thread it
   through `learn()` + `has_new_corrections()`.
 - `core/pipeline.py` — `_apply_memory_pre` passes `dataset=config.memory.dataset`

--- a/docs/superpowers/specs/2026-07-01-postgres-memory-store-design.md
+++ b/docs/superpowers/specs/2026-07-01-postgres-memory-store-design.md
@@ -55,13 +55,19 @@ query shaped by the driver's placeholder/upsert. (This is a targeted refactor of
 an existing file that has grown a second backend's worth of responsibility —
 in-scope, not gratuitous.)
 
-### 2. `psycopg` as an optional extra
+### 2. `psycopg` — reuse the existing `postgres` extra
 
-Add `psycopg[binary]` (v3) under an optional extra `postgres`
-(`goldenmatch[postgres]`). Lazy-import inside the postgres branch (mirrors the
-lazy `sqlite3`/`import os` in the sqlite branch) so the base install and every
-non-Postgres caller are unaffected. A clear error if the extra is missing:
+**No new extra.** `pyproject.toml` already declares
+`postgres = ["psycopg[binary]>=3.1", "psycopg-pool>=3.2", "alembic>=1.13"]`
+(used today by `identity/store.py`). `MemoryStore` reuses it. Lazy-import
+`psycopg` inside the postgres branch (mirrors the lazy `sqlite3`/`import os` in
+the sqlite branch) so the base install and every non-Postgres caller are
+unaffected. A clear error if the extra is missing:
 `ImportError("backend='postgres' requires: pip install goldenmatch[postgres]")`.
+Note: `psycopg-pool` and `alembic` are in that extra for the identity store's
+sake — this feature uses **neither** (pooling and Alembic migrations are out of
+scope; §6 + Out of scope). We use a single owned `psycopg` connection and
+`CREATE TABLE IF NOT EXISTS` DDL on connect (matching `IdentityStore`).
 
 ### 3. Postgres schema
 
@@ -94,28 +100,61 @@ threshold for the same matchkey. So the Postgres backend scopes adjustments by
 `(dataset, matchkey_name)`, and `save_adjustment` / `get_adjustment` /
 `get_all_adjustments` accept/filter a `dataset`.
 
-**Interface impact + SQLite back-compat:** these three methods gain an optional
-`dataset: str | None = None` parameter.
-- Postgres: uses it as the first PK column (NULL → `''` sentinel).
-- SQLite: when `dataset` is None (the default), behaves exactly as today
-  (matchkey-only). Optionally, SQLite may also honor a passed `dataset` by adding
-  a `dataset` column + composite key behind a schema migration, but the MVP only
-  requires **not breaking** existing SQLite callers — the added param defaults
-  keep every current call site (`learner.py`, `corrections.py`, CLI, TUI, MCP)
-  working unchanged.
-- `MemoryLearner.learn()` (which calls `save_adjustment`) passes the `dataset`
-  it learned over when one is in scope; today it learns per-matchkey, so it
-  threads the store's active dataset through. Confirm the learner's call sites in
-  implementation and thread `dataset` where the store is Postgres.
+**Interface impact + SQLite back-compat.** `save_adjustment` / `get_adjustment` /
+`get_all_adjustments` gain an optional `dataset: str | None = None` parameter.
+- Postgres: `dataset` is the first PK column (NULL → `''` sentinel).
+- SQLite: `dataset=None` (default) behaves exactly as today (matchkey-only). The
+  MVP only requires **not breaking** SQLite callers — the defaults keep every
+  current call site (`learner.py`, `corrections.py`, CLI, TUI, MCP) unchanged.
+- `LearnedAdjustment` gains a `dataset: str | None = None` field so reads are
+  tenant-tagged. `get_all_adjustments(dataset=None)` on Postgres returns all
+  rows, each `LearnedAdjustment` carrying its `dataset`; with a `dataset` it
+  filters. SQLite: unchanged (field stays None).
+
+**The learn side must be dataset-scoped too (required, not "confirm later").**
+This is the crux the first review surfaced: isolating the *storage* of
+adjustments is useless if `learn()` still pools corrections across tenants.
+Today `MemoryLearner.learn()` calls `self._store.get_corrections()` with **no
+dataset filter** and groups by `matchkey_name`; `has_new_corrections()` calls
+`count_corrections()` / `corrections_since()` unfiltered; and
+`pipeline._apply_memory_pre` builds `MemoryLearner(...)` + calls `learn()`
+**without** threading `config.memory.dataset` (only `_apply_memory_post` →
+`apply_corrections` gets `dataset=config.memory.dataset`). Required changes:
+- `get_corrections`, `count_corrections`, `corrections_since` gain an optional
+  `dataset: str | None = None` filter (Postgres: `WHERE COALESCE(dataset,'')=…`;
+  SQLite: `dataset=None` → today's unfiltered behavior, back-compat).
+- `MemoryLearner.__init__` gains an optional `dataset: str | None = None`;
+  `learn()` and `has_new_corrections()` pass it to the store reads and
+  `save_adjustment(..., dataset=self._dataset)`. Default None → today's pooled
+  behavior for SQLite one-file-per-dataset callers.
+- `pipeline._apply_memory_pre` threads `config.memory.dataset` into
+  `MemoryLearner(store, dataset=config.memory.dataset)` — mirroring how
+  `_apply_memory_post` already passes `dataset=config.memory.dataset`.
+
+Net: for a Postgres run, `learn()` reads only that tenant's corrections and
+writes the adjustment under `(dataset, matchkey_name)`; no cross-tenant pooling.
 
 ### 5. Table coexistence
 
-golden-truth's Postgres holds app tables too. Add an optional
-`table_prefix: str = ""` (or `schema`) to `MemoryStore` so the Postgres tables
-can be namespaced (e.g. `goldenmatch_corrections`, `goldenmatch_adjustments`).
-Default empty = bare `corrections`/`adjustments` (matches SQLite). golden-truth
-sets a prefix/schema. DDL + every query interpolate the (validated,
-regex-guarded) prefix — never user input.
+golden-truth's Postgres holds app tables too, so the engine's tables must be
+namespaceable. Add an optional `table_prefix: str = ""` to `MemoryStore`
+(e.g. `goldenmatch_corrections`, `goldenmatch_adjustments`). Default empty = bare
+`corrections`/`adjustments` (matches SQLite). DDL + every query interpolate the
+prefix, which is **regex-validated** (`^[A-Za-z_][A-Za-z0-9_]*$`) at construction
+— never raw user input (mirrors the readers'/writers' `_safe_*_identifier`
+guard).
+
+**Config path (required — this param must reach the config-driven pipeline).**
+Because golden-truth drives memory via `config.memory` → `dedupe_df` (not by
+constructing `MemoryStore` directly), `table_prefix` needs a route through the
+config:
+- Add `table_prefix: str = ""` to `MemoryConfig` (`config/schemas.py`).
+- Thread it in `pipeline._open_memory_store`:
+  `MemoryStore(backend=config.memory.backend, path=config.memory.path,
+  connection=config.memory.connection, table_prefix=config.memory.table_prefix)`.
+- SQLite ignores a set `table_prefix` for MVP (or honors it — either is fine; the
+  requirement is that Postgres can namespace and existing SQLite callers are
+  unaffected since the field defaults to "").
 
 ### 6. Concurrency
 
@@ -126,33 +165,61 @@ and race-safe.
 ## Contract (consumed by the golden-truth integration spec)
 
 - `MemoryStore(backend="postgres", connection="postgresql://…", table_prefix="goldenmatch_")`.
-- `MemoryConfig(enabled=True, backend="postgres", connection=<dsn>, dataset=<tenant/org id>, trust=…, learning=…, reanchor=True)` → `dedupe_df` applies + persists corrections in Postgres, isolated by `dataset`.
+- `MemoryConfig(enabled=True, backend="postgres", connection=<dsn>, dataset=<tenant/org id>, table_prefix="goldenmatch_", trust=…, learning=…, reanchor=True)` → `dedupe_df` applies + persists + learns corrections in Postgres, isolated by `dataset` (both the apply/write path and the `learn()` path).
 - Corrections isolated by `dataset` (existing column); adjustments isolated by `(dataset, matchkey_name)` (new).
 - Same `Correction` / `LearnedAdjustment` shapes as SQLite; `apply_corrections` /
   `MemoryLearner` unchanged (they take a store object, dialect-agnostic).
 
 ## Testing
 
-DB-gated (skip cleanly when no test Postgres DSN is set, mirroring the repo's
-DB-gated test convention). Use a `GOLDENMATCH_TEST_PG_DSN` env var (or a
-testcontainer if the suite already has one).
+Reuse the repo's existing DB-gated Postgres convention — **do not invent a new
+env var/fixture**. `tests/_pg_helpers.py` already provides `HAS_POSTGRES`
+(gated on `GOLDENMATCH_TEST_DATABASE_URL`) and the `pg_url_fixture`; the identity
+store + pgvector tests use it. Skip cleanly when unset.
 
-- **Parity:** the same `Correction` written + read back is byte-identical across
+- **Parity:** the same `Correction` written + read back is equivalent across
   sqlite and postgres (`add_correction` → `get_pair_correction`,
   `get_corrections`, `count_corrections`, `corrections_since`).
 - **Trust-wins upsert:** a lower-trust correction does not overwrite a
   higher-trust one; equal trust = latest wins — same as SQLite.
 - **NULL-dataset upsert:** two writes to the same pair with `dataset=None` upsert
   (don't duplicate) via the COALESCE sentinel.
-- **Adjustments tenant-isolation:** `save_adjustment(dataset="A")` and
-  `save_adjustment(dataset="B")` for the same matchkey coexist; `get_adjustment`
-  returns the right one per dataset; neither overwrites the other.
+- **Corrections dataset filter:** `get_corrections(dataset="A")` /
+  `count_corrections(dataset="A")` return only A's rows on Postgres; `dataset=None`
+  returns all.
+- **Adjustments tenant-isolation:** `save_adjustment(adj, dataset="A")` and
+  `save_adjustment(adj, dataset="B")` for the same matchkey coexist;
+  `get_adjustment(name, dataset=…)` returns the right one; neither overwrites the
+  other; `get_all_adjustments(dataset="A")` returns only A's, each carrying
+  `dataset="A"`.
+- **`learn()` per-dataset isolation (the crux):** ≥`threshold_min` corrections
+  for a matchkey in dataset A and a *different* set in dataset B produce two
+  independent `LearnedAdjustment`s under `(A, mk)` and `(B, mk)` — `learn()` with
+  a dataset does NOT pool across tenants.
 - **SQLite back-compat:** every existing SQLite test still passes with the new
-  optional `dataset` param defaulted (no behavioral change).
+  optional params defaulted (no behavioral change); `MemoryLearner()` with no
+  dataset behaves as today.
+- **`table_prefix`:** a prefixed Postgres store creates/reads
+  `goldenmatch_corrections`/`goldenmatch_adjustments`; an invalid prefix raises at
+  construction.
 - **Missing extra:** `backend="postgres"` without `psycopg` raises the actionable
   ImportError.
-- **`learn()` round-trip on Postgres:** ≥`threshold_min` corrections for a
-  matchkey in dataset A produce a `LearnedAdjustment` stored under `(A, matchkey)`.
+
+## Files touched
+
+- `core/memory/store.py` — dialect driver + postgres branch; `dataset` param on
+  `get_corrections`/`count_corrections`/`corrections_since`/`save_adjustment`/
+  `get_adjustment`/`get_all_adjustments`; `table_prefix` (+ regex guard);
+  `dataset` field on `LearnedAdjustment`.
+- `core/memory/learner.py` — `MemoryLearner.__init__(dataset=…)`; thread it
+  through `learn()` + `has_new_corrections()`.
+- `core/pipeline.py` — `_apply_memory_pre` passes `dataset=config.memory.dataset`
+  to `MemoryLearner`; `_open_memory_store` passes
+  `table_prefix=config.memory.table_prefix`.
+- `config/schemas.py` — `MemoryConfig.table_prefix: str = ""`.
+- `pyproject.toml` — **no change** (the `postgres` extra already exists).
+- `tests/` — new DB-gated `test_memory_store_postgres.py` (+ any learner test);
+  reuse `tests/_pg_helpers.py`.
 
 ## Out of scope (this spec)
 

--- a/docs/superpowers/specs/2026-07-01-postgres-memory-store-design.md
+++ b/docs/superpowers/specs/2026-07-01-postgres-memory-store-design.md
@@ -1,0 +1,164 @@
+# Postgres backend for MemoryStore — design spec
+
+_Date: 2026-07-01_
+_Status: approved (brainstorm), pre-implementation_
+_Repo: goldenmatch (monorepo) — `packages/python/goldenmatch`_
+
+## Summary
+
+Add a **Postgres backend** to `MemoryStore` (Learning Memory persistence) so a
+run can read/write corrections + adjustments in a shared Postgres database,
+multi-tenant, isolated by `dataset`. Today `MemoryStore` is SQLite-only
+(`backend != "sqlite"` → `NotImplementedError`), which forces a local file per
+store — unusable from a stateless, multi-tenant web backend (golden-truth) where
+state must live in Postgres.
+
+After this change:
+`MemoryStore(backend="postgres", connection="postgresql://…")` works, and
+`config.memory = MemoryConfig(enabled=True, backend="postgres", connection=<dsn>,
+dataset=<tenant>)` makes `dedupe_df` apply + persist corrections natively — no
+SQLite, no per-tenant file.
+
+This spec is the **engine half** of the Learning Memory feature. The consumer
+(golden-truth: correction capture + `config.memory` wiring + UI) is a separate
+spec that depends on the contract at the bottom of this doc.
+
+## Current state (verified against `main`)
+
+- `core/memory/store.py`: `MemoryStore(backend="sqlite", path=".goldenmatch/memory.db", connection=None)`. `__init__` handles `sqlite`; else raises `NotImplementedError`. `connection` is an unused placeholder.
+- `_SCHEMA` — two tables:
+  - `corrections (id PK, id_a, id_b, decision, source, trust, field_hash, record_hash, original_score, matchkey_name, reason, dataset, created_at, field_name, original_value, corrected_value, cluster_score, cluster_outcome, UNIQUE(id_a, id_b, dataset))`.
+  - `adjustments (matchkey_name TEXT PRIMARY KEY, threshold, field_weights, sample_size, learned_at)` — **keyed by matchkey_name alone**.
+- ~15 methods, all `self._conn.execute(...)` with `?` placeholders. `add_correction` upserts via DELETE+INSERT in a transaction (trust-wins).
+- `core/pipeline.py` already constructs the store as
+  `MemoryStore(backend=config.memory.backend, path=config.memory.path, connection=config.memory.connection)` — **so the run path needs no change** once the backend exists.
+- `MemoryConfig` fields already present: `enabled, backend, path, connection, trust, learning, reanchor, dataset`.
+
+## Design
+
+### 1. Dialect driver (keep one public class)
+
+Refactor `MemoryStore` so SQL-dialect specifics live behind a small internal
+driver selected in `__init__`:
+
+- `_SqliteDriver` — wraps the existing `sqlite3` connection; `?` placeholders;
+  DELETE+INSERT upsert; `executescript` DDL. Preserves today's behavior exactly.
+- `_PostgresDriver` — wraps a `psycopg` (v3) connection; `%s` placeholders;
+  `INSERT … ON CONFLICT … DO UPDATE` upsert; executes DDL statements individually.
+
+The ~15 method bodies stay shared and dialect-neutral by going through the
+driver for: `execute(sql, params) -> rows`, `executemany`, `commit`/transaction
+context, the parameter placeholder, and the upsert idiom. Rationale: branching
+`self._backend` inside every method, or forking two full subclasses, both
+duplicate the query logic; a thin driver keeps one class + one copy of each
+query shaped by the driver's placeholder/upsert. (This is a targeted refactor of
+an existing file that has grown a second backend's worth of responsibility —
+in-scope, not gratuitous.)
+
+### 2. `psycopg` as an optional extra
+
+Add `psycopg[binary]` (v3) under an optional extra `postgres`
+(`goldenmatch[postgres]`). Lazy-import inside the postgres branch (mirrors the
+lazy `sqlite3`/`import os` in the sqlite branch) so the base install and every
+non-Postgres caller are unaffected. A clear error if the extra is missing:
+`ImportError("backend='postgres' requires: pip install goldenmatch[postgres]")`.
+
+### 3. Postgres schema
+
+Mirror the two tables with Postgres types, created idempotently
+(`CREATE TABLE IF NOT EXISTS`) on connect:
+
+- `corrections`: `id TEXT PRIMARY KEY, id_a BIGINT, id_b BIGINT, decision TEXT,
+  source TEXT, trust DOUBLE PRECISION, field_hash TEXT, record_hash TEXT,
+  original_score DOUBLE PRECISION, matchkey_name TEXT, reason TEXT, dataset TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(), field_name TEXT, original_value TEXT,
+  corrected_value TEXT, cluster_score DOUBLE PRECISION, cluster_outcome TEXT`.
+- Upsert on the natural key. SQLite uses `UNIQUE(id_a, id_b, dataset)` and
+  matches NULL dataset via `IS ?`. Postgres treats `NULL` as distinct in a
+  unique constraint, so ON CONFLICT can't target a NULL dataset directly. Use a
+  **`COALESCE(dataset, '')` sentinel in a unique index** and target it:
+  `CREATE UNIQUE INDEX … ON corrections (id_a, id_b, COALESCE(dataset, ''))`;
+  `INSERT … ON CONFLICT (id_a, id_b, COALESCE(dataset, '')) DO UPDATE SET …`.
+  Keep the trust-wins semantics: `DO UPDATE … WHERE EXCLUDED.trust >= corrections.trust`.
+- `adjustments`: **PK `(dataset, matchkey_name)`** (composite) —
+  `dataset TEXT NOT NULL DEFAULT '', matchkey_name TEXT, threshold DOUBLE
+  PRECISION, field_weights TEXT (JSON), sample_size INTEGER, learned_at TIMESTAMPTZ,
+  PRIMARY KEY (dataset, matchkey_name)`.
+
+### 4. Adjustments scoped by `(dataset, matchkey_name)` — the key decision
+
+The SQLite schema keys `adjustments` by `matchkey_name` alone. That is correct
+for the one-file-per-dataset SQLite model, but in a **shared Postgres** serving
+many tenants it collides: tenant B's `learn()` overwrites tenant A's learned
+threshold for the same matchkey. So the Postgres backend scopes adjustments by
+`(dataset, matchkey_name)`, and `save_adjustment` / `get_adjustment` /
+`get_all_adjustments` accept/filter a `dataset`.
+
+**Interface impact + SQLite back-compat:** these three methods gain an optional
+`dataset: str | None = None` parameter.
+- Postgres: uses it as the first PK column (NULL → `''` sentinel).
+- SQLite: when `dataset` is None (the default), behaves exactly as today
+  (matchkey-only). Optionally, SQLite may also honor a passed `dataset` by adding
+  a `dataset` column + composite key behind a schema migration, but the MVP only
+  requires **not breaking** existing SQLite callers — the added param defaults
+  keep every current call site (`learner.py`, `corrections.py`, CLI, TUI, MCP)
+  working unchanged.
+- `MemoryLearner.learn()` (which calls `save_adjustment`) passes the `dataset`
+  it learned over when one is in scope; today it learns per-matchkey, so it
+  threads the store's active dataset through. Confirm the learner's call sites in
+  implementation and thread `dataset` where the store is Postgres.
+
+### 5. Table coexistence
+
+golden-truth's Postgres holds app tables too. Add an optional
+`table_prefix: str = ""` (or `schema`) to `MemoryStore` so the Postgres tables
+can be namespaced (e.g. `goldenmatch_corrections`, `goldenmatch_adjustments`).
+Default empty = bare `corrections`/`adjustments` (matches SQLite). golden-truth
+sets a prefix/schema. DDL + every query interpolate the (validated,
+regex-guarded) prefix — never user input.
+
+### 6. Concurrency
+
+Postgres handles concurrent writers natively; no WAL step. The atomic
+DELETE+INSERT becomes a single `INSERT … ON CONFLICT DO UPDATE`, which is atomic
+and race-safe.
+
+## Contract (consumed by the golden-truth integration spec)
+
+- `MemoryStore(backend="postgres", connection="postgresql://…", table_prefix="goldenmatch_")`.
+- `MemoryConfig(enabled=True, backend="postgres", connection=<dsn>, dataset=<tenant/org id>, trust=…, learning=…, reanchor=True)` → `dedupe_df` applies + persists corrections in Postgres, isolated by `dataset`.
+- Corrections isolated by `dataset` (existing column); adjustments isolated by `(dataset, matchkey_name)` (new).
+- Same `Correction` / `LearnedAdjustment` shapes as SQLite; `apply_corrections` /
+  `MemoryLearner` unchanged (they take a store object, dialect-agnostic).
+
+## Testing
+
+DB-gated (skip cleanly when no test Postgres DSN is set, mirroring the repo's
+DB-gated test convention). Use a `GOLDENMATCH_TEST_PG_DSN` env var (or a
+testcontainer if the suite already has one).
+
+- **Parity:** the same `Correction` written + read back is byte-identical across
+  sqlite and postgres (`add_correction` → `get_pair_correction`,
+  `get_corrections`, `count_corrections`, `corrections_since`).
+- **Trust-wins upsert:** a lower-trust correction does not overwrite a
+  higher-trust one; equal trust = latest wins — same as SQLite.
+- **NULL-dataset upsert:** two writes to the same pair with `dataset=None` upsert
+  (don't duplicate) via the COALESCE sentinel.
+- **Adjustments tenant-isolation:** `save_adjustment(dataset="A")` and
+  `save_adjustment(dataset="B")` for the same matchkey coexist; `get_adjustment`
+  returns the right one per dataset; neither overwrites the other.
+- **SQLite back-compat:** every existing SQLite test still passes with the new
+  optional `dataset` param defaulted (no behavioral change).
+- **Missing extra:** `backend="postgres"` without `psycopg` raises the actionable
+  ImportError.
+- **`learn()` round-trip on Postgres:** ≥`threshold_min` corrections for a
+  matchkey in dataset A produce a `LearnedAdjustment` stored under `(A, matchkey)`.
+
+## Out of scope (this spec)
+
+- golden-truth's correction-capture UI, `config.memory` wiring, and Postgres
+  table provisioning — separate spec.
+- Adding a `dataset` column to the SQLite `adjustments` schema (only the
+  non-breaking optional param is required here).
+- Connection pooling / an injected-connection constructor — MVP takes a DSN and
+  owns one connection (a pool/injected-conn overload can follow).

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -901,6 +901,7 @@ class MemoryConfig(BaseModel):
     learning: LearningConfig = Field(default_factory=LearningConfig)
     reanchor: bool = True
     dataset: str | None = None
+    table_prefix: str = ""
 
     @field_validator("dataset")
     @classmethod
@@ -911,6 +912,14 @@ class MemoryConfig(BaseModel):
         if not stripped:
             raise ValueError("MemoryConfig.dataset must be non-empty (or None)")
         return stripped
+
+    @field_validator("table_prefix")
+    @classmethod
+    def _validate_table_prefix(cls, v: str) -> str:
+        import re
+        if v and not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", v):
+            raise ValueError("table_prefix must match ^[A-Za-z_][A-Za-z0-9_]*$")
+        return v
 
 
 # ── MatchSettingsConfig ─────────────────────────────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/core/memory/learner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/learner.py
@@ -18,22 +18,24 @@ class MemoryLearner:
         store: MemoryStore,
         threshold_min: int = 10,
         weights_min: int = 50,
+        dataset: str | None = None,
     ) -> None:
         self._store = store
         self._threshold_min = threshold_min
         self._weights_min = weights_min
+        self._dataset = dataset
 
     def has_new_corrections(self) -> bool:
         """True if corrections exist since the last learning pass."""
         last = self._store.last_learn_time()
         if last is None:
-            return self._store.count_corrections() > 0
-        since = self._store.corrections_since(last)
+            return self._store.count_corrections(dataset=self._dataset) > 0
+        since = self._store.corrections_since(last, dataset=self._dataset)
         return len(since) > 0
 
     def learn(self, matchkey_name: str | None = None) -> list[LearnedAdjustment]:
         """Run learning pass. Returns list of learned adjustments."""
-        all_corrections = self._store.get_corrections()
+        all_corrections = self._store.get_corrections(dataset=self._dataset)
         if not all_corrections:
             return []
 
@@ -69,8 +71,9 @@ class MemoryLearner:
                 field_weights=field_weights,
                 sample_size=len(corrections),
                 learned_at=datetime.now(),
+                dataset=self._dataset,
             )
-            self._store.save_adjustment(adj)
+            self._store.save_adjustment(adj, dataset=self._dataset)
             results.append(adj)
 
         return results

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -259,6 +259,16 @@ class MemoryStore:
     def __exit__(self, *exc: Any) -> None:
         self.close()
 
+    def _ph(self, sql: str) -> str:
+        """Translate '?' placeholders to the backend's style."""
+        return sql if self._backend == "sqlite" else sql.replace("?", "%s")
+
+    def _execute(self, sql: str, params: tuple = ()):  # returns a cursor/iterable of rows
+        return self._conn.execute(self._ph(sql), params)
+
+    def _commit(self):
+        self._conn.commit()
+
     def add_correction(self, correction: Correction) -> None:
         """Upsert a correction. Higher trust wins; same trust = latest wins.
 
@@ -283,30 +293,30 @@ class MemoryStore:
                 return
 
         # Atomic upsert: DELETE + INSERT in one transaction
-        with self._conn:
-            self._conn.execute(
-                "DELETE FROM corrections WHERE id_a = ? AND id_b = ? AND dataset IS ?",
-                (ca, cb, correction.dataset),
-            )
-            self._conn.execute(
-                "INSERT INTO corrections "
-                "(id, id_a, id_b, decision, source, trust, field_hash, record_hash, "
-                "original_score, matchkey_name, reason, dataset, created_at, "
-                "field_name, original_value, corrected_value, "
-                "cluster_score, cluster_outcome) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    correction.id, ca, cb,
-                    correction.decision, correction.source, correction.trust,
-                    correction.field_hash, correction.record_hash,
-                    correction.original_score, correction.matchkey_name,
-                    correction.reason, correction.dataset,
-                    correction.created_at.isoformat(),
-                    correction.field_name, correction.original_value,
-                    correction.corrected_value,
-                    correction.cluster_score, correction.cluster_outcome,
-                ),
-            )
+        self._execute(
+            "DELETE FROM corrections WHERE id_a = ? AND id_b = ? AND dataset IS ?",
+            (ca, cb, correction.dataset),
+        )
+        self._execute(
+            "INSERT INTO corrections "
+            "(id, id_a, id_b, decision, source, trust, field_hash, record_hash, "
+            "original_score, matchkey_name, reason, dataset, created_at, "
+            "field_name, original_value, corrected_value, "
+            "cluster_score, cluster_outcome) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                correction.id, ca, cb,
+                correction.decision, correction.source, correction.trust,
+                correction.field_hash, correction.record_hash,
+                correction.original_score, correction.matchkey_name,
+                correction.reason, correction.dataset,
+                correction.created_at.isoformat(),
+                correction.field_name, correction.original_value,
+                correction.corrected_value,
+                correction.cluster_score, correction.cluster_outcome,
+            ),
+        )
+        self._commit()
         log.debug("Correction stored: (%d, %d) %s [%s]", ca, cb,
                    correction.decision, correction.source)
 
@@ -377,12 +387,12 @@ class MemoryStore:
     ) -> Correction | None:
         ca, cb = _canon_pair(id_a, id_b)
         if dataset is not None:
-            row = self._conn.execute(
+            row = self._execute(
                 "SELECT * FROM corrections WHERE id_a = ? AND id_b = ? AND dataset = ?",
                 (ca, cb, dataset),
             ).fetchone()
         else:
-            row = self._conn.execute(
+            row = self._execute(
                 "SELECT * FROM corrections WHERE id_a = ? AND id_b = ? AND dataset IS NULL",
                 (ca, cb),
             ).fetchone()
@@ -403,36 +413,36 @@ class MemoryStore:
 
     def get_corrections(self, dataset: str | None = None) -> list[Correction]:
         if dataset is not None:
-            rows = self._conn.execute(
+            rows = self._execute(
                 "SELECT * FROM corrections WHERE dataset = ? ORDER BY created_at",
                 (dataset,),
             ).fetchall()
         else:
-            rows = self._conn.execute(
+            rows = self._execute(
                 "SELECT * FROM corrections ORDER BY created_at",
             ).fetchall()
         return [self._row_to_correction(r) for r in rows]
 
     def count_corrections(self, dataset: str | None = None) -> int:
         if dataset is not None:
-            row = self._conn.execute(
+            row = self._execute(
                 "SELECT COUNT(*) FROM corrections WHERE dataset = ?", (dataset,),
             ).fetchone()
         else:
-            row = self._conn.execute("SELECT COUNT(*) FROM corrections").fetchone()
+            row = self._execute("SELECT COUNT(*) FROM corrections").fetchone()
         return row[0] if row else 0
 
     def corrections_since(
         self, since: datetime, dataset: str | None = None,
     ) -> list[Correction]:
         if dataset is not None:
-            rows = self._conn.execute(
+            rows = self._execute(
                 "SELECT * FROM corrections WHERE created_at > ? AND dataset = ? "
                 "ORDER BY created_at",
                 (since.isoformat(), dataset),
             ).fetchall()
         else:
-            rows = self._conn.execute(
+            rows = self._execute(
                 "SELECT * FROM corrections WHERE created_at > ? ORDER BY created_at",
                 (since.isoformat(),),
             ).fetchall()
@@ -450,14 +460,14 @@ class MemoryStore:
         if adj.dataset is None and dataset is not None:
             adj.dataset = dataset
         weights_json = json.dumps(adj.field_weights) if adj.field_weights else None
-        with self._conn:
-            self._conn.execute(
-                "INSERT OR REPLACE INTO adjustments "
-                "(matchkey_name, threshold, field_weights, sample_size, learned_at) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (adj.matchkey_name, adj.threshold, weights_json,
-                 adj.sample_size, adj.learned_at.isoformat()),
-            )
+        self._execute(
+            "INSERT OR REPLACE INTO adjustments "
+            "(matchkey_name, threshold, field_weights, sample_size, learned_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (adj.matchkey_name, adj.threshold, weights_json,
+             adj.sample_size, adj.learned_at.isoformat()),
+        )
+        self._commit()
         log.debug("Adjustment saved: %s threshold=%.3f samples=%d",
                    adj.matchkey_name, adj.threshold or 0, adj.sample_size)
 
@@ -467,7 +477,7 @@ class MemoryStore:
         """SQLite ignores `dataset` for lookup (matchkey-only); the passed
         value is used to tag the returned adjustment for caller consistency.
         """
-        row = self._conn.execute(
+        row = self._execute(
             "SELECT * FROM adjustments WHERE matchkey_name = ?",
             (matchkey_name,),
         ).fetchone()
@@ -480,11 +490,11 @@ class MemoryStore:
 
     def get_all_adjustments(self, dataset: str | None = None) -> list[LearnedAdjustment]:
         """SQLite ignores `dataset` and returns all rows (no dataset column)."""
-        rows = self._conn.execute("SELECT * FROM adjustments").fetchall()
+        rows = self._execute("SELECT * FROM adjustments").fetchall()
         return [self._row_to_adjustment(r) for r in rows]
 
     def last_learn_time(self) -> datetime | None:
-        row = self._conn.execute(
+        row = self._execute(
             "SELECT MAX(learned_at) FROM adjustments",
         ).fetchone()
         if row and row[0]:

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -119,6 +119,7 @@ class LearnedAdjustment:
     field_weights: dict[str, float] | None = None
     sample_size: int = 0
     learned_at: datetime = field(default_factory=datetime.now)
+    dataset: str | None = None
 
 
 def _canon_pair(id_a: int, id_b: int) -> tuple[int, int]:
@@ -467,7 +468,8 @@ class MemoryStore:
             original_score=row["original_score"],
             matchkey_name=row["matchkey_name"],
             reason=row["reason"], dataset=row["dataset"],
-            created_at=datetime.fromisoformat(row["created_at"]),
+            created_at=(row["created_at"] if isinstance(row["created_at"], datetime)
+                        else datetime.fromisoformat(row["created_at"])),
             field_name=row["field_name"] if "field_name" in keys else None,
             original_value=row["original_value"] if "original_value" in keys else None,
             corrected_value=row["corrected_value"] if "corrected_value" in keys else None,
@@ -479,10 +481,13 @@ class MemoryStore:
     @staticmethod
     def _row_to_adjustment(row: Any) -> LearnedAdjustment:
         weights = json.loads(row["field_weights"]) if row["field_weights"] else None
+        keys = row.keys() if hasattr(row, "keys") else ()
         return LearnedAdjustment(
             matchkey_name=row["matchkey_name"],
             threshold=row["threshold"],
             field_weights=weights,
             sample_size=row["sample_size"],
-            learned_at=datetime.fromisoformat(row["learned_at"]),
+            learned_at=(row["learned_at"] if isinstance(row["learned_at"], datetime)
+                        else datetime.fromisoformat(row["learned_at"])),
+            dataset=row["dataset"] if "dataset" in keys else None,
         )

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -211,14 +211,18 @@ class MemoryStore:
             self._migrate_cluster_decision_columns()
             log.debug("MemoryStore opened: %s (journal_mode=WAL)", path)
         elif backend == "postgres":
+            # Validate the DSN BEFORE importing the optional dep: a missing DSN
+            # is a usage error regardless of whether psycopg is installed (and
+            # keeps `test_postgres_requires_connection` a ValueError in CI lanes
+            # that don't install the `postgres` extra).
+            if not connection:
+                raise ValueError("backend='postgres' requires a connection DSN")
             try:
                 import psycopg  # noqa: PLC0415 — lazy, optional extra
             except ImportError as e:
                 raise ImportError(
                     "backend='postgres' requires: pip install goldenmatch[postgres]"
                 ) from e
-            if not connection:
-                raise ValueError("backend='postgres' requires a connection DSN")
             # autocommit=True: the store's writes are single-statement upserts
             # (atomic on their own) and it is a long-lived connection (golden-truth
             # holds one per request/worker). Without it, read methods open a

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -413,14 +413,33 @@ class MemoryStore:
             row = self._conn.execute("SELECT COUNT(*) FROM corrections").fetchone()
         return row[0] if row else 0
 
-    def corrections_since(self, since: datetime) -> list[Correction]:
-        rows = self._conn.execute(
-            "SELECT * FROM corrections WHERE created_at > ? ORDER BY created_at",
-            (since.isoformat(),),
-        ).fetchall()
+    def corrections_since(
+        self, since: datetime, dataset: str | None = None,
+    ) -> list[Correction]:
+        if dataset is not None:
+            rows = self._conn.execute(
+                "SELECT * FROM corrections WHERE created_at > ? AND dataset = ? "
+                "ORDER BY created_at",
+                (since.isoformat(), dataset),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM corrections WHERE created_at > ? ORDER BY created_at",
+                (since.isoformat(),),
+            ).fetchall()
         return [self._row_to_correction(r) for r in rows]
 
-    def save_adjustment(self, adj: LearnedAdjustment) -> None:
+    def save_adjustment(self, adj: LearnedAdjustment, dataset: str | None = None) -> None:
+        """Persist a learned adjustment.
+
+        SQLite keeps the original `INSERT OR REPLACE` keyed by
+        `matchkey_name` (its schema has no `dataset` column) --
+        `dataset` is accepted + ignored here (honored on Postgres,
+        Task 6). If `adj.dataset` is unset and `dataset` was passed,
+        tag `adj.dataset` so the returned object stays consistent.
+        """
+        if adj.dataset is None and dataset is not None:
+            adj.dataset = dataset
         weights_json = json.dumps(adj.field_weights) if adj.field_weights else None
         with self._conn:
             self._conn.execute(
@@ -433,16 +452,25 @@ class MemoryStore:
         log.debug("Adjustment saved: %s threshold=%.3f samples=%d",
                    adj.matchkey_name, adj.threshold or 0, adj.sample_size)
 
-    def get_adjustment(self, matchkey_name: str) -> LearnedAdjustment | None:
+    def get_adjustment(
+        self, matchkey_name: str, dataset: str | None = None,
+    ) -> LearnedAdjustment | None:
+        """SQLite ignores `dataset` for lookup (matchkey-only); the passed
+        value is used to tag the returned adjustment for caller consistency.
+        """
         row = self._conn.execute(
             "SELECT * FROM adjustments WHERE matchkey_name = ?",
             (matchkey_name,),
         ).fetchone()
         if not row:
             return None
-        return self._row_to_adjustment(row)
+        adj = self._row_to_adjustment(row)
+        if adj.dataset is None and dataset is not None:
+            adj.dataset = dataset
+        return adj
 
-    def get_all_adjustments(self) -> list[LearnedAdjustment]:
+    def get_all_adjustments(self, dataset: str | None = None) -> list[LearnedAdjustment]:
+        """SQLite ignores `dataset` and returns all rows (no dataset column)."""
         rows = self._conn.execute("SELECT * FROM adjustments").fetchall()
         return [self._row_to_adjustment(r) for r in rows]
 

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -175,14 +175,23 @@ class MemoryStore:
                 f"table_prefix must match ^[A-Za-z_][A-Za-z0-9_]*$; got {table_prefix!r}",
             )
         self._backend = backend
-        # Accepted for both backends (regex-guarded above); unused by SQLite
-        # today -- honored by the Postgres branch (Task 6).
         self._table_prefix = table_prefix
-        # Table names: bare for sqlite (table_prefix="" there), prefixed for
-        # postgres. Prefix is validated above against ^[A-Za-z_][A-Za-z0-9_]*$,
-        # so f-string interpolation into SQL below is safe (never raw user input).
-        self._corrections = f"{table_prefix}corrections"
-        self._adjustments = f"{table_prefix}adjustments"
+        # Table names drive the f-stringed SQL in every query method, so they
+        # MUST agree with the DDL that actually created the tables:
+        #   - SQLite creates BARE `corrections`/`adjustments` (the module-level
+        #     `_SCHEMA` + the `_migrate_*` helpers hardcode bare names), and per
+        #     spec SQLite ignores `table_prefix` — so use bare names here too.
+        #     (Applying the prefix on SQLite would query `<prefix>corrections`
+        #     while the DDL made `corrections` → OperationalError at write time.)
+        #   - Postgres applies the validated prefix so its tables can coexist in
+        #     a shared multi-tenant DB.
+        # The prefix is regex-validated above, so interpolation is safe here.
+        if backend == "postgres":
+            self._corrections = f"{table_prefix}corrections"
+            self._adjustments = f"{table_prefix}adjustments"
+        else:
+            self._corrections = "corrections"
+            self._adjustments = "adjustments"
         if backend == "sqlite":
             import os
             import sqlite3  # noqa: PLC0415 -- lazy, see #364
@@ -210,7 +219,13 @@ class MemoryStore:
                 ) from e
             if not connection:
                 raise ValueError("backend='postgres' requires a connection DSN")
-            self._conn = psycopg.connect(connection, row_factory=psycopg.rows.dict_row)
+            # autocommit=True: the store's writes are single-statement upserts
+            # (atomic on their own) and it is a long-lived connection (golden-truth
+            # holds one per request/worker). Without it, read methods open a
+            # transaction that lingers idle-in-transaction until the next write.
+            self._conn = psycopg.connect(
+                connection, autocommit=True, row_factory=psycopg.rows.dict_row,
+            )
             for stmt in self._pg_schema():   # split DDL; execute individually
                 self._conn.execute(stmt)
             self._conn.commit()

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -167,8 +167,17 @@ class MemoryStore:
         backend: str = "sqlite",
         path: str = ".goldenmatch/memory.db",
         connection: str | None = None,
+        table_prefix: str = "",
     ) -> None:
+        import re
+        if table_prefix and not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", table_prefix):
+            raise ValueError(
+                f"table_prefix must match ^[A-Za-z_][A-Za-z0-9_]*$; got {table_prefix!r}",
+            )
         self._backend = backend
+        # Accepted for both backends (regex-guarded above); unused by SQLite
+        # today -- honored by the Postgres branch (Task 6).
+        self._table_prefix = table_prefix
         if backend == "sqlite":
             import os
             import sqlite3  # noqa: PLC0415 -- lazy, see #364

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -178,6 +178,11 @@ class MemoryStore:
         # Accepted for both backends (regex-guarded above); unused by SQLite
         # today -- honored by the Postgres branch (Task 6).
         self._table_prefix = table_prefix
+        # Table names: bare for sqlite (table_prefix="" there), prefixed for
+        # postgres. Prefix is validated above against ^[A-Za-z_][A-Za-z0-9_]*$,
+        # so f-string interpolation into SQL below is safe (never raw user input).
+        self._corrections = f"{table_prefix}corrections"
+        self._adjustments = f"{table_prefix}adjustments"
         if backend == "sqlite":
             import os
             import sqlite3  # noqa: PLC0415 -- lazy, see #364
@@ -196,8 +201,63 @@ class MemoryStore:
             self._migrate_field_correction_columns()
             self._migrate_cluster_decision_columns()
             log.debug("MemoryStore opened: %s (journal_mode=WAL)", path)
+        elif backend == "postgres":
+            try:
+                import psycopg  # noqa: PLC0415 — lazy, optional extra
+            except ImportError as e:
+                raise ImportError(
+                    "backend='postgres' requires: pip install goldenmatch[postgres]"
+                ) from e
+            if not connection:
+                raise ValueError("backend='postgres' requires a connection DSN")
+            self._conn = psycopg.connect(connection, row_factory=psycopg.rows.dict_row)
+            for stmt in self._pg_schema():   # split DDL; execute individually
+                self._conn.execute(stmt)
+            self._conn.commit()
+            log.debug("MemoryStore opened: postgres (table_prefix=%r)", table_prefix)
         else:
             raise NotImplementedError(f"Backend '{backend}' not yet implemented")
+
+    def _pg_schema(self) -> list[str]:
+        """DDL statements for the postgres backend, executed individually.
+
+        Table names use ``self._corrections``/``self._adjustments`` (the
+        validated, prefix-applied names set in ``__init__``).
+        """
+        return [
+            f"""
+            CREATE TABLE IF NOT EXISTS {self._corrections} (
+                id TEXT PRIMARY KEY,
+                id_a BIGINT, id_b BIGINT,
+                decision TEXT, source TEXT, trust DOUBLE PRECISION,
+                field_hash TEXT, record_hash TEXT,
+                original_score DOUBLE PRECISION,
+                matchkey_name TEXT,
+                reason TEXT, dataset TEXT,
+                created_at TIMESTAMPTZ DEFAULT now(),
+                field_name TEXT,
+                original_value TEXT,
+                corrected_value TEXT,
+                cluster_score DOUBLE PRECISION,
+                cluster_outcome TEXT
+            )
+            """,
+            f"""
+            CREATE UNIQUE INDEX IF NOT EXISTS {self._table_prefix}corrections_pair
+            ON {self._corrections} (id_a, id_b, COALESCE(dataset, ''))
+            """,
+            f"""
+            CREATE TABLE IF NOT EXISTS {self._adjustments} (
+                dataset TEXT NOT NULL DEFAULT '',
+                matchkey_name TEXT,
+                threshold DOUBLE PRECISION,
+                field_weights TEXT,
+                sample_size INTEGER,
+                learned_at TIMESTAMPTZ,
+                PRIMARY KEY (dataset, matchkey_name)
+            )
+            """,
+        ]
 
     def _migrate_field_correction_columns(self) -> None:
         """#437: add field_name/original_value/corrected_value to
@@ -285,6 +345,47 @@ class MemoryStore:
             ca, cb = correction.id_a, correction.id_b
         else:
             ca, cb = _canon_pair(correction.id_a, correction.id_b)
+
+        if self._backend == "postgres":
+            # Trust-wins upsert done atomically in one statement -- no
+            # separate read-then-DELETE+INSERT needed (that pattern is
+            # sqlite-only; see below).
+            self._execute(
+                f"INSERT INTO {self._corrections} "
+                "(id, id_a, id_b, decision, source, trust, field_hash, record_hash, "
+                "original_score, matchkey_name, reason, dataset, created_at, "
+                "field_name, original_value, corrected_value, "
+                "cluster_score, cluster_outcome) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (id_a, id_b, COALESCE(dataset, '')) DO UPDATE SET "
+                "id=EXCLUDED.id, decision=EXCLUDED.decision, source=EXCLUDED.source, "
+                "trust=EXCLUDED.trust, field_hash=EXCLUDED.field_hash, "
+                "record_hash=EXCLUDED.record_hash, "
+                "original_score=EXCLUDED.original_score, "
+                "matchkey_name=EXCLUDED.matchkey_name, reason=EXCLUDED.reason, "
+                "created_at=EXCLUDED.created_at, field_name=EXCLUDED.field_name, "
+                "original_value=EXCLUDED.original_value, "
+                "corrected_value=EXCLUDED.corrected_value, "
+                "cluster_score=EXCLUDED.cluster_score, "
+                "cluster_outcome=EXCLUDED.cluster_outcome "
+                f"WHERE EXCLUDED.trust >= {self._corrections}.trust",
+                (
+                    correction.id, ca, cb,
+                    correction.decision, correction.source, correction.trust,
+                    correction.field_hash, correction.record_hash,
+                    correction.original_score, correction.matchkey_name,
+                    correction.reason, correction.dataset,
+                    correction.created_at,
+                    correction.field_name, correction.original_value,
+                    correction.corrected_value,
+                    correction.cluster_score, correction.cluster_outcome,
+                ),
+            )
+            self._commit()
+            log.debug("Correction stored: (%d, %d) %s [%s]", ca, cb,
+                       correction.decision, correction.source)
+            return
+
         existing = self.get_pair_correction(ca, cb, correction.dataset)
 
         if existing is not None:
@@ -294,11 +395,11 @@ class MemoryStore:
 
         # Atomic upsert: DELETE + INSERT in one transaction
         self._execute(
-            "DELETE FROM corrections WHERE id_a = ? AND id_b = ? AND dataset IS ?",
+            f"DELETE FROM {self._corrections} WHERE id_a = ? AND id_b = ? AND dataset IS ?",
             (ca, cb, correction.dataset),
         )
         self._execute(
-            "INSERT INTO corrections "
+            f"INSERT INTO {self._corrections} "
             "(id, id_a, id_b, decision, source, trust, field_hash, record_hash, "
             "original_score, matchkey_name, reason, dataset, created_at, "
             "field_name, original_value, corrected_value, "
@@ -382,18 +483,28 @@ class MemoryStore:
         self.add_correction(correction)
         return correction
 
+    def _null_dataset_pred(self) -> str:
+        """Predicate matching a NULL/absent `dataset`, per backend.
+
+        SQLite: `dataset IS NULL`. Postgres: `COALESCE(dataset, '') = ''`
+        (the unique index is defined on `COALESCE(dataset, '')`, so reads
+        against a NULL dataset must match the same way).
+        """
+        return "dataset IS NULL" if self._backend == "sqlite" else "COALESCE(dataset, '') = ''"
+
     def get_pair_correction(
         self, id_a: int, id_b: int, dataset: str | None = None,
     ) -> Correction | None:
         ca, cb = _canon_pair(id_a, id_b)
         if dataset is not None:
             row = self._execute(
-                "SELECT * FROM corrections WHERE id_a = ? AND id_b = ? AND dataset = ?",
+                f"SELECT * FROM {self._corrections} WHERE id_a = ? AND id_b = ? AND dataset = ?",
                 (ca, cb, dataset),
             ).fetchone()
         else:
             row = self._execute(
-                "SELECT * FROM corrections WHERE id_a = ? AND id_b = ? AND dataset IS NULL",
+                f"SELECT * FROM {self._corrections} WHERE id_a = ? AND id_b = ? "
+                f"AND {self._null_dataset_pred()}",
                 (ca, cb),
             ).fetchone()
         return self._row_to_correction(row) if row else None
@@ -414,37 +525,43 @@ class MemoryStore:
     def get_corrections(self, dataset: str | None = None) -> list[Correction]:
         if dataset is not None:
             rows = self._execute(
-                "SELECT * FROM corrections WHERE dataset = ? ORDER BY created_at",
+                f"SELECT * FROM {self._corrections} WHERE dataset = ? ORDER BY created_at",
                 (dataset,),
             ).fetchall()
         else:
             rows = self._execute(
-                "SELECT * FROM corrections ORDER BY created_at",
+                f"SELECT * FROM {self._corrections} ORDER BY created_at",
             ).fetchall()
         return [self._row_to_correction(r) for r in rows]
 
     def count_corrections(self, dataset: str | None = None) -> int:
         if dataset is not None:
             row = self._execute(
-                "SELECT COUNT(*) FROM corrections WHERE dataset = ?", (dataset,),
+                f"SELECT COUNT(*) AS cnt FROM {self._corrections} WHERE dataset = ?",
+                (dataset,),
             ).fetchone()
         else:
-            row = self._execute("SELECT COUNT(*) FROM corrections").fetchone()
-        return row[0] if row else 0
+            row = self._execute(
+                f"SELECT COUNT(*) AS cnt FROM {self._corrections}",
+            ).fetchone()
+        if not row:
+            return 0
+        return row["cnt"] if self._backend == "postgres" else row[0]
 
     def corrections_since(
         self, since: datetime, dataset: str | None = None,
     ) -> list[Correction]:
+        since_val = since if self._backend == "postgres" else since.isoformat()
         if dataset is not None:
             rows = self._execute(
-                "SELECT * FROM corrections WHERE created_at > ? AND dataset = ? "
+                f"SELECT * FROM {self._corrections} WHERE created_at > ? AND dataset = ? "
                 "ORDER BY created_at",
-                (since.isoformat(), dataset),
+                (since_val, dataset),
             ).fetchall()
         else:
             rows = self._execute(
-                "SELECT * FROM corrections WHERE created_at > ? ORDER BY created_at",
-                (since.isoformat(),),
+                f"SELECT * FROM {self._corrections} WHERE created_at > ? ORDER BY created_at",
+                (since_val,),
             ).fetchall()
         return [self._row_to_correction(r) for r in rows]
 
@@ -460,13 +577,26 @@ class MemoryStore:
         if adj.dataset is None and dataset is not None:
             adj.dataset = dataset
         weights_json = json.dumps(adj.field_weights) if adj.field_weights else None
-        self._execute(
-            "INSERT OR REPLACE INTO adjustments "
-            "(matchkey_name, threshold, field_weights, sample_size, learned_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (adj.matchkey_name, adj.threshold, weights_json,
-             adj.sample_size, adj.learned_at.isoformat()),
-        )
+
+        if self._backend == "postgres":
+            self._execute(
+                f"INSERT INTO {self._adjustments} "
+                "(dataset, matchkey_name, threshold, field_weights, sample_size, learned_at) "
+                "VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (dataset, matchkey_name) DO UPDATE SET "
+                "threshold=EXCLUDED.threshold, field_weights=EXCLUDED.field_weights, "
+                "sample_size=EXCLUDED.sample_size, learned_at=EXCLUDED.learned_at",
+                (adj.dataset or "", adj.matchkey_name, adj.threshold, weights_json,
+                 adj.sample_size, adj.learned_at),
+            )
+        else:
+            self._execute(
+                f"INSERT OR REPLACE INTO {self._adjustments} "
+                "(matchkey_name, threshold, field_weights, sample_size, learned_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (adj.matchkey_name, adj.threshold, weights_json,
+                 adj.sample_size, adj.learned_at.isoformat()),
+            )
         self._commit()
         log.debug("Adjustment saved: %s threshold=%.3f samples=%d",
                    adj.matchkey_name, adj.threshold or 0, adj.sample_size)
@@ -476,9 +606,17 @@ class MemoryStore:
     ) -> LearnedAdjustment | None:
         """SQLite ignores `dataset` for lookup (matchkey-only); the passed
         value is used to tag the returned adjustment for caller consistency.
+        Postgres filters by `dataset` (real tenant isolation, dataset or '').
         """
+        if self._backend == "postgres":
+            row = self._execute(
+                f"SELECT * FROM {self._adjustments} WHERE matchkey_name = ? AND dataset = ?",
+                (matchkey_name, dataset or ""),
+            ).fetchone()
+            return self._row_to_adjustment(row) if row else None
+
         row = self._execute(
-            "SELECT * FROM adjustments WHERE matchkey_name = ?",
+            f"SELECT * FROM {self._adjustments} WHERE matchkey_name = ?",
             (matchkey_name,),
         ).fetchone()
         if not row:
@@ -489,17 +627,33 @@ class MemoryStore:
         return adj
 
     def get_all_adjustments(self, dataset: str | None = None) -> list[LearnedAdjustment]:
-        """SQLite ignores `dataset` and returns all rows (no dataset column)."""
-        rows = self._execute("SELECT * FROM adjustments").fetchall()
+        """SQLite ignores `dataset` and returns all rows (no dataset column).
+        Postgres filters by `dataset` when given (dataset or ''), else
+        returns all rows.
+        """
+        if self._backend == "postgres":
+            if dataset is not None:
+                rows = self._execute(
+                    f"SELECT * FROM {self._adjustments} WHERE dataset = ?",
+                    (dataset or "",),
+                ).fetchall()
+            else:
+                rows = self._execute(f"SELECT * FROM {self._adjustments}").fetchall()
+            return [self._row_to_adjustment(r) for r in rows]
+
+        rows = self._execute(f"SELECT * FROM {self._adjustments}").fetchall()
         return [self._row_to_adjustment(r) for r in rows]
 
     def last_learn_time(self) -> datetime | None:
         row = self._execute(
-            "SELECT MAX(learned_at) FROM adjustments",
+            f"SELECT MAX(learned_at) AS max_learned_at FROM {self._adjustments}",
         ).fetchone()
-        if row and row[0]:
-            return datetime.fromisoformat(row[0])
-        return None
+        if not row:
+            return None
+        value = row["max_learned_at"] if self._backend == "postgres" else row[0]
+        if not value:
+            return None
+        return value if isinstance(value, datetime) else datetime.fromisoformat(value)
 
     @staticmethod
     def _row_to_correction(row: Any) -> Correction:

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -300,6 +300,7 @@ def _open_memory_store(config: GoldenMatchConfig):
             backend=config.memory.backend,
             path=config.memory.path,
             connection=config.memory.connection,
+            table_prefix=config.memory.table_prefix,
         )
     except Exception as e:
         logger.warning("Memory store init failed, continuing without memory: %s", e)
@@ -520,6 +521,7 @@ def _apply_memory_pre(memory_store: Any, config: GoldenMatchConfig, matchkeys: l
             memory_store,
             threshold_min=config.memory.learning.threshold_min_corrections,
             weights_min=config.memory.learning.weights_min_corrections,
+            dataset=config.memory.dataset,
         )
         if not learner.has_new_corrections():
             return

--- a/packages/python/goldenmatch/tests/test_corrections.py
+++ b/packages/python/goldenmatch/tests/test_corrections.py
@@ -165,3 +165,59 @@ class TestCorrectionStatsInvariant:
         """Synthetic / unset construction should not trip the invariant."""
         stats = CorrectionStats(applied=10, total_pairs=0)
         assert stats.validate() is True
+
+
+# ── Postgres MemoryStore backend: Task 1 -- LearnedAdjustment.dataset ────────
+
+
+def test_learned_adjustment_has_dataset_field():
+    from goldenmatch.core.memory.store import LearnedAdjustment
+
+    adj = LearnedAdjustment(matchkey_name="mk", threshold=0.9)
+    assert adj.dataset is None
+    adj2 = LearnedAdjustment(matchkey_name="mk", threshold=0.9, dataset="org_1")
+    assert adj2.dataset == "org_1"
+
+
+def test_correction_roundtrip_created_at_parseable(store):
+    """Guards the Task 1 timestamp-guard refactor on `_row_to_correction`."""
+    _make_correction(store, 1, 2, "reject")
+    got = store.get_pair_correction(1, 2, dataset="test")
+    assert got is not None
+    assert isinstance(got.created_at, datetime)
+
+
+# ── Postgres MemoryStore backend: Task 2 -- dataset params (sqlite back-compat) ──
+
+
+def test_corrections_since_dataset_filter(tmp_path):
+    from datetime import timedelta
+
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+
+    s = MemoryStore(path=str(tmp_path / "m.db"))
+    old = datetime.now() - timedelta(hours=1)
+
+    def mk(a, b, ds):
+        return Correction(
+            id=f"{a}-{b}-{ds}", id_a=a, id_b=b, decision="reject",
+            source="steward", trust=1.0, field_hash="", record_hash="",
+            original_score=0.5, dataset=ds,
+        )
+
+    s.add_correction(mk(1, 2, "A"))
+    s.add_correction(mk(3, 4, "B"))
+    assert len(s.corrections_since(old, dataset="A")) == 1
+    assert len(s.corrections_since(old)) == 2  # back-compat: unfiltered
+
+
+def test_adjustment_roundtrip_ignores_dataset_on_sqlite(tmp_path):
+    from goldenmatch.core.memory.store import LearnedAdjustment, MemoryStore
+
+    s = MemoryStore(path=str(tmp_path / "m.db"))
+    s.save_adjustment(
+        LearnedAdjustment("mk", threshold=0.9, sample_size=12, learned_at=datetime.now()),
+        dataset="A",
+    )
+    got = s.get_adjustment("mk", dataset="A")
+    assert got is not None and got.threshold == 0.9

--- a/packages/python/goldenmatch/tests/test_corrections.py
+++ b/packages/python/goldenmatch/tests/test_corrections.py
@@ -221,3 +221,17 @@ def test_adjustment_roundtrip_ignores_dataset_on_sqlite(tmp_path):
     )
     got = s.get_adjustment("mk", dataset="A")
     assert got is not None and got.threshold == 0.9
+
+
+def test_sqlite_ignores_table_prefix(tmp_path):
+    """SQLite creates bare tables and ignores table_prefix — a set prefix must
+    not break reads/writes (regression: prefixed query vs bare DDL)."""
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+
+    s = MemoryStore(path=str(tmp_path / "m.db"), table_prefix="goldenmatch_")
+    s.add_correction(Correction(
+        id="1-2-A", id_a=1, id_b=2, decision="reject", source="steward",
+        trust=1.0, field_hash="", record_hash="", original_score=0.5, dataset="A",
+    ))
+    assert s.count_corrections(dataset="A") == 1
+    assert s.get_pair_correction(1, 2, dataset="A") is not None

--- a/packages/python/goldenmatch/tests/test_learner.py
+++ b/packages/python/goldenmatch/tests/test_learner.py
@@ -122,3 +122,28 @@ class TestMultipleMatchkeys:
         names = {r.matchkey_name for r in result}
         assert "mk1" in names
         assert "mk2" in names
+
+
+# ── Postgres MemoryStore backend: Task 3 -- MemoryLearner dataset scoping ────
+
+
+def test_learner_scopes_to_dataset(tmp_path):
+    s = MemoryStore(path=str(tmp_path / "m.db"))
+
+    def mk(a, b, ds, dec, score):
+        return Correction(
+            id=f"{a}-{b}-{ds}", id_a=a, id_b=b, decision=dec,
+            source="steward", trust=1.0, field_hash="", record_hash="",
+            original_score=score, matchkey_name="mk", dataset=ds,
+        )
+
+    # 10 approves high, 10 rejects low in dataset A; noise in B
+    for i in range(10):
+        s.add_correction(mk(i, 100 + i, "A", "approve", 0.9))
+    for i in range(10):
+        s.add_correction(mk(200 + i, 300 + i, "A", "reject", 0.2))
+    s.add_correction(mk(999, 1000, "B", "approve", 0.1))
+    learner = MemoryLearner(s, dataset="A")
+    adjustments = learner.learn()
+    assert adjustments and adjustments[0].dataset == "A"
+    assert 0.2 <= adjustments[0].threshold <= 0.9

--- a/packages/python/goldenmatch/tests/test_memory_config.py
+++ b/packages/python/goldenmatch/tests/test_memory_config.py
@@ -1,0 +1,11 @@
+"""Tests for MemoryConfig.table_prefix (Postgres MemoryStore backend, Task 4)."""
+import pytest
+
+
+def test_memory_config_table_prefix():
+    from goldenmatch.config.schemas import MemoryConfig
+
+    assert MemoryConfig().table_prefix == ""
+    assert MemoryConfig(table_prefix="goldenmatch_").table_prefix == "goldenmatch_"
+    with pytest.raises(Exception):
+        MemoryConfig(table_prefix="bad-prefix; DROP")

--- a/packages/python/goldenmatch/tests/test_memory_store.py
+++ b/packages/python/goldenmatch/tests/test_memory_store.py
@@ -164,7 +164,15 @@ class TestPairCanonicalization:
 class TestUnsupportedBackend:
     def test_raises_not_implemented(self, tmp_path):
         import pytest
-        with pytest.raises(NotImplementedError, match="postgres"):
+        with pytest.raises(NotImplementedError, match="mysql"):
+            MemoryStore(backend="mysql", path=str(tmp_path / "x.db"))
+
+    def test_postgres_requires_connection(self, tmp_path):
+        """backend='postgres' is implemented (see test_memory_store_postgres.py)
+        but requires a connection DSN -- no DSN raises ValueError, not
+        NotImplementedError."""
+        import pytest
+        with pytest.raises(ValueError, match="connection"):
             MemoryStore(backend="postgres", path=str(tmp_path / "x.db"))
 
 

--- a/packages/python/goldenmatch/tests/test_memory_store_postgres.py
+++ b/packages/python/goldenmatch/tests/test_memory_store_postgres.py
@@ -1,0 +1,70 @@
+import pytest
+
+from tests._pg_helpers import HAS_POSTGRES, pg_url_fixture
+
+pytestmark = pytest.mark.skipif(not HAS_POSTGRES, reason="no test postgres")
+
+@pytest.fixture
+def pg():
+    # pg_url_fixture is a generator (NOT a context manager) — mirror the existing
+    # pattern in tests/test_db.py: `yield from`. The yielded holder exposes .url().
+    yield from pg_url_fixture()
+
+def _mk(a, b, ds, dec="reject", score=0.5, trust=1.0, src="steward"):
+    from goldenmatch.core.memory.store import Correction
+    return Correction(id=f"{a}-{b}-{ds}", id_a=a, id_b=b, decision=dec, source=src,
+                      trust=trust, field_hash="", record_hash="", original_score=score,
+                      matchkey_name="mk", dataset=ds)
+
+def test_pg_correction_roundtrip_and_trust_wins(pg):
+    from goldenmatch.core.memory.store import MemoryStore
+    s = MemoryStore(backend="postgres", connection=pg.url(), table_prefix="goldenmatch_")
+    s.add_correction(_mk(1, 2, "A"))
+    assert s.count_corrections(dataset="A") == 1
+    # lower-trust does not overwrite higher-trust
+    s.add_correction(_mk(1, 2, "A", dec="approve", trust=0.5, src="agent"))
+    got = s.get_pair_correction(1, 2, dataset="A")
+    assert got.decision == "reject"           # steward (1.0) kept
+    s.close()
+
+def test_pg_null_dataset_upsert(pg):
+    from goldenmatch.core.memory.store import MemoryStore
+    s = MemoryStore(backend="postgres", connection=pg.url(), table_prefix="goldenmatch_")
+    s.add_correction(_mk(1, 2, None)); s.add_correction(_mk(1, 2, None, dec="approve"))
+    assert s.count_corrections() == 1          # upsert, not duplicate
+    s.close()
+
+def test_pg_adjustments_tenant_isolation(pg):
+    from datetime import datetime
+
+    from goldenmatch.core.memory.store import LearnedAdjustment, MemoryStore
+    s = MemoryStore(backend="postgres", connection=pg.url(), table_prefix="goldenmatch_")
+    s.save_adjustment(LearnedAdjustment("mk", threshold=0.8, learned_at=datetime.now()), dataset="A")
+    s.save_adjustment(LearnedAdjustment("mk", threshold=0.6, learned_at=datetime.now()), dataset="B")
+    assert s.get_adjustment("mk", dataset="A").threshold == 0.8
+    assert s.get_adjustment("mk", dataset="B").threshold == 0.6
+    got = s.get_all_adjustments(dataset="A")
+    assert len(got) == 1 and got[0].dataset == "A"
+    s.close()
+
+def test_pg_missing_extra_message(monkeypatch):
+    # Force `import psycopg` to fail → the actionable ImportError, without a DB.
+    import sys
+    monkeypatch.setitem(sys.modules, "psycopg", None)
+    from goldenmatch.core.memory.store import MemoryStore
+    with pytest.raises(ImportError, match=r"goldenmatch\[postgres\]"):
+        MemoryStore(backend="postgres", connection="postgresql://unused")
+
+def test_pg_learn_per_dataset_isolation(pg):
+    from goldenmatch.core.memory.learner import MemoryLearner
+    from goldenmatch.core.memory.store import MemoryStore
+    s = MemoryStore(backend="postgres", connection=pg.url(), table_prefix="goldenmatch_")
+    for i in range(10): s.add_correction(_mk(i, 100+i, "A", "approve", 0.9))
+    for i in range(10): s.add_correction(_mk(200+i, 300+i, "A", "reject", 0.2))
+    for i in range(10): s.add_correction(_mk(i, 100+i, "B", "approve", 0.3))
+    for i in range(10): s.add_correction(_mk(200+i, 300+i, "B", "reject", 0.25))
+    MemoryLearner(s, dataset="A").learn()
+    MemoryLearner(s, dataset="B").learn()
+    a, b = s.get_adjustment("mk", dataset="A"), s.get_adjustment("mk", dataset="B")
+    assert a and b and a.threshold != b.threshold   # not pooled
+    s.close()


### PR DESCRIPTION
## Summary

Adds a `backend='postgres'` path to `MemoryStore` so Learning Memory (corrections + learned adjustments) can persist in a shared, multi-tenant Postgres, isolated by `dataset` — enabling stateless web backends to use Learning Memory without a per-tenant SQLite file. SQLite remains the default and is behaviorally unchanged.

`config.memory = MemoryConfig(enabled=True, backend='postgres', connection=<dsn>, dataset=<tenant>, table_prefix='goldenmatch_')` → `dedupe_df` applies + persists + learns corrections in Postgres, per-tenant.

## What changed

- **`MemoryStore`:** internal dialect seam (`_ph`/`_execute`/`_commit`) so method bodies stay shared; new `backend='postgres'` branch (lazy `psycopg` import + actionable `ImportError`, `_pg_schema` DDL, `ON CONFLICT` upserts, `COALESCE(dataset,'')` NULL handling, `autocommit=True`). Table names namespaced via a regex-guarded `table_prefix` (Postgres); SQLite keeps bare names.
- **Tenant isolation on both sides:** corrections filtered by `dataset`; `adjustments` keyed `(dataset, matchkey_name)`; **`MemoryLearner(dataset=…)`** so `learn()` never pools corrections across tenants; `_apply_memory_pre` threads `config.memory.dataset`.
- **`LearnedAdjustment.dataset`** field; dialect-safe timestamp parsing (`datetime` vs ISO string).
- **`MemoryConfig.table_prefix`** + validator; threaded through `pipeline._open_memory_store`.
- Reuses the existing `postgres` extra + `tests/_pg_helpers.py` (no `pyproject` change).

## Testing

- Full SQLite memory suite green (133 passed) — the dialect refactor is behavior-preserving; new coverage for `dataset` params, learner scoping, `table_prefix`, and a sqlite+prefix regression guard.
- Postgres backend tests (`tests/test_memory_store_postgres.py`): roundtrip + trust-wins upsert, NULL-dataset upsert, adjustments tenant-isolation, per-dataset `learn()` isolation, missing-extra ImportError.

> ⚠️ **The Postgres tests are DB-gated** (`skipif(not HAS_POSTGRES)`) and **skipped** in this local run — no `GOLDENMATCH_TEST_DATABASE_URL` was available. The Postgres path was verified by review, not by a run; **please run the suite with `GOLDENMATCH_TEST_DATABASE_URL` set in CI** to exercise it before merge.

Spec + plan: `docs/superpowers/specs/2026-07-01-postgres-memory-store-design.md`, `docs/superpowers/plans/2026-07-01-postgres-memory-store.md`.

## Follow-ups (non-blocking)

- Naive `datetime.now()` defaults into `TIMESTAMPTZ` (self-consistent per session; consider `datetime.now(timezone.utc)`).
- The regex prefix guard is duplicated in `MemoryStore.__init__` + `MemoryConfig` (defense-in-depth; a shared constant would prevent drift).
- Connection pooling / injected-connection constructor (MVP owns one DSN connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)