### PR TITLE
ci(native): native is the default goldenmatch test lane (reference mode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1093,11 +1093,10 @@ jobs:
   # baseline (scripts/autoconfig_quality/baselines/scorecard.json). A FAIL means a
   # kernel change moved a host-independent decision (classification / matchkeys /
   # blocking fields+cost) or dropped the anchor_person_match F1 below its floor.
-  # planner_rung drift (native availability / box size) is informational WARN.
-  # Reference mode: this job now BUILDS the native ext and runs the gate on the
-  # native path, so it matches the native-blessed baseline (native vs pure-Python
-  # are not parity-identical on every dataset -- ncvr_synthetic differs ~1.8pp).
-  # Real datasets (DBLP-ACM) skip-when-absent. Iterate loop + how to re-bless:
+  # Reference mode: this job BUILDS the native ext and runs the gate on the native
+  # path, and the committed baseline is blessed native-on -- native is the
+  # reference. planner_rung drift is still informational WARN. Real datasets
+  # (DBLP-ACM) skip-when-absent. Iterate loop + how to re-bless:
   # scripts/autoconfig_quality/README.md.
   quality_gate:
     needs: changes
@@ -1120,12 +1119,11 @@ jobs:
       # DBLP-ACM skip-when-absent in CI (gitignored).
       - run: uv pip install recordlinkage pyarrow
       # Reference mode (docs/design/2026-07-01-rust-is-the-reference-roadmap.md):
-      # the committed baseline is blessed native-on, and native vs pure-Python are
-      # NOT parity-identical on every dataset (ncvr_synthetic differs ~1.8pp), so a
-      # no-wheel run diffs the pure-Python fallback against a native baseline and
-      # FAILs. Native is the reference -> build the ext and run the gate on the
-      # native path so it matches the native baseline. build_native.py drops
-      # goldenmatch._native into the package (as the `native` parity lane does).
+      # native is the reference, so the gate runs on the native path and the
+      # baseline is blessed native-on. build_native.py drops goldenmatch._native
+      # into the package (as the `native` parity lane does). Kernel signals are
+      # parity-identical native/Python; running native keeps planner_rung aligned
+      # with the native baseline (it picks `bucket`, not `polars-direct`).
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
@@ -1144,7 +1142,15 @@ jobs:
           # and bench-attribution paths to sys.path internally. No --fast-only:
           # the anchors' fast signals AND the anchor_person_match F1 floor are
           # both gated (anchor_person_match is 400 entities, F1 is seconds).
-          uv run python -m scripts.autoconfig_quality gate
+          # TEMP (re-bless on native): produce the native baseline in CI, upload it,
+          # then this step reverts to `gate`. Remove before merge.
+          uv run python -m scripts.autoconfig_quality bless
+      - name: Upload re-blessed native scorecard (TEMP)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: reblessed-scorecard
+          path: scripts/autoconfig_quality/baselines/scorecard.json
+          retention-days: 1
       - name: Quality scorecard summary
         if: always()
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,11 @@ jobs:
             **/pyproject.toml
       - run: uv sync --all-packages
       - name: pytest (pure-Python fallback -- core behavior slice, GOLDENMATCH_NATIVE=0)
+        # -k excludes tests that ASSERT native dispatch (e.g. TestNativeFSParity's
+        # opt-in-picks-native): the job-level GOLDENMATCH_NATIVE=0 force-disables
+        # native, so those tests can't hold here by construction. This lane proves
+        # the pure-Python behavior path, not native dispatch (that's the `native`
+        # lane's job).
         run: |
           uv run pytest \
             packages/python/goldenmatch/tests/test_cluster.py \
@@ -827,6 +832,7 @@ jobs:
             packages/python/goldenmatch/tests/test_pipeline.py \
             packages/python/goldenmatch/tests/test_pairs.py \
             packages/python/goldenmatch/tests/test_probabilistic.py \
+            -k "not native and not Native" \
             -n auto --timeout=120 --timeout-method=thread -q
 
   # Visibility lanes for tests that the main `python` job currently --ignores.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1142,15 +1142,7 @@ jobs:
           # and bench-attribution paths to sys.path internally. No --fast-only:
           # the anchors' fast signals AND the anchor_person_match F1 floor are
           # both gated (anchor_person_match is 400 entities, F1 is seconds).
-          # TEMP (re-bless on native): produce the native baseline in CI, upload it,
-          # then this step reverts to `gate`. Remove before merge.
-          uv run python -m scripts.autoconfig_quality bless
-      - name: Upload re-blessed native scorecard (TEMP)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
-        with:
-          name: reblessed-scorecard
-          path: scripts/autoconfig_quality/baselines/scorecard.json
-          retention-days: 1
+          uv run python -m scripts.autoconfig_quality gate
       - name: Quality scorecard summary
         if: always()
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1093,10 +1093,12 @@ jobs:
   # baseline (scripts/autoconfig_quality/baselines/scorecard.json). A FAIL means a
   # kernel change moved a host-independent decision (classification / matchkeys /
   # blocking fields+cost) or dropped the anchor_person_match F1 below its floor.
-  # planner_rung drift (native availability / box size) is informational WARN, so
-  # this normal-runner job (no native wheel) doesn't flap the native-on dev
-  # baseline. Real datasets (DBLP-ACM) skip-when-absent. Iterate loop + how to
-  # re-bless: scripts/autoconfig_quality/README.md.
+  # planner_rung drift (native availability / box size) is informational WARN.
+  # Reference mode: this job now BUILDS the native ext and runs the gate on the
+  # native path, so it matches the native-blessed baseline (native vs pure-Python
+  # are not parity-identical on every dataset -- ncvr_synthetic differs ~1.8pp).
+  # Real datasets (DBLP-ACM) skip-when-absent. Iterate loop + how to re-bless:
+  # scripts/autoconfig_quality/README.md.
   quality_gate:
     needs: changes
     if: needs.changes.outputs.quality_gate == 'true' || needs.changes.outputs.force_all == 'true'
@@ -1117,6 +1119,19 @@ jobs:
       # historical_50k (vendored parquet) need no extra install; real-NCVR +
       # DBLP-ACM skip-when-absent in CI (gitignored).
       - run: uv pip install recordlinkage pyarrow
+      # Reference mode (docs/design/2026-07-01-rust-is-the-reference-roadmap.md):
+      # the committed baseline is blessed native-on, and native vs pure-Python are
+      # NOT parity-identical on every dataset (ncvr_synthetic differs ~1.8pp), so a
+      # no-wheel run diffs the pure-Python fallback against a native baseline and
+      # FAILs. Native is the reference -> build the ext and run the gate on the
+      # native path so it matches the native baseline. build_native.py drops
+      # goldenmatch._native into the package (as the `native` parity lane does).
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+      - name: Build native ext (reference mode -> gate runs on the native path)
+        run: uv run python scripts/build_native.py
       - name: Run auto-config quality gate
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,7 +658,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          workspaces: packages/rust/extensions/datafusion-udf
+          workspaces: |
+            packages/rust/extensions/datafusion-udf
+            packages/rust/extensions/native
       # THE BUILD-TIME WIN: cache the built FFI UDF wheel keyed on the Rust
       # sources it's compiled from (the crate + every path-dep crate). On a hit
       # (the common case — these change rarely) the ~6.5-min --release maturin
@@ -685,6 +687,15 @@ jobs:
             echo "::notice::datafusion-udf wheel restored from cache; skipping the maturin build"
           fi
           uv pip install dist-dfudf/*.whl
+      # Reference mode (docs/design/2026-07-01-rust-is-the-reference-roadmap.md):
+      # Rust is the reference implementation, so the DEFAULT goldenmatch suite runs
+      # with the native ext BUILT -- native is the test path, not an opt-in lane
+      # that skips. Pure-Python is the lossy fallback, asserted separately in
+      # python_goldenmatch_fallback (GOLDENMATCH_NATIVE=0). The rust toolchain +
+      # cache are already set up above (for datafusion-udf); build_native.py drops
+      # goldenmatch._native into the package the way the `native` parity job does.
+      - name: Build native ext (reference mode -> native is the default test path)
+        run: uv run python scripts/build_native.py
       # Shard the suite with pytest-split (deterministic collection -> stable,
       # disjoint groups). The OOM-prone heavy files run in python_goldenmatch_heavy
       # and are --ignored here so they're neither double-run nor split. The
@@ -783,6 +794,40 @@ jobs:
           uv run coverage xml --rcfile=packages/python/goldenmatch/pyproject.toml \
             -o packages/python/goldenmatch/coverage.xml
           uv run python scripts/check_coverage_floors.py packages/python/goldenmatch/coverage.xml
+
+  # Reference mode: python_goldenmatch now runs NATIVE by default. This lean lane
+  # asserts the pure-Python FALLBACK still imports and passes on a core behavior
+  # slice -- the no-wheel path (musl / unsupported platform / GOLDENMATCH_NATIVE=0)
+  # must keep working, even though it is non-authoritative (native-vs-python parity
+  # is asserted in the `native` lane, not here). No native ext is built; the env
+  # var additionally forces the fallback even if a wheel were present.
+  python_goldenmatch_fallback:
+    needs: changes
+    if: needs.changes.outputs.python_goldenmatch == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GOLDENMATCH_NATIVE: "0"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: pytest (pure-Python fallback -- core behavior slice, GOLDENMATCH_NATIVE=0)
+        run: |
+          uv run pytest \
+            packages/python/goldenmatch/tests/test_cluster.py \
+            packages/python/goldenmatch/tests/test_golden.py \
+            packages/python/goldenmatch/tests/test_lineage.py \
+            packages/python/goldenmatch/tests/test_config.py \
+            packages/python/goldenmatch/tests/test_pipeline.py \
+            packages/python/goldenmatch/tests/test_pairs.py \
+            packages/python/goldenmatch/tests/test_probabilistic.py \
+            -n auto --timeout=120 --timeout-method=thread -q
 
   # Visibility lanes for tests that the main `python` job currently --ignores.
   # Each lane runs the gated tests with explicit prerequisites; when prereqs
@@ -2605,6 +2650,7 @@ jobs:
       - python_goldenmatch
       - python_goldenmatch_heavy
       - python_goldenmatch_coverage
+      - python_goldenmatch_fallback
       - python_skipped_lanes
       - python_postgres
       - synthetic_benchmarks

--- a/scripts/autoconfig_quality/baselines/scorecard.json
+++ b/scripts/autoconfig_quality/baselines/scorecard.json
@@ -43,7 +43,7 @@
           "email"
         ],
         "planner_rung": {
-          "backend": "polars-direct",
+          "backend": "bucket",
           "rule_name": "plan_selected_simple"
         }
       }
@@ -74,7 +74,7 @@
           "phone"
         ],
         "planner_rung": {
-          "backend": "polars-direct",
+          "backend": "bucket",
           "rule_name": "plan_selected_simple"
         }
       }
@@ -83,15 +83,18 @@
       "kind": "anchor",
       "signals": {
         "blocking_cost": {
-          "candidate_pairs": 1529,
-          "max_block": 4,
-          "n_blocks": 1411,
-          "p99": 3,
-          "reduction_ratio": 1.0
+          "candidate_pairs": 415097,
+          "max_block": 49,
+          "n_blocks": 1407,
+          "p99": 43,
+          "reduction_ratio": 0.9991
         },
         "blocking_fields": [
+          "email",
           "first_name",
           "last_name",
+          "npi",
+          "phone_number",
           "zip5"
         ],
         "classification": {
@@ -108,7 +111,7 @@
           "npi"
         ],
         "planner_rung": {
-          "backend": "polars-direct",
+          "backend": "bucket",
           "rule_name": "plan_selected_simple"
         }
       }
@@ -116,36 +119,35 @@
     "febrl3": {
       "f1": {
         "attribution": {
-          "blocking_recall": 0.9787,
-          "final_recall": 0.9824,
-          "threshold_loss": -0.0037
+          "blocking_recall": 0.9296,
+          "final_recall": 0.9618,
+          "threshold_loss": -0.0321
         },
-        "f1": 0.9665,
-        "precision": 0.9418,
-        "recall": 0.9925
+        "f1": 0.9921,
+        "precision": 0.9997,
+        "recall": 0.9847
       },
       "f1_probabilistic": {
         "attribution": {
-          "blocking_recall": 0.9787,
-          "final_recall": 0.9504,
-          "threshold_loss": 0.0283
+          "blocking_recall": 0.9296,
+          "final_recall": 0.9524,
+          "threshold_loss": -0.0228
         },
-        "f1": 0.9907,
+        "f1": 0.9908,
         "precision": 1.0,
-        "recall": 0.9816
+        "recall": 0.9818
       },
       "kind": "real",
       "signals": {
         "blocking_cost": {
-          "candidate_pairs": 202462,
-          "max_block": 186,
-          "n_blocks": 4384,
-          "p99": 43,
-          "reduction_ratio": 0.9838
+          "candidate_pairs": 15484,
+          "max_block": 36,
+          "n_blocks": 1974,
+          "p99": 14,
+          "reduction_ratio": 0.9988
         },
         "blocking_fields": [
-          "date_of_birth",
-          "given_name",
+          "soc_sec_id",
           "state",
           "surname"
         ],
@@ -171,7 +173,7 @@
           "surname"
         ],
         "planner_rung": {
-          "backend": "polars-direct",
+          "backend": "bucket",
           "rule_name": "plan_selected_simple"
         }
       }
@@ -181,16 +183,16 @@
         "attribution": {
           "skipped": "scale"
         },
-        "f1": 0.4663,
-        "precision": 0.5714,
-        "recall": 0.3938
+        "f1": 0.3409,
+        "precision": 0.2474,
+        "recall": 0.5478
       },
       "f1_probabilistic": {
         "attribution": {
           "skipped": "scale"
         },
-        "f1": 0.8294,
-        "precision": 0.931,
+        "f1": 0.8279,
+        "precision": 0.9272,
         "recall": 0.7478
       },
       "kind": "real",
@@ -223,7 +225,7 @@
           "full_name"
         ],
         "planner_rung": {
-          "backend": "polars-direct",
+          "backend": "bucket",
           "rule_name": "plan_selected_simple"
         }
       }
@@ -232,12 +234,12 @@
       "f1": {
         "attribution": {
           "blocking_recall": 1.0,
-          "final_recall": 0.9716,
-          "threshold_loss": 0.0284
+          "final_recall": 0.936,
+          "threshold_loss": 0.064
         },
-        "f1": 0.9828,
-        "precision": 0.9943,
-        "recall": 0.9716
+        "f1": 0.9649,
+        "precision": 0.9957,
+        "recall": 0.936
       },
       "f1_probabilistic": {
         "attribution": {
@@ -279,7 +281,7 @@
           "last_name"
         ],
         "planner_rung": {
-          "backend": "polars-direct",
+          "backend": "bucket",
           "rule_name": "plan_selected_simple"
         }
       }
@@ -298,7 +300,7 @@
       "dblp_acm": "absent",
       "ncvr_real": "absent"
     },
-    "git_sha": "3234de9aeaa33acdbf0e23ffab725c900f2a1259",
-    "native_version": "0.1.5"
+    "git_sha": "5db27b2fce7f84487d680b02bd229a4b805cabe7",
+    "native_version": "0.1.12"
   }
 }


### PR DESCRIPTION
## What

Inverts the goldenmatch CI so the **native path is the default test lane** and pure-Python is the explicitly-asserted fallback — the CI expression of Rust-is-the-reference (roadmap: `docs/design/2026-07-01-rust-is-the-reference-roadmap.md`). **PR of the goldenmatch Rust-reference pilot** (alongside #1343 gate flip + the FS-authoritative follow-up).

Today the default `python_goldenmatch` suite runs `uv sync` only — it does **not** build `goldenmatch._native`, so every `@native_only` test skips and the default run validates **pure-Python**. Native is exercised only in a path-filtered opt-in `native` parity lane. That's backwards under reference mode.

## Changes

- **`python_goldenmatch` builds the native ext** (`scripts/build_native.py`) so the full sharded suite runs the **native path by default**. Reuses the rust toolchain + cache already set up for `datafusion-udf` (native crate added to the `rust-cache` workspaces).
- **New `python_goldenmatch_fallback` lane** (`GOLDENMATCH_NATIVE=0`, no native build) asserts the pure-Python **fallback** still imports and passes on a core behavior slice (`cluster`/`golden`/`lineage`/`config`/`pipeline`/`pairs`/`probabilistic`). The no-wheel path stays working, though non-authoritative — native-vs-python **parity** stays in the existing `native` lane. Wired into `ci-required`.

## Risk / why not auto-merged

Running the full suite with native present may surface tests that only ever ran pure-Python (behavior assumptions, coverage-floor shifts). That's exactly what this inversion is meant to expose — but it can't be validated locally (full-suite runs OOM on this box per the repo CLAUDE.md). **This PR is intentionally not armed for auto-merge**: CI is the validation. If lanes go red, the reds are real findings to reconcile (update the test's expectation to the native path, or file a parity gap) before merge.

Workflow-file edits force the full matrix to re-run, so this PR exercises everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)