### PR TITLE
feat(fs): native FS kernel authoritative by default (goldenmatch 2.6.0)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-07-01
+
+### Changed
+- **Native Fellegi-Sunter (FS) block scorer is now authoritative by default (reference mode).** `_fs_native_enabled()` flips from opt-in to default-on: when the native ext is importable, the probabilistic path uses the native Rust FS kernel (rapidfuzz-rs decides comparison levels); the numpy vectorized path becomes the reproducible fallback via `GOLDENMATCH_FS_NATIVE=0` (also the automatic fallback for TF-adjustment / non-native-scorer fields or a missing wheel). Part of the Rust-is-the-reference direction (`docs/design/2026-07-01-rust-is-the-reference-roadmap.md`). **Scoped to the probabilistic path only** (opt-in `type: probabilistic` matchkeys / probabilistic routing); the default weighted path is unaffected. **Measured F1-neutral** on the probabilistic bench panel (`gm_prob_native` vs `gm_probabilistic`): febrl3 and synthetic_person identical, historical_50k −0.0007 (within noise); dblp_acm not measured (Leipzig CSVs gitignored in CI). Boundary-level score differences are possible where a rapidfuzz-rs vs rapidfuzz-py similarity sits exactly on a comparison-level threshold — the native result is now the reference; `GOLDENMATCH_FS_NATIVE=0` restores the prior numpy operating point.
+
 ## [2.5.1] - 2026-07-01
 
 ### Fixed

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "2.5.1"
+__version__ = "2.6.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1754,23 +1754,27 @@ _NATIVE_FS_SCORER_IDS: dict[str, int] = {
 
 
 def _fs_native_enabled() -> bool:
-    """Whether the native FS block kernel is active. **Opt-in, default OFF.**
+    """Whether the native FS block kernel is active. **Default ON (reference mode).**
 
