### PR TITLE
feat(goldenflow): native phone_national via canonical-NANP gate

### DIFF
--- a/docs/design/2026-07-02-goldenflow-reference-mode-spec.md
+++ b/docs/design/2026-07-02-goldenflow-reference-mode-spec.md
@@ -1,0 +1,118 @@
+# GoldenFlow reference-mode completion — decision + spec
+
+Date: 2026-07-02
+Status: **DECIDED 2026-07-02 — phone_validate = `is_possible_number` (Option B, non-breaking): fix the Rust kernel to match Python.** Spec below is the plan of record.
+Depends on: `docs/design/2026-07-01-rust-is-the-reference-roadmap.md`,
+`docs/design/2026-07-01-native-gate-audit-and-goldenflow-parity-design.md`
+
+## Goal
+
+Finish the Rust-is-the-reference arc for goldenflow: every phone transform runs the
+native kernel by default, with pure-Python as the lossy fallback. Unlike goldencheck /
+goldenanalysis (mechanical `_has_symbol` flips), goldenflow needs **real Rust work + one
+product decision**, because two of its four phone kernels are *complete-but-divergent*.
+
+## Current state (main)
+
+`_GATED_ON = {"phone"}` (family-level). Four native kernels in `native-flow/src/phone.rs`:
+
+| transform | kernel | wired native? | status |
+| --- | --- | --- | --- |
+| `phone_e164` | `phone_e164_arrow` | yes | ✅ native-default, parity-tested (~20k corpus vs `phonenumbers`) |
+| `phone_country_code` | `phone_country_code_arrow` | yes | ✅ native-default, parity-tested |
+| `phone_validate` | `phone_valid_arrow` | **no** (pure-Python) | ❌ divergent predicate — **needs the decision below** |
+| `phone_national` | `phone_national_arrow` | **no** (pure-Python) | ❌ no canonical gate for leading-1 ambiguity |
+| `phone_digits` | — (pure Polars regex) | n/a | ✅ already fast; no kernel warranted |
+
+So goldenflow is *already* native-default for its faithful surface. This spec closes the
+two remaining transforms.
+
+## THE DECISION — `phone_validate` validity semantic
+
+The kernel and the Python reference compute **different things**:
+
+- **Python (`phone.py:112`)**: `phonenumbers.is_possible_number(parsed)` — a **length-only**
+  check. Permissive: "could this be a phone number by digit count for the region."
+- **Rust (`phone.rs:102`)**: `phonenumber::is_valid(&n)` — **full metadata validation**
+  (length + prefix + region assignment rules). Strict: "is this an actually-assignable
+  number." Strictly stricter than `is_possible_number`.
+
+Plus a secondary difference: the kernel returns **null** on parse failure; Python returns
+**False**. (Reconcilable in the bridge either way; not the crux.)
+
+Under reference mode the native result becomes the spec, so we must pick which semantic
+`phone_validate` *should* mean. This is a product call, not a code detail:
+
+- **Option A — `is_valid` (strict) is the spec.** A "valid phone" means a real, assignable
+  number. Better for data-quality/ER (catches right-length-but-fake numbers). **Breaking**:
+  numbers currently `True` that are possible-but-not-valid flip to `False`. Fix Python to
+  call `is_valid`; wire the kernel as-is; parity test; document + version bump.
+- **Option B — `is_possible_number` (permissive) is the spec.** Keep today's Python behavior
+  as the reference. **Non-breaking** for existing users. The *kernel* is then "wrong" and
+  must be fixed: change `phone.rs:102` to the crate's possible-length API to match; then wire
+  + parity test.
+- **Option C — expose both.** `phone_validate(strict=False)` (possible) vs `strict=True`
+  (valid). Most flexible; largest surface; defers the default question.
+
+Recommendation: **Option B** unless you specifically want stricter validation. Rationale:
+(1) it's non-breaking (`is_possible_number` stays the default meaning of "validate"), (2) it
+keeps goldenflow's `phone_validate` a *permissive* filter (callers who want strict validity
+already have `phone_country_code` + downstream rules), (3) "possible" is the lower-surprise
+default for a transform named `validate` on messy input. If you value strict validity as the
+product stance, Option A is defensible and cleaner long-term — just breaking.
+
+**DECISION (2026-07-02): Option B.** `phone_validate` stays `is_possible_number`; the Rust
+kernel is fixed to match. Non-breaking → minor version bump, `GOLDENFLOW_NATIVE=0` escape hatch.
+
+## Spec — implementation per transform (once the decision lands)
+
+### 1. `phone_validate` — BLOCKED by the crate; stays pure-Python (RESOLVED 2026-07-02)
+**Finding:** `phonenumber` 0.3.9 exposes **no public `is_possible_number`** — only `is_valid`
+(lib.rs:56 re-exports `is_valid`/`is_valid_with`/`is_viable`/`Validation`; the
+`validator::length(meta, ParseNumber, Type) -> Validation` fn that would compute it is private
+and takes internal types, not a `PhoneNumber`). `PhoneNumber` has `is_valid` but no
+`is_possible`.
+
+Under the Option-B decision (`is_possible` is the spec), there is **no faithful native kernel
+we can build without vendoring libphonenumber's length tables** (fragile, would drift). So the
+reference-mode-correct outcome is: **`phone_validate` stays pure-Python** (native only where a
+faithful kernel exists — same class as `phone_digits`). This requires **no code change** — it
+is already pure-Python (`phone.py:114` `map_elements`, no `native_fn`).
+
+Cleanup (optional, low priority): the existing `phone_valid_arrow` (is_valid) kernel is unwired
+dead code that computes the wrong semantic for the spec. It is not reachable from Python
+(`phone_validate` has no native wiring, so even `GOLDENFLOW_NATIVE=1` never calls it). Leave it,
+or drop it from `native-flow` in a later cleanup; not load-bearing either way.
+
+(If we ever want native validate, the path is either upgrading to a `phonenumber` release that
+exposes `is_possible`, or re-deciding to Option A / adding a `strict=` param — a separate call.)
+
+### 2. `phone_national` (second — needs a canonical gate)
+- The divergence is leading-1 ambiguity with no cheap canonical form (unlike E.164's
+  `^\+1[2-9]\d{9}$` at `_native.py:56`). Design a canonical-NANP national-format acceptance
+  predicate — e.g. accept only `(NXX) NXX-XXXX`-shaped country-code-1 output; null the rest
+  so tier-3 Python settles them (same shape as the E.164 path).
+- Add `phone_national_native()` in `_native.py` with that null-out; wire into `phone_national`
+  (`phone.py:76`).
+- Full-corpus parity test. Higher risk than validate because the safe residual is narrower.
+
+### 3. `phone_digits` — no change (pure Polars, already fast).
+
+### Out of scope
+- International (non-NANP) parity: blocked by the hardcoded `_DEFAULT_REGION = "US"`
+  (`_native.py:22`) + the `+CC`-with-US-default national-prefix mis-strip. Threading a
+  per-row default region is a larger, separate change.
+
+## Version + gate posture
+- Wiring `phone_validate` + `phone_national` native makes them native-default → an output
+  change on those transforms for native-wheel users. **Minor bump** with a `GOLDENFLOW_NATIVE=0`
+  escape-hatch note (matches how the FS flip shipped as goldenmatch 2.6.0), unless Option A is
+  chosen for validate (then call out the breaking validity change explicitly).
+- The loader docstring's "`=1` WILL change outputs" warning gets updated once both kernels are
+  faithful (no remaining divergence under the `"phone"` gate).
+
+## Sequencing
+1. Decide the `phone_validate` semantic (A / B / C).
+2. Ship `phone_validate` (Rust fix or Python realign per the decision) + wiring + parity test.
+3. Ship `phone_national` (canonical gate) + wiring + parity test.
+4. Update loader docstring; minor version bump; done → goldenflow is reference-mode complete.

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -7,12 +7,14 @@ parity gate — the pure-Python transform paths run unchanged.
 
 ``GOLDENFLOW_NATIVE`` env:
 - ``"0"``    -> force the Python path (never use native).
