### PR TITLE
GOLDENGRAPH_LLM_SEED: reproducible extraction — chunking CONFIRMED, re-prompt REFUTED as noise

### DIFF
--- a/docs/superpowers/reports/2026-07-01-relation-reprompt-verdict.md
+++ b/docs/superpowers/reports/2026-07-01-relation-reprompt-verdict.md
@@ -1,5 +1,15 @@
 # Relation Re-Prompt — Verdict
 
+> **⚠️ CORRECTION (2026-07-02): this "WIN" was REFUTED by seeded re-measurement.** The +33% R(B) / +26% F1
+> reported below was an **unseeded single-leg artifact** — the control (leg 100) and re-prompt (leg 101) legs
+> were two independent draws from a distribution with ~0.14 F1 run-to-run spread (the 7B extraction is
+> non-deterministic; see `2026-07-02-rebel-fuse-verdict.md`). Re-measured at a fixed `GOLDENGRAPH_LLM_SEED`
+> across seeds 42 and 7, the re-prompt delta is **0.000 / −0.046** — no gain, slightly negative. See
+> `2026-07-02-seed-determinism-verdict.md` for the corrected result. The `GOLDENGRAPH_RELATION_REPROMPT` gate
+> is default-off (nothing incorrect shipped to users) but is **NOT recommended**. Chunking (the predecessor
+> lever) was re-confirmed as a genuine win at both seeds. The analysis below is retained as-written for the
+> record; treat its headline as superseded.
+
 **Date:** 2026-07-01
 **Branch:** `feat/relation-reprompt`
 **Spec/Plan:** `docs/superpowers/specs/2026-07-01-relation-reprompt-design.md` · `docs/superpowers/plans/2026-07-01-relation-reprompt.md`

