### PR TITLE
docs: sync docs to the non-interactive dedupe default

### DIFF
--- a/docs-site/goldenmatch/cli.mdx
+++ b/docs-site/goldenmatch/cli.mdx
@@ -38,6 +38,8 @@ keywords: ["cli", "commands", "dedupe", "flags"]
 
 | Flag | Effect |
 |------|--------|
+| `--tui` | Open the interactive review TUI instead of running directly. `dedupe` is **non-interactive by default** — it auto-configs, writes golden records, and prints a summary. (`--no-tui` is accepted as a no-op for back-compat.) |
+| `--output-all` / `--output-dir DIR` | Write every artifact (golden/clusters/dupes/unique/report) / choose the output directory. On the zero-config path, golden records are written by default. |
 | `--anomalies` | Detect fake emails, placeholder data, and suspicious records. |
 | `--preview` | Preview results on a sample without writing files. |
 | `--merge-preview` | Show the merge preview (what will change) without writing. |

--- a/docs-site/goldenmatch/quickstart.mdx
+++ b/docs-site/goldenmatch/quickstart.mdx
@@ -10,7 +10,7 @@ keywords: ["goldenmatch", "quickstart", "dedupe", "match", "config", "matchkey"]
 goldenmatch dedupe customers.csv
 ```
 
-This auto-detects column types, assigns scorers, picks a blocking strategy, and launches a review TUI. The same in Python:
+This auto-detects column types, assigns scorers, picks a blocking strategy, runs, and writes golden records (a timestamped `*_golden.csv` in the current directory) — no config, no prompts. Add `--tui` to review interactively instead, or `--output-all` for every artifact. The same in Python:
 
 ```python
 import goldenmatch as gm

--- a/docs-site/goldenmatch/tui.mdx
+++ b/docs-site/goldenmatch/tui.mdx
@@ -4,7 +4,7 @@ description: "Gold-themed terminal UI for GoldenMatch: 8 tabs for data profiling
 keywords: ["tui", "terminal", "interactive", "textual", "goldenmatch interactive"]
 ---
 
-GoldenMatch includes a gold-themed terminal UI built with Textual. Launch it with `goldenmatch interactive` or `goldenmatch dedupe` (zero-config mode opens the TUI automatically).
+GoldenMatch includes a gold-themed terminal UI built with Textual. Launch it with `goldenmatch interactive`, or add `--tui` to a `goldenmatch dedupe` run to review that run interactively. (As of v2.7.x `dedupe` is non-interactive by default — it writes golden records and prints a summary; `--tui` opts into review.)
 
 ```bash
 goldenmatch interactive customers.csv

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -701,7 +701,7 @@ GoldenMatch is the only tool that combines zero-config operation, probabilistic 
 goldenmatch dedupe customers.csv
 ```
 
-Auto-detects column types (name, email, phone, zip, address, description), assigns appropriate scorers, picks blocking strategy, and launches the TUI for review.
+Auto-detects column types (name, email, phone, zip, address, description), assigns appropriate scorers, picks a blocking strategy, runs, and writes golden records (a timestamped `*_golden.csv` in the current directory) with a printed summary — zero config, no prompts. Add `--tui` to review interactively, or `--output-all` / `--output-dir` to control outputs.
 
 ### With Config
 


### PR DESCRIPTION
Follow-up to #1376 (the CLI default flip). The docs still said `goldenmatch dedupe <file>` *"launches a review TUI"* — including the docs-site quickstart, the first thing a new user reads. Fixes the 4 goldenmatch surfaces (quickstart / tui / cli-reference / package README quick-start) to describe the write-golden default + `--tui` opt-in. goldencheck / TS / the `interactive` subcommand docs are left as-is. Doc-only, 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)