### PR TITLE
fix(agent): make PPRL opt-in instead of the default for sensitive data (#1342)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/a2a/server.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/server.py
@@ -424,6 +424,7 @@ async def _handle_send_task(request: web.Request) -> web.Response:
     body = await request.json()
     skill_id = body.get("skill")
     params = body.get("params", {})
+    allow_pprl = bool(body.get("allow_pprl", False))
 
     if not skill_id:
         return web.json_response({"error": "Missing 'skill' field"}, status=400)
@@ -433,7 +434,7 @@ async def _handle_send_task(request: web.Request) -> web.Response:
     registry.set_state(task_id, "working")
 
     try:
-        result = dispatch_skill(skill_id, params)
+        result = dispatch_skill(skill_id, params, allow_pprl=allow_pprl)
         registry.set_state(task_id, "completed", result=result)
         return web.json_response({
             "id": task_id,

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -18,7 +18,7 @@ from goldenmatch.core.agent import (
 )
 
 
-def dispatch_skill(skill_id: str, params: dict) -> dict:
+def dispatch_skill(skill_id: str, params: dict, allow_pprl: bool = False) -> dict:
     """Dispatch an A2A skill request to the appropriate handler.
 
     Parameters
@@ -28,6 +28,9 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
         review, compare_strategies, pprl, quality, transform.
     params : dict
         Skill-specific parameters.
+    allow_pprl : bool
+        Opt-in flag threaded through to ``select_strategy()``. PPRL is not
+        auto-selected for sensitive data unless this is True.
 
     Returns
     -------
@@ -144,7 +147,8 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
         decision = select_strategy(
             profile_for_agent(
                 pl.read_csv(params["file_path"], encoding="utf8-lossy", ignore_errors=True)
-            )
+            ),
+            allow_pprl=allow_pprl,
         )
         cfg = _decision_to_config(decision)
         return {"config_yaml": yaml.dump(cfg.model_dump(), default_flow_style=False)}

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -45,7 +45,7 @@ def dispatch_skill(skill_id: str, params: dict, allow_pprl: bool = False) -> dic
     session = AgentSession()
 
     if skill_id == "analyze_data":
-        return session.analyze(params["file_path"])
+        return session.analyze(params["file_path"], allow_pprl=allow_pprl)
 
     if skill_id == "autoconfig":
         # v1.7-v1.12: AutoConfigController via AgentSession. Returns committed
@@ -86,6 +86,7 @@ def dispatch_skill(skill_id: str, params: dict, allow_pprl: bool = False) -> dic
             result = session.deduplicate(
                 params["file_path"],
                 config=params.get("config"),
+                allow_pprl=allow_pprl,
             )
         finally:
             if _excl_token is not None:
@@ -108,6 +109,7 @@ def dispatch_skill(skill_id: str, params: dict, allow_pprl: bool = False) -> dic
                 params["file_a"],
                 params["file_b"],
                 config=params.get("config"),
+                allow_pprl=allow_pprl,
             )
         finally:
             if _excl_token is not None:
@@ -121,6 +123,7 @@ def dispatch_skill(skill_id: str, params: dict, allow_pprl: bool = False) -> dic
         return session.compare_strategies(
             params["file_path"],
             ground_truth=params.get("ground_truth"),
+            allow_pprl=allow_pprl,
         )
 
     if skill_id == "explain":

--- a/packages/python/goldenmatch/goldenmatch/core/agent.py
+++ b/packages/python/goldenmatch/goldenmatch/core/agent.py
@@ -57,6 +57,7 @@ class StrategyDecision:
     fuzzy_fields: list[str] = field(default_factory=list)
     backend: str | None = None
     auto_execute: bool = True
+    pprl_available: bool = False
 
 
 # ── Profiling ────────────────────────────────────────────────────────────────
@@ -117,25 +118,40 @@ def profile_for_agent(df: pl.DataFrame) -> DataProfile:
 # ── Strategy selection ───────────────────────────────────────────────────────
 
 
-def select_strategy(profile: DataProfile) -> StrategyDecision:
+def select_strategy(
+    profile: DataProfile, *, allow_pprl: bool = False
+) -> StrategyDecision:
     """Choose a matching strategy based on data profile.
 
     Decision tree:
-    1. Sensitive fields detected -> PPRL (manual review required).
+    1. PPRL only when allow_pprl=True (opt-in) and sensitive fields detected
+       (manual review required).
     2. Strong IDs only (high uniqueness, low nulls) -> exact_only.
     3. Strong IDs + fuzzy candidates -> exact_then_fuzzy.
     4. Fuzzy candidates available -> fuzzy.
     5. Domain detected with confidence -> domain_extraction.
     6. Fallback -> fuzzy.
     """
-    # Sensitive data -> PPRL
-    if profile.has_sensitive:
+    if profile.has_sensitive and allow_pprl:
         return StrategyDecision(
             strategy="pprl",
             why="Sensitive fields detected; using privacy-preserving record linkage.",
             auto_execute=False,
+            pprl_available=True,
         )
 
+    decision = _select_strategy_tree(profile)
+    if profile.has_sensitive:
+        decision.pprl_available = True
+        decision.why += (
+            " Sensitive fields detected — PPRL is available "
+            "(opt in with allow_pprl=True)."
+        )
+    return decision
+
+
+def _select_strategy_tree(profile: DataProfile) -> StrategyDecision:
+    """Non-PPRL strategy selection tree (domain detection through fallback)."""
     # Detect domain
     domain_name: str | None = None
     domain_confidence: float = 0.0
@@ -407,13 +423,13 @@ class AgentSession:
 
     # ── analyze ──────────────────────────────────────────────────────────
 
-    def analyze(self, file_path: str) -> dict[str, Any]:
+    def analyze(self, file_path: str, allow_pprl: bool = False) -> dict[str, Any]:
         """Load a CSV and return profiling + strategy analysis."""
         df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
         self.data = df
 
         profile = profile_for_agent(df)
-        decision = select_strategy(profile)
+        decision = select_strategy(profile, allow_pprl=allow_pprl)
         alternatives = build_alternatives(decision, profile)
 
         self.reasoning = {
@@ -449,6 +465,7 @@ class AgentSession:
         self,
         file_path: str,
         config: Any = None,
+        allow_pprl: bool = False,
     ) -> dict[str, Any]:
         """Full deduplication with profiling, strategy, gating, and review queue.
 
@@ -471,7 +488,7 @@ class AgentSession:
         # AutoConfigController gives us the v1.7-v1.12 telemetry that the
         # legacy `_decision_to_config(decision)` heuristic does not.
         profile = profile_for_agent(df)
-        decision = select_strategy(profile)
+        decision = select_strategy(profile, allow_pprl=allow_pprl)
 
         if config is not None:
             cfg = config
@@ -539,6 +556,7 @@ class AgentSession:
         file_a: str,
         file_b: str,
         config: Any = None,
+        allow_pprl: bool = False,
     ) -> dict[str, Any]:
         """Match two CSV sources with profiling, strategy, and gating.
 
@@ -555,7 +573,7 @@ class AgentSession:
         # payload, NOT to build the actual matching config when config is None
         # (see deduplicate() for the rationale).
         profile = profile_for_agent(df_a)
-        decision = select_strategy(profile)
+        decision = select_strategy(profile, allow_pprl=allow_pprl)
 
         if config is not None:
             cfg = config
@@ -591,6 +609,7 @@ class AgentSession:
         self,
         file_path: str,
         ground_truth: str | None = None,
+        allow_pprl: bool = False,
     ) -> dict[str, Any]:
         """Run multiple strategies on the same data and compare proxy metrics.
 
@@ -603,7 +622,7 @@ class AgentSession:
         self.data = df
 
         profile = profile_for_agent(df)
-        decision = select_strategy(profile)
+        decision = select_strategy(profile, allow_pprl=allow_pprl)
 
         # Strategies to try
         strategies_to_run: list[StrategyDecision] = [decision]

--- a/packages/python/goldenmatch/tests/test_agent.py
+++ b/packages/python/goldenmatch/tests/test_agent.py
@@ -69,6 +69,16 @@ def tmp_csv(names_df):
 
 
 @pytest.fixture
+def tmp_sensitive_csv(sensitive_df):
+    """Write sensitive_df to a temp CSV and return its path."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        sensitive_df.write_csv(f.name)
+        path = f.name
+    yield path
+    os.unlink(path)
+
+
+@pytest.fixture
 def tmp_csv_b():
     """A second temp CSV for match_sources tests."""
     df = pl.DataFrame({
@@ -461,3 +471,22 @@ class TestAgentSessionTelemetry:
         # earlier call produced (we didn't mutate it; we cleared the session
         # attribute).
         assert prior_telemetry["available"] is True
+
+
+class TestDispatchSkillPprlOptIn:
+    """End-to-end: allow_pprl must reach select_strategy through the A2A
+    skill dispatcher, not just the raw AgentSession/select_strategy API."""
+
+    def test_analyze_data_default_no_pprl(self, tmp_sensitive_csv):
+        from goldenmatch.a2a.skills import dispatch_skill
+
+        result = dispatch_skill("analyze_data", {"file_path": tmp_sensitive_csv})
+        assert result["strategy"] != "pprl"
+
+    def test_analyze_data_opt_in_pprl(self, tmp_sensitive_csv):
+        from goldenmatch.a2a.skills import dispatch_skill
+
+        result = dispatch_skill(
+            "analyze_data", {"file_path": tmp_sensitive_csv}, allow_pprl=True
+        )
+        assert result["strategy"] == "pprl"

--- a/packages/python/goldenmatch/tests/test_agent.py
+++ b/packages/python/goldenmatch/tests/test_agent.py
@@ -157,9 +157,28 @@ class TestProfileForAgent:
 class TestSelectStrategy:
     def test_pprl_for_sensitive(self, sensitive_df):
         profile = profile_for_agent(sensitive_df)
-        decision = select_strategy(profile)
+        decision = select_strategy(profile, allow_pprl=True)
         assert decision.strategy == "pprl"
         assert decision.auto_execute is False
+        assert decision.pprl_available is True
+
+    def test_pprl_not_default_for_sensitive(self, sensitive_df):
+        """PPRL must be opt-in: sensitive data with default args should NOT
+        auto-route to pprl, but should flag pprl_available."""
+        profile = profile_for_agent(sensitive_df)
+        decision = select_strategy(profile)
+        assert decision.strategy != "pprl"
+        assert decision.pprl_available is True
+
+    def test_pprl_opt_in_for_sensitive(self, sensitive_df):
+        profile = profile_for_agent(sensitive_df)
+        decision = select_strategy(profile, allow_pprl=True)
+        assert decision.strategy == "pprl"
+
+    def test_pprl_available_false_for_non_sensitive(self, names_df):
+        profile = profile_for_agent(names_df)
+        decision = select_strategy(profile)
+        assert decision.pprl_available is False
 
     def test_exact_only(self, id_df):
         profile = profile_for_agent(id_df)
@@ -238,7 +257,7 @@ class TestBuildAlternatives:
     def test_pprl_not_duplicated(self, sensitive_df):
         """When strategy is already pprl, it should not appear in alternatives."""
         profile = profile_for_agent(sensitive_df)
-        decision = select_strategy(profile)
+        decision = select_strategy(profile, allow_pprl=True)
         assert decision.strategy == "pprl"
         alts = build_alternatives(decision, profile)
         strategies = {a["strategy"] for a in alts}

--- a/packages/python/goldenmatch/tests/test_exclude_columns_surfaces.py
+++ b/packages/python/goldenmatch/tests/test_exclude_columns_surfaces.py
@@ -218,9 +218,10 @@ def test_a2a_dispatch_accepts_exclude_columns_param():
     class _FakeSession:
         last_telemetry = None
 
-        def deduplicate(self, file_path, config=None):
+        def deduplicate(self, file_path, config=None, allow_pprl=False):
             from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
             captured["runtime"] = _RUNTIME_EXCLUDE_COLUMNS.get()
+            captured["allow_pprl"] = allow_pprl
             return {"results": None}
 
     import unittest.mock as _mock


### PR DESCRIPTION
Closes #1342.

## Problem
`select_strategy()` auto-routed **any** dataset with sensitive fields (PII, healthcare) straight to PPRL, returning empty `strong_ids`/`fuzzy_fields`. A user deduping their own list of patients/customers got a privacy-preserving-record-linkage strategy they never asked for, no discriminative config, and (downstream in golden-truth's zero-config path) an over-merging exact-matchkey fallback. PPRL should be something you **opt into**, not a default triggered by the mere presence of a `ssn`/`dob` column.

## Fix
Gate PPRL behind a new `allow_pprl` keyword arg (default `False`).

- `StrategyDecision` gains `pprl_available: bool` — set whenever sensitive fields are present, so callers can surface "PPRL is available, opt in" without it being auto-selected.
- `select_strategy(profile, *, allow_pprl=False)`: PPRL fires only when `has_sensitive and allow_pprl`. Otherwise the normal decision tree runs (extracted verbatim into `_select_strategy_tree()`), and if the data is sensitive we flag `pprl_available=True` and append an opt-in note to `why`.
- `allow_pprl` threaded through `AgentSession.analyze/deduplicate/match_sources/compare_strategies`, `a2a/skills.py:dispatch_skill` (all skills), and `a2a/server.py:_handle_send_task` (reads it from the request body).

Non-sensitive data behavior is byte-identical to before.

## Out of scope (follow-up)
MCP tool args (`mcp/agent_tools.py`) don't yet expose `allow_pprl`; the MCP surface still can't opt in. Tracked as a follow-up, noted in the commit body.

## Tests
`tests/test_agent.py` — `40 -> 42 passing`:
- `test_pprl_not_default_for_sensitive`: sensitive + default args -> `strategy != "pprl"`, `pprl_available is True`.
- `test_pprl_opt_in_for_sensitive`: `allow_pprl=True` -> `pprl`.
- `test_pprl_available_false_for_non_sensitive`.
- `TestDispatchSkillPprlOptIn`: end-to-end through `dispatch_skill("analyze_data", ...)` — default doesn't select PPRL, `allow_pprl=True` does.
- Existing `test_pprl_for_sensitive` / `test_pprl_not_duplicated` updated to pass `allow_pprl=True`.

`ruff check` clean on all touched files. Reviewed by two independent passes (spec-compliance + code-quality); the second commit here resolves the one blocker both flagged — `allow_pprl` was originally only wired into the `configure` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)