--- a/docs/superpowers/reports/2026-07-02-seed-determinism-verdict.md
+++ b/docs/superpowers/reports/2026-07-02-seed-determinism-verdict.md
@@ -1,0 +1,64 @@
+# Seed Determinism + Win Re-Confirmation — Verdict
+
+**Date:** 2026-07-02
+**Branch:** `feat/llm-seed`
+**Spec:** brainstorm spike (measure-first gate for the replication harness the REBEL verdict called for)
+**Run:** Modal `gg-bench`, 7B (`qwen2.5-7b-instruct`), `--corpus wiki`, `name_ci`, `GOLDENGRAPH_LLM_SEED` set. 19 docs, 65 gold.
+
+## What this tested
+
+The REBEL verdict discovered the substrate R(B)/F1 metric swings ~0.14 F1 run-to-run (control F1 0.370 vs 0.511, same config) because the 7B extraction is non-deterministic — making single-leg A/B deltas underpowered and casting doubt on the chunking + re-prompt "wins." The fix was assumed to be a replication harness. First, the cheap test: extraction already runs at `temperature=0` but with **no seed**. Does adding a fixed `GOLDENGRAPH_LLM_SEED` make it reproducible? If so, no harness is needed.
+
+## Result 1 — the seed fixes reproducibility (harness unnecessary)
+
+Same best-config fired as two independent Modal legs, both `GOLDENGRAPH_LLM_SEED=42`:
+
+| leg | R(B) | P(B) | F1(B) | coverage | components |
+|---|---|---|---|---|---|
+| 120 | 0.3030 | 1.0000 | 0.4651 | 0.4923 | 15 |
+| 121 | 0.3030 | 1.0000 | 0.4651 | 0.4923 | 16 |
+
+**R(B), P(B), F1, coverage are byte-identical across containers.** Only `components` differs by 1 (15 vs 16) — negligible residual GPU non-determinism that does not touch the B-cubed headline. The missing seed *was* the dominant variance source. **The replication harness is unnecessary:** a fixed seed makes single-leg deltas reproducible. Set `GOLDENGRAPH_LLM_SEED` for all bench runs.
+
+## Result 2 — re-confirming the wins at fixed seeds (the important part)
+
+With reproducibility, the two shipped "wins" were re-measured at **two seeds** (42, 7). Configs: A = `name_ci` only; B = +chunking `(6,2)`; C = +re-prompt.
+
+| config | F1 @ seed 42 | F1 @ seed 7 |
+|---|---|---|
+| A: name_ci only | 0.3149 | 0.4348 |
+| B: +chunking | 0.4651 | 0.5113 |
+| C: +re-prompt | 0.4651 | 0.4651 |
+
+- **Chunking delta (B − A): +0.150 (s42), +0.077 (s7) — positive and substantial at BOTH seeds. The chunking win is REAL** (also lifts coverage 0.40→0.49 / 0.43→0.51). Confirmed.
+- **Re-prompt delta (C − B): 0.000 (s42), −0.046 (s7) — neutral-to-negative at both seeds. The re-prompt "win" does NOT replicate.** At seed 42 it is byte-identical to no-re-prompt (F1/R(B)/coverage all equal; only components move 15→9); at seed 7 it *lowers* F1. **Refuted as a win.**
+
+### Why the re-prompt looked like a win before
+
+The original re-prompt verdict compared an unseeded control (leg 100, F1 0.370) against an unseeded re-prompt leg (leg 101, F1 0.465) and read the +0.095 as the treatment effect. But those were two *independent* draws from a distribution with ~0.14 F1 spread — the "effect" was almost entirely the sampling difference between the two draws, not the re-prompt. Controlling the draw with a fixed seed collapses the effect to ~0. This is exactly the false positive the REBEL verdict warned single-leg deltas could produce.
+
+Re-prompt *does* change the graph (at seed 42 it dropped components 15→9 — more cross-doc merging) but that structural change does not improve B-cubed quality and at seed 7 hurts it. Graph-connectivity change ≠ substrate-quality gain.
+
+## Corrections to the record
+
+- **`2026-07-01-relation-reprompt-verdict.md` overclaimed.** Its "WIN (R(B) +33%, F1 +26%)" was an unseeded single-leg artifact. A correction note is appended to that file. The `GOLDENGRAPH_RELATION_REPROMPT` gate is default-off (opt-in), so nothing incorrect shipped to users — but the claim was wrong, and the gate is **not recommended** (no measured benefit; slightly negative at seed 7).
+- **Chunking (#1350) stands, now on firmer ground** — positive at both seeds.
+
+## Decisions
+
+- **Ship `GOLDENGRAPH_LLM_SEED`** (this change). Reproducible bench is now the standard.
+- **New measurement standard:** every substrate delta claim must (a) set a fixed seed and (b) report ≥2 seeds; a "win" requires the delta positive across seeds, not a single unseeded pair.
+- **No replication harness.** The seed + multi-seed reporting is the methodology; a K-replicate aggregator is not worth building.
+- **Re-prompt is refuted as a win**; chunking is confirmed. The real-prose substrate stack that holds up is **name_ci + chunking**.
+
+## Honest caveats
+
+- **Two seeds, small N.** The chunking win is positive at both (robust); the re-prompt non-win is 0.000/−0.046 at both (consistent). A third seed would tighten both but the signs are stable.
+- **Seed reproducibility is metric-level, not bit-level** — components still wobble ±1 at a fixed seed, so extremely fine-grained metrics retain a little noise; R(B)/F1/coverage do not.
+- **This does not re-audit the whole arc.** name_ci was validated at multiple levels earlier; the two levers re-checked here are the ones the REBEL verdict flagged. Other single-leg deltas in the arc (e.g. the L1/L2 numbers) were larger-magnitude and less likely to be pure noise, but the general lesson — seed everything, report multiple seeds — now applies going forward.
+
+## Follow-ons
+
+1. **Optional third seed** for the re-prompt to fully close it (expected: still ~0).
+2. **Consider deprecating the `RELATION_REPROMPT` gate** (or leave as an opt-in, clearly not-recommended, since it costs an LLM call for no gain).
+3. Apply the seed + multi-seed standard to any future substrate lever.

--- a/packages/python/goldengraph/goldengraph/llm.py
+++ b/packages/python/goldengraph/goldengraph/llm.py
@@ -8,6 +8,7 @@ extraction stays testable + provider-swappable.
 
 from __future__ import annotations
 
+import os
 from typing import Protocol
 
 
@@ -65,6 +66,15 @@ class OpenAIClient:
             "messages": [{"role": "user", "content": prompt}],
             "temperature": temperature,
         }
