### PR TITLE
feat(golden-suite): dependency-only meta-package for one-line suite install

### DIFF
--- a/.github/workflows/golden-suite.yml
+++ b/.github/workflows/golden-suite.yml
@@ -53,7 +53,10 @@ jobs:
           PY
       - name: Smoke the introspection helpers + doctor CLI (--no-deps, fast)
         run: |
-          pip install --no-deps dist/*.whl typer rich
+          # --no-deps ONLY for the meta-package (skip the heavy suite deps); typer
+          # + rich install WITH their own deps (typer needs annotated_doc etc.).
+          pip install --no-deps dist/*.whl
+          pip install typer rich
           python -c "import golden_suite; print('version', golden_suite.__version__); print(golden_suite.installed()); print(golden_suite.native_status())"
           # doctor --no-strict must exit 0 even with the suite absent (reports None, doesn't fail)
           golden-suite doctor --json --no-strict

--- a/.github/workflows/golden-suite.yml
+++ b/.github/workflows/golden-suite.yml
@@ -1,0 +1,60 @@
+# golden-suite meta-package lane. `golden-suite` is a dependency-only meta-package
+# (one-line install for the whole suite + native acceleration, on by default) that
+# is EXCLUDED from the uv workspace -- its heavy dep tree (4 native wheels +
+# goldensuite-mcp) would otherwise enter the main uv.lock (the goldenmatch[native]
+# uv-sync footgun). So this is its only CI: build the wheel (packaging + the native
+# Requires-Dist), then smoke the introspection helpers + doctor CLI WITHOUT the
+# heavy deps installed (--no-deps), so the lane stays fast. Real install behavior
+# is covered by the standalone `pip install golden-suite` path, not the workspace.
+#
+# Informational lane (not part of ci-required). Confirm green before arming
+# auto-merge. Published via publish-golden-suite.yml on a `golden-suite-v*` tag.
+name: golden-suite
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "packages/python/golden-suite/**"
+      - ".github/workflows/golden-suite.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: packages/python/golden-suite
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build the meta-package wheel + sdist
+        run: |
+          pip install build
+          python -m build
+      - name: Wheel carries the native Requires-Dist (native on by default)
+        run: |
+          python - <<'PY'
+          import glob, zipfile, sys
+          whl = glob.glob("dist/*.whl")[0]
+          meta = zipfile.ZipFile(whl).read(
+              [n for n in zipfile.ZipFile(whl).namelist() if n.endswith("METADATA")][0]
+          ).decode()
+          reqs = [l for l in meta.splitlines() if l.startswith("Requires-Dist")]
+          need = ["goldenmatch-native", "goldencheck-native", "goldenflow-native", "goldenanalysis-native"]
+          missing = [n for n in need if not any(n in r and "extra ==" not in r for r in reqs)]
+          assert not missing, f"native not in BASE deps: {missing}"
+          print(f"OK: {len(reqs)} Requires-Dist, native in base deps")
+          PY
+      - name: Smoke the introspection helpers + doctor CLI (--no-deps, fast)
+        run: |
+          pip install --no-deps dist/*.whl typer rich
+          python -c "import golden_suite; print('version', golden_suite.__version__); print(golden_suite.installed()); print(golden_suite.native_status())"
+          # doctor --no-strict must exit 0 even with the suite absent (reports None, doesn't fail)
+          golden-suite doctor --json --no-strict
+          golden-suite version

--- a/.github/workflows/publish-golden-suite.yml
+++ b/.github/workflows/publish-golden-suite.yml
@@ -1,0 +1,57 @@
+name: Publish golden-suite to PyPI
+
+# Fires on GitHub releases tagged `golden-suite-v*` (e.g. `golden-suite-v0.1.0`).
+# Builds the dependency-only meta-package and uploads to PyPI. Mirrors the
+# publish-goldensuite-mcp.yml pattern. Tag prefix `golden-suite-v` is distinct
+# from `goldensuite-mcp-v`, so the two do not collide.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'golden-suite-v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    defaults:
+      run:
+        working-directory: packages/python/golden-suite
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify version matches tag
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${TAG#golden-suite-v}"
+          PKG_VERSION=$(python -c "import tomllib,sys; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match pyproject.toml ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: packages/python/golden-suite/dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 [![DBLP-ACM F1](https://img.shields.io/badge/DBLP--ACM%20F1-96.4%25-d4a017)](packages/python/goldenmatch/README.md#benchmarks)
 
 <!-- Reach -->
-[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+goldenanalysis+infermap+goldencheck-types+goldensuite-mcp+goldenmatch-duckdb+goldenmatch-native+goldenflow-native+goldencheck-native+goldenanalysis-native+goldenmatch-embed)
+[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+goldenanalysis+infermap+goldencheck-types+goldensuite-mcp+goldenmatch-duckdb+goldenmatch-native+goldenflow-native+goldencheck-native+goldenanalysis-native+goldenmatch-embed+golden-suite)
 [![npm downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fnpm-downloads.json)](https://www.npmjs.com/~benzsevern)
 [![GitHub stars](https://img.shields.io/github/stars/benseverndev-oss/goldenmatch?style=flat&color=d4a017&logo=github)](https://github.com/benseverndev-oss/goldenmatch/stargazers)
 
@@ -130,6 +130,7 @@ Zero-config gets you most of the way in one pass; the healing loop closes the ga
 
 | Package | Lang | What it does | Install |
 |---|---|---|---|
+| **[golden-suite](packages/python/golden-suite/README.md)** | Python | One-line meta-install: the whole suite + native acceleration, defaulted to the perf-optimized config. `golden-suite doctor` verifies the setup. | `pip install golden-suite` |
 | **[GoldenMatch](packages/python/goldenmatch/README.md)** | Python · TS | Zero-config entity resolution. Fuzzy + exact + probabilistic + LLM. Headline package. | `pip install goldenmatch` · `npm i goldenmatch` |
 | **[GoldenCheck](packages/python/goldencheck/README.md)** | Python · TS | Data-quality scanning: encoding, Unicode, format validation, anomaly detection. | `pip install goldencheck` · `npm i goldencheck` |
 | **[GoldenFlow](packages/python/goldenflow/README.md)** | Python · TS | Transforms & standardizers: phone, date, address, categorical normalization. | `pip install goldenflow` · `npm i goldenflow` |

--- a/packages/python/golden-suite/AGENTS.md
+++ b/packages/python/golden-suite/AGENTS.md
@@ -1,0 +1,151 @@
+# Integrating the Golden Suite (agent guide)
+
+You are wiring the Golden Suite into a project. This is the canonical setup — follow it
+instead of re-deriving one. If you only read one thing: **`goldenpipe` is the front door.
+Install `golden-suite`, drive `goldenpipe`, reach for individual tools only when you need
+a single capability.**
+
+`pip install golden-suite` gives you the whole suite **plus native acceleration, defaulted
+to the perf-optimized configuration** — no env vars to set. It should never silently run
+the slow pure-Python path; `golden-suite doctor` verifies that and `golden-suite optimize`
+repairs it.
+
+## The suite in one screen
+
+| Package | PyPI | What it does | Import |
+| --- | --- | --- | --- |
+| **GoldenPipe** | `goldenpipe` | Orchestrator. Chains the tools as pluggable stages. **Start here.** | `import goldenpipe as gp` |
+| **GoldenMatch** | `goldenmatch` | Entity resolution: dedupe, match across sources, golden records | `import goldenmatch as gm` |
+| **GoldenCheck** | `goldencheck` | Data validation — discovers rules from the data, no rule-writing | `import goldencheck` |
+| **GoldenFlow** | `goldenflow` | Transform / standardize / normalize messy data | `import goldenflow` |
+| **GoldenSchema** | `infermap` | Inference-driven schema mapping (import name is `infermap`) | `import infermap` |
+| **GoldenAnalysis** | `goldenanalysis` | Read-only cross-cutting metrics + reporting | `import goldenanalysis` |
+| `goldencheck-types` | `goldencheck-types` | Shared field-type contracts (transitive; you won't install directly) | — |
+| `goldensuite-mcp` | `goldensuite-mcp` | One MCP server exposing every tool (the agent front door) | — |
+
+Dependency shape (a clean DAG — **GoldenMatch is a leaf, not the root**):
+
+```
+goldencheck-types  ──►  everything (shared contracts)
+infermap (GoldenSchema) ─┐
+goldenmatch ─────────────┤
+goldencheck ─────────────┼──►  goldenpipe  ──►  golden-suite (this meta-package)
+goldenflow  ─────────────┤            └──► goldensuite-mcp (all tools, one MCP)
+goldenanalysis ──────────┘
+```
+
+## Install — pick ONE line
+
+Native acceleration is **included by default** (it's a hard dependency, not an extra).
+
+| You want... | Install |
+| --- | --- |
+| The whole suite + native, perf-optimized | `pip install golden-suite` |
+| Suite + one MCP server for agents | `pip install "golden-suite[mcp]"` |
+| Everything (suite + mcp + serving) | `pip install "golden-suite[all]"` |
+| Just entity resolution | `pip install goldenmatch` |
+| Just validation | `pip install goldencheck` |
+| Orchestrator + the three core tools only | `pip install "goldenpipe[golden-suite]"` |
+
+Supported native platforms: Linux x86_64/aarch64, macOS x86_64/arm64, Windows amd64. On a
+platform without a published wheel the install **fails loudly** (by design — the suite does
+not silently degrade to pure-Python). Those users install the individual pure-Python
+packages directly instead of `golden-suite`.
+
+## Verify + repair the setup (do this after install)
+
+```bash
+golden-suite doctor      # lists every component + whether native is ACTIVE; exits non-zero if silently slow
+golden-suite optimize    # installs any missing native kernels for this platform, then re-verifies
+```
+
+`doctor` is read-only and CI-safe (non-zero exit when a package is silently on the
+pure-Python path). Programmatic equivalents:
+
+```python
+from golden_suite import installed, native_status
+print(installed())        # {"goldenpipe": "1.2.1", "goldenmatch": "1.30.0", ...}
+print(native_status())    # per-package: native_active / silently_slow / env_mode
+```
+
+## Three ways to integrate (choose by consumer)
+
+1. **Python API** — you're inside a Python codebase. Import `goldenpipe` (or a single tool).
+2. **MCP** — the consumer is an agent/LLM. Run **one** server: `goldensuite-mcp` (or `golden-suite[mcp]`). Do **not** wire six per-package MCP servers by hand.
+3. **CLI** — one-off / shell / CI. Every package ships a Typer CLI: `goldenpipe run`, `goldenmatch dedupe`, `goldencheck scan`, etc.
+
+## Canonical quick-starts
+
+### Full pipeline (validate → transform → match), one call
+
+```python
+import goldenpipe as gp
+
+result = gp.run("customers.csv")     # zero-config
+print(result.status)                 # "success"
+print(result.check)                  # quality findings
+print(result.transform)              # what got standardized
+print(result.match)                  # deduplicated clusters
+print(result.reasoning)              # why each decision was made
+```
+
+### Just deduplicate
+
+```python
+import goldenmatch as gm
+result = gm.dedupe("customers.csv")              # zero-config
+# explicit:
+result = gm.dedupe("customers.csv", exact=["email"], fuzzy={"name": 0.85}, blocking=["zip"])
+result.golden.write_csv("deduped.csv")
+```
+
+### Match two sources
+
+```python
+result = gm.match("crm.csv", "billing.csv", fuzzy={"name": 0.85, "address": 0.80})
+```
+
+### Validate (rules discovered from the data)
+
+```python
+import goldencheck
+report = goldencheck.scan("customers.csv")
+```
+
+### Map an unknown schema to a canonical one
+
+```python
+import infermap                       # GoldenSchema
+mapping = infermap.infer("raw_export.csv")
+```
+
+### One MCP server for all of it
+
+```bash
+pip install "golden-suite[mcp]"
+goldensuite-mcp                        # every suite tool, one server
+```
+
+## Anti-patterns that cause the back-and-forth (don't do these)
+
+- **Installing `goldenmatch` and expecting the pipeline / check / transform.** GoldenMatch is
+  entity resolution only. For the end-to-end flow use `goldenpipe`.
+- **Hand-wiring each tool into a bespoke pipeline.** `goldenpipe` already registers every tool
+  as a stage (`goldencheck.scan`, `goldenflow.transform`, `goldenmatch.dedupe`,
+  `goldenmatch.identity_resolve`, `goldenanalysis.report`) via entry-points. Use it.
+- **Running six MCP servers.** One `goldensuite-mcp` exposes them all.
+- **Importing `goldenschema`.** The import name is `infermap` (PyPI/product name is GoldenSchema).
+- **Assuming native is off and setting `<PKG>_NATIVE=1` "to turn it on".** It's already on by
+  default (`auto` runs the parity-signed-off hot paths native automatically). `=1` is a
+  *require-and-force* mode that also runs components NOT yet parity-signed-off (notably
+  goldenflow) and **can change outputs** — only use it via `golden-suite optimize --strict`
+  after validating parity for your workload.
+- **Pinning tools to each other's versions.** They release independently. Let `golden-suite`
+  carry the compatible lower bounds; don't hard-pin cross-package versions in the consumer.
+
+## Notes
+
+- Python 3.11–3.13. Everything is Polars-backed.
+- Repo: `benseverndev-oss/goldenmatch` (monorepo — all suite packages live here under
+  `packages/python/<pkg>`).
+- Per-tool detail: each package has its own `AGENTS.md` and `llms.txt`.

--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to golden-suite are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/); this project uses semantic
+versioning.
+
+## [0.1.0] - unreleased
+
+Initial release. A one-line, perf-optimized install and a single canonical front
+door for the whole Golden Suite.
+
+### Added
+- `pip install golden-suite` pulls the whole suite — `goldenpipe[golden-suite]`
+  (orchestrator + check/flow/match/analysis), plus `goldenmatch`, `goldencheck`,
+  `goldenflow`, `infermap` (GoldenSchema), `goldenanalysis`, `goldencheck-types`.
+- **Native acceleration on by default.** The four native (Rust/abi3) kernels
+  (`goldenmatch-native`, `goldencheck-native`, `goldenflow-native`,
+  `goldenanalysis-native`) are **hard dependencies**, not an opt-in extra, so the
+  suite defaults to the perf-optimized configuration and never silently runs the
+  slow pure-Python path. Wheels cover Linux x86_64/aarch64, macOS x86_64/arm64,
+  and Windows amd64; on an unsupported platform the install fails loudly by design.
+- `golden-suite` CLI:
+  - `doctor` — reports every component + version and whether each native kernel is
+    actually active; exits non-zero when a package is silently on the pure-Python
+    path (CI/verification-safe).
+  - `optimize` — installs any missing native kernels for the current platform, then
+    re-verifies. `--strict` additionally emits the require-native env vars
+    (`<PKG>_NATIVE=1`), with a warning that strict mode force-runs components not
+    yet parity-signed-off (notably goldenflow) and can change outputs.
+- Introspection helpers: `golden_suite.installed()` (dist -> version|None) and
+  `golden_suite.native_status()` (per-package `native_active` / `silently_slow` /
+  `env_mode`).
+- Optional extras: `[mcp]` (`goldensuite-mcp` — one server for every tool),
+  `[agent]` (GoldenPipe tui/api/agent serving surfaces), and `[all]`.
+- Integration guide for agents and humans: `AGENTS.md`, `llms.txt`, `README.md`.
+
+### Notes
+- Ships no data-processing logic of its own beyond the CLI + introspection helpers.
+- Published on the `golden-suite-v*` release tag via `publish-golden-suite.yml`
+  (distinct from the `goldensuite-mcp-v*` tag).

--- a/packages/python/golden-suite/README.md
+++ b/packages/python/golden-suite/README.md
@@ -1,0 +1,72 @@
+# golden-suite
+
+One-line, perf-optimized install and single front door for the whole **Golden Suite**.
+
+```bash
+pip install golden-suite      # whole suite + native acceleration, defaulted to the fast config
+golden-suite doctor           # verify native is actually active
+```
+
+This is a thin meta-package. It pulls in every suite tool **plus the native (Rust)
+acceleration kernels, on by default**, and gives you (and your agents) one canonical entry
+point. It ships no data-processing logic of its own — just a `doctor`/`optimize` CLI and
+introspection helpers.
+
+## What you get
+
+| Tool | Does | Import |
+| --- | --- | --- |
+| **GoldenPipe** | Orchestrator — chains the tools as pluggable stages. **Start here.** | `import goldenpipe as gp` |
+| **GoldenMatch** | Entity resolution: dedupe, match, golden records | `import goldenmatch as gm` |
+| **GoldenCheck** | Data validation (rules discovered from your data) | `import goldencheck` |
+| **GoldenFlow** | Transform / standardize / normalize | `import goldenflow` |
+| **GoldenSchema** | Inference-driven schema mapping (import name: `infermap`) | `import infermap` |
+| **GoldenAnalysis** | Read-only metrics + reporting | `import goldenanalysis` |
+
+`goldenpipe` is the front door: it adapts every other tool as a stage, so most integrations
+only ever touch `goldenpipe`. `goldenmatch` is a leaf (entity resolution only), not the root.
+
+## Install options
+
+Native acceleration is included by default (a hard dependency, not an extra).
+
+| You want | Install |
+| --- | --- |
+| The whole suite + native | `pip install golden-suite` |
+| Suite + one MCP server | `pip install "golden-suite[mcp]"` |
+| Everything (suite + mcp + serving) | `pip install "golden-suite[all]"` |
+
+Native wheels cover Linux x86_64/aarch64, macOS x86_64/arm64, Windows amd64. On an
+unsupported platform the install fails loudly rather than silently degrading — install the
+individual pure-Python packages directly there.
+
+## Quick start
+
+```python
+import goldenpipe as gp
+
+result = gp.run("customers.csv")   # validate -> transform -> match, one call
+print(result.status, result.match, result.reasoning)
+```
+
+Verify + repair the perf setup:
+
+```bash
+golden-suite doctor      # every component + whether native is ACTIVE (non-zero exit if silently slow)
+golden-suite optimize    # install any missing native kernels, then re-verify
+```
+
+```python
+from golden_suite import installed, native_status
+print(installed())       # {"goldenpipe": "1.2.1", "goldenmatch": "1.30.0", ...}
+print(native_status())   # per-package native_active / silently_slow / env_mode
+```
+
+## For agents
+
+See [`AGENTS.md`](./AGENTS.md) and [`llms.txt`](./llms.txt) — the canonical integration guide,
+including the anti-patterns that cause most of the "wrong setup" back-and-forth.
+
+## License
+
+MIT. Part of the [Golden Suite monorepo](https://github.com/benseverndev-oss/goldenmatch).

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -1,0 +1,120 @@
+"""Golden Suite meta-package.
+
+One-line, perf-optimized install and a single canonical entry point for the whole
+suite. Ships almost no logic of its own — just introspection helpers and a
+``golden-suite`` CLI (``doctor`` / ``optimize``). For real work, import the
+individual tools (or, most of the time, just ``goldenpipe`` — the orchestrator
+that adapts every other tool as a stage).
+
+    import goldenpipe as gp
+    result = gp.run("customers.csv")   # runs check -> transform -> match end to end
+
+Native acceleration is installed by default. Use :func:`installed` to see which
+components resolved, and :func:`native_status` to see whether each native kernel
+is actually active (the truth behind "am I on the fast path").
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from importlib import metadata
+
+__version__ = "0.1.0"
+
+# PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
+_COMPONENTS: dict[str, str] = {
+    "goldenpipe": "goldenpipe",
+    "goldenmatch": "goldenmatch",
+    "goldencheck": "goldencheck",
+    "goldenflow": "goldenflow",
+    "infermap": "infermap",  # GoldenSchema
+    "goldenanalysis": "goldenanalysis",
+    "goldencheck-types": "goldencheck_types",
+    "goldensuite-mcp": "goldensuite_mcp",
+}
+
+# Packages that ship an optional native (Rust/abi3) accelerator, and the pieces
+# needed to reason about it WITHOUT importing the heavy top-level package:
+#   base package -> (native distribution, standalone native import module, env var)
+# The runtime loader tries ``<pkg>._native`` (in-tree build) then
+# ``<pkg>_native._native`` (the published wheel). For a pip user only the wheel
+# path exists, so probing the standalone ``<pkg>_native`` module is both accurate
+# and lightweight (it does not pull in polars et al.).
+_NATIVE: dict[str, tuple[str, str, str]] = {
+    "goldenmatch": ("goldenmatch-native", "goldenmatch_native", "GOLDENMATCH_NATIVE"),
+    "goldencheck": ("goldencheck-native", "goldencheck_native", "GOLDENCHECK_NATIVE"),
+    "goldenflow": ("goldenflow-native", "goldenflow_native", "GOLDENFLOW_NATIVE"),
+    "goldenanalysis": (
+        "goldenanalysis-native",
+        "goldenanalysis_native",
+        "GOLDENANALYSIS_NATIVE",
+    ),
+}
+
+
+def _version_or_none(dist: str) -> str | None:
+    try:
+        return metadata.version(dist)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def installed() -> dict[str, str | None]:
+    """Return ``{distribution_name: version-or-None}`` for every suite component.
+
+    ``None`` means the component is not installed in this environment. The fastest
+    way to confirm an integration actually got the intended setup.
+    """
+    return {dist: _version_or_none(dist) for dist in _COMPONENTS}
+
+
+def _native_importable(native_module: str) -> bool:
+    """Whether the standalone native wheel (e.g. ``goldenmatch_native._native``)
+    imports cleanly — the same path the runtime loader uses under a pip install."""
+    try:
+        mod = importlib.import_module(native_module)
+    except Exception:  # noqa: BLE001 - any import/load failure => not available
+        return False
+    if getattr(mod, "_native", None) is not None:
+        return True
+    try:  # some builds expose ``_native`` only as a submodule
+        importlib.import_module(f"{native_module}._native")
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def native_status() -> dict[str, dict[str, object]]:
+    """Per-package native-acceleration status.
+
+    For each accel-capable package returns a dict with:
+      - ``base_installed``  : the base package version, or ``None``
+      - ``native_version``  : the native wheel version, or ``None``
+      - ``native_active``   : whether the native kernel imports (fast path live)
+      - ``env_mode``        : the ``<PKG>_NATIVE`` env value (``auto`` if unset)
+      - ``silently_slow``   : base installed but native NOT active AND env != "0"
+                              — i.e. the runtime is silently on the pure-Python path
+    """
+    out: dict[str, dict[str, object]] = {}
+    for pkg, (native_dist, native_module, env_var) in _NATIVE.items():
+        base_installed = _version_or_none(pkg)
+        native_version = _version_or_none(native_dist)
+        native_active = _native_importable(native_module)
+        env_mode = os.environ.get(env_var, "auto").lower()
+        silently_slow = (
+            base_installed is not None and not native_active and env_mode != "0"
+        )
+        out[pkg] = {
+            "base_installed": base_installed,
+            "native_dist": native_dist,
+            "native_version": native_version,
+            "native_active": native_active,
+            "env_var": env_var,
+            "env_mode": env_mode,
+            "silently_slow": silently_slow,
+        }
+    return out
+
+
+__all__ = ["__version__", "installed", "native_status"]

--- a/packages/python/golden-suite/golden_suite/cli.py
+++ b/packages/python/golden-suite/golden_suite/cli.py
@@ -1,0 +1,182 @@
+"""``golden-suite`` CLI: verify and repair the perf-optimized setup.
+
+    golden-suite doctor      # report every component + whether native is actually active
+    golden-suite optimize    # install any missing native kernels, then re-verify
+
+``doctor`` is read-only and exits non-zero when the runtime would silently run the
+slow pure-Python path — so it doubles as a CI/verification gate. ``optimize`` acts.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import subprocess
+import sys
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from . import __version__, installed, native_status
+
+app = typer.Typer(
+    add_completion=False,
+    help="Verify and repair the perf-optimized Golden Suite setup.",
+    no_args_is_help=True,
+)
+_console = Console()
+_err = Console(stderr=True)
+
+
+def _components_table() -> Table:
+    table = Table(title="Golden Suite components", title_style="bold")
+    table.add_column("Package")
+    table.add_column("Version")
+    for dist, version in installed().items():
+        if version is None:
+            table.add_row(dist, "[yellow]not installed[/]")
+        else:
+            table.add_row(dist, version)
+    return table
+
+
+def _native_table(status: dict[str, dict[str, object]]) -> Table:
+    table = Table(title="Native acceleration", title_style="bold")
+    table.add_column("Package")
+    table.add_column("Native wheel")
+    table.add_column("Fast path")
+    table.add_column("Env")
+    table.add_column("Verdict")
+    for pkg, s in status.items():
+        if s["base_installed"] is None:
+            continue  # base package not installed; nothing to accelerate
+        wheel = s["native_version"] or "[yellow]missing[/]"
+        if s["native_active"]:
+            fast = "[green]native[/]"
+        else:
+            fast = "[red]pure-python[/]"
+        if s["env_mode"] == "0":
+            verdict = "[yellow]native disabled (env=0)[/]"
+        elif s["silently_slow"]:
+            verdict = "[red]SILENTLY SLOW[/]"
+        elif s["native_active"]:
+            verdict = "[green]OK[/]"
+        else:
+            verdict = "[yellow]inactive[/]"
+        table.add_row(pkg, str(wheel), fast, str(s["env_mode"]), verdict)
+    return table
+
+
+@app.command()
+def doctor(
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+    strict: bool = typer.Option(
+        True,
+        "--strict/--no-strict",
+        help="Exit non-zero if any package is silently on the pure-Python path.",
+    ),
+) -> None:
+    """Report every component and whether the native fast path is actually active."""
+    status = native_status()
+    silently_slow = [p for p, s in status.items() if s["silently_slow"]]
+    missing_base = [d for d, v in installed().items() if v is None]
+
+    if as_json:
+        _console.print_json(
+            _json.dumps(
+                {
+                    "version": __version__,
+                    "installed": installed(),
+                    "native": status,
+                    "silently_slow": silently_slow,
+                    "missing_components": missing_base,
+                }
+            )
+        )
+    else:
+        _console.print(_components_table())
+        _console.print(_native_table(status))
+        if silently_slow:
+            _err.print(
+                f"\n[red]FAIL[/]: {', '.join(silently_slow)} installed but running "
+                f"pure-Python. Run [bold]golden-suite optimize[/] to fix."
+            )
+        else:
+            _console.print("\n[green]OK[/]: native acceleration active where expected.")
+
+    if strict and silently_slow:
+        raise typer.Exit(code=1)
+
+
+@app.command()
+def optimize(
+    strict_runtime: bool = typer.Option(
+        False,
+        "--strict/--no-strict",
+        help=(
+            "Also emit require-native env vars (<PKG>_NATIVE=1). WARNING: strict "
+            "mode forces native for components NOT yet parity-signed-off (notably "
+            "goldenflow) and can change outputs. Off by default."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be installed, do nothing."
+    ),
+) -> None:
+    """Install any missing native kernels for this platform, then re-verify."""
+    status = native_status()
+    # A package needs repair when its base is installed but the native wheel is
+    # absent or won't import on this interpreter.
+    to_install = [
+        str(s["native_dist"])
+        for s in status.values()
+        if s["base_installed"] is not None and not s["native_active"]
+    ]
+
+    if not to_install:
+        _console.print("[green]Already optimal[/]: every native kernel is active.")
+    else:
+        _console.print(
+            f"Native kernels to install: [bold]{', '.join(to_install)}[/]"
+        )
+        if dry_run:
+            _console.print("[yellow]--dry-run[/]: nothing installed.")
+        else:
+            cmd = [sys.executable, "-m", "pip", "install", "--upgrade", *to_install]
+            _console.print(f"$ {' '.join(cmd)}")
+            result = subprocess.run(cmd, check=False)
+            if result.returncode != 0:
+                _err.print(
+                    "[red]pip install failed[/]. On a platform without a published "
+                    "wheel, native cannot be enabled — see the docs for supported "
+                    "platforms."
+                )
+                raise typer.Exit(code=result.returncode)
+
+    if strict_runtime:
+        _console.print(
+            "\n[bold]Require-native env[/] (add to your shell/.env to make a missing "
+            "kernel raise instead of silently falling back):"
+        )
+        for s in status.values():
+            if s["base_installed"] is not None:
+                _console.print(f"  export {s['env_var']}=1")
+        _err.print(
+            "\n[yellow]WARNING[/]: <PKG>_NATIVE=1 forces native for components not "
+            "yet parity-signed-off (e.g. goldenflow) and MAY change outputs. Only "
+            "use it if you have validated parity for your workload."
+        )
+
+    if not dry_run:
+        _console.print()
+        doctor(as_json=False, strict=False)
+
+
+@app.command()
+def version() -> None:
+    """Print the golden-suite meta-package version."""
+    _console.print(__version__)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/packages/python/golden-suite/llms.txt
+++ b/packages/python/golden-suite/llms.txt
@@ -1,0 +1,94 @@
+# Golden Suite
+
+> One-line, perf-optimized install and single front door for the whole Golden Suite: entity
+> resolution (GoldenMatch), data validation (GoldenCheck), transformation (GoldenFlow),
+> schema mapping (GoldenSchema/infermap), read-only analysis (GoldenAnalysis), all
+> orchestrated by GoldenPipe. Native (Rust) acceleration is included and on by default;
+> the suite never silently runs the slow pure-Python path. Ships a tiny `golden-suite` CLI
+> (doctor/optimize) plus introspection helpers.
+
+## Mental model
+- `goldenpipe` is the orchestrator and the front door. It adapts every other tool as a
+  pluggable stage. Most integrations only touch `goldenpipe`.
+- `goldenmatch` is a LEAF (entity resolution), not the root. Do not expect the pipeline,
+  validation, or transforms from it.
+- `goldensuite-mcp` is one MCP server exposing every tool — the agent front door.
+
+## Components
+- GoldenPipe (`goldenpipe`) — orchestrator; `import goldenpipe as gp`
+- GoldenMatch (`goldenmatch`) — dedupe, match, golden records; `import goldenmatch as gm`
+- GoldenCheck (`goldencheck`) — validation, rules discovered from data; `import goldencheck`
+- GoldenFlow (`goldenflow`) — transform / standardize / normalize; `import goldenflow`
+- GoldenSchema (`infermap`) — inference-driven schema mapping; `import infermap`
+- GoldenAnalysis (`goldenanalysis`) — read-only metrics + reporting; `import goldenanalysis`
+- `goldencheck-types` — shared field-type contracts (transitive)
+- `goldensuite-mcp` — one MCP server, every tool
+
+## Install
+- `pip install golden-suite` — whole suite + native acceleration, perf-optimized (Python)
+- `pip install "golden-suite[mcp]"` — suite + one MCP server (`goldensuite-mcp`)
+- `pip install "golden-suite[all]"` — suite + mcp + serving surfaces
+- Single tool instead: `pip install goldenmatch` / `goldencheck` / `goldenflow` / `infermap`
+- Orchestrator + core three: `pip install "goldenpipe[golden-suite]"`
+- Native wheels cover Linux x86_64/aarch64, macOS x86_64/arm64, Windows amd64. On an
+  unsupported platform the install fails loudly (no silent pure-Python) — install the
+  individual pure-Python packages directly there.
+
+## Verify + repair the setup
+- `golden-suite doctor` — every component + whether native is ACTIVE; non-zero exit if silently slow (CI-safe)
+- `golden-suite optimize` — install missing native kernels for this platform, then re-verify
+```python
+from golden_suite import installed, native_status
+print(installed())      # dist -> version|None for every suite component
+print(native_status())  # per-package native_active / silently_slow / env_mode
+```
+
+## Quick examples
+
+### Full pipeline (validate -> transform -> match), one call
+```python
+import goldenpipe as gp
+result = gp.run("customers.csv")
+print(result.status, result.check, result.transform, result.match, result.reasoning)
+```
+
+### Deduplicate
+```python
+import goldenmatch as gm
+result = gm.dedupe("customers.csv", exact=["email"], fuzzy={"name": 0.85}, blocking=["zip"])
+result.golden.write_csv("deduped.csv")
+```
+
+### Match two sources
+```python
+result = gm.match("crm.csv", "billing.csv", fuzzy={"name": 0.85, "address": 0.80})
+```
+
+### Validate
+```python
+import goldencheck
+report = goldencheck.scan("customers.csv")
+```
+
+### Map an unknown schema
+```python
+import infermap                       # GoldenSchema
+mapping = infermap.infer("raw_export.csv")
+```
+
+### One MCP server for everything
+```bash
+pip install "golden-suite[mcp]" && goldensuite-mcp
+```
+
+## Anti-patterns
+- Installing `goldenmatch` and expecting the pipeline/check/transform — use `goldenpipe`.
+- Hand-wiring each tool — `goldenpipe` already registers them as stages.
+- Running six MCP servers — use one `goldensuite-mcp`.
+- `import goldenschema` — the import name is `infermap`.
+- Setting `<PKG>_NATIVE=1` "to enable native" — it's already on by default; `=1` force-runs
+  non-signed-off components (goldenflow) and can change outputs. Use `optimize --strict` only
+  after validating parity.
+
+## Repo
+- Monorepo: benseverndev-oss/goldenmatch (packages/python/<pkg>). Python 3.11-3.13, Polars-backed.

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -1,0 +1,76 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "golden-suite"
+version = "0.1.0"
+description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
+readme = "README.md"
+requires-python = ">=3.11,<3.14"
+license = { text = "MIT" }
+authors = [{ name = "Ben Severn", email = "ben@bensevern.dev" }]
+keywords = ["data-quality", "entity-resolution", "pipeline", "schema-inference", "golden-suite", "meta-package"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+# `pip install golden-suite` gets the WHOLE suite AND the native acceleration
+# kernels, in one line, defaulting to the perf-optimized configuration.
+#
+# `goldenpipe` is the orchestrator (adapts every tool as a stage). The native
+# wheels are HARD dependencies on purpose: the suite should never silently run
+# the slow pure-Python path. abi3 wheels are published for the five mainstream
+# platforms (Linux x86_64/aarch64, macOS x86_64/arm64, Windows amd64); on any
+# platform without a wheel the install fails LOUDLY rather than degrading.
+# Under each package's default `auto` gate, the parity-signed-off hot paths then
+# run native automatically — no env vars to set. `golden-suite doctor` verifies
+# it; `golden-suite optimize` repairs it.
+dependencies = [
+    # --- suite ---
+    "goldenpipe[golden-suite]>=1.2.1",  # orchestrator + check/flow/match/analysis
+    "goldenmatch>=1.30",                # entity resolution: dedupe, match, golden records
+    "goldencheck>=1.3",                 # data validation (rules discovered from your data)
+    "goldenflow>=1.2",                  # transform / standardize / normalize
+    "infermap>=0.5",                    # GoldenSchema: inference-driven schema mapping
+    "goldenanalysis>=0.1",              # read-only cross-cutting metrics + reporting
+    "goldencheck-types>=0.1",           # shared canonical field-type contracts
+    # --- native acceleration (on by default; see note above) ---
+    "goldenmatch-native>=0.1.11",       # >=0.1.11 carries the #692 rayon-park fix
+    "goldencheck-native>=0.1",
+    "goldenflow-native>=0.1.1",
+    "goldenanalysis-native>=0.1",
+    # --- CLI (doctor / optimize) ---
+    "typer>=0.12",
+    "rich>=13.0",
+]
+
+[project.optional-dependencies]
+# One MCP server exposing every tool — the agent front door.
+mcp = ["goldensuite-mcp>=0.2"]
+# GoldenPipe serving surfaces (A2A + async transports + TUI + REST).
+agent = ["goldenpipe[tui,api,agent]>=1.2.1"]
+# Everything: full suite + native + MCP + serving.
+all = ["golden-suite[mcp,agent]"]
+dev = ["pytest>=8", "ruff>=0.6"]
+
+[project.scripts]
+golden-suite = "golden_suite.cli:app"
+
+[project.urls]
+Homepage = "https://github.com/benseverndev-oss/goldenmatch"
+Repository = "https://github.com/benseverndev-oss/goldenmatch"
+Documentation = "https://github.com/benseverndev-oss/goldenmatch/tree/main/packages/python/golden-suite#readme"
+Issues = "https://github.com/benseverndev-oss/goldenmatch/issues"
+Changelog = "https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/python/golden-suite/CHANGELOG.md"
+
+[tool.hatch.build.targets.wheel]
+packages = ["golden_suite"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ members = ["packages/python/*"]
 # goldengraph (SP4b) is EXCLUDED for the same reasons: it depends on the
 # goldengraph-native engine wheel (maturin-built) + optional LLM extras, so it is
 # standalone, built + tested by .github/workflows/goldengraph-pipeline.yml.
-exclude = ["packages/python/goldenmatch-kg", "packages/python/goldengraph"]
+exclude = ["packages/python/goldenmatch-kg", "packages/python/goldengraph", "packages/python/golden-suite"]
 
 [tool.uv.sources]
 goldenmatch = { workspace = true }

--- a/scripts/suite_download_badges.py
+++ b/scripts/suite_download_badges.py
@@ -30,6 +30,10 @@ PYPI_PACKAGES = [
     "infermap",
     "goldencheck-types",
     "goldensuite-mcp",
+    # One-line meta-package (whole suite + native, on by default). A distinct PyPI
+    # distribution whose downloads partially overlap its component packages --
+    # counted here for the same reason as the *-native extras below.
+    "golden-suite",
     # SQL extension + the optional compiled `*-native` / embed runtimes. These
     # are extras (goldenmatch[native], goldenanalysis[native], ...), so their
     # downloads partially overlap their parent packages -- counted here because


### PR DESCRIPTION
## What

`pip install golden-suite` installs the **whole Golden Suite + native acceleration** in one line, defaulting to the perf-optimized config. A thin, dependency-only meta-package (no data-processing logic) that gives humans and agents one canonical front door.

## Contents

- **Package** (`packages/python/golden-suite/`): `pyproject.toml`, `golden_suite/{__init__,cli}.py`, README/CHANGELOG/AGENTS.md/llms.txt.
- **CLI**: `golden-suite doctor` (reports every component + whether native is *active*; exits non-zero if silently on the pure-Python path — CI-usable) and `golden-suite optimize` (installs missing native kernels). Helpers: `installed()` / `native_status()`.
- **Native is a hard base dep** (goldenmatch/check/flow/analysis-native): the suite should never silently run pure-Python. abi3 wheels cover the 5 mainstream platforms; unsupported platforms fail the install loudly by design.
- **`golden-suite.yml`** standalone lane (build wheel + doctor smoke, informational — mirrors the `goldenmatch-kg` posture).
- **`publish-golden-suite.yml`** publishes on a `golden-suite-v*` tag (distinct from `goldensuite-mcp-v*`).

## Key correctness detail

**Excluded from the uv workspace** (root `pyproject.toml`, alongside `goldenmatch-kg`/`goldengraph`). Its heavy dep tree (4 native wheels + `goldensuite-mcp`) would otherwise enter the main `uv.lock` and risk breaking `uv sync --all-packages` — the documented `goldenmatch[native]` footgun. So `uv.lock` is untouched; the package installs standalone from PyPI.

## Validation

Wheel builds clean (isolated env); Requires-Dist carries the 4 native wheels in base deps + `[mcp]`/`[agent]`/`[all]` extras; `console_scripts: golden-suite = golden_suite.cli:app`; `doctor`/`optimize`/`installed()`/`native_status()` exercised locally (doctor correctly flagged a partially-native env). Both workflow YAMLs parse; workspace exclude verified.

The `golden-suite` lane is informational (not `ci-required`) — confirm it green before merge (kg precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)