### PR TITLE
feat(native): reference-mode gate for goldencheck + goldenanalysis

### DIFF
--- a/packages/python/goldenanalysis/goldenanalysis/core/_native_loader.py
+++ b/packages/python/goldenanalysis/goldenanalysis/core/_native_loader.py
@@ -7,9 +7,10 @@ call sites have one place to read. Mirrors ``goldencheck.core._native_loader``.
 ``GOLDENANALYSIS_NATIVE`` env:
 - ``"0"``    -> force the Python path (never use native).
 - ``"1"``    -> require native; raise if it isn't importable (CI parity lane).
-- ``"auto"`` / unset -> use native iff importable AND the component has cleared
-  parity (is in ``_GATED_ON``). ``_GATED_ON`` is empty until Phase 4, so ``auto``
-  always uses the pure path today.
+- ``"auto"`` / unset -> reference mode: use native wherever the component's kernel
+  symbol exists (``_COMPONENT_SYMBOLS`` / ``_has_symbol``); the pure-Python path is
+  the lossy fallback. ``histogram`` and ``quantile`` run native under ``auto`` when
+  the ext is importable.
 
 The kernel would be reachable two ways, tried in order:
   1. ``goldenanalysis._native``        -- the in-tree build (local dev / parity lane).
@@ -39,6 +40,20 @@ except Exception:  # noqa: BLE001 - any import/load failure falls back below
 # same two gates clear (heed the goldenmatch-native footguns in the root CLAUDE.md).
 _GATED_ON: frozenset[str] = frozenset({"histogram", "quantile"})
 
+# Component -> the native symbol that backs it (component name == symbol here). A
+# component is only usable when its symbol is present on the loaded module.
+_COMPONENT_SYMBOLS: dict[str, str] = {
+    "histogram": "histogram",
+    "quantile": "quantile",
+}
+
+
+def _has_symbol(component: str) -> bool:
+    if _native is None:
+        return False
+    symbol = _COMPONENT_SYMBOLS.get(component)
+    return symbol is not None and hasattr(_native, symbol)
+
 
 def native_module() -> Any:
     """The imported ``goldenanalysis._native`` module, or ``None`` if unavailable."""
@@ -52,8 +67,11 @@ def native_available() -> bool:
 def native_enabled(component: str) -> bool:
     """Whether to use the native kernel for ``component`` on this call.
 
-    Always ``False`` today (``_GATED_ON`` is empty). With ``GOLDENANALYSIS_NATIVE=1``
-    and no built kernel, raises — the require-native CI parity contract.
+    Reference mode (docs/design/2026-07-01-rust-is-the-reference-roadmap.md): native
+    runs wherever the component's kernel symbol exists; ``_GATED_ON`` is retained as
+    byte-exact sign-off documentation but no longer governs ``auto``. With
+    ``GOLDENANALYSIS_NATIVE=1`` and no built kernel, raises — the require-native CI
+    parity contract.
     """
     mode = os.environ.get("GOLDENANALYSIS_NATIVE", "auto").lower()
     if mode == "0":
@@ -63,5 +81,5 @@ def native_enabled(component: str) -> bool:
             raise RuntimeError(
                 "GOLDENANALYSIS_NATIVE=1 but goldenanalysis._native is not built/importable"
             )
-        return component in _GATED_ON
-    return _native is not None and component in _GATED_ON
+        return _has_symbol(component)
+    return _native is not None and _has_symbol(component)

--- a/packages/python/goldenanalysis/tests/test_native_loader_reference.py
+++ b/packages/python/goldenanalysis/tests/test_native_loader_reference.py
@@ -1,0 +1,56 @@
+"""Reference-mode gate tests (docs/design/2026-07-01-rust-is-the-reference-roadmap.md).
+
+Under GOLDENANALYSIS_NATIVE=auto, native runs wherever a component's kernel symbol
+exists; pure-Python is the lossy fallback. _GATED_ON no longer governs auto.
+"""
+from __future__ import annotations
+
+from goldenanalysis.core import _native_loader as nl
+
+
+def test_auto_runs_native_when_symbol_present(monkeypatch):
+    class FakeNative:
+        histogram = staticmethod(lambda *a, **k: None)
+        quantile = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNative)
+    monkeypatch.delenv("GOLDENANALYSIS_NATIVE", raising=False)
+    assert nl.native_enabled("histogram") is True
+    assert nl.native_enabled("quantile") is True
+
+
+def test_auto_falls_back_when_symbol_absent(monkeypatch):
+    class FakeNativeNoQuantile:
+        histogram = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNativeNoQuantile)
+    monkeypatch.delenv("GOLDENANALYSIS_NATIVE", raising=False)
+    assert nl.native_enabled("histogram") is True
+    assert nl.native_enabled("quantile") is False  # symbol absent -> fallback
+
+
+def test_unknown_component_is_fallback(monkeypatch):
+    class FakeNative:
+        histogram = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNative)
+    monkeypatch.delenv("GOLDENANALYSIS_NATIVE", raising=False)
+    assert nl.native_enabled("frame.row_count") is False
+
+
+def test_env_zero_forces_fallback(monkeypatch):
+    class FakeNative:
+        histogram = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNative)
+    monkeypatch.setenv("GOLDENANALYSIS_NATIVE", "0")
+    assert nl.native_enabled("histogram") is False
+
+
+def test_env_one_requires_native(monkeypatch):
+    import pytest
+
+    monkeypatch.setattr(nl, "_native", None)
+    monkeypatch.setenv("GOLDENANALYSIS_NATIVE", "1")
+    with pytest.raises(RuntimeError):
+        nl.native_enabled("histogram")

