### PR TITLE
REBEL fusion (GOLDENGRAPH_REBEL_FUSE): REFUTED (harmful) + surfaces measurement-variance problem

### DIFF
--- a/docs/superpowers/plans/2026-07-02-rebel-fuse.md
+++ b/docs/superpowers/plans/2026-07-02-rebel-fuse.md
@@ -24,7 +24,7 @@ PYTHONPATH="D:/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_C
 | File | Responsibility |
 |---|---|
 | `packages/python/goldengraph/goldengraph/rebel_fuse.py` | **Create.** `rebel_fuse_enabled`, `_rebel_params`, `_load_rebel` (cached singleton), `_match_mention`, `rebel_fuse`. |
-| `packages/python/goldengraph/tests/test_rebel_fuse.py` | **Create.** 7 tests (mapping, drop-unmapped/self-loop, windowing, gate/empty, wiring, raise-preserves). All inject a fake REBEL. |
+| `packages/python/goldengraph/tests/test_rebel_fuse.py` | **Create.** 8 tests: Task 1 (mapping, substring/casefold, drop-unmapped+self-loop, per-window, gate, empty) + Task 2 (gated wiring, raise-preserves). All inject/monkeypatch a fake REBEL (real model never loaded). |
 | `packages/python/goldengraph/goldengraph/ingest.py` | **Modify** — import + gated seam after line 687 (after re-prompt, before `_maybe_canonicalize`). |
 | `docs/superpowers/reports/2026-07-02-rebel-fuse-verdict.md` | **Create** in Task 3 after the Modal run. |
 

