### PR TITLE
fix(throughput): skip golden-record survivorship in the throughput tier (#1151)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2258,11 +2258,22 @@ def _run_dedupe_pipeline(
     golden_df: pl.DataFrame | None = None
     golden_rules = config.golden_rules or GoldenRulesConfig(default_strategy="most_complete")
 
+    # Throughput tier (#1151): corpus dedup consumes the clusters / dup mapping,
+    # not canonical golden records — that's the whole point of the tier. Golden
+    # survivorship's per-cluster build is an O(N) polars iter_rows that wedges the
+    # 100k+ corpus ceiling (a 100k FineWeb run was faulthandler-killed at 150s in
+    # this stage). When the throughput plan engaged, skip the golden/survivorship
+    # stage (and its quality scan + adaptive refinement) entirely: golden_df stays
+    # None and clusters/dupes/unique carry the result. Same posture as the #1134
+    # quality-scan skip already applied to this tier. `_throughput_posture` is a
+    # non-None dict only after the throughput scoring branch actually ran.
+    _skip_golden = _throughput_posture is not None
+
     # v1.18: post-cluster golden-rules refinement. When the user opted
     # in via `golden_rules.adaptive=True`, refine per-field strategies
     # using cluster shape + column profiles. Refinement is a NEW config
     # (immutable mutation); the original golden_rules is unchanged.
-    if golden_rules.adaptive:
+    if not _skip_golden and golden_rules.adaptive:
         try:
             from goldenmatch.core.golden_rules_refiner import refine_golden_rules
 
@@ -2298,7 +2309,7 @@ def _run_dedupe_pipeline(
     # unless there are real quality issues). The field defaulted True but was a
     # documented no-op until now.
     quality_scores = None
-    if getattr(golden_rules, "quality_weighting", False):
+    if not _skip_golden and getattr(golden_rules, "quality_weighting", False):
         from goldenmatch.core.quality import compute_quality_scores
         with stage("golden_quality_scores"):
             quality_scores = compute_quality_scores(collected_df)
@@ -2327,7 +2338,14 @@ def _run_dedupe_pipeline(
     # rebuilt by the shared block below). quality_scores is always None in this
     # pipeline (matching the dict path's _polars_native_eligible(..., None)
     # gate); provenance mirrors config.output.lineage_provenance.
-    if cluster_frames is not None:
+    if _skip_golden:
+        with stage("golden"):
+            # Throughput tier: no survivorship (see _skip_golden above). golden_df
+            # stays None; the DedupeResult exposes clusters/dupes/unique instead.
+            logger.info(
+                "throughput tier: skipping golden-record survivorship (#1151)"
+            )
+    elif cluster_frames is not None:
         with stage("golden"):
             from goldenmatch.core.golden import build_golden_records_from_frames
             _provenance_on = config.output.lineage_provenance

--- a/packages/python/goldenmatch/tests/test_throughput_integration.py
+++ b/packages/python/goldenmatch/tests/test_throughput_integration.py
@@ -91,6 +91,47 @@ def test_dedupe_df_throughput_posture_fields():
     assert not missing, f"posture missing keys: {missing}"
 
 
+def test_throughput_skips_golden_survivorship(monkeypatch):
+    """#1151: the throughput tier skips golden-record survivorship (the O(N)
+    polars iter_rows that wedged the 100k+ corpus ceiling). Golden stays empty;
+    clusters — what corpus dedup actually consumes — are intact."""
+    from goldenmatch.core import autoconfig
+    monkeypatch.setattr(autoconfig, "_embedder_available", lambda config=None: False)
+
+    base = ["the quick brown fox jumps over the lazy dog"]
+    near = ["the quick brown fox jumps over the lazy dogs"]
+    far = ["completely unrelated text about quantum computing"]
+    df = pl.DataFrame({"body": (base * 3) + (near * 3) + (far * 3)})
+
+    from goldenmatch import dedupe_df
+
+    res = dedupe_df(df, throughput=0.95)
+    assert res.throughput_posture is not None, "throughput tier did not engage"
+    # Survivorship skipped -> no golden records built.
+    golden = res.golden
+    assert golden is None or getattr(golden, "height", 0) == 0, (
+        f"expected golden skipped on throughput path; got {golden}"
+    )
+    # The actual deliverable — clusters / dup mapping — is still there.
+    assert res.clusters, "throughput run must still produce clusters"
+
+
+def test_non_throughput_still_builds_golden():
+    """Guard: the golden skip is scoped to throughput only — a normal run still
+    builds golden records for a multi-member cluster."""
+    df = pl.DataFrame({
+        "name": ["Alice Smith", "Alice Smith", "Bob Jones"],
+        "email": ["a@x.com", "a@x.com", "b@y.com"],
+    })
+    from goldenmatch import dedupe_df
+
+    res = dedupe_df(df)
+    assert res.throughput_posture is None
+    assert res.golden is not None and res.golden.height >= 1, (
+        "normal run must still produce golden records"
+    )
+
+
 def test_throughput_off_is_byte_identical():
     import polars as pl
     from goldenmatch import dedupe_df


### PR DESCRIPTION
Closes #1151.

## Problem
The throughput tier (#1083) wedges on corpora **>~70k docs**: a 100k FineWeb `bench-corpus-dedup` run is faulthandler-killed at 150s inside golden-record **survivorship** — an O(N) pure-Python polars `iter_rows` over the full frame. The tier consumes the clusters / dup mapping, not canonical golden records (the corpus-dedup runner reads `ded.clusters`, never `ded.golden`), so that stage is pure waste on this path.

## Fix
Gate the golden stage on the throughput plan: `_skip_golden = _throughput_posture is not None`. When the tier engaged, skip golden survivorship **and** its quality scan + adaptive golden-rules refinement — `golden_df` stays `None`, and `clusters`/`dupes`/`unique` carry the result. Same posture as the #1134 quality-scan skip already applied to this tier. Every downstream `golden_df` consumer is already `None`-guarded (the `output_golden` write gate, the `if golden_records` builder, the result dict), so nothing breaks.

Scoped strictly to the opt-in throughput path — `_throughput_posture` is `None` on a normal run, so the golden stage is **byte-identical** there.

## Tests
- `test_throughput_skips_golden_survivorship` — throughput run: posture set, golden empty/None, clusters intact.
- `test_non_throughput_still_builds_golden` — a normal run still builds golden records.
- Existing `test_throughput_off_is_byte_identical` + 27 `test_golden*` tests unchanged (normal path untouched).

## Validation note
The 100k+ ceiling-lift itself is proven by the `bench-corpus-dedup` lane (the hang can't be reproduced locally without triggering it); this change removes the hanging stage from the throughput path. **Follow-up:** raise the bench default scales past 10k/50k once the lane confirms green at 100k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)