### PR TITLE
feat(erkgbench): substrate staged-ejection tuner (SP-B2)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-substrate-staged-tuner.md
+++ b/docs/superpowers/plans/2026-07-02-substrate-staged-tuner.md
@@ -1,0 +1,542 @@
+# Substrate Staged Tuner (SP-B2) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `erkgbench/substrate_tuner.py` — a deterministic staged-ejection optimizer that builds a config on a cheap gold slice, scores it with the SP-A three-axis scorecard, escalates the config along the failing axis, and promotes the best-so-far config to the full build.
+
+**Architecture:** One pure module. `evaluate_gate` reads the SP-A scorecard; `escalate` walks `LEVER_AXIS_MAP[axis]` applying next-state lever ladders and returns `(lever, new_config)`; `run_staged` loops slice-build→gate→escalate up to a budget and promotes the argmax config to the full build. The real build is injected via a `build_and_score` callable, so the whole control flow is box-testable with a fake; a thin `build_and_score_real` adapter wires the actual `ingest_corpus`+`substrate_scorecard` (Modal-smoke only, not TDD).
+
+**Tech Stack:** Python stdlib (`dataclasses`, `contextlib`), pytest. Imports `goldengraph.config` (SP-B1) + `erkgbench.substrate_eval` (SP-A).
+
+**Spec:** `docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md`
+
+**Branch:** `feat/substrate-tuner` (off `origin/main`). SP-B1 (#1373) is merged to main, so **rebase onto `origin/main` before starting Task 1** (`git fetch origin main && git rebase origin/main`) to bring `goldengraph.config` in; otherwise the imports fail.
+
+---
+
+## Files
+
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py` — the whole SP-B2 harness + the thin real adapter.
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_tuner.py` — pure box-safe tests (fake `build_and_score`).
+
+## Test runner (box-safe)
+
+From the er-kg-bench package dir (`PYTHONPATH=$PWD` so `erkgbench` + `goldengraph` resolve; env flags avoid the polars WMI hang / stale native wheel):
+
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD" PYTHONIOENCODING=utf-8 PYTHONUTF8=1 POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_substrate_tuner.py -q
+```
+
+## Ground-truth facts (verified — do not re-derive)
+
+- **`SubstrateConfig`** (frozen dataclass, `goldengraph.config`): fields `xdoc_key=""`, `chunk_extract=False`, `chunk_sentences=6`, `chunk_overlap=2`, `entity_type_canon=False`, `entity_type_vocab=()`, `schema_canon=False`, `relation_vocab=()`, `extractor="api"`, `relation_reprompt=False`, `rebel_fuse=False`, `extract_recall=False`. Frozen → build new configs with `dataclasses.replace`.
+- **`LEVER_AXIS_MAP`** (`erkgbench.substrate_eval`): `{"presence": ["chunk_extract","extract_recall","extractor"], "relational": ["xdoc_key","entity_type_canon","schema_canon","relation_vocab","relation_reprompt","rebel_fuse"], "connectivity": ["relation_reprompt","rebel_fuse","relation_vocab"]}`.
+- **Refuted levers** (never escalated unless `allow_refuted`): `relation_reprompt`, `rebel_fuse`, `extract_recall`.
+- **`substrate_scorecard` return shape**: `{"presence": {"coverage": float}|None, "relational": {"f1","recall","precision"}, "connectivity": {"coverage"|None,"f1"|None,"edge_recall"}, "coherence": {"components","largest_fraction"}}`. The tuner reads `presence.coverage` and `relational.f1`.
+
+---
+
+### Task 1: `GateThresholds` + `GateResult` + `evaluate_gate`
+
+**Files:**
+- Create: `erkgbench/substrate_tuner.py`
+- Test: `tests/test_substrate_tuner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_substrate_tuner.py`:
+
+```python
+"""SP-B2 substrate staged tuner: gate / escalate / run_staged (pure, box-safe with a fake scorer)."""
+from __future__ import annotations
+
+import pytest
+
+from goldengraph.config import SubstrateConfig
+from erkgbench import substrate_tuner as st
+
+
+def _sc(presence, rel_f1, *, conn_cov=0.5):
+    """A minimal scorecard dict in the substrate_scorecard shape."""
+    return {
+        "presence": None if presence is None else {"coverage": presence},
+        "relational": {"f1": rel_f1, "recall": rel_f1, "precision": 1.0},
+        "connectivity": {"coverage": conn_cov, "f1": conn_cov, "edge_recall": 0.9},
+        "coherence": {"components": 1, "largest_fraction": 1.0},
+    }
+
+
+def test_gate_passes_when_both_axes_clear():
+    g = st.evaluate_gate(_sc(0.95, 0.60), st.GateThresholds())
+    assert g.passed is True and g.failing_axis is None
+
+
+def test_gate_routes_presence_before_relational():
+    g = st.evaluate_gate(_sc(0.10, 0.10), st.GateThresholds())
+    assert g.passed is False and g.failing_axis == "presence"
+
+
+def test_gate_relational_when_presence_ok():
+    g = st.evaluate_gate(_sc(0.95, 0.10), st.GateThresholds())
+    assert g.failing_axis == "relational"
+
+
+def test_gate_skips_presence_when_none():
+    # engineered/no-alias path: presence None -> only relational gated
+    g = st.evaluate_gate(_sc(None, 0.60), st.GateThresholds())
+    assert g.passed is True
+    g2 = st.evaluate_gate(_sc(None, 0.10), st.GateThresholds())
+    assert g2.failing_axis == "relational"
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k gate`. Expected: `ModuleNotFoundError: erkgbench.substrate_tuner`.
+
+- [ ] **Step 3: Implement**
+
+Create `erkgbench/substrate_tuner.py`:
+
+```python
+"""SP-B2 substrate staged tuner.
+
+A deterministic staged-ejection optimizer: build a config on a cheap gold slice, score it with the
+SP-A three-axis scorecard (erkgbench.substrate_eval.substrate_scorecard), escalate the config along
+the failing axis, and promote the best-so-far config to the full build. The real build is injected
+(build_and_score) so the whole control flow is pure + box-testable; build_and_score_real wires the
+actual ingest_corpus + scorecard (Modal-smoke only). See
+docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from goldengraph.config import SubstrateConfig, for_profile, profile_corpus
+
+from erkgbench.substrate_eval import LEVER_AXIS_MAP
+
+_REFUTED = ("relation_reprompt", "rebel_fuse", "extract_recall")
+
+
+@dataclass(frozen=True)
+class GateThresholds:
+    """Per-axis pass floors. Hypotheses tuned by running the harness; env-overridable by the caller."""
+    presence_min: float = 0.90
+    relational_f1_min: float = 0.50
+
+
+@dataclass(frozen=True)
+class GateResult:
+    passed: bool
+    failing_axis: str | None
+    scorecard: dict
+
+
+def evaluate_gate(scorecard: dict, thresholds: GateThresholds) -> GateResult:
+    """Presence before relational (can't fix relational quality on absent entities). Presence is
+    skipped when the scorecard's presence is None (engineered/no-alias path)."""
+    presence = scorecard.get("presence")
+    if presence is not None and presence["coverage"] < thresholds.presence_min:
+        return GateResult(False, "presence", scorecard)
+    if scorecard["relational"]["f1"] < thresholds.relational_f1_min:
+        return GateResult(False, "relational", scorecard)
+    return GateResult(True, None, scorecard)
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k gate`. Expected: PASS (4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py \
+        packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_tuner.py
+git commit -m "feat(erkgbench): GateThresholds + evaluate_gate (presence-before-relational) (SP-B2 task 1)"
+```
+
+---
+
+### Task 2: `escalate` next-state ladder
+
+**Files:**
+- Modify: `erkgbench/substrate_tuner.py`
+- Test: `tests/test_substrate_tuner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_escalate_presence_enables_chunking_first():
+    step = st.escalate(SubstrateConfig(), "presence", set())
+    assert step is not None
+    lever, cfg = step
+    assert lever == "chunk_extract" and cfg.chunk_extract is True
+
+
+def test_escalate_relational_ladder_bumps_xdoc_key_twice():
+    tried = set()
+    l1, c1 = st.escalate(SubstrateConfig(), "relational", tried)
+    assert l1 == "xdoc_key" and c1.xdoc_key == "name_ci"
+    l2, c2 = st.escalate(c1, "relational", tried)
+    assert l2 == "xdoc_key" and c2.xdoc_key == "name_ci_type" and c2.entity_type_canon is True
+
+
+def test_escalate_schema_canon_sets_vocab():
+    # xdoc_key ladder + entity_type_canon exhausted -> schema_canon fires, setting BOTH fields
+    c = SubstrateConfig(xdoc_key="name_ci_type", entity_type_canon=True)
+    tried = {("xdoc_key", "name_ci"), ("xdoc_key", "name_ci_type"), ("entity_type_canon", "True")}
+    step = st.escalate(c, "relational", tried, relation_vocab=("acquired",))
+    assert step is not None
+    lever, cfg = step
+    assert lever == "schema_canon" and cfg.schema_canon is True and cfg.relation_vocab == ("acquired",)
+
+
+def test_escalate_schema_canon_skipped_without_vocab():
+    c = SubstrateConfig(xdoc_key="name_ci_type", entity_type_canon=True)
+    tried = {("xdoc_key", "name_ci"), ("xdoc_key", "name_ci_type"), ("entity_type_canon", "True")}
+    step = st.escalate(c, "relational", tried, relation_vocab=())  # no vocab -> schema_canon ineligible
+    assert step is None
+
+
+def test_escalate_skips_refuted():
+    # presence levers: chunk_extract (ok), extract_recall (REFUTED), extractor. With chunking already on
+    # and gliner tried, the only remaining is extract_recall which must be skipped -> None.
+    c = SubstrateConfig(chunk_extract=True, extractor="gliner")
+    step = st.escalate(c, "presence", {("chunk_extract", "True"), ("extractor", "gliner")})
+    assert step is None
+
+
+def test_escalate_returns_none_when_exhausted():
+    c = SubstrateConfig(chunk_extract=True, extractor="gliner")
+    step = st.escalate(c, "presence", {("chunk_extract", "True"), ("extractor", "gliner")})
+    assert step is None
+
+
+def test_escalate_returns_lever_and_config():
+    step = st.escalate(SubstrateConfig(), "presence", set())
+    assert isinstance(step, tuple) and step[0] == "chunk_extract" and isinstance(step[1], SubstrateConfig)
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k escalate`. Expected: FAIL — no `escalate`.
+
+- [ ] **Step 3: Implement**
+
+Add to `substrate_tuner.py`. Each lever's `_advance(config) -> (next_value_repr, new_config) | None`:
+
+```python
+def _advance_chunk_extract(c):
+    if c.chunk_extract:
+        return None
+    return "True", replace(c, chunk_extract=True, chunk_sentences=6, chunk_overlap=2)
+
+
+def _advance_extractor(c):
+    if c.extractor != "api":
+        return None
+    return "gliner", replace(c, extractor="gliner")
+
+
+def _advance_xdoc_key(c):
+    nxt = {"": "name_ci", "name_ci": "name_ci_type"}.get(c.xdoc_key)
+    if nxt is None:
+        return None
+    if nxt == "name_ci_type":
+        return nxt, replace(c, xdoc_key=nxt, entity_type_canon=True)
+    return nxt, replace(c, xdoc_key=nxt)
+
+
+def _advance_entity_type_canon(c):
+    if c.entity_type_canon:
+        return None
+    return "True", replace(c, entity_type_canon=True)
+
+
+def _advance_schema_canon(c, relation_vocab):
+    if c.schema_canon or not relation_vocab:
+        return None
+    return "True", replace(c, schema_canon=True, relation_vocab=tuple(relation_vocab))
+
+
+#: lever -> its _advance. Refuted levers + relation_vocab (no self-ladder) are absent -> never advanced.
+_ADVANCERS = {
+    "chunk_extract": lambda c, v: _advance_chunk_extract(c),
+    "extractor": lambda c, v: _advance_extractor(c),
+    "xdoc_key": lambda c, v: _advance_xdoc_key(c),
+    "entity_type_canon": lambda c, v: _advance_entity_type_canon(c),
+    "schema_canon": lambda c, v: _advance_schema_canon(c, v),
+}
+
+
+def escalate(config, failing_axis, tried, *, relation_vocab=(), allow_refuted=False):
+    """First eligible next-state advance along LEVER_AXIS_MAP[failing_axis]. Returns (lever, new_config)
+    and records (lever, next_value_repr) in `tried` (sole mutator), or None when the axis is exhausted."""
+    for lever in LEVER_AXIS_MAP.get(failing_axis, ()):
+        if lever in _REFUTED and not allow_refuted:
+            continue
+        adv = _ADVANCERS.get(lever)
+        if adv is None:
+            continue
+        step = adv(config, relation_vocab)
+        if step is None:
+            continue
+        next_repr, new_config = step
+        if (lever, next_repr) in tried:
+            continue
+        tried.add((lever, next_repr))
+        return lever, new_config
+    return None
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k escalate`. Expected: PASS (7).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py \
+        packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_tuner.py
+git commit -m "feat(erkgbench): escalate next-state ladder, returns (lever, config), skips refuted (SP-B2 task 2)"
+```
+
+---
+
+### Task 3: `RoundReport` + `TunerResult` + `run_staged`
+
+**Files:**
+- Modify: `erkgbench/substrate_tuner.py`
+- Test: `tests/test_substrate_tuner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def _tiny_corpus():
+    # docs/gold/aliases the fake ignores; run_staged only passes them through to build_and_score.
+    return ["doc one.", "doc two."], [("Q1", "a", "d1")], {"Q1": ["a"]}
+
+
+def test_run_staged_rejects_budget_below_one():
+    docs, gold, al = _tiny_corpus()
+    with pytest.raises(ValueError):
+        st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(1.0, 1.0), budget=0)
+
+
+def test_run_staged_passes_first_round():
+    docs, gold, al = _tiny_corpus()
+    calls = []
+
+    def fake(cfg, ds):
+        calls.append(ds)
+        return _sc(0.95, 0.60)  # passes immediately
+
+    res = st.run_staged(docs, gold, al, build_and_score=fake, budget=3)
+    assert res.stopped_reason == "passed"
+    assert len(res.trace) == 1
+    assert len(calls) == 2  # 1 slice round + 1 full build
+
+
+def test_run_staged_escalates_then_passes():
+    docs, gold, al = _tiny_corpus()
+    scores = iter([_sc(0.95, 0.10), _sc(0.95, 0.60)])  # fail relational, then pass after escalate
+
+    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: next(scores), budget=5)
+    assert res.stopped_reason == "passed"
+    assert len(res.trace) == 2
+    assert res.trace[0].escalated_to == "xdoc_key"  # relational fail -> xdoc_key bump
+
+
+def test_run_staged_budget_exhausted():
+    docs, gold, al = _tiny_corpus()
+    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(0.95, 0.10), budget=2)
+    assert res.stopped_reason == "budget" and len(res.trace) == 2
+
+
+def test_run_staged_promotes_argmax_not_last():
+    docs, gold, al = _tiny_corpus()
+    # round0 high, then regressions; best-so-far must be round0's config, and the full build uses it.
+    scores = iter([_sc(0.95, 0.80), _sc(0.95, 0.10), _sc(0.95, 0.10)])
+    seen = []
+
+    def fake(cfg, ds):
+        seen.append(cfg)
+        return next(scores)
+
+    res = st.run_staged(docs, gold, al, build_and_score=fake, budget=3)
+    # best config == the round-0 config (default from for_profile), full build invoked with it
+    assert res.config == res.trace[0].config
+    assert seen[-1] == res.config  # last call (the full build) used the argmax config
+
+
+def test_run_staged_terminal_eject():
+    docs, gold, al = _tiny_corpus()
+    # force presence axis to fail with all presence levers pre-exhausted so escalate returns None
+    cfg0 = SubstrateConfig(chunk_extract=True, extractor="gliner")
+    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(0.10, 0.95),
+                        budget=5, initial_config=cfg0)
+    assert res.stopped_reason == "exhausted"
+
+
+def test_tuner_result_trace_is_serializable():
+    docs, gold, al = _tiny_corpus()
+    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(0.95, 0.60), budget=1)
+    r0 = res.trace[0]
+    assert r0.round == 0 and isinstance(r0.config, SubstrateConfig) and "relational" in r0.scorecard
+    assert r0.escalated_to is None
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k run_staged or tuner_result`. Expected: FAIL — no `run_staged`.
+
+- [ ] **Step 3: Implement**
+
+Add to `substrate_tuner.py`:
+
+```python
+@dataclass(frozen=True)
+class RoundReport:
+    round: int
+    config: SubstrateConfig
+    scorecard: dict
+    gate: GateResult
+    escalated_to: str | None
+
+
+@dataclass(frozen=True)
+class TunerResult:
+    config: SubstrateConfig
+    slice_scorecard: dict
+    full_scorecard: dict
+    trace: list = field(default_factory=list)
+    stopped_reason: str = ""
+
+
+def _score(scorecard: dict) -> float:
+    """Round-ranking scalar: relational.f1 (+ presence.coverage when present). Higher wins."""
+    s = scorecard["relational"]["f1"]
+    presence = scorecard.get("presence")
+    if presence is not None:
+        s += presence["coverage"]
+    return s
+
+
+def run_staged(docs, gold, qid_aliases, *, build_and_score, thresholds=None, budget=5,
+               relation_vocab=(), expect_homographs=False, has_known_schema=False,
+               initial_config=None):
+    """Slice-gated deterministic optimizer. Escalates on the failing axis up to `budget` rounds, then
+    promotes the best-so-far (argmax _score) config to a full build. `build_and_score(config, dataset)`
+    is the injection seam (dataset = (docs, gold, qid_aliases)). Raises ValueError on budget < 1."""
+    if budget < 1:
+        raise ValueError(f"budget must be >= 1, got {budget}")
+    thresholds = thresholds or GateThresholds()
+    if initial_config is None:
+        initial_config = for_profile(
+            profile_corpus(docs), has_known_schema=has_known_schema,
+            expect_homographs=expect_homographs, relation_vocab=relation_vocab,
+        )
+    dataset = (docs, gold, qid_aliases)
+    config = initial_config
+    tried: set = set()
+    rounds: list[RoundReport] = []
+    stopped = "budget"
+    for r in range(budget):
+        sc = build_and_score(config, dataset)
+        gate = evaluate_gate(sc, thresholds)
+        step = None if gate.passed else escalate(config, gate.failing_axis, tried,
+                                                 relation_vocab=relation_vocab)
+        escalated_to, next_config = (None, None) if step is None else step
+        rounds.append(RoundReport(r, config, sc, gate, escalated_to))
+        if gate.passed:
+            stopped = "passed"
+            break
+        if step is None:
+            stopped = "exhausted"
+            break
+        config = next_config
+    best = max(rounds, key=lambda rr: _score(rr.scorecard))
+    full_sc = build_and_score(best.config, dataset)
+    return TunerResult(best.config, best.scorecard, full_sc, rounds, stopped)
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k "run_staged or tuner_result"`. Expected: PASS (7).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py \
+        packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_tuner.py
+git commit -m "feat(erkgbench): run_staged slice-gated loop + best-so-far argmax + budget guard (SP-B2 task 3)"
+```
+
+---
+
+### Task 4: `build_and_score_real` adapter (thin, Modal-smoke only — NOT TDD)
+
+**Files:**
+- Modify: `erkgbench/substrate_tuner.py`
+
+- [ ] **Step 1: Implement the adapter** (no unit test — needs native store + LLM; validated by a Modal smoke, not the box)
+
+Add to `substrate_tuner.py`:
+
+```python
+def build_and_score_real(config, dataset):
+    """Real build_and_score: under config.apply(), build the graph over the dataset docs and score it
+    with the SP-A three-axis scorecard. Needs the native store + an LLM -> Modal/CI only, NOT box-safe.
+    Kept thin; the pure harness above is the tested surface."""
+    from erkgbench import substrate_eval
+    from erkgbench.run_substrate_eval import _build_graph_from_documents
+
+    docs, gold, qid_aliases = dataset
+
+    class _Doc:  # _build_graph_from_documents wants .text/.id; wrap raw (text, id) pairs
+        __slots__ = ("text", "id")
+
+        def __init__(self, text, doc_id):
+            self.text, self.id = text, doc_id
+
+    with config.apply():
+        documents = [_Doc(t, f"d{i}") for i, t in enumerate(docs)] if not hasattr(docs[0], "text") else docs
+        graph = _build_graph_from_documents(documents)
+    return substrate_eval.substrate_scorecard(graph, gold, qid_aliases)
+```
+
+> NOTE: the exact `dataset`/`_Doc` shape must match whatever the Modal smoke passes (wiki `load_wiki_corpus` yields `Document` objects with `.text`/`.id` + real `gold`/`qid_aliases`). Adjust the wrapper at smoke time; this adapter is deliberately NOT locked by a box test. Do NOT import it at module top in a way that forces `run_substrate_eval` (which pulls native) into the box test path — it is imported INSIDE the function so the pure harness stays box-safe.
+
+- [ ] **Step 2: Static-check** — confirm the module imports cleanly box-safe (the real adapter's heavy imports are function-local):
+
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD" POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -c "import erkgbench.substrate_tuner as st; print('import-ok', hasattr(st, 'build_and_score_real'))"
+```
+Expected: `import-ok True` with no native/LLM import triggered.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py
+git commit -m "feat(erkgbench): thin build_and_score_real adapter (Modal-smoke only, heavy imports fn-local) (SP-B2 task 4)"
+```
+
+---
+
+### Task 5: Finish the branch
+
+- [ ] **Step 1: Rebase onto main** (SP-B1 #1373 is merged — should already be done pre-Task-1; re-confirm clean):
+  ```bash
+  unset GH_TOKEN; export GH_TOKEN=$(gh auth token --user benzsevern)
+  git fetch origin main && git rebase origin/main
+  ```
+- [ ] **Step 2: Full file green** — box-safe command on the whole file; expect all green (Tasks 1-3 = 18 tests).
+- [ ] **Step 3: Lint** — `ruff check` the two files; fix any finding.
+  ```bash
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_tuner.py
+  ```
+- [ ] **Step 4: Spec status** — flip the spec `Status:` to `implemented`; commit.
+- [ ] **Step 5: Push + PR** — `git push -u origin feat/substrate-tuner`; open PR base `main`; arm `gh pr merge <N> --repo benseverndev-oss/goldenmatch --auto` and STOP (no CI poll).
+- [ ] **Step 6: Update memory** — append SP-B2 shipped to `project_goldengraph_local_oss_llm_lane.md` (deterministic staged tuner; the Modal smoke of `build_and_score_real` + SP-C LLM loop are the follow-ons).
+
+---
+
+## Notes for the implementer
+
+- **Box-safe only.** Run just `tests/test_substrate_tuner.py`. The pure harness has NO native/LLM/Modal dependency — that is the whole point of the injected `build_and_score`. If a test triggers a native/polars import, something leaked; the real adapter's heavy imports MUST stay function-local.
+- **`escalate` never re-arms a refuted lever** unless `allow_refuted=True` (which nothing in SP-B2 passes). `relation_reprompt`/`rebel_fuse`/`extract_recall` have no `_ADVANCERS` entry AND are in `_REFUTED` — double-guarded.
+- **`tried` is a `(lever, next_value_repr)` set**, keyed by the RESULTING state so a ladder lever (`xdoc_key`) can advance multiple times. Never key it by lever name.
+- **best-so-far, not last.** `run_staged` returns the argmax-`_score` config, and the full build runs on THAT, on every exit (`passed`/`budget`/`exhausted`).
+- **The real adapter is not unit-tested by design.** Its correctness is a Modal smoke (a follow-up), because it needs the native store + an LLM. Don't try to make it box-testable.

--- a/docs/superpowers/plans/2026-07-02-substrate-staged-tuner.md
+++ b/docs/superpowers/plans/2026-07-02-substrate-staged-tuner.md
@@ -343,24 +343,30 @@ def test_run_staged_escalates_then_passes():
 
 def test_run_staged_budget_exhausted():
     docs, gold, al = _tiny_corpus()
-    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(0.95, 0.10), budget=2)
+    # Start from a bare config (xdoc_key="") so the relational ladder has TWO steps (""->name_ci->
+    # name_ci_type); with budget=2 both rounds fail + escalate successfully, so the for-loop reaches
+    # its cap -> "budget" (NOT "exhausted", which the 1-step for_profile default would hit at round1).
+    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(0.95, 0.10),
+                        budget=2, initial_config=SubstrateConfig())
     assert res.stopped_reason == "budget" and len(res.trace) == 2
 
 
 def test_run_staged_promotes_argmax_not_last():
     docs, gold, al = _tiny_corpus()
