### PR TITLE
Recall-tuned extraction prompt (GOLDENGRAPH_EXTRACT_RECALL): REFUTED for substrate, gate ships default-off

### DIFF
--- a/docs/superpowers/plans/2026-07-01-extract-recall-prompt.md
+++ b/docs/superpowers/plans/2026-07-01-extract-recall-prompt.md
@@ -1,0 +1,116 @@
+# Recall-Tuned Extraction Prompt — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A gated `GOLDENGRAPH_EXTRACT_RECALL=1` recall-tuned extract prompt, measured on the wiki corpus via `coverage` — the first real-prose extraction-recall lever (and a diagnostic: framing vs density).
+
+**Spec:** `docs/superpowers/specs/2026-07-01-extract-recall-prompt-design.md`
+**Branch:** `feat/extract-recall-prompt` (off main; rebase onto main-with-#1345 before the Modal run for the aliased aligner).
+
+**Box-safe test invocation (goldengraph pkg, worktree shadow):**
+```bash
+PY="/d/show_case/goldenmatch/.venv/Scripts/python.exe"
+cd packages/python/goldengraph
+PYTHONPATH="D:/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 "$PY" -m pytest <test> -q -p no:cacheprovider
+```
+
+---
+
+## Task 1: `_RECALL_INSTRUCTION` + gate
+
+**Files:**
+- Modify: `packages/python/goldengraph/goldengraph/extract.py`
+- Test: `packages/python/goldengraph/tests/test_extract_recall.py`
+
+- [ ] **Step 1: Write the failing test** (mirror `test_entity_type_constraint.py`):
+
+```python
+"""GOLDENGRAPH_EXTRACT_RECALL prepends an exhaustive-entity instruction to the extract prompt."""
+from goldengraph.extract import extract
+
+
+class _CaptureLLM:
+    def __init__(self):
+        self.prompt = None
+
+    def complete(self, prompt):
+        self.prompt = prompt
+        return '{"entities": [], "relationships": []}'
+    # no complete_json -> extract() falls back to .complete
+
+
+def test_recall_instruction_absent_by_default(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_EXTRACT_RECALL", raising=False)
+    llm = _CaptureLLM()
+    extract("some text", llm)
+    assert "Extract EVERY named entity" not in llm.prompt
+
+
+def test_recall_instruction_present_when_gated(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_EXTRACT_RECALL", "1")
+    monkeypatch.setenv("GOLDENGRAPH_EXTRACT_JSON_MODE", "0")  # force .complete for the stub
+    llm = _CaptureLLM()
+    extract("some text", llm)
+    assert "Extract EVERY named entity" in llm.prompt
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement in `extract.py`** — add the constant near `_ENTITY_TYPE_VOCAB_INSTRUCTION`:
+
+```python
+#: Prepended when GOLDENGRAPH_EXTRACT_RECALL is on. The default prompt is relation-centric (entities exist
+#: to be indexed by relationships), so a 7B drops entities mentioned without a clear relation -- the ~0.44
+#: real-prose extraction-recall ceiling (L2). This instruction pushes exhaustive named-entity extraction.
+_RECALL_INSTRUCTION = (
+    "Extract EVERY named entity mentioned -- people, organizations, places, products, works -- and list "
+    "it in `entities` even if it does not participate in any relationship. Do not omit an entity just "
+    "because it lacks a clear relation.\n\n"
+)
+
+
+def extract_recall_enabled() -> bool:
+    """`GOLDENGRAPH_EXTRACT_RECALL` gate: push exhaustive named-entity extraction (recall over precision)."""
+    return os.environ.get("GOLDENGRAPH_EXTRACT_RECALL", "0") not in ("0", "false", "")
+```
+In `extract()`, after the entity-type-vocab prepend (before `return parse_extraction(...)`):
+```python
+    if extract_recall_enabled():
+        prompt = _RECALL_INSTRUCTION + prompt
+```
+
+- [ ] **Step 4: Run tests, verify pass** + `ruff check extract.py`.
+- [ ] **Step 5: Commit** — `feat(goldengraph): gated recall-tuned extraction prompt (GOLDENGRAPH_EXTRACT_RECALL)`.
+
+---
+
+## Task 2: Modal wiki measurement + verdict
+
+**Files:** Create `docs/superpowers/reports/2026-07-01-extract-recall-prompt-verdict.md`.
+
+- [ ] **Step 0: Rebase onto main once #1345 merges** (so the wiki eval uses the aliased aligner):
+```bash
+git fetch origin && git rebase origin/main   # or --onto if stacked
+```
+
+- [ ] **Step 1: Fire two legs** (wiki, `name_ci`, baseline vs recall; distinct `--n`; `PYTHONIOENCODING=utf-8 PYTHONUTF8=1`):
+```bash
+M="/d/show_case/goldenmatch/.venv/Scripts/modal.exe"
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 70 \
+  --opts $'GOLDENGRAPH_SUBSTRATE_CORPUS=wiki\nGOLDENGRAPH_XDOC_KEY=name_ci' --spawn                     # control (no recall)
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 71 \
+  --opts $'GOLDENGRAPH_SUBSTRATE_CORPUS=wiki\nGOLDENGRAPH_XDOC_KEY=name_ci\nGOLDENGRAPH_EXTRACT_RECALL=1' --spawn   # recall
+```
+Monitor `results/substrate_7{0,1}_*.md` for `[substrate-wiki]`.
+
+- [ ] **Step 2: Read** `coverage` (0.44 →?), `R(B)`, `P(B)`, `components` for both. The control leg re-confirms the ~0.44 baseline on the current build.
+
+- [ ] **Step 3: Write the verdict** — coverage delta + the P(B)/components guardrails, and the diagnostic read: framing (ship) / density (→ chunking) / over-extraction tradeoff.
+
+- [ ] **Step 4: Commit** the report.
+
+---
+
+## Completion
+
+Use superpowers:finishing-a-development-branch: box-safe tests, PR (base `main`), arm auto-merge. If refuted (flat coverage), the chunking lever is the next sub-project.

--- a/docs/superpowers/reports/2026-07-01-extract-recall-prompt-verdict.md
+++ b/docs/superpowers/reports/2026-07-01-extract-recall-prompt-verdict.md
@@ -1,0 +1,33 @@
+# Recall-Tuned Extraction Prompt — Verdict
+
+**Date:** 2026-07-01
+**Branch:** `feat/extract-recall-prompt`
+**Spec/Plan:** `docs/superpowers/specs/2026-07-01-extract-recall-prompt-design.md` · `docs/superpowers/plans/2026-07-01-extract-recall-prompt.md`
+**Run:** Modal `gg-bench` (7B), `--corpus wiki`, `name_ci`, surface aligner (the *delta* is aligner-independent).
+
+## What this tested
+
+The L2 clean-absolute finding put the real-prose substrate ceiling at extraction recall (~0.44 coverage — the 7B doesn't extract ~56% of wikilinked entities from dense prose). First lever, cheapest-first: does a **recall-tuned prompt** (`GOLDENGRAPH_EXTRACT_RECALL=1`, "extract EVERY named entity even without a relationship") lift extraction recall? Also a diagnostic: is the miss relation-centric *framing* (fixable by prompt) or *density* (needs chunking)?
+
+## Result — REFUTED (counterproductive)
+
+| leg | coverage | R(B) | P(B) | components |
+|---|---|---|---|---|
+| control (no recall) | 0.4000 | 0.2323 | 1.0 | 12 |
+| `EXTRACT_RECALL=1` | **0.3538** | 0.1616 | 1.0 | **25** |
+
+The recall prompt made every substrate signal **worse**: coverage −0.05, R(B) −0.07, components **doubled** (12→25). Precision held (1.0).
+
+**Mechanism:** "extract EVERY entity" pushed the 7B to *list more entities* at the expense of *extracting relations*. The substrate build is edge-centric (a node exists via the edges it participates in; the aligner keys on edge `source_refs`), so fewer edges → fewer gold mentions alignable (coverage down) and the extra entity-only nodes fragment the graph (components up). The prompt **traded edges for entity noise.**
+
+## Conclusion
+
+- **The real-prose miss is NOT relation-centric framing.** Exhaustive-entity prompting is the wrong lever — it degrades the substrate. A clean negative, consistent with the arc's prior that 7B prompt-constraints are hit-or-miss.
+- **The gate ships default-off** as a documented, opt-in recall-over-precision knob (legitimate for a NER-style goal), NOT recommended for the substrate.
+- **Next lever: chunking.** Extract per sentence/paragraph and union — preserves *both* entities and relations per chunk (unlike this prompt, which sacrificed relations), directly attacking the one-pass-over-a-long-dense-doc problem. That is the next sub-project.
+
+## Follow-ons
+
+1. **Sentence/paragraph chunking** — the next extraction-recall lever (preserves edges).
+2. **GLiNER NER extractor** (`extract_local.gliner_extractor`) — high-recall entities + LLM relations (hybrid), if chunking under-delivers.
+3. Re-confirm any positive lever on the aliased aligner (this run used the surface aligner; the delta is aligner-independent, but absolutes should be read on the clean aligner).

--- a/docs/superpowers/specs/2026-07-01-extract-recall-prompt-design.md
+++ b/docs/superpowers/specs/2026-07-01-extract-recall-prompt-design.md
@@ -1,0 +1,53 @@
+# Recall-Tuned Extraction Prompt — Design
+
+**Date:** 2026-07-01
+**Status:** Design (approved for spec)
+**Follows:** the L2 clean-absolute finding (PR #1345) — real-prose `coverage` is ~0.44 *even with the best alignment*, so the substrate ceiling on real prose is **extraction recall**: the 7B doesn't extract ~56% of the wikilinked entities from dense Wikipedia sentences. This is the first extraction-recall lever.
+
+## Problem
+
+The extract prompt is **relation-centric** — it frames the task as "extract a knowledge graph" where entities exist to be indexed by relationships. It never instructs exhaustive named-entity extraction, so a wikilinked entity mentioned *without* a clear relation is dropped. `ingest` also does ONE extraction pass per doc, so a dense multi-entity lead yields only the salient subset. This lever tests the cheapest hypothesis first: **is the miss relation-centric framing?** (If not, it's density → chunking, a separate follow-on.)
+
+## Approach (decided)
+
+A gated recall-tuned instruction (`GOLDENGRAPH_EXTRACT_RECALL=1`) prepended to the extract prompt, mirroring the existing `_RELATION_VOCAB_INSTRUCTION` / `_ENTITY_TYPE_VOCAB_INSTRUCTION` gates. Measured on the wiki corpus via `coverage` (the extraction-recall instrument). Both a candidate fix and a diagnostic.
+
+## Architecture
+
+Source-side, gated, prompt-only. text → **extract (recall instruction prepended when gated)** → resolve → store. No new machinery; no goldengraph structural change. Validation reuses the existing `--corpus wiki` eval (aliased aligner, the clean instrument).
+
+## Components
+
+### 1. `_RECALL_INSTRUCTION` + gate (`extract.py`)
+- A new constant, e.g.: *"Extract EVERY named entity mentioned — people, organizations, places, products, works — and list it in `entities` even if it does not participate in any relationship. Do not omit an entity just because it lacks a clear relation."*
+- Prepended in `extract()` when `GOLDENGRAPH_EXTRACT_RECALL` is truthy (a `extract_recall_enabled()` helper or an inline env read, consistent with the sibling gates). Composes with the relation-vocab / type-vocab instructions.
+
+### 2. Measurement (existing `--corpus wiki` eval)
+- Run the wiki substrate eval baseline vs `EXTRACT_RECALL=1`, compare **`coverage`** (the fraction of gold mentions aligned = extraction recall proxy) AND the guardrails **P(B)** + **component count** (over-extraction could add junk entities / fragment the graph).
+
+## Validation / read
+
+Wiki eval, `GOLDENGRAPH_EXTRACT_RECALL` ∈ {off, on}, with `name_ci` (the shipped key):
+- **coverage up (0.44 → higher), P(B) holds, components stable** → relation-centric framing WAS the miss; ship the gate (default-off); the clean real-prose absolute rises. Best outcome.
+- **coverage flat** → the miss is density, not framing; recall-prompt REFUTED; chunking is the next lever (separate sub-project). A clean negative.
+- **coverage up but P(B) drops / components explode** → over-extraction adds noise (spurious entities that fragment the graph); a measured tradeoff, documented, and argues for a more targeted lever.
+
+This is a **calibration**, not a pass/fail gate — report honestly whatever the numbers say.
+
+## Scope
+
+**v1:** the recall-prompt gate + the wiki measurement. **Default-off.** Deferred (escalation path if refuted): sentence/paragraph **chunking** (extract per chunk, union); **GLiNER** NER extractor (`extract_local.gliner_extractor`).
+
+## File plan
+
+- `packages/python/goldengraph/goldengraph/extract.py` — `_RECALL_INSTRUCTION` + gated prepend in `extract()`.
+- Test: `packages/python/goldengraph/tests/test_extract_recall.py` — recall instruction present only when gated (capturing-stub LLM, `GOLDENGRAPH_EXTRACT_JSON_MODE=0` to force `.complete`, like `test_entity_type_constraint.py`).
+
+## Testing
+
+Box-safe: the instruction is prepended when `GOLDENGRAPH_EXTRACT_RECALL=1`, absent by default; composes with other prepends. One Modal wiki run (baseline vs recall) for coverage. The measurement uses the aliased aligner (#1345), so the impl branch rebases onto main-with-#1345 before the run.
+
+## Risks
+
+- **Over-extraction noise** — exhaustive extraction may surface spurious/partial entities that fragment the graph or dilute precision. The wiki P(B) + component count are the guardrails; if they degrade, the lever is a tradeoff, not a win.
+- **Prompt-constraint unreliability** — the arc's lesson (`SCHEMA_CANON` / entity-type) is that prompt instructions on a 7B are hit-or-miss; a flat coverage result is an expected, informative outcome (→ chunking), not a failure of the experiment.

--- a/packages/python/goldengraph/goldengraph/extract.py
+++ b/packages/python/goldengraph/goldengraph/extract.py
@@ -164,6 +164,20 @@ _ENTITY_TYPE_VOCAB_INSTRUCTION = (
     "Pick the single closest; do not invent other type labels.\n\n"
 )
 
+#: Prepended when GOLDENGRAPH_EXTRACT_RECALL is on. The default prompt is relation-centric (entities exist
+#: to be indexed by relationships), so a 7B drops entities mentioned without a clear relation -- the ~0.44
+#: real-prose extraction-recall ceiling (L2). This instruction pushes exhaustive named-entity extraction.
+_RECALL_INSTRUCTION = (
+    "Extract EVERY named entity mentioned -- people, organizations, places, products, works -- and list "
+    "it in `entities` even if it does not participate in any relationship. Do not omit an entity just "
+    "because it lacks a clear relation.\n\n"
+)
+
+
+def extract_recall_enabled() -> bool:
+    """`GOLDENGRAPH_EXTRACT_RECALL` gate: push exhaustive named-entity extraction (recall over precision)."""
+    return os.environ.get("GOLDENGRAPH_EXTRACT_RECALL", "0") not in ("0", "false", "")
+
 
 def _relation_vocab(explicit) -> tuple[str, ...]:
     """The closed relation vocabulary: explicit arg, else the comma-separated
@@ -191,6 +205,8 @@ def extract(text: str, llm: LLMClient, *, literals: bool | None = None,
     from .schema import entity_type_canon_enabled, entity_type_vocab
     if entity_type_canon_enabled():
         prompt = _ENTITY_TYPE_VOCAB_INSTRUCTION.format(vocab=", ".join(entity_type_vocab())) + prompt
+    if extract_recall_enabled():
+        prompt = _RECALL_INSTRUCTION + prompt
     return parse_extraction(_complete_extraction(llm, prompt))
 
 

--- a/packages/python/goldengraph/tests/test_extract_recall.py
+++ b/packages/python/goldengraph/tests/test_extract_recall.py
@@ -1,0 +1,27 @@
+"""GOLDENGRAPH_EXTRACT_RECALL prepends an exhaustive-entity instruction to the extract prompt."""
+from goldengraph.extract import extract
+
+
+class _CaptureLLM:
+    def __init__(self):
+        self.prompt = None
+
+    def complete(self, prompt):
+        self.prompt = prompt
+        return '{"entities": [], "relationships": []}'
+    # no complete_json -> extract() falls back to .complete
+
+
+def test_recall_instruction_absent_by_default(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_EXTRACT_RECALL", raising=False)
+    llm = _CaptureLLM()
+    extract("some text", llm)
+    assert "Extract EVERY named entity" not in llm.prompt
+
+
+def test_recall_instruction_present_when_gated(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_EXTRACT_RECALL", "1")
+    monkeypatch.setenv("GOLDENGRAPH_EXTRACT_JSON_MODE", "0")  # force .complete for the stub
+    llm = _CaptureLLM()
+    extract("some text", llm)
+    assert "Extract EVERY named entity" in llm.prompt


### PR DESCRIPTION
## Summary

First real-prose extraction-recall lever (the ~0.44 L2 coverage ceiling). Gated `GOLDENGRAPH_EXTRACT_RECALL=1` prepends an exhaustive-named-entity instruction to the extract prompt. **Measured: refuted — it degrades the substrate.**

## Result (wiki, name_ci)

| leg | coverage | R(B) | P(B) | components |
|---|---|---|---|---|
| control | 0.40 | 0.232 | 1.0 | 12 |
| `EXTRACT_RECALL=1` | **0.354** | 0.162 | 1.0 | **25** |

"Extract EVERY entity" pushed the 7B to *list entities* at the expense of *relations*. The substrate build is edge-centric, so fewer edges → fewer gold mentions alignable (coverage down) and entity-only nodes fragment the graph (components 12→25). It **traded edges for entity noise.**

## Conclusion
- The real-prose miss is **NOT relation-centric framing** — a clean negative (consistent with the arc's prior that 7B prompt-constraints are hit-or-miss).
- **Gate ships default-off** as a documented opt-in recall-over-precision knob; not recommended for the substrate.
- **Next lever: chunking** (extract per sentence/paragraph, union — preserves both entities *and* relations). That's the next sub-project.

Full write-up: `docs/superpowers/reports/2026-07-01-extract-recall-prompt-verdict.md`.

## Test Plan
- [x] 4 box-safe pure tests green (recall instruction present only when gated; entity-type-constraint regression)
- [x] ruff clean
- [x] Modal wiki measurement produced the refutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)