+        # Optional fixed seed for reproducible decoding (GOLDENGRAPH_LLM_SEED). Ollama's
+        # OpenAI-compatible endpoint honors `seed` + temperature=0; unset/non-int -> omitted
+        # (unchanged behavior). Reduces run-to-run extraction variance for bench determinism.
+        _raw_seed = os.environ.get("GOLDENGRAPH_LLM_SEED", "").strip()
+        if _raw_seed:
+            try:
+                kwargs["seed"] = int(_raw_seed)
+            except ValueError:
+                pass
         if json_mode:
             kwargs["response_format"] = {"type": "json_object"}
         resp = client.chat.completions.create(**kwargs)

--- a/packages/python/goldengraph/tests/test_llm_seed.py
+++ b/packages/python/goldengraph/tests/test_llm_seed.py
@@ -1,0 +1,53 @@
+"""GOLDENGRAPH_LLM_SEED: pass a fixed `seed` to the completion request for reproducible decoding."""
+from goldengraph.llm import OpenAIClient
+
+
+class _CaptureClient:
+    """Fake OpenAI client capturing the create() kwargs; returns a minimal response."""
+    def __init__(self):
+        self.kwargs = None
+
+        class _Resp:
+            class _Choice:
+                class _Msg:
+                    content = "ok"
+                message = _Msg()
+            choices = [_Choice()]
+            usage = None
+
+        class _Completions:
+            def __init__(self, outer):
+                self._outer = outer
+
+            def create(self, **kwargs):
+                self._outer.kwargs = kwargs
+                return _Resp()
+
+        class _Chat:
+            def __init__(self, outer):
+                self.completions = _Completions(outer)
+
+        self.chat = _Chat(self)
+
+
+def test_seed_absent_by_default(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_LLM_SEED", raising=False)
+    cap = _CaptureClient()
+    OpenAIClient(model="m", client=cap).complete("hi")
+    assert "seed" not in cap.kwargs
+
+
+def test_seed_present_when_set(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_LLM_SEED", "42")
+    cap = _CaptureClient()
+    OpenAIClient(model="m", client=cap).complete("hi")
+    assert cap.kwargs.get("seed") == 42
+    assert cap.kwargs.get("temperature") == 0
+
+
+def test_seed_empty_or_garbage_ignored(monkeypatch):
+    for bad in ("", " ", "abc"):
+        monkeypatch.setenv("GOLDENGRAPH_LLM_SEED", bad)
+        cap = _CaptureClient()
+        OpenAIClient(model="m", client=cap).complete("hi")
+        assert "seed" not in cap.kwargs, bad


### PR DESCRIPTION
## Summary

Adds an optional `GOLDENGRAPH_LLM_SEED` passthrough (temp=0 + fixed `seed`) for reproducible decoding, then uses it to re-confirm the substrate arc's "wins" that the REBEL verdict flagged as possibly noise. Default unset → behavior unchanged.

## Why

The REBEL verdict found the substrate R(B)/F1 metric swings ~0.14 F1 run-to-run (the 7B extraction is non-deterministic), making single-leg A/B deltas underpowered. Extraction already ran at `temperature=0` but with no seed. This tests the cheap fix before building a replication harness.

## Result 1 — the seed fixes reproducibility (harness unnecessary)

Same config, two independent Modal legs, `GOLDENGRAPH_LLM_SEED=42`: R(B)/P(B)/F1/coverage **byte-identical** (components ±1, negligible). The missing seed was the dominant variance source. No replication harness needed.

## Result 2 — re-confirming the wins at seeds 42 and 7

| config | F1 @ seed 42 | F1 @ seed 7 |
|---|---|---|
| name_ci only | 0.315 | 0.435 |
| +chunking(6,2) | 0.465 | 0.511 |
| +re-prompt | 0.465 | 0.465 |

- **Chunking delta +0.150 / +0.077 — positive at both seeds. REAL win** (also lifts coverage). Confirmed.
- **Re-prompt delta 0.000 / −0.046 — the "win" does NOT replicate.** It was an unseeded single-leg artifact (two independent draws from a ±0.14-F1 distribution). Refuted.

## Corrections

- `2026-07-01-relation-reprompt-verdict.md` header corrected (superseded). The `RELATION_REPROMPT` gate is default-off (nothing incorrect shipped) but **not recommended**.
- New measurement standard: set a fixed seed + report ≥2 seeds for any substrate delta claim.

Full write-up: `docs/superpowers/reports/2026-07-02-seed-determinism-verdict.md`.

## Test plan
- [x] `tests/test_llm_seed.py` — 3 passed (seed absent by default; present when set; empty/garbage ignored)
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)