### PR TITLE
Real-corpus substrate validation: name_ci generalizes (0.73->0.976 on real entities)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-real-corpus-substrate.md
+++ b/docs/superpowers/plans/2026-07-01-real-corpus-substrate.md
@@ -1,0 +1,148 @@
+# Real-Corpus (Wikidata/RxNorm/events) Substrate Validation — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Feed the engineered substrate generator **real** entities from `records.csv` (48 QID/rxcui/slug ids, real aliases, real types) via a `GOLDENGRAPH_BENCH_ENTITIES=real` gate, then run the existing substrate eval to calibrate whether the `name_ci` type-jitter fix holds on real entities and whether the baseline is less jitter-prone on real crisp types.
+
+**Architecture:** One new loader + one gated line in `generate_engineered`; everything downstream (edges, rendering, gold, scoring) reused. Then a Modal calibration run (baseline vs `name_ci`, real entities) beside the engineered numbers.
+
+**Tech Stack:** Python (er-kg-bench), pytest (box-safe pure), Modal for the run.
+
+**Spec:** `docs/superpowers/specs/2026-07-01-real-corpus-substrate-design.md`
+
+**Branch:** `feat/real-corpus-substrate` (already off current main; no rebase needed).
+
+**Box-safe test invocation:**
+```bash
+PY="/d/show_case/goldenmatch/.venv/Scripts/python.exe"
+cd packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="." POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 "$PY" -m pytest <test> -q -p no:cacheprovider
+```
+
+---
+
+## Task 1: `_load_real_entities()` + the `GOLDENGRAPH_BENCH_ENTITIES=real` gate
+
+**Files:**
+- Modify: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engineered.py`
+- Test: `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_entities.py`
+
+- [ ] **Step 1: Write the failing test:**
+
+```python
+"""GOLDENGRAPH_BENCH_ENTITIES=real feeds the engineered generator real records.csv entities."""
+from erkgbench.qa_e2e.engineered import (
+    _load_real_entities,
+    emit_gold_mentions,
+    generate_engineered,
+)
+
+
+def test_load_real_entities_groups_by_entity_id_verbatim():
+    ents = _load_real_entities()
+    assert len(ents) == 48
+    ids = {e.id for e in ents}
+    # ids are verbatim across 3 sources -- a QID, an rxcui:, and a slug all survive (NOT Q-filtered)
+    assert any(i.startswith("Q") for i in ids)
+    assert any(i.startswith("rxcui:") for i in ids)
+    assert any("-" in i for i in ids)          # event slug
+    # Q37156 (IBM) carries real aliases; canonical is not also a variant
+    ibm = next(e for e in ents if e.id == "Q37156")
+    assert ibm.canonical
+    assert len(ibm.variants) >= 2
+    assert ibm.canonical not in ibm.variants
+
+
+def test_real_gate_yields_real_id_gold(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_BENCH_ENTITIES", "real")
+    corpus = generate_engineered(seed=20260620, n_questions=1, ambiguity=0.0)
+    gold_ids = {eid for eid, _s, _d in emit_gold_mentions(corpus.documents)}
+    assert gold_ids
+    assert all(i.startswith("Q") or i.startswith("rxcui:") or "-" in i for i in gold_ids)
+
+
+def test_real_gate_off_by_default_uses_concepts(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_BENCH_ENTITIES", raising=False)
+    corpus = generate_engineered(seed=20260620, n_questions=1, ambiguity=0.0)
+    gold_ids = {eid for eid, _s, _d in emit_gold_mentions(corpus.documents)}
+    # concept ids are gm:* / Q* concept ids, never rxcui: -> proves the real source is NOT used
+    assert not any(i.startswith("rxcui:") for i in gold_ids)
+```
+
+- [ ] **Step 2: Run, verify fail** (`ImportError: cannot import name '_load_real_entities'`).
+
+- [ ] **Step 3: Implement.** In `engineered.py`, add the loader beside `_load_entities`:
+
+```python
+def _load_real_entities() -> list[_Entity]:
+    """Real entities from dataset/records.csv (Wikidata / RxNorm / event reference data). Group rows by
+    `entity_id` VERBATIM (a QID `Q37156`, an `rxcui:<n>`, or an event slug -- never assume a `Q` prefix,
+    that would drop 24/48). canonical = the lowest-`record_id` mention (numeric sort); variants = the other
+    distinct real aliases. The entity_id is the ground truth. Pure / no network (records.csv is committed)."""
+    import csv
+
+    bench_root = Path(__file__).resolve().parents[2]
+    path = bench_root / "dataset" / "records.csv"
+    by_id: dict[str, list[tuple[int, str]]] = {}
+    with open(path, encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            eid = (row.get("entity_id") or "").strip()
+            mention = (row.get("mention") or "").strip()
+            if not eid or not mention:
+                continue
+            by_id.setdefault(eid, []).append((int(row["record_id"]), mention))
+    entities: list[_Entity] = []
+    for eid, rows in by_id.items():
+        rows.sort(key=lambda t: t[0])          # numeric record_id (int, not lexical)
+        canonical = rows[0][1]
+        variants = tuple(dict.fromkeys(m for _rid, m in rows[1:] if m != canonical))
+        entities.append(_Entity(id=eid, canonical=canonical, variants=variants))
+    return entities
+```
+
+- [ ] **Step 4: Gate the entity source** in `generate_engineered`, replacing the sole `entities = _load_entities()` call:
+
+```python
+    import os as _os_src
+    if _os_src.environ.get("GOLDENGRAPH_BENCH_ENTITIES", "").strip().lower() == "real":
+        entities = _load_real_entities()
+    else:
+        entities = _load_entities()
+```
+
+- [ ] **Step 5: Run tests, verify pass** + `ruff check`.
+- [ ] **Step 6: Commit** — `feat(er-kg-bench): real-entity source for the substrate generator (records.csv)`.
+
+---
+
+## Task 2: Modal calibration run + verdict report
+
+**Files:**
+- Create: `docs/superpowers/reports/2026-07-01-real-corpus-substrate-verdict.md`
+
+- [ ] **Step 1: Fire two Modal legs** (detached+spawn, distinct `--n`, `PYTHONIOENCODING=utf-8 PYTHONUTF8=1`; full ambiguity sweep 0/0.3/0.6 to compare the whole curve vs engineered):
+
+```bash
+M="/d/show_case/goldenmatch/.venv/Scripts/modal.exe"
+# baseline (name,typ) key on REAL entities
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 50 \
+  --opts $'GOLDENGRAPH_BENCH_ENTITIES=real' --spawn
+# name_ci key on REAL entities
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 51 \
+  --opts $'GOLDENGRAPH_BENCH_ENTITIES=real\nGOLDENGRAPH_XDOC_KEY=name_ci' --spawn
+```
+Poll each `results/substrate_<n>_goldengraph-qwen2.5-7b-instruct.md` with a Monitor.
+
+- [ ] **Step 2: Read the calibration** — the `[substrate]` R(B)/P(B)/edge_recall lines per ambiguity, both legs.
+  - **Baseline R(B) on real entities vs engineered's 0.23** — is it higher (real crisp types jitter less)?
+  - **name_ci vs baseline on real entities** — does the fix still help, and by how much?
+
+- [ ] **Step 3: Write the verdict report** — the real-entity curve beside the engineered curve; state which of the three spec outcomes held (universal jitter / concept-corpus overstated / fix was an artifact). This is a **calibration**, not a pass/fail gate — report honestly whatever the numbers say.
+
+- [ ] **Step 4: Commit** the report.
+
+---
+
+## Completion
+
+Use superpowers:finishing-a-development-branch: verify box-safe tests pass, PR (base `main`), arm auto-merge. Deferred follow-ons stay out of scope (real-homograph `name_ci_type` validation; real Wikidata edges; real Wikipedia prose / level-2).

--- a/docs/superpowers/reports/2026-07-01-real-corpus-substrate-verdict.md
+++ b/docs/superpowers/reports/2026-07-01-real-corpus-substrate-verdict.md
@@ -1,0 +1,36 @@
+# Real-Corpus Substrate Validation — Verdict
+
+**Date:** 2026-07-01
+**Branch:** `feat/real-corpus-substrate`
+**Spec/Plan:** `docs/superpowers/specs/2026-07-01-real-corpus-substrate-design.md` · `docs/superpowers/plans/2026-07-01-real-corpus-substrate.md`
+**Run:** Modal `gg-bench` (A10G, `qwen2.5-7b-instruct`), substrate eval, 48 real entities (`records.csv`: Wikidata / RxNorm / event ids), `GOLDENGRAPH_BENCH_ENTITIES=real`, full ambiguity sweep.
+
+## What this validates
+
+The entire substrate arc — the R(B)=0.23 floor, the type-jitter root cause, the `name_ci` 0.23→0.75 win — was measured on the synthetic **engineered concept corpus**. The step-back flagged two risks: (1) unvalidated on real entities, (2) the all-concept corpus is plausibly a *worst case* for type-jitter (abstract entities, effectively one type → maximal jitter). This run swaps in 48 real entities with real types (org/drug/place) and real aliases, and re-runs the same eval.
+
+## Results — R(B), real entities vs engineered
+
+| ambiguity | baseline (name,typ) **real** | `name_ci` **real** | baseline **engineered** | `name_ci` **engineered** |
+|---|---|---|---|---|
+| 0.0 | **0.7303** | **0.9760** | 0.2314 | 0.7475 |
+| 0.3 | 0.3872 | 0.5514 | 0.1126 | 0.4282 |
+| 0.6 | 0.2096 | 0.3111 | 0.0743 | 0.3502 |
+
+(Real, ambiguity=0: baseline P(B)=0.968 / 1 component; `name_ci` P(B)=0.966, F1(B)=0.971, A−B gap **−0.014** — the built graph *beats* the type-blind resolver-in-isolation.)
+
+## Verdict — two findings, both important
+
+**1. `name_ci` GENERALIZES to real entities — and does even better.** On real entities `name_ci` lifts R(B) 0.7303 → **0.9760** at ambiguity=0 (near-perfect cross-doc resolution), and helps at every ambiguity level (0.39→0.55, 0.21→0.31). The fix is **not** a concept-corpus artifact: real entities still carry residual cross-doc type-jitter, and `name_ci` closes it. The ceiling is actually *higher* on real entities (0.976 vs the engineered 0.75) — real names have less residual noise once type-jitter is removed. This retires the step-back's biggest risk: **the substrate fix is validated on real entities.**
+
+**2. The engineered corpus OVERSTATED the baseline severity.** The real `(name,typ)` baseline is **0.73** at ambiguity=0 — vs the engineered corpus's 0.23. Real entities (IBM, NATO, warfarin, drug brands, places) have crisp, stable types, so the 7B types them consistently and the plain baseline *already* resolves most of them. The dramatic engineered 0.23→0.75 headline was, in the baseline term, a property of the abstract all-concept domain (where every entity is a fuzzy "concept" and jitter is maximal). The **value** of `name_ci` holds (0.73→0.976); the **starting floor** it was rescuing from was domain-specific.
+
+Honest synthesis: *the fix is real and generalizes; the concept corpus was a worst-case stress test that made the baseline look more broken than it is on real, crisply-typed data.* Both halves matter — the first says ship the fix with confidence, the second recalibrates how we quote the headline (name_ci is a smaller relative win on real data, but a higher absolute ceiling).
+
+## Ambiguity note
+
+At ambiguity 0.3/0.6 the real R(B) drops (0.55, 0.31 with `name_ci`) — this is **real alias variance** (IBM ↔ International Business Machines ↔ IBM Corp.), not type-jitter, and `name_ci` can't merge distinct surfaces. That residual is the genuine surface-variance frontier (the deferred profile-link-on-`name_ci` lever), now shown to be real on real aliases too.
+
+## Scope / boundary
+
+Validates real *entities / types / aliases*, **not** real sentence prose — edges + rendering stay synthetic (semantically-empty `X {rel} Y` over real entities). So this confirms the type-jitter fix survives a real entity/type distribution; a **real Wikipedia-prose run (level 2)** is still the remaining de-risk before the substrate story is fully closed. Deferred (unchanged): real-homograph `name_ci_type` validation (`Georgia`→country/state is in the data), real Wikidata edges, real prose.

--- a/docs/superpowers/specs/2026-07-01-real-corpus-substrate-design.md
+++ b/docs/superpowers/specs/2026-07-01-real-corpus-substrate-design.md
@@ -15,7 +15,7 @@ This validates the fix on **real entities** with real types and real aliases, re
 
 ## Approach (decided)
 
-Wikidata-grounded, reusing `dataset/records.csv` (built by `dataset/build_real.py`): 48 real QIDs, each with real surface variants (`IBM` / `International Business Machines Corporation` / `IBM Corp.`), real `entity_type`, real `context`, `entity_id`=QID as ground truth. Feed these to the **existing engineered generator** as the entity source; everything downstream is reused. The alternatives (real Wikipedia prose + string-match gold; an off-the-shelf entity-linking dataset) are recorded under Deferred — this is the low-friction, highest-signal first cut.
+Reuse `dataset/records.csv` (built by `dataset/build_real.py`): **48 distinct real entities** across three sources — Wikidata (`Q37156`), RxNorm drug brand/generic (`rxcui:11289`, e.g. Coumadin/warfarin), and events (slug ids like `fifa-world-cup-2018`). Each entity has real surface variants (`IBM` / `International Business Machines Corporation` / `IBM Corp.`), real `entity_type`, real `context`, and `entity_id` (its QID / rxcui / slug) as ground truth. **The `entity_id` is NOT always a QID — group on it verbatim, never assume a `Q` prefix (that would drop 24 of 48 entities).** Feed these to the **existing engineered generator** as the entity source; everything downstream is reused. The alternatives (real Wikipedia prose + string-match gold; an off-the-shelf entity-linking dataset) are recorded under Deferred — this is the low-friction, highest-signal first cut.
 
 ## Architecture
 
@@ -24,8 +24,8 @@ Wikidata-grounded, reusing `dataset/records.csv` (built by `dataset/build_real.p
 ## Components
 
 ### 1. `_load_real_entities()` (engineered.py)
-- Read `dataset/records.csv`; group rows by `entity_id` (QID).
-- Per QID → `_Entity(id=QID, canonical=<primary label>, variants=<other distinct mentions>)`. Primary label = the mention with the lowest `record_id` (deterministic). Variants = the remaining distinct `mention` strings (real aliases).
+- Read `dataset/records.csv`; group rows by `entity_id` **verbatim** (may be a QID, `rxcui:<n>`, or a slug — do NOT assume a `Q` prefix).
+- Per entity → `_Entity(id=entity_id, canonical=<primary label>, variants=<other distinct mentions>)`. Primary label = the mention with the lowest `record_id`, sorted **numerically** (`record_id` is an int stored as string — a lexical sort would put `"10"` before `"2"`). Variants = the remaining distinct `mention` strings (real aliases).
 - Anchored to `__file__` (CWD differs local vs Modal). Pure / no network (`records.csv` is committed).
 
 ### 2. Gate in `generate_engineered`
@@ -35,7 +35,7 @@ Wikidata-grounded, reusing `dataset/records.csv` (built by `dataset/build_real.p
 - `_render_mention` already picks a random `variant` at rate `ambiguity`. With real entities, variants are real aliases, so the ambiguity sweep exercises **real** surface variation (abbreviations, full names, exonyms) instead of synthetic corruptions.
 
 ### 4. Gold + eval (unchanged)
-- `emit_gold_mentions` derives `(entity_id, surface, doc_id)` off the generated docs; the QID flows through as `entity_id`. `run_substrate_eval` + `score_substrate` need no change.
+- `emit_gold_mentions` derives `(entity_id, surface, doc_id)` off the generated docs; the real id (QID / rxcui / slug) flows through as `entity_id`. `run_substrate_eval` + `score_substrate` need no change.
 
 ## Data flow / what it tests
 
@@ -56,18 +56,18 @@ Reading the outcome (all are informative, none is a pass/fail — this is a *cal
 ## Scope
 
 **v1:** the real-entity loader + gate + one calibration run. **Deferred:**
-- **Real-homograph validation of `name_ci_type`** — `records.csv`'s `failure_class` collisions are real same-surface/distinct-QID homographs; a natural next test of the homograph work on real data.
+- **Real-homograph validation of `name_ci_type`** — `records.csv` has real same-surface/distinct-id homographs (`Georgia` → Q230 country vs Q1428 US state, `failure_class=same_name_collision`); a natural next test of the homograph work on real data.
 - **Real Wikidata edges** (vs synthetic edge-gen over real entities) — the sourced QIDs aren't interconnected, so v1 keeps synthetic edges.
 - **Real Wikipedia prose** (level-2 realism) — real sentences/ambiguity; the explicitly set-aside deeper validation.
 
 ## File plan
 
 - `benchmarks/.../qa_e2e/engineered.py` — `_load_real_entities()`; the `GOLDENGRAPH_BENCH_ENTITIES=real` gate in `generate_engineered`.
-- Test: `benchmarks/.../tests/test_real_entities.py` — `_load_real_entities` groups records.csv by QID into `_Entity`s (correct id/canonical/aliases); the gate switches the source; `emit_gold_mentions` yields QID gold.
+- Test: `benchmarks/.../tests/test_real_entities.py` — `_load_real_entities` groups records.csv by `entity_id` (verbatim: QID/rxcui/slug) into `_Entity`s (correct id/canonical/aliases); the gate switches the source; `emit_gold_mentions` yields real-id gold.
 
 ## Testing
 
-Box-safe: `_load_real_entities` returns 48 `_Entity`s with QID ids and real aliases as variants; a QID with multiple mentions (e.g. Q37156) has ≥2 variants; the gate makes `generate_engineered` emit QID-keyed gold mentions. One Modal substrate run for the calibration table.
+Box-safe: `_load_real_entities` returns 48 `_Entity`s keyed on the verbatim `entity_id` (assert a mix — a `Q…`, an `rxcui:…`, and a slug are all present, NOT filtered to `Q`-prefix), with real aliases as variants; an entity with multiple mentions (e.g. Q37156) has ≥2 variants; the gate makes `generate_engineered` emit real-id-keyed gold mentions. One Modal substrate run for the calibration table.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-07-01-real-corpus-substrate-design.md
+++ b/docs/superpowers/specs/2026-07-01-real-corpus-substrate-design.md
@@ -1,0 +1,77 @@
+# Real-Corpus (Wikidata) Substrate Validation — Design
+
+**Date:** 2026-07-01
+**Status:** Design (approved for spec)
+**Follows:** the substrate-eval arc — type-jitter fix `GOLDENGRAPH_XDOC_KEY=name_ci` (#1331, R(B) 0.23→0.75) and the homograph variant (#1335/#1336/#1337). All of it was measured on the **synthetic engineered corpus**.
+
+## Problem
+
+Every substrate finding this arc — the R(B)=0.23 floor, the type-jitter root cause, the name_ci 0.23→0.75 win — rides on one synthetic corpus built from ER/dedup **concepts** (`Levenshtein distance`, `blocking`, …). Two things make that a risk worth retiring first:
+
+1. **Unvalidated on real entities.** The type-jitter magnitude and the name_ci win may be a property of the engineered rendering, not real prose/entities.
+2. **The concept corpus is plausibly a WORST case.** Its entities are all abstract and effectively one type, so the 7B has maximal room to jitter. Real entities (people, organizations, places) have **crisp, stable types**, where the 7B may jitter far less — meaning the engineered corpus could have *overstated* the whole problem.
+
+This validates the fix on **real entities** with real types and real aliases, reusing the existing eval.
+
+## Approach (decided)
+
+Wikidata-grounded, reusing `dataset/records.csv` (built by `dataset/build_real.py`): 48 real QIDs, each with real surface variants (`IBM` / `International Business Machines Corporation` / `IBM Corp.`), real `entity_type`, real `context`, `entity_id`=QID as ground truth. Feed these to the **existing engineered generator** as the entity source; everything downstream is reused. The alternatives (real Wikipedia prose + string-match gold; an off-the-shelf entity-linking dataset) are recorded under Deferred — this is the low-friction, highest-signal first cut.
+
+## Architecture
+
+`generate_engineered` gains a gated entity source. When `GOLDENGRAPH_BENCH_ENTITIES=real`, entities come from `records.csv` (QID id, real label canonical, real aliases as `variants`) instead of `concepts.jsonl`. The synthetic typed-edge graph, ambiguity-dialed rendering, and `emit_gold_mentions` are **entity-source-agnostic** and reused verbatim. The ambiguity dial now draws variant surfaces from *real* aliases. `run_substrate_eval` runs unchanged (the gate is env, threaded through Modal `--opts`).
+
+## Components
+
+### 1. `_load_real_entities()` (engineered.py)
+- Read `dataset/records.csv`; group rows by `entity_id` (QID).
+- Per QID → `_Entity(id=QID, canonical=<primary label>, variants=<other distinct mentions>)`. Primary label = the mention with the lowest `record_id` (deterministic). Variants = the remaining distinct `mention` strings (real aliases).
+- Anchored to `__file__` (CWD differs local vs Modal). Pure / no network (`records.csv` is committed).
+
+### 2. Gate in `generate_engineered`
+- At entity load: `entities = _load_real_entities() if os.environ.get("GOLDENGRAPH_BENCH_ENTITIES","").strip().lower()=="real" else _load_entities()`. Default (`concepts.jsonl`) unchanged. Mirrors the existing `GOLDENGRAPH_BENCH_COOCCUR` / `_HOMOGRAPH` env-gate pattern.
+
+### 3. Real surface variance (free)
+- `_render_mention` already picks a random `variant` at rate `ambiguity`. With real entities, variants are real aliases, so the ambiguity sweep exercises **real** surface variation (abbreviations, full names, exonyms) instead of synthetic corruptions.
+
+### 4. Gold + eval (unchanged)
+- `emit_gold_mentions` derives `(entity_id, surface, doc_id)` off the generated docs; the QID flows through as `entity_id`. `run_substrate_eval` + `score_substrate` need no change.
+
+## Data flow / what it tests
+
+Rendered doc: `"{surface_of_QID_a} {rel} {surface_of_QID_b}."` (synthetic edge over real entities). The 7B extracts + types each real entity; the store keys on `record_key`. Two questions:
+
+1. **Does `name_ci` still beat the `(name,typ)` baseline on real entities?** (does the fix generalize)
+2. **Is the `(name,typ)` baseline R(B) HIGHER here than the engineered 0.23?** (are real crisp types less jitter-prone — did the concept corpus overstate the problem?)
+
+## Validation
+
+Substrate eval on the real-entity corpus, `GOLDENGRAPH_XDOC_KEY` ∈ {unset baseline, `name_ci`}, ambiguity sweep {0.0, 0.3, 0.6} (real aliases). Report the R(B)/P(B)/gap curve beside the engineered numbers.
+
+Reading the outcome (all are informative, none is a pass/fail — this is a *calibration*, not a gate):
+- **baseline ≈ 0.23, name_ci ≈ 0.75** → type-jitter is universal; the engineered corpus was representative; the arc's conclusions hold on real entities.
+- **baseline ≫ 0.23 (e.g. 0.5+), name_ci smaller win** → real crisp types jitter less; the concept corpus overstated the problem; name_ci still helps but the headline number was domain-specific.
+- **name_ci ≤ baseline** → the fix is a concept-corpus artifact (would be a genuine surprise; would re-open the whole finding).
+
+## Scope
+
+**v1:** the real-entity loader + gate + one calibration run. **Deferred:**
+- **Real-homograph validation of `name_ci_type`** — `records.csv`'s `failure_class` collisions are real same-surface/distinct-QID homographs; a natural next test of the homograph work on real data.
+- **Real Wikidata edges** (vs synthetic edge-gen over real entities) — the sourced QIDs aren't interconnected, so v1 keeps synthetic edges.
+- **Real Wikipedia prose** (level-2 realism) — real sentences/ambiguity; the explicitly set-aside deeper validation.
+
+## File plan
+
+- `benchmarks/.../qa_e2e/engineered.py` — `_load_real_entities()`; the `GOLDENGRAPH_BENCH_ENTITIES=real` gate in `generate_engineered`.
+- Test: `benchmarks/.../tests/test_real_entities.py` — `_load_real_entities` groups records.csv by QID into `_Entity`s (correct id/canonical/aliases); the gate switches the source; `emit_gold_mentions` yields QID gold.
+
+## Testing
+
+Box-safe: `_load_real_entities` returns 48 `_Entity`s with QID ids and real aliases as variants; a QID with multiple mentions (e.g. Q37156) has ≥2 variants; the gate makes `generate_engineered` emit QID-keyed gold mentions. One Modal substrate run for the calibration table.
+
+## Risks
+
+- **Synthetic edges are nonsensical on real entities** (`IBM {rel} NATO`) — acceptable: the substrate eval scores entity *co-reference* (mention→node via edge endpoints), not relation semantics, so semantically-empty edges still exercise the resolution path. Documented, user-accepted.
+- **48 entities is small** — a signal, not a leaderboard; enough to calibrate the baseline-vs-name_ci delta. Expandable via `sources.jsonl` later.
+- **Not real prose** — validates real entities/types/aliases, NOT real sentence structure; the honest boundary, and the reason level-2 (real Wikipedia prose) stays a named follow-on.
+- **Canonical-label choice is heuristic** (lowest `record_id`) — at ambiguity=0 the canonical is used throughout, so the choice shifts which real string is "canonical" but not the resolution logic; deterministic, low-stakes.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engineered.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engineered.py
@@ -52,6 +52,33 @@ def _load_entities() -> list[_Entity]:
     return entities
 
 
+def _load_real_entities() -> list[_Entity]:
+    """Real entities from dataset/records.csv (Wikidata / RxNorm / event reference data). Group rows by
+    `entity_id` VERBATIM (a QID `Q37156`, an `rxcui:<n>`, or an event slug -- never assume a `Q` prefix,
+    that would drop the 26 non-Q ids). canonical = the lowest-`record_id` mention (numeric sort); variants =
+    the other distinct real aliases. The entity_id is the ground truth. Pure / no network (records.csv is
+    committed) -- the real-corpus counterpart to `_load_entities`, feeding the SAME generator."""
+    import csv
+
+    bench_root = Path(__file__).resolve().parents[2]
+    path = bench_root / "dataset" / "records.csv"
+    by_id: dict[str, list[tuple[int, str]]] = {}
+    with open(path, encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            eid = (row.get("entity_id") or "").strip()
+            mention = (row.get("mention") or "").strip()
+            if not eid or not mention:
+                continue
+            by_id.setdefault(eid, []).append((int(row["record_id"]), mention))
+    entities: list[_Entity] = []
+    for eid, rows in by_id.items():
+        rows.sort(key=lambda t: t[0])          # numeric record_id (int, not lexical)
+        canonical = rows[0][1]
+        variants = tuple(dict.fromkeys(m for _rid, m in rows[1:] if m != canonical))
+        entities.append(_Entity(id=eid, canonical=canonical, variants=variants))
+    return entities
+
+
 def _render_mention(ent: _Entity, rng: random.Random, ambiguity: float) -> str:
     if ent.variants and rng.random() < ambiguity:
         return rng.choice(list(ent.variants))
@@ -125,7 +152,11 @@ def generate_engineered(
     *, seed: int, n_questions: int, ambiguity: float, max_hops: int = 4
 ) -> QACorpus:
     rng = random.Random(seed)
-    entities = _load_entities()
+    import os as _os_src
+    if _os_src.environ.get("GOLDENGRAPH_BENCH_ENTITIES", "").strip().lower() == "real":
+        entities = _load_real_entities()
+    else:
+        entities = _load_entities()
     by_id = {e.id: e for e in entities}
     ids = [e.id for e in entities]
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_entities.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_real_entities.py
@@ -1,0 +1,37 @@
+"""GOLDENGRAPH_BENCH_ENTITIES=real feeds the engineered generator real records.csv entities."""
+from erkgbench.qa_e2e.engineered import (
+    _load_real_entities,
+    emit_gold_mentions,
+    generate_engineered,
+)
+
+
+def test_load_real_entities_groups_by_entity_id_verbatim():
+    ents = _load_real_entities()
+    assert len(ents) == 48
+    ids = {e.id for e in ents}
+    # ids are verbatim across 3 sources -- a QID, an rxcui:, and a slug all survive (NOT Q-filtered)
+    assert any(i.startswith("Q") for i in ids)
+    assert any(i.startswith("rxcui:") for i in ids)
+    assert any("-" in i for i in ids)          # event slug
+    # Q37156 (IBM) carries real aliases; canonical is not also a variant
+    ibm = next(e for e in ents if e.id == "Q37156")
+    assert ibm.canonical
+    assert len(ibm.variants) >= 2
+    assert ibm.canonical not in ibm.variants
+
+
+def test_real_gate_yields_real_id_gold(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_BENCH_ENTITIES", "real")
+    corpus = generate_engineered(seed=20260620, n_questions=1, ambiguity=0.0)
+    gold_ids = {eid for eid, _s, _d in emit_gold_mentions(corpus.documents)}
+    assert gold_ids
+    assert all(i.startswith("Q") or i.startswith("rxcui:") or "-" in i for i in gold_ids)
+
+
+def test_real_gate_off_by_default_uses_concepts(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_BENCH_ENTITIES", raising=False)
+    corpus = generate_engineered(seed=20260620, n_questions=1, ambiguity=0.0)
+    gold_ids = {eid for eid, _s, _d in emit_gold_mentions(corpus.documents)}
+    # concept ids are gm:* / Q* (concepts_loader enforces ^(Q\d+|gm:...)$), never rxcui: -> real source unused
+    assert not any(i.startswith("rxcui:") for i in gold_ids)


### PR DESCRIPTION
## Summary

Validates the substrate type-jitter fix (`GOLDENGRAPH_XDOC_KEY=name_ci`, #1331) on **real entities** instead of the synthetic concept corpus. Adds a `GOLDENGRAPH_BENCH_ENTITIES=real` gate that feeds the engineered generator 48 real entities from `records.csv` (Wikidata / RxNorm / event ids, real aliases, QID/rxcui/slug = gold); reuses the eval unchanged.

## Result (substrate eval, 7B, ambiguity sweep)

| ambiguity | baseline (name,typ) **real** | `name_ci` **real** | baseline **engineered** | `name_ci` **engineered** |
|---|---|---|---|---|
| 0.0 | **0.7303** | **0.9760** | 0.2314 | 0.7475 |
| 0.3 | 0.3872 | 0.5514 | 0.1126 | 0.4282 |
| 0.6 | 0.2096 | 0.3111 | 0.0743 | 0.3502 |

**Two findings:**
1. **`name_ci` generalizes — and does better.** Real R(B) 0.73 → **0.976** at ambiguity=0 (higher ceiling than engineered's 0.75), helps at every level. The fix is **not** a concept-corpus artifact.
2. **The engineered corpus overstated the baseline severity.** Real `(name,typ)` baseline is **0.73** vs engineered's 0.23 — real crisp types (org/drug/place) jitter far less, so the plain baseline already resolves most of them. The dramatic 0.23→0.75 headline was, in the baseline term, a worst-case property of the all-concept domain.

Honest synthesis: the fix is real and ships with confidence; the concept corpus was a worst-case stress test. Full write-up: `docs/superpowers/reports/2026-07-01-real-corpus-substrate-verdict.md`.

## Scope

Validates real entities/types/aliases, **not** real sentence prose (edges/rendering stay synthetic). A real-Wikipedia-prose run (level 2) is the remaining de-risk. Higher-ambiguity residual is real *alias* variance (the deferred profile-link-on-name_ci lever).

## Test Plan
- [x] 3 box-safe pure tests green (`test_real_entities.py`: verbatim-id grouping, real-id gold, off-by-default)
- [x] no regression (`test_homograph_corpus.py` green)
- [x] ruff clean
- [x] Modal calibration produced the table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)