### PR TITLE
Chunked extraction (GOLDENGRAPH_CHUNK_EXTRACT): overlapping sentence windows — substrate WIN at (6,2)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-chunked-extraction.md
+++ b/docs/superpowers/plans/2026-07-01-chunked-extraction.md
@@ -1,0 +1,472 @@
+# Chunked Extraction — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A gated `GOLDENGRAPH_CHUNK_EXTRACT=1` path that splits each document into overlapping sentence windows, extracts each window with the same extractor, and unions the results before resolution — the second real-prose extraction-recall lever, measured on the wiki corpus.
+
+**Architecture:** A new pure-Python module `goldengraph/chunk_extract.py` holds three units: `split_sentences` (regex sentence split), `sentence_windows` (overlapping windows), and `chunk_extract` (per-window extraction + index-offset union). `ingest._prepare_doc` calls `chunk_extract` instead of the single `_extract` when the gate is on; off = byte-identical to today. Everything downstream (`resolve → build_batch → cross-doc link → append`) is untouched.
+
+**Tech Stack:** Python 3.11, stdlib `re`/`os` only (no nltk/spacy/network), pytest. Reuses `goldengraph.extract` dataclasses (`Extraction`, `Mention`, `Relationship`, `Attribute`).
+
+**Spec:** `docs/superpowers/specs/2026-07-01-chunked-extraction-design.md`
+**Branch:** `feat/chunked-extraction` (off `main`, already created).
+
+**Box-safe test invocation** (run these yourself — do NOT let a subagent import/pytest/uv on this box):
+```bash
+PY="/d/show_case/goldenmatch/.venv/Scripts/python.exe"
+cd packages/python/goldengraph
+PYTHONPATH="D:/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 \
+  "$PY" -m pytest tests/test_chunk_extract.py -q -p no:cacheprovider
+```
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `packages/python/goldengraph/goldengraph/chunk_extract.py` | **Create.** `split_sentences`, `sentence_windows`, config helpers, `chunk_extract`. Pure w.r.t. the store; only depends on `extract` dataclasses + `os`/`re`. |
+| `packages/python/goldengraph/tests/test_chunk_extract.py` | **Create.** Unit tests for all three units + gate wiring (via a stub, no LLM). |
+| `packages/python/goldengraph/goldengraph/ingest.py` | **Modify** line 671 (the one extraction call site) + add import. |
+| `docs/superpowers/reports/2026-07-01-chunked-extraction-verdict.md` | **Create** in Task 4 after the Modal sweep. |
+
+---
+
+## Task 1: `split_sentences` + `sentence_windows` (pure, no LLM)
+
+**Files:**
+- Create: `packages/python/goldengraph/goldengraph/chunk_extract.py`
+- Test: `packages/python/goldengraph/tests/test_chunk_extract.py`
+
+- [ ] **Step 1: Write the failing tests.** Create `tests/test_chunk_extract.py`:
+
+```python
+"""Chunked extraction: sentence splitting, overlapping windows, and index-offset union."""
+from goldengraph.chunk_extract import sentence_windows, split_sentences
+
+
+def test_split_sentences_basic():
+    s = "Amazon was founded in 1994. Jeff Bezos was the CEO. It sells books."
+    assert len(split_sentences(s)) == 3
+
+
+def test_split_sentences_empty():
+    assert split_sentences("") == []
+    assert split_sentences("   ") == []
+
+
+def test_split_sentences_lower_bound_with_abbreviations():
+    # "Inc." may over-split; we only require the real breaks are found (lower bound).
+    s = "Apple Inc. is a company. Steve Jobs founded it."
+    assert len(split_sentences(s)) >= 2
+
+
+def test_windows_size_and_overlap_spans():
+    sents = [f"s{i}." for i in range(9)]  # 9 sentences
+    # size=4, overlap=1 -> stride 3 -> windows [0:4], [3:7], [6:9]
+    wins = sentence_windows(sents, size=4, overlap=1)
+    assert wins == ["s0. s1. s2. s3.", "s3. s4. s5. s6.", "s6. s7. s8."]
+
+
+def test_windows_shorter_than_size_is_one_window():
+    sents = ["a.", "b."]
+    assert sentence_windows(sents, size=4, overlap=1) == ["a. b."]
+
+
+def test_windows_empty_input_no_windows():
+    assert sentence_windows([], size=4, overlap=1) == []
+
+
+def test_windows_overlap_ge_size_clamped_terminates():
+    sents = [f"s{i}." for i in range(6)]
+    # overlap >= size must clamp to size-1 (stride 1), cover all, and terminate.
+    wins = sentence_windows(sents, size=3, overlap=5)
+    assert wins[0] == "s0. s1. s2."
+    assert wins[-1].endswith("s5.")
+    assert len(wins) == 4  # stride 1: [0:3],[1:4],[2:5],[3:6]
+
+
+def test_windows_size_zero_floored_to_one():
+    sents = ["a.", "b.", "c."]
+    # size<=0 must floor to 1 (no zero/negative stride, no infinite loop).
+    wins = sentence_windows(sents, size=0, overlap=0)
+    assert wins == ["a.", "b.", "c."]
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+Run the box-safe invocation above. Expected: FAIL with `ModuleNotFoundError: No module named 'goldengraph.chunk_extract'`.
+
+- [ ] **Step 3: Implement `split_sentences` + `sentence_windows`.** Create `goldengraph/chunk_extract.py`:
+
+```python
+"""Chunked extraction (GOLDENGRAPH_CHUNK_EXTRACT): split a dense document into
+overlapping sentence windows, extract each window with the SAME extractor, and
+union the results before resolution. The default single-pass extraction attends
+over a whole ~20-sentence Wikipedia lead in one call and drops entities (the ~0.44
+real-prose extraction-recall ceiling); a short window lets a weak model extract
+both entities AND relations well, and the union aggregates. resolve() collapses
+duplicate mentions across windows downstream, so no new dedup is needed here.
+
+Pure w.r.t. the store: stdlib only, depends on the extract dataclasses. Gate is
+off by default -- the single-pass path is unchanged when GOLDENGRAPH_CHUNK_EXTRACT
+is unset.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from .extract import Attribute, Extraction, Mention, Relationship  # noqa: F401  (Mention re-exported for callers/tests)
+from .llm import LLMClient
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split `text` into sentences on `.!?` boundaries (stdlib regex, network-free).
+    Empty / whitespace-only input -> [] (no windows, no wasted extractor call).
+    Abbreviations may over-split; harmless for extraction (a fragment yields fewer
+    entities, never wrong ones)."""
+    if not text or not text.strip():
+        return []
+    return [s.strip() for s in _SENTENCE_SPLIT.split(text.strip()) if s.strip()]
+
+
+def sentence_windows(sents: list[str], size: int, overlap: int) -> list[str]:
+    """Overlapping sentence windows joined back into text. Advances by `size -
+    overlap`. Guards (in order): size<=0 -> 1; overlap<0 -> 0; overlap>=size ->
+    size-1 (stride>=1, terminates); [] -> []; len<=size -> one whole-doc window."""
+    size = max(1, size)
+    overlap = max(0, overlap)
+    if overlap >= size:
+        overlap = size - 1
+    stride = size - overlap  # >= 1
+    if not sents:
+        return []
+    if len(sents) <= size:
+        return [" ".join(sents)]
+    out: list[str] = []
+    i = 0
+    n = len(sents)
+    while i < n:
+        out.append(" ".join(sents[i : i + size]))
+        if i + size >= n:  # last window reached the end
+            break
+        i += stride
+    return out
+```
+
+- [ ] **Step 4: Run tests, verify pass** (box-safe invocation). Expected: 7 passed. Then `ruff check goldengraph/chunk_extract.py`.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add goldengraph/chunk_extract.py tests/test_chunk_extract.py
+git commit -m "feat(goldengraph): sentence splitting + overlapping windows for chunked extraction"
+```
+
+---
+
+## Task 2: config helpers + `chunk_extract` union
+
+**Files:**
+- Modify: `packages/python/goldengraph/goldengraph/chunk_extract.py`
+- Test: `packages/python/goldengraph/tests/test_chunk_extract.py`
+
+- [ ] **Step 1: Add the failing tests.** Append to `tests/test_chunk_extract.py`:
+
+```python
+from goldengraph.chunk_extract import (
+    chunk_extract,
+    chunk_extract_enabled,
+    _chunk_params,
+)
+from goldengraph.extract import Extraction, Mention, Relationship
+
+
+class _WindowStub:
+    """Extractor stub: records each window text it saw and returns a fixed
+    2-entity/1-relationship extraction per call (rel points 0->1 within the call)."""
+
+    def __init__(self):
+        self.seen = []
+
+    def __call__(self, text, llm=None):
+        self.seen.append(text)
+        k = len(self.seen)
+        return Extraction(
+            mentions=[Mention(name=f"E{k}a", typ="org"), Mention(name=f"E{k}b", typ="person")],
+            relationships=[Relationship(subj=0, predicate="founded_by", obj=1)],
+        )
+
+
+def test_chunk_extract_enabled_gate(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
+    assert chunk_extract_enabled() is False
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_EXTRACT", "1")
+    assert chunk_extract_enabled() is True
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_EXTRACT", "")  # set-but-empty -> off
+    assert chunk_extract_enabled() is False
+
+
+def test_chunk_params_defaults_and_empty_string(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_SENTENCES", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_OVERLAP", raising=False)
+    assert _chunk_params() == (4, 1)
+    # empty-string env must fall back to default, not raise ValueError
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "")
+    assert _chunk_params() == (4, 1)
+    # garbage falls back too
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "abc")
+    assert _chunk_params() == (4, 1)
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "3")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "2")
+    assert _chunk_params() == (3, 2)
+
+
+def test_chunk_extract_unions_and_offsets_indices(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "1")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "0")
+    text = "Sentence one is here. Sentence two is here. Sentence three is here."
+    stub = _WindowStub()
+    ex = chunk_extract(text, llm=None, extractor=stub)
+    # 3 windows -> 6 mentions, 3 relationships
+    assert len(stub.seen) == 3
+    assert len(ex.mentions) == 6
+    assert len(ex.relationships) == 3
+    # window k's relationship must point into window k's mention block (offset applied)
+    # window 0: mentions 0,1 -> rel (0,1); window 1: mentions 2,3 -> rel (2,3); window 2: (4,5)
+    assert (ex.relationships[0].subj, ex.relationships[0].obj) == (0, 1)
+    assert (ex.relationships[1].subj, ex.relationships[1].obj) == (2, 3)
+    assert (ex.relationships[2].subj, ex.relationships[2].obj) == (4, 5)
+
+
+def test_chunk_extract_skips_failing_window(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "1")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "0")
+
+    calls = {"n": 0}
+
+    def flaky(text, llm=None):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("boom")
+        return Extraction(mentions=[Mention(name="X", typ="org")], relationships=[])
+
+    text = "One here. Two here. Three here."
+    ex = chunk_extract(text, llm=None, extractor=flaky)
+    # 3 windows, middle one raises -> 2 mentions survive, no crash
+    assert len(ex.mentions) == 2
+```
+
+- [ ] **Step 2: Run, verify fail.** Expected: `ImportError: cannot import name 'chunk_extract'` (and `_chunk_params`, `chunk_extract_enabled`).
+
+- [ ] **Step 3: Implement.** Append to `goldengraph/chunk_extract.py`:
+
+```python
+def _env_int(name: str, default: int) -> int:
+    """Parse an int env var defensively: unset OR set-but-empty OR non-numeric ->
+    `default` (the empty-string-env footgun -- `NAME=` must not raise ValueError)."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def chunk_extract_enabled() -> bool:
+    """`GOLDENGRAPH_CHUNK_EXTRACT` gate. Off by default; "0"/"false"/"" -> off."""
+    return os.environ.get("GOLDENGRAPH_CHUNK_EXTRACT", "0") not in ("0", "false", "")
+
+
+def _chunk_params() -> tuple[int, int]:
+    """(window size, overlap) from env; defaults (4, 1). Defensive parse."""
+    return _env_int("GOLDENGRAPH_CHUNK_SENTENCES", 4), _env_int("GOLDENGRAPH_CHUNK_OVERLAP", 1)
+
+
+def chunk_extract(text: str, llm: LLMClient | None, extractor) -> Extraction:
+    """Split `text` into overlapping sentence windows, run `extractor(window, llm)`
+    on each, and union: concatenate mentions and OFFSET each window's relationship /
+    attribute indices by the running mention count. A window whose extractor raises
+    is skipped (its mentions just don't contribute), never fatal to the doc.
+
+    `extractor` is the same callable the single-pass path uses (`extract.extract`,
+    or a rebel/gliner closure) -- it still honors LITERAL_ATTRS / vocab / recall
+    gates internally per window."""
+    size, overlap = _chunk_params()
+    windows = sentence_windows(split_sentences(text), size, overlap)
+    merged_mentions: list[Mention] = []
+    merged_rels: list[Relationship] = []
+    merged_attrs: list[Attribute] = []
+    for window in windows:
+        try:
+            ex = extractor(window, llm)
+        except Exception:
+            continue  # a bad window degrades recall, never sinks the doc
+        base = len(merged_mentions)  # captured BEFORE the append -> correct per-window offset
+        merged_mentions += ex.mentions
+        merged_rels += [
+            Relationship(r.subj + base, r.predicate, r.obj + base) for r in ex.relationships
+        ]
+        merged_attrs += [
+            Attribute(a.subj + base, a.predicate, a.value, a.typ)
+            for a in getattr(ex, "attributes", ())
+        ]
+    return Extraction(mentions=merged_mentions, relationships=merged_rels, attributes=merged_attrs)
+```
+
+- [ ] **Step 4: Run tests, verify pass** (box-safe). Expected: 11 passed total. Then `ruff check goldengraph/chunk_extract.py`.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add goldengraph/chunk_extract.py tests/test_chunk_extract.py
+git commit -m "feat(goldengraph): chunk_extract union + config gates (GOLDENGRAPH_CHUNK_EXTRACT/_SENTENCES/_OVERLAP)"
+```
+
+---
+
+## Task 3: wire the gate into `_prepare_doc`
+
+**Files:**
+- Modify: `packages/python/goldengraph/goldengraph/ingest.py` (import near line 19-23; call site line 671)
+- Test: `packages/python/goldengraph/tests/test_chunk_extract.py`
+
+- [ ] **Step 1: Add the failing wiring test.** Append to `tests/test_chunk_extract.py`:
+
+```python
+def test_prepare_doc_uses_chunking_only_when_gated(monkeypatch):
+    """_prepare_doc calls the extractor once when off, once-per-window when on."""
+    from goldengraph import ingest
+    from goldengraph.extract import Extraction, Mention
+
+    calls = {"n": 0}
+
+    def counting_extractor(text, llm=None):
+        calls["n"] += 1
+        return Extraction(mentions=[Mention(name="X", typ="org")], relationships=[])
+
+    # identity resolver: one entity per mention (no goldenmatch needed)
+    from goldengraph.resolve import ResolvedEntity
+
+    def resolver(mentions):
+        return [
+            ResolvedEntity(
+                local_id=i, canonical_name=m.name, typ=m.typ,
+                surface_names=[m.name], record_keys=[], member_idx=[i],
+            )
+            for i, m in enumerate(mentions)
+        ]
+
+    text = "One here. Two here. Three here. Four here. Five here. Six here. Seven here."
+
+    # gate OFF -> single call
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
+    calls["n"] = 0
+    ingest._prepare_doc(text, llm=None, resolver=resolver, profile_fps=False,
+                        extractor=counting_extractor)
+    assert calls["n"] == 1
+
+    # gate ON, size=3 overlap=1 (stride 2) over 7 sentences -> windows [0:3],[2:5],[4:7] = 3 calls
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_EXTRACT", "1")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "3")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "1")
+    calls["n"] = 0
+    ingest._prepare_doc(text, llm=None, resolver=resolver, profile_fps=False,
+                        extractor=counting_extractor)
+    assert calls["n"] == 3
+```
+
+> Note: `ResolvedEntity`'s fields are verified against `goldengraph/resolve.py:20-27` — `local_id, canonical_name, typ, surface_names, record_keys, member_idx` (exactly as used above). The resolver just returns one entity per mention so no goldenmatch import is needed; the assertion that matters is the extractor call count.
+
+- [ ] **Step 2: Run, verify fail.** Expected: gate-ON assertion fails (`assert 1 == 3`) because `_prepare_doc` still calls the extractor once.
+
+- [ ] **Step 3: Wire the gate.** In `ingest.py`, add the import beside the existing extract imports (after line 20 `from .extract import extract as _extract`):
+
+```python
+from .chunk_extract import chunk_extract, chunk_extract_enabled
+```
+
+Then replace line 671:
+
+```python
+        extraction = (extractor or _extract)(text, llm)
+```
+
+with:
+
+```python
+        _extractor = extractor or _extract
+        extraction = (
+            chunk_extract(text, llm, _extractor)
+            if chunk_extract_enabled()
+            else _extractor(text, llm)
+        )
+```
+
+- [ ] **Step 4: Run tests, verify pass.** Run the full `tests/test_chunk_extract.py` (box-safe). Expected: 12 passed. Then a quick regression on the neighbouring extract tests to prove the off-path is unchanged:
+
+```bash
+PYTHONPATH="D:/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 \
+  "$PY" -m pytest tests/test_extract_recall.py tests/test_chunk_extract.py -q -p no:cacheprovider
+```
+Then `ruff check goldengraph/ingest.py goldengraph/chunk_extract.py`.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add goldengraph/ingest.py tests/test_chunk_extract.py
+git commit -m "feat(goldengraph): gate chunked extraction into _prepare_doc (off = single-pass unchanged)"
+```
+
+---
+
+## Task 4: Modal wiki measurement + verdict
+
+**Files:** Create `docs/superpowers/reports/2026-07-01-chunked-extraction-verdict.md`.
+
+Run these yourself (Modal, `PYTHONIOENCODING=utf-8 PYTHONUTF8=1`, `--detach --spawn`, distinct `--n` so the `gg-bench-cache` volume doesn't clobber). The substrate branch of `scripts/distill/modal_bench.py` honors the env passed via `--opts`.
+
+- [ ] **Step 1: Fire the control + sweep legs** (wiki, `name_ci`, aliased aligner on `main`):
+
+```bash
+M="/d/show_case/goldenmatch/.venv/Scripts/modal.exe"
+BASE=$'GOLDENGRAPH_SUBSTRATE_CORPUS=wiki\nGOLDENGRAPH_XDOC_KEY=name_ci'
+# control (chunking off) -- establishes the real aliased baseline
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 80 \
+  --opts "$BASE" --spawn
+# chunked (4,1)
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 81 \
+  --opts $'GOLDENGRAPH_SUBSTRATE_CORPUS=wiki\nGOLDENGRAPH_XDOC_KEY=name_ci\nGOLDENGRAPH_CHUNK_EXTRACT=1\nGOLDENGRAPH_CHUNK_SENTENCES=4\nGOLDENGRAPH_CHUNK_OVERLAP=1' --spawn
+# chunked (3,1) -- more granular
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 82 \
+  --opts $'GOLDENGRAPH_SUBSTRATE_CORPUS=wiki\nGOLDENGRAPH_XDOC_KEY=name_ci\nGOLDENGRAPH_CHUNK_EXTRACT=1\nGOLDENGRAPH_CHUNK_SENTENCES=3\nGOLDENGRAPH_CHUNK_OVERLAP=1' --spawn
+# chunked (6,2) -- larger window (recover cross-window edges)
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 83 \
+  --opts $'GOLDENGRAPH_SUBSTRATE_CORPUS=wiki\nGOLDENGRAPH_XDOC_KEY=name_ci\nGOLDENGRAPH_CHUNK_EXTRACT=1\nGOLDENGRAPH_CHUNK_SENTENCES=6\nGOLDENGRAPH_CHUNK_OVERLAP=2' --spawn
+```
+
+Poll the `gg-bench-cache` volume for `results/substrate_8{0,1,2,3}_*.md` (Monitor the volume; do not sit in a foreground loop). Look for the `[substrate-wiki]` lines: `coverage`, `R(B)`, `P(B)`, `components`.
+
+- [ ] **Step 2: Read the four legs.** Tabulate coverage / R(B) / P(B) / components for control vs each `(size, overlap)`.
+
+- [ ] **Step 3: Write the verdict** `docs/superpowers/reports/2026-07-01-chunked-extraction-verdict.md`. State the control baseline (aliased), the sweep table, and the read against the falsifiable bar from the spec:
+  - **WIN:** coverage ↑ AND R(B) ↑ with components not materially worse and P(B) ~1.0. Name the winning `(size, overlap)`.
+  - **REFUTED:** coverage flat/down, or coverage up only by fragmenting (components blow up). Ship gate default-off, escalate to GLiNER.
+  - Either way, report the sweep *shape* (does smaller window buy entities at the cost of edges?).
+
+- [ ] **Step 4: Commit** the report.
+
+```bash
+git add docs/superpowers/reports/2026-07-01-chunked-extraction-verdict.md
+git commit -m "docs(goldengraph): chunked-extraction verdict (wiki sweep)"
+```
+
+---
+
+## Completion
+
+Use superpowers:finishing-a-development-branch: run the box-safe `tests/test_chunk_extract.py` suite, then open a PR (base `main`) and arm auto-merge (`gh pr merge --auto --squash`). The PR ships the gate default-off regardless of the verdict (an opt-in recall knob); the verdict records whether the substrate improved. If REFUTED, GLiNER (`extract_local.gliner_extractor`) is the next extraction-recall lever.

--- a/docs/superpowers/reports/2026-07-01-chunked-extraction-verdict.md
+++ b/docs/superpowers/reports/2026-07-01-chunked-extraction-verdict.md
@@ -1,0 +1,48 @@
+# Chunked Extraction — Verdict
+
+**Date:** 2026-07-01
+**Branch:** `feat/chunked-extraction`
+**Spec/Plan:** `docs/superpowers/specs/2026-07-01-chunked-extraction-design.md` · `docs/superpowers/plans/2026-07-01-chunked-extraction.md`
+**Run:** Modal `gg-bench`, 7B (`qwen2.5-7b-instruct`), `--corpus wiki`, `GOLDENGRAPH_XDOC_KEY=name_ci`, **aliased aligner** (on `main` via #1345). 19 docs, 65 gold mentions.
+
+## What this tested
+
+The recall-tuned prompt lever was REFUTED — the real-prose extraction-recall miss is **density**, not framing: the 7B attends over a whole ~20-sentence Wikipedia lead in one pass and drops entities. This lever splits each doc into **overlapping sentence windows**, extracts each independently, and unions the results (concat mentions, offset relationship/attribute indices) before resolution. Unlike the recall prompt, each short window preserves *both* its entities and its relations. Gated `GOLDENGRAPH_CHUNK_EXTRACT=1`, env-tunable window size / overlap, swept over 3 `(size, overlap)` points against a fresh control.
+
+## Result — WIN at (6, 2)
+
+| leg | (size, overlap) | coverage | R(B) | P(B) | F1(B) | components |
+|---|---|---|---|---|---|---|
+| 80 | control (off) | 0.4462 | 0.3182 | 1.000 | 0.4828 | 13 |
+| 81 | (4, 1) | 0.3692 | 0.1162 | 0.958 | 0.2072 | 10 |
+| 82 | (3, 1) | **0.4769** | 0.2020 | 0.930 | 0.3320 | **26** |
+| 83 | **(6, 2)** | **0.5077** | **0.3434** | 1.000 | **0.5113** | 14 |
+
+**(6, 2) lifts every signal with the guardrails intact:** coverage +0.062 (0.446 → 0.508), R(B) +0.025 (0.318 → 0.343), F1 +0.028 (0.483 → 0.511), **P(B) held at 1.0, components essentially flat (13 → 14)**. This is the first substrate improvement in the extraction-recall thread.
+
+## The sweep shape is the finding
+
+The three chunked points trace exactly the tension the spec predicted:
+
+- **(3, 1) small window** — coverage *up* (0.477) but R(B) *down* (0.202), components **double** (13 → 26), P(B) drops to 0.93. Classic fragmentation: a 3-sentence window recovers more entities but severs cross-sentence relations, so the graph shatters into edge-starved components. This is the REFUTED signature (the exact trap the recall prompt fell into).
+- **(4, 1)** — the worst point: every signal below control. A 4-sentence stride-3 window is the unhappy middle — small enough to lose relations, not small enough to maximize entity recall, and the lost edges drag coverage down too (the aligner is edge-centric).
+- **(6, 2) large window + overlap** — the sweet spot. Six sentences keep most cross-sentence relations inside a single window; +2 overlap stitches the boundaries; and chunking ~20 sentences into ~7 windows still lifts entity recall over the single dense pass. Recall goes up *without* fragmenting.
+
+So the mechanism is confirmed: **window size trades entity recall against relation preservation**, and only a large-enough window with overlap gets the recall lift while keeping the graph connected. Component count + P(B) were the guardrails that distinguished the real win (83) from fragmentation dressed as coverage (82).
+
+## Decisions
+
+- **Ship the gate**, default-off (opt-in). **Shipped default is `(6, 2)`** — the measured winner — so an opt-in with no tuning lands on the good config, not the degrading `(4, 1)` the plan originally proposed. `_chunk_params` and its test were updated to `(6, 2)` after the sweep.
+- **Not flipped default-on.** The lift is real and directionally clean but modest on a 19-doc / 65-gold corpus (+0.062 coverage ≈ 4 more gold mentions aligned). A default-on flip needs the win to hold across more than the wiki corpus and at a 7-10× extraction-call cost — a separate decision.
+
+## Honest caveats
+
+- **Small N.** 19 docs / 65 gold. The direction is clean across all four signals and the sweep shape is mechanistically coherent, but the absolute magnitudes are small — read this as "chunking with a large-enough window is the right lever," not "+6pp coverage is a stable number."
+- **Cost.** (6, 2) is ~4 windows/doc here; (3, 1) would be ~10×. The gate stays off partly for this — chunking is an opt-in quality/throughput trade, not free.
+- **Only the surface-realizable ceiling moved.** Coverage 0.508 still leaves ~half the gold unaligned; the remaining miss is entities the 7B never emits in any window. The next lever attacks *that*.
+
+## Follow-ons
+
+1. **GLiNER hybrid** (`extract_local.gliner_extractor`) — high-recall NER for entities + LLM for relations, composed with chunking. The next extraction-recall lever for the residual ~0.49 miss.
+2. **Confirm (6, 2) on a second corpus** before any default-on consideration.
+3. **Larger windows** — the sweep stopped at 6; (8, 2)/(10, 3) might recover more edges still, at higher cost. Worth one more point if GLiNER underdelivers.

--- a/docs/superpowers/specs/2026-07-01-chunked-extraction-design.md
+++ b/docs/superpowers/specs/2026-07-01-chunked-extraction-design.md
@@ -6,7 +6,7 @@
 
 ## Problem
 
-The L2 clean-absolute finding put the real-prose substrate ceiling at **extraction recall**: on the wiki corpus the 7B extracts only ~0.44 of the wikilinked entities, and the aliased aligner sees coverage ~0.40 / R(B) ~0.23 over 12 components. The recall-prompt lever tried to lift this by *instructing* exhaustive entity extraction; it made the substrate **worse** (coverage −0.05, R(B) −0.07, components 12→25) because "extract EVERY entity" pushed the model to list entities at the expense of relations, and the substrate is edge-centric.
+The L2 clean-absolute finding put the real-prose substrate ceiling at **extraction recall**: on the wiki corpus the 7B extracts only ~0.44 of the wikilinked entities. The recall-prompt lever's **surface-aligner** control measured coverage 0.40 / R(B) 0.23 over 12 components; those are the *surface-aligner prior*, not an aliased-aligner baseline (the predecessor verdict explicitly flags "re-confirm on the aliased aligner" as follow-on #3). The recall-prompt lever tried to lift recall by *instructing* exhaustive entity extraction; it made the substrate **worse** (coverage −0.05, R(B) −0.07, components 12→25) because "extract EVERY entity" pushed the model to list entities at the expense of relations, and the substrate is edge-centric.
 
 The diagnostic from that negative: the miss is **not** relation-centric framing — it is **density**. The docs are a single dense ~2750-char, ~20-sentence paragraph, extracted in one LLM pass. A weak model attending over the whole lead drops entities regardless of how exhaustively it is prompted.
 
@@ -20,6 +20,12 @@ A gated `GOLDENGRAPH_CHUNK_EXTRACT=1` path that splits each document into **over
 - No new cross-document or within-doc entity-dedup machinery — the existing `resolve()` already collapses duplicate mentions within a doc.
 - No edge-multiplicity dedup (see Union semantics).
 - Not a general RAG chunker: this chunks for *extraction*, not retrieval.
+
+## Known failure modes
+
+- **Cross-window relation loss (structural).** Chunking drops any relationship whose two entities never co-occur in a single window — e.g. a subject in sentence 1 and its object in sentence 12 at `size=4`. This is the mechanism most likely to *fragment components* (the REFUTED signature), and overlap only partially compensates (it recovers relations that straddle a window boundary, not ones spanning many sentences). Larger windows recover these edges but blunt the entity-recall gain — that tension is why the sweep varies both size and overlap, and why component count is a primary guardrail.
+- **Resolution distribution shift (soft).** "resolve() collapses duplicates for free" is not perfectly transparent: `_fuzzy_resolve` calls `gm.dedupe_df`, whose zero-config auto-calibration is distribution-sensitive. Feeding it 3-7× duplicated mentions changes the row distribution and can shift which *borderline, non-identical* entities merge versus the single-pass path. The union is therefore an approximation, not an identity, on the resolution step — a real (usually small) source of behavior change to keep in mind when reading the delta.
+- **LLM-call multiplication (operational).** A ~20-sentence doc at `(4,1)` (stride 3) is ~7 windows ≈ 7× extraction calls per doc; `(3,1)` (stride 2) is ~10×. The wiki corpus is only 19 docs, so even 10× keeps a Modal `gg-bench` leg cheap (tens of extraction calls × 19 docs), but the multiplier is real and would matter at corpus scale — the gate stays default-off partly for this reason.
 
 ## Architecture
 
@@ -62,14 +68,16 @@ Three units in a new module `goldengraph/chunk_extract.py`, each independently t
 
 ### 1. `split_sentences(text: str) -> list[str]`
 
-Stdlib `re` only (network-free, no nltk/spacy — matches the repo norm set by `build_wiki_corpus`). Split on `(?<=[.!?])\s+`; drop empties/whitespace. Abbreviations ("Inc.", "U.S.") will occasionally over-split; that is harmless for extraction (a fragment yields fewer entities, never wrong ones), so tests assert a lower bound, not an exact count.
+Stdlib `re` only (network-free, no nltk/spacy — matches the repo norm set by `build_wiki_corpus`). Split on `(?<=[.!?])\s+`; drop empties/whitespace. Empty/whitespace-only input → `[]` (so an empty doc yields zero windows, not one wasted `extractor("", llm)` call). Abbreviations ("Inc.", "U.S.") will occasionally over-split; that is harmless for extraction (a fragment yields fewer entities, never wrong ones), so tests assert a lower bound, not an exact count.
 
 ### 2. `sentence_windows(sents, size, overlap) -> list[str]`
 
-Slide a window of `size` sentences advancing by `size - overlap`, each window joined back with a space. Guards:
+Slide a window of `size` sentences advancing by `size - overlap`, each window joined back with a space. Guards (applied in order):
+- `size <= 0` → floor to `1` (a typo like `GOLDENGRAPH_CHUNK_SENTENCES=0` must not produce a zero/negative stride).
+- `overlap < 0` → treat as `0`.
+- `overlap >= size` → clamp to `size - 1` (guarantees stride ≥ 1, forward progress; no infinite loop).
+- `sents == []` → `[]` (no windows).
 - `len(sents) <= size` → one window containing the whole doc (chunking is a correct no-op).
-- `overlap >= size` → clamp to `size - 1` (guarantees forward progress; no infinite loop).
-- `overlap < 0` → treat as 0.
 
 ### 3. `chunk_extract(text, llm, extractor) -> Extraction`
 
@@ -89,15 +97,17 @@ return Extraction(mentions=merged_mentions, relationships=merged_rels, attribute
 ```
 
 **Config (read at call time so the sweep varies env between Modal legs):**
-- `GOLDENGRAPH_CHUNK_EXTRACT` — the gate (default off).
+- `GOLDENGRAPH_CHUNK_EXTRACT` — the gate (default off; `"0"`/`"false"`/`""` → off).
 - `GOLDENGRAPH_CHUNK_SENTENCES` — window size (default `4`).
 - `GOLDENGRAPH_CHUNK_OVERLAP` — sentence overlap (default `1`).
+
+Parse the two int knobs **defensively** against the empty-string-env footgun already recorded in this project's memory: `GOLDENGRAPH_CHUNK_SENTENCES=` (set but empty) must fall back to the default, not throw `ValueError`. Use a helper like `int(v) if (v := os.environ.get(name, "").strip()) else default` (and a `try/except ValueError → default` around it), not a bare `int(os.environ.get(name, "4"))`.
 
 ### Union semantics — no dedup (deliberate)
 
 Overlap re-extracts some mentions and edges. We do **not** dedup at union time:
 - Duplicate **mentions** → `resolve()` collapses them into one entity downstream. No action needed.
-- Duplicate **edges** between the same resolved pair are benign: identical `(subj_local, predicate, obj_local)` edges union their `source_refs` in the store and do not change graph structure. The substrate metrics key on entity-pairs and components, not edge multiplicity.
+- Duplicate **edges** between the same resolved pair are benign *for the metrics*: `build_batch` emits one edge per relationship with no intra-batch dedup, so overlap does produce duplicate `(subj_local, predicate, obj_local)` edges within a doc. Whether `store.rs::append` collapses them intra-batch or keeps both, it does not matter — coverage / R(B) / components / P(B) key on entity-pairs and components, not edge multiplicity, so duplicates cannot distort the measurement. (The claim deliberately does not depend on unverified intra-batch store dedup behavior.)
 
 Adding edge-dedup would mean touching shared `build_batch` — out of scope. If the measurement shows edge inflation distorting a signal, that is a follow-up, not part of this lever.
 
@@ -109,7 +119,7 @@ Fail-soft, matching the existing per-doc guard:
 
 ## Measurement — falsifiable bar
 
-Same rig as the recall-prompt verdict, so results are directly comparable: Modal `gg-bench`, 7B, `--corpus wiki`, `GOLDENGRAPH_XDOC_KEY=name_ci`, aliased aligner (on `main` via #1345). One control leg (chunking off) re-confirms the ~0.40 coverage / 0.23 R(B) / 12-component baseline on the current build, then 2-3 chunked legs varying `(GOLDENGRAPH_CHUNK_SENTENCES, GOLDENGRAPH_CHUNK_OVERLAP)` — e.g. `(4,1)`, `(3,1)`, `(6,2)`.
+Same rig as the recall-prompt verdict (7B, `--corpus wiki`, `GOLDENGRAPH_XDOC_KEY=name_ci`) but on the **aliased aligner** (on `main` via #1345). The comparison that matters is control-vs-chunked *within this run*, both on the aliased aligner — so the fresh control leg establishes the real aliased baseline rather than assuming the surface-aligner prior (0.40 / 0.23 / 12) reproduces. Then 2-3 chunked legs varying `(GOLDENGRAPH_CHUNK_SENTENCES, GOLDENGRAPH_CHUNK_OVERLAP)` — e.g. `(4,1)`, `(3,1)`, `(6,2)`. Distinct `--n` per leg so the `gg-bench-cache` volume results don't clobber.
 
 | Outcome | Signature | Action |
 |---|---|---|

--- a/docs/superpowers/specs/2026-07-01-chunked-extraction-design.md
+++ b/docs/superpowers/specs/2026-07-01-chunked-extraction-design.md
@@ -1,0 +1,132 @@
+# Chunked Extraction — Design
+
+**Date:** 2026-07-01
+**Branch:** `feat/chunked-extraction` (off `main`)
+**Program:** goldengraph substrate-quality arc — the second real-prose *extraction-recall* lever, after the recall-tuned prompt (`GOLDENGRAPH_EXTRACT_RECALL`) was **REFUTED** (`docs/superpowers/reports/2026-07-01-extract-recall-prompt-verdict.md`).
+
+## Problem
+
+The L2 clean-absolute finding put the real-prose substrate ceiling at **extraction recall**: on the wiki corpus the 7B extracts only ~0.44 of the wikilinked entities, and the aliased aligner sees coverage ~0.40 / R(B) ~0.23 over 12 components. The recall-prompt lever tried to lift this by *instructing* exhaustive entity extraction; it made the substrate **worse** (coverage −0.05, R(B) −0.07, components 12→25) because "extract EVERY entity" pushed the model to list entities at the expense of relations, and the substrate is edge-centric.
+
+The diagnostic from that negative: the miss is **not** relation-centric framing — it is **density**. The docs are a single dense ~2750-char, ~20-sentence paragraph, extracted in one LLM pass. A weak model attending over the whole lead drops entities regardless of how exhaustively it is prompted.
+
+## Goal
+
+A gated `GOLDENGRAPH_CHUNK_EXTRACT=1` path that splits each document into **overlapping sentence windows**, extracts each window independently, and **unions** the extractions into one `Extraction` before resolution. Unlike the recall prompt, each window preserves *both* its entities and its relations (the model sees a short span, so it extracts both well); the union then aggregates. Env-tunable window size / overlap, measured on the wiki corpus with a 2-3 point sweep. Default-off; single-pass path byte-identical when the gate is off.
+
+## Non-goals
+
+- No change to `extract.py` (the single-text primitive stays independent of the vocab / recall / literal gates).
+- No new cross-document or within-doc entity-dedup machinery — the existing `resolve()` already collapses duplicate mentions within a doc.
+- No edge-multiplicity dedup (see Union semantics).
+- Not a general RAG chunker: this chunks for *extraction*, not retrieval.
+
+## Architecture
+
+### The seam
+
+`ingest._prepare_doc` does exactly one `extraction = (extractor or _extract)(text, llm)` per document (`ingest.py:671`). That single call is the density bottleneck. The lever inserts a thin wrapper at that one call site:
+
+```
+extraction = (extractor or _extract)(text, llm)          # today
+        │
+        ▼  when GOLDENGRAPH_CHUNK_EXTRACT=1
+extraction = chunk_extract(text, llm, extractor or _extract)
+```
+
+`chunk_extract` splits the text, calls the *same* extractor per window, and unions. Everything downstream — `resolve → build_batch → _cross_doc_link → store.append` — is untouched. When the gate is off, `_prepare_doc` calls the extractor exactly as before.
+
+### Data flow
+
+```
+text
+ ├─ split_sentences(text)              -> [s0, s1, … sN]           (pure, no LLM)
+ ├─ sentence_windows(sents, size, ov)  -> [w0, w1, … wk]           (pure, no LLM)
+ ├─ for each window:  extractor(w, llm) -> Extraction_i            (one LLM call each)
+ └─ union: concat mentions; OFFSET each window's rel/attr indices  -> one Extraction
+                                        │
+                                        ▼
+                          resolve()  (collapses duplicate mentions across windows for free)
+                                        │
+                                        ▼
+                          build_batch → cross-doc link → append   (UNCHANGED)
+```
+
+### Why this seam
+
+`resolve()` clusters duplicate mentions *within a document* into single entities, so an entity that appears in three overlapping windows becomes one node with no new code. The union is pure index arithmetic. `extract.py` is never touched, so chunking composes cleanly with the literal / vocab / recall gates (each window's `_extract` still honors them internally).
+
+## Components
+
+Three units in a new module `goldengraph/chunk_extract.py`, each independently testable.
+
+### 1. `split_sentences(text: str) -> list[str]`
+
+Stdlib `re` only (network-free, no nltk/spacy — matches the repo norm set by `build_wiki_corpus`). Split on `(?<=[.!?])\s+`; drop empties/whitespace. Abbreviations ("Inc.", "U.S.") will occasionally over-split; that is harmless for extraction (a fragment yields fewer entities, never wrong ones), so tests assert a lower bound, not an exact count.
+
+### 2. `sentence_windows(sents, size, overlap) -> list[str]`
+
+Slide a window of `size` sentences advancing by `size - overlap`, each window joined back with a space. Guards:
+- `len(sents) <= size` → one window containing the whole doc (chunking is a correct no-op).
+- `overlap >= size` → clamp to `size - 1` (guarantees forward progress; no infinite loop).
+- `overlap < 0` → treat as 0.
+
+### 3. `chunk_extract(text, llm, extractor) -> Extraction`
+
+```python
+merged_mentions, merged_rels, merged_attrs = [], [], []
+for window in sentence_windows(split_sentences(text), size, overlap):
+    try:
+        ex = extractor(window, llm)          # honors LITERAL_ATTRS / vocab / recall internally
+    except Exception:
+        continue                             # a bad window degrades recall, never sinks the doc
+    base = len(merged_mentions)
+    merged_mentions += ex.mentions
+    merged_rels  += [Relationship(r.subj + base, r.predicate, r.obj + base) for r in ex.relationships]
+    merged_attrs += [Attribute(a.subj + base, a.predicate, a.value, a.typ)
+                     for a in getattr(ex, "attributes", ())]
+return Extraction(mentions=merged_mentions, relationships=merged_rels, attributes=merged_attrs)
+```
+
+**Config (read at call time so the sweep varies env between Modal legs):**
+- `GOLDENGRAPH_CHUNK_EXTRACT` — the gate (default off).
+- `GOLDENGRAPH_CHUNK_SENTENCES` — window size (default `4`).
+- `GOLDENGRAPH_CHUNK_OVERLAP` — sentence overlap (default `1`).
+
+### Union semantics — no dedup (deliberate)
+
+Overlap re-extracts some mentions and edges. We do **not** dedup at union time:
+- Duplicate **mentions** → `resolve()` collapses them into one entity downstream. No action needed.
+- Duplicate **edges** between the same resolved pair are benign: identical `(subj_local, predicate, obj_local)` edges union their `source_refs` in the store and do not change graph structure. The substrate metrics key on entity-pairs and components, not edge multiplicity.
+
+Adding edge-dedup would mean touching shared `build_batch` — out of scope. If the measurement shows edge inflation distorting a signal, that is a follow-up, not part of this lever.
+
+## Error handling
+
+Fail-soft, matching the existing per-doc guard:
+- `_prepare_doc` already wraps extract+resolve in a try/except yielding an empty extraction on failure; `chunk_extract` runs inside it.
+- Additionally, a single window whose `extractor` raises is skipped (its mentions simply don't contribute) rather than failing the whole doc.
+
+## Measurement — falsifiable bar
+
+Same rig as the recall-prompt verdict, so results are directly comparable: Modal `gg-bench`, 7B, `--corpus wiki`, `GOLDENGRAPH_XDOC_KEY=name_ci`, aliased aligner (on `main` via #1345). One control leg (chunking off) re-confirms the ~0.40 coverage / 0.23 R(B) / 12-component baseline on the current build, then 2-3 chunked legs varying `(GOLDENGRAPH_CHUNK_SENTENCES, GOLDENGRAPH_CHUNK_OVERLAP)` — e.g. `(4,1)`, `(3,1)`, `(6,2)`.
+
+| Outcome | Signature | Action |
+|---|---|---|
+| **WIN** | coverage ↑ **and** R(B) ↑, components not materially worse than control, P(B) ~1.0 | Ship the gate; document the winning `(size, overlap)`; consider default-on only if robust |
+| **REFUTED** | coverage flat/down, **or** coverage up only by fragmenting the graph (components blow up) | Ship gate default-off; write the negative; escalate to GLiNER (next lever) |
+
+The **shape of the sweep is itself a result**: if larger windows recover edges while smaller windows recover entities, that tension is the finding regardless of a single win/lose verdict. Precision (P(B) ~1.0) and component count are the guardrails that distinguish "real recall lift" from "fragmentation dressed as recall" — the exact trap the recall prompt fell into.
+
+## Testing
+
+All box-safe: no LLM, no network. Run via the main `.venv` + `PYTHONPATH` shadow, `POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 -p no:cacheprovider`.
+
+1. **`split_sentences`** — a multi-sentence string yields ≥ N sentences (lower-bound assertion tolerates abbreviation over-split); empty string → `[]`.
+2. **`sentence_windows`** — `size/overlap` produce the expected index spans; `len(sents) <= size` → exactly one window equal to the whole text; `overlap >= size` clamped (terminates, covers all sentences).
+3. **`chunk_extract` union** — a capturing stub LLM returns a fixed 2-entity/1-relationship extraction per call; assert mentions concatenate across windows and that a relationship from window *k* has `subj`/`obj` pointing into window *k*'s mention block (offset applied), not window 0's.
+4. **Gate wiring** — `GOLDENGRAPH_CHUNK_EXTRACT` off → `_prepare_doc` calls a monkeypatched counting extractor exactly once; on → called once per window.
+
+## Rollout
+
+Default-off gated feature. If the sweep produces a WIN, the verdict records the winning `(size, overlap)` and the gate ships opt-in; a default-on flip would be a separate decision gated on robustness across more than the wiki corpus. If REFUTED, the gate still ships (an opt-in recall knob for callers who want it) and the verdict escalates to the GLiNER hybrid extractor (`extract_local.gliner_extractor`) as the next extraction-recall lever.

--- a/packages/python/goldengraph/goldengraph/chunk_extract.py
+++ b/packages/python/goldengraph/goldengraph/chunk_extract.py
@@ -1,0 +1,52 @@
+"""Chunked extraction (GOLDENGRAPH_CHUNK_EXTRACT): split a dense document into
+overlapping sentence windows, extract each window with the SAME extractor, and
+union the results before resolution. The default single-pass extraction attends
+over a whole ~20-sentence Wikipedia lead in one call and drops entities (the ~0.44
+real-prose extraction-recall ceiling); a short window lets a weak model extract
+both entities AND relations well, and the union aggregates. resolve() collapses
+duplicate mentions across windows downstream, so no new dedup is needed here.
+
+Pure w.r.t. the store: stdlib only, depends on the extract dataclasses. Gate is
+off by default -- the single-pass path is unchanged when GOLDENGRAPH_CHUNK_EXTRACT
+is unset.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split `text` into sentences on `.!?` boundaries (stdlib regex, network-free).
+    Empty / whitespace-only input -> [] (no windows, no wasted extractor call).
+    Abbreviations may over-split; harmless for extraction (a fragment yields fewer
+    entities, never wrong ones)."""
+    if not text or not text.strip():
+        return []
+    return [s.strip() for s in _SENTENCE_SPLIT.split(text.strip()) if s.strip()]
+
+
+def sentence_windows(sents: list[str], size: int, overlap: int) -> list[str]:
+    """Overlapping sentence windows joined back into text. Advances by `size -
+    overlap`. Guards (in order): size<=0 -> 1; overlap<0 -> 0; overlap>=size ->
+    size-1 (stride>=1, terminates); [] -> []; len<=size -> one whole-doc window."""
+    size = max(1, size)
+    overlap = max(0, overlap)
+    if overlap >= size:
+        overlap = size - 1
+    stride = size - overlap  # >= 1
+    if not sents:
+        return []
+    if len(sents) <= size:
+        return [" ".join(sents)]
+    out: list[str] = []
+    i = 0
+    n = len(sents)
+    while i < n:
+        out.append(" ".join(sents[i : i + size]))
+        if i + size >= n:  # last window reached the end
+            break
+        i += stride
+    return out

--- a/packages/python/goldengraph/goldengraph/chunk_extract.py
+++ b/packages/python/goldengraph/goldengraph/chunk_extract.py
@@ -81,8 +81,11 @@ def chunk_extract_enabled() -> bool:
 
 
 def _chunk_params() -> tuple[int, int]:
-    """(window size, overlap) from env; defaults (4, 1). Defensive parse."""
-    return _env_int("GOLDENGRAPH_CHUNK_SENTENCES", 4), _env_int("GOLDENGRAPH_CHUNK_OVERLAP", 1)
+    """(window size, overlap) from env; defaults (6, 2) -- the measured wiki-sweep
+    winner (2026-07-01 verdict): 6-sentence windows keep cross-sentence relations
+    intact while lifting entity recall, +2 overlap stitches boundaries. Smaller
+    windows ((3,1)/(4,1)) fragmented the graph and lost edges. Defensive parse."""
+    return _env_int("GOLDENGRAPH_CHUNK_SENTENCES", 6), _env_int("GOLDENGRAPH_CHUNK_OVERLAP", 2)
 
 
 def chunk_extract(text: str, llm: LLMClient | None, extractor) -> Extraction:

--- a/packages/python/goldengraph/goldengraph/chunk_extract.py
+++ b/packages/python/goldengraph/goldengraph/chunk_extract.py
@@ -13,7 +13,11 @@ is unset.
 
 from __future__ import annotations
 
+import os
 import re
+
+from .extract import Attribute, Extraction, Mention, Relationship
+from .llm import LLMClient
 
 _SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
 
@@ -50,3 +54,56 @@ def sentence_windows(sents: list[str], size: int, overlap: int) -> list[str]:
             break
         i += stride
     return out
+
+
+def _env_int(name: str, default: int) -> int:
+    """Parse an int env var defensively: unset OR set-but-empty OR non-numeric ->
+    `default` (the empty-string-env footgun -- `NAME=` must not raise ValueError)."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def chunk_extract_enabled() -> bool:
+    """`GOLDENGRAPH_CHUNK_EXTRACT` gate. Off by default; "0"/"false"/"" -> off."""
+    return os.environ.get("GOLDENGRAPH_CHUNK_EXTRACT", "0") not in ("0", "false", "")
+
+
+def _chunk_params() -> tuple[int, int]:
+    """(window size, overlap) from env; defaults (4, 1). Defensive parse."""
+    return _env_int("GOLDENGRAPH_CHUNK_SENTENCES", 4), _env_int("GOLDENGRAPH_CHUNK_OVERLAP", 1)
+
+
+def chunk_extract(text: str, llm: LLMClient | None, extractor) -> Extraction:
+    """Split `text` into overlapping sentence windows, run `extractor(window, llm)`
+    on each, and union: concatenate mentions and OFFSET each window's relationship /
+    attribute indices by the running mention count. A window whose extractor raises
+    is skipped (its mentions just don't contribute), never fatal to the doc.
+
+    `extractor` is the same callable the single-pass path uses (`extract.extract`,
+    or a rebel/gliner closure) -- it still honors LITERAL_ATTRS / vocab / recall
+    gates internally per window."""
+    size, overlap = _chunk_params()
+    windows = sentence_windows(split_sentences(text), size, overlap)
+    merged_mentions: list[Mention] = []
+    merged_rels: list[Relationship] = []
+    merged_attrs: list[Attribute] = []
+    for window in windows:
+        try:
+            ex = extractor(window, llm)
+        except Exception:
+            continue  # a bad window degrades recall, never sinks the doc
+        base = len(merged_mentions)  # captured BEFORE the append -> correct per-window offset
+        merged_mentions += ex.mentions
+        merged_rels += [
+            Relationship(r.subj + base, r.predicate, r.obj + base) for r in ex.relationships
+        ]
+        merged_attrs += [
+            Attribute(a.subj + base, a.predicate, a.value, a.typ)
+            for a in getattr(ex, "attributes", ())
+        ]
+    return Extraction(mentions=merged_mentions, relationships=merged_rels, attributes=merged_attrs)

--- a/packages/python/goldengraph/goldengraph/chunk_extract.py
+++ b/packages/python/goldengraph/goldengraph/chunk_extract.py
@@ -69,8 +69,15 @@ def _env_int(name: str, default: int) -> int:
 
 
 def chunk_extract_enabled() -> bool:
-    """`GOLDENGRAPH_CHUNK_EXTRACT` gate. Off by default; "0"/"false"/"" -> off."""
-    return os.environ.get("GOLDENGRAPH_CHUNK_EXTRACT", "0") not in ("0", "false", "")
+    """`GOLDENGRAPH_CHUNK_EXTRACT` gate. Off by default; case-insensitive, stripped:
+    ""/"0"/"false"/"no"/"off" -> off so `=False` doesn't surprisingly enable it."""
+    return os.environ.get("GOLDENGRAPH_CHUNK_EXTRACT", "0").strip().lower() not in (
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    )
 
 
 def _chunk_params() -> tuple[int, int]:

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 
 import numpy as np
 
+from .chunk_extract import chunk_extract, chunk_extract_enabled
 from .extract import Extraction, Mention
 from .extract import extract as _extract
 from .llm import LLMClient
@@ -668,7 +669,12 @@ def _prepare_doc(
         t0 = time.perf_counter()
         # `_extract` honors GOLDENGRAPH_LITERAL_ATTRS internally, so this call stays
         # 2-arg (custom rebel/gliner extractors and test stubs keep that shape).
-        extraction = (extractor or _extract)(text, llm)
+        _extractor = extractor or _extract
+        extraction = (
+            chunk_extract(text, llm, _extractor)
+            if chunk_extract_enabled()
+            else _extractor(text, llm)
+        )
         # In discovery mode the schema isn't known until the whole corpus is extracted, so defer
         # canonicalization to the post-discovery pass in `ingest_corpus`.
         if not _schema_discover_enabled():

--- a/packages/python/goldengraph/tests/test_chunk_extract.py
+++ b/packages/python/goldengraph/tests/test_chunk_extract.py
@@ -131,3 +131,48 @@ def test_chunk_extract_skips_failing_window(monkeypatch):
     ex = chunk_extract(text, llm=None, extractor=flaky)
     # 3 windows, middle one raises -> 2 mentions survive, no crash
     assert len(ex.mentions) == 2
+
+
+def test_prepare_doc_uses_chunking_only_when_gated(monkeypatch):
+    """_prepare_doc calls the extractor once when off, once-per-window when on."""
+    import importlib
+
+    from goldengraph.resolve import ResolvedEntity
+
+    # goldengraph/__init__ re-exports the `ingest` FUNCTION, shadowing the submodule,
+    # so import the module object explicitly to reach `_prepare_doc`.
+    ingest = importlib.import_module("goldengraph.ingest")
+
+    calls = {"n": 0}
+
+    def counting_extractor(text, llm=None):
+        calls["n"] += 1
+        return Extraction(mentions=[Mention(name="X", typ="org")], relationships=[])
+
+    # identity resolver: one entity per mention (no goldenmatch needed)
+    def resolver(mentions):
+        return [
+            ResolvedEntity(
+                local_id=i, canonical_name=m.name, typ=m.typ,
+                surface_names=[m.name], record_keys=[], member_idx=[i],
+            )
+            for i, m in enumerate(mentions)
+        ]
+
+    text = "One here. Two here. Three here. Four here. Five here. Six here. Seven here."
+
+    # gate OFF -> single call
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
+    calls["n"] = 0
+    ingest._prepare_doc(text, llm=None, resolver=resolver, profile_fps=False,
+                        extractor=counting_extractor)
+    assert calls["n"] == 1
+
+    # gate ON, size=3 overlap=1 (stride 2) over 7 sentences -> windows [0:3],[2:5],[4:7] = 3 calls
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_EXTRACT", "1")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "3")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "1")
+    calls["n"] = 0
+    ingest._prepare_doc(text, llm=None, resolver=resolver, profile_fps=False,
+                        extractor=counting_extractor)
+    assert calls["n"] == 3

--- a/packages/python/goldengraph/tests/test_chunk_extract.py
+++ b/packages/python/goldengraph/tests/test_chunk_extract.py
@@ -99,17 +99,17 @@ def test_chunk_extract_enabled_case_insensitive_off(monkeypatch):
 def test_chunk_params_defaults_and_empty_string(monkeypatch):
     monkeypatch.delenv("GOLDENGRAPH_CHUNK_SENTENCES", raising=False)
     monkeypatch.delenv("GOLDENGRAPH_CHUNK_OVERLAP", raising=False)
-    assert _chunk_params() == (4, 1)
+    assert _chunk_params() == (6, 2)  # measured wiki-sweep winner
     # empty-string env must fall back to default, not raise ValueError
     monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "")
     monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "")
-    assert _chunk_params() == (4, 1)
+    assert _chunk_params() == (6, 2)
     # garbage falls back too
     monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "abc")
-    assert _chunk_params() == (4, 1)
+    assert _chunk_params() == (6, 2)
     monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "3")
-    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "2")
-    assert _chunk_params() == (3, 2)
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "1")
+    assert _chunk_params() == (3, 1)
 
 
 def test_chunk_extract_unions_and_offsets_indices(monkeypatch):

--- a/packages/python/goldengraph/tests/test_chunk_extract.py
+++ b/packages/python/goldengraph/tests/test_chunk_extract.py
@@ -6,7 +6,7 @@ from goldengraph.chunk_extract import (
     sentence_windows,
     split_sentences,
 )
-from goldengraph.extract import Extraction, Mention, Relationship
+from goldengraph.extract import Attribute, Extraction, Mention, Relationship
 
 
 class _WindowStub:
@@ -73,6 +73,13 @@ def test_windows_size_zero_floored_to_one():
     assert wins == ["a.", "b.", "c."]
 
 
+def test_windows_negative_overlap_treated_as_zero():
+    sents = [f"s{i}." for i in range(6)]
+    # overlap<0 must clamp to 0 -> stride == size, no gaps, no crash.
+    wins = sentence_windows(sents, size=3, overlap=-2)
+    assert wins == ["s0. s1. s2.", "s3. s4. s5."]
+
+
 def test_chunk_extract_enabled_gate(monkeypatch):
     monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
     assert chunk_extract_enabled() is False
@@ -80,6 +87,13 @@ def test_chunk_extract_enabled_gate(monkeypatch):
     assert chunk_extract_enabled() is True
     monkeypatch.setenv("GOLDENGRAPH_CHUNK_EXTRACT", "")  # set-but-empty -> off
     assert chunk_extract_enabled() is False
+
+
+def test_chunk_extract_enabled_case_insensitive_off(monkeypatch):
+    # "False"/"Off"/" 0 " must read as OFF (case-insensitive, stripped), not surprisingly on.
+    for off in ("False", "FALSE", "off", "No", " 0 "):
+        monkeypatch.setenv("GOLDENGRAPH_CHUNK_EXTRACT", off)
+        assert chunk_extract_enabled() is False, off
 
 
 def test_chunk_params_defaults_and_empty_string(monkeypatch):
@@ -131,6 +145,25 @@ def test_chunk_extract_skips_failing_window(monkeypatch):
     ex = chunk_extract(text, llm=None, extractor=flaky)
     # 3 windows, middle one raises -> 2 mentions survive, no crash
     assert len(ex.mentions) == 2
+
+
+def test_chunk_extract_offsets_attribute_subj(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "1")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "0")
+
+    def attr_extractor(text, llm=None):
+        # one entity + one attribute on subj=0 per window
+        return Extraction(
+            mentions=[Mention(name="Amazon", typ="org")],
+            relationships=[],
+            attributes=[Attribute(subj=0, predicate="founded", value="1994", typ="date")],
+        )
+
+    text = "One here. Two here. Three here."
+    ex = chunk_extract(text, llm=None, extractor=attr_extractor)
+    # window k's attribute subj must offset to window k's mention block: 0, 1, 2
+    assert [a.subj for a in ex.attributes] == [0, 1, 2]
+    assert all(a.value == "1994" for a in ex.attributes)
 
 
 def test_prepare_doc_uses_chunking_only_when_gated(monkeypatch):

--- a/packages/python/goldengraph/tests/test_chunk_extract.py
+++ b/packages/python/goldengraph/tests/test_chunk_extract.py
@@ -1,5 +1,28 @@
 """Chunked extraction: sentence splitting, overlapping windows, and index-offset union."""
-from goldengraph.chunk_extract import sentence_windows, split_sentences
+from goldengraph.chunk_extract import (
+    _chunk_params,
+    chunk_extract,
+    chunk_extract_enabled,
+    sentence_windows,
+    split_sentences,
+)
+from goldengraph.extract import Extraction, Mention, Relationship
+
+
+class _WindowStub:
+    """Extractor stub: records each window text it saw and returns a fixed
+    2-entity/1-relationship extraction per call (rel points 0->1 within the call)."""
+
+    def __init__(self):
+        self.seen = []
+
+    def __call__(self, text, llm=None):
+        self.seen.append(text)
+        k = len(self.seen)
+        return Extraction(
+            mentions=[Mention(name=f"E{k}a", typ="org"), Mention(name=f"E{k}b", typ="person")],
+            relationships=[Relationship(subj=0, predicate="founded_by", obj=1)],
+        )
 
 
 def test_split_sentences_basic():
@@ -48,3 +71,63 @@ def test_windows_size_zero_floored_to_one():
     # size<=0 must floor to 1 (no zero/negative stride, no infinite loop).
     wins = sentence_windows(sents, size=0, overlap=0)
     assert wins == ["a.", "b.", "c."]
+
+
+def test_chunk_extract_enabled_gate(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
+    assert chunk_extract_enabled() is False
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_EXTRACT", "1")
+    assert chunk_extract_enabled() is True
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_EXTRACT", "")  # set-but-empty -> off
+    assert chunk_extract_enabled() is False
+
+
+def test_chunk_params_defaults_and_empty_string(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_SENTENCES", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_OVERLAP", raising=False)
+    assert _chunk_params() == (4, 1)
+    # empty-string env must fall back to default, not raise ValueError
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "")
+    assert _chunk_params() == (4, 1)
+    # garbage falls back too
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "abc")
+    assert _chunk_params() == (4, 1)
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "3")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "2")
+    assert _chunk_params() == (3, 2)
+
+
+def test_chunk_extract_unions_and_offsets_indices(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "1")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "0")
+    text = "Sentence one is here. Sentence two is here. Sentence three is here."
+    stub = _WindowStub()
+    ex = chunk_extract(text, llm=None, extractor=stub)
+    # 3 windows -> 6 mentions, 3 relationships
+    assert len(stub.seen) == 3
+    assert len(ex.mentions) == 6
+    assert len(ex.relationships) == 3
+    # window k's relationship must point into window k's mention block (offset applied)
+    # window 0: mentions 0,1 -> rel (0,1); window 1: mentions 2,3 -> rel (2,3); window 2: (4,5)
+    assert (ex.relationships[0].subj, ex.relationships[0].obj) == (0, 1)
+    assert (ex.relationships[1].subj, ex.relationships[1].obj) == (2, 3)
+    assert (ex.relationships[2].subj, ex.relationships[2].obj) == (4, 5)
+
+
+def test_chunk_extract_skips_failing_window(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_SENTENCES", "1")
+    monkeypatch.setenv("GOLDENGRAPH_CHUNK_OVERLAP", "0")
+
+    calls = {"n": 0}
+
+    def flaky(text, llm=None):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("boom")
+        return Extraction(mentions=[Mention(name="X", typ="org")], relationships=[])
+
+    text = "One here. Two here. Three here."
+    ex = chunk_extract(text, llm=None, extractor=flaky)
+    # 3 windows, middle one raises -> 2 mentions survive, no crash
+    assert len(ex.mentions) == 2

--- a/packages/python/goldengraph/tests/test_chunk_extract.py
+++ b/packages/python/goldengraph/tests/test_chunk_extract.py
@@ -1,0 +1,50 @@
+"""Chunked extraction: sentence splitting, overlapping windows, and index-offset union."""
+from goldengraph.chunk_extract import sentence_windows, split_sentences
+
+
+def test_split_sentences_basic():
+    s = "Amazon was founded in 1994. Jeff Bezos was the CEO. It sells books."
+    assert len(split_sentences(s)) == 3
+
+
+def test_split_sentences_empty():
+    assert split_sentences("") == []
+    assert split_sentences("   ") == []
+
+
+def test_split_sentences_lower_bound_with_abbreviations():
+    # "Inc." may over-split; we only require the real breaks are found (lower bound).
+    s = "Apple Inc. is a company. Steve Jobs founded it."
+    assert len(split_sentences(s)) >= 2
+
+
+def test_windows_size_and_overlap_spans():
+    sents = [f"s{i}." for i in range(9)]  # 9 sentences
+    # size=4, overlap=1 -> stride 3 -> windows [0:4], [3:7], [6:9]
+    wins = sentence_windows(sents, size=4, overlap=1)
+    assert wins == ["s0. s1. s2. s3.", "s3. s4. s5. s6.", "s6. s7. s8."]
+
+
+def test_windows_shorter_than_size_is_one_window():
+    sents = ["a.", "b."]
+    assert sentence_windows(sents, size=4, overlap=1) == ["a. b."]
+
+
+def test_windows_empty_input_no_windows():
+    assert sentence_windows([], size=4, overlap=1) == []
+
+
+def test_windows_overlap_ge_size_clamped_terminates():
+    sents = [f"s{i}." for i in range(6)]
+    # overlap >= size must clamp to size-1 (stride 1), cover all, and terminate.
+    wins = sentence_windows(sents, size=3, overlap=5)
+    assert wins[0] == "s0. s1. s2."
+    assert wins[-1].endswith("s5.")
+    assert len(wins) == 4  # stride 1: [0:3],[1:4],[2:5],[3:6]
+
+
+def test_windows_size_zero_floored_to_one():
+    sents = ["a.", "b.", "c."]
+    # size<=0 must floor to 1 (no zero/negative stride, no infinite loop).
+    wins = sentence_windows(sents, size=0, overlap=0)
+    assert wins == ["a.", "b.", "c."]


### PR DESCRIPTION
## Summary

Second real-prose **extraction-recall** lever for the goldengraph substrate arc, after the recall-tuned prompt was REFUTED. Gated `GOLDENGRAPH_CHUNK_EXTRACT=1` splits each document into **overlapping sentence windows**, extracts each with the same extractor, and unions the results (concat mentions, offset relationship/attribute indices) before resolution. `resolve()` collapses the duplicate mentions across windows for free, so nothing downstream changes. Default-off; off-path is byte-identical to before.

## Why

The real-prose miss is **density**, not prompt framing: the 7B attends over a whole ~20-sentence Wikipedia lead in one pass and drops ~half the wikilinked entities. A short window lets a weak model extract both entities AND relations well; the union aggregates.

## Result — WIN at (6, 2)

Modal wiki/7B/aliased-aligner sweep (19 docs, 65 gold):

| (size, overlap) | coverage | R(B) | P(B) | F1(B) | components |
|---|---|---|---|---|---|
| control (off) | 0.446 | 0.318 | 1.00 | 0.483 | 13 |
| (4, 1) | 0.369 | 0.116 | 0.96 | 0.207 | 10 |
| (3, 1) | 0.477 | 0.202 | 0.93 | 0.332 | 26 |
| **(6, 2)** | **0.508** | **0.343** | **1.00** | **0.511** | 14 |

`(6, 2)` lifts every signal — coverage +0.06, R(B) +0.025, F1 +0.028 — with **P(B)=1.0 and components flat**. The sweep *shape* confirms the predicted mechanism: small windows ((3,1)) recover entities but shatter cross-sentence relations (components 13→26, R down); a large-enough window with overlap gets the recall lift without fragmenting. Shipped default is the measured winner `(6, 2)`.

Full write-up: `docs/superpowers/reports/2026-07-01-chunked-extraction-verdict.md`.

## Scope / safety

- **Default-off, opt-in.** Gate unset => single-pass path, byte-identical (final review confirmed).
- New pure module `goldengraph/chunk_extract.py`; one gated call site in `ingest._prepare_doc`.
- 16 unit tests (splitting, windows, union index-offset, attribute-offset, fail-soft, defensive/case-insensitive env, gate wiring). Spec + plan + final code review all passed.
- Not flipped default-on (modest lift, small N, 4-10x extraction cost) — a separate decision. Next lever: GLiNER hybrid.

## Test plan
- [x] `tests/test_chunk_extract.py` — 16 passed (box-safe: `GOLDENGRAPH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1`)
- [x] recall-lever regression passes (off-path unchanged)
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)