-    # round0 high, then regressions; best-so-far must be round0's config, and the full build uses it.
-    scores = iter([_sc(0.95, 0.80), _sc(0.95, 0.10), _sc(0.95, 0.10)])
+    # round0 FAILS the gate (0.40<0.50) but is the highest scorer; later rounds regress lower. Best-so-
+    # far must be round0's config, and the full build must use it. Bare init gives a 2-step ladder so
+    # rounds 0/1 escalate and round2 exhausts (trace has 3 rounds to argmax over).
+    scores = iter([_sc(0.95, 0.40), _sc(0.95, 0.10), _sc(0.95, 0.10)])
     seen = []
 
     def fake(cfg, ds):
         seen.append(cfg)
         return next(scores)
 
-    res = st.run_staged(docs, gold, al, build_and_score=fake, budget=3)
-    # best config == the round-0 config (default from for_profile), full build invoked with it
-    assert res.config == res.trace[0].config
-    assert seen[-1] == res.config  # last call (the full build) used the argmax config
+    res = st.run_staged(docs, gold, al, build_and_score=fake, budget=3,
+                        initial_config=SubstrateConfig())
+    assert res.config == res.trace[0].config  # argmax = round0, not the last (regressed) config
+    assert seen[-1] == res.config             # the full build used the argmax config
 
 
 def test_run_staged_terminal_eject():
