### PR TITLE
feat(cli): non-interactive dedupe by default + golden-suite README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,18 @@
 <p align="center"><sub><em>Pair drilldown in the web workbench: cluster members, field-level diff, and a one-line NL explanation per pair. <code>pip install goldenmatch[web]</code> then <code>goldenmatch serve-ui &lt;project&gt;</code>. <a href="https://github.com/benseverndev-oss/goldenmatch/wiki/Web-UI">More screenshots →</a></em></sub></p>
 
 ```bash
-# Headline package: dedupe a CSV in 30 seconds
+# Dedupe a CSV in 30 seconds — zero config, writes <timestamp>_golden.csv to the
+# current directory. Add --tui to review interactively, --output-all for every artifact.
 pip install goldenmatch && goldenmatch dedupe customers.csv
+
+# From Python — zero-config, returns golden records
+python -c "import goldenmatch as gm; gm.dedupe('customers.csv').golden.write_csv('deduped.csv')"
 
 # TypeScript / Edge runtimes
 npm install goldenmatch
+
+# The WHOLE suite (Check + Flow + Match + Analysis + Pipe + InferMap) + native acceleration, one line:
+pip install golden-suite
 ```
 
 <!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
@@ -250,6 +257,40 @@ Reproducible end-to-end pipelines running GoldenMatch on public data at scale, e
 - **[goldenmatch-shell-company-network](https://github.com/benseverndev-oss/goldenmatch-shell-company-network)** — investigative ER across ICIJ Offshore Leaks + OpenSanctions + GLEIF + UK PSC + UK disqualified-directors. Confidence-weighted graph, structure mining, named investigative candidates. **−62.5% analyst-hours to triage** vs single-source baselines; +133% adversarial perturbation recovery.
 - **[goldenmatch-vuln-attribution](https://github.com/benseverndev-oss/goldenmatch-vuln-attribution)** — cross-database ER on 6.1M OSS vulnerability records across 40 sources (OSV, GHSA, PyPA, RustSec, Go vulndb, EPSS, CISA KEV, CVE Project bulk). **6,126,895 records → 847,475 canonical vulns** in ~5 minutes end-to-end on a single 64GB runner via the full Golden Suite (Check + Flow + Match + Pipe).
 - **[goldenmatch-sanctions-reconciliation](https://github.com/benseverndev-oss/goldenmatch-sanctions-reconciliation)** — cross-list coverage analysis on 85 public sanctions lists across 50+ jurisdictions via OpenSanctions, plus 10-year OFAC SDN history and PEP/crypto cross-analysis. Coverage-gap benchmark for any sanctions-screening vendor.
+
+---
+
+## The whole suite in one line — `golden-suite`
+
+Want everything, configured for speed, without hand-picking packages? The
+[`golden-suite`](packages/python/golden-suite/README.md) meta-package pulls in
+the entire suite plus the native (Rust) acceleration in a single install:
+
+```bash
+pip install golden-suite
+```
+
+That one command installs **GoldenMatch** (entity resolution), **GoldenCheck**
+(data quality), **GoldenFlow** (transforms), **GoldenAnalysis** (reporting),
+**GoldenPipe** (orchestration), **InferMap** (schema mapping), and the
+`goldenmatch-native` / `goldencheck-native` / `goldenflow-native` /
+`goldenanalysis-native` compiled kernels — all pinned to compatible versions and
+defaulted to the perf-optimized configuration (native paths on, no env vars to
+set). The native wheels are **hard** dependencies on purpose: on a platform
+without a wheel the install fails loudly rather than silently running the slow
+pure-Python path.
+
+```bash
+golden-suite doctor      # verify every package + native kernel is importable and healthy
+golden-suite optimize    # repair / re-enable the perf-optimized config if doctor finds a gap
+
+pip install golden-suite[mcp]     # + the aggregator MCP server (every tool, one endpoint)
+pip install golden-suite[agent]   # + GoldenPipe serving surfaces (A2A + REST + TUI)
+pip install golden-suite[all]     # everything above
+```
+
+Prefer to install just one tool, or pick your own extras? Use the per-package
+installs below.
 
 ---
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Changed
+- **`goldenmatch dedupe <file>` is now non-interactive by default.** A bare `goldenmatch dedupe customers.csv` runs auto-config, writes golden records (a timestamped `*_golden.csv` in the current directory), and prints a summary — so the advertised "CSV in, 30 seconds, CSV out" is what actually happens. The interactive review TUI is now opt-in via **`--tui`** (previously it opened by default). `--no-tui` is still accepted as a no-op for back-compat. When no explicit output flag is given on the auto-config path, golden records are written by default (use `--output-all` / `--output-dir` to control, `--tui` to review). An explicit `--config` run keeps its exact prior behavior.
+
 ## [2.7.0] - 2026-07-02
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/cli/dedupe.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/dedupe.py
@@ -67,7 +67,14 @@ def dedupe_cmd(
     config: str | None = typer.Option(
         None, "--config", "-c", help="Path to YAML config file (optional - auto-detects if omitted)"
     ),
-    no_tui: bool = typer.Option(False, "--no-tui", help="Skip TUI, run with auto-config directly"),
+    tui: bool = typer.Option(
+        False, "--tui",
+        help="Open the interactive review TUI instead of running directly (auto-config path only).",
+    ),
+    no_tui: bool = typer.Option(
+        False, "--no-tui",
+        help="Deprecated: non-interactive is now the default. Accepted for back-compat (no-op).",
+    ),
     model: str | None = typer.Option(None, "--model", help="Override embedding model selection"),
     preview: bool = typer.Option(False, "--preview", help="Preview results without writing files"),
     preview_size: int = typer.Option(10000, "--preview-size", help="Number of records for preview sample"),
@@ -185,8 +192,12 @@ def dedupe_cmd(
                         if f.scorer in ("embedding", "record_embedding"):
                             f.model = model
 
-            # Launch TUI for review (unless --no-tui)
-            if not no_tui and not preview:
+            # Launch the interactive TUI only when explicitly requested via
+            # --tui. The default is non-interactive (run auto-config, write
+            # output, print a summary) so `goldenmatch dedupe file.csv` delivers
+            # CSV-in/CSV-out without a full-screen app. --no-tui stays accepted
+            # (now a no-op) for back-compat.
+            if tui and not no_tui and not preview:
                 from goldenmatch.tui.app import GoldenMatchApp
                 file_paths = [fp for fp, _name in parsed_files]
                 tui_app = GoldenMatchApp(files=file_paths)
@@ -242,6 +253,26 @@ def dedupe_cmd(
         output_dupes = True
         output_unique = True
         output_report = True
+
+    # Zero-config default: a bare `goldenmatch dedupe file.csv` (auto-config path,
+    # no explicit output flag) writes golden records by default, so "CSV in ->
+    # CSV out" actually happens without needing --output-golden. Confined to the
+    # auto-config path -- an explicit --config run keeps its exact prior behavior.
+    if (
+        _used_autoconfig
+        and not preview
+        and not merge_preview
+        and not any([
+            output_golden, output_clusters, output_dupes, output_unique,
+            output_report, html_report, dashboard,
+        ])
+    ):
+        output_golden = True
+        if not quiet:
+            console.print(
+                "[dim]No output flag given -- writing golden records by default "
+                "(use --output-all / --output-dir to control, --tui to review).[/dim]"
+            )
 
     # Enable auto-fix from CLI flag
     if auto_fix:


### PR DESCRIPTION
Makes the advertised 30-second one-liner actually deliver, and documents the one-line whole-suite install. Motivated by a speed-to-value review: the Python path was already fast, but the CLI hero command surprised users with a TUI.

## 1. CLI: `dedupe` is non-interactive by default
`goldenmatch dedupe customers.csv` (bare) previously opened a full-screen TUI. Now it runs auto-config, **writes golden records** (a timestamped `*_golden.csv` in the cwd), and prints a summary. The review TUI is opt-in via **`--tui`**; `--no-tui` stays accepted as a no-op for back-compat. On the auto-config path with no explicit output flag, golden is written by default (`--output-all` / `--output-dir` to control). **Explicit `--config` runs are byte-for-byte unchanged.**

## 2. README hero + golden-suite section
- Hero block is now honest: shows the CLI writes `*_golden.csv`, adds the Python one-liner, and `pip install golden-suite`.
- New **"The whole suite in one line — `golden-suite`"** section documenting the meta-package that installs every package (Match/Check/Flow/Analysis/Pipe/InferMap) + the native kernels in one command, defaulted to the perf-optimized config, with `golden-suite doctor` / `optimize` and the `[mcp]` / `[agent]` / `[all]` extras.

## Tests
`test_cli_dedupe.py` + `test_cli_preview.py` (18) + `test_tui.py` pass. The `--no-tui` test still holds; verified end-to-end that a bare `dedupe tiny.csv` runs non-interactively (no TUI hang) and writes a golden CSV.

CHANGELOG `[Unreleased]` documents the default change; ships in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)