### PR TITLE
release: goldenmatch 2.5.0 (Postgres MemoryStore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,10 @@ jobs:
             python_goldenmatch_postgres:
               - 'packages/python/goldenmatch/tests/test_db.py'
               - 'packages/python/goldenmatch/tests/test_reconcile.py'
+              - 'packages/python/goldenmatch/tests/test_memory_store_postgres.py'
               - 'packages/python/goldenmatch/tests/_pg_helpers.py'
               - 'packages/python/goldenmatch/goldenmatch/db/**'
+              - 'packages/python/goldenmatch/goldenmatch/core/memory/**'
             # #1086 throughput-tier perf gate: re-run when the tier code or the
             # bench harness changes (so a regression in the sketch-then-verify
             # cost is caught), and on ci.yml edits (keeps the gate logic tested).
@@ -916,7 +918,8 @@ jobs:
           # -n 0 (serial): per-test DB provisioning + the shared admin
           # connection make xdist worker contention plausible; serial avoids
           # the headache for a small (~30-test) lane.
-          uv run pytest tests/test_db.py tests/test_reconcile.py \
+          uv run --extra postgres pytest tests/test_db.py tests/test_reconcile.py \
+            tests/test_memory_store_postgres.py \
             -n 0 --timeout=180 --timeout-method=thread -v
 
   # Synthetic-fixture benchmark smoke. Runs on every PR against committed

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-07-01
+
+### Added
+- **MemoryStore: Postgres backend for Learning Memory (#1338).** `MemoryStore(backend='postgres', connection=<dsn>, table_prefix='goldenmatch_')` and `MemoryConfig(backend='postgres', connection, dataset=<tenant>, table_prefix)` persist dedupe corrections + learned adjustments in Postgres, isolated per tenant: corrections filtered by `dataset`, `adjustments` keyed `(dataset, matchkey_name)`, and `MemoryLearner(dataset=…)` so `learn()` never pools corrections across tenants. Adds `LearnedAdjustment.dataset` and `MemoryConfig.table_prefix` (regex-guarded). Reuses the existing `postgres` extra (`psycopg[binary]`) — no new hard deps. **SQLite remains the default; every existing call path, signature default, and behavior is unchanged** (the dialect refactor is behavior-preserving; full SQLite memory suite green).
+
 ### Changed
 - **Auto-config: `name_freq_weighted_jw` now downweights agreements on high-frequency name values using a per-dataset frequency table** (data-driven, applied across the whole score range), so identical common surnames (e.g. two "Smith") score below identical rare surnames - a higher matchkey threshold then separates same-name strangers from true matches (#1207, PR2a). Default-on; kill-switch `GOLDENMATCH_TF_NAME_WEIGHTING=0` restores the static-census behavior. Validated by the CI accuracy gates (#528/DQbench/Febrl/NCVR); this is an accuracy change, not a measured-local win.
 - **Auto-config: per-identifier blocking union on null-sparse multi-source data (#1207, PR1).**

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "2.4.0"
+version = "2.5.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release: goldenmatch `2.4.0` → `2.5.0` (MINOR)

Cuts a PyPI release including #1338 (Postgres MemoryStore backend), requested by golden-truth (downstream, gated on this release). Backward-compatible: SQLite stays the default, every existing call path/signature/behavior unchanged.

### Changes
- Version `2.4.0` → `2.5.0` (pyproject / `__init__.py` / server.json ×2 — lockstep, `check_version_consistency` green).
- CHANGELOG `[2.5.0]` entry (Postgres MemoryStore feature).
- **CI fix (the reason #1338's Postgres tests never ran):** the `python_goldenmatch_postgres` path filter watched `db/**` + `test_db.py`/`test_reconcile.py` but **not** `core/memory/**` or `test_memory_store_postgres.py`, so #1338's memory changes didn't trigger the `python_postgres` lane — the tests **skipped**. Fixed the filter *and* added `test_memory_store_postgres.py` to the lane's run command (with `--extra postgres`). The `ci.yml` edit force-runs all jobs, so this PR exercises the Postgres tests against the `postgres:16` service.

### Gate before tag
The Postgres-backed tests (`test_memory_store_postgres.py`) were skipped in #1338's CI. This PR makes the `python_postgres` lane run them (roundtrip + trust-wins, NULL-dataset, tenant isolation, per-dataset `learn()`, missing-extra ImportError). **Do not tag `v2.5.0` until that lane is green here.**

This PR does **not** tag or publish — that's a separate step after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)