@@ -380,7 +386,7 @@ def test_tuner_result_trace_is_serializable():
     assert r0.escalated_to is None
 ```
 
-- [ ] **Step 2: Run to verify it fails** — box-safe `-k run_staged or tuner_result`. Expected: FAIL — no `run_staged`.
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k "run_staged or tuner_result"` (quote the expression — the shell splits an unquoted `or`). Expected: FAIL — no `run_staged`.
 
 - [ ] **Step 3: Implement**
 
@@ -489,8 +495,10 @@ def build_and_score_real(config, dataset):
         def __init__(self, text, doc_id):
             self.text, self.id = text, doc_id
 
+    if not docs:
+        raise ValueError("build_and_score_real: empty docs")
     with config.apply():
-        documents = [_Doc(t, f"d{i}") for i, t in enumerate(docs)] if not hasattr(docs[0], "text") else docs
+        documents = docs if hasattr(docs[0], "text") else [_Doc(t, f"d{i}") for i, t in enumerate(docs)]
         graph = _build_graph_from_documents(documents)
     return substrate_eval.substrate_scorecard(graph, gold, qid_aliases)
 ```

--- a/docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md
+++ b/docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md
@@ -28,16 +28,18 @@ SP-B1 gives a config object + a static rule-table pick (`for_profile`). But whic
 run_staged(docs, gold, qid_aliases, *, build_and_score, thresholds, budget, relation_vocab=(), ...)
   1. config = for_profile(profile_corpus(docs), ...)          # SP-B1 initial pick
   2. slice = a fixed gold-bearing subset (docs+gold+aliases)
+  # precondition: budget >= 1 (else there is no round to score and best_config is undefined)
   3. tried = set()                                            # (lever, next_value) pairs, mutated ONLY by escalate
      rounds = []
      for r in range(budget):
        sc = build_and_score(config, slice)                    # INJECTED: real=Modal, test=fake
        gate = evaluate_gate(sc, thresholds)
-       config2 = None if gate.passed else escalate(config, gate.failing_axis, tried,
-                                                    relation_vocab=relation_vocab)
-       rounds.append(RoundReport(r, config, sc, gate, escalated_to=_lever_of(config, config2)))
+       step = None if gate.passed else escalate(config, gate.failing_axis, tried,
+                                                 relation_vocab=relation_vocab)   # (lever, new_config) | None
+       escalated_to, config2 = (None, None) if step is None else step
+       rounds.append(RoundReport(r, config, sc, gate, escalated_to=escalated_to))
        if gate.passed: stopped = "passed"; break
-       if config2 is None: stopped = "exhausted"; break       # no eligible lever left on the failing axis
+       if step is None: stopped = "exhausted"; break          # no eligible lever left on the failing axis
        config = config2
      else:
        stopped = "budget"
@@ -65,12 +67,12 @@ Env-overridable defaults. Thresholds are *hypotheses* (like SP-B1's `CHUNK_MIN_S
 
 **Connectivity is intentionally ungated in v1.** `GateThresholds` has only `presence_min` + `relational_f1_min`, so `evaluate_gate` only ever routes to `{presence, relational}`. This is deliberate: `LEVER_AXIS_MAP["connectivity"]` is `[relation_reprompt, rebel_fuse, relation_vocab]` — all refuted or not-auto-toggled — so a connectivity failure would have no eligible escalation and immediately exhaust. Connectivity is reported in the scorecard (visible in the trace) but is not a gate axis; that is why the escalate transform table has no connectivity-only rows. Adding a connectivity gate waits until there's a non-refuted lever that moves it.
 
