### PR TITLE
fix(golden-suite): floor goldenmatch>=2.5 (>=2.6 is unsatisfiable on PyPI)

### DIFF
--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
-    "goldenmatch>=2.6",                 # entity resolution: dedupe, match, golden records
+    "goldenmatch>=2.5",                 # entity resolution: dedupe, match, golden records (2.5.1 is latest on PyPI; 2.6.0 unreleased)
     "goldencheck>=1.4",                 # data validation (rules discovered from your data)
     "goldenflow>=1.3",                  # transform / standardize / normalize
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping


### PR DESCRIPTION
#1362 floored the `golden-suite` meta-package at `goldenmatch>=2.6`, but the latest **published** goldenmatch on PyPI is **2.5.1** — 2.6.0 exists only in-repo (unreleased). So the flagship one-line `pip install golden-suite` (and any from-source install that resolves deps from the index) would fail to resolve the headline package.

Drops the floor to `goldenmatch>=2.5` (2.5.1 satisfies it). Every other floor was already satisfiable. golden-suite is unreleased (0.1.0, not on PyPI), so no live install hit this — it was latent, caught by walking the repo as a fresh user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)