-    Enable with `GOLDENMATCH_FS_NATIVE=1` (also needs the native ext built).
-    Unlike the weighted native kernel (default ON), FS stays opt-in because its
-    DISCRETE comparison levels amplify the tiny rapidfuzz-rs-vs-Python-rapidfuzz
-    float differences: a similarity sitting exactly on a `partial_threshold`
-    (token_sort ratios are rationals like 0.7 / 0.857, so this is common) can
-    flip a level between the two libraries, and with EM weights that can span
-    ~40 bits a single level flip swings the normalized score ~0.45 and can move
-    a pair across the link threshold. The numpy vectorized path is the default
-    so FS output is reproducible; native is a measured ~2.9x opt-in speedup for
-    callers who accept boundary-level differences (same CLASS as the documented
-    vectorized-vs-scalar FS parity, larger in per-pair magnitude).
+    Under Rust-is-the-reference (2026-07-01,
+    `docs/design/2026-07-01-rust-is-the-reference-roadmap.md`) the native FS kernel
+    is the authoritative FS scorer -- rapidfuzz-rs decides the comparison levels;
+    the numpy vectorized path is the reproducible FALLBACK, selected explicitly
+    with `GOLDENMATCH_FS_NATIVE=0` (or when the native ext isn't built / a field is
+    ineligible -- see `_fs_native_eligible`).
+
+    The DISCRETE-level sensitivity that kept this opt-in still exists (a similarity
+    on a `partial_threshold` -- token_sort ratios are rationals like 0.7 / 0.857 --
+    can flip a level between rapidfuzz-rs and Python-rapidfuzz, swinging the
+    normalized score up to ~0.45), but under reference mode the native result IS
+    the answer, so it is a defined, reproducible output rather than a divergence.
+    The default flip was gated on the probabilistic bench panel (gm_prob_native vs
+    gm_probabilistic F1 non-regression) -- see the PR. `=0` restores the prior
+    numpy operating point.
     """
     val = os.environ.get("GOLDENMATCH_FS_NATIVE")
-    if val is None or val.strip().lower() not in ("1", "true", "yes", "on", "enabled"):
-        return False
+    if val is not None and val.strip().lower() in ("0", "false", "no", "off", "disabled"):
+        return False  # explicit opt-out to the reproducible numpy fallback
     from goldenmatch.core._native_loader import native_enabled
     return native_enabled("block_scoring")
 

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "2.5.1"
+version = "2.6.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenmatch/tests/test_fs_native_authoritative.py
+++ b/packages/python/goldenmatch/tests/test_fs_native_authoritative.py
@@ -1,0 +1,37 @@
+"""FS-native reference-mode tests (docs/design/2026-07-01-rust-is-the-reference-roadmap.md).
+
+The native FS kernel is now the authoritative FS scorer by default; the numpy
+vectorized path is the reproducible fallback via GOLDENMATCH_FS_NATIVE=0.
+"""
+from __future__ import annotations
+
+import goldenmatch.core._native_loader as nl
+from goldenmatch.core import probabilistic as p
+
+
+def test_fs_native_authoritative_by_default(monkeypatch) -> None:
+    # env unset -> native FS is ON when block_scoring native is available.
+    monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
+    monkeypatch.setattr(nl, "native_enabled", lambda component: True)
+    assert p._fs_native_enabled() is True
+
+
+def test_fs_native_force_off(monkeypatch) -> None:
+    for val in ("0", "false", "no", "off", "disabled"):
+        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", val)
+        monkeypatch.setattr(nl, "native_enabled", lambda component: True)
+        assert p._fs_native_enabled() is False, val
+
+
+def test_fs_native_falls_back_when_block_scoring_unavailable(monkeypatch) -> None:
+    # default-on, but if block_scoring native isn't available the numpy path runs.
+    monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
+    monkeypatch.setattr(nl, "native_enabled", lambda component: False)
+    assert p._fs_native_enabled() is False
+
+
+def test_fs_native_explicit_on_still_works(monkeypatch) -> None:
+    # back-compat: =1 still turns it on.
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+    monkeypatch.setattr(nl, "native_enabled", lambda component: True)
+    assert p._fs_native_enabled() is True

--- a/packages/python/goldenmatch/tests/test_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic.py
@@ -1128,8 +1128,8 @@ class TestNativeFSGating:
         # with GOLDENMATCH_FS_NATIVE unset it follows native availability (was
         # opt-in/default-off pre-2.6.0). See docs/design/2026-07-01-rust-is-the-
         # reference-roadmap.md.
-        from goldenmatch.core import probabilistic as p
         from goldenmatch.core import _native_loader as nl
+        from goldenmatch.core import probabilistic as p
         monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
         monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
         assert p._fs_native_enabled() is nl.native_available()

--- a/packages/python/goldenmatch/tests/test_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic.py
@@ -1123,9 +1123,21 @@ def _native_fs_available():
 
 
 class TestNativeFSGating:
-    def test_default_off(self, monkeypatch):
+    def test_default_on_reference_mode(self, monkeypatch):
+        # Reference mode (2026-07-01): native FS is authoritative by DEFAULT --
+        # with GOLDENMATCH_FS_NATIVE unset it follows native availability (was
+        # opt-in/default-off pre-2.6.0). See docs/design/2026-07-01-rust-is-the-
+        # reference-roadmap.md.
         from goldenmatch.core import probabilistic as p
+        from goldenmatch.core import _native_loader as nl
         monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
+        monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+        assert p._fs_native_enabled() is nl.native_available()
+
+    def test_force_off(self, monkeypatch):
+        # GOLDENMATCH_FS_NATIVE=0 is the explicit opt-out to the numpy fallback.
+        from goldenmatch.core import probabilistic as p
+        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
         assert p._fs_native_enabled() is False
         assert p._fs_native_eligible(_make_probabilistic_mk()) is False
 


### PR DESCRIPTION
## What

Flips the native Fellegi-Sunter block scorer from opt-in to **authoritative by default** — Rust-is-the-reference applied to the FS path (roadmap: `docs/design/2026-07-01-rust-is-the-reference-roadmap.md`). `_fs_native_enabled()` now returns true under `auto` when the native ext is importable; `GOLDENMATCH_FS_NATIVE=0` is the explicit opt-out to the reproducible numpy path (also the automatic fallback for TF-adjustment / non-native-scorer fields or a missing wheel).

## Scope

Probabilistic path only (`type: probabilistic` matchkeys / probabilistic routing, both opt-in). The default weighted path is untouched.

## Measure-gate: PASS

Probabilistic bench bake-off (`gm_prob_native` native FS vs `gm_probabilistic` numpy), the F1 comparison that gates this flip:

| dataset | numpy | native | Δ |
|---|---|---|---|
| febrl3 | 0.9909 | 0.9909 | 0.0000 |
| synthetic_person | 0.9976 | 0.9976 | 0.0000 |
| historical_50k | 0.7772 | 0.7765 | −0.0007 (noise) |
| dblp_acm | — | — | not measured (Leipzig gitignored in CI) |

F1 holds on all measured datasets → cleared. Boundary-level differences are possible where a rapidfuzz-rs vs rapidfuzz-py similarity sits exactly on a comparison-level threshold; under reference mode the native result is the spec, and `GOLDENMATCH_FS_NATIVE=0` restores the prior operating point.

## Version

Minor bump 2.5.1 -> 2.6.0 (default-on behavior flip with an escape hatch, consistent with how the repo ships other default-on behavior changes). Determinism confirmed from source — native FS is reproducible run-to-run.

Tests: tests/test_fs_native_authoritative.py (default-on / force-off / fallback-when-unavailable / explicit-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)