### PR TITLE
fix(autoconfig): discriminative-power veto for exact matchkeys (#1351)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-discriminative-veto.md
+++ b/docs/superpowers/plans/2026-07-02-discriminative-veto.md
@@ -1,0 +1,590 @@
+# Discriminative-power veto for exact matchkeys (#1351) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `AutoConfigController` from committing a standalone `exact` matchkey on high-density locality columns (e.g. `zip`) by vetoing any proposed exact key whose shared-value records don't co-agree on other identity fields — without regressing genuine identity keys (`npi`, `email`).
+
+**Architecture:** A new, isolated estimator module computes each candidate exact key's *discriminative power* (mean co-agreement of shared-value record pairs across a basket of *other identity-typed* columns). `build_matchkeys` calls a veto helper at the exact-matchkey gate: demote (skip) the exact key when support is sufficient AND co-agreement is below a threshold. Veto-only — never promotes; leaves classification and blocking untouched. Fail-safe = keep on thin evidence, so near-unique identity keys (few shared-value pairs) are auto-protected.
+
+**Tech Stack:** Python, Polars, pytest. Target file `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`; new module `autoconfig_discriminative.py`. Spec: `docs/superpowers/specs/2026-07-02-discriminative-power-veto-design.md`.
+
+**Hard environment constraints:**
+- Test runner: `UV=/c/Users/bsevern/AppData/Local/Programs/Python/Python312/Scripts/uv.exe && "$UV" run --package goldenmatch --extra dev python -m pytest <files> -q`
+- Local quality gate (Windows needs utf-8): `GOLDENMATCH_AUTOCONFIG_MEMORY=0 PYTHONUTF8=1 PYTHONIOENCODING=utf-8 "$UV" run python -m scripts.autoconfig_quality gate` (run from repo root, ~1 min).
+- **NEVER** run the full pytest suite, `test_autoconfig_benchmarks.py`, `dedupe_df` on large data, or native builds — they OOM this machine. Only targeted unit tests + the quality gate.
+- If `uv.lock` drifts from `uv run`, `git checkout -- uv.lock` (don't commit it).
+- Lint: `"$UV" run --package goldenmatch --extra dev ruff check <files>` and `"$UV" run pyright` (autoconfig.py is in the pyright slice — the new module should be too or kept type-clean).
+
+---
+
+## File Structure
+
+- **Create:** `packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py` — the estimator + veto decision. One responsibility: "should this proposed exact key be vetoed?" Pure functions over a Polars frame + the profile list. No imports from `autoconfig.py` (avoid cycles); it may import `ColumnProfile` only if needed via `TYPE_CHECKING`.
+- **Modify:** `packages/python/goldenmatch/goldenmatch/core/autoconfig.py` — call the veto helper inside `build_matchkeys`'s exact-matchkey gate loop (~line 1108, alongside the floor/surrogate gates). ~5 lines.
+- **Create:** `packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py` — unit tests for the estimator + veto decision.
+- **Create:** `packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py` — build_matchkeys-level tests (zip vetoed, npi kept, df=None no-op).
+
+Basket taxonomy (from the classifier `col_type` set `{email, name, multi_name, phone, zip, address, geo, identifier, description, numeric, date, string, year}`):
+- **Identity basket (co-agree against):** `{name, multi_name, email, phone, identifier}`.
+- **Excluded** (locality/attribute/non-discriminative): everything else, notably `{zip, geo, address}`.
+
+---
+
+## Task 1: Estimator module — constants, env knobs, `identity_basket`
+
+**Files:**
+- Create: `packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py`
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py`
+
+- [ ] **Step 1: Write failing tests for `identity_basket`**
+
+```python
+# test_autoconfig_discriminative_1351.py
+from dataclasses import dataclass
+from goldenmatch.core import autoconfig_discriminative as disc
+
+
+@dataclass
+class _P:  # minimal stand-in for ColumnProfile (only .name/.col_type used)
+    name: str
+    col_type: str
+
+
+def test_identity_basket_includes_identity_types_excludes_locality():
+    profiles = [
+        _P("zip", "zip"), _P("first_name", "name"), _P("last_name", "name"),
+        _P("email", "email"), _P("npi", "identifier"), _P("city", "geo"),
+        _P("notes", "description"),
+    ]
+    basket = disc.identity_basket("zip", profiles)
+    assert set(basket) == {"first_name", "last_name", "email", "npi"}
+    # candidate itself excluded; geo/description excluded
+    assert "zip" not in basket and "city" not in basket and "notes" not in basket
+
+
+def test_identity_basket_excludes_the_candidate_even_if_identity_typed():
+    profiles = [_P("npi", "identifier"), _P("email", "email")]
+    assert disc.identity_basket("npi", profiles) == ["email"]
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `"$UV" run --package goldenmatch --extra dev python -m pytest packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py -q`
+Expected: FAIL (module / function not found).
+
+- [ ] **Step 3: Create the module skeleton + `identity_basket`**
+
+```python
+# packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
+"""Discriminative-power veto for exact/identity matchkeys (#1351).
+
+Cardinality cannot separate a shared identity key (``npi``: records sharing a
+value are the SAME entity) from a shared locality attribute (``zip``: records
+sharing a value are DIFFERENT people in one area) -- both have moderate
+cardinality. This module measures, from the data, whether records that SHARE a
+candidate value also AGREE on other identity fields. Low co-agreement => the
+value is a locality/attribute, not an identity key => veto its standalone exact
+matchkey (demote to blocking-only). Veto-only; never promotes.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import polars as pl
+
+# col_type values that are identity signals we co-agree AGAINST. Locality /
+# attribute / non-discriminative types are excluded -- including zip/geo/address
+# would let same-locality pairs spuriously co-agree and defeat the veto.
+_IDENTITY_BASKET_TYPES = frozenset({"name", "multi_name", "email", "phone", "identifier"})
+
+_TAU_DEFAULT = 0.5
+_MIN_SHARED_PAIRS = 20
+_MAX_PAIRS = 200
+
+
+def veto_enabled() -> bool:
+    """Kill-switch: GOLDENMATCH_DISCRIMINATIVE_VETO=0 disables the veto."""
+    return os.environ.get("GOLDENMATCH_DISCRIMINATIVE_VETO", "1") != "0"
+
+
+def tau() -> float:
+    """Co-agreement floor below which an exact key is vetoed (env-overridable)."""
+    raw = os.environ.get("GOLDENMATCH_DISCRIMINATIVE_TAU")
+    if raw is None:
+        return _TAU_DEFAULT
+    try:
+        val = float(raw)
+    except (ValueError, TypeError):
+        return _TAU_DEFAULT
+    return val if 0.0 <= val <= 1.0 else _TAU_DEFAULT
+
+
+def identity_basket(candidate_col: str, profiles: list[Any]) -> list[str]:
+    """Other columns whose col_type is an identity signal (excludes candidate).
+
+    ``profiles`` items need only ``.name`` and ``.col_type`` attributes.
+    """
+    return [
+        p.name
+        for p in profiles
+        if p.name != candidate_col and getattr(p, "col_type", None) in _IDENTITY_BASKET_TYPES
+    ]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: same pytest command as Step 2. Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
+git commit -m "feat(autoconfig): discriminative-veto module skeleton + identity_basket (#1351)"
+```
+
+---
+
+## Task 2: `discriminative_power` estimator
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py`
+- Test: `packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+import polars as pl
+from goldenmatch.core import autoconfig_discriminative as disc
+
+
+def _zip_like_df(n=300):
+    # 30 zips x 10 rows each; each row a DIFFERENT person (names all unique)
+    zips = [f"{10000 + (i % 30):05d}" for i in range(n)]
+    names = [f"person{i}" for i in range(n)]   # unique -> shared-zip pairs disagree
+    return pl.DataFrame({"zip": zips, "name": names})
+
+
+def _npi_like_df(n=300):
+    # 30 providers x 10 rows each; rows for the SAME npi share the SAME name
+    npis = [f"{1000000000 + (i % 30)}" for i in range(n)]
+    names = [f"provider{i % 30}" for i in range(n)]  # shared-npi pairs agree
+    return pl.DataFrame({"npi": npis, "name": names})
+
+
+def test_discriminative_power_low_for_shared_locality():
+    df = _zip_like_df()
+    power, support = disc.discriminative_power(df, "zip", ["name"])
+    assert support >= disc._MIN_SHARED_PAIRS
+    assert power < 0.5
+
+
+def test_discriminative_power_high_for_shared_identity():
+    df = _npi_like_df()
+    power, support = disc.discriminative_power(df, "npi", ["name"])
+    assert support >= disc._MIN_SHARED_PAIRS
+    assert power > 0.9
+
+
+def test_discriminative_power_zero_support_when_all_unique():
+    df = pl.DataFrame({"id": [str(i) for i in range(100)], "name": [f"n{i}" for i in range(100)]})
+    power, support = disc.discriminative_power(df, "id", ["name"])
+    assert support == 0  # no value shared -> no pairs to measure
+
+
+def test_discriminative_power_empty_basket_zero():
+    df = _zip_like_df()
+    power, support = disc.discriminative_power(df, "zip", [])
+    assert (power, support) == (0.0, 0)
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `"$UV" run --package goldenmatch --extra dev python -m pytest packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py -q`
+Expected: FAIL (`discriminative_power` not defined).
+
+- [ ] **Step 3: Implement `discriminative_power`**
+
+```python
+def _norm(v: Any) -> str | None:
+    """Normalize a cell for equality: str -> stripped lower; blank/None -> None."""
+    if v is None:
+        return None
+    s = str(v).strip().lower()
+    return s or None
+
+
+def discriminative_power(
+    df: pl.DataFrame,
+    candidate_col: str,
+    basket: list[str],
+    *,
+    max_pairs: int = _MAX_PAIRS,
+) -> tuple[float, int]:
+    """Mean co-agreement over shared-value pairs, and the support (n pairs measured).
+
+    Groups ``df`` by ``candidate_col``; for value-groups with >=2 rows, forms up
+    to ``max_pairs`` record-pairs deterministically (row 0 paired with rows
+    1..k-1 within each group, groups visited in sorted-value order). For each
+    pair, agreement = (# basket fields where BOTH cells are non-null and
+    normalized-equal) / (# basket fields where BOTH are non-null); pairs with no
+    jointly-populated basket field are skipped. Returns (mean agreement over
+    measured pairs, count of measured pairs). (0.0, 0) if basket empty, candidate
+    absent, or no measurable shared-value pair exists.
+    """
+    if not basket or candidate_col not in df.columns:
+        return 0.0, 0
+    keep = [candidate_col, *[c for c in basket if c in df.columns]]
+    if len(keep) < 2:
+        return 0.0, 0
+    sub = df.select(keep)
+    basket_cols = keep[1:]
+
+    # group rows (as normalized candidate value -> list of row dicts), skipping
+    # null/blank candidate values; deterministic sorted-value iteration.
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for row in sub.iter_rows(named=True):
+        cv = _norm(row[candidate_col])
+        if cv is None:
+            continue
+        groups.setdefault(cv, []).append(row)
+
+    total = 0.0
+    measured = 0
+    for cv in sorted(groups):
+        rows = groups[cv]
+        if len(rows) < 2 or measured >= max_pairs:
+            continue
+        anchor = rows[0]
+        for other in rows[1:]:
+            if measured >= max_pairs:
+                break
+            agree = 0
+            comparable = 0
+            for c in basket_cols:
+                a, b = _norm(anchor[c]), _norm(other[c])
+                if a is None or b is None:
+                    continue
+                comparable += 1
+                if a == b:
+                    agree += 1
+            if comparable == 0:
+                continue
+            total += agree / comparable
+            measured += 1
+    if measured == 0:
+        return 0.0, 0
+    return total / measured, measured
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: same pytest command. Expected: all pass (the earlier basket tests too).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
+git commit -m "feat(autoconfig): discriminative_power co-agreement estimator (#1351)"
+```
+
+---
+
+## Task 3: `should_veto_exact` decision (kill-switch, support, tau, df=None)
+
+**Files:**
+- Modify: `autoconfig_discriminative.py`
+- Test: `test_autoconfig_discriminative_1351.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_should_veto_zip_true():
+    df = _zip_like_df()
+    profiles = [_P("zip", "zip"), _P("name", "name")]
+    assert disc.should_veto_exact(df, "zip", profiles) is True
+
+
+def test_should_veto_npi_false():
+    df = _npi_like_df()
+    profiles = [_P("npi", "identifier"), _P("name", "name")]
+    assert disc.should_veto_exact(df, "npi", profiles) is False
+
+
+def test_should_veto_thin_support_false():
+    # all-unique candidate -> no shared pairs -> insufficient support -> keep
+    df = pl.DataFrame({"id": [str(i) for i in range(100)], "name": [f"n{i}" for i in range(100)]})
+    profiles = [_P("id", "identifier"), _P("name", "name")]
+    assert disc.should_veto_exact(df, "id", profiles) is False
+
+
+def test_should_veto_df_none_false():
+    profiles = [_P("zip", "zip"), _P("name", "name")]
+    assert disc.should_veto_exact(None, "zip", profiles) is False
+
+
+def test_should_veto_empty_basket_false():
+    df = _zip_like_df()
+    profiles = [_P("zip", "zip")]  # no identity columns -> empty basket
+    assert disc.should_veto_exact(df, "zip", profiles) is False
+
+
+def test_should_veto_kill_switch_false(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_DISCRIMINATIVE_VETO", "0")
+    df = _zip_like_df()
+    profiles = [_P("zip", "zip"), _P("name", "name")]
+    assert disc.should_veto_exact(df, "zip", profiles) is False
+```
+
+(`_P` is the dataclass from Task 1; ensure `_zip_like_df`/`_npi_like_df` are module-level in the test file.)
+
+- [ ] **Step 2: Run to verify fail**
+
+Expected: FAIL (`should_veto_exact` not defined).
+
+- [ ] **Step 3: Implement `should_veto_exact`**
+
+```python
+def should_veto_exact(
+    df: pl.DataFrame | None,
+    candidate_col: str,
+    profiles: list[Any],
+    *,
+    min_shared_pairs: int = _MIN_SHARED_PAIRS,
+    max_pairs: int = _MAX_PAIRS,
+) -> bool:
+    """True => demote the proposed standalone exact matchkey on ``candidate_col``.
+
+    Fail-safe = keep (return False) on: kill-switch off, ``df is None``, empty
+    identity basket, or insufficient shared-value support. Only vetoes a
+    high-density column whose shared-value pairs measurably fail to co-agree on
+    other identity fields (support >= min_shared_pairs AND power < tau()).
+    """
+    if not veto_enabled() or df is None:
+        return False
+    basket = identity_basket(candidate_col, profiles)
+    if not basket:
+        return False
+    power, support = discriminative_power(df, candidate_col, basket, max_pairs=max_pairs)
+    if support < min_shared_pairs:
+        return False
+    return power < tau()
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 5: ruff + pyright on the new module**
+
+Run: `"$UV" run --package goldenmatch --extra dev ruff check packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py` and `"$UV" run pyright` (add the new module to `pyrightconfig.json` `include` if the slice is enforced and it isn't picked up; keep it type-clean either way).
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(autoconfig): should_veto_exact decision + fail-safes (#1351)"
+```
+
+---
+
+## Task 4: Wire the veto into `build_matchkeys`
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py` (exact-matchkey gate loop, ~line 1108, near the `_exact_floor` gate and the `>= 1.0` surrogate gate)
+- Test: `packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py`
+
+**Context:** In `build_matchkeys(profiles, df=None, *, multi_source=False)`, the per-field loop appends columns to `exact_fields` after passing the zip/geo guard (~1089), the `_exact_floor` gate (~1108), and the `>= 1.0` surrogate gate. Add a veto check in that loop: when a column would otherwise become an exact field, call `should_veto_exact(df, p.name, profiles)`; if True, add to `skipped_exact` with a reason and `continue` (mirror the existing skip branches). Import at top: `from goldenmatch.core.autoconfig_discriminative import should_veto_exact`.
+
+- [ ] **Step 1: Write failing test at the build_matchkeys level**
+
+```python
+# test_build_matchkeys_veto_1351.py
+import polars as pl
+from goldenmatch.core.autoconfig import build_matchkeys, ColumnProfile
+
+
+def _exact_fields(mks):
+    return {f.field for mk in mks if mk.type == "exact" for f in mk.fields if f.field}
+
+
+def _mk_profiles(specs):  # specs: list[(name, col_type, cardinality_ratio)]
+    return [
+        ColumnProfile(name=n, dtype="str", col_type=t, confidence=0.9,
+                      sample_values=["x"], null_rate=0.0, cardinality_ratio=c, avg_len=6.0)
+        for (n, t, c) in specs
+    ]
+
+
+def test_zip_promoted_to_identifier_is_vetoed_from_exact():
+    # zip mis-typed as identifier (the sample-inflation reclassification), high
+    # sample cardinality so it would clear the exact floor; df shows shared zips
+    # whose sharers DISagree on name -> veto.
+    profiles = _mk_profiles([("zip", "identifier", 0.96), ("first_name", "name", 0.9),
+                             ("last_name", "name", 0.9)])
+    n = 400
+    df = pl.DataFrame({
+        "zip": [f"{10000 + (i % 40):05d}" for i in range(n)],
+        "first_name": [f"fn{i}" for i in range(n)],
+        "last_name": [f"ln{i}" for i in range(n)],
+    })
+    assert "zip" not in _exact_fields(build_matchkeys(profiles, df=df))
+
+
+def test_npi_identifier_is_kept_as_exact():
+    profiles = _mk_profiles([("npi", "identifier", 0.9), ("first_name", "name", 0.9)])
+    n = 400
+    df = pl.DataFrame({
+        "npi": [f"{1000000000 + (i % 40)}" for i in range(n)],
+        "first_name": [f"fn{i % 40}" for i in range(n)],  # shared-npi sharers agree
+    })
+    assert "npi" in _exact_fields(build_matchkeys(profiles, df=df))
+
+
+def test_df_none_is_noop_keep():
+    # with no df the veto can't run; behavior identical to pre-#1351
+    profiles = _mk_profiles([("email", "identifier", 0.9)])
+    mks = build_matchkeys(profiles, df=None)
+    assert "email" in _exact_fields(mks)
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `"$UV" run --package goldenmatch --extra dev python -m pytest packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py -q`
+Expected: `test_zip_...` FAILS (zip currently emitted as exact); the npi/df-none tests may already pass.
+
+- [ ] **Step 3: Add the veto to the exact-field gate loop**
+
+In `autoconfig.py`, add the import near the other `goldenmatch.core.*` imports, then in the per-field loop, immediately AFTER the `>= 1.0` surrogate-key gate and BEFORE the column is recorded as an exact field, insert:
+
+```python
+        # #1351: discriminative-power veto. A column that clears the cardinality
+        # gates can still be a shared LOCALITY attribute (e.g. a zip mis-promoted
+        # to "identifier") rather than an identity key. Veto its exact matchkey
+        # when records sharing its value don't co-agree on other identity fields.
+        # Fail-safe keep (df is None / thin support / empty basket) is handled
+        # inside should_veto_exact, so near-unique identity keys are unaffected.
+        if scorer == "exact" and should_veto_exact(df, p.name, profiles):
+            reason = "discriminative-power veto: shared-value records do not co-agree on identity fields"
+            logger.warning("Skipping exact matchkey for '%s' (%s).", p.name, reason)
+            skipped_exact.append((p.name, reason))
+            continue
+```
+
+(Match the exact variable names in that loop — `p`, `scorer`, `skipped_exact`. If the loop uses a different accumulation than `skipped_exact`, mirror whatever the adjacent floor/surrogate skip branches do.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: same as Step 2. Expected: all 3 pass.
+
+- [ ] **Step 5: Confirm no regression on the existing exact-matchkey unit tests**
+
+Run: `"$UV" run --package goldenmatch --extra dev python -m pytest packages/python/goldenmatch/tests/test_exact_matchkey_floor_s3.py packages/python/goldenmatch/tests/test_autoconfig_pincer_715.py packages/python/goldenmatch/tests/test_autoconfig.py -q`
+Expected: all pass, none modified. (These build profiles with `df=None` or fully-distinct `_df_with`, so the veto is a no-op keep for them.)
+
+- [ ] **Step 6: ruff + pyright**
+
+Run ruff + pyright on `autoconfig.py`. Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "feat(autoconfig): wire discriminative-power veto into build_matchkeys (#1351)"
+```
+
+---
+
+## Task 5: Validate + tune against the local quality gate
+
+**Files:** none (validation + possible constant tuning in `autoconfig_discriminative.py`)
+
+- [ ] **Step 1: Run the local quality gate**
+
+Run (from repo root `D:\ER\gm-1351`):
+```
+GOLDENMATCH_AUTOCONFIG_MEMORY=0 PYTHONUTF8=1 PYTHONIOENCODING=utf-8 "$UV" run python -m scripts.autoconfig_quality gate 2>&1 | grep -vE "score_buckets|bucket_score|keyed|bucketed|partition|ready for scoring|starting bucket" | tail -50
+```
+Expected target: `verdict: PASS`. Specifically:
+- `anchor_sparse_zip`: `exact_matchkeys` stays `['email', 'npi']`, `classification.npi` / `classification.phone_number` unchanged (still `identifier`), blocking unchanged.
+- `ncvr_synthetic` / `historical_50k`: F1 within tolerance of the main baseline (no regression).
+
+- [ ] **Step 2: If any FAIL, diagnose and tune**
+
+- If a genuine identity key is vetoed (e.g. an anchor's `npi`/`email` disappears from `exact_matchkeys`): its shared-value pairs are under-agreeing or support is over-counted. Options in order of preference: raise `_MIN_SHARED_PAIRS` (require more evidence), lower `tau` (require stronger disagreement to veto), or check the basket (are other identity columns being mis-typed, shrinking the basket?). Adjust the module constant, re-run.
+- If `zip` is NOT vetoed where expected: lower `_MIN_SHARED_PAIRS` or raise `tau`, or confirm the basket is non-empty for that dataset.
+- Re-run the gate after each change. Do NOT loosen a real regression away — the goal is `anchor` identity keys kept AND `zip`-class vetoed.
+
+- [ ] **Step 3: Commit any tuning**
+
+```bash
+git checkout -- uv.lock 2>/dev/null; git add -A && git commit -m "chore(autoconfig): tune discriminative-veto thresholds against quality gate (#1351)"
+```
+(Skip the commit if no tuning was needed.)
+
+---
+
+## Task 6: Regression anchor for the DERM zip shape (stretch — inspect harness first)
+
+**Files:**
+- Investigate: `scripts/autoconfig_quality/` (anchor definitions + fixture format)
+- Possibly Create/Modify: an anchor fixture + expectation
+
+- [ ] **Step 1: Inspect how anchors are defined**
+
+Read `scripts/autoconfig_quality/` to find where anchors (e.g. `anchor_sparse_zip`) and their expected metrics live. Determine whether a new anchor is a fixture file + an expectations entry, and whether it runs within the gate's fast budget.
+
+- [ ] **Step 2: If cheap to add, add a `anchor_zip_dense` anchor**
+
+A synthetic person dataset (a few thousand rows) with a `zip` column dense enough that the promotion would emit `exact[zip]` absent the veto, plus name/email/npi columns. Expectation: `zip` NOT in `exact_matchkeys`; F1 not degenerate (no mega-cluster). This regression-protects the fix going forward.
+
+- [ ] **Step 3: Run the gate; confirm the new anchor passes and others are unaffected**
+
+Same gate command as Task 5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "test(autoconfig): add zip-dense regression anchor for the discriminative veto (#1351)"
+```
+
+> If the anchor harness is non-trivial to extend within the time box, STOP and note it — the unit tests (Task 4) + the existing gate passing (Task 5) are sufficient to ship; the anchor is protective, not blocking.
+
+---
+
+## Task 7: Final verification + PR
+
+- [ ] **Step 1: Full targeted test sweep (NOT the whole suite)**
+
+Run:
+```
+"$UV" run --package goldenmatch --extra dev python -m pytest \
+  packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py \
+  packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py \
+  packages/python/goldenmatch/tests/test_exact_matchkey_floor_s3.py \
+  packages/python/goldenmatch/tests/test_autoconfig_pincer_715.py \
+  packages/python/goldenmatch/tests/test_autoconfig.py -q
+```
+Expected: all pass.
+
+- [ ] **Step 2: ruff + pyright clean; quality gate PASS (re-run Task 5 Step 1).**
+
+- [ ] **Step 3: Revert any uv.lock drift, push, open PR**
+
+```bash
+git checkout -- uv.lock 2>/dev/null
+git push -u origin fix/1351-discriminative-veto
+gh pr create --repo benseverndev-oss/goldenmatch --base main \
+  --title "fix(autoconfig): discriminative-power veto for exact matchkeys (#1351)" \
+  --body "<summary: veto-only co-agreement gate; zip vetoed, npi kept; quality gate PASS; CI accuracy gates are final validation>"
+```
+
+- [ ] **Step 4: Watch CI (esp. the accuracy gates / quality_gate + pyright) to green before requesting merge.**
+
+---
+
+## Notes for the implementer
+- Reference @superpowers:subagent-driven-development for execution discipline.
+- The veto is intentionally narrow: it removes only the standalone `exact` matchkey. It must not touch `col_type`, blocking, or composite matchkeys.
+- Determinism: the estimator iterates value-groups in sorted order and pairs deterministically — no RNG — so the quality gate is reproducible.
+- Every `uv run` may drift `uv.lock`; always `git checkout -- uv.lock` before committing.
+- The DERM real dataset is NOT used in any test (PII + 19k rows OOM risk). All fixtures are tiny synthetic frames.

--- a/docs/superpowers/plans/2026-07-02-discriminative-veto.md
+++ b/docs/superpowers/plans/2026-07-02-discriminative-veto.md
@@ -394,7 +394,9 @@ git add -A && git commit -m "feat(autoconfig): should_veto_exact decision + fail
 - Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig.py` (exact-matchkey gate loop, ~line 1108, near the `_exact_floor` gate and the `>= 1.0` surrogate gate)
 - Test: `packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py`
 
-**Context:** In `build_matchkeys(profiles, df=None, *, multi_source=False)`, the per-field loop appends columns to `exact_fields` after passing the zip/geo guard (~1089), the `_exact_floor` gate (~1108), and the `>= 1.0` surrogate gate. Add a veto check in that loop: when a column would otherwise become an exact field, call `should_veto_exact(df, p.name, profiles)`; if True, add to `skipped_exact` with a reason and `continue` (mirror the existing skip branches). Import at top: `from goldenmatch.core.autoconfig_discriminative import should_veto_exact`.
+**Context:** In `build_matchkeys(profiles, df=None, *, multi_source=False)`, the per-field loop appends columns to `exact_fields` after passing the zip/geo guard (~948, `col_type in ("zip","geo")`), the `_exact_floor` gate (~966), and the `>= 1.0` surrogate gate (~993–1002). **Insert the veto directly after the surrogate gate (~line 1002)** — before the intervening multi_source name-demotion block and the `mf`/`tf_freqs` construction, and before the `if scorer == "exact": exact_fields.append(mf)` record (~1058). Placing it there means the `continue` fires before `mf` is built, and `p`, `scorer`, `profiles`, `df`, `skipped_exact` are all in scope. Call `should_veto_exact(df, p.name, profiles)`; if True, append to `skipped_exact` with a reason and `continue` (mirror the three adjacent skip branches byte-for-byte). Import at top: `from goldenmatch.core.autoconfig_discriminative import should_veto_exact`.
+
+**Note (perf, non-blocking):** the estimator groups rows via `iter_rows` into Python dicts over the whole `df` before capping pairs — O(rows). Fine for the controller's ~1.5k-row sample and the tiny test fixtures; if a future caller passes a large frame, cap/sample rows before grouping.
 
 - [ ] **Step 1: Write failing test at the build_matchkeys level**
 

--- a/docs/superpowers/specs/2026-07-02-discriminative-power-veto-design.md
+++ b/docs/superpowers/specs/2026-07-02-discriminative-power-veto-design.md
@@ -1,0 +1,171 @@
+# Discriminative-power veto for exact/identity matchkeys (#1351)
+
+**Date:** 2026-07-02
+**Issue:** benseverndev-oss/goldenmatch#1351
+**Status:** design approved, pending spec review
+
+## Problem
+
+`AutoConfigController`'s zero-config path commits a standalone `exact` matchkey
+on low-cardinality, high-density columns (observed: `exact[zip]` on a
+19,278-row circulation dataset where thousands of records share a zip),
+collapsing dozens of distinct people into one cluster (~55% over-merge,
+52-member false clusters).
+
+The proximate mechanism is a cardinality-driven identifier promotion in
+`_classify_by_data` (autoconfig.py ~297–314) fed a **sample-inflated** cardinality
+(profiling samples 1,000 rows; a moderate-cardinality `zip` reads ~0.96 in a
+1k sample vs a true ~0.26), which reclassifies `zip -> "identifier"`, defeating
+the zip/geo blocking-signal guard, and lets `exact[zip]` through.
+
+### Why cardinality is the wrong signal (the real root cause)
+
+Making cardinality honest (full-column `n_unique`) was implemented and **failed
+the auto-config accuracy gate**: `npi` and `phone_number` (genuine identity keys
+that legitimately repeat — the same provider/phone recurs across records) have
+*moderate* full-data cardinality too, so honest cardinality demoted them
+`identifier -> phone`, exploding blocking (candidate pairs 1,529 -> 415,097) and
+dropping F1 (`ncvr_synthetic` 0.983 -> 0.921, `historical_50k` 0.466 -> 0.340).
+
+`zip` and `npi` have **the same moderate cardinality but opposite correct
+answers** — so no cardinality threshold (sampled or honest) can separate them.
+Cardinality conflates "shared attribute" (zip: sharers are different people in
+one area) with "shared identity key" (npi: sharers are the same entity).
+
+### The distinguishing signal
+
+Discriminative power: **among records that share a candidate value, do they also
+agree on the rest of the identity?**
+- `npi` sharers also agree on name/other ids -> shared value predicts identity
+  -> valid exact key.
+- `zip` sharers have unrelated names -> shared value does NOT predict identity
+  -> blocking-only attribute.
+
+Label-free, cheap, sample-estimable, and generic across entity types (no name
+lists, no per-column special-casing).
+
+## Existing machinery (reused / not reused)
+
+- `ColumnPrior.identity_score` (complexity_profile.py) — type + high-cardinality
+  based, so it shares the zip/npi blind spot. **Not** the basis for this fix.
+- `_make_weak_positive_fn` / `_default_discriminative_fields`
+  (blocking_pass_selection.py) — an existing "pair agrees on >=2 discriminative
+  fields" co-agreement predicate, currently used only for blocking-pass pruning.
+  Close in spirit; reuse its shape where practical rather than inventing.
+- Chao1 sample->full cardinality extrapolation (autoconfig_verify.py) — a
+  cardinality axis; not applicable (cardinality is the wrong signal here).
+
+## Design
+
+### Posture: veto layer (not replace)
+
+Keep the current identifier promotion as the CANDIDATE generator. Add a
+discriminative-power gate that only **demotes** a proposed standalone `exact`
+key when records sharing its value do not co-agree on other identity fields.
+It never promotes new keys. By construction it cannot regress the npi/email
+promotions the gate checks; it only closes the `zip` hole.
+
+### 1. Insertion point
+
+A veto step in `build_matchkeys` (autoconfig.py; `df` is a parameter, passed by
+the production caller `auto_configure_df`), adjacent to the existing exact
+machinery — approximate anchors: zip/geo guard ~line 1089, exact-matchkey floor
+gate ~1108, standalone-exact emit site ~1199. `df` is in scope here.
+It runs after a column is proposed as a standalone `exact` key. Scope is
+deliberately narrow:
+- Only removes the `exact` MATCHKEY for the vetoed column.
+- Leaves `col_type` classification and blocking untouched — a vetoed `zip` can
+  still be a blocking key (blocking only groups candidates; the matchkey decides
+  merges).
+
+This is the minimal surface that fixes the over-merge and keeps the accuracy
+gate's classification/blocking metrics unchanged for non-vetoed columns.
+
+### 2. Estimator — `discriminative_power(col, df, basket)`
+
+For a proposed exact key `C`, on the `df` passed to `build_matchkeys`:
+
+1. Group rows by `C`'s value; keep groups with >=2 rows (shared-value groups).
+2. Deterministically (seeded) sample up to `MAX_PAIRS` record-pairs from those
+   groups — bounded cost.
+3. **Basket B** = the OTHER columns whose `col_type` is an identity signal,
+   drawn from the ACTUAL classifier taxonomy (full set: `email, name,
+   multi_name, phone, zip, address, geo, identifier, description, numeric, date,
+   string, year`):
+   - **Identity basket (include):** `{name, multi_name, email, phone,
+     identifier}`.
+   - **Exclude (locality/attribute + non-discriminative):** `{zip, geo,
+     address, description, numeric, date, year, string}`.
+   - Load-bearing exclusion: `zip`/`geo`/`address` are locality signals — if they
+     were in the basket, `zip`-sharers would spuriously co-agree (same locality)
+     and never be vetoed. When judging an *identity* column, geo columns in the
+     basket are harmless; when judging a *geo* column, the basket must be
+     identity-only. Basket membership is decided from the existing `col_type`
+     values above — generic, no per-name logic. (Note: `city`/`state`/`postcode`
+     are not distinct types — they fold into `geo`/`zip`.)
+4. `discriminative_power(C)` = mean over sampled shared-value pairs of their
+   agreement rate across B (cheap normalized/exact compare per basket field).
+
+### 3. Veto decision + fail-safes
+
+- Demote `exact[C]` -> blocking-only iff
+  **support >= `MIN_SHARED_PAIRS`** AND **`discriminative_power(C) < TAU`**
+  (start `TAU` ≈ 0.5, tuned against the gate; both env-overridable per repo
+  convention).
+- **Fail-safe = keep** whenever evidence is thin: `df is None` (unit-test /
+  ad-hoc callers — same guard as the existing `df is not None` blocks in
+  `build_matchkeys`), too few shared-value pairs, or an empty basket. This is why
+  near-unique identity keys (`npi`, `email`) are
+  protected automatically: they have few shared-value pairs -> low support ->
+  insufficient evidence -> kept. The veto only ever fires on **high-density**
+  columns (many value collisions) with low co-agreement — exactly the `zip`
+  shape. (The support-gate is the primary protection for legit identity keys;
+  no explicit type carve-out is added — keep it simple.)
+- Kill-switch `GOLDENMATCH_DISCRIMINATIVE_VETO=0` disables the veto (default on).
+- Deterministic: seeded pair sampling so the quality gate is reproducible.
+
+### 4. Constants (initial, env-overridable, tuned against the gate)
+
+- `MIN_SHARED_PAIRS` — minimum sampled shared-value pairs required to veto
+  (start ~20).
+- `MAX_PAIRS` — cap on sampled pairs per candidate (start ~200).
+- `TAU` — discriminative-power floor below which a key is vetoed (start ~0.5).
+- Env: `GOLDENMATCH_DISCRIMINATIVE_VETO`, `GOLDENMATCH_DISCRIMINATIVE_TAU`.
+
+## Testing / validation
+
+- **Local auto-config quality gate** (`python -m scripts.autoconfig_quality
+  gate`, ~1 min, no OOM) is the primary harness. Bar: `anchor_sparse_zip` keeps
+  `exact['email','npi']`, `npi`/`phone_number` stay `identifier`,
+  `ncvr_synthetic`/`historical_50k` F1 within tolerance of the main baseline
+  (no regression), verdict PASS.
+- **New gate anchor** reproducing the DERM shape (a zip-dense person dataset
+  where `zip` currently promotes to an exact key) with an assertion that `zip`
+  is vetoed out of the exact matchkeys — regression-protects the fix going
+  forward.
+- **Unit tests** on `discriminative_power` with tiny in-memory frames: zip-like
+  (low co-agreement, high support -> veto), npi-like (high co-agreement -> keep),
+  thin-support near-unique (keep), empty-basket (keep), kill-switch off (keep).
+- CI's full accuracy gates (Febrl / DBLP-ACM / NCVR / #528) remain the final
+  cross-dataset validation.
+
+## Non-goals
+
+- Not replacing the cardinality-based promotion (veto only).
+- Not changing profiling/sampling, `_classify_by_data`'s promotion, the
+  `exact_matchkey_floor` oracle, or blocking selection.
+- Not addressing the near-unique-at-huge-scale promotion-floor limitation noted
+  in #1351 (separate, low-harm, pre-existing).
+- Not touching probabilistic (Fellegi-Sunter) matchkeys.
+
+## Risks
+
+- **Basket selection depends on the col_type taxonomy** being roughly right
+  about identity-vs-locality types. If a genuine identity column is typed as
+  locality (or vice versa) the basket could mislead — mitigated by the
+  support-gate + fail-safe-keep and validated by the gate.
+- **Thin sample support** on the controller's ~1.5k-row sample could make the
+  veto inert for mid-density columns; acceptable (fail-safe keep) and the DERM
+  over-merge case is high-density (ample support).
+- **Threshold tuning** (`TAU`, `MIN_SHARED_PAIRS`) is empirical; the local gate
+  gives a fast loop, and env overrides allow tuning without code changes.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -31,6 +31,7 @@ from goldenmatch.config.schemas import (
     MemoryConfig,
     OutputConfig,
 )
+from goldenmatch.core.autoconfig_discriminative import should_veto_exact
 from goldenmatch.core.complexity_profile import DataProfile
 from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter
 from goldenmatch.core.profiler import _guess_type
@@ -998,6 +999,18 @@ def build_matchkeys(
             logger.info(
                 "Skipping exact matchkey for '%s' (%s).", p.name, reason,
             )
+            skipped_exact.append((p.name, reason))
+            continue
+
+        # #1351: discriminative-power veto. A column that clears the cardinality
+        # gates can still be a shared LOCALITY attribute (e.g. a zip mis-promoted
+        # to "identifier") rather than an identity key. Veto its exact matchkey
+        # when records sharing its value don't co-agree on other identity fields.
+        # Fail-safe keep (df is None / thin support / empty basket) is handled
+        # inside should_veto_exact, so near-unique identity keys are unaffected.
+        if scorer == "exact" and should_veto_exact(df, p.name, profiles):
+            reason = "discriminative-power veto: shared-value records do not co-agree on identity fields"
+            logger.warning("Skipping exact matchkey for '%s' (%s).", p.name, reason)
             skipped_exact.append((p.name, reason))
             continue
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
@@ -1,0 +1,48 @@
+"""Discriminative-power veto for exact/identity matchkeys (#1351).
+
+Cardinality cannot separate a shared identity key (``npi``: records sharing a
+value are the SAME entity) from a shared locality attribute (``zip``: records
+sharing a value are DIFFERENT people in one area) -- both have moderate
+cardinality. This module measures, from the data, whether records that SHARE a
+candidate value also AGREE on other identity fields. Low co-agreement => the
+value is a locality/attribute, not an identity key => veto its standalone exact
+matchkey (demote to blocking-only). Veto-only; never promotes.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import polars as pl
+
+_IDENTITY_BASKET_TYPES = frozenset({"name", "multi_name", "email", "phone", "identifier"})
+
+_TAU_DEFAULT = 0.5
+_MIN_SHARED_PAIRS = 20
+_MAX_PAIRS = 200
+
+
+def veto_enabled() -> bool:
+    """Kill-switch: GOLDENMATCH_DISCRIMINATIVE_VETO=0 disables the veto."""
+    return os.environ.get("GOLDENMATCH_DISCRIMINATIVE_VETO", "1") != "0"
+
+
+def tau() -> float:
+    """Co-agreement floor below which an exact key is vetoed (env-overridable)."""
+    raw = os.environ.get("GOLDENMATCH_DISCRIMINATIVE_TAU")
+    if raw is None:
+        return _TAU_DEFAULT
+    try:
+        val = float(raw)
+    except (ValueError, TypeError):
+        return _TAU_DEFAULT
+    return val if 0.0 <= val <= 1.0 else _TAU_DEFAULT
+
+
+def identity_basket(candidate_col: str, profiles: list[Any]) -> list[str]:
+    """Other columns whose col_type is an identity signal (excludes candidate)."""
+    return [
+        p.name
+        for p in profiles
+        if p.name != candidate_col and getattr(p, "col_type", None) in _IDENTITY_BASKET_TYPES
+    ]

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
@@ -115,3 +115,29 @@ def discriminative_power(
     if measured == 0:
         return 0.0, 0
     return total / measured, measured
+
+
+def should_veto_exact(
+    df: pl.DataFrame | None,
+    candidate_col: str,
+    profiles: list[Any],
+    *,
+    min_shared_pairs: int = _MIN_SHARED_PAIRS,
+    max_pairs: int = _MAX_PAIRS,
+) -> bool:
+    """True => demote the proposed standalone exact matchkey on candidate_col.
+
+    Fail-safe = keep (False) on: kill-switch off, df is None, empty identity
+    basket, or insufficient shared-value support. Only vetoes a high-density
+    column whose shared-value pairs measurably fail to co-agree on other identity
+    fields (support >= min_shared_pairs AND power < tau()).
+    """
+    if not veto_enabled() or df is None:
+        return False
+    basket = identity_basket(candidate_col, profiles)
+    if not basket:
+        return False
+    power, support = discriminative_power(df, candidate_col, basket, max_pairs=max_pairs)
+    if support < min_shared_pairs:
+        return False
+    return power < tau()

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
@@ -11,15 +11,24 @@ matchkey (demote to blocking-only). Veto-only; never promotes.
 from __future__ import annotations
 
 import os
+from difflib import SequenceMatcher
 from typing import Any
 
 import polars as pl
 
 _IDENTITY_BASKET_TYPES = frozenset({"name", "multi_name", "email", "phone", "identifier"})
+# Basket types compared FUZZILY (a true duplicate's name is often corrupted --
+# "Smith"/"Smyth" -- so exact-equality would read a genuine identity key's
+# shared-value pairs as disagreement and wrongly veto it, e.g. soc_sec_id on
+# febrl3). Structured ids (email/phone/identifier) are compared exactly: a
+# near-miss there means a DIFFERENT entity, not a corruption of the same one.
+_NAME_FUZZY_TYPES = frozenset({"name", "multi_name"})
 
 _TAU_DEFAULT = 0.5
 _MIN_SHARED_PAIRS = 20
 _MAX_PAIRS = 200
+# SequenceMatcher ratio at/above which two name strings count as agreement.
+_AGREE_THRESHOLD = 0.85
 
 
 def veto_enabled() -> bool:
@@ -39,13 +48,19 @@ def tau() -> float:
     return val if 0.0 <= val <= 1.0 else _TAU_DEFAULT
 
 
-def identity_basket(candidate_col: str, profiles: list[Any]) -> list[str]:
-    """Other columns whose col_type is an identity signal (excludes candidate)."""
-    return [
-        p.name
-        for p in profiles
-        if p.name != candidate_col and getattr(p, "col_type", None) in _IDENTITY_BASKET_TYPES
-    ]
+def identity_basket(candidate_col: str, profiles: list[Any]) -> list[tuple[str, bool]]:
+    """Other identity-typed columns as ``(name, fuzzy)`` pairs (excludes candidate).
+
+    ``fuzzy`` is True for name-typed columns (compared with a similarity
+    threshold to tolerate duplicate-record corruption), False for structured
+    identity types (email/phone/identifier, compared exactly).
+    """
+    out: list[tuple[str, bool]] = []
+    for p in profiles:
+        col_type = getattr(p, "col_type", None)
+        if p.name != candidate_col and col_type in _IDENTITY_BASKET_TYPES:
+            out.append((p.name, col_type in _NAME_FUZZY_TYPES))
+    return out
 
 
 def _norm(v: Any) -> str | None:
@@ -56,31 +71,41 @@ def _norm(v: Any) -> str | None:
     return s or None
 
 
+def _agree(a: str, b: str, fuzzy: bool) -> bool:
+    """Whether two normalized cells agree. Exact match always counts; for fuzzy
+    (name) fields, a SequenceMatcher ratio >= _AGREE_THRESHOLD also counts."""
+    if a == b:
+        return True
+    if not fuzzy:
+        return False
+    return SequenceMatcher(None, a, b).ratio() >= _AGREE_THRESHOLD
+
+
 def discriminative_power(
     df: pl.DataFrame,
     candidate_col: str,
-    basket: list[str],
+    basket: list[tuple[str, bool]],
     *,
     max_pairs: int = _MAX_PAIRS,
 ) -> tuple[float, int]:
     """Mean co-agreement over shared-value pairs, and support (n pairs measured).
 
-    Groups df by candidate_col; for value-groups with >=2 rows, forms up to
-    max_pairs record-pairs deterministically (row 0 paired with rows 1..k-1
-    within each group, groups visited in sorted-value order). Per pair,
-    agreement = (# basket fields where BOTH cells are non-null and
-    normalized-equal) / (# basket fields where BOTH are non-null); pairs with no
-    jointly-populated basket field are skipped. Returns (mean over measured
-    pairs, count of measured pairs); (0.0, 0) when basket empty, candidate
-    absent, or no measurable shared-value pair exists.
+    ``basket`` is a list of ``(column, fuzzy)`` pairs. Groups df by
+    candidate_col; for value-groups with >=2 rows, forms up to max_pairs
+    record-pairs deterministically (row 0 paired with rows 1..k-1 within each
+    group, groups visited in sorted-value order). Per pair, agreement =
+    (# basket fields where BOTH cells are non-null and :func:`_agree`) /
+    (# basket fields where BOTH are non-null); name-typed fields agree fuzzily,
+    structured ids exactly. Pairs with no jointly-populated basket field are
+    skipped. Returns (mean over measured pairs, count of measured pairs);
+    (0.0, 0) when basket empty, candidate absent, or no measurable pair exists.
     """
     if not basket or candidate_col not in df.columns:
         return 0.0, 0
-    keep = [candidate_col, *[c for c in basket if c in df.columns]]
-    if len(keep) < 2:
+    basket_cols = [(c, fuzzy) for (c, fuzzy) in basket if c in df.columns]
+    if not basket_cols:
         return 0.0, 0
-    sub = df.select(keep)
-    basket_cols = keep[1:]
+    sub = df.select([candidate_col, *[c for (c, _f) in basket_cols]])
 
     groups: dict[str, list[dict[str, Any]]] = {}
     for row in sub.iter_rows(named=True):
@@ -101,12 +126,12 @@ def discriminative_power(
                 break
             agree = 0
             comparable = 0
-            for c in basket_cols:
+            for c, fuzzy in basket_cols:
                 a, b = _norm(anchor[c]), _norm(other[c])
                 if a is None or b is None:
                     continue
                 comparable += 1
-                if a == b:
+                if _agree(a, b, fuzzy):
                     agree += 1
             if comparable == 0:
                 continue

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
@@ -46,3 +46,72 @@ def identity_basket(candidate_col: str, profiles: list[Any]) -> list[str]:
         for p in profiles
         if p.name != candidate_col and getattr(p, "col_type", None) in _IDENTITY_BASKET_TYPES
     ]
+
+
+def _norm(v: Any) -> str | None:
+    """Normalize a cell for equality: str -> stripped lower; blank/None -> None."""
+    if v is None:
+        return None
+    s = str(v).strip().lower()
+    return s or None
+
+
+def discriminative_power(
+    df: pl.DataFrame,
+    candidate_col: str,
+    basket: list[str],
+    *,
+    max_pairs: int = _MAX_PAIRS,
+) -> tuple[float, int]:
+    """Mean co-agreement over shared-value pairs, and support (n pairs measured).
+
+    Groups df by candidate_col; for value-groups with >=2 rows, forms up to
+    max_pairs record-pairs deterministically (row 0 paired with rows 1..k-1
+    within each group, groups visited in sorted-value order). Per pair,
+    agreement = (# basket fields where BOTH cells are non-null and
+    normalized-equal) / (# basket fields where BOTH are non-null); pairs with no
+    jointly-populated basket field are skipped. Returns (mean over measured
+    pairs, count of measured pairs); (0.0, 0) when basket empty, candidate
+    absent, or no measurable shared-value pair exists.
+    """
+    if not basket or candidate_col not in df.columns:
+        return 0.0, 0
+    keep = [candidate_col, *[c for c in basket if c in df.columns]]
+    if len(keep) < 2:
+        return 0.0, 0
+    sub = df.select(keep)
+    basket_cols = keep[1:]
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for row in sub.iter_rows(named=True):
+        cv = _norm(row[candidate_col])
+        if cv is None:
+            continue
+        groups.setdefault(cv, []).append(row)
+
+    total = 0.0
+    measured = 0
+    for cv in sorted(groups):
+        rows = groups[cv]
+        if len(rows) < 2 or measured >= max_pairs:
+            continue
+        anchor = rows[0]
+        for other in rows[1:]:
+            if measured >= max_pairs:
+                break
+            agree = 0
+            comparable = 0
+            for c in basket_cols:
+                a, b = _norm(anchor[c]), _norm(other[c])
+                if a is None or b is None:
+                    continue
+                comparable += 1
+                if a == b:
+                    agree += 1
+            if comparable == 0:
+                continue
+            total += agree / comparable
+            measured += 1
+    if measured == 0:
+        return 0.0, 0
+    return total / measured, measured

--- a/packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
@@ -25,3 +25,37 @@ def test_identity_basket_includes_identity_types_excludes_locality():
 def test_identity_basket_excludes_the_candidate_even_if_identity_typed():
     profiles = [_P("npi", "identifier"), _P("email", "email")]
     assert disc.identity_basket("npi", profiles) == ["email"]
+
+
+def _zip_like_df(n=300):
+    zips = [f"{10000 + (i % 30):05d}" for i in range(n)]
+    names = [f"person{i}" for i in range(n)]   # unique -> shared-zip pairs DISAGREE
+    return pl.DataFrame({"zip": zips, "name": names})
+
+
+def _npi_like_df(n=300):
+    npis = [f"{1000000000 + (i % 30)}" for i in range(n)]
+    names = [f"provider{i % 30}" for i in range(n)]  # shared-npi pairs AGREE
+    return pl.DataFrame({"npi": npis, "name": names})
+
+
+def test_discriminative_power_low_for_shared_locality():
+    power, support = disc.discriminative_power(_zip_like_df(), "zip", ["name"])
+    assert support >= disc._MIN_SHARED_PAIRS
+    assert power < 0.5
+
+
+def test_discriminative_power_high_for_shared_identity():
+    power, support = disc.discriminative_power(_npi_like_df(), "npi", ["name"])
+    assert support >= disc._MIN_SHARED_PAIRS
+    assert power > 0.9
+
+
+def test_discriminative_power_zero_support_when_all_unique():
+    df = pl.DataFrame({"id": [str(i) for i in range(100)], "name": [f"n{i}" for i in range(100)]})
+    power, support = disc.discriminative_power(df, "id", ["name"])
+    assert support == 0
+
+
+def test_discriminative_power_empty_basket_zero():
+    assert disc.discriminative_power(_zip_like_df(), "zip", []) == (0.0, 0)

--- a/packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
@@ -17,42 +17,80 @@ def test_identity_basket_includes_identity_types_excludes_locality():
         _P("notes", "description"),
     ]
     basket = disc.identity_basket("zip", profiles)
-    assert set(basket) == {"first_name", "last_name", "email", "npi"}
-    assert "zip" not in basket and "city" not in basket and "notes" not in basket
+    names = {b[0] for b in basket}
+    assert names == {"first_name", "last_name", "email", "npi"}
+    assert "zip" not in names and "city" not in names and "notes" not in names
+    # name-typed fields compare fuzzily; structured ids exactly.
+    fuzzy = dict(basket)
+    assert fuzzy["first_name"] is True and fuzzy["last_name"] is True
+    assert fuzzy["email"] is False and fuzzy["npi"] is False
 
 
 def test_identity_basket_excludes_the_candidate_even_if_identity_typed():
     profiles = [_P("npi", "identifier"), _P("email", "email")]
-    assert disc.identity_basket("npi", profiles) == ["email"]
+    assert disc.identity_basket("npi", profiles) == [("email", False)]
+
+
+def _distinct_name(seed: int) -> str:
+    """Deterministic 6-letter pseudo-random token. Different seeds are mutually
+    DISSIMILAR (low SequenceMatcher ratio), modeling unrelated people's names;
+    the same seed reproduces the same name, modeling one entity."""
+    x = ((seed + 1) * 2654435761) & 0xFFFFFFFF
+    return "".join(chr(97 + ((x >> (5 * j)) % 26)) for j in range(6))
 
 
 def _zip_like_df(n=300):
     zips = [f"{10000 + (i % 30):05d}" for i in range(n)]
-    names = [f"person{i}" for i in range(n)]   # unique -> shared-zip pairs DISAGREE
+    names = [_distinct_name(i) for i in range(n)]  # different people -> dissimilar
     return pl.DataFrame({"zip": zips, "name": names})
 
 
 def _npi_like_df(n=300):
     npis = [f"{1000000000 + (i % 30)}" for i in range(n)]
-    names = [f"provider{i % 30}" for i in range(n)]  # shared-npi pairs AGREE
+    names = [_distinct_name(i % 30) for i in range(n)]  # same provider -> same name
     return pl.DataFrame({"npi": npis, "name": names})
 
 
+def _corrupted_dup_df(n=300):
+    # 30 SSNs x 10 rows each; rows sharing an SSN are the SAME person, but ~half
+    # carry a CORRUPTED surname (one extra char) -- exact-equal fails on those,
+    # fuzzy agrees. Models febrl3's corrupted duplicates.
+    ssns = [f"{700000000 + (i % 30)}" for i in range(n)]
+    surnames = []
+    for i in range(n):
+        base = _distinct_name(i % 30)          # same person per SSN group
+        corrupt = (i // 30) % 2 == 1            # ~half the group's rows, by position
+        surnames.append(base + "z" if corrupt else base)
+    return pl.DataFrame({"soc_sec_id": ssns, "surname": surnames})
+
+
 def test_discriminative_power_low_for_shared_locality():
-    power, support = disc.discriminative_power(_zip_like_df(), "zip", ["name"])
+    power, support = disc.discriminative_power(_zip_like_df(), "zip", [("name", True)])
     assert support >= disc._MIN_SHARED_PAIRS
     assert power < 0.5
 
 
 def test_discriminative_power_high_for_shared_identity():
-    power, support = disc.discriminative_power(_npi_like_df(), "npi", ["name"])
+    power, support = disc.discriminative_power(_npi_like_df(), "npi", [("name", True)])
     assert support >= disc._MIN_SHARED_PAIRS
     assert power > 0.9
 
 
+def test_discriminative_power_fuzzy_keeps_corrupted_duplicate_ids():
+    # The febrl3 failure in miniature: a genuine id whose duplicate records have
+    # corrupted (fuzzy-similar) names. Exact comparison would read this as
+    # disagreement and veto the id; fuzzy comparison keeps it.
+    df = _corrupted_dup_df()
+    fuzzy_power, support = disc.discriminative_power(df, "soc_sec_id", [("surname", True)])
+    exact_power, _ = disc.discriminative_power(df, "soc_sec_id", [("surname", False)])
+    assert support >= disc._MIN_SHARED_PAIRS
+    assert exact_power < 0.6  # exact under-counts the corrupted duplicates
+    assert fuzzy_power > 0.9  # fuzzy recovers them
+
+
 def test_discriminative_power_zero_support_when_all_unique():
     df = pl.DataFrame({"id": [str(i) for i in range(100)], "name": [f"n{i}" for i in range(100)]})
-    power, support = disc.discriminative_power(df, "id", ["name"])
+    power, support = disc.discriminative_power(df, "id", [("name", True)])
     assert support == 0
 
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+import polars as pl
+
+from goldenmatch.core import autoconfig_discriminative as disc
+
+
+@dataclass
+class _P:
+    name: str
+    col_type: str
+
+
+def test_identity_basket_includes_identity_types_excludes_locality():
+    profiles = [
+        _P("zip", "zip"), _P("first_name", "name"), _P("last_name", "name"),
+        _P("email", "email"), _P("npi", "identifier"), _P("city", "geo"),
+        _P("notes", "description"),
+    ]
+    basket = disc.identity_basket("zip", profiles)
+    assert set(basket) == {"first_name", "last_name", "email", "npi"}
+    assert "zip" not in basket and "city" not in basket and "notes" not in basket
+
+
+def test_identity_basket_excludes_the_candidate_even_if_identity_typed():
+    profiles = [_P("npi", "identifier"), _P("email", "email")]
+    assert disc.identity_basket("npi", profiles) == ["email"]

--- a/packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_discriminative_1351.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 import polars as pl
-
 from goldenmatch.core import autoconfig_discriminative as disc
 
 
@@ -59,3 +58,35 @@ def test_discriminative_power_zero_support_when_all_unique():
 
 def test_discriminative_power_empty_basket_zero():
     assert disc.discriminative_power(_zip_like_df(), "zip", []) == (0.0, 0)
+
+
+def test_should_veto_zip_true():
+    profiles = [_P("zip", "zip"), _P("name", "name")]
+    assert disc.should_veto_exact(_zip_like_df(), "zip", profiles) is True
+
+
+def test_should_veto_npi_false():
+    profiles = [_P("npi", "identifier"), _P("name", "name")]
+    assert disc.should_veto_exact(_npi_like_df(), "npi", profiles) is False
+
+
+def test_should_veto_thin_support_false():
+    df = pl.DataFrame({"id": [str(i) for i in range(100)], "name": [f"n{i}" for i in range(100)]})
+    profiles = [_P("id", "identifier"), _P("name", "name")]
+    assert disc.should_veto_exact(df, "id", profiles) is False
+
+
+def test_should_veto_df_none_false():
+    profiles = [_P("zip", "zip"), _P("name", "name")]
+    assert disc.should_veto_exact(None, "zip", profiles) is False
+
+
+def test_should_veto_empty_basket_false():
+    profiles = [_P("zip", "zip")]
+    assert disc.should_veto_exact(_zip_like_df(), "zip", profiles) is False
+
+
+def test_should_veto_kill_switch_false(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_DISCRIMINATIVE_VETO", "0")
+    profiles = [_P("zip", "zip"), _P("name", "name")]
+    assert disc.should_veto_exact(_zip_like_df(), "zip", profiles) is False

--- a/packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py
+++ b/packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py
@@ -1,0 +1,41 @@
+import polars as pl
+from goldenmatch.core.autoconfig import ColumnProfile, build_matchkeys
+
+
+def _exact_fields(mks):
+    return {f.field for mk in mks if mk.type == "exact" for f in mk.fields if f.field}
+
+
+def _mk_profiles(specs):  # specs: list[(name, col_type, cardinality_ratio)]
+    return [
+        ColumnProfile(name=n, dtype="str", col_type=t, confidence=0.9,
+                      sample_values=["x"], null_rate=0.0, cardinality_ratio=c, avg_len=6.0)
+        for (n, t, c) in specs
+    ]
+
+
+def test_zip_promoted_to_identifier_is_vetoed_from_exact():
+    profiles = _mk_profiles([("zip", "identifier", 0.96), ("first_name", "name", 0.9),
+                             ("last_name", "name", 0.9)])
+    n = 400
+    df = pl.DataFrame({
+        "zip": [f"{10000 + (i % 40):05d}" for i in range(n)],
+        "first_name": [f"fn{i}" for i in range(n)],
+        "last_name": [f"ln{i}" for i in range(n)],
+    })
+    assert "zip" not in _exact_fields(build_matchkeys(profiles, df=df))
+
+
+def test_npi_identifier_is_kept_as_exact():
+    profiles = _mk_profiles([("npi", "identifier", 0.9), ("first_name", "name", 0.9)])
+    n = 400
+    df = pl.DataFrame({
+        "npi": [f"{1000000000 + (i % 40)}" for i in range(n)],
+        "first_name": [f"fn{i % 40}" for i in range(n)],
+    })
+    assert "npi" in _exact_fields(build_matchkeys(profiles, df=df))
+
+
+def test_df_none_is_noop_keep():
+    profiles = _mk_profiles([("email", "identifier", 0.9)])
+    assert "email" in _exact_fields(build_matchkeys(profiles, df=None))

--- a/packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py
+++ b/packages/python/goldenmatch/tests/test_build_matchkeys_veto_1351.py
@@ -14,24 +14,34 @@ def _mk_profiles(specs):  # specs: list[(name, col_type, cardinality_ratio)]
     ]
 
 
+def _distinct_name(seed: int) -> str:
+    """Deterministic 6-letter token; different seeds are mutually dissimilar
+    (models unrelated people), the same seed reproduces one entity's name."""
+    x = ((seed + 1) * 2654435761) & 0xFFFFFFFF
+    return "".join(chr(97 + ((x >> (5 * j)) % 26)) for j in range(6))
+
+
 def test_zip_promoted_to_identifier_is_vetoed_from_exact():
+    # zip mis-typed as identifier; shared-zip records are DIFFERENT people with
+    # dissimilar names -> low co-agreement -> vetoed out of the exact matchkeys.
     profiles = _mk_profiles([("zip", "identifier", 0.96), ("first_name", "name", 0.9),
                              ("last_name", "name", 0.9)])
     n = 400
     df = pl.DataFrame({
         "zip": [f"{10000 + (i % 40):05d}" for i in range(n)],
-        "first_name": [f"fn{i}" for i in range(n)],
-        "last_name": [f"ln{i}" for i in range(n)],
+        "first_name": [_distinct_name(i) for i in range(n)],
+        "last_name": [_distinct_name(i + 100000) for i in range(n)],
     })
     assert "zip" not in _exact_fields(build_matchkeys(profiles, df=df))
 
 
 def test_npi_identifier_is_kept_as_exact():
+    # shared-npi records are the SAME provider (same name) -> high co-agreement -> kept.
     profiles = _mk_profiles([("npi", "identifier", 0.9), ("first_name", "name", 0.9)])
     n = 400
     df = pl.DataFrame({
         "npi": [f"{1000000000 + (i % 40)}" for i in range(n)],
-        "first_name": [f"fn{i % 40}" for i in range(n)],
+        "first_name": [_distinct_name(i % 40) for i in range(n)],
     })
     assert "npi" in _exact_fields(build_matchkeys(profiles, df=df))
 


### PR DESCRIPTION
Closes #1351.

## Problem
`AutoConfigController` commits a standalone `exact` matchkey on high-density locality columns (e.g. `exact[zip]` on a 19,278-row circulation dataset where thousands share a zip → ~55% over-merge, 52-member false clusters). The proximate cause is a sample-cardinality-inflated identifier promotion, but the **root** problem is deeper: **cardinality cannot separate a shared identity key from a shared locality attribute.** `zip` (sharers are different people in one area) and `npi`/`phone` (sharers are the same entity) both have *moderate* cardinality — opposite correct answers, same signal.

A prior full-data-cardinality attempt (closed PR #1354) proved this: making cardinality honest demoted genuine identity keys (`npi`, `phone_number`) and dropped accuracy-gate F1 by 6–13 points. Cardinality is the wrong axis.

## Fix: discriminative-power veto
The distinguishing signal is **co-agreement**: among records that *share* a candidate value, do they also agree on other identity fields?
- `npi` sharers agree on name/other ids → shared value predicts identity → **keep** the exact key.
- `zip` sharers have unrelated names → shared value does not predict identity → **veto** (blocking-only).

**Veto-only, minimal blast radius.** A new isolated module `autoconfig_discriminative.py` computes discriminative power; `build_matchkeys` calls `should_veto_exact` at the exact-matchkey gate (right after the `>=1.0` surrogate gate) and *demotes* a proposed exact key when its shared-value pairs fail to co-agree. It never promotes, never touches classification/blocking/composite matchkeys.

- **Basket** = other columns whose `col_type` is an identity signal `{name, multi_name, email, phone, identifier}`, **excluding** locality types `{zip, geo, address, …}` (so same-locality pairs can't spuriously co-agree).
- **Fail-safe = keep** on: `df is None`, empty basket, or thin shared-value support (`< MIN_SHARED_PAIRS=20`). This auto-protects near-unique identity keys (`npi`/`email` have few shared-value pairs → not enough evidence to veto). The veto only ever fires on high-density columns with low co-agreement — exactly the `zip` shape.
- Deterministic (sorted-value grouping, row-0 pairing — no RNG), so the quality gate is reproducible.
- Kill-switch `GOLDENMATCH_DISCRIMINATIVE_VETO=0`; `GOLDENMATCH_DISCRIMINATIVE_TAU` (default 0.5).

Design + plan: `docs/superpowers/specs/2026-07-02-discriminative-power-veto-design.md`, `docs/superpowers/plans/2026-07-02-discriminative-veto.md`.

## Validation
- **Unit tests (fix proven):** `test_build_matchkeys_veto_1351.py` — a `zip` mis-promoted to `identifier` with disagreeing shared-value records is vetoed out of the exact matchkeys; a real `npi` (shared-value records co-agree) is kept; `df=None` is a no-op keep. Plus `test_autoconfig_discriminative_1351.py` (12 tests on the estimator + fail-safes).
- **Local auto-config quality gate (no harm proven):** everything the veto touches holds vs baseline — `anchor_person_match` F1, `ncvr_synthetic` F1 + F1-probabilistic, `historical_50k` F1, and `anchor_sparse_zip` (undisturbed; on the anchors `zip` is already caught by the existing `col_type=="zip"` guard, so the veto correctly never fires there).
- 145 passed / 3 skipped across the exact-matchkey test suite; no existing test modified. ruff + pyright clean.

## Known local-gate note (NOT caused by this change)
The local gate flags `historical_50k f1_probabilistic` (0.828 → ~0.776). This **reproduces with the veto disabled** (`GOLDENMATCH_DISCRIMINATIVE_VETO=0`, code path a no-op) and produces **different values across runs** (0.776 vs 0.779) — i.e. it's a non-deterministic FS/EM metric failing a baseline calibrated on CI (Linux), not a regression from this PR. The probabilistic path (`build_probabilistic_matchkeys`) is untouched here. CI's gate is the authoritative check.

## Follow-up (noted, not blocking)
Add a gate anchor reproducing the DERM shape (a locality column *mis-classified* to `identifier` on >1k rows) so the gate exercises the veto's positive effect end-to-end — currently only the unit tests do (the existing anchors' `zip` is caught upstream by the `col_type` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)