### PR TITLE
feat(erkgbench): staged-tuner Modal smoke + deterministic baseline (SP-B2 follow-on)

### DIFF
--- a/docs/superpowers/reports/2026-07-02-staged-tuner-smoke-verdict.md
+++ b/docs/superpowers/reports/2026-07-02-staged-tuner-smoke-verdict.md
@@ -1,0 +1,47 @@
+# Staged-Tuner Smoke — Verdict (SP-B2 follow-on)
+
+**Date:** 2026-07-02
+**Branch:** `feat/substrate-tuner-smoke`
+**Run:** Modal `gg-bench`, `--eval tuner`, wiki corpus, 7B (`qwen2.5:7b-instruct`), `GOLDENGRAPH_LLM_SEED=42`, budget=3.
+
+## What this validated
+
+The SP-B2 `run_staged` + `build_and_score_real` path end-to-end on real data (`erkgbench/run_substrate_tuner.py` + a `tuner` mode in `modal_bench.py`). The whole loop ran on Modal: `for_profile` picked the initial config, `build_and_score_real` built the wiki graph under `config.apply()` and scored it with the SP-A three-axis scorecard, `evaluate_gate` ran, and the winner was promoted to a full build. **The wiring is proven** — real scorecards flow through the injected seam exactly as the box-tested harness assumed.
+
+## Result — deterministic baseline + a reproducibility problem
+
+`for_profile` picked **`name_ci` + `chunk_extract(6,2)`** (dense wiki → chunking on), the arc's known-best config. The gate passed on round 0 → **no escalation** (`stopped=passed`, 1 round). So the deterministic tuner confirms its rule-table pick on wiki — expected, since name_ci+chunking is already the measured best and every escalation beyond it (name_ci_type, refuted levers) is known to cost recall on non-homograph prose.
+
+| | round-0 (slice) | full build |
+|---|---|---|
+| presence | **1.0000** | 0.9077 |
+| relational F1 | **0.8214** | 0.6667 |
+| relational R | 0.6970 | 0.5000 |
+| P(B) | 1.0000 | 1.0000 |
+| components | 17 | 11 |
+
+**The honest finding: the slice and full builds are the SAME corpus + SAME seeded config, yet they diverge hard (F1 0.82 → 0.67, presence 1.0 → 0.91).** I did not implement slice-subsetting, so `dataset` is the whole wiki corpus for both the round-0 build and the full build — two sequential builds of an identical `(config, corpus, seed=42)` that should be byte-identical per the seed-determinism verdict (#1360), but aren't.
+
+## Why this matters (and the open question)
+
+The seed-determinism verdict established that `GOLDENGRAPH_LLM_SEED` makes a build byte-identical **across containers** (single build per container). This smoke runs **two builds in one process sequentially**, and they differ by ~0.15 F1. Candidate causes (unresolved):
+- 7B/ollama seed determinism not holding across two builds in one warm process (KV-cache / model-state carryover between the first and second build);
+- concurrent per-doc ingest (`GOLDENGRAPH_BUILD_WORKERS`) → thread-scheduling-dependent request interleaving that the per-request seed doesn't pin;
+- a state leak in the harness (less likely — `build_and_score_real` makes a fresh `PyStore` each call).
+
+**Consequence for the tuner:** its gate/escalation decisions are made on a single-build slice read (here 0.82) while the promoted full result is a different draw (0.67). A noisy slice read means the gate could pass/fail and the escalation could route on noise. This re-raises the seed-determinism lesson at the *harness* level: **the tuner needs a reproducible (or replicated) build before its gate decisions can be trusted.**
+
+## Baseline for SP-C
+
+The deterministic baseline SP-C must beat on wiki/7B: **relational F1 ≈ 0.67–0.82 (noisy), presence ≈ 0.91–1.0, at P=1.0, config = name_ci+chunk.** Given the arc has explored every lever and name_ci+chunk is the measured best, an LLM proposer is **unlikely to beat this on wiki** — the honest expectation is SP-C *confirms* the deterministic pick here. SP-C's real value is on corpora where `for_profile`'s flags bite: homograph-heavy (name_ci_type) or known-schema (schema_canon+vocab), where the config choice is non-obvious.
+
+## Decisions / follow-ons
+
+1. **Ship the smoke tooling** (`run_substrate_tuner.py` + `modal_bench.py` `tuner` mode) — it's the reusable harness for the baseline and for SP-C's A/B.
+2. **BEFORE SP-C: fix or quantify the build reproducibility.** Either (a) make the double-build reproducible (investigate the seed/concurrency interaction; possibly `GOLDENGRAPH_BUILD_WORKERS=1` for tuning runs), or (b) replicate each config's build N times and gate on the median — else the tuner (and SP-C's self-verify) chase noise. This is the priority follow-on, not SP-C itself.
+3. **SP-C framing:** an LLM proposer over the `RoundReport` diagnostic, gated to beat this baseline via the (reproducible) scorecard — most informative on a homograph/known-schema corpus, not wiki.
+
+## Honest caveats
+
+- One corpus, one seed, one 7B model. The 0.67–0.82 range is two draws, not a distribution — the reproducibility issue means even the baseline number is a range, not a point.
+- The tuner "passing on round 0" is the *expected* deterministic outcome; the smoke did not exercise escalation (would need a harder gate or a corpus where the initial pick fails).

