### PR TITLE
release: goldenmatch 2.5.1

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-07-01
+
+### Fixed
+- **PPRL is now opt-in instead of the default for sensitive data (#1342, #1344).** `select_strategy()` auto-routed any dataset with sensitive fields (PII/health) to privacy-preserving record linkage, returning empty `strong_ids`/`fuzzy_fields` even for a user deduping their own list. PPRL now fires only when the caller opts in via `allow_pprl=True`; sensitive data otherwise gets a normal weighted/fuzzy strategy, with `StrategyDecision.pprl_available=True` flagging that PPRL can be opted into. `allow_pprl` is threaded through `AgentSession.analyze/deduplicate/match_sources/compare_strategies`, `a2a.dispatch_skill`, and the A2A `_handle_send_task` HTTP handler (reads `allow_pprl` from the request body). MCP tool args (`mcp/agent_tools.py`) are a tracked follow-up. Non-sensitive-data behavior is unchanged.
+
+### Changed
+- `StrategyDecision` gains a `pprl_available: bool` field.
+
 ## [2.5.0] - 2026-07-01
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "2.5.0"
+version = "2.5.1"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump for the **goldenmatch 2.5.1** release. Merge this, then cut the release by pushing the `v2.5.1` tag (ADR 0019 — the `publish-goldenmatch.yml` workflow owns the release lifecycle; do NOT `gh release create` by hand).

## What's in 2.5.1
`#1344` ("make PPRL opt-in instead of the default for sensitive data", closes #1342) — the **only** change to the `goldenmatch` package since 2.5.0. Confirmed the other post-2.5.0 merges (#1347 golden-suite meta-package, #1348/#1345 goldengraph, #1343 native reference-mode gate) touch **zero** files under `packages/python/goldenmatch/`, so they're out of scope for this package's release notes (they carry their own package versions).

## Changes
- Version 2.5.0 → 2.5.1 in the three lockstep spots the `version_consistency` gate enforces: `pyproject.toml`, `goldenmatch/__init__.py`, `server.json` (top-level `.version` + nested `packages[].version`).
- `CHANGELOG.md`: new `## [2.5.1]` section (Fixed: PPRL opt-in; Changed: `StrategyDecision.pprl_available`).
- **Native crate untouched** — #1344 is pure-Python, no `goldenmatch_native` (0.1.x) rebuild.

## Verification
`python scripts/check_version_consistency.py` → "Version consistency OK: 19 packages, all files in lockstep."

## After merge
1. `git push origin v2.5.1` → workflow publishes to PyPI + cosign-signs + drafts the release from the CHANGELOG.
2. Downstream: golden-truth pin bump `goldenmatch[native]==2.5.0 → ==2.5.1` activates golden-truth PR #45's `allow_pprl` opt-in on `/analyze`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)