### PR TITLE
fix(erkgbench): reset Ollama between tuner builds for a reproducible scorecard

### DIFF
--- a/docs/superpowers/reports/2026-07-02-staged-tuner-smoke-verdict.md
+++ b/docs/superpowers/reports/2026-07-02-staged-tuner-smoke-verdict.md
@@ -35,11 +35,29 @@ The seed-determinism verdict established that `GOLDENGRAPH_LLM_SEED` makes a bui
 
 The deterministic baseline SP-C must beat on wiki/7B: **relational F1 ≈ 0.67–0.82 (noisy), presence ≈ 0.91–1.0, at P=1.0, config = name_ci+chunk.** Given the arc has explored every lever and name_ci+chunk is the measured best, an LLM proposer is **unlikely to beat this on wiki** — the honest expectation is SP-C *confirms* the deterministic pick here. SP-C's real value is on corpora where `for_profile`'s flags bite: homograph-heavy (name_ci_type) or known-schema (schema_canon+vocab), where the config choice is non-obvious.
 
+## ROOT CAUSE + FIX (resolved — systematic-debugging pass)
+
+The slice-vs-full divergence was **not stochastic** — it reproduced byte-identically across two independent Modal containers (build-1 = 0.8214, build-2 = 0.6667 in *both* the workers=8 and workers=1 runs), so it is **deterministic state carryover** between the first and second in-process build. Root cause found by elimination:
+
+- **Not a missing seed** — `llm._chat` passes `seed` on *every* request at temperature=0 (llm.py:72-77).
+- **Not the resolver** — goldenmatch's controller samples with a *content-derived* seed (`hash(n_rows, column_names)`, `autoconfig_controller.py:_take_sample`), deterministic given its input.
+- **Not concurrency** — a `GOLDENGRAPH_BUILD_WORKERS=1` (serial) run diverged *byte-identically* to the workers=8 run, so batched inference is not the cause.
+- **→ Ollama warm-server state (KV/model cache) carryover.** The seed-determinism verdict (#1360) validated reproducibility with *one build per fresh container*; the 2-builds-in-one-warm-process path was never exercised until this smoke. Build-2's requests hit an Ollama server warmed by build-1 → different decode path → different extractions despite the seed.
+
+**Fix (verified):** `build_and_score_real` now calls `_reset_llm_state()` before each build — unloads the Ollama model (`keep_alive=0`) so every build reloads cold, matching the reproducible single-cold-build regime. Gated `GOLDENGRAPH_TUNER_RESET_LLM` (default on), Ollama-specific, no-op off a local endpoint. **Measured effect:**
+
+| axis | build-1 vs build-2, no reset | with reset |
+|---|---|---|
+| presence | 1.0000 vs 0.9077 (Δ0.09) | **0.9077 vs 0.9077 (identical)** |
+| relational F1 | 0.8214 vs 0.6667 (Δ**0.15**) | 0.6844 vs 0.6667 (Δ**0.018**) |
+
+The reset collapses the build-to-build gap **~8×**; the residual ±0.018 F1 / ±1 component is the "GPU float wobble" the seed verdict already documented (metric-level, not bit-level determinism). The tuner's gate/escalation now ride on a trustworthy signal. Since the fix lives in `build_and_score_real` (not just the runner), **SP-C inherits reproducibility automatically.** For byte-identical determinism (if ever needed), run each build in a fresh subprocess/container — the reset is the lightweight in-process approximation and is sufficient here.
+
 ## Decisions / follow-ons
 
-1. **Ship the smoke tooling** (`run_substrate_tuner.py` + `modal_bench.py` `tuner` mode) — it's the reusable harness for the baseline and for SP-C's A/B.
-2. **BEFORE SP-C: fix or quantify the build reproducibility.** Either (a) make the double-build reproducible (investigate the seed/concurrency interaction; possibly `GOLDENGRAPH_BUILD_WORKERS=1` for tuning runs), or (b) replicate each config's build N times and gate on the median — else the tuner (and SP-C's self-verify) chase noise. This is the priority follow-on, not SP-C itself.
-3. **SP-C framing:** an LLM proposer over the `RoundReport` diagnostic, gated to beat this baseline via the (reproducible) scorecard — most informative on a homograph/known-schema corpus, not wiki.
+1. **Ship the smoke tooling + reproducibility fix** (`run_substrate_tuner.py`, `modal_bench.py` `tuner` mode, `_reset_llm_state` in `build_and_score_real`).
+2. **Reproducibility RESOLVED** (above) — the blocker before SP-C is cleared; the tuner signal is trustworthy to ±0.018 F1.
+3. **SP-C framing:** an LLM proposer over the `RoundReport` diagnostic, gated to beat this baseline via the now-reproducible scorecard — most informative on a homograph/known-schema corpus (where `for_profile`'s flags bite), not wiki (where the deterministic pick is already best).
 
 ## Honest caveats
 

--- a/docs/superpowers/reports/data/2026-07-02-tuner-smoke-wiki-7b-reset.md
+++ b/docs/superpowers/reports/data/2026-07-02-tuner-smoke-wiki-7b-reset.md
@@ -1,0 +1,979 @@
+[controller.run n_rows=61] t=0.0s: entry
+[controller.run n_rows=61] t=0.0s: _initial_config done
+[controller.run n_rows=61] t=0.0s: _take_sample done (sample.height=61)
+[controller.run n_rows=61] t=0.0s: compute_column_priors done
+[controller.run n_rows=61] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=61] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=61] t=0.1s: entering iteration loop
+[controller.run n_rows=61] t=0.1s: iter 0 start
+[controller.run n_rows=61] t=1.0s: iter 0 _run_pipeline_sample done in 0.9s
+[controller.run n_rows=61] t=1.0s: iter 1 start
+[controller.run n_rows=61] t=1.1s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=61] t=1.1s: iter 2 start
+[controller.run n_rows=61] t=1.1s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=61] t=1.2s: iter 3 start
+[controller.run n_rows=61] t=1.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=61 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=61 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 7 blocks, 13 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=61 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 10 blocks, 40 pairs
+[controller.run n_rows=78] t=0.0s: entry
+[controller.run n_rows=78] t=0.0s: _initial_config done
+[controller.run n_rows=78] t=0.0s: _take_sample done (sample.height=78)
+[controller.run n_rows=78] t=0.0s: compute_column_priors done
+[controller.run n_rows=78] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=78] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=78] t=0.0s: entering iteration loop
+[controller.run n_rows=78] t=0.0s: iter 0 start
+[controller.run n_rows=78] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=78] t=0.1s: iter 1 start
+[controller.run n_rows=78] t=0.2s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=78 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 44 buckets
+[score_buckets] t=0.00s: 44 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.03s: bucket_score done in 0.02s, 2 blocks, 4 pairs
+[score_buckets] t=0.03s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.03s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.03s: partition_by(bucket) in 0.00s -> 33 buckets
+[score_buckets] t=0.03s: 33 non-empty buckets ready for scoring
+[score_buckets] t=0.03s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.09s: bucket_score done in 0.06s, 22 blocks, 33 pairs
+[controller.run n_rows=6] t=0.0s: entry
+[controller.run n_rows=6] t=0.0s: _initial_config done
+[controller.run n_rows=6] t=0.0s: _take_sample done (sample.height=6)
+[controller.run n_rows=6] t=0.0s: compute_column_priors done
+[controller.run n_rows=6] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=6] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=6] t=0.0s: entering iteration loop
+[controller.run n_rows=6] t=0.0s: iter 0 start
+[controller.run n_rows=6] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.0s: iter 1 start
+[controller.run n_rows=6] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=6 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=6] t=0.0s: entry
+[controller.run n_rows=6] t=0.0s: _initial_config done
+[controller.run n_rows=6] t=0.0s: _take_sample done (sample.height=6)
+[controller.run n_rows=6] t=0.0s: compute_column_priors done
+[controller.run n_rows=6] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=6] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=6] t=0.0s: entering iteration loop
+[controller.run n_rows=6] t=0.0s: iter 0 start
+[controller.run n_rows=6] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.0s: iter 1 start
+[controller.run n_rows=6] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=6 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=5] t=0.0s: entry
+[controller.run n_rows=5] t=0.0s: _initial_config done
+[controller.run n_rows=5] t=0.0s: _take_sample done (sample.height=5)
+[controller.run n_rows=5] t=0.0s: compute_column_priors done
+[controller.run n_rows=5] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=5] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=5] t=0.0s: entering iteration loop
+[controller.run n_rows=5] t=0.0s: iter 0 start
+[controller.run n_rows=5] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=5] t=0.0s: iter 1 start
+[controller.run n_rows=5] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=5 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=52] t=0.0s: entry
+[controller.run n_rows=52] t=0.0s: _initial_config done
+[controller.run n_rows=52] t=0.0s: _take_sample done (sample.height=52)
+[controller.run n_rows=52] t=0.0s: compute_column_priors done
+[controller.run n_rows=52] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=52] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=52] t=0.0s: entering iteration loop
+[controller.run n_rows=52] t=0.0s: iter 0 start
+[controller.run n_rows=52] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=52] t=0.1s: iter 1 start
+[controller.run n_rows=52] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=52 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=52 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=52 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 5 blocks, 9 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=47] t=0.0s: entry
+[controller.run n_rows=47] t=0.0s: _initial_config done
+[controller.run n_rows=47] t=0.0s: _take_sample done (sample.height=47)
+[controller.run n_rows=47] t=0.0s: compute_column_priors done
+[controller.run n_rows=47] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=47] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=47] t=0.0s: entering iteration loop
+[controller.run n_rows=47] t=0.0s: iter 0 start
+[controller.run n_rows=47] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.1s: iter 1 start
+[controller.run n_rows=47] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.1s: iter 2 start
+[controller.run n_rows=47] t=0.2s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=47] t=0.2s: iter 3 start
+[controller.run n_rows=47] t=0.2s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=47 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 2 blocks, 18 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=47 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.02s, 16 blocks, 4 pairs
+[controller.run n_rows=50] t=0.0s: entry
+[controller.run n_rows=50] t=0.0s: _initial_config done
+[controller.run n_rows=50] t=0.0s: _take_sample done (sample.height=50)
+[controller.run n_rows=50] t=0.0s: compute_column_priors done
+[controller.run n_rows=50] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=50] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=50] t=0.0s: entering iteration loop
+[controller.run n_rows=50] t=0.0s: iter 0 start
+[controller.run n_rows=50] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=50] t=0.1s: iter 1 start
+[controller.run n_rows=50] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=50 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=50 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 4 blocks, 6 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=50 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 12 blocks, 20 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=9] t=0.0s: entry
+[controller.run n_rows=9] t=0.0s: _initial_config done
+[controller.run n_rows=9] t=0.0s: _take_sample done (sample.height=9)
+[controller.run n_rows=9] t=0.0s: compute_column_priors done
+[controller.run n_rows=9] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=9] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=9] t=0.0s: entering iteration loop
+[controller.run n_rows=9] t=0.0s: iter 0 start
+[controller.run n_rows=9] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=9] t=0.0s: iter 1 start
+[controller.run n_rows=9] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=9 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=9 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=9 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=27] t=0.0s: entry
+[controller.run n_rows=27] t=0.0s: _initial_config done
+[controller.run n_rows=27] t=0.0s: _take_sample done (sample.height=27)
+[controller.run n_rows=27] t=0.0s: compute_column_priors done
+[controller.run n_rows=27] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=27] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=27] t=0.0s: entering iteration loop
+[controller.run n_rows=27] t=0.0s: iter 0 start
+[controller.run n_rows=27] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=27] t=0.0s: iter 1 start
+[controller.run n_rows=27] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=27] t=0.1s: iter 2 start
+[controller.run n_rows=27] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=27] t=0.1s: iter 3 start
+[controller.run n_rows=27] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=27 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=27 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 2 blocks, 1 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=27 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 6 blocks, 9 pairs
+[controller.run n_rows=11] t=0.0s: entry
+[controller.run n_rows=11] t=0.0s: _initial_config done
+[controller.run n_rows=11] t=0.0s: _take_sample done (sample.height=11)
+[controller.run n_rows=11] t=0.0s: compute_column_priors done
+[controller.run n_rows=11] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=11] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=11] t=0.0s: entering iteration loop
+[controller.run n_rows=11] t=0.0s: iter 0 start
+[controller.run n_rows=11] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=11] t=0.0s: iter 1 start
+[controller.run n_rows=11] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=11 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=11 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 2 blocks, 7 pairs
+[controller.run n_rows=22] t=0.0s: entry
+[controller.run n_rows=22] t=0.0s: _initial_config done
+[controller.run n_rows=22] t=0.0s: _take_sample done (sample.height=22)
+[controller.run n_rows=22] t=0.0s: compute_column_priors done
+[controller.run n_rows=22] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=22] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=22] t=0.0s: entering iteration loop
+[controller.run n_rows=22] t=0.0s: iter 0 start
+[controller.run n_rows=22] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=22] t=0.0s: iter 1 start
+[controller.run n_rows=22] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=22] t=0.1s: iter 2 start
+[controller.run n_rows=22] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=22] t=0.1s: iter 3 start
+[controller.run n_rows=22] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=22 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=22 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=22 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=61] t=0.0s: entry
+[controller.run n_rows=61] t=0.0s: _initial_config done
+[controller.run n_rows=61] t=0.0s: _take_sample done (sample.height=61)
+[controller.run n_rows=61] t=0.0s: compute_column_priors done
+[controller.run n_rows=61] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=61] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=61] t=0.0s: entering iteration loop
+[controller.run n_rows=61] t=0.0s: iter 0 start
+[controller.run n_rows=61] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=61] t=0.1s: iter 1 start
+[controller.run n_rows=61] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=61] t=0.1s: iter 2 start
+[controller.run n_rows=61] t=0.2s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=61] t=0.2s: iter 3 start
+[controller.run n_rows=61] t=0.2s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=61 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=61 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 6 blocks, 11 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=61 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 10 blocks, 45 pairs
+[controller.run n_rows=77] t=0.0s: entry
+[controller.run n_rows=77] t=0.0s: _initial_config done
+[controller.run n_rows=77] t=0.0s: _take_sample done (sample.height=77)
+[controller.run n_rows=77] t=0.0s: compute_column_priors done
+[controller.run n_rows=77] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=77] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=77] t=0.0s: entering iteration loop
+[controller.run n_rows=77] t=0.0s: iter 0 start
+[controller.run n_rows=77] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=77] t=0.1s: iter 1 start
+[controller.run n_rows=77] t=0.2s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=77 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 46 buckets
+[score_buckets] t=0.00s: 46 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.03s: bucket_score done in 0.02s, 1 blocks, 3 pairs
+[score_buckets] t=0.03s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.03s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.03s: partition_by(bucket) in 0.00s -> 31 buckets
+[score_buckets] t=0.03s: 31 non-empty buckets ready for scoring
+[score_buckets] t=0.03s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.09s: bucket_score done in 0.05s, 21 blocks, 33 pairs
+[controller.run n_rows=6] t=0.0s: entry
+[controller.run n_rows=6] t=0.0s: _initial_config done
+[controller.run n_rows=6] t=0.0s: _take_sample done (sample.height=6)
+[controller.run n_rows=6] t=0.0s: compute_column_priors done
+[controller.run n_rows=6] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=6] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=6] t=0.0s: entering iteration loop
+[controller.run n_rows=6] t=0.0s: iter 0 start
+[controller.run n_rows=6] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.0s: iter 1 start
+[controller.run n_rows=6] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=6 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=6] t=0.0s: entry
+[controller.run n_rows=6] t=0.0s: _initial_config done
+[controller.run n_rows=6] t=0.0s: _take_sample done (sample.height=6)
+[controller.run n_rows=6] t=0.0s: compute_column_priors done
+[controller.run n_rows=6] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=6] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=6] t=0.0s: entering iteration loop
+[controller.run n_rows=6] t=0.0s: iter 0 start
+[controller.run n_rows=6] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=6] t=0.0s: iter 1 start
+[controller.run n_rows=6] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=6 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=6 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=5] t=0.0s: entry
+[controller.run n_rows=5] t=0.0s: _initial_config done
+[controller.run n_rows=5] t=0.0s: _take_sample done (sample.height=5)
+[controller.run n_rows=5] t=0.0s: compute_column_priors done
+[controller.run n_rows=5] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=5] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=5] t=0.0s: entering iteration loop
+[controller.run n_rows=5] t=0.0s: iter 0 start
+[controller.run n_rows=5] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=5] t=0.0s: iter 1 start
+[controller.run n_rows=5] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=5 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=5 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=72] t=0.0s: entry
+[controller.run n_rows=72] t=0.0s: _initial_config done
+[controller.run n_rows=72] t=0.0s: _take_sample done (sample.height=72)
+[controller.run n_rows=72] t=0.0s: compute_column_priors done
+[controller.run n_rows=72] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=72] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=72] t=0.0s: entering iteration loop
+[controller.run n_rows=72] t=0.0s: iter 0 start
+[controller.run n_rows=72] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=72] t=0.1s: iter 1 start
+[controller.run n_rows=72] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=72] t=0.1s: iter 2 start
+[controller.run n_rows=72] t=0.2s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=72] t=0.2s: iter 3 start
+[controller.run n_rows=72] t=0.3s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=72 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 44 buckets
+[score_buckets] t=0.00s: 44 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.02s, 3 blocks, 2 pairs
+[score_buckets] t=0.02s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.02s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.03s: partition_by(bucket) in 0.00s -> 35 buckets
+[score_buckets] t=0.03s: 35 non-empty buckets ready for scoring
+[score_buckets] t=0.03s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.07s: bucket_score done in 0.04s, 17 blocks, 24 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.0s: iter 1 start
+[controller.run n_rows=4] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=48] t=0.0s: entry
+[controller.run n_rows=48] t=0.0s: _initial_config done
+[controller.run n_rows=48] t=0.0s: _take_sample done (sample.height=48)
+[controller.run n_rows=48] t=0.0s: compute_column_priors done
+[controller.run n_rows=48] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=48] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=48] t=0.0s: entering iteration loop
+[controller.run n_rows=48] t=0.0s: iter 0 start
+[controller.run n_rows=48] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=48] t=0.1s: iter 1 start
+[controller.run n_rows=48] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=48] t=0.1s: iter 2 start
+[controller.run n_rows=48] t=0.2s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=48] t=0.2s: iter 3 start
+[controller.run n_rows=48] t=0.2s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=48 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=48 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 2 blocks, 18 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=48 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.02s, 16 blocks, 4 pairs
+[controller.run n_rows=49] t=0.0s: entry
+[controller.run n_rows=49] t=0.0s: _initial_config done
+[controller.run n_rows=49] t=0.0s: _take_sample done (sample.height=49)
+[controller.run n_rows=49] t=0.0s: compute_column_priors done
+[controller.run n_rows=49] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=49] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=49] t=0.0s: entering iteration loop
+[controller.run n_rows=49] t=0.0s: iter 0 start
+[controller.run n_rows=49] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=49] t=0.1s: iter 1 start
+[controller.run n_rows=49] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=49 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=49 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 4 blocks, 6 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=49 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 12 blocks, 19 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=9] t=0.0s: entry
+[controller.run n_rows=9] t=0.0s: _initial_config done
+[controller.run n_rows=9] t=0.0s: _take_sample done (sample.height=9)
+[controller.run n_rows=9] t=0.0s: compute_column_priors done
+[controller.run n_rows=9] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=9] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=9] t=0.0s: entering iteration loop
+[controller.run n_rows=9] t=0.0s: iter 0 start
+[controller.run n_rows=9] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=9] t=0.0s: iter 1 start
+[controller.run n_rows=9] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=9 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=9 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=9 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=27] t=0.0s: entry
+[controller.run n_rows=27] t=0.0s: _initial_config done
+[controller.run n_rows=27] t=0.0s: _take_sample done (sample.height=27)
+[controller.run n_rows=27] t=0.0s: compute_column_priors done
+[controller.run n_rows=27] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=27] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=27] t=0.0s: entering iteration loop
+[controller.run n_rows=27] t=0.0s: iter 0 start
+[controller.run n_rows=27] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=27] t=0.0s: iter 1 start
+[controller.run n_rows=27] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=27] t=0.1s: iter 2 start
+[controller.run n_rows=27] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=27] t=0.1s: iter 3 start
+[controller.run n_rows=27] t=0.2s: iter 3 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=27 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=27 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 3 blocks, 2 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=27 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 6 blocks, 8 pairs
+[controller.run n_rows=8] t=0.0s: entry
+[controller.run n_rows=8] t=0.0s: _initial_config done
+[controller.run n_rows=8] t=0.0s: _take_sample done (sample.height=8)
+[controller.run n_rows=8] t=0.0s: compute_column_priors done
+[controller.run n_rows=8] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=8] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=8] t=0.0s: entering iteration loop
+[controller.run n_rows=8] t=0.0s: iter 0 start
+[controller.run n_rows=8] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=8] t=0.0s: iter 1 start
+[controller.run n_rows=8] t=0.0s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=8 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=8 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=8 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 6 pairs
+[controller.run n_rows=22] t=0.0s: entry
+[controller.run n_rows=22] t=0.0s: _initial_config done
+[controller.run n_rows=22] t=0.0s: _take_sample done (sample.height=22)
+[controller.run n_rows=22] t=0.0s: compute_column_priors done
+[controller.run n_rows=22] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=22] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=22] t=0.0s: entering iteration loop
+[controller.run n_rows=22] t=0.0s: iter 0 start
+[controller.run n_rows=22] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=22] t=0.0s: iter 1 start
+[controller.run n_rows=22] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=22] t=0.1s: iter 2 start
+[controller.run n_rows=22] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=22] t=0.1s: iter 3 start
+[controller.run n_rows=22] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=22 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=22 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 2 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=22 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[substrate-tuner] stopped=passed rounds=1 init_xdoc=name_ci init_chunk=True
+[tuner-round 0] xdoc=name_ci chunk=True schema_canon=False | presence=0.9077 relational_F1=0.6844 R=0.5202 P=1.0000 conn_edge_recall=1.0000 comp=15 | gate_passed=True failing_axis=None escalated_to=None
+[substrate-tuner] WINNER xdoc=name_ci chunk=True schema_canon=False | FULL presence=0.9077 relational_F1=0.6667 R=0.5000 P=1.0000 conn_edge_recall=1.0000 comp=16
+
+# Substrate Staged-Tuner Smoke (wiki)
+
+- stopped_reason: `passed`  rounds: 1
+- WINNER config: xdoc_key=`name_ci` chunk_extract=True schema_canon=False
+- FULL scorecard: presence=0.9077 relational_F1=0.6667 R=0.5000 P=1.0000 conn_edge_recall=1.0000 comp=16
+
+| round | xdoc_key | chunk | presence | relational_F1 | gate_passed | failing_axis | escalated_to |
+|---|---|---|---|---|---|---|---|
+| 0 | name_ci | True | 0.9077 | 0.6844 | True | None | None |
+
+
+===== RESULTS_MD =====
+# Substrate Staged-Tuner Smoke (wiki)
+
+- stopped_reason: `passed`  rounds: 1
+- WINNER config: xdoc_key=`name_ci` chunk_extract=True schema_canon=False
+- FULL scorecard: presence=0.9077 relational_F1=0.6667 R=0.5000 P=1.0000 conn_edge_recall=1.0000 comp=16
+
+| round | xdoc_key | chunk | presence | relational_F1 | gate_passed | failing_axis | escalated_to |
+|---|---|---|---|---|---|---|---|
+| 0 | name_ci | True | 0.9077 | 0.6844 | True | None | None |

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_tuner.py
@@ -172,16 +172,50 @@ def run_staged(docs, gold, qid_aliases, *, build_and_score, thresholds=None, bud
     return TunerResult(best.config, best.scorecard, full_sc, rounds, stopped)
 
 
+def _reset_llm_state() -> None:
+    """Unload the Ollama model (keep_alive=0) so the NEXT build reloads it cold, clearing the KV/model
+    cache that otherwise carries from one in-process build to the next. WITHOUT this, build-2 of the same
+    seeded config diverges from build-1 by ~0.15 F1 (measured: staged-tuner slice-vs-full smoke); WITH it
+    the gap collapses to ~0.018 F1 / +/-1 component (the residual GPU float wobble the seed-determinism
+    verdict already documented), so each build matches the reproducible single-cold-build regime and the
+    tuner's gate/escalation decisions ride on a trustworthy signal. Root cause: Ollama warm-server state,
+    NOT concurrency (workers=1 diverged identically) and NOT a missing seed (llm._chat seeds every
+    request). Best-effort + Ollama-specific (no-op off a local endpoint / on failure). Gate:
+    GOLDENGRAPH_TUNER_RESET_LLM (default on)."""
+    import json
+    import os
+    import urllib.request
+
+    if os.environ.get("GOLDENGRAPH_TUNER_RESET_LLM", "1") in ("0", "false", ""):
+        return
+    base = (os.environ.get("OPENAI_BASE_URL") or "").rstrip("/")
+    if not base or ("localhost" not in base and "127.0.0.1" not in base):
+        return  # only meaningful against a local Ollama server
+    host = base[: -len("/v1")] if base.endswith("/v1") else base
+    model = os.environ.get("OPENAI_MODEL") or ""
+    if not model:
+        return
+    try:
+        body = json.dumps({"model": model, "keep_alive": 0}).encode()
+        req = urllib.request.Request(f"{host}/api/generate", data=body,
+                                     headers={"Content-Type": "application/json"})
+        urllib.request.urlopen(req, timeout=30).read()
+    except Exception as e:  # noqa: BLE001 -- best-effort reset; a failed unload just means warm state
+        print(f"[tuner] LLM reset failed ({e!r}); continuing", flush=True)
+
+
 def build_and_score_real(config, dataset):
     """Real build_and_score: under config.apply(), build the graph over the dataset docs and score it
-    with the SP-A three-axis scorecard. Needs the native store + an LLM -> Modal/CI only, NOT box-safe.
-    Kept thin; the pure harness above is the tested surface."""
+    with the SP-A three-axis scorecard. Resets the LLM (cold) BEFORE each build so builds are independent
+    and reproducible (see _reset_llm_state). Needs the native store + an LLM -> Modal/CI only, NOT
+    box-safe. Kept thin; the pure harness above is the tested surface."""
     from erkgbench import substrate_eval
     from erkgbench.run_substrate_eval import _build_graph_from_documents
 
     docs, gold, qid_aliases = dataset
     if not docs:
         raise ValueError("build_and_score_real: empty docs")
+    _reset_llm_state()
 
     class _Doc:  # _build_graph_from_documents wants .text/.id; wrap raw text strings
         __slots__ = ("text", "id")


### PR DESCRIPTION
Fixes the build-reproducibility problem the staged-tuner smoke (#1377) surfaced — the blocker before SP-C.

## Root cause (systematic-debugging, by elimination)
The tuner's slice-build and full-build of the SAME seeded config diverged **F1 0.82 vs 0.67**. It's **deterministic** (byte-identical across two independent containers), not noise:
- **Not a missing seed** — `llm._chat` passes `seed` on every request at temp=0.
- **Not the resolver** — goldenmatch's controller samples with a content-derived seed (`hash(n_rows, columns)`), deterministic given input.
- **Not concurrency** — a `GOLDENGRAPH_BUILD_WORKERS=1` run diverged byte-identically to workers=8.
- **→ Ollama warm-server state (KV/model cache) carryover.** The seed-determinism verdict validated *one build per fresh container*; the 2-builds-in-one-warm-process path was never exercised. Build-2 hits an Ollama warmed by build-1 → different decode → different extractions despite the seed.

## Fix
`build_and_score_real` calls `_reset_llm_state()` before each build — unloads the model (`keep_alive=0`) so every build reloads cold, matching the reproducible single-cold-build regime. Gated `GOLDENGRAPH_TUNER_RESET_LLM` (default on), Ollama-specific, no-op off a local endpoint.

## Measured effect
| axis | no reset (build-1 vs build-2) | with reset |
|---|---|---|
| presence | 1.0000 vs 0.9077 (Δ0.09) | **0.9077 vs 0.9077 (identical)** |
| relational F1 | 0.8214 vs 0.6667 (Δ**0.15**) | 0.6844 vs 0.6667 (Δ**0.018**) |

~8× tighter; the residual ±0.018 F1 / ±1 comp is the GPU float wobble the seed verdict already documented. The fix lives in `build_and_score_real`, so **SP-C inherits reproducibility automatically**.

18 box tests unaffected (they use the fake `build_and_score`), ruff clean. Full write-up: `docs/superpowers/reports/2026-07-02-staged-tuner-smoke-verdict.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)