### PR TITLE
GLiNER entity-recall probe: REFUTED — real-prose residual is edge-miss, not NER-miss

### DIFF
--- a/docs/superpowers/plans/2026-07-01-gliner-recall-probe.md
+++ b/docs/superpowers/plans/2026-07-01-gliner-recall-probe.md
@@ -311,13 +311,15 @@ def run_wiki_gliner_probe() -> dict:
     return r
 ```
 
-- [ ] **Step 3: Route it in `main`.** Add the flag and branch:
+- [ ] **Step 3: Route it in `main`.** Two edits to the EXISTING `main` (do NOT add a second `ap.parse_args()` — it already exists at `run_substrate_eval.py:136`):
 
+  (a) Insert this `add_argument` line just BEFORE the existing `args = ap.parse_args()`:
 ```python
     ap.add_argument("--gliner-probe", action="store_true",
                     help="run the GLiNER entity-recall probe instead of the plain wiki eval")
-    args = ap.parse_args()
-
+```
+  (b) Insert the probe branch AFTER `args = ap.parse_args()` and BEFORE the existing `if args.corpus == "wiki":` (line ~138):
+```python
     _probe = args.gliner_probe or os.environ.get("GOLDENGRAPH_GLINER_PROBE", "") not in ("", "0", "false")
     if args.corpus == "wiki" and _probe:
         r = run_wiki_gliner_probe()