-### 3. `escalate(config, failing_axis, tried, *, relation_vocab=(), allow_refuted=False) -> SubstrateConfig | None`
+### 3. `escalate(config, failing_axis, tried, *, relation_vocab=(), allow_refuted=False) -> tuple[str, SubstrateConfig] | None`
 Deterministic policy, built on **next-state transitions** (NOT a "tried lever name" set — that breaks the `xdoc_key` ladder). Each lever has an `_advance(config) -> (next_value_repr, new_config) | None` that moves it ONE step from its current state (returns `None` when already at the end of its ladder). `escalate` walks `LEVER_AXIS_MAP[failing_axis]` in order and selects the **first** lever that is:
   (a) not refuted [unless `allow_refuted`], and
   (b) `_advance` yields a step (`next != current`), and
   (c) the `(lever, next_value_repr)` pair is not already in `tried`.
-It records `(lever, next_value_repr)` in `tried` (escalate is the **sole** mutator of `tried`) and returns the new (frozen) config via `dataclasses.replace`. Returns `None` when every axis lever is exhausted → terminal eject.
+It records `(lever, next_value_repr)` in `tried` (escalate is the **sole** mutator of `tried`) and returns **`(lever_name, new_config)`** — the new frozen config via `dataclasses.replace`, PAIRED WITH the advanced lever's name so the caller records `escalated_to` directly instead of diffing (a diff is ambiguous: the `xdoc_key→name_ci_type` and `schema_canon` steps each change two fields). Returns `None` when every axis lever is exhausted → terminal eject (`escalated_to` is then `None`, as it is for a passed round).
 
 **Termination:** every lever's ladder is finite (`chunk_extract`: F→T; `extractor`: api→gliner; `xdoc_key`: ""→name_ci→name_ci_type; `entity_type_canon`: F→T; `schema_canon`: F→T), each `(lever, next)` pair is recorded once and never re-selected, so the total number of escalations across all rounds is bounded by the sum of ladder lengths → the loop always terminates (independent of `budget`).
 
@@ -111,6 +113,8 @@ Under `config.apply()`: run `ingest_corpus` over the dataset's docs → graph �
 - `run_staged_budget_exhausted` — fake always fails → stops at `budget`, `stopped_reason="budget"`, full build still runs on best-so-far.
 - `run_staged_promotes_argmax_not_last` — fake returns a HIGH score on round 1 then LOWER on later rounds (a regressing escalation) → `TunerResult.config` is round-1's config (argmax), and the full build is invoked with it (not the last-tried config).
 - `run_staged_terminal_eject` — fail on an axis with no eligible lever → `stopped_reason="exhausted"`, full build still runs on best-so-far.
+- `run_staged_rejects_budget_below_one` — `run_staged(..., budget=0)` raises `ValueError` (no round → `best_config` undefined; guard the precondition rather than degenerate the argmax over an empty trace).
+- `escalate_returns_lever_and_config` — a successful escalate returns a `(lever_name, SubstrateConfig)` tuple whose lever_name is the advanced lever (e.g. `"chunk_extract"`), so `RoundReport.escalated_to` is set without diffing.
 - `tuner_result_trace_is_serializable` — `trace` RoundReports carry the scorecard + config + escalated_to (the SP-C hand-off shape).
 
 ## Design choices flagged for review

--- a/docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md
+++ b/docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md
@@ -25,21 +25,31 @@ SP-B1 gives a config object + a static rule-table pick (`for_profile`). But whic
 ## Architecture
 
 ```
-run_staged(docs, gold, qid_aliases, *, build_and_score, thresholds, budget, ...)
+run_staged(docs, gold, qid_aliases, *, build_and_score, thresholds, budget, relation_vocab=(), ...)
   1. config = for_profile(profile_corpus(docs), ...)          # SP-B1 initial pick
   2. slice = a fixed gold-bearing subset (docs+gold+aliases)
-  3. for round in range(budget):
+  3. tried = set()                                            # (lever, next_value) pairs, mutated ONLY by escalate
+     rounds = []
+     for r in range(budget):
        sc = build_and_score(config, slice)                    # INJECTED: real=Modal, test=fake
        gate = evaluate_gate(sc, thresholds)
-       if gate.passed: break
-       tried.add(...); config2 = escalate(config, gate.failing_axis, tried)
-       if config2 is None: break                              # escalation exhausted -> eject terminal
+       config2 = None if gate.passed else escalate(config, gate.failing_axis, tried,
+                                                    relation_vocab=relation_vocab)
+       rounds.append(RoundReport(r, config, sc, gate, escalated_to=_lever_of(config, config2)))
+       if gate.passed: stopped = "passed"; break
+       if config2 is None: stopped = "exhausted"; break       # no eligible lever left on the failing axis
        config = config2
-  4. full_sc = build_and_score(best_config, full)             # promote winner to full build
-  5. return TunerResult(config, slice_scorecard, full_scorecard, trace=[RoundReport...])
+     else:
+       stopped = "budget"
+  4. best_config = argmax over rounds by _score(round.scorecard)   # escalation is NOT monotonic -> pick best
+     full_sc = build_and_score(best_config, full)             # ALWAYS promote best-so-far to the full build
+  5. return TunerResult(best_config, slice_scorecard=best_round.scorecard, full_scorecard=full_sc,
+                        trace=rounds, stopped_reason=stopped)
 ```
 
 `build_and_score(config, dataset) -> scorecard_dict` is the single injection seam. The pure harness never imports Modal or runs a real build; it calls this callable and reads the SP-A scorecard shape (`{"presence": {...}|None, "relational": {...}, "connectivity": {...}, "coherence": {...}}`).
+
+`_score(scorecard) -> float` is the round-ranking scalar used to pick `best_config`: `relational.f1 + presence.coverage` (or just `relational.f1` when `presence is None`). Higher wins; ties → earliest round. This is what makes "promote the best-so-far" well-defined even though escalation can regress (e.g. an `extractor` swap).
 
 ## Components (in `erkgbench/substrate_tuner.py`)
 