--- a/docs/superpowers/reports/data/2026-07-02-tuner-smoke-wiki-7b.md
+++ b/docs/superpowers/reports/data/2026-07-02-tuner-smoke-wiki-7b.md
@@ -1,0 +1,1265 @@
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.7s: iter 0 _run_pipeline_sample done in 0.7s
+[controller.run n_rows=4] t=0.7s: iter 1 start
+[controller.run n_rows=4] t=0.7s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.7s: iter 2 start
+[controller.run n_rows=4] t=0.7s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.7s: iter 3 start
+[controller.run n_rows=4] t=0.8s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=6] t=0.0s: entry
+[controller.run n_rows=6] t=0.0s: _initial_config done
+[controller.run n_rows=6] t=0.0s: _take_sample done (sample.height=6)
+[controller.run n_rows=6] t=0.0s: compute_column_priors done
+[controller.run n_rows=6] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=6] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=6] t=0.0s: entering iteration loop
+[controller.run n_rows=6] t=0.0s: iter 0 start
+[controller.run n_rows=6] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.1s: iter 1 start
+[controller.run n_rows=6] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.1s: iter 2 start
+[controller.run n_rows=6] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.1s: iter 3 start
+[controller.run n_rows=6] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=6 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=6] t=0.0s: entry
+[controller.run n_rows=6] t=0.0s: _initial_config done
+[controller.run n_rows=6] t=0.0s: _take_sample done (sample.height=6)
+[controller.run n_rows=6] t=0.0s: compute_column_priors done
+[controller.run n_rows=6] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=6] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=6] t=0.0s: entering iteration loop
+[controller.run n_rows=6] t=0.0s: iter 0 start
+[controller.run n_rows=6] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.1s: iter 1 start
+[controller.run n_rows=6] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.1s: iter 2 start
+[controller.run n_rows=6] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.1s: iter 3 start
+[controller.run n_rows=6] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=6 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 2 start
+[controller.run n_rows=4] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 3 start
+[controller.run n_rows=4] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=5] t=0.0s: entry
+[controller.run n_rows=5] t=0.0s: _initial_config done
+[controller.run n_rows=5] t=0.0s: _take_sample done (sample.height=5)
+[controller.run n_rows=5] t=0.0s: compute_column_priors done
+[controller.run n_rows=5] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=5] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=5] t=0.0s: entering iteration loop
+[controller.run n_rows=5] t=0.0s: iter 0 start
+[controller.run n_rows=5] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=5] t=0.1s: iter 1 start
+[controller.run n_rows=5] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=5] t=0.1s: iter 2 start
+[controller.run n_rows=5] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=5] t=0.1s: iter 3 start
+[controller.run n_rows=5] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=5 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 2 start
+[controller.run n_rows=4] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 3 start
+[controller.run n_rows=4] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=12] t=0.0s: entry
+[controller.run n_rows=12] t=0.0s: _initial_config done
+[controller.run n_rows=12] t=0.0s: _take_sample done (sample.height=12)
+[controller.run n_rows=12] t=0.0s: compute_column_priors done
+[controller.run n_rows=12] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=12] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=12] t=0.0s: entering iteration loop
+[controller.run n_rows=12] t=0.0s: iter 0 start
+[controller.run n_rows=12] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=12] t=0.1s: iter 1 start
+[controller.run n_rows=12] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=12] t=0.1s: iter 2 start
+[controller.run n_rows=12] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=12] t=0.1s: iter 3 start
+[controller.run n_rows=12] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=12 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 3 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 3 blocks, 0 pairs
+[controller.run n_rows=13] t=0.0s: entry
+[controller.run n_rows=13] t=0.0s: _initial_config done
+[controller.run n_rows=13] t=0.0s: _take_sample done (sample.height=13)
+[controller.run n_rows=13] t=0.0s: compute_column_priors done
+[controller.run n_rows=13] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=13] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=13] t=0.0s: entering iteration loop
+[controller.run n_rows=13] t=0.0s: iter 0 start
+[controller.run n_rows=13] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=13] t=0.1s: iter 1 start
+[controller.run n_rows=13] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=13 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=13 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=13 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 2 blocks, 2 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=13 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=13 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 3 blocks, 2 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=13 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.00s, 3 blocks, 2 pairs
+[controller.run n_rows=57] t=0.0s: entry
+[controller.run n_rows=57] t=0.0s: _initial_config done
+[controller.run n_rows=57] t=0.0s: _take_sample done (sample.height=57)
+[controller.run n_rows=57] t=0.0s: compute_column_priors done
+[controller.run n_rows=57] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=57] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=57] t=0.0s: entering iteration loop
+[controller.run n_rows=57] t=0.0s: iter 0 start
+[controller.run n_rows=57] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=57] t=0.1s: iter 1 start
+[controller.run n_rows=57] t=0.2s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=57] t=0.3s: iter 2 start
+[controller.run n_rows=57] t=0.3s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=57] t=0.3s: iter 3 start
+[controller.run n_rows=57] t=0.4s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=57 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.02s, 10 blocks, 39 pairs
+[score_buckets] t=0.02s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.02s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.02s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.02s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.03s: bucket_score done in 0.01s, 9 blocks, 39 pairs
+[score_buckets] t=0.03s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.03s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.03s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.03s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.04s: bucket_score done in 0.01s, 12 blocks, 16 pairs
+[score_buckets] t=0.04s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.04s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.04s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.04s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.05s: bucket_score done in 0.01s, 6 blocks, 54 pairs
+[score_buckets] t=0.05s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.05s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.05s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.05s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.06s: bucket_score done in 0.01s, 6 blocks, 54 pairs
+[controller.run n_rows=11] t=0.0s: entry
+[controller.run n_rows=11] t=0.0s: _initial_config done
+[controller.run n_rows=11] t=0.0s: _take_sample done (sample.height=11)
+[controller.run n_rows=11] t=0.0s: compute_column_priors done
+[controller.run n_rows=11] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=11] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=11] t=0.0s: entering iteration loop
+[controller.run n_rows=11] t=0.0s: iter 0 start
+[controller.run n_rows=11] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=11] t=0.1s: iter 1 start
+[controller.run n_rows=11] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=11] t=0.1s: iter 2 start
+[controller.run n_rows=11] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=11] t=0.1s: iter 3 start
+[controller.run n_rows=11] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=11 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 2 blocks, 4 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 2 blocks, 7 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 2 blocks, 2 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 2 blocks, 7 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.00s, 2 blocks, 7 pairs
+[controller.run n_rows=78] t=0.0s: entry
+[controller.run n_rows=78] t=0.0s: _initial_config done
+[controller.run n_rows=78] t=0.0s: _take_sample done (sample.height=78)
+[controller.run n_rows=78] t=0.0s: compute_column_priors done
+[controller.run n_rows=78] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=78] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=78] t=0.0s: entering iteration loop
+[controller.run n_rows=78] t=0.0s: iter 0 start
+[controller.run n_rows=78] t=0.2s: iter 0 _run_pipeline_sample done in 0.2s
+[controller.run n_rows=78] t=0.2s: iter 1 start
+[controller.run n_rows=78] t=0.4s: iter 1 _run_pipeline_sample done in 0.2s
+[controller.run n_rows=78] t=0.4s: iter 2 start
+[controller.run n_rows=78] t=0.5s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=78] t=0.5s: iter 3 start
+[controller.run n_rows=78] t=0.7s: iter 3 _run_pipeline_sample done in 0.2s
+[score_buckets] entry: prepared_df.height=78 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 34 buckets
+[score_buckets] t=0.00s: 34 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.06s: bucket_score done in 0.05s, 16 blocks, 39 pairs
+[score_buckets] t=0.06s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.06s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.06s: partition_by(bucket) in 0.00s -> 33 buckets
+[score_buckets] t=0.06s: 33 non-empty buckets ready for scoring
+[score_buckets] t=0.06s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.10s: bucket_score done in 0.04s, 20 blocks, 34 pairs
+[score_buckets] t=0.10s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.10s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.10s: partition_by(bucket) in 0.00s -> 35 buckets
+[score_buckets] t=0.10s: 35 non-empty buckets ready for scoring
+[score_buckets] t=0.10s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.14s: bucket_score done in 0.04s, 15 blocks, 24 pairs
+[score_buckets] t=0.14s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.14s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.14s: partition_by(bucket) in 0.00s -> 16 buckets
+[score_buckets] t=0.14s: 16 non-empty buckets ready for scoring
+[score_buckets] t=0.14s: starting bucket_score with max_workers=16 path=find_fuzzy_matches
+[score_buckets] t=0.18s: bucket_score done in 0.03s, 14 blocks, 112 pairs
+[score_buckets] t=0.18s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.18s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.18s: partition_by(bucket) in 0.00s -> 16 buckets
+[score_buckets] t=0.18s: 16 non-empty buckets ready for scoring
+[score_buckets] t=0.18s: starting bucket_score with max_workers=16 path=find_fuzzy_matches
+[score_buckets] t=0.21s: bucket_score done in 0.03s, 14 blocks, 112 pairs
+[controller.run n_rows=47] t=0.0s: entry
+[controller.run n_rows=47] t=0.0s: _initial_config done
+[controller.run n_rows=47] t=0.0s: _take_sample done (sample.height=47)
+[controller.run n_rows=47] t=0.0s: compute_column_priors done
+[controller.run n_rows=47] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=47] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=47] t=0.0s: entering iteration loop
+[controller.run n_rows=47] t=0.0s: iter 0 start
+[controller.run n_rows=47] t=0.2s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.2s: iter 1 start
+[controller.run n_rows=47] t=0.3s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.3s: iter 2 start
+[controller.run n_rows=47] t=0.4s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.4s: iter 3 start
+[controller.run n_rows=47] t=0.6s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=47 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.02s, 16 blocks, 4 pairs
+[score_buckets] t=0.02s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.02s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.02s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.02s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.03s: bucket_score done in 0.02s, 16 blocks, 4 pairs
+[score_buckets] t=0.03s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.03s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.03s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.03s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.05s: bucket_score done in 0.02s, 16 blocks, 4 pairs
+[score_buckets] t=0.05s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.05s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.05s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.05s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.06s: bucket_score done in 0.01s, 9 blocks, 39 pairs
+[score_buckets] t=0.06s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.06s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.06s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.06s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.07s: bucket_score done in 0.01s, 9 blocks, 39 pairs
+[controller.run n_rows=71] t=0.0s: entry
+[controller.run n_rows=71] t=0.0s: _initial_config done
+[controller.run n_rows=71] t=0.0s: _take_sample done (sample.height=71)
+[controller.run n_rows=71] t=0.0s: compute_column_priors done
+[controller.run n_rows=71] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=71] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=71] t=0.0s: entering iteration loop
+[controller.run n_rows=71] t=0.0s: iter 0 start
+[controller.run n_rows=71] t=0.2s: iter 0 _run_pipeline_sample done in 0.2s
+[controller.run n_rows=71] t=0.2s: iter 1 start
+[controller.run n_rows=71] t=0.3s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=71] t=0.3s: iter 2 start
+[controller.run n_rows=71] t=0.3s: iter 2 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=71 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 34 buckets
+[score_buckets] t=0.00s: 34 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.05s: bucket_score done in 0.05s, 17 blocks, 24 pairs
+[score_buckets] t=0.05s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.05s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.05s: partition_by(bucket) in 0.00s -> 36 buckets
+[score_buckets] t=0.05s: 36 non-empty buckets ready for scoring
+[score_buckets] t=0.05s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.08s: bucket_score done in 0.03s, 8 blocks, 21 pairs
+[controller.run n_rows=57] t=0.0s: entry
+[controller.run n_rows=57] t=0.0s: _initial_config done
+[controller.run n_rows=57] t=0.0s: _take_sample done (sample.height=57)
+[controller.run n_rows=57] t=0.0s: compute_column_priors done
+[controller.run n_rows=57] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=57] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=57] t=0.0s: entering iteration loop
+[controller.run n_rows=57] t=0.0s: iter 0 start
+[controller.run n_rows=57] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=57] t=0.1s: iter 1 start
+[controller.run n_rows=57] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=57 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 13 blocks, 21 pairs
+[score_buckets] t=0.02s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.02s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.02s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.02s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.03s: bucket_score done in 0.01s, 13 blocks, 13 pairs
+[controller.run n_rows=27] t=0.0s: entry
+[controller.run n_rows=27] t=0.0s: _initial_config done
+[controller.run n_rows=27] t=0.0s: _take_sample done (sample.height=27)
+[controller.run n_rows=27] t=0.0s: compute_column_priors done
+[controller.run n_rows=27] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=27] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=27] t=0.0s: entering iteration loop
+[controller.run n_rows=27] t=0.0s: iter 0 start
+[controller.run n_rows=27] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=27] t=0.1s: iter 1 start
+[controller.run n_rows=27] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=27 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=27 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 6 blocks, 13 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=27 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 7 blocks, 11 pairs
+[controller.run n_rows=22] t=0.0s: entry
+[controller.run n_rows=22] t=0.0s: _initial_config done
+[controller.run n_rows=22] t=0.0s: _take_sample done (sample.height=22)
+[controller.run n_rows=22] t=0.0s: compute_column_priors done
+[controller.run n_rows=22] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=22] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=22] t=0.0s: entering iteration loop
+[controller.run n_rows=22] t=0.0s: iter 0 start
+[controller.run n_rows=22] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=22] t=0.0s: iter 1 start
+[controller.run n_rows=22] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=22 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=22 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=22 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 4 blocks, 3 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 2 start
+[controller.run n_rows=4] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 3 start
+[controller.run n_rows=4] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=6] t=0.0s: entry
+[controller.run n_rows=6] t=0.0s: _initial_config done
+[controller.run n_rows=6] t=0.0s: _take_sample done (sample.height=6)
+[controller.run n_rows=6] t=0.0s: compute_column_priors done
+[controller.run n_rows=6] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=6] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=6] t=0.0s: entering iteration loop
+[controller.run n_rows=6] t=0.0s: iter 0 start
+[controller.run n_rows=6] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.0s: iter 1 start
+[controller.run n_rows=6] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=6 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 2 start
+[controller.run n_rows=4] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 3 start
+[controller.run n_rows=4] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=6] t=0.0s: entry
+[controller.run n_rows=6] t=0.0s: _initial_config done
+[controller.run n_rows=6] t=0.0s: _take_sample done (sample.height=6)
+[controller.run n_rows=6] t=0.0s: compute_column_priors done
+[controller.run n_rows=6] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=6] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=6] t=0.0s: entering iteration loop
+[controller.run n_rows=6] t=0.0s: iter 0 start
+[controller.run n_rows=6] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.0s: iter 1 start
+[controller.run n_rows=6] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.0s: iter 2 start
+[controller.run n_rows=6] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=6 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=5] t=0.0s: entry
+[controller.run n_rows=5] t=0.0s: _initial_config done
+[controller.run n_rows=5] t=0.0s: _take_sample done (sample.height=5)
+[controller.run n_rows=5] t=0.0s: compute_column_priors done
+[controller.run n_rows=5] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=5] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=5] t=0.0s: entering iteration loop
+[controller.run n_rows=5] t=0.0s: iter 0 start
+[controller.run n_rows=5] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=5] t=0.0s: iter 1 start
+[controller.run n_rows=5] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=5 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 2 start
+[controller.run n_rows=4] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 3 start
+[controller.run n_rows=4] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 2 start
+[controller.run n_rows=3] t=0.0s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=12] t=0.0s: entry
+[controller.run n_rows=12] t=0.0s: _initial_config done
+[controller.run n_rows=12] t=0.0s: _take_sample done (sample.height=12)
+[controller.run n_rows=12] t=0.0s: compute_column_priors done
+[controller.run n_rows=12] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=12] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=12] t=0.0s: entering iteration loop
+[controller.run n_rows=12] t=0.0s: iter 0 start
+[controller.run n_rows=12] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=12] t=0.0s: iter 1 start
+[controller.run n_rows=12] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=12] t=0.1s: iter 2 start
+[controller.run n_rows=12] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=12] t=0.1s: iter 3 start
+[controller.run n_rows=12] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=12 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=12] t=0.0s: entry
+[controller.run n_rows=12] t=0.0s: _initial_config done
+[controller.run n_rows=12] t=0.0s: _take_sample done (sample.height=12)
+[controller.run n_rows=12] t=0.0s: compute_column_priors done
+[controller.run n_rows=12] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=12] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=12] t=0.0s: entering iteration loop
+[controller.run n_rows=12] t=0.0s: iter 0 start
+[controller.run n_rows=12] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=12] t=0.0s: iter 1 start
+[controller.run n_rows=12] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=12 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 3 blocks, 3 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=12 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 2 blocks, 3 pairs
+[controller.run n_rows=57] t=0.0s: entry
+[controller.run n_rows=57] t=0.0s: _initial_config done
+[controller.run n_rows=57] t=0.0s: _take_sample done (sample.height=57)
+[controller.run n_rows=57] t=0.0s: compute_column_priors done
+[controller.run n_rows=57] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=57] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=57] t=0.0s: entering iteration loop
+[controller.run n_rows=57] t=0.0s: iter 0 start
+[controller.run n_rows=57] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=57] t=0.1s: iter 1 start
+[controller.run n_rows=57] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=57] t=0.1s: iter 2 start
+[controller.run n_rows=57] t=0.2s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=57] t=0.2s: iter 3 start
+[controller.run n_rows=57] t=0.3s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=57 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 9 blocks, 39 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 11 blocks, 23 pairs
+[controller.run n_rows=11] t=0.0s: entry
+[controller.run n_rows=11] t=0.0s: _initial_config done
+[controller.run n_rows=11] t=0.0s: _take_sample done (sample.height=11)
+[controller.run n_rows=11] t=0.0s: compute_column_priors done
+[controller.run n_rows=11] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=11] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=11] t=0.0s: entering iteration loop
+[controller.run n_rows=11] t=0.0s: iter 0 start
+[controller.run n_rows=11] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=11] t=0.0s: iter 1 start
+[controller.run n_rows=11] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=11 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 2 blocks, 7 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 2 blocks, 0 pairs
+[controller.run n_rows=78] t=0.0s: entry
+[controller.run n_rows=78] t=0.0s: _initial_config done
+[controller.run n_rows=78] t=0.0s: _take_sample done (sample.height=78)
+[controller.run n_rows=78] t=0.0s: compute_column_priors done
+[controller.run n_rows=78] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=78] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=78] t=0.0s: entering iteration loop
+[controller.run n_rows=78] t=0.0s: iter 0 start
+[controller.run n_rows=78] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=78] t=0.1s: iter 1 start
+[controller.run n_rows=78] t=0.2s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=78] t=0.2s: iter 2 start
+[controller.run n_rows=78] t=0.2s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=78] t=0.2s: iter 3 start
+[controller.run n_rows=78] t=0.3s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=78 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 33 buckets
+[score_buckets] t=0.00s: 33 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.05s: bucket_score done in 0.05s, 20 blocks, 31 pairs
+[score_buckets] t=0.05s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.05s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.05s: partition_by(bucket) in 0.00s -> 34 buckets
+[score_buckets] t=0.05s: 34 non-empty buckets ready for scoring
+[score_buckets] t=0.05s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.09s: bucket_score done in 0.04s, 15 blocks, 31 pairs
+[controller.run n_rows=47] t=0.0s: entry
+[controller.run n_rows=47] t=0.0s: _initial_config done
+[controller.run n_rows=47] t=0.0s: _take_sample done (sample.height=47)
+[controller.run n_rows=47] t=0.0s: compute_column_priors done
+[controller.run n_rows=47] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=47] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=47] t=0.0s: entering iteration loop
+[controller.run n_rows=47] t=0.0s: iter 0 start
+[controller.run n_rows=47] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.1s: iter 1 start
+[controller.run n_rows=47] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.1s: iter 2 start
+[controller.run n_rows=47] t=0.2s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.2s: iter 3 start
+[controller.run n_rows=47] t=0.2s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=47 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 15 blocks, 5 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 6 blocks, 20 pairs
+[controller.run n_rows=71] t=0.0s: entry
+[controller.run n_rows=71] t=0.0s: _initial_config done
+[controller.run n_rows=71] t=0.0s: _take_sample done (sample.height=71)
+[controller.run n_rows=71] t=0.0s: compute_column_priors done
+[controller.run n_rows=71] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=71] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=71] t=0.0s: entering iteration loop
+[controller.run n_rows=71] t=0.0s: iter 0 start
+[controller.run n_rows=71] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=71] t=0.1s: iter 1 start
+[controller.run n_rows=71] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=71 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 34 buckets
+[score_buckets] t=0.00s: 34 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.04s: bucket_score done in 0.04s, 17 blocks, 24 pairs
+[score_buckets] t=0.05s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.05s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.05s: partition_by(bucket) in 0.00s -> 36 buckets
+[score_buckets] t=0.05s: 36 non-empty buckets ready for scoring
+[score_buckets] t=0.05s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.07s: bucket_score done in 0.03s, 8 blocks, 21 pairs
+[controller.run n_rows=57] t=0.0s: entry
+[controller.run n_rows=57] t=0.0s: _initial_config done
+[controller.run n_rows=57] t=0.0s: _take_sample done (sample.height=57)
+[controller.run n_rows=57] t=0.0s: compute_column_priors done
+[controller.run n_rows=57] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=57] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=57] t=0.0s: entering iteration loop
+[controller.run n_rows=57] t=0.0s: iter 0 start
+[controller.run n_rows=57] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=57] t=0.1s: iter 1 start
+[controller.run n_rows=57] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=57 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 13 blocks, 21 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=57 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.02s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.02s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.03s: bucket_score done in 0.01s, 13 blocks, 15 pairs
+[controller.run n_rows=34] t=0.0s: entry
+[controller.run n_rows=34] t=0.0s: _initial_config done
+[controller.run n_rows=34] t=0.0s: _take_sample done (sample.height=34)
+[controller.run n_rows=34] t=0.0s: compute_column_priors done
+[controller.run n_rows=34] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=34] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=34] t=0.0s: entering iteration loop
+[controller.run n_rows=34] t=0.0s: iter 0 start
+[controller.run n_rows=34] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=34] t=0.1s: iter 1 start
+[controller.run n_rows=34] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=34] t=0.1s: iter 2 start
+[controller.run n_rows=34] t=0.2s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=34] t=0.2s: iter 3 start
+[controller.run n_rows=34] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=34 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=34 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 6 blocks, 8 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=34 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 6 blocks, 7 pairs
+[controller.run n_rows=29] t=0.0s: entry
+[controller.run n_rows=29] t=0.0s: _initial_config done
+[controller.run n_rows=29] t=0.0s: _take_sample done (sample.height=29)
+[controller.run n_rows=29] t=0.0s: compute_column_priors done
+[controller.run n_rows=29] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=29] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=29] t=0.0s: entering iteration loop
+[controller.run n_rows=29] t=0.0s: iter 0 start
+[controller.run n_rows=29] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=29] t=0.1s: iter 1 start
+[controller.run n_rows=29] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=29] t=0.1s: iter 2 start
+[controller.run n_rows=29] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=29] t=0.2s: iter 3 start
+[controller.run n_rows=29] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=29 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=29 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 11 blocks, 10 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=29 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 6 blocks, 3 pairs
+[substrate-tuner] stopped=passed rounds=1 init_xdoc=name_ci init_chunk=True
+[tuner-round 0] xdoc=name_ci chunk=True schema_canon=False | presence=1.0000 relational_F1=0.8214 R=0.6970 P=1.0000 conn_edge_recall=1.0000 comp=17 | gate_passed=True failing_axis=None escalated_to=None
+[substrate-tuner] WINNER xdoc=name_ci chunk=True schema_canon=False | FULL presence=0.9077 relational_F1=0.6667 R=0.5000 P=1.0000 conn_edge_recall=1.0000 comp=11
+
+# Substrate Staged-Tuner Smoke (wiki)
+
+- stopped_reason: `passed`  rounds: 1
+- WINNER config: xdoc_key=`name_ci` chunk_extract=True schema_canon=False
+- FULL scorecard: presence=0.9077 relational_F1=0.6667 R=0.5000 P=1.0000 conn_edge_recall=1.0000 comp=11
+
+| round | xdoc_key | chunk | presence | relational_F1 | gate_passed | failing_axis | escalated_to |
+|---|---|---|---|---|---|---|---|
+| 0 | name_ci | True | 1.0000 | 0.8214 | True | None | None |
+
+
+===== RESULTS_MD =====
+# Substrate Staged-Tuner Smoke (wiki)
+
+- stopped_reason: `passed`  rounds: 1
+- WINNER config: xdoc_key=`name_ci` chunk_extract=True schema_canon=False
+- FULL scorecard: presence=0.9077 relational_F1=0.6667 R=0.5000 P=1.0000 conn_edge_recall=1.0000 comp=11
+
+| round | xdoc_key | chunk | presence | relational_F1 | gate_passed | failing_axis | escalated_to |
+|---|---|---|---|---|---|---|---|
+| 0 | name_ci | True | 1.0000 | 0.8214 | True | None | None |

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_tuner.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_tuner.py
@@ -1,0 +1,80 @@
+"""SP-B2 staged-tuner smoke: run the deterministic staged-ejection optimizer end-to-end on the wiki
+corpus with the REAL build (build_and_score_real). Establishes the deterministic baseline scorecard
+that SP-C's LLM proposer must beat. Needs the native store + an LLM -> Modal/CI, NOT box-safe.
+
+The initial config is computed from the raw doc TEXTS (profile_corpus wants strings), then passed
+explicitly so run_staged does not re-profile the Document objects it hands to the build.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+from goldengraph.config import for_profile, profile_corpus
+
+from erkgbench.substrate_tuner import GateThresholds, build_and_score_real, run_staged
+
+
+def _fmt_sc(sc: dict) -> str:
+    p = sc.get("presence")
+    pres = "None" if p is None else f"{p['coverage']:.4f}"
+    r = sc["relational"]
+    c = sc["connectivity"]
+    return (f"presence={pres} relational_F1={r['f1']:.4f} R={r['recall']:.4f} P={r['precision']:.4f} "
+            f"conn_edge_recall={c['edge_recall']:.4f} comp={sc['coherence']['components']}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Staged-tuner smoke on the wiki corpus (real build).")
+    ap.add_argument("--budget", type=int, default=3)
+    ap.add_argument("--presence-min", type=float, default=0.90)
+    ap.add_argument("--relational-f1-min", type=float, default=0.50)
+    ap.add_argument("--out-md", default="SUBSTRATE_TUNER.md")
+    args = ap.parse_args()
+
+    from erkgbench.qa_e2e.wiki_corpus import load_wiki_corpus
+
+    documents, gold, qid_aliases = load_wiki_corpus()
+    # Profile off the raw texts (Document objects would choke profile_corpus); wiki is dense -> for_profile
+    # enables chunking + name_ci. Pass it in so run_staged doesn't re-profile the Documents.
+    init = for_profile(profile_corpus([d.text for d in documents]))
+    thresholds = GateThresholds(presence_min=args.presence_min, relational_f1_min=args.relational_f1_min)
+
+    res = run_staged(documents, gold, qid_aliases, build_and_score=build_and_score_real,
+                     thresholds=thresholds, budget=args.budget, initial_config=init)
+
+    print(f"[substrate-tuner] stopped={res.stopped_reason} rounds={len(res.trace)} "
+          f"init_xdoc={init.xdoc_key} init_chunk={init.chunk_extract}", flush=True)
+    for rr in res.trace:
+        print(f"[tuner-round {rr.round}] xdoc={rr.config.xdoc_key} chunk={rr.config.chunk_extract} "
+              f"schema_canon={rr.config.schema_canon} | {_fmt_sc(rr.scorecard)} | "
+              f"gate_passed={rr.gate.passed} failing_axis={rr.gate.failing_axis} "
+              f"escalated_to={rr.escalated_to}", flush=True)
+    print(f"[substrate-tuner] WINNER xdoc={res.config.xdoc_key} chunk={res.config.chunk_extract} "
+          f"schema_canon={res.config.schema_canon} | FULL {_fmt_sc(res.full_scorecard)}", flush=True)
+
+    lines = [
+        "# Substrate Staged-Tuner Smoke (wiki)\n",
+        f"- stopped_reason: `{res.stopped_reason}`  rounds: {len(res.trace)}",
+        f"- WINNER config: xdoc_key=`{res.config.xdoc_key}` chunk_extract={res.config.chunk_extract} "
+        f"schema_canon={res.config.schema_canon}",
+        f"- FULL scorecard: {_fmt_sc(res.full_scorecard)}\n",
+        "| round | xdoc_key | chunk | presence | relational_F1 | gate_passed | failing_axis | escalated_to |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for rr in res.trace:
+        p = rr.scorecard.get("presence")
+        pres = "None" if p is None else f"{p['coverage']:.4f}"
+        lines.append(
+            f"| {rr.round} | {rr.config.xdoc_key} | {rr.config.chunk_extract} | {pres} | "
+            f"{rr.scorecard['relational']['f1']:.4f} | {rr.gate.passed} | {rr.gate.failing_axis} | "
+            f"{rr.escalated_to} |"
+        )
+    with open(args.out_md, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+    if os.environ.get("GOLDENGRAPH_TUNER_ECHO_MD", "") not in ("", "0", "false"):
+        print("\n" + "\n".join(lines), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/distill/modal_bench.py
+++ b/scripts/distill/modal_bench.py
@@ -54,6 +54,7 @@ _EVAL = {
     "retrieval_coverage": ("erkgbench.qa_e2e.run_retrieval_eval", []),
     "end_to_end": ("erkgbench.qa_e2e.run_qa_e2e", []),  # full pipeline + localize trace (stdout)
     "substrate": ("erkgbench.run_substrate_eval", []),  # substrate-quality A/B ambiguity sweep
+    "tuner": ("erkgbench.run_substrate_tuner", []),  # SP-B2 staged-tuner smoke (handled specially above)
 }
 
 
@@ -214,6 +215,17 @@ def _bench_impl(eval: str, n: int, ambiguity: float, opts: str, chat: str, embed
         results = pathlib.Path(out_md).read_text() if os.path.exists(out_md) else "(no results md)"
         return _persist(eval, n, f"{engine}-{chat}",
                         proc.stdout + "\n\n===== RESULTS_MD =====\n" + results)
+    if eval == "tuner":
+        # SP-B2 staged-tuner smoke on the wiki corpus with the REAL build. Establishes the deterministic
+        # baseline scorecard SP-C must beat. goldengraph only (native store + resolver + LLM). budget=3.
+        env["GOLDENGRAPH_TUNER_ECHO_MD"] = "1"
+        proc = subprocess.run(
+            ["python", "-m", "erkgbench.run_substrate_tuner", "--budget", "3", "--out-md", out_md],
+            cwd=_BENCH, env=env, capture_output=True, text=True, check=True,
+        )
+        results = pathlib.Path(out_md).read_text() if os.path.exists(out_md) else "(no results md)"
+        return _persist(eval, n, f"{engine}-{chat}",
+                        proc.stdout + "\n\n===== RESULTS_MD =====\n" + results)
     module, extra = _EVAL[eval]
     subprocess.run(
         ["python", "-m", module, *extra, "--n-questions", str(n),
@@ -295,7 +307,7 @@ def main(eval: str = "extraction_f1", n: int = 20, ambiguity: float = 0.6, opts:
     # runs on the same local model don't collide. Non-default corpora get a `-{corpus}` suffix. This MUST
     # mirror the tag `_persist` actually writes, or the printed SPAWNED path points at the wrong file.
     csuf = "" if corpus == "engineered" else f"-{corpus}"
-    tag = (f"{engine}-{chat}{csuf}" if eval in ("end_to_end", "substrate") else chat).replace(":", "-").replace("/", "-")
+    tag = (f"{engine}-{chat}{csuf}" if eval in ("end_to_end", "substrate", "tuner") else chat).replace(":", "-").replace("/", "-")
     if spawn:
         # fire-and-forget: queue the call SERVER-SIDE and return instantly, so a local-CLI kill can't
         # cancel it. Result lands at results/<eval>_<n>_<model>.md. Pair with `modal run --detach`.


### PR DESCRIPTION
Validates the SP-B2 `run_staged` + `build_and_score_real` path end-to-end on real data, and establishes the deterministic baseline SP-C's LLM proposer must beat.

## What
- `erkgbench/run_substrate_tuner.py` — runs `run_staged` over the wiki corpus with `build_and_score_real`, prints the `RoundReport` trace + winner scorecard, writes a report md.
- `modal_bench.py` — a `tuner` eval mode wiring it onto Modal (goldengraph native store + 7B).

## Result (wiki, 7B, seed=42)
`for_profile` picked **name_ci + chunk(6,2)** (the arc's known-best); the gate passed on round 0 → no escalation (`stopped=passed`). Baseline: **relational F1 ≈ 0.67–0.82, presence ≈ 0.91–1.0, P=1.0**.

**Finding:** the round-0 (slice) and full builds are the SAME corpus + SAME seeded config yet diverge (F1 0.82 → 0.67, presence 1.0 → 0.91) — two sequential in-process builds aren't reproducible even with `GOLDENGRAPH_LLM_SEED`, contradicting the single-build seed-determinism verdict (#1360). So the tuner's gate/escalation rides on a noisy single-build read.

## Decision
- Ship the smoke tooling (reusable for SP-C's A/B).
- **Priority follow-on BEFORE SP-C: fix or quantify build reproducibility** (investigate seed×concurrency, or replicate + median) — else the tuner and SP-C's self-verify chase noise.
- SP-C's LLM proposer is most informative on a homograph/known-schema corpus (where `for_profile`'s flags bite), not wiki (where the deterministic pick is already best).

Full verdict: `docs/superpowers/reports/2026-07-02-staged-tuner-smoke-verdict.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)