--- a/docs/superpowers/plans/2026-07-01-gliner-recall-probe.md
+++ b/docs/superpowers/plans/2026-07-01-gliner-recall-probe.md
@@ -1,0 +1,403 @@
+# GLiNER Entity-Recall Probe — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A measurement-only Modal probe that reports how much of the real-prose substrate residual GLiNER could recover — splitting NER-miss (GLiNER-addressable) from edge-miss — to gate whether the GLiNER-hybrid lever is worth building.
+
+**Architecture:** A pure scorer `gliner_probe_report` in `substrate_eval.py` (box-unit-tested) plus an impure runner `run_wiki_gliner_probe` in `run_substrate_eval.py` that builds the best-config graph, runs GLiNER per-doc, and calls the scorer. One shared alias-match primitive backs both the aligner and the probe so they can't drift. No production engine change; gate stays off.
+
+**Tech Stack:** Python 3.11, pure stdlib for the scorer; `gliner` (Modal image only) for the runner; pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-01-gliner-recall-probe-design.md`
+**Branch:** `feat/gliner-recall-probe` (off `main`, chunking already merged).
+
+**Box-safe test invocation** (run yourself; the scorer is pure so no goldengraph/polars import is triggered):
+```bash
+PY="/d/show_case/goldenmatch/.venv/Scripts/python.exe"
+BENCH="D:/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench"
+cd "$BENCH"
+PYTHONPATH="$BENCH" POLARS_SKIP_CPU_CHECK=1 "$PY" -m pytest tests/test_substrate_eval.py -q -p no:cacheprovider
+```
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_eval.py` | **Modify.** Add pure `_alias_match_surface` primitive + `gliner_probe_report`. Point the aligner's inline substring test at the primitive (DRY, no-drift). |
+| `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_eval.py` | **Modify.** 5 new pure-scorer tests + confirm existing aligner tests still pass. |
+| `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_eval.py` | **Modify.** Factor `_wiki_build()`; add `run_wiki_gliner_probe()`; add `--gliner-probe` flag + `GOLDENGRAPH_GLINER_PROBE` env in `main`. |
+| `scripts/distill/modal_bench.py` | **Modify.** Add `gliner` to the image `pip_install`. |
+| `docs/superpowers/reports/2026-07-01-gliner-recall-probe-verdict.md` | **Create** in Task 4 after the Modal run. |
+
+---
+
+## Task 1: pure `_alias_match_surface` primitive + `gliner_probe_report`
+
+**Files:**
+- Modify: `erkgbench/substrate_eval.py`
+- Test: `tests/test_substrate_eval.py`
+
+- [ ] **Step 1: Write the failing tests.** Append to `tests/test_substrate_eval.py`:
+
+```python
+from erkgbench.substrate_eval import gliner_probe_report
+
+
+def _graph(entities, edges):
+    return {"entities": entities, "edges": edges}
+
+
+def test_probe_splits_ner_miss_from_edge_miss():
+    # gold A: aligned (node 1 has an in-doc edge). gold B: edge-miss (node 2 exists, no edge in its doc).
+    # gold C: ner-miss (no node matches its aliases anywhere).
+    entities = [
+        {"entity_id": 1, "canonical_name": "Apple", "surface_names": ["Apple"], "typ": "org"},
+        {"entity_id": 2, "canonical_name": "Tim Cook", "surface_names": ["Tim Cook"], "typ": "person"},
+    ]
+    edges = [{"subj": 1, "obj": 1, "predicate": "is", "source_refs": ["docA"]}]  # only docA has an edge
+    graph = _graph(entities, edges)
+    gold = [
+        ("Qa", "apple", "docA"),      # aligned (node 1, docA edge)
+        ("Qb", "tim cook", "docB"),   # edge-miss: node 2 exists but docB has no edge
+        ("Qc", "sundar pichai", "docC"),  # ner-miss: no node matches
+    ]
+    aliases = {"Qa": ["apple"], "Qb": ["tim cook"], "Qc": ["sundar pichai"]}
+    # GLiNER finds the edge-miss AND the ner-miss entity in their docs
+    gliner_by_doc = {"docB": {"Tim Cook"}, "docC": {"Sundar Pichai"}}
+    r = gliner_probe_report(graph, gold, aliases, gliner_by_doc)
+    assert r["n_gold"] == 3
+    assert r["n_missed"] == 2          # B and C
+    assert r["n_edge_miss"] == 1       # B
+    assert r["n_ner_miss"] == 1        # C
+    # the true prize: of the 1 ner-miss, GLiNER found 1
+    assert r["ner_recovered_frac"] == 1.0
+    # conflated context metric counts both missed that GLiNER matched
+    assert r["residual_recovered_frac"] == 1.0
+
+
+def test_probe_case_folds_gliner_surface():
+    # cased GLiNER surface must match a lowercased alias/gold set (guards false REFUTED).
+    graph = _graph([], [])
+    gold = [("Qx", "barack obama", "d1")]
+    aliases = {"Qx": ["barack obama"]}
+    r = gliner_probe_report(graph, gold, aliases, {"d1": {"Barack Obama"}})
+    assert r["gliner_recall"] == 1.0
+
+
+def test_probe_alias_and_substring_and_per_doc_match():
+    graph = _graph([], [])
+    gold = [
+        ("Qibm", "big blue", "d1"),        # matches via alias "ibm"
+        ("Qn", "thomas nabbes", "d2"),     # matches via substring "nabbes"
+        ("Qz", "zeta", "d3"),              # no gliner match
+    ]
+    aliases = {"Qibm": ["ibm", "big blue"], "Qn": ["thomas nabbes"], "Qz": ["zeta"]}
+    gliner_by_doc = {
+        "d1": {"IBM"},          # alias match
+        "d2": {"Nabbes"},       # substring match
+        "d3": {"Yeti"},         # unrelated -> junk, no gold match
+    }
+    r = gliner_probe_report(graph, gold, aliases, gliner_by_doc)
+    assert r["gliner_recall"] == 2 / 3
+    # per-doc: a d1 surface must not match a d3 gold
+    # junk: "Yeti" in d3 matches no d3 gold -> 1 junk of 3 total surfaces
+    assert r["junk_rate"] == 1 / 3
+
+
+def test_probe_junk_rate_all_match_is_zero():
+    graph = _graph([], [])
+    gold = [("Qa", "apple", "d1")]
+    aliases = {"Qa": ["apple"]}
+    r = gliner_probe_report(graph, gold, aliases, {"d1": {"Apple"}})
+    assert r["junk_rate"] == 0.0
+
+
+def test_probe_degenerate_guards():
+    graph = _graph([], [])
+    # empty gliner
+    r = gliner_probe_report(graph, [("Qa", "apple", "d1")], {"Qa": ["apple"]}, {})
+    assert r["gliner_recall"] == 0.0 and r["ner_recovered_frac"] == 0.0 and r["junk_rate"] == 0.0
+    # empty gold
+    r0 = gliner_probe_report(graph, [], {}, {"d1": {"Apple"}})
+    assert r0["n_gold"] == 0 and r0["residual_recovered_frac"] == 0.0
+    # all-aligned (|missed| == 0): one gold, one node with an in-doc edge
+    g2 = _graph([{"entity_id": 1, "canonical_name": "Apple", "surface_names": ["Apple"], "typ": "org"}],
+                [{"subj": 1, "obj": 1, "predicate": "is", "source_refs": ["d1"]}])
+    r2 = gliner_probe_report(g2, [("Qa", "apple", "d1")], {"Qa": ["apple"]}, {"d1": {"Apple"}})
+    assert r2["n_missed"] == 0 and r2["residual_recovered_frac"] == 0.0 and r2["ner_recovered_frac"] == 0.0
+```
+
+- [ ] **Step 2: Run, verify fail.** Box-safe invocation. Expected: `ImportError: cannot import name 'gliner_probe_report'`.
+
+- [ ] **Step 3: Implement in `substrate_eval.py`.** Add the primitive near `_base_doc_id`, then the report at the end of the file:
+
+```python
+def _alias_match_surface(surf_lc: str, match_set: set[str]) -> bool:
+    """True iff a (already lowercased) surface matches a lowercased alias/gold `match_set`:
+    exact membership OR substring either way. The single shared predicate behind both the
+    aligned-node substring fallback and the GLiNER-probe match, so they cannot drift."""
+    if not surf_lc:
+        return False
+    if surf_lc in match_set:
+        return True
+    return any(surf_lc in m or m in surf_lc for m in match_set if m)
+
+
+def gliner_probe_report(graph: dict, gold_mentions, qid_aliases, gliner_by_doc) -> dict:
+    """Measure GLiNER's addressable recall against the real-prose substrate residual.
+
+    Splits the unaligned gold (`_assign_real_nodes_aliased` node_of < 0) into NER-miss (no graph node
+    matches the alias set anywhere -> GLiNER-addressable) vs edge-miss (a node exists but produced no
+    in-doc edge -> GLiNER can't help). The gate number is `ner_recovered_frac`: of the NER-miss gold,
+    the share whose entity GLiNER surfaces (in the same doc). Pure; `gliner_by_doc` maps base doc id ->
+    set of raw GLiNER surface strings."""
+    node_of = _assign_real_nodes_aliased(graph, gold_mentions, qid_aliases)
+    # node surfaces (case-folded), exactly as the aligner builds them
+    id2surf: dict[int, set[str]] = {}
+    for e in graph.get("entities", ()):
+        surfs = {str(s).strip().lower() for s in e.get("surface_names", ()) if s}
+        cn = str(e.get("canonical_name", "")).strip().lower()
+        if cn:
+            surfs.add(cn)
+        id2surf[e.get("entity_id")] = surfs
+
+    def _match_set(qid, surface):
+        return set(qid_aliases.get(qid, ())) | {str(surface).strip().lower()}
+
+    def _entity_exists(match_set):  # any node anywhere whose surfaces match -> NER present
+        return any(
+            any(_alias_match_surface(s, match_set) for s in surfs) for surfs in id2surf.values()
+        )
+
+    def _gliner_hit(doc, match_set):  # any GLiNER surface IN THIS DOC matches
+        surfaces = gliner_by_doc.get(_base_doc_id(doc), ())
+        return any(_alias_match_surface(str(g).strip().lower(), match_set) for g in surfaces)
+
+    n_gold = len(gold_mentions)
+    gliner_matched = ner_miss = edge_miss = ner_recovered = missed_recovered = missed = 0
+    for i, (qid, surface, doc) in enumerate(gold_mentions):
+        ms = _match_set(qid, surface)
+        hit = _gliner_hit(doc, ms)
+        gliner_matched += hit
+        if node_of.get(i, -1) < 0:
+            missed += 1
+            if hit:
+                missed_recovered += 1
+            if _entity_exists(ms):
+                edge_miss += 1
+            else:
+                ner_miss += 1
+                if hit:
+                    ner_recovered += 1
+
+    # junk proxy: GLiNER surfaces (per doc) matching NO gold of that doc
+    gold_by_doc: dict[str, list] = {}
+    for (qid, surface, doc) in gold_mentions:
+        gold_by_doc.setdefault(_base_doc_id(doc), []).append(_match_set(qid, surface))
+    total_surf = junk = 0
+    for doc, surfaces in gliner_by_doc.items():
+        base = _base_doc_id(doc)
+        golds = gold_by_doc.get(base, [])
+        for g in surfaces:
+            total_surf += 1
+            g_lc = str(g).strip().lower()
+            if not any(_alias_match_surface(g_lc, ms) for ms in golds):
+                junk += 1
+
+    def _frac(num, den):
+        return num / den if den else 0.0
+
+    return {
+        "n_gold": n_gold,
+        "n_missed": missed,
+        "n_ner_miss": ner_miss,
+        "n_edge_miss": edge_miss,
+        "gliner_recall": _frac(gliner_matched, n_gold),
+        "llm_coverage": _frac(sum(1 for v in node_of.values() if v >= 0), n_gold),
+        "ner_recovered_frac": _frac(ner_recovered, ner_miss),
+        "residual_recovered_frac": _frac(missed_recovered, missed),
+        "junk_rate": _frac(junk, total_surf),
+    }
+```
+
+- [ ] **Step 4: Point the aligner at the shared primitive (no-drift, low-risk).** In `_assign_real_nodes_aliased`, replace the inline substring fallback:
+
+```python
+        if best is None:                                           # substring fallback (parity with surface
+            for n in cands:                                        # aligner): any alias/surface term overlaps
+                if any(m and any(m in sn or sn in m for sn in id2surf.get(n, ())) for m in match):
+                    best = n
+                    break
+```
+with:
+```python
+        if best is None:                                           # substring fallback via the shared primitive
+            for n in cands:
+                if any(_alias_match_surface(sn, match) for sn in id2surf.get(n, ())):
+                    best = n
+                    break
+```
+(`_alias_match_surface` also matches exact members, a superset of the old substring-only test — but exact members were already caught by the intersection loop above, so behavior is unchanged for the aligner.)
+
+- [ ] **Step 5: Run tests, verify pass** (box-safe) — the 5 new tests AND the existing `test_substrate_eval.py` suite (regression on the aligner refactor). Then `ruff check erkgbench/substrate_eval.py`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add erkgbench/substrate_eval.py tests/test_substrate_eval.py
+git commit -m "feat(erkgbench): gliner_probe_report pure scorer (NER-miss vs edge-miss split) + shared alias-match primitive"
+```
+
+---
+
+## Task 2: runner `_wiki_build` + `run_wiki_gliner_probe` + `--gliner-probe`
+
+**Files:**
+- Modify: `erkgbench/run_substrate_eval.py`
+
+No box unit test (needs the native store + LLM + GLiNER). Verified by `ruff`, `py_compile`, and the Modal run in Task 3. Keep the diff mechanical.
+
+- [ ] **Step 1: Factor the build.** Replace the body of `run_wiki` so the corpus load + graph build live in a shared helper:
+
+```python
+def _wiki_build():
+    """Load the wiki corpus and build the graph with the current env config. Returns
+    (documents, gold, qid_aliases, graph) so both run_wiki and the GLiNER probe reuse it."""
+    from erkgbench.qa_e2e.wiki_corpus import load_wiki_corpus
+    documents, gold, qid_aliases = load_wiki_corpus()
+    graph = _build_graph_from_documents(documents)
+    return documents, gold, qid_aliases, graph
+
+
+def run_wiki() -> dict:
+    """Level 2: build over REAL Wikipedia prose; align gold to nodes by alias+doc; score R(B)/P(B)+coverage."""
+    from erkgbench import metrics
+    documents, gold, qid_aliases, graph = _wiki_build()
+    clustering = substrate_eval.align_real_mentions_to_nodes_aliased(graph, gold, qid_aliases)
+    coverage = substrate_eval.real_alignment_coverage_aliased(graph, gold, qid_aliases)
+    b = metrics.score([m[0] for m in gold], clustering)
+    coh = substrate_eval.graph_coherence(graph)
+    return {"er_r_b": b.recall, "er_p_b": b.precision, "er_f1_b": b.f1, "coverage": coverage,
+            "n_docs": len(documents), "n_gold": len(gold), "components": coh["components"]}
+```
+
+- [ ] **Step 2: Add the probe runner** (after `run_wiki`):
+
+```python
+def _gliner_by_doc(documents, *, threshold: float) -> dict:
+    """Run GLiNER per-doc (whole lead), returning {base_doc_id: set(entity surfaces)}. GLiNER loads once."""
+    from erkgbench.substrate_eval import _base_doc_id
+    from goldengraph.extract_local import gliner_extractor
+    extractor = gliner_extractor(threshold=threshold)
+    out: dict[str, set[str]] = {}
+    for d in documents:
+        ex = extractor(d.text)
+        out[_base_doc_id(d.id)] = {m.name for m in ex.mentions}
+    return out
+
+
+def run_wiki_gliner_probe() -> dict:
+    """GLiNER entity-recall probe: build best-config graph, run GLiNER per-doc, report NER-addressable
+    recovery of the residual. Threshold from GOLDENGRAPH_GLINER_THRESHOLD (default 0.4)."""
+    documents, gold, qid_aliases, graph = _wiki_build()
+    threshold = float(os.environ.get("GOLDENGRAPH_GLINER_THRESHOLD", "0.4") or "0.4")
+    try:
+        gbd = _gliner_by_doc(documents, threshold=threshold)
+    except Exception as e:  # noqa: BLE001 -- fail-soft: still report the LLM baseline
+        print(f"[gliner-probe] GLiNER failed ({e!r}); reporting empty gliner_by_doc", flush=True)
+        gbd = {}
+    r = substrate_eval.gliner_probe_report(graph, gold, qid_aliases, gbd)
+    r.update(n_docs=len(documents), threshold=threshold)
+    return r
+```
+
+- [ ] **Step 3: Route it in `main`.** Add the flag and branch:
+
+```python
+    ap.add_argument("--gliner-probe", action="store_true",
+                    help="run the GLiNER entity-recall probe instead of the plain wiki eval")
+    args = ap.parse_args()
+
+    _probe = args.gliner_probe or os.environ.get("GOLDENGRAPH_GLINER_PROBE", "") not in ("", "0", "false")
+    if args.corpus == "wiki" and _probe:
+        r = run_wiki_gliner_probe()
+        print(
+            f"[gliner-probe] thr={r['threshold']} gliner_recall={r['gliner_recall']:.4f} "
+            f"llm_coverage={r['llm_coverage']:.4f} n_missed={r['n_missed']} "
+            f"ner_miss={r['n_ner_miss']} edge_miss={r['n_edge_miss']} "
+            f"NER_recovered={r['ner_recovered_frac']:.4f} residual_recovered={r['residual_recovered_frac']:.4f} "
+            f"junk_rate={r['junk_rate']:.4f}",
+            flush=True,
+        )
+        md = (
+            "# GLiNER Entity-Recall Probe (wiki)\n\n"
+            "| threshold | gliner_recall | llm_coverage | n_missed | ner_miss | edge_miss | "
+            "NER_recovered | residual_recovered | junk_rate |\n"
+            "|---|---|---|---|---|---|---|---|---|\n"
+            f"| {r['threshold']} | {r['gliner_recall']:.4f} | {r['llm_coverage']:.4f} | {r['n_missed']} | "
+            f"{r['n_ner_miss']} | {r['n_edge_miss']} | {r['ner_recovered_frac']:.4f} | "
+            f"{r['residual_recovered_frac']:.4f} | {r['junk_rate']:.4f} |\n\n"
+            "NER_recovered = of the NER-miss gold (entity absent from the graph), share GLiNER surfaces. "
+            "residual_recovered conflates NER-miss + edge-miss (context only). junk_rate is inflated by "
+            "wikilink-only gold.\n"
+        )
+        with open(args.out_md, "w", encoding="utf-8") as fh:
+            fh.write(md)
+        print("\n" + md, flush=True)
+        return
+```
+(place this block BEFORE the existing `if args.corpus == "wiki":` plain-eval branch so the probe wins when requested).
+
+- [ ] **Step 4: Verify** — `ruff check erkgbench/run_substrate_eval.py` and `"$PY" -m py_compile erkgbench/run_substrate_eval.py`. (No import/pytest — the module pulls goldengraph.)
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add erkgbench/run_substrate_eval.py
+git commit -m "feat(erkgbench): --gliner-probe runner (per-doc GLiNER + _wiki_build helper)"
+```
+
+---
+
+## Task 3: Modal image + measurement + verdict
+
+**Files:**
+- Modify: `scripts/distill/modal_bench.py`
+- Create: `docs/superpowers/reports/2026-07-01-gliner-recall-probe-verdict.md`
+
+- [ ] **Step 1: Add `gliner` to the image.** In `modal_bench.py`, extend the `pip_install(...)` list (currently `"maturin", "goldenmatch", "datasets", "openai", "numpy", "pytest", "lightrag-hku>=1.5,<1.6"`) with `"gliner"`. Commit:
+
+```bash
+git add scripts/distill/modal_bench.py
+git commit -m "chore(bench): add gliner to the gg-bench Modal image for the entity-recall probe"
+```
+
+- [ ] **Step 2: Fire the probe** (2 threshold points; run yourself, `PYTHONIOENCODING=utf-8 PYTHONUTF8=1`, `--detach --spawn`, distinct `--n`). The probe needs the same best-config env as leg 83 PLUS the probe switch:
+
+```bash
+M="/d/show_case/goldenmatch/.venv/Scripts/modal.exe"
+BEST=$'GOLDENGRAPH_SUBSTRATE_CORPUS=wiki\nGOLDENGRAPH_XDOC_KEY=name_ci\nGOLDENGRAPH_CHUNK_EXTRACT=1\nGOLDENGRAPH_CHUNK_SENTENCES=6\nGOLDENGRAPH_CHUNK_OVERLAP=2\nGOLDENGRAPH_GLINER_PROBE=1'
+# threshold 0.4 (default)
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 90 --opts "$BEST" --spawn
+# threshold 0.3 (recall-friendlier second point)
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 91 \
+  --opts "$BEST"$'\nGOLDENGRAPH_GLINER_THRESHOLD=0.3' --spawn
+```
+Poll `gg-bench-cache` for `results/substrate_9{0,1}_*.md`; read the `[gliner-probe]` line.
+
+> Note: the modal substrate branch runs `run_substrate_eval --corpus wiki`; `GOLDENGRAPH_GLINER_PROBE=1` (set via `--opts`) routes it to the probe. If the flag doesn't thread through the subprocess env, fall back to appending `--gliner-probe` to the substrate subprocess argv in `modal_bench.py` (one line) and re-run.
+
+- [ ] **Step 3: Write the verdict** `docs/superpowers/reports/2026-07-01-gliner-recall-probe-verdict.md`: the two-threshold table, the NER-miss/edge-miss split, and the gate call against the spec's bar (`ner_recovered_frac ≳ 0.25` at tolerable junk). Include the caveats: junk_rate inflated by wikilink-only gold, PASS = necessity not sufficiency, GLiNER seq-length truncation (if REFUTED, note the chunked-GLiNER sanity pass as the pre-belief check).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add docs/superpowers/reports/2026-07-01-gliner-recall-probe-verdict.md
+git commit -m "docs(goldengraph): GLiNER entity-recall probe verdict (wiki)"
+```
+
+---
+
+## Completion
+
+Use superpowers:finishing-a-development-branch: run the box-safe `tests/test_substrate_eval.py` suite, then open a PR (base `main`) and arm auto-merge. This is measurement-only — the PR ships the probe tooling regardless of the verdict. If PASS, the verdict hands off to a new GLiNER-hybrid spec (GLiNER entities → LLM relation prompt); if REFUTED, the extraction-recall thread closes at chunking and the arc moves to cross-corpus robustness of the name_ci + chunking stack.

--- a/docs/superpowers/reports/2026-07-01-edge-miss-diagnostic-verdict.md
+++ b/docs/superpowers/reports/2026-07-01-edge-miss-diagnostic-verdict.md
@@ -1,0 +1,39 @@
+# Edge-Miss Diagnostic — Verdict
+
+**Date:** 2026-07-01
+**Branch:** `feat/gliner-recall-probe` (follow-on to the GLiNER probe, same tooling)
+**Run:** Modal `gg-bench`, 7B, `--corpus wiki`, best config (`name_ci` + chunking `(6,2)`) + `--gliner-probe`. Leg 90 = fuzzy resolver (default); leg 92 = `GOLDENGRAPH_SUBSTRATE_RESOLVER=exact`.
+
+## What this tested
+
+The GLiNER probe found the real-prose residual is 100% **edge-miss** (33 gold whose entity is in the graph but has no surviving edge), 0% NER-miss. Edge-miss has two possible causes:
+1. **Relation-never-extracted** — the 7B produced the entities but no relation connecting them, in any window.
+2. **Resolver-dropped self-loop** — the fuzzy resolver merged a doc's src+dst into one node, so `build_batch` dropped the resulting self-loop.
+
+This diagnostic isolates the second with the existing `GOLDENGRAPH_SUBSTRATE_RESOLVER=exact` lever (exact `(name,typ)` resolution → zero within-doc over-merge → zero collapsed self-loops). If edge-miss drops under exact, the resolver was the cause; if flat, the relations were never extracted.
+
+## Result — relation-never-extracted
+
+| leg | resolver | coverage | n_missed | ner_miss | edge_miss |
+|---|---|---|---|---|---|
+| 90 | fuzzy (default) | 0.4923 | 33 | 0 | 33 |
+| 92 | **exact** | 0.4923 | 33 | 0 | **33** |
+
+**Exact resolution recovers zero edges — edge-miss is unchanged at 33.** Perfect within-doc resolution changes nothing, so the missing edges are not resolver-collapsed self-loops. The 7B simply never extracts a relation touching those entities.
+
+### Confirmation the flag took effect (not a no-op)
+
+Byte-identical metrics across two runs warranted a check that `RESOLVER=exact` actually applied. It did: leg 90's captured stdout carries 738 lines of `[controller.run]` / `[score_buckets]` debug from goldenmatch's fuzzy dedupe controller (invoked per-doc during `resolve()`); **leg 92 has none of it**, because `_exact_resolve` bypasses the goldenmatch dedupe path entirely. The absence of that logging is the signature of the exact path running. So the flag threaded, the resolution path genuinely changed, and edge-miss still held at 33 — the result is real, not a caching artifact (the two runs' stdout differ).
+
+## Conclusion
+
+- **The residual is relation-recall-bound, not resolver-bound.** Entity extraction is solved; within-doc resolution is not the bottleneck (fuzzy vs exact is a wash here). The gap is relations the 7B never emits.
+- **Edge survival through resolve is NOT a frontier** — there are ~0 resolver-dropped self-loops on this corpus. That candidate sub-project is refuted before being built (the second cheap kill this thread, after GLiNER).
+- **Next frontier: relation recall.** The 7B, even over short `(6,2)` windows, extracts entities but omits the relation linking them. Candidate levers (separate sub-project, to be scoped):
+  1. **Relation-focused prompting / re-prompt for edges** — after extraction, a second pass asking specifically "what relations hold among these entities?" (the entities are already correct; only the edge is missing).
+  2. **REBEL fusion** — the local end-to-end relation extractor already stubbed in `extract_local.rebel_extractor`, fused with the LLM's entities (mirror of the GLiNER-hybrid shape, but for edges — the direction the GLiNER probe pointed at).
+  3. **Predicate-vocab / density levers** on the existing extract prompt, measured per-window.
+
+## Method note
+
+Two frontiers (relation recall, edge survival) were on the table after the GLiNER probe. This diagnostic — one Modal leg, zero new code, an existing lever — killed one of them cleanly and pointed all remaining effort at relation recall. Cheap redirection before any build, consistent with the arc.

--- a/docs/superpowers/reports/2026-07-01-gliner-recall-probe-verdict.md
+++ b/docs/superpowers/reports/2026-07-01-gliner-recall-probe-verdict.md
@@ -1,0 +1,49 @@
+# GLiNER Entity-Recall Probe — Verdict
+
+**Date:** 2026-07-01
+**Branch:** `feat/gliner-recall-probe`
+**Spec/Plan:** `docs/superpowers/specs/2026-07-01-gliner-recall-probe-design.md` · `docs/superpowers/plans/2026-07-01-gliner-recall-probe.md`
+**Run:** Modal `gg-bench`, 7B (`qwen2.5-7b-instruct`), `--corpus wiki`, best config (`name_ci` + chunking `(6,2)`), aliased aligner. 19 docs, 65 gold.
+
+## What this tested
+
+Chunking (#1350) lifted real-prose substrate coverage to ~0.51. The residual was assumed to be **entities the 7B never emits** — an NER-recall gap GLiNER could close. This probe measured that assumption before building the hybrid: split the unaligned gold into **NER-miss** (no node exists — GLiNER-addressable) vs **edge-miss** (node exists, edge dropped — GLiNER can't help), and measured GLiNER's recovery of the NER-miss subset.
+
+## Result — REFUTED (and the assumption was wrong)
+
+| threshold | gliner_recall | llm_coverage | n_missed | **ner_miss** | **edge_miss** | ner_recovered | junk_rate |
+|---|---|---|---|---|---|---|---|
+| 0.4 | 0.5231 | 0.4923 | 33 | **0** | **33** | 0.0000 | 0.8884 |
+| 0.3 | 0.5231 | 0.4923 | 33 | **0** | **33** | 0.0000 | 0.8980 |
+
+**Every one of the 33 unaligned gold mentions is edge-miss. Zero are NER-miss.** The entity is already a node in the built graph; it simply has no surviving edge in its doc, so the edge-centric aligner can't reach it. 32 aligned + 33 exist-but-unedged = **all 65 gold entities are already extracted**. GLiNER — which only adds entities — has nothing to recover. `ner_recovered_frac = 0/0 = 0` at both thresholds, robustly.
+
+## The real finding: the residual is an EDGE gap, not an entity gap
+
+This is the valuable part, and it redirects the arc:
+
+- **Entity extraction on real prose is essentially solved** by the current stack (name_ci + chunking). Every gold entity that the wikilinks name is present as a node. There is no entity-recall headroom for GLiNER to exploit.
+- **The real-prose substrate ceiling is edge/relation recall** (and edge *survival* through resolution): the 7B extracts the entities but drops the relation between them, or the fuzzy resolver collapses a doc's src+dst into a self-loop that `build_batch` discards. Either way the node exists edgeless, invisible to the aligner.
+- This coheres with the whole thread: coverage was always edge-gated (the aligner's candidate set is edge-derived), chunking WON by producing *more edges* per short window, and the recall-prompt was REFUTED precisely because it traded edges for entity noise. The consistent signal across three levers is that **edges, not entities, are the constraint.**
+
+`gliner_recall = 0.52 ≈ llm_coverage = 0.49` independently confirms it: GLiNER's raw entity recall is no better than the pipeline's, and even the entities it surfaces are all already in the graph.
+
+## Guardrails / caveats (as designed)
+
+- **`junk_rate ≈ 0.89` is expected and NOT a precision indictment.** Gold is only the 65 *wikilinked* mentions; a real lead names many legitimate non-wikilinked entities that GLiNER correctly surfaces, all of which land in the junk numerator. The high value confirms GLiNER surfaces *many* entities — and still zero of them are NER-addressable misses, which only strengthens the refutation.
+- **Threshold-robust.** 0.3 vs 0.4 are identical on the split (0 NER-miss either way); lowering the threshold surfaces more entities but no new *missed* gold, because there are none to surface.
+- **Seq-length caveat is moot here.** The truncation concern biases toward REFUTED by undercounting GLiNER recall — but the refutation isn't driven by GLiNER's recall (0.52 is healthy); it's driven by `ner_miss = 0`. Even perfect GLiNER recall changes nothing when the residual contains zero NER-miss. No chunked-GLiNER sanity pass needed.
+
+## Decision
+
+- **Do NOT build the GLiNER hybrid.** The measure-first gate did exactly its job: ~one Modal run refuted a plausible lever before any linking pipeline was written.
+- **The extraction-recall thread closes at chunking.** name_ci + chunking got the entities in; entity recall is not the frontier.
+- **Next frontier: edge/relation recall + edge survival.** Two candidate sub-projects, to be scoped separately:
+  1. **Relation recall** — the 7B extracts entities but drops the edge between them. Levers: relation-focused prompting, per-window relation density, or a dedicated relation extractor (e.g. REBEL, already stubbed in `extract_local`) fused with the LLM.
+  2. **Edge survival through resolve** — quantify how many edges die as dropped self-loops when the fuzzy resolver merges a doc's src+dst. The `GOLDENGRAPH_SUBSTRATE_RESOLVER=exact` diagnostic lever already exists to isolate this. If a material share of the 33 edge-misses are resolver-induced self-loops, that's a cheaper fix than relation extraction.
+
+The honest next step is a **diagnostic split of the 33 edge-misses**: relation-never-extracted vs edge-dropped-by-resolver. That decides which of the two frontiers to pursue.
+
+## Shipped
+
+Measurement tooling only (`gliner_probe_report` + `--gliner-probe` runner + `gliner` in the Modal image). No engine behavior change. The probe is reusable for any future NER-vs-edge diagnosis.

--- a/docs/superpowers/specs/2026-07-01-gliner-recall-probe-design.md
+++ b/docs/superpowers/specs/2026-07-01-gliner-recall-probe-design.md
@@ -1,0 +1,94 @@
+# GLiNER Entity-Recall Probe — Design
+
+**Date:** 2026-07-01
+**Branch:** `feat/gliner-recall-probe` (off `main`)
+**Program:** goldengraph substrate-quality arc — a **measure-first gate** for the GLiNER-hybrid extraction-recall lever. This sub-project does NOT build the hybrid; it decides whether the hybrid is worth building.
+
+## Problem
+
+Chunking (WIN, #1350) lifted real-prose substrate coverage to ~0.508 on the wiki corpus. The residual ~0.49 is **entities the generative 7B never emits in any window** — a pure NER-recall gap. GLiNER (a discriminative NER encoder, no generative density limit) is the candidate next lever. But it only helps if two things hold:
+
+1. **(a) GLiNER actually surfaces the missed entities** — the ones the LLM pipeline fails to align.
+2. **(b) those entities can be given edges** — the substrate aligner's candidate node set is built **only from edges** (`substrate_eval.py:120-123`: `by_doc` collects `subj`/`obj` of edges). An **edgeless node can never align**, so a naive "add GLiNER entities as nodes" union moves coverage by exactly zero. Any real hybrid must make GLiNER's entities edge-participating (the LLM must relate them).
+
+Building the linking hybrid (b) is only justified if (a) is true. The recall-prompt lever taught us to **measure before building**. So this sub-project measures (a) — GLiNER's incremental entity recall — and gates the hybrid on it.
+
+## Goal
+
+A measurement-only probe that, in one Modal run on the wiki corpus, reports **how much of the residual gold GLiNER would recover**, plus a noise proxy. No production engine change; the gate stays off. The output is a single verdict: PASS (build the hybrid) or REFUTED (stop).
+
+## Non-goals
+
+- **Not the hybrid.** No relation-linking, no prompt change, no `ingest` change. That is a separate, conditional sub-project designed only if this probe PASSES.
+- No new GLiNER wiring beyond the existing `extract_local.gliner_extractor` (reused as-is, or called directly for entity spans).
+- No change to the substrate metric or the aligner — the probe *reuses* the aligner's match logic so its numbers are apples-to-apples.
+
+## Architecture
+
+Two units: a **pure scorer** (box-testable) and an **impure runner** (Modal).
+
+### Data flow
+
+```
+wiki corpus (19 docs, 65 gold, aliases)
+ ├─ build best-config graph (name_ci + chunking (6,2))     [existing run_wiki path]
+ │     └─ _assign_real_nodes_aliased -> node_of: which gold ALIGNED (>=0) vs MISSED (<0)
+ ├─ GLiNER per-doc (whole lead; encoder, no density limit) -> {doc_id: set(entity surfaces)}
+ └─ gliner_probe_report(graph, gold, aliases, gliner_by_doc)   [PURE, unit-tested]
+        -> { gliner_recall, llm_coverage, incremental_recall,
+             residual_recovered_frac, junk_rate, n_gold, n_missed }
+```
+
+### Unit 1 — pure scorer `substrate_eval.gliner_probe_report(...)`
+
+Signature: `gliner_probe_report(graph, gold_mentions, qid_aliases, gliner_by_doc) -> dict`.
+
+- `node_of = _assign_real_nodes_aliased(graph, gold_mentions, qid_aliases)` — reuse the exact aligner, so "LLM missed this gold" means the same thing the coverage metric means.
+- A gold mention `(qid, surface, doc)` is **GLiNER-matched** iff some GLiNER surface in that doc matches its alias set, using the **same match rule as the aligner** (`match = aliases[qid] | {surface_lc}`; a GLiNER surface `g` matches iff `g in match` OR substring-either-way `g in m or m in g` for some `m in match`). This is factored into a shared helper so the aligner and the probe cannot drift.
+- Metrics:
+  - `gliner_recall` = |gold GLiNER-matched| / |gold| — GLiNER's raw NER recall ceiling.
+  - `llm_coverage` = |node_of ≥ 0| / |gold| — the current pipeline baseline (should ≈ 0.508).
+  - `incremental_recall` = |gold with node_of < 0 AND GLiNER-matched| / |gold| — the prize, as a share of ALL gold.
+  - `residual_recovered_frac` = |missed ∩ GLiNER-matched| / |missed| — the prize as a share of the *residual* (more interpretable: "GLiNER recovers X% of what the LLM missed").
+  - `junk_rate` = |GLiNER surfaces matching NO gold| / |all GLiNER surfaces| — a noise proxy for the fragmentation/precision cost the hybrid would inherit.
+
+Pure (no GLiNER call, no I/O) → unit-tested on the box with hand-built `graph` / `gold` / `gliner_by_doc`.
+
+### Unit 2 — impure runner `run_substrate_eval.run_wiki_gliner_probe()`
+
+- Reuses `run_wiki`'s build (so it inherits the best config from env: `GOLDENGRAPH_XDOC_KEY=name_ci`, `GOLDENGRAPH_CHUNK_EXTRACT=1`, `(6,2)`).
+- Loads GLiNER via the existing `extract_local.gliner_extractor` (or `GLiNER.from_pretrained` directly for raw spans), runs it **per-doc on the whole lead** (the NER upper bound; GLiNER has no density limit), builds `gliner_by_doc`.
+- Calls the pure scorer, prints one `[gliner-probe] ...` line + a markdown block (same persistence path as `run_wiki`).
+- Selected by `GOLDENGRAPH_GLINER_PROBE=1` inside `run_wiki` (env switch, so the Modal invocation matches the chunking legs — just add the env). GLiNER labels/threshold: the existing recall-friendly defaults (`person/organization/location/work/event/date`, threshold 0.4); the probe may also try threshold 0.3 as a second reading since it is a recall ceiling.
+
+### Infra — Modal image
+
+Add `gliner` to `modal_bench.py`'s `pip_install` list (currently absent). The `urchade/gliner_mediumv2.1` model downloads from HF at first run; acceptable for a one-off probe.
+
+## The falsifiable gate
+
+Read `residual_recovered_frac` and `junk_rate` together:
+
+| Outcome | Signature | Action |
+|---|---|---|
+| **PASS** | GLiNER recovers a material share of the residual (`residual_recovered_frac` clearly non-trivial, e.g. ≳ 0.25) at a tolerable `junk_rate` | Build the GLiNER-hybrid sub-project (GLiNER entities → LLM relation prompt so they get edges). |
+| **REFUTED** | GLiNER barely finds the missed gold (`residual_recovered_frac` ≈ 0), or only by drowning in junk (`junk_rate` high) | Stop. The residual is not an NER-recall gap GLiNER can close; record the negative. |
+
+The exact PASS threshold is a judgment call surfaced in the verdict, not hard-coded — the point is to see the number before committing to build. `gliner_recall` and `llm_coverage` are reported as context (is GLiNER even competitive with the LLM on entities it *does* share?).
+
+## Error handling
+
+- GLiNER load / predict failure → the runner logs and emits an empty `gliner_by_doc` (probe reports zeros, not a crash) — the run still yields the LLM baseline.
+- The pure scorer is total: empty `gliner_by_doc` → `gliner_recall=0`, `incremental_recall=0`, `junk_rate=0` (guard the `/0`); empty gold → all-zeros with `n_gold=0`.
+
+## Testing
+
+Pure scorer, box-safe (no GLiNER, no network), in `tests/test_substrate_eval.py`:
+1. **Incremental recall** — a graph where some gold aligns (has edges) and some doesn't; a `gliner_by_doc` that covers one missed gold and one already-aligned gold → assert `incremental_recall` counts only the missed one, `residual_recovered_frac` = 1/|missed_here|.
+2. **Match parity with the aligner** — a GLiNER surface that matches only via alias (e.g. `Big Blue` vs gold `IBM` with `IBM` in aliases) counts as matched; a substring case (`Nabbes` vs `Thomas Nabbes`) counts; an unrelated surface does not.
+3. **Junk rate** — GLiNER surfaces matching no gold raise `junk_rate`; all-matching → 0.
+4. **Degenerate guards** — empty `gliner_by_doc` → all GLiNER metrics 0, no divide-by-zero; empty gold → `n_gold=0`, no crash.
+
+## Rollout
+
+Measurement artifact only. Emits `docs/superpowers/reports/2026-07-01-gliner-recall-probe-verdict.md` with the numbers and the PASS/REFUTED call. Nothing ships to the engine. If PASS, the verdict hands off to the GLiNER-hybrid spec; if REFUTED, the extraction-recall thread closes at chunking and the arc moves to a different frontier (e.g. cross-corpus robustness of the name_ci + chunking stack).

--- a/docs/superpowers/specs/2026-07-01-gliner-recall-probe-design.md
+++ b/docs/superpowers/specs/2026-07-01-gliner-recall-probe-design.md
@@ -6,12 +6,17 @@
 
 ## Problem
 
-Chunking (WIN, #1350) lifted real-prose substrate coverage to ~0.508 on the wiki corpus. The residual ~0.49 is **entities the generative 7B never emits in any window** — a pure NER-recall gap. GLiNER (a discriminative NER encoder, no generative density limit) is the candidate next lever. But it only helps if two things hold:
+Chunking (WIN, #1350) lifted real-prose substrate coverage to ~0.508 on the wiki corpus. The residual ~0.49 is gold that never aligned. **But an unaligned gold mention (`node_of < 0`) has two distinct causes** (`substrate_eval.py` `edge_recall` :235-248 and the KNOWN-LIMIT note :42-45):
+
+- **NER-miss** — the entity was never extracted, so no node exists for it anywhere in the graph. *This is what GLiNER can close.*
+- **Edge-miss** — the entity *was* extracted (a node exists) but its doc produced no surviving edge (the LLM dropped the relation, or the fuzzy resolver collapsed src+dst into a dropped self-loop), so it isn't in the aligner's edge-derived candidate set for that doc. **GLiNER surfacing the same entity changes nothing here** — the failure is a lost *edge*, not a missing entity.
+
+GLiNER is a discriminative NER encoder (no generative density limit) and is the candidate lever for the **NER-miss** subset only. It helps iff two things hold:
 
 1. **(a) GLiNER actually surfaces the missed entities** — the ones the LLM pipeline fails to align.
 2. **(b) those entities can be given edges** — the substrate aligner's candidate node set is built **only from edges** (`substrate_eval.py:120-123`: `by_doc` collects `subj`/`obj` of edges). An **edgeless node can never align**, so a naive "add GLiNER entities as nodes" union moves coverage by exactly zero. Any real hybrid must make GLiNER's entities edge-participating (the LLM must relate them).
 
-Building the linking hybrid (b) is only justified if (a) is true. The recall-prompt lever taught us to **measure before building**. So this sub-project measures (a) — GLiNER's incremental entity recall — and gates the hybrid on it.
+Building the linking hybrid (b) is only justified if (a) is true **and the residual is actually NER-miss, not edge-miss**. The recall-prompt lever taught us to **measure before building**. So this sub-project measures the NER-addressable share of the residual and GLiNER's recall over it, and gates the hybrid on that.
 
 ## Goal
 
@@ -33,33 +38,38 @@ Two units: a **pure scorer** (box-testable) and an **impure runner** (Modal).
 wiki corpus (19 docs, 65 gold, aliases)
  ├─ build best-config graph (name_ci + chunking (6,2))     [existing run_wiki path]
  │     └─ _assign_real_nodes_aliased -> node_of: which gold ALIGNED (>=0) vs MISSED (<0)
- ├─ GLiNER per-doc (whole lead; encoder, no density limit) -> {doc_id: set(entity surfaces)}
+ ├─ GLiNER per-doc -> {base_doc_id: set(entity surfaces)}   (see seq-length caveat)
  └─ gliner_probe_report(graph, gold, aliases, gliner_by_doc)   [PURE, unit-tested]
-        -> { gliner_recall, llm_coverage, incremental_recall,
-             residual_recovered_frac, junk_rate, n_gold, n_missed }
+        -> { gliner_recall, llm_coverage, n_gold, n_missed,
+             n_ner_miss, n_edge_miss, ner_recovered_frac,
+             residual_recovered_frac, junk_rate }
 ```
 
 ### Unit 1 — pure scorer `substrate_eval.gliner_probe_report(...)`
 
 Signature: `gliner_probe_report(graph, gold_mentions, qid_aliases, gliner_by_doc) -> dict`.
 