@@ -53,25 +63,33 @@ Env-overridable defaults. Thresholds are *hypotheses* (like SP-B1's `CHUNK_MIN_S
 ### 2. `GateResult` + `evaluate_gate(scorecard, thresholds) -> GateResult`
 `GateResult{passed: bool, failing_axis: str | None, scorecard: dict}`. Axis-precedence when both fail: **presence before relational** (you can't fix relational quality on entities that aren't in the KB — fix presence first). If `presence is None` (engineered/no-alias path), the presence check is skipped and only relational is gated.
 
+**Connectivity is intentionally ungated in v1.** `GateThresholds` has only `presence_min` + `relational_f1_min`, so `evaluate_gate` only ever routes to `{presence, relational}`. This is deliberate: `LEVER_AXIS_MAP["connectivity"]` is `[relation_reprompt, rebel_fuse, relation_vocab]` — all refuted or not-auto-toggled — so a connectivity failure would have no eligible escalation and immediately exhaust. Connectivity is reported in the scorecard (visible in the trace) but is not a gate axis; that is why the escalate transform table has no connectivity-only rows. Adding a connectivity gate waits until there's a non-refuted lever that moves it.
+
 ### 3. `escalate(config, failing_axis, tried, *, relation_vocab=(), allow_refuted=False) -> SubstrateConfig | None`
-Deterministic policy. Walks `LEVER_AXIS_MAP[failing_axis]` in order; for the first lever that is (a) not refuted [unless `allow_refuted`], (b) not already tried, and (c) has an applicable transform that *changes* the config, returns a new config with that transform applied and records it in `tried`. Returns `None` when the axis is exhausted (→ terminal eject).
+Deterministic policy, built on **next-state transitions** (NOT a "tried lever name" set — that breaks the `xdoc_key` ladder). Each lever has an `_advance(config) -> (next_value_repr, new_config) | None` that moves it ONE step from its current state (returns `None` when already at the end of its ladder). `escalate` walks `LEVER_AXIS_MAP[failing_axis]` in order and selects the **first** lever that is:
+  (a) not refuted [unless `allow_refuted`], and
+  (b) `_advance` yields a step (`next != current`), and
+  (c) the `(lever, next_value_repr)` pair is not already in `tried`.
+It records `(lever, next_value_repr)` in `tried` (escalate is the **sole** mutator of `tried`) and returns the new (frozen) config via `dataclasses.replace`. Returns `None` when every axis lever is exhausted → terminal eject.
 
-Per-lever transforms (the escalation "moves"):
-| lever | transform | notes |
+**Termination:** every lever's ladder is finite (`chunk_extract`: F→T; `extractor`: api→gliner; `xdoc_key`: ""→name_ci→name_ci_type; `entity_type_canon`: F→T; `schema_canon`: F→T), each `(lever, next)` pair is recorded once and never re-selected, so the total number of escalations across all rounds is bounded by the sum of ladder lengths → the loop always terminates (independent of `budget`).
+
+Per-lever `_advance` transitions (the escalation "moves"):
+| lever | advance (current → next) | notes |
 |---|---|---|
-| `chunk_extract` | `False→True` (6,2) | presence lever, the measured win |
-| `extractor` | `"api"→"gliner"` | presence lever, a swap |
-| `xdoc_key` | `""→"name_ci"→"name_ci_type"` (+`entity_type_canon=True` on the last) | relational lever |
-| `entity_type_canon` | `False→True` | relational (usually rides xdoc_key) |
-| `schema_canon` | `False→True` **only if `relation_vocab` non-empty** | relational; needs a vocab |
+| `chunk_extract` | `False → True` (with `chunk_sentences=6, chunk_overlap=2`) | presence lever, the measured win |
+| `extractor` | `"api" → "gliner"` | presence lever, a swap |
+| `xdoc_key` | `"" → "name_ci" → "name_ci_type"` (sets `entity_type_canon=True` on the `→name_ci_type` step) | relational ladder (2 steps) |
+| `entity_type_canon` | `False → True` | relational (usually already set by the xdoc_key ladder) |
+| `schema_canon` | `False → True` **AND set `relation_vocab=<escalate's relation_vocab param>`** — eligible ONLY if that param is non-empty and `config.schema_canon` is False | relational; enabling canon WITHOUT a vocab is engine-defeated (SP-B1 §2), so the two are set together |
 | `relation_reprompt`, `rebel_fuse`, `extract_recall` | skipped unless `allow_refuted` | REFUTED levers |
-| `relation_vocab` | not auto-toggled (needs an external vocab) | skipped in auto-escalation |
+| `relation_vocab` | not auto-toggled on its own (has no ladder; it rides `schema_canon`) | — |
 
-Refuted levers are gated behind `allow_refuted=False` (default) so the deterministic policy never re-arms a dead path; SP-C can flip it to let the LLM *propose* a measurement-gated re-test.
+The `relation_vocab` param carries EXTERNAL knowledge (the caller's known schema, same as SP-B1's `for_profile(relation_vocab=)`); it is read from the param, not `config.relation_vocab`, and written onto the config together with `schema_canon`. Refuted levers are gated behind `allow_refuted=False` (default) so the deterministic policy never re-arms a dead path; SP-C can flip it to let the LLM *propose* a measurement-gated re-test.
 
 ### 4. `RoundReport` + `TunerResult`
-- `RoundReport{round: int, config: SubstrateConfig, scorecard: dict, gate: GateResult, escalated_to: str | None}` — the ejection diagnostic (`escalated_to` = the lever toggled, or None if passed/exhausted). This is the structured hand-off SP-C's LLM will consume in place of `escalate`.
-- `TunerResult{config, slice_scorecard, full_scorecard, trace: list[RoundReport], stopped_reason: str}` (`"passed" | "budget" | "exhausted"`).
+- `RoundReport{round: int, config: SubstrateConfig, scorecard: dict, gate: GateResult, escalated_to: str | None}` — the ejection diagnostic (`escalated_to` = the lever advanced this round, or None if passed/exhausted). This is the structured hand-off SP-C's LLM will consume in place of `escalate`.
+- `TunerResult{config, slice_scorecard, full_scorecard, trace: list[RoundReport], stopped_reason: str}` (`"passed" | "budget" | "exhausted"`). `config` = the **best-so-far** config (argmax of `_score` over `trace`, not necessarily the last one tried), and `full_scorecard` is that best config re-scored on the full corpus. The full build ALWAYS runs on the best-so-far, including on the `budget` and `exhausted` exits (escalate returning `None` means "no further improvement available," so the best already-seen config is the answer).
 
 ### 5. Real adapter `build_and_score_real(config, dataset)` (thin, erkgbench)
 Under `config.apply()`: run `ingest_corpus` over the dataset's docs → graph → `substrate_scorecard(graph, gold, qid_aliases)`. Reuses `run_substrate_eval._wiki_build`-style plumbing. NOT box-testable (needs native store + LLM) → validated by a Modal smoke, not TDD. The pure harness is validated with a fake.
@@ -83,13 +101,16 @@ Under `config.apply()`: run `ingest_corpus` over the dataset's docs → graph �
 - `gate_routes_presence_before_relational` — both below floor → `failing_axis == "presence"`.
 - `gate_skips_presence_when_none` — engineered `presence=None` → only relational gated.
 - `escalate_presence_enables_chunking_first` — presence fail on a default config → `chunk_extract` turned on.
-- `escalate_relational_bumps_xdoc_key` — relational fail with `xdoc_key=""` → `"name_ci"`; again → `"name_ci_type"` + `entity_type_canon`.
+- `escalate_relational_ladder_bumps_xdoc_key_twice` — relational fail with `xdoc_key=""` → `"name_ci"` (records `(xdoc_key, name_ci)`); escalate the RESULT again → `"name_ci_type"` + `entity_type_canon` (records `(xdoc_key, name_ci_type)`). Proves the ladder advances across calls (the Critical: `tried` keyed by `(lever, next_value)`, not lever name).
+- `escalate_schema_canon_sets_vocab` — relational fail, `relation_vocab=("acquired",)` passed, xdoc_key ladder exhausted → `schema_canon=True` AND `relation_vocab==("acquired",)` on the new config (never one without the other).
+- `escalate_schema_canon_skipped_without_vocab` — same but `relation_vocab=()` → `schema_canon` NOT selected (would be engine-defeated).
 - `escalate_skips_refuted` — no escalation path selects reprompt/rebel/extract_recall (allow_refuted=False).
-- `escalate_returns_none_when_exhausted` — all axis levers tried → `None`.
+- `escalate_returns_none_when_exhausted` — all axis levers advanced → `None`.
 - `run_staged_passes_first_round` — fake returns a passing scorecard immediately → 1 round, `stopped_reason="passed"`, full build invoked once.
 - `run_staged_escalates_then_passes` — fake returns fail then pass → 2 rounds, config escalated once, trace records the ejection, then the full build runs on the winner.
 - `run_staged_budget_exhausted` — fake always fails → stops at `budget`, `stopped_reason="budget"`, full build still runs on best-so-far.
-- `run_staged_terminal_eject` — fail on an axis with no eligible lever → `stopped_reason="exhausted"`.
+- `run_staged_promotes_argmax_not_last` — fake returns a HIGH score on round 1 then LOWER on later rounds (a regressing escalation) → `TunerResult.config` is round-1's config (argmax), and the full build is invoked with it (not the last-tried config).
+- `run_staged_terminal_eject` — fail on an axis with no eligible lever → `stopped_reason="exhausted"`, full build still runs on best-so-far.
 - `tuner_result_trace_is_serializable` — `trace` RoundReports carry the scorecard + config + escalated_to (the SP-C hand-off shape).
 
 ## Design choices flagged for review

--- a/docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md
+++ b/docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md
@@ -1,7 +1,7 @@
 # Substrate Staged Tuner — Design (SP-B2)
 
 **Date:** 2026-07-02
-**Status:** design, pre-implementation
+**Status:** implemented (branch `feat/substrate-tuner`)
 **Sub-project:** SP-B2 of the substrate-builder config-surface program (SP-A metric split #1371 merged; SP-B1 config surface #1373 armed; SP-C MCP/LLM loop follows this).
 
 ## Scope decisions (flagged for review)

--- a/docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md
+++ b/docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md
@@ -1,0 +1,110 @@
+# Substrate Staged Tuner — Design (SP-B2)
+
+**Date:** 2026-07-02
+**Status:** design, pre-implementation
+**Sub-project:** SP-B2 of the substrate-builder config-surface program (SP-A metric split #1371 merged; SP-B1 config surface #1373 armed; SP-C MCP/LLM loop follows this).
+
+## Scope decisions (flagged for review)
+
+1. **A working deterministic optimizer, not just a reporter.** SP-B2 ships a staged loop with a *deterministic escalation policy* — the honest baseline SP-C's LLM proposer must later beat. No LLM in SP-B2.
+2. **Slice-gated loop.** Iterate on a cheap gold *slice* (build + score), and only promote a config that passes the slice gate to the expensive full build. This is the "don't pay a full build per candidate" idea. The unsupervised cheap-proxy *sample-extract* stage (parse-fail/density on unlabeled text) is **deferred** — it's the no-gold/production follow-on and needs proxy-validation first.
+3. **Pure harness + injected `build_and_score`.** The control flow (staging, gates, ejection routing, escalation) is pure and box-TDD'd against a *fake* scorer. A thin real adapter wires the actual `ingest_corpus` + `substrate_scorecard` build; its end-to-end Modal run is a follow-up smoke, not part of the TDD.
+4. **Lives in `erkgbench`** (`erkgbench/substrate_tuner.py`) — the bench/tuning layer that already owns `LEVER_AXIS_MAP` + `substrate_scorecard` (SP-A) and imports goldengraph. Consumes `SubstrateConfig`/`for_profile` (SP-B1).
+
+## Problem
+
+SP-B1 gives a config object + a static rule-table pick (`for_profile`). But which config is actually best for a corpus is an empirical question — the rule table is a hypothesis. SP-B2 closes the loop: build a slice under a config, score it with the SP-A three-axis scorecard, and if a gate axis is lackluster, **eject** with a diagnostic and **escalate** the config along that axis, iterating cheaply on the slice before paying for the full build. This is the deterministic core of Ben's staged-ejection optimizer.
+
+## Non-goals
+
+- No LLM / MCP (SP-C).
+- No unsupervised (no-gold) gates — gold slice required (bench/dev setting; the production proxy path is a documented follow-on).
+- No change to `ingest_corpus` or the scorers — SP-B2 orchestrates existing pieces.
+- No new levers — escalation only toggles levers already in `SubstrateConfig`/`LEVER_AXIS_MAP`.
+
+## Architecture
+
+```
+run_staged(docs, gold, qid_aliases, *, build_and_score, thresholds, budget, ...)
+  1. config = for_profile(profile_corpus(docs), ...)          # SP-B1 initial pick
+  2. slice = a fixed gold-bearing subset (docs+gold+aliases)
+  3. for round in range(budget):
+       sc = build_and_score(config, slice)                    # INJECTED: real=Modal, test=fake
+       gate = evaluate_gate(sc, thresholds)
+       if gate.passed: break
+       tried.add(...); config2 = escalate(config, gate.failing_axis, tried)
+       if config2 is None: break                              # escalation exhausted -> eject terminal
+       config = config2
+  4. full_sc = build_and_score(best_config, full)             # promote winner to full build
+  5. return TunerResult(config, slice_scorecard, full_scorecard, trace=[RoundReport...])
+```
+
+`build_and_score(config, dataset) -> scorecard_dict` is the single injection seam. The pure harness never imports Modal or runs a real build; it calls this callable and reads the SP-A scorecard shape (`{"presence": {...}|None, "relational": {...}, "connectivity": {...}, "coherence": {...}}`).
+
+## Components (in `erkgbench/substrate_tuner.py`)
+
+### 1. `GateThresholds` (frozen dataclass)
+```
+presence_min: float = 0.90       # presence.coverage floor (wiki-path; None-presence skips this axis)
+relational_f1_min: float = 0.50  # relational.f1 floor
+```
+Env-overridable defaults. Thresholds are *hypotheses* (like SP-B1's `CHUNK_MIN_SENTENCES`) — documented, tuned by running the harness.
+
+### 2. `GateResult` + `evaluate_gate(scorecard, thresholds) -> GateResult`
+`GateResult{passed: bool, failing_axis: str | None, scorecard: dict}`. Axis-precedence when both fail: **presence before relational** (you can't fix relational quality on entities that aren't in the KB — fix presence first). If `presence is None` (engineered/no-alias path), the presence check is skipped and only relational is gated.
+
+### 3. `escalate(config, failing_axis, tried, *, relation_vocab=(), allow_refuted=False) -> SubstrateConfig | None`
+Deterministic policy. Walks `LEVER_AXIS_MAP[failing_axis]` in order; for the first lever that is (a) not refuted [unless `allow_refuted`], (b) not already tried, and (c) has an applicable transform that *changes* the config, returns a new config with that transform applied and records it in `tried`. Returns `None` when the axis is exhausted (→ terminal eject).
+
+Per-lever transforms (the escalation "moves"):
+| lever | transform | notes |
+|---|---|---|
+| `chunk_extract` | `False→True` (6,2) | presence lever, the measured win |
+| `extractor` | `"api"→"gliner"` | presence lever, a swap |
+| `xdoc_key` | `""→"name_ci"→"name_ci_type"` (+`entity_type_canon=True` on the last) | relational lever |
+| `entity_type_canon` | `False→True` | relational (usually rides xdoc_key) |
+| `schema_canon` | `False→True` **only if `relation_vocab` non-empty** | relational; needs a vocab |
+| `relation_reprompt`, `rebel_fuse`, `extract_recall` | skipped unless `allow_refuted` | REFUTED levers |
+| `relation_vocab` | not auto-toggled (needs an external vocab) | skipped in auto-escalation |
+
+Refuted levers are gated behind `allow_refuted=False` (default) so the deterministic policy never re-arms a dead path; SP-C can flip it to let the LLM *propose* a measurement-gated re-test.
+
+### 4. `RoundReport` + `TunerResult`
+- `RoundReport{round: int, config: SubstrateConfig, scorecard: dict, gate: GateResult, escalated_to: str | None}` — the ejection diagnostic (`escalated_to` = the lever toggled, or None if passed/exhausted). This is the structured hand-off SP-C's LLM will consume in place of `escalate`.
+- `TunerResult{config, slice_scorecard, full_scorecard, trace: list[RoundReport], stopped_reason: str}` (`"passed" | "budget" | "exhausted"`).
+
+### 5. Real adapter `build_and_score_real(config, dataset)` (thin, erkgbench)
+Under `config.apply()`: run `ingest_corpus` over the dataset's docs → graph → `substrate_scorecard(graph, gold, qid_aliases)`. Reuses `run_substrate_eval._wiki_build`-style plumbing. NOT box-testable (needs native store + LLM) → validated by a Modal smoke, not TDD. The pure harness is validated with a fake.
+
+## Testing (TDD, box-safe — pure harness with a FAKE `build_and_score`)
+
+`erkgbench/tests/test_substrate_tuner.py`. A fake `build_and_score` returns scripted scorecards keyed by config, so control flow is deterministic:
+- `gate_passes_when_both_axes_clear` — scorecard above both floors → `passed`, no escalation.
+- `gate_routes_presence_before_relational` — both below floor → `failing_axis == "presence"`.
+- `gate_skips_presence_when_none` — engineered `presence=None` → only relational gated.
+- `escalate_presence_enables_chunking_first` — presence fail on a default config → `chunk_extract` turned on.
+- `escalate_relational_bumps_xdoc_key` — relational fail with `xdoc_key=""` → `"name_ci"`; again → `"name_ci_type"` + `entity_type_canon`.
+- `escalate_skips_refuted` — no escalation path selects reprompt/rebel/extract_recall (allow_refuted=False).
+- `escalate_returns_none_when_exhausted` — all axis levers tried → `None`.
+- `run_staged_passes_first_round` — fake returns a passing scorecard immediately → 1 round, `stopped_reason="passed"`, full build invoked once.
+- `run_staged_escalates_then_passes` — fake returns fail then pass → 2 rounds, config escalated once, trace records the ejection, then the full build runs on the winner.
+- `run_staged_budget_exhausted` — fake always fails → stops at `budget`, `stopped_reason="budget"`, full build still runs on best-so-far.
+- `run_staged_terminal_eject` — fail on an axis with no eligible lever → `stopped_reason="exhausted"`.
+- `tuner_result_trace_is_serializable` — `trace` RoundReports carry the scorecard + config + escalated_to (the SP-C hand-off shape).
+
+## Design choices flagged for review
+
+- **Gate thresholds + escalation ORDER are hypotheses.** They encode the arc's findings (presence→chunking, relational→name_ci→name_ci_type) but the *right* floors are unknown until the harness runs on real corpora. Shipped as documented, env-overridable defaults; the harness is the instrument that tunes them.
+- **Slice choice.** For the wiki corpus the "slice" is a fixed doc subset with its gold; the caller passes `(docs, gold, qid_aliases)` and a `slice_size`. Escalating on a slice that's too small risks over-fitting the tune to noise — documented; `slice_size` defaults to the whole corpus for the small (19-doc) wiki case, i.e. slice==full until a corpus is large enough to warrant a true subset.
+- **`build_and_score` is injected**, so the pure harness has ZERO Modal/LLM/native dependency and is fully box-testable; the real adapter is the only Modal-touching piece.
+- **Refuted levers gated** behind `allow_refuted` — off for the deterministic baseline, the flag SP-C flips to let an LLM propose a gated re-test.
+
+## Dependency / branch note
+
+- Needs `SubstrateConfig`/`for_profile` (SP-B1 #1373) and `LEVER_AXIS_MAP`/`substrate_scorecard` (SP-A #1371, already on main). This branch (`feat/substrate-tuner`) is off main **before #1373 merged** → `goldengraph.config` is absent here. Implementation: **rebase onto `origin/main` after #1373 merges** before the final PR (same pattern SP-B1 used for SP-A). The pure harness imports `SubstrateConfig`/`for_profile` from `goldengraph.config` and `LEVER_AXIS_MAP` from `erkgbench.substrate_eval`.
+
+## Follow-ons
+
+- **Modal smoke** of `build_and_score_real` on the wiki corpus — confirm the loop actually improves the scorecard end-to-end (the deterministic baseline number SP-C must beat).
+- **SP-C:** `suggest_substrate_config` MCP tool that swaps the deterministic `escalate` for a bounded LLM proposer over the `RoundReport` diagnostic; final config must beat this SP-B2 deterministic baseline on the scorecard (`review_config` self-verify).
+- **No-gold production gates:** validate unsupervised proxies (fragmentation/density) against the gold axes on the bench, then reuse them as the sample-extract stage for arbitrary corpora.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py
@@ -1,0 +1,195 @@
+"""SP-B2 substrate staged tuner.
+
+A deterministic staged-ejection optimizer: build a config on a cheap gold slice, score it with the
+SP-A three-axis scorecard (erkgbench.substrate_eval.substrate_scorecard), escalate the config along
+the failing axis, and promote the best-so-far config to the full build. The real build is injected
+(build_and_score) so the whole control flow is pure + box-testable; build_and_score_real wires the
+actual ingest_corpus + scorecard (Modal-smoke only). See
+docs/superpowers/specs/2026-07-02-substrate-staged-tuner-design.md.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from goldengraph.config import SubstrateConfig, for_profile, profile_corpus
+
+from erkgbench.substrate_eval import LEVER_AXIS_MAP
+
+_REFUTED = ("relation_reprompt", "rebel_fuse", "extract_recall")
+
+
+@dataclass(frozen=True)
+class GateThresholds:
+    """Per-axis pass floors. Hypotheses tuned by running the harness; env-overridable by the caller."""
+    presence_min: float = 0.90
+    relational_f1_min: float = 0.50
+
+
+@dataclass(frozen=True)
+class GateResult:
+    passed: bool
+    failing_axis: str | None
+    scorecard: dict
+
+
+def evaluate_gate(scorecard: dict, thresholds: GateThresholds) -> GateResult:
+    """Presence before relational (can't fix relational quality on absent entities). Presence is
+    skipped when the scorecard's presence is None (engineered/no-alias path)."""
+    presence = scorecard.get("presence")
+    if presence is not None and presence["coverage"] < thresholds.presence_min:
+        return GateResult(False, "presence", scorecard)
+    if scorecard["relational"]["f1"] < thresholds.relational_f1_min:
+        return GateResult(False, "relational", scorecard)
+    return GateResult(True, None, scorecard)
+
+
+# --- escalation: per-lever next-state advances (return (next_value_repr, new_config) | None) ----------
+def _advance_chunk_extract(c):
+    if c.chunk_extract:
+        return None
+    return "True", replace(c, chunk_extract=True, chunk_sentences=6, chunk_overlap=2)
+
+
+def _advance_extractor(c):
+    if c.extractor != "api":
+        return None
+    return "gliner", replace(c, extractor="gliner")
+
+
+def _advance_xdoc_key(c):
+    nxt = {"": "name_ci", "name_ci": "name_ci_type"}.get(c.xdoc_key)
+    if nxt is None:
+        return None
+    if nxt == "name_ci_type":
+        return nxt, replace(c, xdoc_key=nxt, entity_type_canon=True)
+    return nxt, replace(c, xdoc_key=nxt)
+
+
+def _advance_entity_type_canon(c):
+    if c.entity_type_canon:
+        return None
+    return "True", replace(c, entity_type_canon=True)
+
+
+def _advance_schema_canon(c, relation_vocab):
+    if c.schema_canon or not relation_vocab:
+        return None
+    return "True", replace(c, schema_canon=True, relation_vocab=tuple(relation_vocab))
+
+
+#: lever -> its _advance. Refuted levers + relation_vocab (no self-ladder) are absent -> never advanced.
+_ADVANCERS = {
+    "chunk_extract": lambda c, v: _advance_chunk_extract(c),
+    "extractor": lambda c, v: _advance_extractor(c),
+    "xdoc_key": lambda c, v: _advance_xdoc_key(c),
+    "entity_type_canon": lambda c, v: _advance_entity_type_canon(c),
+    "schema_canon": lambda c, v: _advance_schema_canon(c, v),
+}
+
+
+def escalate(config, failing_axis, tried, *, relation_vocab=(), allow_refuted=False):
+    """First eligible next-state advance along LEVER_AXIS_MAP[failing_axis]. Returns (lever, new_config)
+    and records (lever, next_value_repr) in `tried` (sole mutator), or None when the axis is exhausted."""
+    for lever in LEVER_AXIS_MAP.get(failing_axis, ()):
+        if lever in _REFUTED and not allow_refuted:
+            continue
+        adv = _ADVANCERS.get(lever)
+        if adv is None:
+            continue
+        step = adv(config, relation_vocab)
+        if step is None:
+            continue
+        next_repr, new_config = step
+        if (lever, next_repr) in tried:
+            continue
+        tried.add((lever, next_repr))
+        return lever, new_config
+    return None
+
+
+@dataclass(frozen=True)
+class RoundReport:
+    round: int
+    config: SubstrateConfig
+    scorecard: dict
+    gate: GateResult
+    escalated_to: str | None
+
+
+@dataclass(frozen=True)
+class TunerResult:
+    config: SubstrateConfig
+    slice_scorecard: dict
+    full_scorecard: dict
+    trace: list = field(default_factory=list)
+    stopped_reason: str = ""
+
+
+def _score(scorecard: dict) -> float:
+    """Round-ranking scalar: relational.f1 (+ presence.coverage when present). Higher wins."""
+    s = scorecard["relational"]["f1"]
+    presence = scorecard.get("presence")
+    if presence is not None:
+        s += presence["coverage"]
+    return s
+
+
+def run_staged(docs, gold, qid_aliases, *, build_and_score, thresholds=None, budget=5,
+               relation_vocab=(), expect_homographs=False, has_known_schema=False,
+               initial_config=None):
+    """Slice-gated deterministic optimizer. Escalates on the failing axis up to `budget` rounds, then
+    promotes the best-so-far (argmax _score) config to a full build. `build_and_score(config, dataset)`
+    is the injection seam (dataset = (docs, gold, qid_aliases)). Raises ValueError on budget < 1."""
+    if budget < 1:
+        raise ValueError(f"budget must be >= 1, got {budget}")
+    thresholds = thresholds or GateThresholds()
+    if initial_config is None:
+        initial_config = for_profile(
+            profile_corpus(docs), has_known_schema=has_known_schema,
+            expect_homographs=expect_homographs, relation_vocab=relation_vocab,
+        )
+    dataset = (docs, gold, qid_aliases)
+    config = initial_config
+    tried: set = set()
+    rounds: list[RoundReport] = []
+    stopped = "budget"
+    for r in range(budget):
+        sc = build_and_score(config, dataset)
+        gate = evaluate_gate(sc, thresholds)
+        step = None if gate.passed else escalate(config, gate.failing_axis, tried,
+                                                 relation_vocab=relation_vocab)
+        escalated_to, next_config = (None, None) if step is None else step
+        rounds.append(RoundReport(r, config, sc, gate, escalated_to))
+        if gate.passed:
+            stopped = "passed"
+            break
+        if step is None:
+            stopped = "exhausted"
+            break
+        config = next_config
+    best = max(rounds, key=lambda rr: _score(rr.scorecard))
+    full_sc = build_and_score(best.config, dataset)
+    return TunerResult(best.config, best.scorecard, full_sc, rounds, stopped)
+
+
+def build_and_score_real(config, dataset):
+    """Real build_and_score: under config.apply(), build the graph over the dataset docs and score it
+    with the SP-A three-axis scorecard. Needs the native store + an LLM -> Modal/CI only, NOT box-safe.
+    Kept thin; the pure harness above is the tested surface."""
+    from erkgbench import substrate_eval
+    from erkgbench.run_substrate_eval import _build_graph_from_documents
+
+    docs, gold, qid_aliases = dataset
+    if not docs:
+        raise ValueError("build_and_score_real: empty docs")
+
+    class _Doc:  # _build_graph_from_documents wants .text/.id; wrap raw text strings
+        __slots__ = ("text", "id")
+
+        def __init__(self, text, doc_id):
+            self.text, self.id = text, doc_id
+
+    with config.apply():
+        documents = docs if hasattr(docs[0], "text") else [_Doc(t, f"d{i}") for i, t in enumerate(docs)]
+        graph = _build_graph_from_documents(documents)
+    return substrate_eval.substrate_scorecard(graph, gold, qid_aliases)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_tuner.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_tuner.py
@@ -1,0 +1,172 @@
+"""SP-B2 substrate staged tuner: gate / escalate / run_staged (pure, box-safe with a fake scorer)."""
+from __future__ import annotations
+
+import pytest
+from erkgbench import substrate_tuner as st
+from goldengraph.config import SubstrateConfig
+
+
+def _sc(presence, rel_f1, *, conn_cov=0.5):
+    """A minimal scorecard dict in the substrate_scorecard shape."""
+    return {
+        "presence": None if presence is None else {"coverage": presence},
+        "relational": {"f1": rel_f1, "recall": rel_f1, "precision": 1.0},
+        "connectivity": {"coverage": conn_cov, "f1": conn_cov, "edge_recall": 0.9},
+        "coherence": {"components": 1, "largest_fraction": 1.0},
+    }
+
+
+# --- Task 1: gate -------------------------------------------------------------------------------------
+def test_gate_passes_when_both_axes_clear():
+    g = st.evaluate_gate(_sc(0.95, 0.60), st.GateThresholds())
+    assert g.passed is True and g.failing_axis is None
+
+
+def test_gate_routes_presence_before_relational():
+    g = st.evaluate_gate(_sc(0.10, 0.10), st.GateThresholds())
+    assert g.passed is False and g.failing_axis == "presence"
+
+
+def test_gate_relational_when_presence_ok():
+    g = st.evaluate_gate(_sc(0.95, 0.10), st.GateThresholds())
+    assert g.failing_axis == "relational"
+
+
+def test_gate_skips_presence_when_none():
+    g = st.evaluate_gate(_sc(None, 0.60), st.GateThresholds())
+    assert g.passed is True
+    g2 = st.evaluate_gate(_sc(None, 0.10), st.GateThresholds())
+    assert g2.failing_axis == "relational"
+
+
+# --- Task 2: escalate ---------------------------------------------------------------------------------
+def test_escalate_presence_enables_chunking_first():
+    step = st.escalate(SubstrateConfig(), "presence", set())
+    assert step is not None
+    lever, cfg = step
+    assert lever == "chunk_extract" and cfg.chunk_extract is True
+
+
+def test_escalate_relational_ladder_bumps_xdoc_key_twice():
+    tried = set()
+    l1, c1 = st.escalate(SubstrateConfig(), "relational", tried)
+    assert l1 == "xdoc_key" and c1.xdoc_key == "name_ci"
+    l2, c2 = st.escalate(c1, "relational", tried)
+    assert l2 == "xdoc_key" and c2.xdoc_key == "name_ci_type" and c2.entity_type_canon is True
+
+
+def test_escalate_schema_canon_sets_vocab():
+    c = SubstrateConfig(xdoc_key="name_ci_type", entity_type_canon=True)
+    tried = {("xdoc_key", "name_ci"), ("xdoc_key", "name_ci_type"), ("entity_type_canon", "True")}
+    step = st.escalate(c, "relational", tried, relation_vocab=("acquired",))
+    assert step is not None
+    lever, cfg = step
+    assert lever == "schema_canon" and cfg.schema_canon is True and cfg.relation_vocab == ("acquired",)
+
+
+def test_escalate_schema_canon_skipped_without_vocab():
+    c = SubstrateConfig(xdoc_key="name_ci_type", entity_type_canon=True)
+    tried = {("xdoc_key", "name_ci"), ("xdoc_key", "name_ci_type"), ("entity_type_canon", "True")}
+    step = st.escalate(c, "relational", tried, relation_vocab=())
+    assert step is None
+
+
+def test_escalate_skips_refuted():
+    c = SubstrateConfig(chunk_extract=True, extractor="gliner")
+    step = st.escalate(c, "presence", {("chunk_extract", "True"), ("extractor", "gliner")})
+    assert step is None
+
+
+def test_escalate_returns_none_when_exhausted():
+    c = SubstrateConfig(chunk_extract=True, extractor="gliner")
+    step = st.escalate(c, "presence", {("chunk_extract", "True"), ("extractor", "gliner")})
+    assert step is None
+
+
+def test_escalate_returns_lever_and_config():
+    step = st.escalate(SubstrateConfig(), "presence", set())
+    assert isinstance(step, tuple) and step[0] == "chunk_extract" and isinstance(step[1], SubstrateConfig)
+
+
+# --- Task 3: run_staged -------------------------------------------------------------------------------
+def _tiny_corpus():
+    return ["doc one.", "doc two."], [("Q1", "a", "d1")], {"Q1": ["a"]}
+
+
+def _scripted(*cards, seen=None):
+    """A fake build_and_score that returns `cards` by call order, clamping to the last once exhausted
+    (run_staged makes one extra call for the full build after the rounds). Records configs in `seen`."""
+    state = {"i": 0}
+
+    def fake(cfg, ds):
+        if seen is not None:
+            seen.append(cfg)
+        card = cards[min(state["i"], len(cards) - 1)]
+        state["i"] += 1
+        return card
+
+    return fake
+
+
+def test_run_staged_rejects_budget_below_one():
+    docs, gold, al = _tiny_corpus()
+    with pytest.raises(ValueError):
+        st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(1.0, 1.0), budget=0)
+
+
+def test_run_staged_passes_first_round():
+    docs, gold, al = _tiny_corpus()
+    calls = []
+
+    def fake(cfg, ds):
+        calls.append(ds)
+        return _sc(0.95, 0.60)
+
+    res = st.run_staged(docs, gold, al, build_and_score=fake, budget=3)
+    assert res.stopped_reason == "passed"
+    assert len(res.trace) == 1
+    assert len(calls) == 2  # 1 slice round + 1 full build
+
+
+def test_run_staged_escalates_then_passes():
+    docs, gold, al = _tiny_corpus()
+    fake = _scripted(_sc(0.95, 0.10), _sc(0.95, 0.60))  # fail relational, then pass after escalate
+    res = st.run_staged(docs, gold, al, build_and_score=fake, budget=5)
+    assert res.stopped_reason == "passed"
+    assert len(res.trace) == 2
+    assert res.trace[0].escalated_to == "xdoc_key"
+
+
+def test_run_staged_budget_exhausted():
+    docs, gold, al = _tiny_corpus()
+    # Bare config -> a 2-step relational ladder (""->name_ci->name_ci_type). budget=2: both rounds fail
+    # + escalate successfully -> for-loop reaches its cap -> "budget" (not "exhausted").
+    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(0.95, 0.10),
+                        budget=2, initial_config=SubstrateConfig())
+    assert res.stopped_reason == "budget" and len(res.trace) == 2
+
+
+def test_run_staged_promotes_argmax_not_last():
+    docs, gold, al = _tiny_corpus()
+    # round0 FAILS (0.40<0.50) but is the highest scorer; later rounds regress lower. best-so-far = round0.
+    seen = []
+    fake = _scripted(_sc(0.95, 0.40), _sc(0.95, 0.10), _sc(0.95, 0.10), seen=seen)
+    res = st.run_staged(docs, gold, al, build_and_score=fake, budget=3, initial_config=SubstrateConfig())
+    assert res.config == res.trace[0].config   # argmax = round0, not the last (regressed) config
+    assert seen[-1] == res.config              # the full build used the argmax config
+
+
+def test_run_staged_terminal_eject():
+    docs, gold, al = _tiny_corpus()
+    cfg0 = SubstrateConfig(chunk_extract=True, extractor="gliner")
+    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(0.10, 0.95),
+                        budget=5, initial_config=cfg0)
+    assert res.stopped_reason == "exhausted"
+
+
+def test_tuner_result_trace_is_serializable():
+    docs, gold, al = _tiny_corpus()
+    res = st.run_staged(docs, gold, al, build_and_score=lambda cfg, ds: _sc(0.95, 0.60), budget=1)
+    r0 = res.trace[0]
+    assert r0.round == 0 and isinstance(r0.config, SubstrateConfig) and "relational" in r0.scorecard
+    assert r0.escalated_to is None


### PR DESCRIPTION
Third sub-project (SP-B2) of the substrate-builder config-surface program. A deterministic staged-ejection optimizer: build a config on a cheap gold slice, score it with the SP-A three-axis scorecard, escalate along the failing axis, and promote the best-so-far config to the full build. This is the deterministic baseline SP-C's LLM proposer must later beat.

## What
New pure module `erkgbench/substrate_tuner.py`:
- **`evaluate_gate`** — presence-before-relational routing (can't fix relational quality on absent entities); presence skipped on the no-alias path; connectivity intentionally ungated (no non-refuted lever moves it).
- **`escalate`** — deterministic next-state lever ladders over `LEVER_AXIS_MAP[failing_axis]`, returns `(lever, new_config)`; `tried` keyed by `(lever, next_value)` so the `xdoc_key` ladder advances across calls; refuted levers (reprompt/rebel/extract_recall) double-guarded off; enabling `schema_canon` sets its vocab together (never one without the other); terminates on finite ladders.
- **`run_staged`** — slice-build → gate → escalate up to `budget` (guarded `>= 1`), then promotes the **best-so-far** (argmax of `relational.f1 + presence.coverage`) to the full build on every exit (passed/budget/exhausted). Emits a `TunerResult` with a `RoundReport` trace — the structured hand-off SP-C's LLM will consume.
- **`build_and_score_real`** — thin adapter wiring `ingest_corpus` + `substrate_scorecard` under `config.apply()`; heavy imports are function-local so the pure harness stays box-safe. Modal-smoke only, not TDD.

## Scope / honesty
- Pure control flow with an **injected `build_and_score`** — no Modal/LLM/native in the tested surface. 18 box-safe tests (gate routing, the `xdoc_key`-twice ladder, refuted-skip, schema-canon+vocab, budget/exhausted/passed termination, argmax-not-last), ruff clean.
- Rebased onto main (SP-A #1371 + SP-B1 #1373 both merged) so `SubstrateConfig`/`for_profile`/`LEVER_AXIS_MAP`/`substrate_scorecard` are present.
- Spec + plan committed under `docs/superpowers/`; both passed reviewer loops (spec 2 rounds — caught the `xdoc_key` ladder-vs-tried-keying bug; plan 1 round — caught two fixtures whose scores didn't exercise their intended control flow).

Follow-ons: a **Modal smoke** of `build_and_score_real` on the wiki corpus (the deterministic baseline number SP-C must beat), then **SP-C** (`suggest_substrate_config` MCP tool swapping `escalate` for a bounded LLM proposer over the `RoundReport` diagnostic; must beat this baseline via `review_config` self-verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)