-- ``"1"``    -> require native; raise if it isn't importable. This is the
-  parity/opt-in lane: it enables native for ALL components regardless of
-  ``_GATED_ON``, so it WILL change outputs where native diverges from the
-  Python reference (see below). Use only when you accept that.
+- ``"1"``    -> require native; raise if it isn't importable (CI parity lane).
 - ``"auto"`` / unset -> use native iff it's importable AND the component is in
-  ``_GATED_ON`` (signed off on parity). Default.
+  ``_GATED_ON``. Default. All wired phone transforms (``phone_e164``,
+  ``phone_country_code``, ``phone_national``) are canonical-NANP-gated and
+  byte-identical to ``phonenumbers`` over the corpus, so both ``auto`` and ``=1``
+  are output-faithful. (``phone_validate`` stays pure-Python -- the ``phonenumber``
+  Rust crate exposes no ``is_possible_number``; see the goldenflow reference-mode
+  spec. ``phone_digits`` is pure Polars.)
 
 The kernel is reachable two ways, tried in order, exactly like goldenmatch:
   1. ``goldenflow._native``        — in-tree build (scripts/build_native.py).

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -69,6 +69,30 @@ def phone_e164_native() -> Callable[[pl.Series], pl.Series] | None:
     return run
 
 
+# Canonical NANP NATIONAL format: "(NXX) NXX-XXXX", area/exchange codes 2-9 (a
+# valid NANP number). The same gate idea as E.164: native and phonenumbers agree
+# on this well-formed shape; the ambiguous leading-1 inputs the loader comment
+# worried about produce a non-canonical shape (or a 1-leading area code) that
+# fails this regex and is nulled for tier-3 Python to settle. So national IS
+# gate-able after all -- the residual is just narrower than E.164's.
+_CANONICAL_NANP_NATIONAL = r"^\([2-9]\d{2}\) [2-9]\d{2}-\d{4}$"
+
+
+def phone_national_native() -> Callable[[pl.Series], pl.Series] | None:
+    inner = _kernel_runner("phone_national_arrow")
+    if inner is None:
+        return None
+
+    def run(s: pl.Series) -> pl.Series:
+        out = inner(s)
+        # Keep only canonical NANP national format; null the rest for Python.
+        return out.set(
+            ~out.str.contains(_CANONICAL_NANP_NATIONAL).fill_null(False), None
+        )
+
+    return run
+
+
 def phone_country_code_native() -> Callable[[pl.Series], pl.Series] | None:
     # Safe under nanp_only: native and phonenumbers agree on the country code
     # (1) for every NANP row; the leading-1 ambiguity only affects the national