--- a/packages/python/goldencheck/goldencheck/core/_native_loader.py
+++ b/packages/python/goldencheck/goldencheck/core/_native_loader.py
@@ -88,7 +88,10 @@ def native_enabled(component: str) -> bool:
                 "GOLDENCHECK_NATIVE=1 but goldencheck._native is not built/importable"
             )
         return _has_symbol(component)
-    return _native is not None and component in _GATED_ON and _has_symbol(component)
+    # Reference mode (docs/design/2026-07-01-rust-is-the-reference-roadmap.md): native
+    # runs wherever the component's kernel symbol exists; ``_GATED_ON`` is retained as
+    # byte-exact sign-off documentation but no longer governs ``auto``.
+    return _native is not None and _has_symbol(component)
 
 
 # Component name -> the native symbol that backs it. A component is only usable

--- a/packages/python/goldencheck/tests/test_native_loader_reference.py
+++ b/packages/python/goldencheck/tests/test_native_loader_reference.py
@@ -1,0 +1,54 @@
+"""Reference-mode gate tests (docs/design/2026-07-01-rust-is-the-reference-roadmap.md).
+
+Under GOLDENCHECK_NATIVE=auto, native runs wherever a component's kernel symbol
+exists; pure-Python is the lossy fallback. _GATED_ON no longer governs auto.
+"""
+from __future__ import annotations
+
+from goldencheck.core import _native_loader as nl
+
+
+def test_auto_runs_native_when_symbol_present(monkeypatch):
+    class FakeNative:
+        benford_leading_digits = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNative)
+    monkeypatch.delenv("GOLDENCHECK_NATIVE", raising=False)
+    assert nl.native_enabled("benford") is True
+
+
+def test_auto_falls_back_when_symbol_absent(monkeypatch):
+    class FakeNativeNoBenford:
+        composite_key_search = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNativeNoBenford)
+    monkeypatch.delenv("GOLDENCHECK_NATIVE", raising=False)
+    assert nl.native_enabled("benford") is False  # symbol absent -> fallback
+    assert nl.native_enabled("composite_keys") is True
+
+
+def test_unknown_component_is_fallback(monkeypatch):
+    class FakeNative:
+        benford_leading_digits = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNative)
+    monkeypatch.delenv("GOLDENCHECK_NATIVE", raising=False)
+    assert nl.native_enabled("does_not_exist") is False
+
+
+def test_env_zero_forces_fallback(monkeypatch):
+    class FakeNative:
+        benford_leading_digits = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNative)
+    monkeypatch.setenv("GOLDENCHECK_NATIVE", "0")
+    assert nl.native_enabled("benford") is False
+
+
+def test_env_one_requires_native(monkeypatch):
+    import pytest
+
+    monkeypatch.setattr(nl, "_native", None)
+    monkeypatch.setenv("GOLDENCHECK_NATIVE", "1")
+    with pytest.raises(RuntimeError):
+        nl.native_enabled("benford")


### PR DESCRIPTION
## What

Extends the Rust-is-the-reference gate (goldenmatch #1343) to **goldencheck** and **goldenanalysis**: `auto` now runs native wherever the component's kernel symbol exists (`_has_symbol`) instead of the `_GATED_ON` allowlist. `_GATED_ON` is kept as byte-exact-signoff documentation but no longer governs `auto`.

- **goldencheck**: drops `component in _GATED_ON` from the auto branch (it already had `_COMPONENT_SYMBOLS` + `_has_symbol`).
- **goldenanalysis**: adds `_COMPONENT_SYMBOLS` + `_has_symbol`, flips `auto` + `mode==1`, and fixes the stale "`_GATED_ON` is empty until Phase 4" docstring (it holds `histogram`, `quantile`).

## Why non-breaking

**Output-identical** — every gated component (goldencheck: benford/composite_keys/functional_dependencies/fuzzy_values/approximate_fd; goldenanalysis: histogram/quantile) already carries its symbol, so the flip changes nothing today. Its value is reference-mode consistency: a future byte-exact kernel is native-by-default without an allowlist edit. No version bump.

## Tests

`test_native_loader_reference.py` in each package (symbol-present → native, symbol-absent → fallback, unknown component → fallback, `=0` forces fallback, `=1` requires native). 5 pass each; ruff clean.

Roadmap: `docs/design/2026-07-01-rust-is-the-reference-roadmap.md`. Next wave after this: goldenflow (needs Rust fixes + a product decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)