-- `node_of = _assign_real_nodes_aliased(graph, gold_mentions, qid_aliases)` — reuse the exact aligner, so "LLM missed this gold" means the same thing the coverage metric means.
-- A gold mention `(qid, surface, doc)` is **GLiNER-matched** iff some GLiNER surface in that doc matches its alias set, using the **same match rule as the aligner** (`match = aliases[qid] | {surface_lc}`; a GLiNER surface `g` matches iff `g in match` OR substring-either-way `g in m or m in g` for some `m in match`). This is factored into a shared helper so the aligner and the probe cannot drift.
+- `node_of = _assign_real_nodes_aliased(graph, gold_mentions, qid_aliases)` — reuse the exact aligner, so "LLM missed this gold" means the same thing the coverage metric means. `missed` = the golds with `node_of < 0`.
+- **NER-miss vs edge-miss split.** For each missed gold, check whether **any** graph entity anywhere (over `id2surf` built exactly as the aligner builds it, `substrate_eval.py:113-119` — `surface_names` + `canonical_name`, case-folded) matches its alias set. If **no** node matches → **NER-miss** (no entity exists; GLiNER-addressable). If some node matches but it wasn't an in-doc edge candidate → **edge-miss** (entity exists, edge lost; GLiNER can't help). This split is the correction that keeps the headline number honest.
+- **Match rule (shared helper, no drift).** A gold mention `(qid, surface, doc)` is **GLiNER-matched** iff some GLiNER surface *in the same doc* (`gliner_by_doc` keyed by `_base_doc_id(doc)`, mirroring the aligner's `_base_doc_id` keying) matches its alias set, using the aligner's rule: `match = aliases[qid] | {surface.strip().lower()}`; a GLiNER surface `g` matches iff `g_lc in match` OR substring-either-way (`g_lc in m or m in g_lc`) for some `m in match`, where **`g_lc = g.strip().lower()`**. GLiNER emits surfaces un-lowercased (`extract_local.py:129`), and the alias/gold sets are fully case-folded (`wiki_corpus.py:38`, `substrate_eval.py:115-127`), so the helper MUST case-fold the GLiNER surface or every cased entity silently fails to match (a false REFUTED). The same helper backs both the aligner's node-surface match and the probe's GLiNER-surface match — same rule, different inputs.
 - Metrics:
   - `gliner_recall` = |gold GLiNER-matched| / |gold| — GLiNER's raw NER recall ceiling.
   - `llm_coverage` = |node_of ≥ 0| / |gold| — the current pipeline baseline (should ≈ 0.508).
-  - `incremental_recall` = |gold with node_of < 0 AND GLiNER-matched| / |gold| — the prize, as a share of ALL gold.
-  - `residual_recovered_frac` = |missed ∩ GLiNER-matched| / |missed| — the prize as a share of the *residual* (more interpretable: "GLiNER recovers X% of what the LLM missed").
-  - `junk_rate` = |GLiNER surfaces matching NO gold| / |all GLiNER surfaces| — a noise proxy for the fragmentation/precision cost the hybrid would inherit.
+  - `n_missed`, `n_ner_miss`, `n_edge_miss` — the residual and its two-way split (`n_missed = n_ner_miss + n_edge_miss`).
+  - **`ner_recovered_frac` = |NER-miss ∩ GLiNER-matched| / |NER-miss|** — **the true prize**: of the entities that are genuinely absent (GLiNER-addressable), what share GLiNER surfaces. This, not the conflated residual, is the gate number.
+  - `residual_recovered_frac` = |missed ∩ GLiNER-matched| / |missed| — reported for context, but explicitly flagged as conflating NER-miss and edge-miss (overstates the prize).
+  - `junk_rate` = |GLiNER surfaces matching NO gold| / |all GLiNER surfaces| — a *rough* noise proxy, read with the gold-incompleteness caveat below.
 
-Pure (no GLiNER call, no I/O) → unit-tested on the box with hand-built `graph` / `gold` / `gliner_by_doc`.
+Pure (no GLiNER call, no I/O) → unit-tested on the box with hand-built `graph` / `gold` / `gliner_by_doc`. All ratios guard their denominators: `|gold|=0`, `|missed|=0`, `|NER-miss|=0`, and empty `gliner_by_doc` each yield `0.0` for the dependent metric, never a `ZeroDivisionError`.
 
 ### Unit 2 — impure runner `run_substrate_eval.run_wiki_gliner_probe()`
 
-- Reuses `run_wiki`'s build (so it inherits the best config from env: `GOLDENGRAPH_XDOC_KEY=name_ci`, `GOLDENGRAPH_CHUNK_EXTRACT=1`, `(6,2)`).
-- Loads GLiNER via the existing `extract_local.gliner_extractor` (or `GLiNER.from_pretrained` directly for raw spans), runs it **per-doc on the whole lead** (the NER upper bound; GLiNER has no density limit), builds `gliner_by_doc`.
+`run_wiki` today returns a metrics-only dict — it does not expose `graph`/`gold`/`aliases`. So first factor its build into a tiny shared helper `_wiki_build() -> (documents, gold, qid_aliases, graph)` that both `run_wiki` and the probe call (no duplicated `load_wiki_corpus()` + `_build_graph_from_documents()`). Then:
+
+- `run_wiki_gliner_probe()` calls `_wiki_build()` (inheriting the best config from env: `GOLDENGRAPH_XDOC_KEY=name_ci`, `GOLDENGRAPH_CHUNK_EXTRACT=1`, `(6,2)`).
+- Loads GLiNER via the existing `extract_local.gliner_extractor` (or `GLiNER.from_pretrained` for raw spans), runs it **per-doc**, builds `gliner_by_doc` keyed by `_base_doc_id(doc)`.
 - Calls the pure scorer, prints one `[gliner-probe] ...` line + a markdown block (same persistence path as `run_wiki`).
-- Selected by `GOLDENGRAPH_GLINER_PROBE=1` inside `run_wiki` (env switch, so the Modal invocation matches the chunking legs — just add the env). GLiNER labels/threshold: the existing recall-friendly defaults (`person/organization/location/work/event/date`, threshold 0.4); the probe may also try threshold 0.3 as a second reading since it is a recall ceiling.
+- **One switch, not two:** a single `--gliner-probe` CLI flag on `main` (and an env alias `GOLDENGRAPH_GLINER_PROBE=1` so the Modal `--opts` mechanism can set it, matching the chunking legs) routes `--corpus wiki` to `run_wiki_gliner_probe()` instead of `run_wiki()`. GLiNER labels/threshold: the existing recall-friendly defaults (`person/organization/location/work/event/date`, threshold 0.4); the probe also reads threshold 0.3 as a second point since it is a recall ceiling.
 
 ### Infra — Modal image
 
@@ -67,27 +77,33 @@ Add `gliner` to `modal_bench.py`'s `pip_install` list (currently absent). The `u
 
 ## The falsifiable gate
 
-Read `residual_recovered_frac` and `junk_rate` together:
+The gate reads **`ner_recovered_frac`** (the true, un-conflated prize) together with `n_ner_miss / n_missed` (is the residual even NER-addressable?) and `junk_rate`:
 
 | Outcome | Signature | Action |
 |---|---|---|
-| **PASS** | GLiNER recovers a material share of the residual (`residual_recovered_frac` clearly non-trivial, e.g. ≳ 0.25) at a tolerable `junk_rate` | Build the GLiNER-hybrid sub-project (GLiNER entities → LLM relation prompt so they get edges). |
-| **REFUTED** | GLiNER barely finds the missed gold (`residual_recovered_frac` ≈ 0), or only by drowning in junk (`junk_rate` high) | Stop. The residual is not an NER-recall gap GLiNER can close; record the negative. |
+| **PASS** | The residual is substantially NER-miss (`n_ner_miss / n_missed` non-trivial) **and** GLiNER recovers a material share of it (`ner_recovered_frac` clearly non-trivial, e.g. ≳ 0.25) | Build the GLiNER-hybrid sub-project (GLiNER entities → LLM relation prompt so they get edges). |
+| **REFUTED** | Residual is mostly edge-miss (GLiNER can't help), **or** GLiNER barely finds the NER-miss gold (`ner_recovered_frac` ≈ 0) | Stop. The residual is not an NER-recall gap GLiNER can close; record the negative. |
 
-The exact PASS threshold is a judgment call surfaced in the verdict, not hard-coded — the point is to see the number before committing to build. `gliner_recall` and `llm_coverage` are reported as context (is GLiNER even competitive with the LLM on entities it *does* share?).
+The exact PASS threshold is a judgment call surfaced in the verdict, not hard-coded. `gliner_recall`, `llm_coverage`, and `residual_recovered_frac` are context.
+
+**Two things the gate does NOT prove (fold into the verdict, not the code):**
+1. **Necessity, not sufficiency.** PASS means GLiNER *surfaces* the missed entities — a *necessary* condition. The hybrid's actual value additionally requires the LLM to *relate* those entities so they earn an edge (the aligner's requirement). "GLiNER finds it but the hybrid still can't edge it" is an un-probed failure mode that carries into the hybrid sub-project as its central risk.
+2. **`junk_rate` over-reads as precision cost.** Gold is only the 65 *wikilinked* mentions; a real lead names many legitimate non-wikilinked entities that GLiNER will correctly surface, all of which land in the `junk` numerator. So a high `junk_rate` partly measures "gold covers only wikilinks," not "GLiNER hallucinates." Read it as a loose upper bound on noise, and say so.
 
 ## Error handling
 
 - GLiNER load / predict failure → the runner logs and emits an empty `gliner_by_doc` (probe reports zeros, not a crash) — the run still yields the LLM baseline.
-- The pure scorer is total: empty `gliner_by_doc` → `gliner_recall=0`, `incremental_recall=0`, `junk_rate=0` (guard the `/0`); empty gold → all-zeros with `n_gold=0`.
+- The pure scorer is total: empty `gliner_by_doc` → GLiNER metrics `0` (guard the `/0`); empty gold → `n_gold=0`, all ratios `0`; `|missed|=0` (all-aligned, `llm_coverage=1.0`) → `residual_recovered_frac=0`; `|NER-miss|=0` → `ner_recovered_frac=0`. Every ratio guards its own denominator.
+- **GLiNER sequence-length truncation (bias caveat, not a bug):** `gliner_mediumv2.1` has a bounded input window (a few hundred tokens); a ~20-sentence lead run per-doc may truncate and drop tail entities, *undercounting* `gliner_recall`/`ner_recovered_frac`. The bias is conservative (toward REFUTED), so a PASS is trustworthy; a REFUTED should be sanity-checked with a chunked-GLiNER pass (run GLiNER over the same `(6,2)` windows and union) before believing it. Note this in the verdict.
 
 ## Testing
 
 Pure scorer, box-safe (no GLiNER, no network), in `tests/test_substrate_eval.py`:
-1. **Incremental recall** — a graph where some gold aligns (has edges) and some doesn't; a `gliner_by_doc` that covers one missed gold and one already-aligned gold → assert `incremental_recall` counts only the missed one, `residual_recovered_frac` = 1/|missed_here|.
-2. **Match parity with the aligner** — a GLiNER surface that matches only via alias (e.g. `Big Blue` vs gold `IBM` with `IBM` in aliases) counts as matched; a substring case (`Nabbes` vs `Thomas Nabbes`) counts; an unrelated surface does not.
-3. **Junk rate** — GLiNER surfaces matching no gold raise `junk_rate`; all-matching → 0.
-4. **Degenerate guards** — empty `gliner_by_doc` → all GLiNER metrics 0, no divide-by-zero; empty gold → `n_gold=0`, no crash.
+1. **NER-miss vs edge-miss split** — build a graph with: (a) an aligned gold (its node has an in-doc edge), (b) an **edge-miss** gold (a node whose surfaces match the alias set EXISTS but participates in no edge for that doc → `node_of<0` yet not NER-addressable), (c) a **NER-miss** gold (no node anywhere matches). Assert `n_edge_miss=1`, `n_ner_miss=1`. Then a `gliner_by_doc` that surfaces both the edge-miss and NER-miss golds → `ner_recovered_frac = 1/1` (only the NER-miss counts as the prize) while `residual_recovered_frac = 2/2` (context, conflated) — the test that proves the correction matters.
+2. **Case-folding** — a GLiNER surface emitted cased (`Barack Obama`) matches a lowercased alias/gold set; assert it counts (guards the false-REFUTED bug).
+3. **Match parity with the aligner** — matches via alias (`Big Blue` vs gold `IBM`, `IBM` in aliases) and via substring (`Nabbes` vs `Thomas Nabbes`) count; an unrelated surface does not; matching is **per-doc** (a GLiNER surface in doc A does not match a gold in doc B).
+4. **Junk rate** — GLiNER surfaces matching no gold raise `junk_rate`; all-matching → 0.
+5. **Degenerate guards** — empty `gliner_by_doc` → GLiNER metrics 0; empty gold → `n_gold=0`; **all-aligned graph (`|missed|=0`) → `residual_recovered_frac=0` and `ner_recovered_frac=0`, no divide-by-zero.**
 
 ## Rollout
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_eval.py
@@ -65,21 +65,58 @@ def _build_graph(corpus) -> dict:
     return _build_graph_from_documents(corpus.documents)
 
 
+def _wiki_build():
+    """Load the wiki corpus and build the graph with the current env config. Returns
+    (documents, gold, qid_aliases, graph) so both run_wiki and the GLiNER probe reuse it."""
+    from erkgbench.qa_e2e.wiki_corpus import load_wiki_corpus
+
+    documents, gold, qid_aliases = load_wiki_corpus()
+    graph = _build_graph_from_documents(documents)
+    return documents, gold, qid_aliases, graph
+
+
 def run_wiki() -> dict:
     """Level 2: build over REAL Wikipedia prose (committed snapshot), align gold to nodes by SURFACE+DOC
     (no engineered doc-id oracle), and score R(B)/P(B) + alignment coverage. Baseline-vs-`name_ci` is
     selected by `GOLDENGRAPH_XDOC_KEY` as usual. No ambiguity dial -- real prose has its own variance."""
     from erkgbench import metrics
-    from erkgbench.qa_e2e.wiki_corpus import load_wiki_corpus
 
-    documents, gold, qid_aliases = load_wiki_corpus()
-    graph = _build_graph_from_documents(documents)
+    documents, gold, qid_aliases, graph = _wiki_build()
     clustering = substrate_eval.align_real_mentions_to_nodes_aliased(graph, gold, qid_aliases)
     coverage = substrate_eval.real_alignment_coverage_aliased(graph, gold, qid_aliases)
     b = metrics.score([m[0] for m in gold], clustering)
     coh = substrate_eval.graph_coherence(graph)
     return {"er_r_b": b.recall, "er_p_b": b.precision, "er_f1_b": b.f1, "coverage": coverage,
             "n_docs": len(documents), "n_gold": len(gold), "components": coh["components"]}
+
+
+def _gliner_by_doc(documents, *, threshold: float) -> dict:
+    """Run GLiNER per-doc (whole lead), returning {base_doc_id: set(entity surfaces)}. GLiNER loads once."""
+    from goldengraph.extract_local import gliner_extractor
+
+    from erkgbench.substrate_eval import _base_doc_id
+
+    extractor = gliner_extractor(threshold=threshold)
+    out: dict[str, set[str]] = {}
+    for d in documents:
+        ex = extractor(d.text)
+        out[_base_doc_id(d.id)] = {m.name for m in ex.mentions}
+    return out
+
+
+def run_wiki_gliner_probe() -> dict:
+    """GLiNER entity-recall probe: build best-config graph, run GLiNER per-doc, report NER-addressable
+    recovery of the residual. Threshold from GOLDENGRAPH_GLINER_THRESHOLD (default 0.4)."""
+    documents, gold, qid_aliases, graph = _wiki_build()
+    threshold = float(os.environ.get("GOLDENGRAPH_GLINER_THRESHOLD", "0.4") or "0.4")
+    try:
+        gbd = _gliner_by_doc(documents, threshold=threshold)
+    except Exception as e:  # noqa: BLE001 -- fail-soft: still report the LLM baseline
+        print(f"[gliner-probe] GLiNER failed ({e!r}); reporting empty gliner_by_doc", flush=True)
+        gbd = {}
+    r = substrate_eval.gliner_probe_report(graph, gold, qid_aliases, gbd)
+    r.update(n_docs=len(documents), threshold=threshold)
+    return r
 
 
 def run_one(seed: int, ambiguity: float) -> dict:
@@ -133,7 +170,37 @@ def main() -> None:
     ap.add_argument("--ambiguity", type=float, nargs="+", default=[0.0, 0.3, 0.6])
     ap.add_argument("--corpus", choices=["engineered", "wiki"], default="engineered")
     ap.add_argument("--out-md", default="SUBSTRATE.md")
+    ap.add_argument("--gliner-probe", action="store_true",
+                    help="run the GLiNER entity-recall probe instead of the plain wiki eval")
     args = ap.parse_args()
+
+    _probe = args.gliner_probe or os.environ.get("GOLDENGRAPH_GLINER_PROBE", "") not in ("", "0", "false")
+    if args.corpus == "wiki" and _probe:
+        r = run_wiki_gliner_probe()
+        print(
+            f"[gliner-probe] thr={r['threshold']} gliner_recall={r['gliner_recall']:.4f} "
+            f"llm_coverage={r['llm_coverage']:.4f} n_missed={r['n_missed']} "
+            f"ner_miss={r['n_ner_miss']} edge_miss={r['n_edge_miss']} "
+            f"NER_recovered={r['ner_recovered_frac']:.4f} residual_recovered={r['residual_recovered_frac']:.4f} "
+            f"junk_rate={r['junk_rate']:.4f}",
+            flush=True,
+        )
+        md = (
+            "# GLiNER Entity-Recall Probe (wiki)\n\n"
+            "| threshold | gliner_recall | llm_coverage | n_missed | ner_miss | edge_miss | "
+            "NER_recovered | residual_recovered | junk_rate |\n"
+            "|---|---|---|---|---|---|---|---|---|\n"
+            f"| {r['threshold']} | {r['gliner_recall']:.4f} | {r['llm_coverage']:.4f} | {r['n_missed']} | "
+            f"{r['n_ner_miss']} | {r['n_edge_miss']} | {r['ner_recovered_frac']:.4f} | "
+            f"{r['residual_recovered_frac']:.4f} | {r['junk_rate']:.4f} |\n\n"
+            "NER_recovered = of the NER-miss gold (entity absent from the graph), share GLiNER surfaces. "
+            "residual_recovered conflates NER-miss + edge-miss (context only). junk_rate is inflated by "
+            "wikilink-only gold.\n"
+        )
+        with open(args.out_md, "w", encoding="utf-8") as fh:
+            fh.write(md)
+        print("\n" + md, flush=True)
+        return
 
     if args.corpus == "wiki":
         r = run_wiki()

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_eval.py
@@ -104,6 +104,17 @@ def real_alignment_coverage(graph: dict, gold_mentions: list[tuple[str, str, str
     return sum(1 for n in node_of.values() if n >= 0) / len(node_of)
 
 
+def _alias_match_surface(surf_lc: str, match_set: set[str]) -> bool:
+    """True iff a (already lowercased) surface matches a lowercased alias/gold `match_set`:
+    exact membership OR substring either way. The single shared predicate behind both the
+    aligned-node substring fallback and the GLiNER-probe match, so they cannot drift."""
+    if not surf_lc:
+        return False
+    if surf_lc in match_set:
+        return True
+    return any(surf_lc in m or m in surf_lc for m in match_set if m)
+
+
 def _assign_real_nodes_aliased(graph: dict, gold_mentions, qid_aliases) -> dict[int, int]:
     """Like `_assign_real_nodes` but the match target is the mention's QID ALIAS SET (union the literal
     wikilink surface), so a built node is found by ANY of the entity's aliases -- dissolving the
@@ -131,9 +142,9 @@ def _assign_real_nodes_aliased(graph: dict, gold_mentions, qid_aliases) -> dict[
             ov = len(id2surf.get(n, set()) & match)
             if ov > best_ov:
                 best, best_ov = n, ov
-        if best is None:                                           # substring fallback (parity with surface
-            for n in cands:                                        # aligner): any alias/surface term overlaps
-                if any(m and any(m in sn or sn in m for sn in id2surf.get(n, ())) for m in match):
+        if best is None:                                           # substring fallback via the shared primitive
+            for n in cands:                                        # (parity with the probe; behavior-preserving)
+                if any(_alias_match_surface(sn, match) for sn in id2surf.get(n, ())):
                     best = n
                     break
         if best is not None:
@@ -274,4 +285,81 @@ def score_substrate(*, gold_mentions, resolver_clusters, graph) -> dict:
         "components": coh["components"], "largest_fraction": coh["largest_fraction"],
         "provenance": provenance_coverage(graph),
         "edge_recall": edge_recall(graph, gold_mentions),
+    }
+
+
+def gliner_probe_report(graph: dict, gold_mentions, qid_aliases, gliner_by_doc) -> dict:
+    """Measure GLiNER's addressable recall against the real-prose substrate residual.
+
+    Splits the unaligned gold (`_assign_real_nodes_aliased` node_of < 0) into NER-miss (no graph node
+    matches the alias set anywhere -> GLiNER-addressable) vs edge-miss (a node exists but produced no
+    in-doc edge -> GLiNER can't help). The gate number is `ner_recovered_frac`: of the NER-miss gold,
+    the share whose entity GLiNER surfaces (in the same doc). Pure; `gliner_by_doc` maps base doc id ->
+    set of raw GLiNER surface strings."""
+    node_of = _assign_real_nodes_aliased(graph, gold_mentions, qid_aliases)
+    # node surfaces (case-folded), exactly as the aligner builds them
+    id2surf: dict[int, set[str]] = {}
+    for e in graph.get("entities", ()):
+        surfs = {str(s).strip().lower() for s in e.get("surface_names", ()) if s}
+        cn = str(e.get("canonical_name", "")).strip().lower()
+        if cn:
+            surfs.add(cn)
+        id2surf[e.get("entity_id")] = surfs
+
+    def _match_set(qid, surface):
+        return set(qid_aliases.get(qid, ())) | {str(surface).strip().lower()}
+
+    def _entity_exists(match_set):  # any node anywhere whose surfaces match -> NER present
+        return any(
+            any(_alias_match_surface(s, match_set) for s in surfs) for surfs in id2surf.values()
+        )
+
+    def _gliner_hit(doc, match_set):  # any GLiNER surface IN THIS DOC matches
+        surfaces = gliner_by_doc.get(_base_doc_id(doc), ())
+        return any(_alias_match_surface(str(g).strip().lower(), match_set) for g in surfaces)
+
+    n_gold = len(gold_mentions)
+    gliner_matched = ner_miss = edge_miss = ner_recovered = missed_recovered = missed = 0
+    for i, (qid, surface, doc) in enumerate(gold_mentions):
+        ms = _match_set(qid, surface)
+        hit = _gliner_hit(doc, ms)
+        gliner_matched += hit
+        if node_of.get(i, -1) < 0:
+            missed += 1
+            if hit:
+                missed_recovered += 1
+            if _entity_exists(ms):
+                edge_miss += 1
+            else:
+                ner_miss += 1
+                if hit:
+                    ner_recovered += 1
+
+    # junk proxy: GLiNER surfaces (per doc) matching NO gold of that doc
+    gold_by_doc: dict[str, list] = {}
+    for (qid, surface, doc) in gold_mentions:
+        gold_by_doc.setdefault(_base_doc_id(doc), []).append(_match_set(qid, surface))
+    total_surf = junk = 0
+    for doc, surfaces in gliner_by_doc.items():
+        base = _base_doc_id(doc)
+        golds = gold_by_doc.get(base, [])
+        for g in surfaces:
+            total_surf += 1
+            g_lc = str(g).strip().lower()
+            if not any(_alias_match_surface(g_lc, ms) for ms in golds):
+                junk += 1
+
+    def _frac(num, den):
+        return num / den if den else 0.0
+
+    return {
+        "n_gold": n_gold,
+        "n_missed": missed,
+        "n_ner_miss": ner_miss,
+        "n_edge_miss": edge_miss,
+        "gliner_recall": _frac(gliner_matched, n_gold),
+        "llm_coverage": _frac(sum(1 for v in node_of.values() if v >= 0), n_gold),
+        "ner_recovered_frac": _frac(ner_recovered, ner_miss),
+        "residual_recovered_frac": _frac(missed_recovered, missed),
+        "junk_rate": _frac(junk, total_surf),
     }

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_eval.py
@@ -226,3 +226,91 @@ def test_score_substrate_assembles_a_b_gap():
     assert sb["er_f1_b"] < sb["er_f1_a"]              # build fragmented A -> B worse
     assert abs(sb["ab_gap"] - (sb["er_f1_a"] - sb["er_f1_b"])) < 1e-9
     assert sb["components"] == 2 and 0.0 <= sb["provenance"] <= 1.0
+
+
+# --- GLiNER entity-recall probe (gliner_probe_report) ---
+from erkgbench.substrate_eval import gliner_probe_report
+
+
+def _graph(entities, edges):
+    return {"entities": entities, "edges": edges}
+
+
+def test_probe_splits_ner_miss_from_edge_miss():
+    # gold A: aligned (node 1 has an in-doc edge). gold B: edge-miss (node 2 exists, no edge in its doc).
+    # gold C: ner-miss (no node matches its aliases anywhere).
+    entities = [
+        {"entity_id": 1, "canonical_name": "Apple", "surface_names": ["Apple"], "typ": "org"},
+        {"entity_id": 2, "canonical_name": "Tim Cook", "surface_names": ["Tim Cook"], "typ": "person"},
+    ]
+    edges = [{"subj": 1, "obj": 1, "predicate": "is", "source_refs": ["docA"]}]  # only docA has an edge
+    graph = _graph(entities, edges)
+    gold = [
+        ("Qa", "apple", "docA"),      # aligned (node 1, docA edge)
+        ("Qb", "tim cook", "docB"),   # edge-miss: node 2 exists but docB has no edge
+        ("Qc", "sundar pichai", "docC"),  # ner-miss: no node matches
+    ]
+    aliases = {"Qa": ["apple"], "Qb": ["tim cook"], "Qc": ["sundar pichai"]}
+    # GLiNER finds the edge-miss AND the ner-miss entity in their docs
+    gliner_by_doc = {"docB": {"Tim Cook"}, "docC": {"Sundar Pichai"}}
+    r = gliner_probe_report(graph, gold, aliases, gliner_by_doc)
+    assert r["n_gold"] == 3
+    assert r["n_missed"] == 2          # B and C
+    assert r["n_edge_miss"] == 1       # B
+    assert r["n_ner_miss"] == 1        # C
+    # the true prize: of the 1 ner-miss, GLiNER found 1
+    assert r["ner_recovered_frac"] == 1.0
+    # conflated context metric counts both missed that GLiNER matched
+    assert r["residual_recovered_frac"] == 1.0
+
+
+def test_probe_case_folds_gliner_surface():
+    # cased GLiNER surface must match a lowercased alias/gold set (guards false REFUTED).
+    graph = _graph([], [])
+    gold = [("Qx", "barack obama", "d1")]
+    aliases = {"Qx": ["barack obama"]}
+    r = gliner_probe_report(graph, gold, aliases, {"d1": {"Barack Obama"}})
+    assert r["gliner_recall"] == 1.0
+
+
+def test_probe_alias_and_substring_and_per_doc_match():
+    graph = _graph([], [])
+    gold = [
+        ("Qibm", "big blue", "d1"),        # matches via alias "ibm"
+        ("Qn", "thomas nabbes", "d2"),     # matches via substring "nabbes"
+        ("Qz", "zeta", "d3"),              # no gliner match
+    ]
+    aliases = {"Qibm": ["ibm", "big blue"], "Qn": ["thomas nabbes"], "Qz": ["zeta"]}
+    gliner_by_doc = {
+        "d1": {"IBM"},          # alias match
+        "d2": {"Nabbes"},       # substring match
+        "d3": {"Yeti"},         # unrelated -> junk, no gold match
+    }
+    r = gliner_probe_report(graph, gold, aliases, gliner_by_doc)
+    assert r["gliner_recall"] == 2 / 3
+    # per-doc: a d1 surface must not match a d3 gold
+    # junk: "Yeti" in d3 matches no d3 gold -> 1 junk of 3 total surfaces
+    assert r["junk_rate"] == 1 / 3
+
+
+def test_probe_junk_rate_all_match_is_zero():
+    graph = _graph([], [])
+    gold = [("Qa", "apple", "d1")]
+    aliases = {"Qa": ["apple"]}
+    r = gliner_probe_report(graph, gold, aliases, {"d1": {"Apple"}})
+    assert r["junk_rate"] == 0.0
+
+
+def test_probe_degenerate_guards():
+    graph = _graph([], [])
+    # empty gliner
+    r = gliner_probe_report(graph, [("Qa", "apple", "d1")], {"Qa": ["apple"]}, {})
+    assert r["gliner_recall"] == 0.0 and r["ner_recovered_frac"] == 0.0 and r["junk_rate"] == 0.0
+    # empty gold
+    r0 = gliner_probe_report(graph, [], {}, {"d1": {"Apple"}})
+    assert r0["n_gold"] == 0 and r0["residual_recovered_frac"] == 0.0
+    # all-aligned (|missed| == 0): one gold, one node with an in-doc edge
+    g2 = _graph([{"entity_id": 1, "canonical_name": "Apple", "surface_names": ["Apple"], "typ": "org"}],
+                [{"subj": 1, "obj": 1, "predicate": "is", "source_refs": ["d1"]}])
+    r2 = gliner_probe_report(g2, [("Qa", "apple", "d1")], {"Qa": ["apple"]}, {"d1": {"Apple"}})
+    assert r2["n_missed"] == 0 and r2["residual_recovered_frac"] == 0.0 and r2["ner_recovered_frac"] == 0.0

--- a/scripts/distill/modal_bench.py
+++ b/scripts/distill/modal_bench.py
@@ -32,7 +32,8 @@ image = (
     .run_commands("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
     .env({"PATH": "/root/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"})
     .pip_install("maturin", "goldenmatch", "datasets", "openai", "numpy", "pytest",
-                 "lightrag-hku>=1.5,<1.6")  # the LightRAG competitor for the local-7B head-to-head
+                 "lightrag-hku>=1.5,<1.6",  # the LightRAG competitor for the local-7B head-to-head
+                 "gliner")  # local NER encoder for the entity-recall probe
     .run_commands("curl -fsSL https://ollama.com/install.sh | sh")
     .add_local_dir(str(REPO / "packages/rust"), "/repo/packages/rust", ignore=["**/target/**"])
     .add_local_dir(str(REPO / "packages/python/goldengraph"), "/repo/packages/python/goldengraph",


### PR DESCRIPTION
## Summary

Measure-first gate for the proposed GLiNER-hybrid extraction-recall lever. One Modal run builds the best-config graph (name_ci + chunking (6,2)), runs GLiNER per-doc, and splits the unaligned gold into **NER-miss** (entity absent — GLiNER-addressable) vs **edge-miss** (entity present, edge dropped — GLiNER can't help). Measurement-only; no engine behavior change.

## Result — REFUTED, and the assumption was wrong

Both thresholds (0.4, 0.3), 19 docs / 65 gold:

| thr | gliner_recall | llm_coverage | n_missed | **ner_miss** | **edge_miss** | ner_recovered | junk_rate |
|---|---|---|---|---|---|---|---|
| 0.4 | 0.523 | 0.492 | 33 | **0** | **33** | 0.000 | 0.888 |
| 0.3 | 0.523 | 0.492 | 33 | **0** | **33** | 0.000 | 0.898 |

**Every unaligned gold is edge-miss; zero are NER-miss.** 32 aligned + 33 exist-but-unedged = all 65 gold entities are *already extracted*. GLiNER (which only adds entities) has nothing to recover.

## The finding

The real-prose substrate ceiling is **edge/relation recall**, not entity recall. Entity extraction is essentially solved by name_ci + chunking; the residual is entities whose edge was dropped (LLM omitted the relation, or the resolver collapsed src+dst into a discarded self-loop). This coheres with the whole thread: coverage is edge-gated, chunking WON by adding edges, the recall-prompt was REFUTED for trading edges for entities.

The gate did its job: ~one Modal run refuted a plausible lever before any linking pipeline was written.

## What ships

Reusable measurement tooling only:
- `substrate_eval.gliner_probe_report` — pure NER-miss/edge-miss scorer + shared `_alias_match_surface` primitive (the aligner now shares it; behavior-preserving).
- `run_substrate_eval --gliner-probe` runner (per-doc GLiNER + `_wiki_build` helper).
- `gliner` added to the gg-bench Modal image.

Verdict + next frontier (relation recall / edge survival): `docs/superpowers/reports/2026-07-01-gliner-recall-probe-verdict.md`.

## Test plan
- [x] `tests/test_substrate_eval.py` — 24 passed (5 new probe tests + 19 aligner regression proving the shared-primitive refactor is behavior-preserving)
- [x] ruff + py_compile clean
- [x] probe legs 90/91 completed on Modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)