--- a/docs/superpowers/plans/2026-07-02-rebel-fuse.md
+++ b/docs/superpowers/plans/2026-07-02-rebel-fuse.md
@@ -1,0 +1,399 @@
+# REBEL Fusion Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A gated `GOLDENGRAPH_REBEL_FUSE=1` pass that runs REBEL per sentence-window, maps each `(head, rel, tail)` triple's endpoints onto the already-extracted entities, and appends an edge only when both map — measured as the marginal delta on top of the shipped relation re-prompt.
+
+**Architecture:** New pure module `goldengraph/rebel_fuse.py` (gate + windowing + surface→entity mapping, injectable REBEL) called from one gated seam in `ingest._prepare_doc` right after the re-prompt block and BEFORE `_maybe_canonicalize`. The real REBEL model loads once via a lock-guarded cached singleton; tests always inject a fake, so no model/network in the box.
+
+**Tech Stack:** Python 3.11, stdlib `os`/`threading`; reuses `chunk_extract` windowing + `extract`/`extract_local` helpers; transformers/torch only inside `_load_rebel` (Modal image already has them via the gliner dep). pytest with an injected fake triple-extractor.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-rebel-fuse-design.md`
+**Branch:** `feat/rebel-fuse` (off `main`, which has chunking + re-prompt).
+
+**Box-safe test invocation** (run yourself; subagents ruff+py_compile only):
+```bash
+PY="/d/show_case/goldenmatch/.venv/Scripts/python.exe"
+cd packages/python/goldengraph
+PYTHONPATH="D:/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 \
+  "$PY" -m pytest tests/test_rebel_fuse.py -q -p no:cacheprovider
+```
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `packages/python/goldengraph/goldengraph/rebel_fuse.py` | **Create.** `rebel_fuse_enabled`, `_rebel_params`, `_load_rebel` (cached singleton), `_match_mention`, `rebel_fuse`. |
+| `packages/python/goldengraph/tests/test_rebel_fuse.py` | **Create.** 7 tests (mapping, drop-unmapped/self-loop, windowing, gate/empty, wiring, raise-preserves). All inject a fake REBEL. |
+| `packages/python/goldengraph/goldengraph/ingest.py` | **Modify** — import + gated seam after line 687 (after re-prompt, before `_maybe_canonicalize`). |
+| `docs/superpowers/reports/2026-07-02-rebel-fuse-verdict.md` | **Create** in Task 3 after the Modal run. |
+
+---
+
+## Task 1: `rebel_fuse.py` module
+
+**Files:**
+- Create: `packages/python/goldengraph/goldengraph/rebel_fuse.py`
+- Test: `packages/python/goldengraph/tests/test_rebel_fuse.py`
+
+- [ ] **Step 1: Write the failing tests.** Create `tests/test_rebel_fuse.py`:
+
+```python
+"""GOLDENGRAPH_REBEL_FUSE: map REBEL (head,rel,tail) triples onto existing entities as edges."""
+from goldengraph.extract import Mention
+from goldengraph.rebel_fuse import rebel_fuse, rebel_fuse_enabled
+
+
+def _mentions():
+    return [Mention(name="Amazon", typ="org"), Mention(name="Jeff Bezos", typ="person")]
+
+
+def _fake_rebel(triples_per_call):
+    """Returns a callable that yields a fixed triple list on every call, recording call count."""
+    state = {"calls": 0}
+
+    def rebel(text):
+        state["calls"] += 1
+        return list(triples_per_call)
+    rebel.state = state
+    return rebel
+
+
+def test_maps_triple_to_existing_entities(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_SENTENCES", "50")  # one window over the short text
+    rebel = _fake_rebel([("Amazon", "founded by", "Jeff Bezos")])
+    rels = rebel_fuse("Amazon was founded by Jeff Bezos.", _mentions(), rebel=rebel)
+    assert len(rels) == 1
+    assert (rels[0].subj, rels[0].predicate, rels[0].obj) == (0, "founded by", 1)
+
+
+def test_substring_and_casefold_match(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_SENTENCES", "50")
+    rebel = _fake_rebel([("amazon", "employs", "Bezos")])  # cased + substring
+    rels = rebel_fuse("t.", _mentions(), rebel=rebel)
+    assert [(r.subj, r.predicate, r.obj) for r in rels] == [(0, "employs", 1)]
+
+
+def test_drops_unmapped_and_self_loops(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_SENTENCES", "50")
+    rebel = _fake_rebel([
+        ("Amazon", "rivals", "Microsoft"),   # tail maps to no mention -> dropped
+        ("Amazon", "is", "Amazon"),           # both map to 0 -> self-loop dropped
+        ("Amazon", "led by", "Jeff Bezos"),   # valid
+    ])
+    rels = rebel_fuse("t.", _mentions(), rebel=rebel)
+    assert [(r.subj, r.predicate, r.obj) for r in rels] == [(0, "led by", 1)]
+
+
+def test_runs_once_per_window(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_SENTENCES", "2")
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_OVERLAP", "0")
+    # 4 sentences, size=2 overlap=0 -> 2 windows
+    text = "S one here. S two here. S three here. S four here."
+    rebel = _fake_rebel([("Amazon", "r", "Jeff Bezos")])
+    rels = rebel_fuse(text, _mentions(), rebel=rebel)
+    assert rebel.state["calls"] == 2          # one call per window
+    assert len(rels) == 2                      # each window contributed the mapped edge
+
+
+def test_gate_enabled(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_REBEL_FUSE", raising=False)
+    assert rebel_fuse_enabled() is False
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_FUSE", "1")
+    assert rebel_fuse_enabled() is True
+    for off in ("", "0", "False", "off", " no "):
+        monkeypatch.setenv("GOLDENGRAPH_REBEL_FUSE", off)
+        assert rebel_fuse_enabled() is False, off
+
+
+def test_empty_mentions_no_rebel_call():
+    def boom(text):
+        raise AssertionError("must not be called on empty mentions")
+    assert rebel_fuse("t.", [], rebel=boom) == []
+```
+
+- [ ] **Step 2: Run, verify fail.** Box-safe invocation. Expected: `ModuleNotFoundError: No module named 'goldengraph.rebel_fuse'`.
+
+- [ ] **Step 3: Implement `rebel_fuse.py`:**
+
+```python
+"""REBEL fusion (GOLDENGRAPH_REBEL_FUSE): a distinct relation-recall lever. Runs REBEL
+(Babelscape/rebel-large, discriminative end-to-end relation extraction) per sentence-window,
+and maps each (head, rel, tail) triple's endpoints onto the ALREADY-extracted entities --
+adding an edge only when BOTH endpoints map, never a new node. Composes with (and is measured
+on top of) the relation re-prompt. Pure w.r.t. the store; REBEL injectable for tests; gate off
+by default.
+
+SCHEMA_CANON note: REBEL emits Wikidata-style predicates that a closed relation vocab won't
+contain, so under GOLDENGRAPH_SCHEMA_CANON=1 canonicalization drops them. This lever targets
+canon-off configs (see the spec)."""
+
+from __future__ import annotations
+
+import os
+import threading
+
+from .chunk_extract import _env_int, sentence_windows, split_sentences
+from .extract import Mention, Relationship
+
+_REBEL_LOCK = threading.Lock()
+_REBEL = None  # cached `text -> list[(head, rel, tail)]` callable
+
+
+def rebel_fuse_enabled() -> bool:
+    """`GOLDENGRAPH_REBEL_FUSE` gate. Off by default; case-insensitive, stripped:
+    ""/"0"/"false"/"no"/"off" -> off."""
+    return os.environ.get("GOLDENGRAPH_REBEL_FUSE", "0").strip().lower() not in (
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _rebel_params() -> tuple[int, int]:
+    """(window size, overlap) for REBEL's 256-token input; defaults (4, 1). Defensive parse."""
+    return _env_int("GOLDENGRAPH_REBEL_SENTENCES", 4), _env_int("GOLDENGRAPH_REBEL_OVERLAP", 1)
+
+
+def _load_rebel():
+    """Lazily load Babelscape/rebel-large ONCE (lock-guarded, double-checked, for the concurrent
+    prepare phase). Returns a `text -> list[(head, rel, tail)]` callable reusing the existing
+    unit-tested `extract_local.parse_rebel_triplets` decoder."""
+    global _REBEL
+    if _REBEL is not None:
+        return _REBEL
+    with _REBEL_LOCK:
+        if _REBEL is None:
+            from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+            from .extract_local import parse_rebel_triplets
+
+            tok = AutoTokenizer.from_pretrained("Babelscape/rebel-large")
+            mdl = AutoModelForSeq2SeqLM.from_pretrained("Babelscape/rebel-large")
+
+            def _triples(text: str):
+                inp = tok(text, return_tensors="pt", truncation=True, max_length=256)
+                out = mdl.generate(**inp, max_length=256)
+                return parse_rebel_triplets(tok.decode(out[0], skip_special_tokens=False))
+
+            _REBEL = _triples
+    return _REBEL
+
+
+def _match_mention(surface_lc: str, mentions: list[Mention]) -> int | None:
+    """Index of the mention whose (case-folded) name matches `surface_lc` -- exact preferred over
+    substring-either-way, lowest index breaking ties; None if none match."""
+    if not surface_lc:
+        return None
+    for i, m in enumerate(mentions):  # exact first
+        if m.name.strip().lower() == surface_lc:
+            return i
+    for i, m in enumerate(mentions):  # substring either way
+        n = m.name.strip().lower()
+        if n and (surface_lc in n or n in surface_lc):
+            return i
+    return None
+
+
+def rebel_fuse(text: str, mentions: list[Mention], *, rebel=None) -> list[Relationship]:
+    """Run REBEL per sentence-window over `text`, map triple endpoints onto `mentions`, and return
+    Relationships for triples where BOTH endpoints map and are distinct. Empty mentions -> [] (no
+    model call). Any error -> [] (fail-soft). `rebel` (injectable) is a `text -> list[(head,rel,tail)]`
+    callable; default None -> the cached real REBEL."""
+    if not mentions:
+        return []
+    try:
+        triples_fn = rebel or _load_rebel()
+        size, overlap = _rebel_params()
+        out: list[Relationship] = []
+        for window in sentence_windows(split_sentences(text), size, overlap):
+            try:
+                triples = triples_fn(window)
+            except Exception:
+                continue  # a bad window skips, never sinks the doc
+            for head, rel, tail in triples:
+                s = _match_mention(str(head).strip().lower(), mentions)
+                o = _match_mention(str(tail).strip().lower(), mentions)
+                if s is not None and o is not None and s != o:
+                    out.append(Relationship(subj=s, predicate=str(rel), obj=o))
+        return out
+    except Exception:
+        return []
+```
+
+- [ ] **Step 4: Run tests, verify pass** (box-safe). Expected: 6 passed. Then `ruff check goldengraph/rebel_fuse.py`.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add goldengraph/rebel_fuse.py tests/test_rebel_fuse.py
+git commit -m "feat(goldengraph): REBEL fusion (GOLDENGRAPH_REBEL_FUSE) -- per-window triples mapped to existing entities"
+```
+
+---
+
+## Task 2: wire the gated seam into `_prepare_doc`
+
+**Files:**
+- Modify: `packages/python/goldengraph/goldengraph/ingest.py` (import near line 23; seam after line 687, before line 688)
+- Test: `packages/python/goldengraph/tests/test_rebel_fuse.py`
+
+- [ ] **Step 1: Add the failing wiring test.** Append to `tests/test_rebel_fuse.py`:
+
+```python
+def _identity_resolver():
+    from goldengraph.resolve import ResolvedEntity
+
+    def resolver(mentions):
+        return [
+            ResolvedEntity(local_id=i, canonical_name=m.name, typ=m.typ,
+                           surface_names=[m.name], record_keys=[], member_idx=[i])
+            for i, m in enumerate(mentions)
+        ]
+    return resolver
+
+
+def test_prepare_doc_appends_rebel_edges_only_when_gated(monkeypatch):
+    import importlib
+
+    from goldengraph.extract import Extraction, Mention, Relationship
+    ingest = importlib.import_module("goldengraph.ingest")  # __init__ shadows the submodule name
+
+    calls = {"n": 0}
+
+    def base_extractor(text, llm=None):
+        return Extraction(mentions=[Mention(name="Amazon", typ="org"),
+                                    Mention(name="Jeff Bezos", typ="person")],
+                          relationships=[])
+
+    def fake_fuse(text, mentions):
+        calls["n"] += 1
+        return [Relationship(subj=0, predicate="founded by", obj=1)]
+
+    monkeypatch.setattr(ingest, "rebel_fuse", fake_fuse)
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_RELATION_REPROMPT", raising=False)
+    resolver = _identity_resolver()
+
+    # gate OFF -> no fuse, no edges
+    monkeypatch.delenv("GOLDENGRAPH_REBEL_FUSE", raising=False)
+    ex, _, _ = ingest._prepare_doc("t", llm=None, resolver=resolver, profile_fps=False,
+                                   extractor=base_extractor)
+    assert calls["n"] == 0 and len(ex.relationships) == 0
+
+    # gate ON -> fuse called once, edge appended
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_FUSE", "1")
+    ex2, _, _ = ingest._prepare_doc("t", llm=None, resolver=resolver, profile_fps=False,
+                                    extractor=base_extractor)
+    assert calls["n"] == 1 and len(ex2.relationships) == 1
+
+
+def test_prepare_doc_rebel_raise_preserves_first_pass(monkeypatch):
+    import importlib
+
+    from goldengraph.extract import Extraction, Mention, Relationship
+    ingest = importlib.import_module("goldengraph.ingest")
+
+    def base_extractor(text, llm=None):
+        return Extraction(mentions=[Mention(name="A", typ="org"), Mention(name="B", typ="org")],
+                          relationships=[Relationship(subj=0, predicate="rel", obj=1)])
+
+    def boom(text, mentions):
+        raise RuntimeError("rebel exploded")
+
+    monkeypatch.setattr(ingest, "rebel_fuse", boom)
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_FUSE", "1")
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_RELATION_REPROMPT", raising=False)
+    ex, ents, _ = ingest._prepare_doc("t", llm=None, resolver=_identity_resolver(),
+                                      profile_fps=False, extractor=base_extractor)
+    assert len(ex.mentions) == 2 and len(ex.relationships) == 1 and len(ents) == 2
+```
+
+- [ ] **Step 2: Run, verify fail.** Expected: `AttributeError` (no `ingest.rebel_fuse` to patch) or the gate-ON assertion failing.
+
+- [ ] **Step 3: Wire the seam.** In `ingest.py`, add the import beside the relation_reprompt import (after line 23 `from .relation_reprompt import relation_reprompt, relation_reprompt_enabled`):
+
+```python
+from .rebel_fuse import rebel_fuse, rebel_fuse_enabled
+```
+(ruff may reorder the local-import block; run `ruff check --fix` if it flags I001.)
+
+Then insert the gated append immediately after the re-prompt block's closing `pass` (after line 687, before the `# In discovery mode...` comment at line 688):
+
+```python
+        # REBEL fusion (2nd relation source): map REBEL triples onto existing entities as edges.
+        # Same before-canonicalization placement + own try/except as the re-prompt.
+        if rebel_fuse_enabled():
+            try:
+                extraction.relationships += rebel_fuse(text, extraction.mentions)
+            except Exception:
+                pass
+```
+
+- [ ] **Step 4: Run tests, verify pass.** Full `tests/test_rebel_fuse.py` (box-safe). Expected: 8 passed. Then a regression sanity on the neighbouring gates + ruff:
+
+```bash
+PYTHONPATH="D:/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 \
+  "$PY" -m pytest tests/test_rebel_fuse.py tests/test_relation_reprompt.py tests/test_chunk_extract.py -q -p no:cacheprovider
+"$PY" -m ruff check goldengraph/ingest.py goldengraph/rebel_fuse.py
+```
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add goldengraph/ingest.py tests/test_rebel_fuse.py
+git commit -m "feat(goldengraph): gate REBEL fusion into _prepare_doc (after re-prompt, before canon, fail-soft)"
+```
+
+---
+
+## Task 3: Modal 3-way measurement + verdict
+
+**Files:** Create `docs/superpowers/reports/2026-07-02-rebel-fuse-verdict.md`.
+
+Run yourself (Modal, `PYTHONIOENCODING=utf-8 PYTHONUTF8=1`, `--detach --spawn`, distinct `--n`). Rig is `SCHEMA_CANON` off / no relation vocab (do NOT set `GOLDENGRAPH_RELATION_VOCAB` or `GOLDENGRAPH_SCHEMA_CANON`).
+
+- [ ] **Step 1: Fire the 3-way (+ optional REBEL-alone):**
+
+```bash
+M="/d/show_case/goldenmatch/.venv/Scripts/modal.exe"
+BEST=$'GOLDENGRAPH_SUBSTRATE_CORPUS=wiki\nGOLDENGRAPH_XDOC_KEY=name_ci\nGOLDENGRAPH_CHUNK_EXTRACT=1\nGOLDENGRAPH_CHUNK_SENTENCES=6\nGOLDENGRAPH_CHUNK_OVERLAP=2'
+# control
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 110 --opts "$BEST" --spawn
+# re-prompt only (reproduce the shipped win baseline)
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 111 \
+  --opts "$BEST"$'\nGOLDENGRAPH_RELATION_REPROMPT=1' --spawn
+# re-prompt + REBEL (the marginal-delta question)
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 112 \
+  --opts "$BEST"$'\nGOLDENGRAPH_RELATION_REPROMPT=1\nGOLDENGRAPH_REBEL_FUSE=1' --spawn
+# REBEL alone (optional bonus read)
+$M run --detach scripts/distill/modal_bench.py --engine goldengraph --eval substrate --n 113 \
+  --opts "$BEST"$'\nGOLDENGRAPH_REBEL_FUSE=1' --spawn
+```
+Poll `gg-bench-cache` for `results/substrate_11{0,1,2,3}_*.md`; read the `[substrate-wiki]` line.
+
+> Note: first REBEL leg downloads Babelscape/rebel-large from HF (~1.6GB) into the container — allow extra startup. transformers/torch are already in the image (gliner dep). If a leg errors on the model download, re-run it (HF hiccup); the fail-soft path would otherwise yield the re-prompt baseline silently.
+
+- [ ] **Step 2: Read all legs.** Tabulate R(B) / P(B) / F1 / coverage / components. The decision compares **112 (re-prompt+REBEL) vs 111 (re-prompt)**.
+
+- [ ] **Step 3: Write the verdict** `docs/superpowers/reports/2026-07-02-rebel-fuse-verdict.md`:
+  - **WIN:** 112 R(B)/F1 above 111, P(B) ~1.0, components not worse.
+  - **REFUTED (redundant):** 112 ≈ 111 → REBEL overlaps the re-prompt; relation-recall saturates there.
+  - **REFUTED (harmful):** P(B) drops / components collapse → REBEL mis-mapped edges (surface collision).
+  - Report the REBEL-alone (113) read as context (standalone relation recall vs control). Note the canon-off scope + the truncation caveat if REFUTED.
+
+- [ ] **Step 4: Commit** the report.
+
+```bash
+git add docs/superpowers/reports/2026-07-02-rebel-fuse-verdict.md
+git commit -m "docs(goldengraph): REBEL fusion verdict (wiki 3-way marginal delta)"
+```
+
+---
+
+## Completion
+
+Use superpowers:finishing-a-development-branch: run the box-safe `tests/test_rebel_fuse.py` suite, open a PR (base `main`), arm auto-merge. The PR ships the gate default-off regardless of the verdict (an opt-in second relation source). If REFUTED, the relation-recall thread closes at the re-prompt and the arc turns to cross-corpus robustness of the shipped stack (name_ci + chunking + re-prompt).

--- a/docs/superpowers/reports/2026-07-02-rebel-fuse-verdict.md
+++ b/docs/superpowers/reports/2026-07-02-rebel-fuse-verdict.md
@@ -1,0 +1,49 @@
+# REBEL Fusion — Verdict
+
+**Date:** 2026-07-02
+**Branch:** `feat/rebel-fuse`
+**Spec/Plan:** `docs/superpowers/specs/2026-07-02-rebel-fuse-design.md` · `docs/superpowers/plans/2026-07-02-rebel-fuse.md`
+**Run:** Modal `gg-bench`, 7B (`qwen2.5-7b-instruct`), `--corpus wiki`, best config (`name_ci` + chunking `(6,2)`), **`SCHEMA_CANON` off**. 19 docs, 65 gold.
+
+## What this tested
+
+Whether REBEL (Babelscape/rebel-large, discriminative relation extraction) recovers correct edges the generative 7B re-prompt misses — measured as the marginal delta on top of the shipped re-prompt.
+
+## Result — REFUTED (harmful / no marginal value)
+
+| leg | config | R(B) | P(B) | F1(B) | coverage | components |
+|---|---|---|---|---|---|---|
+| 110 | control | 0.3434 | 1.0000 | 0.5113 | 0.5077 | 14 |
+| 111 | re-prompt | 0.3030 | 1.0000 | 0.4651 | 0.4923 | 9 |
+| **112** | **re-prompt + REBEL** | 0.2525 | 1.0000 | **0.4032** | 0.5231 | 6 |
+| 113 | REBEL-alone | 0.3434 | **0.9067** | 0.4982 | 0.5077 | 11 |
+
+Two robust, mechanism-level findings (not level noise):
+
+1. **REBEL does not add value on top of the re-prompt.** 112 (re-prompt+REBEL) F1 = 0.403 is *below* 111 (re-prompt) F1 = 0.465 — adding REBEL hurt, didn't help. The marginal delta the whole lever was built to measure is negative.
+2. **REBEL breaks precision.** REBEL-alone (113) is the *only* leg with `P(B) < 1.0` (0.9067). A precision drop means REBEL's surface-mapping injected **false edges** that drove *incorrect* cross-doc merges — exactly the substring-collision risk the spec flagged (a short REBEL surface matching the wrong entity). This is a mechanism (precision breaks), not run variance: every non-REBEL leg holds `P(B) = 1.0`.
+
+REBEL is refuted as a relation-recall lever for this substrate: it recovers nothing the re-prompt misses and actively degrades precision. **The relation-recall thread closes at the re-prompt.**
+
+## The larger finding: the substrate measurement is high-variance
+
+This run's **control** (leg 110) is F1 = 0.5113 / R(B) = 0.3434. But the re-prompt verdict's control (leg 100, identical config) was F1 = 0.3704 / R(B) = 0.2273. **Same config, ±0.14 F1 between runs.** The 7B extraction is sampled (Ollama default temperature), so each Modal leg re-extracts non-deterministically, and the pairwise R(B)/F1 (sensitive to the exact clustering) swings widely run-to-run. Coverage is coarser (it lands on 32 or 33 of 65 — one-mention granularity) and looks stable, which masked the variance until now.
+
+**Implication (honest):** single-leg A/B deltas across this arc are **underpowered**. The REBEL refutation survives this — its verdict rests on a *precision break* (a mechanism) and a negative delta in the same direction, not on a fragile positive. But the chunking and re-prompt **wins were single-leg deltas** of a similar magnitude to the noise floor, so they should be **re-confirmed with replicated measurement** before any default-on decision. This does not retract them — the re-prompt win had corroborating structural signals (components down, P held) — but it lowers the confidence bar they cleared.
+
+## Decisions
+
+- **Ship the gate default-off** (opt-in second relation source), consistent with the arc, but **not recommended** — it degrades precision.
+- **Close the relation-recall thread at the re-prompt.** REBEL adds nothing; further relation-recall levers are not indicated on this evidence.
+- **Methodological fix is now the priority, not another lever.** The next substrate step should be **replicated measurement** (N seeds per config, or `temperature=0` extraction if the harness allows) to establish the noise floor and re-confirm the chunking + re-prompt wins with error bars. Measuring a new lever against a ±0.14-F1 control is not worth doing until the instrument is tightened.
+
+## Honest caveats
+
+- **Small N + high variance.** 19 docs / 65 gold, non-deterministic extraction. The REBEL refutation is safe (precision-break mechanism); the *magnitudes* everywhere in this arc are noisier than the single-leg tables implied.
+- **REBEL-alone precision break did not manifest in 112** (re-prompt+REBEL held P=1.0) — likely because that run's particular extraction didn't hit a colliding surface, or the re-prompt edges dominated. Precision is not *reliably* broken, but it is *demonstrably breakable* by REBEL, which is disqualifying for a default-on knob.
+- **SCHEMA_CANON-off scope** — as designed; REBEL's verbatim Wikidata predicates would be dropped under a canon config anyway.
+
+## Follow-ons
+
+1. **Replicated-measurement harness** — the real next step: quantify the run-to-run variance and re-confirm chunking + re-prompt with error bars. Turns the arc's single-leg deltas into defensible effects.
+2. Relation recall is otherwise **saturated at the re-prompt** on this evidence; no further edge-source lever is indicated.

--- a/docs/superpowers/specs/2026-07-02-rebel-fuse-design.md
+++ b/docs/superpowers/specs/2026-07-02-rebel-fuse-design.md
@@ -1,0 +1,106 @@
+# REBEL Fusion — Design
+
+**Date:** 2026-07-02
+**Branch:** `feat/rebel-fuse` (off `main`)
+**Program:** goldengraph substrate-quality arc — a second, distinct **relation-recall** lever, after the relation re-prompt WON (R(B) +33%, F1 +26%, PR #1355). This tests whether a discriminative relation extractor (REBEL) recovers correct edges the generative 7B re-prompt still misses.
+
+**Source note:** the motivating findings (edge-miss residual is relation-never-extracted; re-prompt win) are in `docs/superpowers/reports/2026-07-01-{edge-miss-diagnostic,relation-reprompt}-verdict.md`, both on `main`.
+
+## Problem
+
+The re-prompt recovered relation recall by re-asking the *same* 7B for relations over a provided entity list. REBEL (Babelscape/rebel-large, a BART seq2seq model trained end-to-end for relation extraction) is a *different kind* of extractor — discriminative, English-Wikipedia-trained, well-suited to lead prose. It may catch relations the 7B omits even on the second pass. But it may also be redundant with the re-prompt, or inject noise via surface-mapping errors. This lever builds the fusion and measures its **marginal value on top of the re-prompt** — the only question that matters, since re-prompt already ships.
+
+## Goal
+
+A gated `GOLDENGRAPH_REBEL_FUSE=1` pass that runs REBEL per window over the doc, maps each `(head, rel, tail)` triple's endpoints onto the **already-extracted** entity set, and appends an edge only when *both* endpoints map — adding edges among known entities, never new nodes. Independent of the re-prompt gate (both can be on). Default-off; measured as the 3-way delta control / re-prompt / re-prompt+REBEL on the wiki rig.
+
+## Non-goals
+
+- **No new entity nodes.** REBEL triples with an endpoint that doesn't map to an existing mention are dropped (the diagnostic proved entities aren't the gap; an unmapped endpoint can't be edged; dropping keeps precision).
+- No predicate-vocab snapping — REBEL's relation labels are kept verbatim (the substrate metric aligns on entity-pairs, not predicate strings; downstream `_maybe_canonicalize` handles them like any edge when `SCHEMA_CANON=1`).
+- No edge dedup (consistent with re-prompt/chunking; duplicates are benign for pair/component metrics).
+- Not a training/fine-tuning effort — off-the-shelf REBEL only.
+
+## Architecture
+
+### New module `goldengraph/rebel_fuse.py`
+
+Isolated, box-testable, parallel to `relation_reprompt.py`:
+
+- `rebel_fuse_enabled() -> bool` — `GOLDENGRAPH_REBEL_FUSE` gate (case-insensitive, stripped, empty-safe: `""/"0"/"false"/"no"/"off"` → off; mirror `relation_reprompt_enabled`).
+- `rebel_fuse(text, mentions, *, rebel=None) -> list[Relationship]` — windows `text`, runs the REBEL triple-extractor per window, maps triple endpoints onto `mentions`, returns `Relationship(subj_idx, rel, obj_idx)` for triples where both endpoints map and `subj_idx != obj_idx`. `rebel` is an injectable `text -> list[(head,rel,tail)]` callable (tests pass a fake); default `None` → the lazily-loaded cached real REBEL. Empty mentions → `[]` (no model call). Any error → `[]` (fail-soft).
+- `_load_rebel()` — module-level cached singleton guarded by a `threading.Lock` (the prepare phase runs concurrently across docs). Loads Babelscape/rebel-large once; returns a `text -> list[(head,rel,tail)]` callable that tokenizes (truncate 256), `generate`s, decodes with special tokens, and reuses the existing unit-tested `extract_local.parse_rebel_triplets`. It does NOT reuse `triplets_to_extraction` (that mints untyped mentions — we want only edges among existing entities).
+
+### The seam — `ingest._prepare_doc`
+
+After the extraction is built and after the re-prompt append, BEFORE `_maybe_canonicalize`:
+
+```python
+extraction = chunk_extract(...) if chunk_extract_enabled() else _extractor(text, llm)
+if relation_reprompt_enabled():
+    try: extraction.relationships += relation_reprompt(text, extraction.mentions, llm)
+    except Exception: pass
+if rebel_fuse_enabled():
+    try: extraction.relationships += rebel_fuse(text, extraction.mentions)
+    except Exception: pass
+# ... then _maybe_canonicalize
+```
+
+Same placement rationale as the re-prompt (edges get direction/schema canonicalization) and the same load-bearing `try/except` (the outer `_prepare_doc` except returns an EMPTY extraction, so a REBEL failure must never propagate there and discard the first-pass work). Downstream (`_maybe_canonicalize → resolve → build_batch → append`) is untouched.
+
+## Components
+
+### `_load_rebel()` triple-extractor
+
+Reuses `rebel_extractor`'s load path (transformers `AutoModelForSeq2SeqLM` + `AutoTokenizer`, `Babelscape/rebel-large`; `transformers`+`torch` are already in the Modal image via the gliner dep). Returns a callable that, per input text: tokenize with `truncation=True, max_length=256`, `generate(max_length=256)`, `decode(skip_special_tokens=False)`, then `parse_rebel_triplets(decoded)` → `list[(head, rel, tail)]`. Cached in a module global under a `threading.Lock` (double-checked) so concurrent first-calls in the parallel prepare phase load it exactly once.
+
+### Windowing
+
+REBEL's ~256-token window can't hold the ~2750-char lead, so window the input: `sentence_windows(split_sentences(text), size, overlap)` (reuse `chunk_extract`'s utilities — DRY) with `GOLDENGRAPH_REBEL_SENTENCES` (default 4) / `GOLDENGRAPH_REBEL_OVERLAP` (default 1), parsed defensively (empty-string-env safe, same helper style as chunk_extract). Run REBEL per window; concatenate triples across windows.
+
+### Surface → entity mapping (`_match_mention`)
+
+`_match_mention(surface_lc: str, mentions) -> int | None`: case-fold the REBEL surface; return the index of the first mention whose name matches — **exact (case-folded) preferred over substring-either-way**, lowest index breaking ties; `None` if none match. A local helper (the bench's `_alias_match_surface` lives in the erkgbench package, not importable here; keep a small self-contained version). A triple `(head, rel, tail)` yields `Relationship(_match_mention(head), rel, _match_mention(tail))` only when both are non-None and distinct.
+
+### Predicate
+
+Kept verbatim from REBEL. No snapping.
+
+## Error handling
+
+Fail-soft at two levels (mirrors re-prompt): `rebel_fuse` returns `[]` on empty mentions or any exception (model load, inference, decode, mapping); a per-window inference error skips that window (continue), not the doc. The seam wraps the call in `try/except: pass` as the load-bearing second guard against the empty-extraction fallback.
+
+## Measurement — the 3-way marginal delta
+
+Same wiki/7B/best-config rig (`name_ci` + chunking `(6,2)`), plain `run_wiki` (coverage / R(B) / P(B) / components):
+
+| leg | config | reads |
+|---|---|---|
+| control | best config | baseline R(B)/F1 |
+| re-prompt | + `RELATION_REPROMPT=1` | the shipped win (~R(B) 0.303 / F1 0.465) |
+| **re-prompt+REBEL** | + `RELATION_REPROMPT=1` + `REBEL_FUSE=1` | **does REBEL add on top?** |
+| REBEL-alone (optional) | + `REBEL_FUSE=1` only | REBEL's standalone relation recall vs control |
+
+- **WIN:** re-prompt+REBEL R(B)/F1 **above** re-prompt-alone, P(B) ~1.0, components not worse — REBEL found correct edges the re-prompt missed.
+- **REFUTED (redundant):** re-prompt+REBEL ≈ re-prompt-alone → REBEL overlaps what re-prompt recovers; ship default-off, relation-recall thread saturates at the re-prompt.
+- **REFUTED (harmful):** P(B) drops / components collapse → REBEL injected spurious or mis-mapped edges. P(B) + components are the guardrails (the recall-prompt lesson).
+
+The REBEL-alone leg is a cheap bonus (is REBEL competitive standalone?); the verdict hinges on the marginal delta over re-prompt.
+
+**Surface-mapping precision is the key risk.** REBEL surfaces may substring-match the wrong entity (e.g. a short head colliding with an unrelated mention), creating a false edge → P(B) drop. The exact-before-substring rule and the P(B) guardrail are the defense; if P(B) falls, that's the signal the mapping is too loose.
+
+## Testing
+
+Box-safe (injected fake REBEL, no model/network), in `packages/python/goldengraph/tests/test_rebel_fuse.py`:
+
+1. **Mapping** — fake rebel returns `[("Amazon","founded by","Jeff Bezos")]` over mentions `[Amazon/org, Jeff Bezos/person]` → one `Relationship(0,"founded by",1)`; a substring case (`"Bezos"` → `"Jeff Bezos"`) maps; case-folded.
+2. **Drop unmapped + self-loop** — a triple whose head matches no mention → dropped; a triple whose head and tail map to the same index → dropped.
+3. **Windowing** — fake rebel asserts it is called once per sentence window (reuses `sentence_windows`); triples concatenate across windows.
+4. **Gate + empty guards** — `rebel_fuse_enabled` env parsing (case-insensitive, empty-safe); empty `mentions` → `[]` with the fake rebel never called.
+5. **Wiring in `_prepare_doc`** — gate off → `rebel_fuse` not invoked (monkeypatch counter); gate on → invoked once, edges appended; a raising `rebel_fuse` preserves the first-pass extraction (not the empty-extraction fallback).
+
+Run via the goldengraph `.venv` + `PYTHONPATH` shadow, `POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 -p no:cacheprovider`. The real REBEL model is never loaded in tests (always injected).
+
+## Rollout
+
+Default-off gated feature. If the marginal delta is a WIN, the verdict records it and the gate ships opt-in (a default-on flip would need a second corpus and weighs REBEL's per-doc inference cost + the model dependency). If REFUTED (redundant or harmful), the gate still ships as an opt-in knob and the verdict closes the relation-recall thread at the re-prompt — the substrate arc then turns to cross-corpus robustness of the shipped stack (name_ci + chunking + re-prompt).

--- a/docs/superpowers/specs/2026-07-02-rebel-fuse-design.md
+++ b/docs/superpowers/specs/2026-07-02-rebel-fuse-design.md
@@ -17,7 +17,7 @@ A gated `GOLDENGRAPH_REBEL_FUSE=1` pass that runs REBEL per window over the doc,
 ## Non-goals
 
 - **No new entity nodes.** REBEL triples with an endpoint that doesn't map to an existing mention are dropped (the diagnostic proved entities aren't the gap; an unmapped endpoint can't be edged; dropping keeps precision).
-- No predicate-vocab snapping — REBEL's relation labels are kept verbatim (the substrate metric aligns on entity-pairs, not predicate strings; downstream `_maybe_canonicalize` handles them like any edge when `SCHEMA_CANON=1`).
+- No predicate-vocab snapping — REBEL's relation labels are kept verbatim (the substrate metric aligns on entity-pairs, not predicate strings). **Caveat (measurement scope):** REBEL emits Wikidata-style labels ("founded by", "country of citizenship"), which will almost never match a closed `GOLDENGRAPH_RELATION_VOCAB`. So under `GOLDENGRAPH_SCHEMA_CANON=1`, `_maybe_canonicalize` (which *drops out-of-schema edges*) would silently discard most REBEL edges — nullifying the lever. This is asymmetric with the re-prompt, which passes the vocab instruction so its edges survive canon. Therefore **the measurement rig runs `SCHEMA_CANON` off / no relation vocab** (as the chunking + re-prompt rig does), and a WIN here is claimed **only for canon-off configs**. Making REBEL edges survive a canon config would need a predicate-normalization step — out of scope for this lever (a follow-on if a canon-on deployment wants it).
 - No edge dedup (consistent with re-prompt/chunking; duplicates are benign for pair/component metrics).
 - Not a training/fine-tuning effort — off-the-shelf REBEL only.
 
@@ -54,9 +54,13 @@ Same placement rationale as the re-prompt (edges get direction/schema canonicali
 
 Reuses `rebel_extractor`'s load path (transformers `AutoModelForSeq2SeqLM` + `AutoTokenizer`, `Babelscape/rebel-large`; `transformers`+`torch` are already in the Modal image via the gliner dep). Returns a callable that, per input text: tokenize with `truncation=True, max_length=256`, `generate(max_length=256)`, `decode(skip_special_tokens=False)`, then `parse_rebel_triplets(decoded)` → `list[(head, rel, tail)]`. Cached in a module global under a `threading.Lock` (double-checked) so concurrent first-calls in the parallel prepare phase load it exactly once.
 
+**Concurrency note (perf, not correctness):** after load, the shared model's `generate` is called from up to `GOLDENGRAPH_BUILD_WORKERS` (default 8) prepare threads. Torch eval-forward is reentrant so this is correct, but it oversubscribes intra-op CPU threads — a perf wrinkle on the shared box, not a bug. Acceptable for a 19-doc measurement; a real deployment might serialize REBEL or lower the worker count.
+
 ### Windowing
 
 REBEL's ~256-token window can't hold the ~2750-char lead, so window the input: `sentence_windows(split_sentences(text), size, overlap)` (reuse `chunk_extract`'s utilities — DRY) with `GOLDENGRAPH_REBEL_SENTENCES` (default 4) / `GOLDENGRAPH_REBEL_OVERLAP` (default 1), parsed defensively (empty-string-env safe, same helper style as chunk_extract). Run REBEL per window; concatenate triples across windows.
+
+**Residual truncation (accepted).** A 4-sentence window is not *guaranteed* ≤256 tokens — a window of long sentences still hits `truncation=True, max_length=256` and silently drops tail relations. Windowing mitigates but does not eliminate this. The bias is conservative (it costs REBEL *fewer* edges, biasing toward REFUTED), so a WIN is trustworthy; if REFUTED, a smaller `REBEL_SENTENCES` is the cheap first retry before believing it. Not token-capped in v1.
 
 ### Surface → entity mapping (`_match_mention`)
 
@@ -72,7 +76,7 @@ Fail-soft at two levels (mirrors re-prompt): `rebel_fuse` returns `[]` on empty 
 
 ## Measurement — the 3-way marginal delta
 
-Same wiki/7B/best-config rig (`name_ci` + chunking `(6,2)`), plain `run_wiki` (coverage / R(B) / P(B) / components):
+Same wiki/7B/best-config rig (`name_ci` + chunking `(6,2)`, **`SCHEMA_CANON` off / no relation vocab** — see the predicate caveat in Non-goals; REBEL edges must survive to drive merges), plain `run_wiki` (coverage / R(B) / P(B) / components):
 
 | leg | config | reads |
 |---|---|---|
@@ -97,9 +101,9 @@ Box-safe (injected fake REBEL, no model/network), in `packages/python/goldengrap
 2. **Drop unmapped + self-loop** — a triple whose head matches no mention → dropped; a triple whose head and tail map to the same index → dropped.
 3. **Windowing** — fake rebel asserts it is called once per sentence window (reuses `sentence_windows`); triples concatenate across windows.
 4. **Gate + empty guards** — `rebel_fuse_enabled` env parsing (case-insensitive, empty-safe); empty `mentions` → `[]` with the fake rebel never called.
-5. **Wiring in `_prepare_doc`** — gate off → `rebel_fuse` not invoked (monkeypatch counter); gate on → invoked once, edges appended; a raising `rebel_fuse` preserves the first-pass extraction (not the empty-extraction fallback).
+5. **Wiring in `_prepare_doc`** — gate off → `rebel_fuse` not invoked (monkeypatch counter); gate on → invoked once, edges appended; a raising `rebel_fuse` preserves the first-pass extraction (not the empty-extraction fallback). For this to patch the seam without loading the real model, `ingest.py` must import `rebel_fuse` as a top-level name (`from .rebel_fuse import rebel_fuse, rebel_fuse_enabled`, mirroring the re-prompt import) so `monkeypatch.setattr(ingest, "rebel_fuse", fake)` intercepts the seam's call.
 
-Run via the goldengraph `.venv` + `PYTHONPATH` shadow, `POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 -p no:cacheprovider`. The real REBEL model is never loaded in tests (always injected).
+Run via the goldengraph `.venv` + `PYTHONPATH` shadow, `POLARS_SKIP_CPU_CHECK=1 GOLDENGRAPH_NATIVE=0 -p no:cacheprovider`. The real REBEL model is never loaded in tests (always injected or monkeypatched).
 
 ## Rollout
 

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -20,6 +20,7 @@ from .chunk_extract import chunk_extract, chunk_extract_enabled
 from .extract import Extraction, Mention
 from .extract import extract as _extract
 from .llm import LLMClient
+from .rebel_fuse import rebel_fuse, rebel_fuse_enabled
 from .relation_reprompt import relation_reprompt, relation_reprompt_enabled
 from .resolve import ResolvedEntity, _record_key
 from .resolve import resolve as _resolve
@@ -683,6 +684,13 @@ def _prepare_doc(
         if relation_reprompt_enabled():
             try:
                 extraction.relationships += relation_reprompt(text, extraction.mentions, llm)
+            except Exception:
+                pass
+        # REBEL fusion (2nd relation source): map REBEL triples onto existing entities as edges.
+        # Same before-canonicalization placement + own try/except as the re-prompt.
+        if rebel_fuse_enabled():
+            try:
+                extraction.relationships += rebel_fuse(text, extraction.mentions)
             except Exception:
                 pass
         # In discovery mode the schema isn't known until the whole corpus is extracted, so defer

--- a/packages/python/goldengraph/goldengraph/rebel_fuse.py
+++ b/packages/python/goldengraph/goldengraph/rebel_fuse.py
@@ -1,0 +1,104 @@
+"""REBEL fusion (GOLDENGRAPH_REBEL_FUSE): a distinct relation-recall lever. Runs REBEL
+(Babelscape/rebel-large, discriminative end-to-end relation extraction) per sentence-window,
+and maps each (head, rel, tail) triple's endpoints onto the ALREADY-extracted entities --
+adding an edge only when BOTH endpoints map, never a new node. Composes with (and is measured
+on top of) the relation re-prompt. Pure w.r.t. the store; REBEL injectable for tests; gate off
+by default.
+
+SCHEMA_CANON note: REBEL emits Wikidata-style predicates that a closed relation vocab won't
+contain, so under GOLDENGRAPH_SCHEMA_CANON=1 canonicalization drops them. This lever targets
+canon-off configs (see the spec)."""
+
+from __future__ import annotations
+
+import os
+import threading
+
+from .chunk_extract import _env_int, sentence_windows, split_sentences
+from .extract import Mention, Relationship
+
+_REBEL_LOCK = threading.Lock()
+_REBEL = None  # cached `text -> list[(head, rel, tail)]` callable
+
+
+def rebel_fuse_enabled() -> bool:
+    """`GOLDENGRAPH_REBEL_FUSE` gate. Off by default; case-insensitive, stripped:
+    ""/"0"/"false"/"no"/"off" -> off."""
+    return os.environ.get("GOLDENGRAPH_REBEL_FUSE", "0").strip().lower() not in (
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _rebel_params() -> tuple[int, int]:
+    """(window size, overlap) for REBEL's 256-token input; defaults (4, 1). Defensive parse."""
+    return _env_int("GOLDENGRAPH_REBEL_SENTENCES", 4), _env_int("GOLDENGRAPH_REBEL_OVERLAP", 1)
+
+
+def _load_rebel():
+    """Lazily load Babelscape/rebel-large ONCE (lock-guarded, double-checked, for the concurrent
+    prepare phase). Returns a `text -> list[(head, rel, tail)]` callable reusing the existing
+    unit-tested `extract_local.parse_rebel_triplets` decoder."""
+    global _REBEL
+    if _REBEL is not None:
+        return _REBEL
+    with _REBEL_LOCK:
+        if _REBEL is None:
+            from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+            from .extract_local import parse_rebel_triplets
+
+            tok = AutoTokenizer.from_pretrained("Babelscape/rebel-large")
+            mdl = AutoModelForSeq2SeqLM.from_pretrained("Babelscape/rebel-large")
+
+            def _triples(text: str):
+                inp = tok(text, return_tensors="pt", truncation=True, max_length=256)
+                out = mdl.generate(**inp, max_length=256)
+                return parse_rebel_triplets(tok.decode(out[0], skip_special_tokens=False))
+
+            _REBEL = _triples
+    return _REBEL
+
+
+def _match_mention(surface_lc: str, mentions: list[Mention]) -> int | None:
+    """Index of the mention whose (case-folded) name matches `surface_lc` -- exact preferred over
+    substring-either-way, lowest index breaking ties; None if none match."""
+    if not surface_lc:
+        return None
+    for i, m in enumerate(mentions):  # exact first
+        if m.name.strip().lower() == surface_lc:
+            return i
+    for i, m in enumerate(mentions):  # substring either way
+        n = m.name.strip().lower()
+        if n and (surface_lc in n or n in surface_lc):
+            return i
+    return None
+
+
+def rebel_fuse(text: str, mentions: list[Mention], *, rebel=None) -> list[Relationship]:
+    """Run REBEL per sentence-window over `text`, map triple endpoints onto `mentions`, and return
+    Relationships for triples where BOTH endpoints map and are distinct. Empty mentions -> [] (no
+    model call). Any error -> [] (fail-soft). `rebel` (injectable) is a `text -> list[(head,rel,tail)]`
+    callable; default None -> the cached real REBEL."""
+    if not mentions:
+        return []
+    try:
+        triples_fn = rebel or _load_rebel()
+        size, overlap = _rebel_params()
+        out: list[Relationship] = []
+        for window in sentence_windows(split_sentences(text), size, overlap):
+            try:
+                triples = triples_fn(window)
+            except Exception:
+                continue  # a bad window skips, never sinks the doc
+            for head, rel, tail in triples:
+                s = _match_mention(str(head).strip().lower(), mentions)
+                o = _match_mention(str(tail).strip().lower(), mentions)
+                if s is not None and o is not None and s != o:
+                    out.append(Relationship(subj=s, predicate=str(rel), obj=o))
+        return out
+    except Exception:
+        return []

--- a/packages/python/goldengraph/tests/test_rebel_fuse.py
+++ b/packages/python/goldengraph/tests/test_rebel_fuse.py
@@ -1,0 +1,71 @@
+"""GOLDENGRAPH_REBEL_FUSE: map REBEL (head,rel,tail) triples onto existing entities as edges."""
+from goldengraph.extract import Mention
+from goldengraph.rebel_fuse import rebel_fuse, rebel_fuse_enabled
+
+
+def _mentions():
+    return [Mention(name="Amazon", typ="org"), Mention(name="Jeff Bezos", typ="person")]
+
+
+def _fake_rebel(triples_per_call):
+    """Returns a callable that yields a fixed triple list on every call, recording call count."""
+    state = {"calls": 0}
+
+    def rebel(text):
+        state["calls"] += 1
+        return list(triples_per_call)
+    rebel.state = state
+    return rebel
+
+
+def test_maps_triple_to_existing_entities(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_SENTENCES", "50")  # one window over the short text
+    rebel = _fake_rebel([("Amazon", "founded by", "Jeff Bezos")])
+    rels = rebel_fuse("Amazon was founded by Jeff Bezos.", _mentions(), rebel=rebel)
+    assert len(rels) == 1
+    assert (rels[0].subj, rels[0].predicate, rels[0].obj) == (0, "founded by", 1)
+
+
+def test_substring_and_casefold_match(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_SENTENCES", "50")
+    rebel = _fake_rebel([("amazon", "employs", "Bezos")])  # cased + substring
+    rels = rebel_fuse("t.", _mentions(), rebel=rebel)
+    assert [(r.subj, r.predicate, r.obj) for r in rels] == [(0, "employs", 1)]
+
+
+def test_drops_unmapped_and_self_loops(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_SENTENCES", "50")
+    rebel = _fake_rebel([
+        ("Amazon", "rivals", "Microsoft"),   # tail maps to no mention -> dropped
+        ("Amazon", "is", "Amazon"),           # both map to 0 -> self-loop dropped
+        ("Amazon", "led by", "Jeff Bezos"),   # valid
+    ])
+    rels = rebel_fuse("t.", _mentions(), rebel=rebel)
+    assert [(r.subj, r.predicate, r.obj) for r in rels] == [(0, "led by", 1)]
+
+
+def test_runs_once_per_window(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_SENTENCES", "2")
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_OVERLAP", "0")
+    # 4 sentences, size=2 overlap=0 -> 2 windows
+    text = "S one here. S two here. S three here. S four here."
+    rebel = _fake_rebel([("Amazon", "r", "Jeff Bezos")])
+    rels = rebel_fuse(text, _mentions(), rebel=rebel)
+    assert rebel.state["calls"] == 2          # one call per window
+    assert len(rels) == 2                      # each window contributed the mapped edge
+
+
+def test_gate_enabled(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_REBEL_FUSE", raising=False)
+    assert rebel_fuse_enabled() is False
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_FUSE", "1")
+    assert rebel_fuse_enabled() is True
+    for off in ("", "0", "False", "off", " no "):
+        monkeypatch.setenv("GOLDENGRAPH_REBEL_FUSE", off)
+        assert rebel_fuse_enabled() is False, off
+
+
+def test_empty_mentions_no_rebel_call():
+    def boom(text):
+        raise AssertionError("must not be called on empty mentions")
+    assert rebel_fuse("t.", [], rebel=boom) == []

--- a/packages/python/goldengraph/tests/test_rebel_fuse.py
+++ b/packages/python/goldengraph/tests/test_rebel_fuse.py
@@ -69,3 +69,72 @@ def test_empty_mentions_no_rebel_call():
     def boom(text):
         raise AssertionError("must not be called on empty mentions")
     assert rebel_fuse("t.", [], rebel=boom) == []
+
+
+def _identity_resolver():
+    from goldengraph.resolve import ResolvedEntity
+
+    def resolver(mentions):
+        return [
+            ResolvedEntity(local_id=i, canonical_name=m.name, typ=m.typ,
+                           surface_names=[m.name], record_keys=[], member_idx=[i])
+            for i, m in enumerate(mentions)
+        ]
+    return resolver
+
+
+def test_prepare_doc_appends_rebel_edges_only_when_gated(monkeypatch):
+    import importlib
+
+    from goldengraph.extract import Extraction, Mention, Relationship
+    ingest = importlib.import_module("goldengraph.ingest")  # __init__ shadows the submodule name
+
+    calls = {"n": 0}
+
+    def base_extractor(text, llm=None):
+        return Extraction(mentions=[Mention(name="Amazon", typ="org"),
+                                    Mention(name="Jeff Bezos", typ="person")],
+                          relationships=[])
+
+    def fake_fuse(text, mentions):
+        calls["n"] += 1
+        return [Relationship(subj=0, predicate="founded by", obj=1)]
+
+    monkeypatch.setattr(ingest, "rebel_fuse", fake_fuse)
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_RELATION_REPROMPT", raising=False)
+    resolver = _identity_resolver()
+
+    # gate OFF -> no fuse, no edges
+    monkeypatch.delenv("GOLDENGRAPH_REBEL_FUSE", raising=False)
+    ex, _, _ = ingest._prepare_doc("t", llm=None, resolver=resolver, profile_fps=False,
+                                   extractor=base_extractor)
+    assert calls["n"] == 0 and len(ex.relationships) == 0
+
+    # gate ON -> fuse called once, edge appended
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_FUSE", "1")
+    ex2, _, _ = ingest._prepare_doc("t", llm=None, resolver=resolver, profile_fps=False,
+                                    extractor=base_extractor)
+    assert calls["n"] == 1 and len(ex2.relationships) == 1
+
+
+def test_prepare_doc_rebel_raise_preserves_first_pass(monkeypatch):
+    import importlib
+
+    from goldengraph.extract import Extraction, Mention, Relationship
+    ingest = importlib.import_module("goldengraph.ingest")
+
+    def base_extractor(text, llm=None):
+        return Extraction(mentions=[Mention(name="A", typ="org"), Mention(name="B", typ="org")],
+                          relationships=[Relationship(subj=0, predicate="rel", obj=1)])
+
+    def boom(text, mentions):
+        raise RuntimeError("rebel exploded")
+
+    monkeypatch.setattr(ingest, "rebel_fuse", boom)
+    monkeypatch.setenv("GOLDENGRAPH_REBEL_FUSE", "1")
+    monkeypatch.delenv("GOLDENGRAPH_CHUNK_EXTRACT", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_RELATION_REPROMPT", raising=False)
+    ex, ents, _ = ingest._prepare_doc("t", llm=None, resolver=_identity_resolver(),
+                                      profile_fps=False, extractor=base_extractor)
+    assert len(ex.mentions) == 2 and len(ex.relationships) == 1 and len(ents) == 2


### PR DESCRIPTION
## Summary

Second relation-recall lever: gated `GOLDENGRAPH_REBEL_FUSE=1` runs REBEL (Babelscape/rebel-large) per sentence-window and maps `(head, rel, tail)` triples onto the already-extracted entities, adding an edge only when both endpoints map. Measured as the marginal delta on top of the shipped re-prompt. Default-off; off-path unchanged.

## Result — REFUTED

Modal wiki/7B/best-config (SCHEMA_CANON off), 4-way:

| leg | config | R(B) | P(B) | F1(B) | components |
|---|---|---|---|---|---|
| control | best | 0.343 | 1.00 | 0.511 | 14 |
| re-prompt | +reprompt | 0.303 | 1.00 | 0.465 | 9 |
| re-prompt+REBEL | +both | 0.253 | 1.00 | **0.403** | 6 |
| REBEL-alone | +rebel | 0.343 | **0.907** | 0.498 | 11 |

1. **REBEL adds no value on top of re-prompt** — 112 F1 (0.403) is *below* 111 (0.465).
2. **REBEL breaks precision** — REBEL-alone is the only leg with P(B) < 1.0 (0.907): surface-mapping injected false edges → incorrect merges. A mechanism, not noise (the spec-flagged substring-collision risk materialized).

Relation recall closes at the re-prompt.

## The bigger finding: the substrate measurement is high-variance

This run's **control** (F1 0.511) vs the re-prompt-verdict's control (F1 0.370) — same config, ±0.14 F1 run-to-run, because the 7B extraction is sampled. Single-leg A/B deltas across this arc are underpowered; chunking + re-prompt wins should be re-confirmed with **replicated measurement + error bars** before any default-on. The REBEL refutation survives this (it rests on a precision break, not a fragile positive).

Full write-up: `docs/superpowers/reports/2026-07-02-rebel-fuse-verdict.md`.

## What ships

- New pure module `goldengraph/rebel_fuse.py` (gate + windowing + surface→entity mapping, injectable REBEL, lock-guarded cached singleton).
- One gated seam in `_prepare_doc` (after re-prompt, before `_maybe_canonicalize`, own fail-soft try/except).
- Default-off. **Not recommended** (degrades precision); ships as the tooling + the negative result + the variance finding.

## Test plan
- [x] `tests/test_rebel_fuse.py` — 8 passed (mapping, substring/casefold, drop-unmapped+self-loop, per-window, gate, empty, wiring, raise-preserves)
- [x] re-prompt + chunk regression green (33 total)
- [x] ruff clean; real REBEL model never loaded in tests (injected/monkeypatched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)