### PR TITLE
fix(autoconfig): compute cardinality on full data, not the 1k sample (#1351)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -185,13 +185,19 @@ def _full_column_cardinality_null(
         if total_rows == 0:
             return 0.0, 0.0
         null_rate = series.null_count() / total_rows
-        # Strip blanks consistently with the sample values filter (str(v).strip()).
-        non_null = series.drop_nulls().cast(pl.Utf8).str.strip_chars()
-        non_blank = non_null.filter(non_null.str.len_chars() > 0)
+        non_null = series.drop_nulls()
+        # Blank-stripping only applies to text: non-string dtypes have no "blank"
+        # once nulls are dropped, so skip the Utf8 cast + per-value scan (pure
+        # overhead on numeric/date/bool) and hash the native dtype directly. For
+        # strings, strip + drop empties to match the sample values filter
+        # (str(v).strip() truthiness).
+        if non_null.dtype in (pl.Utf8, pl.String, pl.Categorical):
+            stripped = non_null.cast(pl.Utf8).str.strip_chars()
+            non_null = stripped.filter(stripped.str.len_chars() > 0)
         if total_rows >= _full_cardinality_max_rows():
-            unique = non_blank.approx_n_unique()
+            unique = non_null.approx_n_unique()
         else:
-            unique = non_blank.n_unique()
+            unique = non_null.n_unique()
         return unique / total_rows, null_rate
     except Exception:  # noqa: BLE001 -- exotic dtype; fall back to sample estimate
         return None
@@ -490,6 +496,17 @@ def profile_columns(
         }
         for prof in profiles:
             if prof.col_type != "identifier":
+                continue
+            # Name-authority guard: a column named like an id (`*_id`, `*_key`,
+            # `uuid`, `account_no`, ...) is "identifier" because its NAME says so,
+            # and the pure-Python path treats that as authoritative over data
+            # shape (identifier in _name_authoritative). Such a column can hold
+            # legitimately-repeating numeric ids (moderate cardinality), so only
+            # demote when the classification is NOT name-authoritative -- i.e.
+            # this "identifier" came from the cardinality promotion we're
+            # correcting, not from the column name. Otherwise a numeric-shaped
+            # `order_id` would be demoted to "numeric" and lose its matchkey.
+            if _classify_by_name(prof.name) == "identifier":
                 continue
             vals = names_to_sample_values.get(prof.name, [])
             honest = honest_ratios.get(prof.name)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -133,6 +133,70 @@ _ID_PATTERNS = re.compile(
 )
 
 
+# Full-data cardinality threshold (#1351). cardinality_ratio + null_rate are
+# measured on the FULL column, not the 1k classification sample, because a small
+# sample systematically OVER-estimates cardinality_ratio (birthday /
+# coupon-collector effect) -- which used to promote moderate-cardinality
+# zip/phone columns to "identifier" and commit a standalone exact matchkey (~55%
+# over-merge). Below this row count use an EXACT n_unique on the full column;
+# at/above it fall back to Polars' HyperLogLog approx_n_unique (still on the FULL
+# column, never the sample). Env override follows the GOLDENMATCH_* knob
+# convention.
+_FULL_CARDINALITY_MAX_ROWS = 2_000_000
+
+# Data shapes whose cardinality promotion to "identifier" is governed by the
+# honest full-data ratio (#1351). Mirrors the scope of the promotion guard in
+# _classify_by_data -- used to gate the native-path demotion correction.
+_CARDINALITY_PROMOTION_SHAPES = frozenset({"phone", "zip", "numeric"})
+
+
+def _full_cardinality_max_rows() -> int:
+    """Row-count threshold for exact vs HyperLogLog full-column cardinality.
+
+    Env override ``GOLDENMATCH_FULL_CARDINALITY_MAX_ROWS``; a missing or malformed
+    value falls back to the module default (#1351)."""
+    raw = os.environ.get("GOLDENMATCH_FULL_CARDINALITY_MAX_ROWS")
+    if raw is None:
+        return _FULL_CARDINALITY_MAX_ROWS
+    try:
+        val = int(raw)
+    except (ValueError, TypeError):
+        return _FULL_CARDINALITY_MAX_ROWS
+    return val if val > 0 else _FULL_CARDINALITY_MAX_ROWS
+
+
+def _full_column_cardinality_null(
+    df: pl.DataFrame, col_name: str,
+) -> tuple[float, float] | None:
+    """Honest full-column ``(cardinality_ratio, null_rate)`` for #1351.
+
+    ``cardinality_ratio`` = n_unique(non-null, non-blank) / total_rows_including_nulls
+    -- the same definition as the sample-based estimate, measured on the FULL
+    column so it isn't inflated by sampling. Exact ``n_unique`` below
+    ``_full_cardinality_max_rows()``, HyperLogLog ``approx_n_unique`` at/above it.
+
+    Returns ``None`` on ANY failure -- cast/filter/n_unique can raise on exotic
+    dtypes (Object/Binary/List/Struct) -- so the caller falls back to the
+    sample-based estimate. This must never raise out of ``profile_columns``.
+    """
+    try:
+        series = df[col_name]
+        total_rows = series.len()
+        if total_rows == 0:
+            return 0.0, 0.0
+        null_rate = series.null_count() / total_rows
+        # Strip blanks consistently with the sample values filter (str(v).strip()).
+        non_null = series.drop_nulls().cast(pl.Utf8).str.strip_chars()
+        non_blank = non_null.filter(non_null.str.len_chars() > 0)
+        if total_rows >= _full_cardinality_max_rows():
+            unique = non_blank.approx_n_unique()
+        else:
+            unique = non_blank.n_unique()
+        return unique / total_rows, null_rate
+    except Exception:  # noqa: BLE001 -- exotic dtype; fall back to sample estimate
+        return None
+
+
 @dataclass
 class ColumnProfile:
     """Profile of a single column for auto-configuration."""
@@ -200,8 +264,16 @@ def _classify_by_name(col_name: str) -> str | None:
     return None
 
 
-def _classify_by_data(values: list[str]) -> tuple[str, float]:
-    """Phase 2: classify column by data profiling. Returns (type, confidence)."""
+def _classify_by_data(
+    values: list[str], *, cardinality_ratio: float | None = None,
+) -> tuple[str, float]:
+    """Phase 2: classify column by data profiling. Returns (type, confidence).
+
+    ``cardinality_ratio`` (#1351): the HONEST full-data ratio for the identifier
+    promotion. When provided it governs the promotion floor instead of the
+    sample recompute; when ``None`` (hand-built value lists, legacy callers) the
+    original sample recompute is used, so existing callers/tests are unchanged.
+    """
     if not values:
         return "string", 0.0
 
@@ -213,7 +285,13 @@ def _classify_by_data(values: list[str]) -> tuple[str, float]:
     # distinct names) as identifiers. Require a non-trivial sample (>=10)
     # so a handful of genuinely-unique zip/phone rows don't trip the guard.
     if data_type in ("phone", "zip", "numeric") and len(values) >= 10:
-        cardinality_ratio = len(set(values)) / len(values)
+        # #1351: prefer the HONEST full-data ratio the caller threaded in; only
+        # fall back to the sample recompute when it's absent (legacy callers).
+        card = (
+            cardinality_ratio
+            if cardinality_ratio is not None
+            else len(set(values)) / len(values)
+        )
         # S2a (spec 2026-06-22): identifier floor max(0.95, 1 - 1/sqrt(n)). At
         # scale the floor RISES above the old fixed 0.95 (a 10k-row 0.95-card
         # column is a high-entropy name, not an ID), and never drops below 0.95
@@ -222,7 +300,7 @@ def _classify_by_data(values: list[str]) -> tuple[str, float]:
         # behavior). math.sqrt is correctly-rounded IEEE 754 -> bit-identical to
         # Rust's .sqrt() (do NOT use n ** 0.5 -- pow isn't correctly-rounded).
         floor = max(0.95, 1.0 - 1.0 / math.sqrt(len(values)))
-        if cardinality_ratio >= floor:
+        if card >= floor:
             return "identifier", 0.9
 
     # Year detection: 4-digit integers in 1900..2100. Cheap blocking signal
@@ -335,16 +413,27 @@ def profile_columns(
         dtype = str(df[col_name].dtype)
 
         col_series = sample[col_name]
-        total_rows = col_series.len()
-        null_count = col_series.null_count()
-        null_rate = null_count / total_rows if total_rows > 0 else 0.0
 
+        # Type-classification value heuristics stay on the SAMPLE (regex/pattern
+        # matching legitimately trades accuracy for speed). #1351: cardinality
+        # and null_rate must be honest, so measure them on the FULL column below.
         values = [
             str(v) for v in col_series.drop_nulls().to_list()
             if v is not None and str(v).strip()
         ]
 
-        cardinality_ratio = len(set(values)) / total_rows if total_rows > 0 else 0.0
+        full_stats = _full_column_cardinality_null(df, col_name)
+        if full_stats is not None:
+            cardinality_ratio, null_rate = full_stats
+        else:
+            # Exotic dtype broke the full-column path -- fall back to the
+            # sample-based estimate (pre-#1351 behavior) rather than fail.
+            total_rows = col_series.len()
+            null_rate = col_series.null_count() / total_rows if total_rows > 0 else 0.0
+            cardinality_ratio = (
+                len(set(values)) / total_rows if total_rows > 0 else 0.0
+            )
+
         avg_len = sum(len(v) for v in values) / len(values) if values else 0.0
 
         col_stats.append((col_name, dtype, values, null_rate, cardinality_ratio, avg_len))
@@ -384,6 +473,34 @@ def profile_columns(
         profiles: list[ColumnProfile] = column_profiles_from_json(
             native_json, names_to_sample_values
         )
+
+        # #1351 NATIVE LANDMINE: the native classifier recomputes cardinality
+        # from `sample_values` and promotes numeric/zip/phone shapes to
+        # "identifier" off that SAMPLE cardinality -- ignoring the honest
+        # full-data `cardinality_ratio` we pass in. That defeats the full-data
+        # fix on the native path. We can't feed the honest ratio into the Rust
+        # promotion, so re-check every native "identifier" here: for a
+        # promotion-eligible data shape (phone/zip/numeric) whose HONEST
+        # full-data ratio is below the promotion floor, demote it to what the
+        # non-promotion classification says. Python-side only (no Rust change);
+        # a no-op when native already agreed with the honest ratio.
+        honest_ratios = {
+            col_name: cardinality_ratio
+            for col_name, _dtype, _values, _nr, cardinality_ratio, _al in col_stats
+        }
+        for prof in profiles:
+            if prof.col_type != "identifier":
+                continue
+            vals = names_to_sample_values.get(prof.name, [])
+            honest = honest_ratios.get(prof.name)
+            if honest is None or _guess_type(vals) not in _CARDINALITY_PROMOTION_SHAPES:
+                continue
+            demoted_type, demoted_conf = _classify_by_data(
+                vals, cardinality_ratio=honest,
+            )
+            if demoted_type != "identifier":
+                prof.col_type = demoted_type
+                prof.confidence = demoted_conf
     else:
         # Pure-Python classification path (unchanged).
         profiles = []
@@ -391,8 +508,11 @@ def profile_columns(
             # Phase 1: name heuristics
             name_type = _classify_by_name(col_name)
 
-            # Phase 2: data profiling
-            data_type, data_confidence = _classify_by_data(values)
+            # Phase 2: data profiling (#1351: thread the honest full-data ratio
+            # into the identifier promotion instead of a sample recompute).
+            data_type, data_confidence = _classify_by_data(
+                values, cardinality_ratio=cardinality_ratio,
+            )
 
             # Combine: name heuristics are authoritative for structural types
             # (date, geo) because data profiling frequently misclassifies them

--- a/packages/python/goldenmatch/tests/test_profile_full_cardinality_1351.py
+++ b/packages/python/goldenmatch/tests/test_profile_full_cardinality_1351.py
@@ -107,3 +107,29 @@ class TestFullDataCardinality1351:
             f"promoted to {prof.col_type!r} on "
             f"{'native' if _NATIVE_AUTOCONFIG else 'python'} classify path"
         )
+
+    def test_name_authoritative_id_not_demoted(self):
+        """A column NAMED like an id (`order_id`) holding legitimately-repeating
+        numeric values (moderate cardinality) must stay ``identifier``.
+
+        The native-path demotion correction (#1351) re-runs the data-only
+        classifier, which would call a moderate-cardinality numeric column
+        "numeric" -- but ``order_id`` is ``identifier`` because its NAME is
+        authoritative, not because of the cardinality promotion being corrected.
+        Demoting it to "numeric" would make ``build_matchkeys`` skip it and the id
+        would silently lose its matchkey. The name-authority guard must prevent
+        that on the native path (the pure-Python path already respects it).
+        """
+        # 900 distinct ids across 3,000 rows -> honest ratio 0.3 (below the
+        # promotion floor); numeric-shaped so _guess_type -> "numeric".
+        ids = [str(700000 + (i % 900)) for i in range(3000)]
+        df = pl.DataFrame({"order_id": ids})
+
+        prof = _profile_by_name(df)["order_id"]
+
+        assert prof.cardinality_ratio == pytest.approx(900 / 3000, abs=1e-3)
+        assert prof.col_type == "identifier", (
+            f"name-authoritative order_id wrongly reclassified to "
+            f"{prof.col_type!r} on "
+            f"{'native' if _NATIVE_AUTOCONFIG else 'python'} classify path"
+        )

--- a/packages/python/goldenmatch/tests/test_profile_full_cardinality_1351.py
+++ b/packages/python/goldenmatch/tests/test_profile_full_cardinality_1351.py
@@ -1,0 +1,109 @@
+"""#1351 -- cardinality_ratio + null_rate must be measured on the FULL column,
+not the 1,000-row classification sample.
+
+Root cause: ``profile_columns`` sampled 1,000 rows and computed
+``cardinality_ratio`` from that sample. A small sample systematically
+OVER-estimates cardinality for moderate-cardinality columns (birthday /
+coupon-collector effect): a zip column with ~5k distinct values in ~19k rows
+reads ~0.96 in a 1k sample vs a true ~0.26. That inflated ratio promoted
+``zip -> "identifier"`` (the numeric-shape cardinality promotion), which
+committed a standalone ``exact[zip]`` matchkey and caused ~55% over-merge.
+
+Type CLASSIFICATION tolerates sampling; CARDINALITY does not. These tests pin
+the decoupling: classification value-heuristics stay on the sample, but
+``cardinality_ratio`` and ``null_rate`` are honest full-column measurements.
+
+All dataframes are small in-memory (<= a few thousand rows) -- profiling-level
+only, no controller/engine/benchmark runs.
+"""
+import polars as pl
+import pytest
+from goldenmatch.core._native_loader import native_enabled
+from goldenmatch.core.autoconfig import profile_columns
+
+# Whether the native autoconfig classify kernel is active in this env. The
+# #1351 promotion fix must hold on BOTH paths; these tests exercise whichever
+# is active. (In the --extra dev env the native wheel is typically present.)
+_NATIVE_AUTOCONFIG = native_enabled("autoconfig")
+
+
+def _profile_by_name(df: pl.DataFrame) -> dict:
+    return {p.name: p for p in profile_columns(df)}
+
+
+class TestFullDataCardinality1351:
+    def test_repro_low_cardinality_ratio_is_honest_not_sample_inflated(self):
+        """A high-density, low-cardinality zip column (26 distinct in 2,000 rows,
+        true ratio ~0.013) must report the HONEST full-column ratio.
+
+        The buggy path divided unique-in-sample by the SAMPLE height (1,000), so
+        even capturing all 26 distinct it read ~0.026 -- double the truth. The
+        honest full-column ratio is 26 / 2,000.
+        """
+        zips = [f"{10000 + (i % 26):05d}" for i in range(2000)]
+        df = pl.DataFrame({"zip": zips, "name": [f"n{i}" for i in range(2000)]})
+
+        prof = _profile_by_name(df)["zip"]
+
+        assert df.height > 1000  # sampling path is active
+        assert prof.cardinality_ratio == pytest.approx(26 / 2000, abs=1e-4)
+        # Guard against the sample denominator (26 / 1000 = 0.026).
+        assert prof.cardinality_ratio < 0.02
+
+    def test_moderate_cardinality_zip_not_promoted_to_identifier(self):
+        """A zip column whose 1k sample looks near-unique (moderate full-data
+        cardinality) must stay ``zip`` -- NOT be promoted to ``identifier``.
+
+        2,500 distinct 5-digit zips across 3,000 rows -> honest ratio ~0.833. A
+        1,000-row sample is almost all-unique (~0.98 >= the 0.95 promotion floor),
+        which is exactly what used to (wrongly) promote it. With honest cardinality
+        threaded into the promotion the column stays a zip.
+        """
+        zips = [f"{10000 + (i % 2500):05d}" for i in range(3000)]
+        df = pl.DataFrame({"zip": zips})
+
+        prof = _profile_by_name(df)["zip"]
+
+        assert prof.cardinality_ratio == pytest.approx(2500 / 3000, abs=1e-3)
+        assert prof.col_type != "identifier"
+        assert prof.col_type == "zip"
+
+    def test_genuinely_high_cardinality_still_identifier(self):
+        """A column with genuinely near-unique full-data cardinality still
+        promotes to identifier and carries ratio ~= 1.0."""
+        phones = [f"{5550000000 + i}" for i in range(2000)]
+        df = pl.DataFrame({"phone": phones})
+
+        prof = _profile_by_name(df)["phone"]
+
+        assert prof.cardinality_ratio == pytest.approx(1.0, abs=1e-6)
+        assert prof.col_type == "identifier"
+
+    def test_null_rate_is_honest_full_column(self):
+        """null_rate reflects the true full-column null fraction, exactly."""
+        values: list[str | None] = [f"val{i}" for i in range(1500)] + [None] * 500
+        df = pl.DataFrame({"code": pl.Series("code", values, dtype=pl.Utf8)})
+
+        prof = _profile_by_name(df)["code"]
+
+        assert df.height == 2000
+        assert prof.null_rate == pytest.approx(0.25, abs=1e-6)
+
+    def test_native_and_python_paths_agree_on_promotion(self):
+        """The promotion fix must hold regardless of which classify path runs.
+
+        This documents the active path so a failure here is attributable. Both
+        paths route through the same honest-cardinality promotion (native via the
+        Python-side post-classify demotion), so a moderate-cardinality zip stays
+        a zip either way.
+        """
+        zips = [f"{20000 + (i % 2200):05d}" for i in range(3000)]
+        df = pl.DataFrame({"zip": zips})
+
+        prof = _profile_by_name(df)["zip"]
+
+        # Assertion holds on native and pure-Python paths alike.
+        assert prof.col_type == "zip", (
+            f"promoted to {prof.col_type!r} on "
+            f"{'native' if _NATIVE_AUTOCONFIG else 'python'} classify path"
+        )


### PR DESCRIPTION
Closes #1351.

## Problem
`profile_columns` measured `cardinality_ratio` (and `null_rate`) on a **1,000-row random sample**. A small sample systematically **over-estimates** cardinality for moderate-cardinality columns (birthday / coupon-collector effect): a `zip` column with ~5k distinct values in ~19k rows reads ~0.96 in a 1k sample vs a true ~0.26. That inflated ratio promoted `zip → "identifier"` (the numeric-shape cardinality promotion), which defeated the zip/geo exact-matchkey guard and committed a standalone `exact[zip]` matchkey → **~55% over-merge** on real circulation data (dozens of distinct people merged on a shared zip). Type CLASSIFICATION tolerates sampling; CARDINALITY does not.

This is the root-cause fix. A discarded surgical version only patched the exact-matchkey gate; per review this was moved to the source so cardinality is honest for **every** consumer (classification, blocking, weighting), not just one gate.

## Fix
Decouple the two: classification value-heuristics keep running on the sample; `cardinality_ratio` + `null_rate` are now measured on the **full column**.
- `_full_column_cardinality_null`: exact `n_unique` below `_FULL_CARDINALITY_MAX_ROWS` (default 2,000,000, env-override `GOLDENMATCH_FULL_CARDINALITY_MAX_ROWS`), Polars HyperLogLog `approx_n_unique` at/above — always on the full column, never the 1k sample. Same ratio definition as before (unique non-null-non-blank / total rows incl nulls). Wrapped in try/except → falls back to the sample estimate on exotic dtypes (Object/Binary/List/Struct), never raises. Blank-strip only applies to string dtypes (numeric/date hash the native dtype directly).
- `_classify_by_data` takes an honest `cardinality_ratio` kwarg, used in the identifier-promotion floor instead of the sample recompute (absent → legacy sample behavior, so hand-built callers/tests are unchanged).
- **Native path:** the Rust classifier recomputes cardinality from `sample_values` and ignores the passed ratio (can't change Rust here). So on the native path we re-check each native `"identifier"` and demote promotion-eligible shapes (phone/zip/numeric) whose honest full-data ratio is below the floor — **respecting name-authority** (a `*_id`/`*_key`/`uuid` column stays `identifier`, mirroring the pure-Python combine, so a numeric `order_id` isn't wrongly demoted to `numeric` and stripped of its matchkey). Python-side only; a no-op when native already agreed.

`build_matchkeys`, the `exact_matchkey_floor` oracle, the zip/geo guard, and the composite paths are **untouched** — with honest cardinality flowing in, the existing floor + guard correctly reject `exact[zip]` unchanged. Phone is not special-cased (its honest ~0.50 still clears the 0.30 phone floor, so real behavior is preserved).

## Tests
New `tests/test_profile_full_cardinality_1351.py` (6 tests): honest low ratio on a >1k-row high-density column; moderate-cardinality zip stays `zip` (the bug repro); genuinely near-unique still `identifier`; honest `null_rate`; native/python promotion agreement; and name-authoritative `order_id` not demoted (the review-found regression guard). Exercises whichever classify path is active (native was on in the dev env).

`test_profile_full_cardinality_1351.py` + `test_autoconfig.py` + `test_exact_matchkey_floor_s3.py` + `test_autoconfig_pincer_715.py` → **136 passed, 3 skipped**. No existing test modified. `ruff check` clean.

## Validation / known limitation
CI's autoconfig **accuracy gates** (Febrl / DBLP-ACM / NCVR / #528) are the regression validation for the classification-shift blast radius — they can't be run locally (they OOM). **Known limitation (follow-up):** the promotion floor `max(0.95, 1−1/√n)` still uses the sample length, so for datasets ≫1k rows a near-unique column (true ratio ~0.97–0.999) can still promote; this is a pre-existing, low-harm case (near-unique columns are cheap/safe as exact keys) and not a regression — the catastrophic low-cardinality case is fixed. Worth a separate tightening (thread true row count into the floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)