--- a/packages/python/goldenflow/goldenflow/transforms/phone.py
+++ b/packages/python/goldenflow/goldenflow/transforms/phone.py
@@ -8,6 +8,7 @@ from goldenflow.transforms._fastpath import _V, apply_with_residual
 from goldenflow.transforms._native import (
     phone_country_code_native,
     phone_e164_native,
+    phone_national_native,
 )
 
 _DEFAULT_REGION = "US"
@@ -82,10 +83,17 @@ def phone_national(series: pl.Series) -> pl.Series:
             return val
         return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.NATIONAL)
 
-    # No native path: the Rust port's national formatting diverges from
-    # phonenumbers on ambiguous leading-1 inputs (e.g. "1234567890"), and unlike
-    # E.164 there's no cheap canonical-form check to gate on. Stays pure Python.
-    return series.map_elements(_format, return_dtype=pl.Utf8)
+    # Native NANP national format, gated to the canonical "(NXX) NXX-XXXX" shape
+    # (phone_national_native nulls the ambiguous leading-1 outputs so tier-3
+    # Python settles them). No Polars fast expr -- a no-op lit + the Python
+    # residual, same shape as phone_country_code.
+    return apply_with_residual(
+        series,
+        pl.lit(None, dtype=pl.Utf8),
+        _format,
+        pl.Utf8,
+        native_fn=phone_national_native(),
+    )
 
 
 @register_transform(

--- a/packages/python/goldenflow/tests/transforms/test_native_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_native_parity.py
@@ -30,7 +30,11 @@ if not native_available():
 pa = pytest.importorskip("pyarrow")
 
 from goldenflow.transforms._native import phone_e164_native  # noqa: E402
-from goldenflow.transforms.phone import phone_country_code, phone_e164  # noqa: E402
+from goldenflow.transforms.phone import (  # noqa: E402
+    phone_country_code,
+    phone_e164,
+    phone_national,
+)
 
 # Use whichever kernel the loader resolved (in-tree build shadows the wheel).
 _native = native_module()
@@ -54,6 +58,16 @@ def _ref_cc(v):
     except phonenumbers.NumberParseException:
         return None
     return p.country_code
+
+
+def _ref_national(v):
+    if v is None:
+        return None
+    try:
+        p = phonenumbers.parse(v, "US")
+    except phonenumbers.NumberParseException:
+        return v  # phone_national preserves the original string on parse failure
+    return phonenumbers.format_number(p, phonenumbers.PhoneNumberFormat.NATIONAL)
 
 
 def _corpus(n=20000):
@@ -118,6 +132,16 @@ def test_phone_country_code_parity_with_native(monkeypatch):
     vals = _corpus()
     got = phone_country_code(pl.Series("ph", vals)).to_list()
     assert got == [_ref_cc(v) for v in vals]
+
+
+def test_phone_national_parity_with_native(monkeypatch):
+    """End-to-end NATIONAL == pure phonenumbers across the full corpus, native on.
+    Native resolves canonical "(NXX) NXX-XXXX"; the ambiguous residual falls to
+    Python via the canonical-form gate."""
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
+    vals = _corpus()
+    got = phone_national(pl.Series("ph", vals)).to_list()
+    assert got == [_ref_national(v) for v in vals]
 
 
 def test_native_actually_resolves_residual(monkeypatch):


### PR DESCRIPTION
## What

Wires `phone_national` to run native by default, closing the last goldenflow reference-mode gap. It was pure-Python because the Rust national formatting diverges from `phonenumbers` on ambiguous leading-1 inputs, and the code assumed "no cheap canonical-form check" existed. **It does** — valid NANP national format is `(NXX) NXX-XXXX` (area/exchange codes 2-9), exactly as gate-able as E.164's `^\+1[2-9]\d{9}$`.

`phone_national_native()` runs the existing `phone_national_arrow` kernel and **nulls any non-canonical output** so tier-3 Python settles the ambiguous residual — same pattern as `phone_e164_native`.

## Non-breaking

**Output-identical** — byte-for-byte vs `phonenumbers` over the full 20k corpus. Verified **locally** (maturin build of `goldenflow-native` + the parity suite — 6/6 pass). No version bump. Python-only change; the kernel already shipped.

## Scope of the goldenflow wave (from the spec)

- `phone_e164`, `phone_country_code`: already native (on main).
- **`phone_national`: this PR** — now native-default, canonical-gated.
- `phone_validate`: stays Python — the `phonenumber` Rust crate exposes no `is_possible_number` (only `is_valid`), so under the Option-B decision (`is_possible` is the spec) there's no faithful native kernel. Reference-mode-correct.
- `phone_digits`: pure Polars (already fast).

Loader docstring updated: all wired phone transforms are now canonical-gated faithful, so `auto` and `=1` are both output-faithful.

Spec: `docs/design/2026-07-02-goldenflow-reference-mode-spec.md` (committed earlier on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)