### PR TITLE
chore(golden-suite): refresh dependency floors to current majors

### DIFF
--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -35,16 +35,16 @@ classifiers = [
 # run native automatically — no env vars to set. `golden-suite doctor` verifies
 # it; `golden-suite optimize` repairs it.
 dependencies = [
-    # --- suite ---
-    "goldenpipe[golden-suite]>=1.2.1",  # orchestrator + check/flow/match/analysis
-    "goldenmatch>=1.30",                # entity resolution: dedupe, match, golden records
-    "goldencheck>=1.3",                 # data validation (rules discovered from your data)
-    "goldenflow>=1.2",                  # transform / standardize / normalize
-    "infermap>=0.5",                    # GoldenSchema: inference-driven schema mapping
-    "goldenanalysis>=0.1",              # read-only cross-cutting metrics + reporting
+    # --- suite (floors track the current majors) ---
+    "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
+    "goldenmatch>=2.6",                 # entity resolution: dedupe, match, golden records
+    "goldencheck>=1.4",                 # data validation (rules discovered from your data)
+    "goldenflow>=1.3",                  # transform / standardize / normalize
+    "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
+    "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
-    "goldenmatch-native>=0.1.11",       # >=0.1.11 carries the #692 rayon-park fix
+    "goldenmatch-native>=0.1.12",       # >=0.1.12 carries perceptual + the current kernel surface
     "goldencheck-native>=0.1",
     "goldenflow-native>=0.1.1",
     "goldenanalysis-native>=0.1",
@@ -55,9 +55,9 @@ dependencies = [
 
 [project.optional-dependencies]
 # One MCP server exposing every tool — the agent front door.
-mcp = ["goldensuite-mcp>=0.2"]
+mcp = ["goldensuite-mcp>=0.3"]
 # GoldenPipe serving surfaces (A2A + async transports + TUI + REST).
-agent = ["goldenpipe[tui,api,agent]>=1.2.1"]
+agent = ["goldenpipe[tui,api,agent]>=1.3"]
 # Everything: full suite + native + MCP + serving.
 all = ["golden-suite[mcp,agent]"]
 dev = ["pytest>=8", "ruff>=0.6"]


### PR DESCRIPTION
Refreshes the `golden-suite` meta-package floors to match the shipped suite (they were behind: `goldenmatch>=1.30` while current is 2.6.0, etc.). Floors-only — a fresh `pip install golden-suite` already resolved to the latest of each; this just makes them read honestly.

- `goldenmatch>=2.6`, `goldencheck>=1.4`, `goldenflow>=1.3`, `goldenpipe>=1.3`, `infermap>=0.5.1`, `goldenanalysis>=0.3`, `goldensuite-mcp>=0.3`
- `goldenmatch-native>=0.1.12` — the 0.1.12 wheel (perceptual kernel + current symbol surface) is being published in the same change (`publish-goldenmatch-native.yml` dispatch).

No version bump (golden-suite is unreleased at 0.1.0). Pairs with the goldenmatch-native 0.1.12 release that closes the one `perceptual_phash_image` gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)