### PR TITLE
feat(erkgbench): SP-C config suggester (LLM corpus-reader, gold-verified, safe)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-substrate-suggest.md
+++ b/docs/superpowers/plans/2026-07-02-substrate-suggest.md
@@ -451,7 +451,10 @@ from erkgbench.substrate_suggest import build_and_score_real, suggest_substrate_
 def _chat(prompt: str) -> str:
     from goldengraph.llm import OpenAIClient
 
-    return OpenAIClient(model=os.environ.get("OPENAI_MODEL") or "gpt-4o-mini")._chat(prompt)
+    # json_mode=True (response_format=json_object): the 7B homograph perception is exactly the weak-OSS-
+    # model "emits prose/fenced/invalid JSON" failure mode -- forcing JSON avoids a null result being
+    # MISATTRIBUTED to "the LLM can't perceive homographs" when it's really a fixable formatting artifact.
+    return OpenAIClient(model=os.environ.get("OPENAI_MODEL") or "gpt-4o-mini")._chat(prompt, json_mode=True)
 
 
 def main() -> None:

--- a/docs/superpowers/plans/2026-07-02-substrate-suggest.md
+++ b/docs/superpowers/plans/2026-07-02-substrate-suggest.md
@@ -1,0 +1,551 @@
+# Substrate Config Suggester (SP-C) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `erkgbench/substrate_suggest.py` — an LLM corpus-reader that proposes the `for_profile` inputs it can't self-derive (homographs / known schema / vocabs), plus a gold-verified self-verify that only accepts a proposal if it beats the deterministic baseline.
+
+**Architecture:** One pure module. `propose_corpus_flags` makes a schema-constrained LLM call (injected `chat`) over a doc sample → `CorpusFlags`; `_parse_flags` salvages the JSON and defaults to all-off on garbage (never raises). `suggest_substrate_config` scores `for_profile(flags-off)` vs `for_profile(**flags)` via an injected `build_and_score` and accepts the proposal only if `_score` improves — so the LLM can never do worse than deterministic. Both the `chat` and the build are injected, so the whole flow is box-TDD'd with fakes; a thin `_unverified` MCP wrapper exposes the perception only.
+
+**Tech Stack:** Python stdlib (`dataclasses`, `json`), pytest. Imports `goldengraph.config` (SP-B1) + `erkgbench.substrate_tuner` (SP-B2).
+
+**Spec:** `docs/superpowers/specs/2026-07-02-substrate-suggest-design.md`
+
+**Branch:** `feat/substrate-suggest` (off `origin/main`). SP-B2 (#1375) is on main. The reset fix (#1380) is armed-not-merged — **the box tests don't need it** (fake build); **rebase onto `origin/main` after #1380 merges before the Modal smoke** (Task 6) so the real verify is reproducible.
+
+---
+
+## Files
+
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py` — the whole SP-C surface.
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py` — the homograph-corpus runner (Modal, not box-TDD).
+- **Modify** `scripts/distill/modal_bench.py` — add a `suggest` eval mode.
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py` — pure box-safe tests (fake `chat` + fake `build_and_score`).
+
+## Test runner (box-safe)
+
+From the er-kg-bench dir (`goldengraph` needs to be on the path too — it's a sibling package):
+
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD:/d/show_case/gg-local-llm/packages/python/goldengraph" PYTHONIOENCODING=utf-8 PYTHONUTF8=1 \
+  POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_substrate_suggest.py -q
+```
+
+## Ground-truth facts (verified — do not re-derive)
+
+- **`for_profile(profile, *, has_known_schema=False, expect_homographs=False, relation_vocab=())`** — does NOT take `entity_type_vocab`. Sets `entity_type_canon=True` iff `expect_homographs`. `SubstrateConfig` HAS an `entity_type_vocab` field.
+- **`_score(scorecard)`** (substrate_tuner) = `relational.f1 (+ presence.coverage when presence not None)`. On the engineered corpus presence is None → `_score` = `relational.f1`.
+- **`build_and_score_real(config, dataset)`**, `dataset=(docs, gold, qid_aliases)`; passes `qid_aliases=None` straight through → `substrate_scorecard` presence=None; only preserves engineered doc-ids when `docs[0]` has `.text`.
+- **`substrate_scorecard`** shape: `{"presence": {"coverage"}|None, "relational": {"f1","recall","precision"}, "connectivity": {...}, "coherence": {...}}`.
+- **Engineered corpus:** `generate_engineered(*, seed, n_questions, ambiguity)` honors `GOLDENGRAPH_BENCH_HOMOGRAPH=k`; `emit_gold_mentions(corpus.documents)` → gold with `src::rel::dst` doc-ids; `corpus.documents` carry `.text`/`.id`.
+
+---
+
+### Task 1: `CorpusFlags` + `_parse_flags` (JSON salvage)
+
+**Files:**
+- Create: `erkgbench/substrate_suggest.py`
+- Test: `tests/test_substrate_suggest.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_substrate_suggest.py`:
+
+```python
+"""SP-C substrate config suggester: parse / propose / self-verify (pure, box-safe with fakes)."""
+from __future__ import annotations
+
+from collections import namedtuple
+
+from goldengraph.config import CorpusProfile, SubstrateConfig, for_profile
+
+from erkgbench import substrate_suggest as ss
+
+
+def test_parse_flags_clean_json():
+    f = ss._parse_flags('{"expect_homographs": true, "has_known_schema": false, '
+                        '"relation_vocab": ["acquired", "works_at"], "entity_type_vocab": ["person"]}')
+    assert f.expect_homographs is True and f.has_known_schema is False
+    assert f.relation_vocab == ("acquired", "works_at") and f.entity_type_vocab == ("person",)
+
+
+def test_parse_flags_fenced():
+    raw = "```json\n{\"expect_homographs\": true}\n```"
+    assert ss._parse_flags(raw).expect_homographs is True
+
+
+def test_parse_flags_garbage_defaults():
+    for raw in ("not json", "", "{oops", "[1,2,3]"):
+        f = ss._parse_flags(raw)
+        assert f == ss.CorpusFlags()  # all-off default, never raises
+
+
+def test_parse_flags_drops_unknown_and_coerces():
+    f = ss._parse_flags('{"expect_homographs": 1, "bogus": "x", "relation_vocab": "acquired"}')
+    assert f.expect_homographs is True          # truthy coerced to bool
+    assert f.relation_vocab == ()               # a non-list vocab is ignored, not split
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k parse_flags`. Expected: `ModuleNotFoundError: erkgbench.substrate_suggest`.
+
+- [ ] **Step 3: Implement**
+
+Create `erkgbench/substrate_suggest.py`:
+
+```python
+"""SP-C substrate config suggester.
+
+An LLM reads a sample of the corpus and proposes the corpus-characteristic inputs `for_profile` cannot
+self-derive (homographs / known schema / vocabs). `suggest_substrate_config` then measurement-verifies
+the resulting config against the flags-off baseline and accepts only a net improvement -- so the LLM can
+never do worse than the deterministic baseline. `chat` and `build_and_score` are injected (box-testable
+with fakes). See docs/superpowers/specs/2026-07-02-substrate-suggest-design.md.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+
+from goldengraph.config import SubstrateConfig, for_profile, profile_corpus
+
+from erkgbench.substrate_tuner import _score, build_and_score_real  # noqa: F401 (real adapter for the runner)
+
+
+@dataclass(frozen=True)
+class CorpusFlags:
+    """The corpus-characteristic inputs `for_profile` needs but can't self-derive. All-off default =
+    the deterministic baseline (a bad/empty LLM read degrades to it)."""
+    expect_homographs: bool = False
+    has_known_schema: bool = False
+    relation_vocab: tuple[str, ...] = ()
+    entity_type_vocab: tuple[str, ...] = ()
+
+
+def _strip_fence(raw: str) -> str:
+    s = raw.strip()
+    if s.startswith("```"):
+        s = s.split("\n", 1)[1] if "\n" in s else s[3:]
+        if s.rstrip().endswith("```"):
+            s = s.rstrip()[:-3]
+    return s.strip()
+
+
+def _vocab(v) -> tuple[str, ...]:
+    """A list of non-empty strings -> lowercased tuple; anything else -> ()."""
+    if not isinstance(v, list):
+        return ()
+    return tuple(s.strip().lower() for s in v if isinstance(s, str) and s.strip())
+
+
+def _parse_flags(raw: str) -> CorpusFlags:
+    """Salvage the LLM's JSON into CorpusFlags. Fence-tolerant; drops unknown keys; coerces types;
+    returns the all-off default on ANYTHING unparseable (never raises) so a bad read == baseline."""
+    try:
+        data = json.loads(_strip_fence(raw))
+    except Exception:  # noqa: BLE001 -- any parse failure degrades to the deterministic baseline
+        return CorpusFlags()
+    if not isinstance(data, dict):
+        return CorpusFlags()
+    return CorpusFlags(
+        expect_homographs=bool(data.get("expect_homographs", False)),
+        has_known_schema=bool(data.get("has_known_schema", False)),
+        relation_vocab=_vocab(data.get("relation_vocab")),
+        entity_type_vocab=_vocab(data.get("entity_type_vocab")),
+    )
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k parse_flags`. Expected: PASS (4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py \
+        packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
+git commit -m "feat(erkgbench): CorpusFlags + _parse_flags JSON salvage (SP-C task 1)"
+```
+
+---
+
+### Task 2: `propose_corpus_flags` (injected `chat`)
+
+**Files:**
+- Modify: `erkgbench/substrate_suggest.py`
+- Test: `tests/test_substrate_suggest.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_propose_flags_calls_chat_once_and_parses():
+    calls = []
+
+    def fake_chat(prompt):
+        calls.append(prompt)
+        return '{"expect_homographs": true, "entity_type_vocab": ["person", "organization"]}'
+
+    f = ss.propose_corpus_flags(["Apple grows.", "Apple ships iPhones."], chat=fake_chat)
+    assert len(calls) == 1
+    assert "Apple grows." in calls[0]  # the sample is in the prompt
+    assert f.expect_homographs is True and f.entity_type_vocab == ("person", "organization")
+
+
+def test_propose_flags_bad_read_is_default():
+    f = ss.propose_corpus_flags(["doc"], chat=lambda p: "sorry I cannot help")
+    assert f == ss.CorpusFlags()
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k propose_flags`. Expected: FAIL — no `propose_corpus_flags`.
+
+- [ ] **Step 3: Implement** — add to `substrate_suggest.py`:
+
+```python
+_PROMPT = """You are analyzing a document corpus to configure an entity-resolution pipeline.
+Read the sample documents and answer STRICTLY as a JSON object with these keys:
+- "expect_homographs": true if the corpus contains DISTINCT entities that share the SAME name
+  (e.g. Apple the company vs Apple the fruit), else false.
+- "has_known_schema": true if the relationships form a small, closed set worth constraining, else false.
+- "relation_vocab": a list of the canonical relation names if has_known_schema, else [].
+- "entity_type_vocab": a list of coarse entity types (e.g. ["person","organization","concept"]) if
+  expect_homographs, else [].
+Output ONLY the JSON object, no prose.
+
+SAMPLE DOCUMENTS:
+{sample}
+"""
+
+
+def propose_corpus_flags(sample_docs, *, chat) -> CorpusFlags:
+    """One schema-constrained LLM call (`chat(prompt) -> str`) over the sample -> CorpusFlags. Any
+    unparseable output degrades to the all-off default (see _parse_flags)."""
+    sample = "\n\n".join(f"[doc {i}] {t}" for i, t in enumerate(sample_docs))
+    return _parse_flags(chat(_PROMPT.format(sample=sample)))
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k propose_flags`. Expected: PASS (2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py \
+        packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
+git commit -m "feat(erkgbench): propose_corpus_flags (schema-constrained LLM read, injected chat) (SP-C task 2)"
+```
+
+---
+
+### Task 3: `suggest_substrate_config` self-verify
+
+**Files:**
+- Modify: `erkgbench/substrate_suggest.py`
+- Test: `tests/test_substrate_suggest.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+_Doc = namedtuple("_Doc", "text")
+
+
+def _sc(rel_f1):
+    """A presence=None scorecard (engineered path) with a given relational F1 -> _score == rel_f1."""
+    return {"presence": None, "relational": {"f1": rel_f1, "recall": rel_f1, "precision": 1.0},
+            "connectivity": {"coverage": None, "f1": None, "edge_recall": 0.9},
+            "coherence": {"components": 1, "largest_fraction": 1.0}}
+
+
+def _short_profile():
+    return CorpusProfile(n_docs=4, mean_sentences_per_doc=2.0, mean_chars_per_doc=40.0)
+
+
+def _fake_chat_homograph(_prompt):
+    return '{"expect_homographs": true, "entity_type_vocab": ["person", "organization"]}'
+
+
+def _bykey(name_ci_score, name_ci_type_score):
+    """Fake build_and_score keyed on config.xdoc_key so accept/fallback is deterministic."""
+    def fake(config, dataset):
+        return _sc(name_ci_type_score if config.xdoc_key == "name_ci_type" else name_ci_score)
+    return fake
+
+
+def test_suggest_accepts_when_proposed_beats_baseline():
+    docs = [_Doc("Apple grows."), _Doc("Apple Inc ships.")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.40, 0.70), chat=_fake_chat_homograph)
+    assert res.accepted is True and res.config.xdoc_key == "name_ci_type"
+
+
+def test_suggest_falls_back_when_proposed_worse():
+    docs = [_Doc("a"), _Doc("b")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.70, 0.40), chat=_fake_chat_homograph)
+    assert res.accepted is False
+    assert res.config == for_profile(_short_profile())   # exactly the baseline, no vocab stamped
+
+
+def test_suggest_homograph_stamps_type_and_vocab():
+    docs = [_Doc("a"), _Doc("b")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.40, 0.70), chat=_fake_chat_homograph)
+    assert res.config.xdoc_key == "name_ci_type" and res.config.entity_type_canon is True
+    assert res.config.entity_type_vocab == ("person", "organization")
+
+
+def test_suggest_schema_only_vocab_not_stamped():
+    # expect_homographs False -> canon OFF -> entity_type_vocab must NOT be stamped even though accepted
+    def chat(_p):
+        return '{"has_known_schema": true, "relation_vocab": ["acquired"], "entity_type_vocab": ["person"]}'
+    docs = [_Doc("a"), _Doc("b")]
+    # proposed differs from baseline via schema_canon (xdoc_key stays name_ci in BOTH) -> key the fake on
+    # schema_canon instead of xdoc_key so proposed scores higher.
+    def fake(config, dataset):
+        return _sc(0.70 if config.schema_canon else 0.40)
+    res = ss.suggest_substrate_config(docs, gold=[], qid_aliases=None, profile=_short_profile(),
+                                      build_and_score=fake, chat=chat)
+    assert res.accepted is True and res.config.schema_canon is True
+    assert res.config.entity_type_canon is False and res.config.entity_type_vocab == ()
+
+
+def test_suggest_bad_llm_read_is_safe():
+    docs = [_Doc("a"), _Doc("b")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.50, 0.50), chat=lambda p: "garbage")
+    # flags default -> proposed == baseline -> equal scores -> not accepted -> baseline
+    assert res.accepted is False and res.config == for_profile(_short_profile())
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k suggest_`. Expected: FAIL — no `suggest_substrate_config`.
+
+- [ ] **Step 3: Implement** — add to `substrate_suggest.py`:
+
+```python
+@dataclass(frozen=True)
+class SuggestResult:
+    config: SubstrateConfig
+    flags: CorpusFlags
+    accepted: bool
+    baseline_scorecard: dict
+    proposed_scorecard: dict
+
+
+def suggest_substrate_config(docs, *, gold, qid_aliases, build_and_score, chat,
+                             profile=None, sample_docs=6) -> SuggestResult:
+    """LLM proposes for_profile flags from a corpus sample; accept the proposed config ONLY if it beats
+    the flags-off baseline on `_score` (else fall back to baseline). `docs` must be Document objects
+    (build_and_score needs .text/.id). `build_and_score(config, (docs, gold, qid_aliases))` injected."""
+    profile = profile or profile_corpus([d.text for d in docs])
+    sample = [d.text for d in docs[:sample_docs]]
+    flags = propose_corpus_flags(sample, chat=chat)
+
+    baseline = for_profile(profile)
+    proposed = for_profile(profile, expect_homographs=flags.expect_homographs,
+                           has_known_schema=flags.has_known_schema, relation_vocab=flags.relation_vocab)
+    dataset = (docs, gold, qid_aliases)
+    base_sc = build_and_score(baseline, dataset)
+    prop_sc = build_and_score(proposed, dataset)
+    accepted = _score(prop_sc) > _score(base_sc)
+    winner = proposed if accepted else baseline
+    # Stamp entity_type_vocab ONLY on an accepted homograph winner (canon is on only via
+    # expect_homographs; `accepted` alone does NOT imply it -- a schema-only proposal can be accepted
+    # with canon off). Both terms required -> never dirties a canon-off config.
+    if accepted and flags.expect_homographs and flags.entity_type_vocab:
+        winner = replace(winner, entity_type_vocab=flags.entity_type_vocab)
+    return SuggestResult(winner, flags, accepted, base_sc, prop_sc)
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k suggest_`. Expected: PASS (5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py \
+        packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
+git commit -m "feat(erkgbench): suggest_substrate_config self-verify (accept iff beats baseline; gated vocab) (SP-C task 3)"
+```
+
+---
+
+### Task 4: `suggest_substrate_config_unverified` (no-gold MCP surface)
+
+**Files:**
+- Modify: `erkgbench/substrate_suggest.py`
+- Test: `tests/test_substrate_suggest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_mcp_unverified_returns_config_and_flag():
+    out = ss.suggest_substrate_config_unverified(
+        ["Apple grows.", "Apple Inc ships."], chat=_fake_chat_homograph)
+    assert out["verified"] is False
+    assert out["config"].xdoc_key == "name_ci_type"           # homograph -> name_ci_type
+    assert out["config"].entity_type_vocab == ("person", "organization")
+    assert out["flags"].expect_homographs is True and "verify" in out["note"].lower()
+
+
+def test_mcp_unverified_bad_read_is_baseline():
+    out = ss.suggest_substrate_config_unverified(["doc"], chat=lambda p: "nope")
+    assert out["config"] == for_profile(profile_corpus(["doc"]))  # baseline, no vocab
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k mcp_unverified`. Expected: FAIL — no `suggest_substrate_config_unverified`.
+
+- [ ] **Step 3: Implement** — add to `substrate_suggest.py` (`docs` here are text STRINGS — the MCP caller has no Document objects):
+
+```python
+def suggest_substrate_config_unverified(sample_texts, *, chat, sample_docs=6) -> dict:
+    """No-gold MCP surface: return the LLM's PERCEIVED config from a corpus sample, labeled UNVERIFIED
+    (an MCP caller has no gold to self-verify). `sample_texts` = list of raw doc strings."""
+    sample = list(sample_texts[:sample_docs])
+    flags = propose_corpus_flags(sample, chat=chat)
+    cfg = for_profile(profile_corpus(sample), expect_homographs=flags.expect_homographs,
+                     has_known_schema=flags.has_known_schema, relation_vocab=flags.relation_vocab)
+    if flags.expect_homographs and flags.entity_type_vocab:
+        cfg = replace(cfg, entity_type_vocab=flags.entity_type_vocab)
+    return {"config": cfg, "flags": flags, "verified": False,
+            "note": "LLM perception only; measurement-verify with gold on the bench"}
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k mcp_unverified`. Expected: PASS (2).
+
+- [ ] **Step 5: Full file green + commit**
+
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD:/d/show_case/gg-local-llm/packages/python/goldengraph" PYTHONIOENCODING=utf-8 PYTHONUTF8=1 \
+  POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 /d/show_case/goldenmatch/.venv/Scripts/python.exe \
+  -m pytest tests/test_substrate_suggest.py -q   # all 13 green
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py \
+        packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
+git commit -m "feat(erkgbench): suggest_substrate_config_unverified no-gold MCP surface (SP-C task 4)"
+```
+
+---
+
+### Task 5: Runner + `modal_bench.py` `suggest` mode (homograph corpus, Modal-smoke only)
+
+**Files:**
+- Create: `erkgbench/run_substrate_suggest.py`
+- Modify: `scripts/distill/modal_bench.py`
+
+- [ ] **Step 1: Create the runner** (`run_substrate_suggest.py`)
+
+```python
+"""SP-C suggester smoke: run suggest_substrate_config on the HOMOGRAPH engineered corpus with the real
+LLM + build. The LLM should detect the injected homographs -> expect_homographs -> name_ci_type, and the
+self-verify should ACCEPT it (beats the naive name_ci baseline on relational F1 via precision recovery).
+Needs the native store + an LLM -> Modal only.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+from erkgbench.qa_e2e.engineered import emit_gold_mentions, generate_engineered
+from erkgbench.substrate_suggest import build_and_score_real, suggest_substrate_config
+
+
+def _chat(prompt: str) -> str:
+    from goldengraph.llm import OpenAIClient
+
+    return OpenAIClient(model=os.environ.get("OPENAI_MODEL") or "gpt-4o-mini")._chat(prompt)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="SP-C suggester smoke (homograph engineered corpus).")
+    ap.add_argument("--homograph", type=int, default=4)
+    ap.add_argument("--ambiguity", type=float, default=0.0)
+    ap.add_argument("--out-md", default="SUBSTRATE_SUGGEST.md")
+    args = ap.parse_args()
+
+    os.environ["GOLDENGRAPH_BENCH_HOMOGRAPH"] = str(args.homograph)
+    os.environ.pop("GOLDENGRAPH_BENCH_COOCCUR", None)
+    corpus = generate_engineered(seed=20260620, n_questions=1, ambiguity=args.ambiguity)
+    gold = emit_gold_mentions(corpus.documents)
+    # PASS Document objects (with .text/.id), NOT [d.text] -- build_and_score_real needs the real doc-ids.
+    res = suggest_substrate_config(corpus.documents, gold=gold, qid_aliases=None,
+                                   build_and_score=build_and_score_real, chat=_chat)
+
+    b, p = res.baseline_scorecard, res.proposed_scorecard
+    print(f"[suggest] accepted={res.accepted} flags={res.flags} "
+          f"baseline_F1={b['relational']['f1']:.4f} proposed_F1={p['relational']['f1']:.4f} "
+          f"winner_xdoc={res.config.xdoc_key} canon={res.config.entity_type_canon}", flush=True)
+    md = (
+        "# SP-C Suggester Smoke (homograph engineered)\n\n"
+        f"- accepted: `{res.accepted}`  flags: `{res.flags}`\n"
+        f"- baseline relational F1: {b['relational']['f1']:.4f} (P={b['relational']['precision']:.4f})\n"
+        f"- proposed relational F1: {p['relational']['f1']:.4f} (P={p['relational']['precision']:.4f})\n"
+        f"- winner: xdoc_key=`{res.config.xdoc_key}` entity_type_canon={res.config.entity_type_canon}\n"
+    )
+    with open(args.out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    print("\n" + md, flush=True)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Add the `suggest` eval mode to `modal_bench.py`**
+
+In `_EVAL` (after the `tuner` entry):
+```python
+    "suggest": ("erkgbench.run_substrate_suggest", []),  # SP-C suggester smoke (handled specially)
+```
+
+In `_bench_impl`, after the `tuner` branch:
+```python
+    if eval == "suggest":
+        proc = subprocess.run(
+            ["python", "-m", "erkgbench.run_substrate_suggest", "--out-md", out_md],
+            cwd=_BENCH, env=env, capture_output=True, text=True, check=True,
+        )
+        results = pathlib.Path(out_md).read_text() if os.path.exists(out_md) else "(no results md)"
+        return _persist(eval, n, f"{engine}-{chat}", proc.stdout + "\n\n===== RESULTS_MD =====\n" + results)
+```
+
+In `main()`, add `"suggest"` to the tag tuple: `if eval in ("end_to_end", "substrate", "tuner", "suggest")`.
+
+- [ ] **Step 3: Static-check** the runner parses + imports box-safe (heavy imports are function-local / engineered is pure):
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD:/d/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -c "import ast; ast.parse(open('erkgbench/run_substrate_suggest.py').read()); import erkgbench.run_substrate_suggest; print('ok')"
+```
+Expected: `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py \
+        scripts/distill/modal_bench.py
+git commit -m "feat(erkgbench): SP-C suggester runner + modal_bench suggest mode (homograph corpus) (SP-C task 5)"
+```
+
+---
+
+### Task 6: Finish the branch + Modal smoke
+
+- [ ] **Step 1: Rebase onto main** once #1380 (the LLM reset in `build_and_score_real`) has merged, so the verify is reproducible:
+  ```bash
+  unset GH_TOKEN; export GH_TOKEN=$(gh auth token --user benzsevern)
+  git fetch origin main && git rebase origin/main
+  ```
+  Re-run the box tests (13 green). If #1380 hasn't merged, note it and land the smoke later.
+- [ ] **Step 2: Lint** — `ruff check` the three files; fix findings.
+- [ ] **Step 3: Modal smoke** (needs Infisical Modal creds; see `feedback_infisical_usage`). Fire `--eval suggest --n 1 --spawn --opts "GOLDENGRAPH_LLM_SEED=42"`, detach, poll `results/suggest_1_goldengraph-qwen2.5-7b-instruct.md`. **Expected:** `accepted=True`, `expect_homographs=True`, winner `xdoc_key=name_ci_type`, proposed F1 > baseline F1. If the 7B doesn't detect homographs (flags stay off → proposed==baseline → accepted=False), that's an HONEST finding (the perception is the bottleneck) — record it, try DeepSeek-V3 (`--chat deepseek-chat`) as the ceiling ref before concluding.
+- [ ] **Step 4: Verdict** — write `docs/superpowers/reports/2026-07-02-suggester-smoke-verdict.md` (did the LLM perceive the homographs; did the self-verify accept; baseline-vs-proposed numbers).
+- [ ] **Step 5: PR + arm** — push, open PR base `main`, arm `--auto`, STOP.
+- [ ] **Step 6: Memory** — append SP-C shipped to `project_goldengraph_local_oss_llm_lane.md`.
+
+---
+
+## Notes for the implementer
+
+- **Box-safe only.** Run just `tests/test_substrate_suggest.py`. The pure surface has NO Modal/LLM/native dependency (fakes injected). The runner + `build_and_score_real`'s heavy imports stay function-local.
+- **`docs` to `suggest_substrate_config` are Document objects** (need `.text`/`.id`); the *sample text* passed to the LLM is `[d.text for d in docs[:n]]`. The MCP `_unverified` variant takes raw text STRINGS (an MCP caller has no Documents).
+- **The LLM only proposes; measurement decides.** If a proposal doesn't beat baseline the winner is exactly `for_profile(profile)` — verified by `test_suggest_falls_back_when_proposed_worse`. Never stamp `entity_type_vocab` unless BOTH `accepted` and `flags.expect_homographs`.
+- **`_score` on the engineered (presence=None) corpus is `relational.f1`.** The homograph win is a precision recovery that raises F1.

--- a/docs/superpowers/reports/2026-07-02-suggester-smoke-verdict.md
+++ b/docs/superpowers/reports/2026-07-02-suggester-smoke-verdict.md
@@ -1,0 +1,47 @@
+# SP-C Suggester Smoke — Verdict
+
+**Date:** 2026-07-02
+**Branch:** `feat/substrate-suggest`
+**Run:** Modal `gg-bench`, `--eval suggest`, homograph engineered corpus (`GOLDENGRAPH_BENCH_HOMOGRAPH=4`, 139 docs), 7B (`qwen2.5:7b-instruct`), `GOLDENGRAPH_LLM_SEED=42`, reproducible build (#1380 reset).
+
+## What this validated
+
+`suggest_substrate_config` end-to-end: the LLM reads the corpus → proposes `for_profile` flags → the gold self-verify scores `for_profile(flags-off)` baseline vs `for_profile(**flags)` proposed via `build_and_score_real` and accepts only if `_score` (relational F1) improves. Two runs (6-doc sample, then whole-corpus sample).
+
+## Result — the guardrail is proven; the win is metric-gated, not perception-gated
+
+### Run 1 (6-doc sample): guardrail validated
+LLM proposed `has_known_schema=True` + `relation_vocab=(works_at, located_in, acquired)` — **incomplete** (missed `part_of`/`authored`; the corpus has 5 relations). `schema_canon` with an incomplete vocab **drops out-of-vocab edges** → F1 collapsed **0.737 → 0.415**. The self-verify **rejected it → deterministic baseline won**. This is SP-C's whole safety guarantee, proven on a real harmful proposal: **the LLM cannot make the substrate worse.**
+
+### Run 2 (whole-corpus sample): perception works; F1 hides the precision win
+The 6-doc miss was a **sampling confound**, not a perception limit (4 homograph pairs diluted across 139 docs; both halves rarely in 6 docs; relations under-sampled). With the whole corpus in the prompt:
+
+| | baseline (`name_ci`) | proposed (`name_ci_type` + canon + schema_canon) |
+|---|---|---|
+| relational F1 | **0.7368** | 0.6723 |
+| relational P | 0.8153 | **0.8916** |
+| accepted | — | **False** (F1 fell) |
+
+- **Perception validated:** the 7B correctly flagged `expect_homographs=True` AND read the **complete** schema — `relation_vocab=(acquired, located in, part of, works at, authored)` (all 5 real relations) + `entity_type_vocab=(person, organization, concept)`. The LLM's corpus-reading is sound once it sees the corpus.
+- **The proposed homograph-safe config did exactly what it's for — raised precision 0.815 → 0.892** (it stopped over-merging the `HGk` homograph pairs, the intended behavior).
+- **But F1 fell 0.737 → 0.672**: the recall cost (`name_ci_type`'s ~0.06 recall hit per #1335 + `schema_canon` edge-dropping) outweighed the precision gain, so the **F1-based accept rejected it** → baseline won. The guardrail held again.
+
+## The finding: `_score` = F1 is the wrong accept metric on a homograph corpus
+
+On a homograph corpus the objective is **precision** (don't conflate distinct same-named entities). The proposed config delivered that (P 0.815 → 0.892) — but the F1 accept metric, which also charges the recall cost, **hides the precision win** and rejects the config. So the homograph win is **metric-gated, not perception-gated**: SP-C perceives correctly and proposes the right config; the F1 gate just doesn't reward it. (`_score` was chosen for consistency with SP-B2, reviewer-approved — this smoke is the first evidence it's the limiting factor on homographs.)
+
+## Decision
+
+- **Ship SP-C.** The two things that make it valuable are validated: (1) the **self-verify guardrail** — a harmful LLM proposal was measured and rejected, twice; the LLM can never do worse than deterministic; (2) **LLM perception** — with an adequate sample the 7B correctly detects homographs + the complete schema. Default-off bench/tuning tool; the no-gold MCP surface returns the (unverified) perception.
+- **Sampling matters:** the proposer must see enough of the corpus. The runner now samples the whole (small) corpus; for large corpora a representative sample (covering all relation types + homograph pairs) is required, else the vocab is incomplete and `schema_canon` self-harms (Run 1).
+
+## Follow-ons (clear, measured)
+
+1. **Precision-aware / configurable accept metric** (the top lever): on a homograph corpus, accept if precision improves at acceptable recall — not F1 alone. Would have ACCEPTED Run 2's config (P 0.815 → 0.892). This is a small, high-value change to the `_score`/accept path (SP-B2 + SP-C both consume it).
+2. **`schema_canon` self-harm even with a complete, correct vocab** (Run 2 still lost recall via schema_canon): worth a separate look — canonicalizing to the right vocab shouldn't drop this many edges. Possibly the 7B renders predicates in forms the closed vocab doesn't match, or a direction-canon interaction.
+3. **DeepSeek-V3 ceiling** — not run; the confound was the corpus/sampling + metric, not the model, so V3 on the same corpus/metric wouldn't change the verdict. Worth it only alongside follow-on 1 (a precision-aware gate).
+
+## Honest caveats
+
+- One corpus (engineered homograph), one seed, one 7B. The precision gain (0.815 → 0.892) is a single measured delta.
+- The homograph surfaces are synthetic (`HG0`…) with appositive type cues — a fair-ish but not natural homograph test; a natural-homograph corpus (Apple co/fruit) would strengthen the perception claim.

--- a/docs/superpowers/reports/data/2026-07-02-suggest-smoke-6doc.md
+++ b/docs/superpowers/reports/data/2026-07-02-suggest-smoke-6doc.md
@@ -1,0 +1,9700 @@
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.1s: compute_column_priors done
+[controller.run n_rows=2] t=0.1s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.1s: entering iteration loop
+[controller.run n_rows=2] t=0.1s: iter 0 start
+[controller.run n_rows=2] t=0.3s: iter 0 _run_pipeline_sample done in 0.2s
+[controller.run n_rows=2] t=0.3s: iter 1 start
+[controller.run n_rows=2] t=0.3s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: entry
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.1s: entering iteration loop
+[controller.run n_rows=2] t=0.1s: iter 0 start
+[controller.run n_rows=2] t=0.7s: iter 0 _run_pipeline_sample done in 0.6s
+[controller.run n_rows=2] t=0.7s: iter 1 start
+[controller.run n_rows=2] t=0.7s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.7s: iter 2 start
+[controller.run n_rows=2] t=0.7s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.7s: iter 3 start
+[controller.run n_rows=2] t=0.7s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.01s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.02s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.02s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.02s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.02s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.01s, 1 blocks, 1 pairs
+[score_buckets] t=0.02s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.02s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.02s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.02s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.02s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.01s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.1s: entering iteration loop
+[controller.run n_rows=2] t=0.1s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.2s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.2s: iter 3 start
+[controller.run n_rows=2] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[suggest] accepted=False flags=CorpusFlags(expect_homographs=False, has_known_schema=True, relation_vocab=('works_at', 'located_in', 'acquired'), entity_type_vocab=()) baseline_F1=0.7368 proposed_F1=0.4148 winner_xdoc=name_ci canon=False
+
+# SP-C Suggester Smoke (homograph engineered)
+
+- accepted: `False`  flags: `CorpusFlags(expect_homographs=False, has_known_schema=True, relation_vocab=('works_at', 'located_in', 'acquired'), entity_type_vocab=())`
+- baseline relational F1: 0.7368 (P=0.8153)
+- proposed relational F1: 0.4148 (P=0.8235)
+- winner: xdoc_key=`name_ci` entity_type_canon=False
+
+
+
+===== RESULTS_MD =====
+# SP-C Suggester Smoke (homograph engineered)
+
+- accepted: `False`  flags: `CorpusFlags(expect_homographs=False, has_known_schema=True, relation_vocab=('works_at', 'located_in', 'acquired'), entity_type_vocab=())`
+- baseline relational F1: 0.7368 (P=0.8153)
+- proposed relational F1: 0.4148 (P=0.8235)
+- winner: xdoc_key=`name_ci` entity_type_canon=False

--- a/docs/superpowers/reports/data/2026-07-02-suggest-smoke-wholecorpus.md
+++ b/docs/superpowers/reports/data/2026-07-02-suggest-smoke-wholecorpus.md
@@ -1,0 +1,10000 @@
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.2s: iter 0 _run_pipeline_sample done in 0.2s
+[controller.run n_rows=2] t=0.2s: iter 1 start
+[controller.run n_rows=2] t=0.3s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.6s: iter 0 _run_pipeline_sample done in 0.6s
+[controller.run n_rows=2] t=0.6s: iter 1 start
+[controller.run n_rows=2] t=0.6s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.6s: iter 2 start
+[controller.run n_rows=2] t=0.6s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.6s: iter 3 start
+[controller.run n_rows=2] t=0.6s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=4] t=0.0s: entry
+[controller.run n_rows=4] t=0.0s: _initial_config done
+[controller.run n_rows=4] t=0.0s: _take_sample done (sample.height=4)
+[controller.run n_rows=4] t=0.0s: compute_column_priors done
+[controller.run n_rows=4] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=4] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=4] t=0.0s: entering iteration loop
+[controller.run n_rows=4] t=0.0s: iter 0 start
+[controller.run n_rows=4] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 1 start
+[controller.run n_rows=4] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=4] t=0.1s: iter 2 start
+[controller.run n_rows=4] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=4 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=4 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[suggest] accepted=False flags=CorpusFlags(expect_homographs=True, has_known_schema=True, relation_vocab=('acquired', 'located in', 'part of', 'works at', 'authored'), entity_type_vocab=('person', 'organization', 'concept')) baseline_F1=0.7368 proposed_F1=0.6723 winner_xdoc=name_ci canon=False
+
+# SP-C Suggester Smoke (homograph engineered)
+
+- accepted: `False`  flags: `CorpusFlags(expect_homographs=True, has_known_schema=True, relation_vocab=('acquired', 'located in', 'part of', 'works at', 'authored'), entity_type_vocab=('person', 'organization', 'concept'))`
+- baseline relational F1: 0.7368 (P=0.8153)
+- proposed relational F1: 0.6723 (P=0.8916)
+- winner: xdoc_key=`name_ci` entity_type_canon=False
+
+
+
+===== RESULTS_MD =====
+# SP-C Suggester Smoke (homograph engineered)
+
+- accepted: `False`  flags: `CorpusFlags(expect_homographs=True, has_known_schema=True, relation_vocab=('acquired', 'located in', 'part of', 'works at', 'authored'), entity_type_vocab=('person', 'organization', 'concept'))`
+- baseline relational F1: 0.7368 (P=0.8153)
+- proposed relational F1: 0.6723 (P=0.8916)
+- winner: xdoc_key=`name_ci` entity_type_canon=False

--- a/docs/superpowers/specs/2026-07-02-substrate-suggest-design.md
+++ b/docs/superpowers/specs/2026-07-02-substrate-suggest-design.md
@@ -1,7 +1,7 @@
 # Substrate Config Suggester — Design (SP-C)
 
 **Date:** 2026-07-02
-**Status:** design, pre-implementation
+**Status:** implemented (branch `feat/substrate-suggest`; smoke verdict `docs/superpowers/reports/2026-07-02-suggester-smoke-verdict.md`)
 **Sub-project:** SP-C of the substrate-builder config-surface program (SP-A metric split #1371 · SP-B1 config #1373 · SP-B2 tuner #1375 · reset fix #1380 armed).
 
 ## Premise (reframed by the SP-B2 smoke)

--- a/docs/superpowers/specs/2026-07-02-substrate-suggest-design.md
+++ b/docs/superpowers/specs/2026-07-02-substrate-suggest-design.md
@@ -39,29 +39,44 @@ proposed  = for_profile(profile, expect_homographs=flags.expect_homographs,
                          relation_vocab=flags.relation_vocab)   # entity_type_vocab via env (below)
 base_sc   = build_and_score(baseline,  (docs, gold, qid_aliases))
 prop_sc   = build_and_score(proposed,  (docs, gold, qid_aliases))
-accepted  = _score(prop_sc) > _score(base_sc)            # SP-B2 _score; str* > baseline, else fall back
+accepted  = _score(prop_sc) > _score(base_sc)            # SP-B2 _score; proposed > baseline, else fall back
 winner    = proposed if accepted else baseline
+# Stamp entity_type_vocab ONLY on the accepted proposed config (never on the baseline fallback):
+if accepted and flags.entity_type_vocab:
+    winner = dataclasses.replace(winner, entity_type_vocab=flags.entity_type_vocab)
 return SuggestResult(config=winner, flags=flags, accepted=accepted,
                      baseline_scorecard=base_sc, proposed_scorecard=prop_sc)
 ```
 - `_score` is imported from `substrate_tuner` (relational.f1 + presence.coverage, or relational.f1 when presence None — the homograph engineered corpus has presence None, so the win shows as relational F1, which rises because `name_ci_type` recovers the precision `name_ci` loses to over-merged homographs).
 - **Reproducibility:** `build_and_score` is `build_and_score_real`, which resets the LLM between builds (#1380) so the baseline-vs-proposed comparison is trustworthy (the reason #1 came first). If a build isn't reproducible, the ±noise could flip `accepted` on a marginal delta.
-- `entity_type_vocab`: `for_profile` doesn't take it as a param (it's env-driven, `GOLDENGRAPH_ENTITY_TYPE_VOCAB`). When `flags.entity_type_vocab` is non-empty and `expect_homographs`, `suggest_substrate_config` sets it on the returned config via `dataclasses.replace(winner, entity_type_vocab=flags.entity_type_vocab)` so `config.apply()` materializes it. (SubstrateConfig HAS the field; `for_profile` just doesn't set it.)
+- **`entity_type_vocab` gating (review fix):** `for_profile` doesn't take `entity_type_vocab` (it's env-driven, `GOLDENGRAPH_ENTITY_TYPE_VOCAB`, and only bites when `entity_type_canon` is on). It is stamped via `dataclasses.replace` **only when `accepted` is true** — i.e. only on the *proposed* winner, which (via `for_profile(expect_homographs=True)`) already has `entity_type_canon=True` so the vocab actually bites. On the `accepted=False` fallback the winner is exactly `for_profile(profile)` (baseline), untouched — preserving the clean "fallback == deterministic baseline" guarantee. (SubstrateConfig HAS the `entity_type_vocab` field; `for_profile` just doesn't set it.)
 
 ### 3. Thin MCP tool `suggest_substrate_config` (no-gold surface)
-Wraps **`propose_corpus_flags` only** → returns the LLM's suggested `SubstrateConfig` (via `for_profile(profile_corpus(sample), **flags)`) **labeled UNVERIFIED**. An MCP caller has a corpus but no gold, so the tool cannot run the self-verify; it returns the perception + a note to measurement-verify with gold on the bench. (The gold-verified self-verify is the bench harness that PROVES the proposer works; the MCP tool is the production perception surface.) Lives alongside goldenmatch's `suggest_config` MCP registration.
+Wraps **`propose_corpus_flags` only** → returns the LLM's suggested `SubstrateConfig` **labeled UNVERIFIED**. An MCP caller has a corpus but no gold, so the tool cannot run the self-verify; it returns the perception + a note to measurement-verify with gold on the bench. Build the config the SAME way as §2 (NOT `**flags` — `CorpusFlags` is a frozen dataclass whose `entity_type_vocab` field `for_profile` doesn't accept, so a splat would `TypeError`):
+```
+flags = propose_corpus_flags(sample, chat)
+cfg = for_profile(profile_corpus(sample_texts),
+                  expect_homographs=flags.expect_homographs,
+                  has_known_schema=flags.has_known_schema, relation_vocab=flags.relation_vocab)
+if flags.expect_homographs and flags.entity_type_vocab:
+    cfg = dataclasses.replace(cfg, entity_type_vocab=flags.entity_type_vocab)
+return {"config": cfg, "flags": flags, "verified": False,
+        "note": "LLM perception only; measurement-verify with gold on the bench"}
+```
+(The gold-verified self-verify is the bench harness that PROVES the proposer works; the MCP tool is the production perception surface.) Lives alongside goldenmatch's `suggest_config` MCP registration.
 
 ### 4. Runner `run_substrate_suggest.py` + `modal_bench.py` `suggest` mode
 Loads the **homograph engineered corpus** (`GOLDENGRAPH_BENCH_HOMOGRAPH=k` via `generate_engineered` + `emit_gold_mentions`, `qid_aliases=None`), runs `suggest_substrate_config`, prints baseline-vs-proposed scorecards + the flags + `accepted`, writes a report. The Modal smoke.
+- **CRITICAL (silent-failure guard):** pass `corpus.documents` (the `Document` objects with `.text`/`.id`) as `docs` to both `suggest_substrate_config` and the sample — NOT `[d.text for d in ...]`. `build_and_score_real` only preserves the real `src::rel::dst` doc-ids when `docs[0]` has a `.text` attribute; raw strings get re-wrapped with synthetic `d{i}` ids, and the engineered gold oracle then matches nothing (both arms score ~0, silently). The proposer's *sample text* is `[d.text for d in docs[:sample_docs]]` (strings, for the prompt), but the build `docs` stay Documents.
 
 ## Testing (TDD, box-safe with FAKE `chat` + FAKE `build_and_score`)
 
 `erkgbench/tests/test_substrate_suggest.py`, all pure:
 - `parse_flags_clean_json` / `parse_flags_fenced` / `parse_flags_garbage_defaults` — `_parse_flags` salvages JSON, drops unknown keys, and returns the empty default on unparseable input (never raises).
 - `propose_flags_calls_chat_once` — fake `chat` returns a scripted JSON; `propose_corpus_flags` returns the parsed `CorpusFlags`.
-- `suggest_accepts_when_proposed_beats_baseline` — fake `build_and_score` scores `proposed` higher → `accepted=True`, `config==proposed`.
-- `suggest_falls_back_when_proposed_worse` — fake scores `proposed` lower → `accepted=False`, `config==baseline` (the LLM can't make it worse).
-- `suggest_homograph_flags_apply_type_vocab` — flags with `expect_homographs=True` + `entity_type_vocab` → the returned winning config has `xdoc_key="name_ci_type"` AND `entity_type_vocab` set.
+- `suggest_accepts_when_proposed_beats_baseline` — fake `build_and_score` returns a HIGHER `_score` for the `name_ci_type` config than for `name_ci` (key the fake on `config.xdoc_key`) → `accepted=True`, `config.xdoc_key=="name_ci_type"`.
+- `suggest_falls_back_when_proposed_worse` — fake returns a LOWER `_score` for the proposed config → `accepted=False`, `config==for_profile(profile)` exactly (baseline, NO entity_type_vocab stamped — the LLM can't make it worse).
+- `suggest_homograph_flags_apply_type_vocab` — fake scores proposed higher (so `accepted=True`); flags `expect_homographs=True` + `entity_type_vocab=(...)` → winning config has `xdoc_key=="name_ci_type"` AND `entity_type_canon is True` AND `entity_type_vocab` set.
 - `suggest_bad_llm_read_is_safe` — fake `chat` returns garbage → flags default → proposed==baseline → `accepted=False`, no crash.
 - `mcp_suggest_returns_unverified_config` — the MCP wrapper returns a config + `verified=False` note without touching gold/build.
 

--- a/docs/superpowers/specs/2026-07-02-substrate-suggest-design.md
+++ b/docs/superpowers/specs/2026-07-02-substrate-suggest-design.md
@@ -1,0 +1,82 @@
+# Substrate Config Suggester — Design (SP-C)
+
+**Date:** 2026-07-02
+**Status:** design, pre-implementation
+**Sub-project:** SP-C of the substrate-builder config-surface program (SP-A metric split #1371 · SP-B1 config #1373 · SP-B2 tuner #1375 · reset fix #1380 armed).
+
+## Premise (reframed by the SP-B2 smoke)
+
+The deterministic `for_profile` + `escalate` (SP-B1/B2) already reach the right levers via the ladder — an LLM that just proposes the *next config* would mostly duplicate it. But `for_profile` **cannot self-derive** whether a corpus *has* homographs or a *known schema* — the caller must set `expect_homographs` / `has_known_schema` / `relation_vocab` / `entity_type_vocab`. SP-C's LLM does the one thing deterministic can't: **read the corpus prose to perceive its structure** and propose those inputs. Measurement then verifies the resulting config beats the flags-off baseline before accepting — so the LLM can never make things worse than deterministic.
+
+## Non-goals
+
+- No escalation-replacement (the smoke showed it mostly matches deterministic).
+- No production/no-gold gate (unsupervised-proxy verification is a documented follow-on; SP-C's verify is gold-based, on the bench).
+- No new levers — SP-C only *supplies inputs* to `for_profile`.
+- No change to `build_and_score_real`, `substrate_scorecard`, `for_profile`.
+
+## Architecture (pure core + injected LLM/build, mirroring SP-B2)
+
+New module `erkgbench/substrate_suggest.py`:
+
+### 1. `CorpusFlags` (frozen dataclass) + `propose_corpus_flags(sample_docs, *, chat) -> CorpusFlags`
+```
+expect_homographs: bool = False
+has_known_schema: bool = False
+relation_vocab: tuple[str, ...] = ()
+entity_type_vocab: tuple[str, ...] = ()
+```
+One **schema-constrained** LLM call over a bounded sample of doc texts (default first `sample_docs` ≤ N chars each). `chat(prompt) -> str` is the injected seam; the prompt asks the model to report, as JSON, whether the corpus contains same-name-different-entity pairs (homographs), and — if the relation set looks small/closed — a candidate `relation_vocab` + coarse `entity_type_vocab`. **Parsing + validation is the box-tested surface**: `_parse_flags(raw_json) -> CorpusFlags` tolerates fenced/messy JSON (reuse the extractor's JSON-salvage pattern), drops unknown keys, coerces types, and returns the all-False/empty default on unparseable output (never raises → a bad LLM read degrades to the deterministic baseline).
+
+### 2. `suggest_substrate_config(docs, gold, qid_aliases, *, build_and_score, chat, profile=None, sample_docs=6) -> SuggestResult`
+The **review_config self-verify** (the config-suggestion-kernel pattern):
+```
+profile   = profile or profile_corpus([d.text for d in docs])
+baseline  = for_profile(profile)                         # flags OFF
+flags     = propose_corpus_flags(sample(docs), chat)
+proposed  = for_profile(profile, expect_homographs=flags.expect_homographs,
+                         has_known_schema=flags.has_known_schema,
+                         relation_vocab=flags.relation_vocab)   # entity_type_vocab via env (below)
+base_sc   = build_and_score(baseline,  (docs, gold, qid_aliases))
+prop_sc   = build_and_score(proposed,  (docs, gold, qid_aliases))
+accepted  = _score(prop_sc) > _score(base_sc)            # SP-B2 _score; str* > baseline, else fall back
+winner    = proposed if accepted else baseline
+return SuggestResult(config=winner, flags=flags, accepted=accepted,
+                     baseline_scorecard=base_sc, proposed_scorecard=prop_sc)
+```
+- `_score` is imported from `substrate_tuner` (relational.f1 + presence.coverage, or relational.f1 when presence None — the homograph engineered corpus has presence None, so the win shows as relational F1, which rises because `name_ci_type` recovers the precision `name_ci` loses to over-merged homographs).
+- **Reproducibility:** `build_and_score` is `build_and_score_real`, which resets the LLM between builds (#1380) so the baseline-vs-proposed comparison is trustworthy (the reason #1 came first). If a build isn't reproducible, the ±noise could flip `accepted` on a marginal delta.
+- `entity_type_vocab`: `for_profile` doesn't take it as a param (it's env-driven, `GOLDENGRAPH_ENTITY_TYPE_VOCAB`). When `flags.entity_type_vocab` is non-empty and `expect_homographs`, `suggest_substrate_config` sets it on the returned config via `dataclasses.replace(winner, entity_type_vocab=flags.entity_type_vocab)` so `config.apply()` materializes it. (SubstrateConfig HAS the field; `for_profile` just doesn't set it.)
+
+### 3. Thin MCP tool `suggest_substrate_config` (no-gold surface)
+Wraps **`propose_corpus_flags` only** → returns the LLM's suggested `SubstrateConfig` (via `for_profile(profile_corpus(sample), **flags)`) **labeled UNVERIFIED**. An MCP caller has a corpus but no gold, so the tool cannot run the self-verify; it returns the perception + a note to measurement-verify with gold on the bench. (The gold-verified self-verify is the bench harness that PROVES the proposer works; the MCP tool is the production perception surface.) Lives alongside goldenmatch's `suggest_config` MCP registration.
+
+### 4. Runner `run_substrate_suggest.py` + `modal_bench.py` `suggest` mode
+Loads the **homograph engineered corpus** (`GOLDENGRAPH_BENCH_HOMOGRAPH=k` via `generate_engineered` + `emit_gold_mentions`, `qid_aliases=None`), runs `suggest_substrate_config`, prints baseline-vs-proposed scorecards + the flags + `accepted`, writes a report. The Modal smoke.
+
+## Testing (TDD, box-safe with FAKE `chat` + FAKE `build_and_score`)
+
+`erkgbench/tests/test_substrate_suggest.py`, all pure:
+- `parse_flags_clean_json` / `parse_flags_fenced` / `parse_flags_garbage_defaults` — `_parse_flags` salvages JSON, drops unknown keys, and returns the empty default on unparseable input (never raises).
+- `propose_flags_calls_chat_once` — fake `chat` returns a scripted JSON; `propose_corpus_flags` returns the parsed `CorpusFlags`.
+- `suggest_accepts_when_proposed_beats_baseline` — fake `build_and_score` scores `proposed` higher → `accepted=True`, `config==proposed`.
+- `suggest_falls_back_when_proposed_worse` — fake scores `proposed` lower → `accepted=False`, `config==baseline` (the LLM can't make it worse).
+- `suggest_homograph_flags_apply_type_vocab` — flags with `expect_homographs=True` + `entity_type_vocab` → the returned winning config has `xdoc_key="name_ci_type"` AND `entity_type_vocab` set.
+- `suggest_bad_llm_read_is_safe` — fake `chat` returns garbage → flags default → proposed==baseline → `accepted=False`, no crash.
+- `mcp_suggest_returns_unverified_config` — the MCP wrapper returns a config + `verified=False` note without touching gold/build.
+
+## Design choices flagged for review
+
+- **Python-API-first; MCP tool is a thin no-gold wrapper.** The gold-verified self-verify is inherently a bench operation (needs gold + a real build); the MCP tool exposes only the LLM perception (unverified). This is the honest split, not a scope cut.
+- **Accept metric = SP-B2 `_score`.** Consistent with the tuner. On the homograph corpus (presence None) that's relational F1; `name_ci_type`'s precision recovery raises it when homographs are prevalent. If the corpus has NO homographs, `name_ci_type` costs recall → lower F1 → `accepted=False` → baseline kept (correct).
+- **The proposer LLM call is seeded** (`GOLDENGRAPH_LLM_SEED`, via the same `llm._chat`) so the perception is reproducible.
+- **Smoke corpus = homograph engineered** (`HOMOGRAPH=k`), per Ben's steer. The measurable success: the LLM detects the injected homographs → `expect_homographs` → `name_ci_type`, and the self-verify accepts it (beats `name_ci` baseline on relational F1).
+
+## Dependency / branch note
+
+Needs `SubstrateConfig`/`for_profile` (SP-B1), `_score`/`build_and_score_real` (SP-B2 #1375, on main), and the **reset in `build_and_score_real` (#1380, armed not merged)** for a trustworthy verify. This branch (`feat/substrate-suggest`) is off main before #1380 merged. **Rebase onto `origin/main` after #1380 merges** before the smoke (else the verify rides on the noisy pre-reset build). The pure box tests don't need it (fake `build_and_score`).
+
+## Follow-ons
+
+- **No-gold production verify:** validate an unsupervised proxy (fragmentation/precision-proxy) against the gold `_score` on the bench, then let the MCP tool self-verify without gold.
+- **Vocab proposal quality:** the arc's SCHEMA_CANON win used a curated `relation_vocab`; whether an LLM-proposed vocab matches it is a measurable follow-on (the homograph flag is the first, cheapest win).

--- a/docs/superpowers/specs/2026-07-02-substrate-suggest-design.md
+++ b/docs/superpowers/specs/2026-07-02-substrate-suggest-design.md
@@ -41,15 +41,18 @@ base_sc   = build_and_score(baseline,  (docs, gold, qid_aliases))
 prop_sc   = build_and_score(proposed,  (docs, gold, qid_aliases))
 accepted  = _score(prop_sc) > _score(base_sc)            # SP-B2 _score; proposed > baseline, else fall back
 winner    = proposed if accepted else baseline
-# Stamp entity_type_vocab ONLY on the accepted proposed config (never on the baseline fallback):
-if accepted and flags.entity_type_vocab:
+# Stamp entity_type_vocab ONLY on an accepted proposed config that ALSO turned canon on (via
+# expect_homographs) -- else the vocab is a no-op AND we'd dirty a canon-off winner. `accepted` does
+# NOT imply expect_homographs (a has_known_schema-only proposal can be accepted with canon off), so
+# BOTH terms are required (matches the MCP gate in section 3):
+if accepted and flags.expect_homographs and flags.entity_type_vocab:
     winner = dataclasses.replace(winner, entity_type_vocab=flags.entity_type_vocab)
 return SuggestResult(config=winner, flags=flags, accepted=accepted,
                      baseline_scorecard=base_sc, proposed_scorecard=prop_sc)
 ```
 - `_score` is imported from `substrate_tuner` (relational.f1 + presence.coverage, or relational.f1 when presence None — the homograph engineered corpus has presence None, so the win shows as relational F1, which rises because `name_ci_type` recovers the precision `name_ci` loses to over-merged homographs).
 - **Reproducibility:** `build_and_score` is `build_and_score_real`, which resets the LLM between builds (#1380) so the baseline-vs-proposed comparison is trustworthy (the reason #1 came first). If a build isn't reproducible, the ±noise could flip `accepted` on a marginal delta.
-- **`entity_type_vocab` gating (review fix):** `for_profile` doesn't take `entity_type_vocab` (it's env-driven, `GOLDENGRAPH_ENTITY_TYPE_VOCAB`, and only bites when `entity_type_canon` is on). It is stamped via `dataclasses.replace` **only when `accepted` is true** — i.e. only on the *proposed* winner, which (via `for_profile(expect_homographs=True)`) already has `entity_type_canon=True` so the vocab actually bites. On the `accepted=False` fallback the winner is exactly `for_profile(profile)` (baseline), untouched — preserving the clean "fallback == deterministic baseline" guarantee. (SubstrateConfig HAS the `entity_type_vocab` field; `for_profile` just doesn't set it.)
+- **`entity_type_vocab` gating (review fix):** `for_profile` doesn't take `entity_type_vocab` (it's env-driven, `GOLDENGRAPH_ENTITY_TYPE_VOCAB`, and — verified — only bites when `entity_type_canon` is on). It is stamped via `dataclasses.replace` only when **both** `accepted` **and** `flags.expect_homographs` — because `entity_type_canon` turns on *only* via `expect_homographs` in `for_profile`, and `accepted` alone does NOT imply `expect_homographs` (a `has_known_schema`-only proposal can be accepted with canon off; §1 explicitly couples proposed `entity_type_vocab` to the *schema* signal, so vocab-without-homographs is the expected shape). Requiring both terms means we never stamp vocab onto a canon-off config. On the `accepted=False` fallback the winner is exactly `for_profile(profile)` (baseline), untouched — preserving the clean "fallback == deterministic baseline" guarantee. (SubstrateConfig HAS the `entity_type_vocab` field; `for_profile` just doesn't set it.)
 
 ### 3. Thin MCP tool `suggest_substrate_config` (no-gold surface)
 Wraps **`propose_corpus_flags` only** → returns the LLM's suggested `SubstrateConfig` **labeled UNVERIFIED**. An MCP caller has a corpus but no gold, so the tool cannot run the self-verify; it returns the perception + a note to measurement-verify with gold on the bench. Build the config the SAME way as §2 (NOT `**flags` — `CorpusFlags` is a frozen dataclass whose `entity_type_vocab` field `for_profile` doesn't accept, so a splat would `TypeError`):
@@ -77,6 +80,7 @@ Loads the **homograph engineered corpus** (`GOLDENGRAPH_BENCH_HOMOGRAPH=k` via `
 - `suggest_accepts_when_proposed_beats_baseline` — fake `build_and_score` returns a HIGHER `_score` for the `name_ci_type` config than for `name_ci` (key the fake on `config.xdoc_key`) → `accepted=True`, `config.xdoc_key=="name_ci_type"`.
 - `suggest_falls_back_when_proposed_worse` — fake returns a LOWER `_score` for the proposed config → `accepted=False`, `config==for_profile(profile)` exactly (baseline, NO entity_type_vocab stamped — the LLM can't make it worse).
 - `suggest_homograph_flags_apply_type_vocab` — fake scores proposed higher (so `accepted=True`); flags `expect_homographs=True` + `entity_type_vocab=(...)` → winning config has `xdoc_key=="name_ci_type"` AND `entity_type_canon is True` AND `entity_type_vocab` set.
+- `suggest_vocab_without_homograph_not_stamped` — flags `expect_homographs=False, has_known_schema=True, entity_type_vocab=(...)`, fake scores proposed higher (`accepted=True` via schema_canon) → winner has `entity_type_canon is False` AND `entity_type_vocab == ()` (vocab NOT stamped on the canon-off config — the §2 gate requires `expect_homographs` too).
 - `suggest_bad_llm_read_is_safe` — fake `chat` returns garbage → flags default → proposed==baseline → `accepted=False`, no crash.
 - `mcp_suggest_returns_unverified_config` — the MCP wrapper returns a config + `verified=False` note without touching gold/build.
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py
@@ -1,0 +1,56 @@
+"""SP-C suggester smoke: run suggest_substrate_config on the HOMOGRAPH engineered corpus with the real
+LLM + build. The LLM should detect the injected homographs -> expect_homographs -> name_ci_type, and the
+self-verify should ACCEPT it (beats the naive name_ci baseline on relational F1 via precision recovery).
+Needs the native store + an LLM -> Modal only.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+from erkgbench.qa_e2e.engineered import emit_gold_mentions, generate_engineered
+from erkgbench.substrate_suggest import build_and_score_real, suggest_substrate_config
+
+
+def _chat(prompt: str) -> str:
+    from goldengraph.llm import OpenAIClient
+
+    # json_mode=True (response_format=json_object): the 7B homograph perception is exactly the weak-OSS-
+    # model "emits prose/fenced/invalid JSON" failure mode -- forcing JSON avoids a null result being
+    # MISATTRIBUTED to "the LLM can't perceive homographs" when it's really a fixable formatting artifact.
+    return OpenAIClient(model=os.environ.get("OPENAI_MODEL") or "gpt-4o-mini")._chat(prompt, json_mode=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="SP-C suggester smoke (homograph engineered corpus).")
+    ap.add_argument("--homograph", type=int, default=4)
+    ap.add_argument("--ambiguity", type=float, default=0.0)
+    ap.add_argument("--out-md", default="SUBSTRATE_SUGGEST.md")
+    args = ap.parse_args()
+
+    os.environ["GOLDENGRAPH_BENCH_HOMOGRAPH"] = str(args.homograph)
+    os.environ.pop("GOLDENGRAPH_BENCH_COOCCUR", None)
+    corpus = generate_engineered(seed=20260620, n_questions=1, ambiguity=args.ambiguity)
+    gold = emit_gold_mentions(corpus.documents)
+    # PASS Document objects (with .text/.id), NOT [d.text] -- build_and_score_real needs the real doc-ids.
+    res = suggest_substrate_config(corpus.documents, gold=gold, qid_aliases=None,
+                                   build_and_score=build_and_score_real, chat=_chat)
+
+    b, p = res.baseline_scorecard, res.proposed_scorecard
+    print(f"[suggest] accepted={res.accepted} flags={res.flags} "
+          f"baseline_F1={b['relational']['f1']:.4f} proposed_F1={p['relational']['f1']:.4f} "
+          f"winner_xdoc={res.config.xdoc_key} canon={res.config.entity_type_canon}", flush=True)
+    md = (
+        "# SP-C Suggester Smoke (homograph engineered)\n\n"
+        f"- accepted: `{res.accepted}`  flags: `{res.flags}`\n"
+        f"- baseline relational F1: {b['relational']['f1']:.4f} (P={b['relational']['precision']:.4f})\n"
+        f"- proposed relational F1: {p['relational']['f1']:.4f} (P={p['relational']['precision']:.4f})\n"
+        f"- winner: xdoc_key=`{res.config.xdoc_key}` entity_type_canon={res.config.entity_type_canon}\n"
+    )
+    with open(args.out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    print("\n" + md, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py
@@ -33,8 +33,12 @@ def main() -> None:
     corpus = generate_engineered(seed=20260620, n_questions=1, ambiguity=args.ambiguity)
     gold = emit_gold_mentions(corpus.documents)
     # PASS Document objects (with .text/.id), NOT [d.text] -- build_and_score_real needs the real doc-ids.
+    # Sample the WHOLE corpus for the proposer: with ~139 SHORT docs, a small sample gives an INCOMPLETE
+    # relation set (schema_canon then drops out-of-vocab edges -> F1 collapse) and misses both halves of
+    # the diluted homograph pairs. Whole-corpus sampling is the fair perception test (prompt stays small).
     res = suggest_substrate_config(corpus.documents, gold=gold, qid_aliases=None,
-                                   build_and_score=build_and_score_real, chat=_chat)
+                                   build_and_score=build_and_score_real, chat=_chat,
+                                   sample_docs=len(corpus.documents))
 
     b, p = res.baseline_scorecard, res.proposed_scorecard
     print(f"[suggest] accepted={res.accepted} flags={res.flags} "

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py
@@ -1,0 +1,131 @@
+"""SP-C substrate config suggester.
+
+An LLM reads a sample of the corpus and proposes the corpus-characteristic inputs `for_profile` cannot
+self-derive (homographs / known schema / vocabs). `suggest_substrate_config` then measurement-verifies
+the resulting config against the flags-off baseline and accepts only a net improvement -- so the LLM can
+never do worse than the deterministic baseline. `chat` and `build_and_score` are injected (box-testable
+with fakes). See docs/superpowers/specs/2026-07-02-substrate-suggest-design.md.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+
+from goldengraph.config import SubstrateConfig, for_profile, profile_corpus
+
+from erkgbench.substrate_tuner import (  # noqa: F401 (real adapter for the runner)
+    _score,
+    build_and_score_real,
+)
+
+
+@dataclass(frozen=True)
+class CorpusFlags:
+    """The corpus-characteristic inputs `for_profile` needs but can't self-derive. All-off default =
+    the deterministic baseline (a bad/empty LLM read degrades to it)."""
+    expect_homographs: bool = False
+    has_known_schema: bool = False
+    relation_vocab: tuple[str, ...] = ()
+    entity_type_vocab: tuple[str, ...] = ()
+
+
+def _strip_fence(raw: str) -> str:
+    s = raw.strip()
+    if s.startswith("```"):
+        s = s.split("\n", 1)[1] if "\n" in s else s[3:]
+        if s.rstrip().endswith("```"):
+            s = s.rstrip()[:-3]
+    return s.strip()
+
+
+def _vocab(v) -> tuple[str, ...]:
+    """A list of non-empty strings -> lowercased tuple; anything else -> ()."""
+    if not isinstance(v, list):
+        return ()
+    return tuple(s.strip().lower() for s in v if isinstance(s, str) and s.strip())
+
+
+def _parse_flags(raw: str) -> CorpusFlags:
+    """Salvage the LLM's JSON into CorpusFlags. Fence-tolerant; drops unknown keys; coerces types;
+    returns the all-off default on ANYTHING unparseable (never raises) so a bad read == baseline."""
+    try:
+        data = json.loads(_strip_fence(raw))
+    except Exception:  # noqa: BLE001 -- any parse failure degrades to the deterministic baseline
+        return CorpusFlags()
+    if not isinstance(data, dict):
+        return CorpusFlags()
+    return CorpusFlags(
+        expect_homographs=bool(data.get("expect_homographs", False)),
+        has_known_schema=bool(data.get("has_known_schema", False)),
+        relation_vocab=_vocab(data.get("relation_vocab")),
+        entity_type_vocab=_vocab(data.get("entity_type_vocab")),
+    )
+
+
+_PROMPT = """You are analyzing a document corpus to configure an entity-resolution pipeline.
+Read the sample documents and answer STRICTLY as a JSON object with these keys:
+- "expect_homographs": true if the corpus contains DISTINCT entities that share the SAME name
+  (e.g. Apple the company vs Apple the fruit), else false.
+- "has_known_schema": true if the relationships form a small, closed set worth constraining, else false.
+- "relation_vocab": a list of the canonical relation names if has_known_schema, else [].
+- "entity_type_vocab": a list of coarse entity types (e.g. ["person","organization","concept"]) if
+  expect_homographs, else [].
+Output ONLY the JSON object, no prose.
+
+SAMPLE DOCUMENTS:
+{sample}
+"""
+
+
+def propose_corpus_flags(sample_docs, *, chat) -> CorpusFlags:
+    """One schema-constrained LLM call (`chat(prompt) -> str`) over the sample -> CorpusFlags. Any
+    unparseable output degrades to the all-off default (see _parse_flags)."""
+    sample = "\n\n".join(f"[doc {i}] {t}" for i, t in enumerate(sample_docs))
+    return _parse_flags(chat(_PROMPT.format(sample=sample)))
+
+
+@dataclass(frozen=True)
+class SuggestResult:
+    config: SubstrateConfig
+    flags: CorpusFlags
+    accepted: bool
+    baseline_scorecard: dict
+    proposed_scorecard: dict
+
+
+def suggest_substrate_config(docs, *, gold, qid_aliases, build_and_score, chat,
+                             profile=None, sample_docs=6) -> SuggestResult:
+    """LLM proposes for_profile flags from a corpus sample; accept the proposed config ONLY if it beats
+    the flags-off baseline on `_score` (else fall back to baseline). `docs` must be Document objects
+    (build_and_score needs .text/.id). `build_and_score(config, (docs, gold, qid_aliases))` injected."""
+    profile = profile or profile_corpus([d.text for d in docs])
+    sample = [d.text for d in docs[:sample_docs]]
+    flags = propose_corpus_flags(sample, chat=chat)
+
+    baseline = for_profile(profile)
+    proposed = for_profile(profile, expect_homographs=flags.expect_homographs,
+                           has_known_schema=flags.has_known_schema, relation_vocab=flags.relation_vocab)
+    dataset = (docs, gold, qid_aliases)
+    base_sc = build_and_score(baseline, dataset)
+    prop_sc = build_and_score(proposed, dataset)
+    accepted = _score(prop_sc) > _score(base_sc)
+    winner = proposed if accepted else baseline
+    # Stamp entity_type_vocab ONLY on an accepted homograph winner (canon is on only via
+    # expect_homographs; `accepted` alone does NOT imply it -- a schema-only proposal can be accepted
+    # with canon off). Both terms required -> never dirties a canon-off config.
+    if accepted and flags.expect_homographs and flags.entity_type_vocab:
+        winner = replace(winner, entity_type_vocab=flags.entity_type_vocab)
+    return SuggestResult(winner, flags, accepted, base_sc, prop_sc)
+
+
+def suggest_substrate_config_unverified(sample_texts, *, chat, sample_docs=6) -> dict:
+    """No-gold MCP surface: return the LLM's PERCEIVED config from a corpus sample, labeled UNVERIFIED
+    (an MCP caller has no gold to self-verify). `sample_texts` = list of raw doc strings."""
+    sample = list(sample_texts[:sample_docs])
+    flags = propose_corpus_flags(sample, chat=chat)
+    cfg = for_profile(profile_corpus(sample), expect_homographs=flags.expect_homographs,
+                     has_known_schema=flags.has_known_schema, relation_vocab=flags.relation_vocab)
+    if flags.expect_homographs and flags.entity_type_vocab:
+        cfg = replace(cfg, entity_type_vocab=flags.entity_type_vocab)
+    return {"config": cfg, "flags": flags, "verified": False,
+            "note": "LLM perception only; measurement-verify with gold on the bench"}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
@@ -1,0 +1,142 @@
+"""SP-C substrate config suggester: parse / propose / self-verify (pure, box-safe with fakes)."""
+from __future__ import annotations
+
+from collections import namedtuple
+
+from erkgbench import substrate_suggest as ss
+from goldengraph.config import CorpusProfile, for_profile, profile_corpus
+
+
+# --- Task 1: _parse_flags -----------------------------------------------------------------------------
+def test_parse_flags_clean_json():
+    f = ss._parse_flags('{"expect_homographs": true, "has_known_schema": false, '
+                        '"relation_vocab": ["acquired", "works_at"], "entity_type_vocab": ["person"]}')
+    assert f.expect_homographs is True and f.has_known_schema is False
+    assert f.relation_vocab == ("acquired", "works_at") and f.entity_type_vocab == ("person",)
+
+
+def test_parse_flags_fenced():
+    raw = "```json\n{\"expect_homographs\": true}\n```"
+    assert ss._parse_flags(raw).expect_homographs is True
+
+
+def test_parse_flags_garbage_defaults():
+    for raw in ("not json", "", "{oops", "[1,2,3]"):
+        f = ss._parse_flags(raw)
+        assert f == ss.CorpusFlags()  # all-off default, never raises
+
+
+def test_parse_flags_drops_unknown_and_coerces():
+    f = ss._parse_flags('{"expect_homographs": 1, "bogus": "x", "relation_vocab": "acquired"}')
+    assert f.expect_homographs is True          # truthy coerced to bool
+    assert f.relation_vocab == ()               # a non-list vocab is ignored, not split
+
+
+# --- Task 2: propose_corpus_flags ---------------------------------------------------------------------
+def test_propose_flags_calls_chat_once_and_parses():
+    calls = []
+
+    def fake_chat(prompt):
+        calls.append(prompt)
+        return '{"expect_homographs": true, "entity_type_vocab": ["person", "organization"]}'
+
+    f = ss.propose_corpus_flags(["Apple grows.", "Apple ships iPhones."], chat=fake_chat)
+    assert len(calls) == 1
+    assert "Apple grows." in calls[0]  # the sample is in the prompt
+    assert f.expect_homographs is True and f.entity_type_vocab == ("person", "organization")
+
+
+def test_propose_flags_bad_read_is_default():
+    f = ss.propose_corpus_flags(["doc"], chat=lambda p: "sorry I cannot help")
+    assert f == ss.CorpusFlags()
+
+
+# --- Task 3: suggest_substrate_config self-verify -----------------------------------------------------
+_Doc = namedtuple("_Doc", "text")
+
+
+def _sc(rel_f1):
+    """A presence=None scorecard (engineered path) with a given relational F1 -> _score == rel_f1."""
+    return {"presence": None, "relational": {"f1": rel_f1, "recall": rel_f1, "precision": 1.0},
+            "connectivity": {"coverage": None, "f1": None, "edge_recall": 0.9},
+            "coherence": {"components": 1, "largest_fraction": 1.0}}
+
+
+def _short_profile():
+    return CorpusProfile(n_docs=4, mean_sentences_per_doc=2.0, mean_chars_per_doc=40.0)
+
+
+def _fake_chat_homograph(_prompt):
+    return '{"expect_homographs": true, "entity_type_vocab": ["person", "organization"]}'
+
+
+def _bykey(name_ci_score, name_ci_type_score):
+    """Fake build_and_score keyed on config.xdoc_key so accept/fallback is deterministic."""
+    def fake(config, dataset):
+        return _sc(name_ci_type_score if config.xdoc_key == "name_ci_type" else name_ci_score)
+    return fake
+
+
+def test_suggest_accepts_when_proposed_beats_baseline():
+    docs = [_Doc("Apple grows."), _Doc("Apple Inc ships.")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.40, 0.70), chat=_fake_chat_homograph)
+    assert res.accepted is True and res.config.xdoc_key == "name_ci_type"
+
+
+def test_suggest_falls_back_when_proposed_worse():
+    docs = [_Doc("a"), _Doc("b")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.70, 0.40), chat=_fake_chat_homograph)
+    assert res.accepted is False
+    assert res.config == for_profile(_short_profile())   # exactly the baseline, no vocab stamped
+
+
+def test_suggest_homograph_stamps_type_and_vocab():
+    docs = [_Doc("a"), _Doc("b")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.40, 0.70), chat=_fake_chat_homograph)
+    assert res.config.xdoc_key == "name_ci_type" and res.config.entity_type_canon is True
+    assert res.config.entity_type_vocab == ("person", "organization")
+
+
+def test_suggest_schema_only_vocab_not_stamped():
+    # expect_homographs False -> canon OFF -> entity_type_vocab must NOT be stamped even though accepted
+    def chat(_p):
+        return '{"has_known_schema": true, "relation_vocab": ["acquired"], "entity_type_vocab": ["person"]}'
+    docs = [_Doc("a"), _Doc("b")]
+    # proposed differs from baseline via schema_canon (xdoc_key stays name_ci in BOTH) -> key the fake on
+    # schema_canon instead of xdoc_key so proposed scores higher.
+    def fake(config, dataset):
+        return _sc(0.70 if config.schema_canon else 0.40)
+    res = ss.suggest_substrate_config(docs, gold=[], qid_aliases=None, profile=_short_profile(),
+                                      build_and_score=fake, chat=chat)
+    assert res.accepted is True and res.config.schema_canon is True
+    assert res.config.entity_type_canon is False and res.config.entity_type_vocab == ()
+
+
+def test_suggest_bad_llm_read_is_safe():
+    docs = [_Doc("a"), _Doc("b")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.50, 0.50), chat=lambda p: "garbage")
+    # flags default -> proposed == baseline -> equal scores -> not accepted -> baseline
+    assert res.accepted is False and res.config == for_profile(_short_profile())
+
+
+# --- Task 4: no-gold MCP surface ----------------------------------------------------------------------
+def test_mcp_unverified_returns_config_and_flag():
+    out = ss.suggest_substrate_config_unverified(
+        ["Apple grows.", "Apple Inc ships."], chat=_fake_chat_homograph)
+    assert out["verified"] is False
+    assert out["config"].xdoc_key == "name_ci_type"           # homograph -> name_ci_type
+    assert out["config"].entity_type_vocab == ("person", "organization")
+    assert out["flags"].expect_homographs is True and "verify" in out["note"].lower()
+
+
+def test_mcp_unverified_bad_read_is_baseline():
+    out = ss.suggest_substrate_config_unverified(["doc"], chat=lambda p: "nope")
+    assert out["config"] == for_profile(profile_corpus(["doc"]))  # baseline, no vocab

--- a/scripts/distill/modal_bench.py
+++ b/scripts/distill/modal_bench.py
@@ -55,6 +55,7 @@ _EVAL = {
     "end_to_end": ("erkgbench.qa_e2e.run_qa_e2e", []),  # full pipeline + localize trace (stdout)
     "substrate": ("erkgbench.run_substrate_eval", []),  # substrate-quality A/B ambiguity sweep
     "tuner": ("erkgbench.run_substrate_tuner", []),  # SP-B2 staged-tuner smoke (handled specially above)
+    "suggest": ("erkgbench.run_substrate_suggest", []),  # SP-C suggester smoke (handled specially above)
 }
 
 
@@ -226,6 +227,16 @@ def _bench_impl(eval: str, n: int, ambiguity: float, opts: str, chat: str, embed
         results = pathlib.Path(out_md).read_text() if os.path.exists(out_md) else "(no results md)"
         return _persist(eval, n, f"{engine}-{chat}",
                         proc.stdout + "\n\n===== RESULTS_MD =====\n" + results)
+    if eval == "suggest":
+        # SP-C suggester smoke: LLM reads the HOMOGRAPH engineered corpus -> proposes for_profile flags;
+        # gold-verified self-verify accepts iff it beats the naive baseline. goldengraph only.
+        proc = subprocess.run(
+            ["python", "-m", "erkgbench.run_substrate_suggest", "--out-md", out_md],
+            cwd=_BENCH, env=env, capture_output=True, text=True, check=True,
+        )
+        results = pathlib.Path(out_md).read_text() if os.path.exists(out_md) else "(no results md)"
+        return _persist(eval, n, f"{engine}-{chat}",
+                        proc.stdout + "\n\n===== RESULTS_MD =====\n" + results)
     module, extra = _EVAL[eval]
     subprocess.run(
         ["python", "-m", module, *extra, "--n-questions", str(n),
@@ -307,7 +318,7 @@ def main(eval: str = "extraction_f1", n: int = 20, ambiguity: float = 0.6, opts:
     # runs on the same local model don't collide. Non-default corpora get a `-{corpus}` suffix. This MUST
     # mirror the tag `_persist` actually writes, or the printed SPAWNED path points at the wrong file.
     csuf = "" if corpus == "engineered" else f"-{corpus}"
-    tag = (f"{engine}-{chat}{csuf}" if eval in ("end_to_end", "substrate", "tuner") else chat).replace(":", "-").replace("/", "-")
+    tag = (f"{engine}-{chat}{csuf}" if eval in ("end_to_end", "substrate", "tuner", "suggest") else chat).replace(":", "-").replace("/", "-")
     if spawn:
         # fire-and-forget: queue the call SERVER-SIDE and return instantly, so a local-CLI kill can't
         # cancel it. Result lands at results/<eval>_<n>_<model>.md. Pair with `modal run --detach`.


### PR DESCRIPTION
Final sub-project of the substrate config-surface program. An LLM reads the corpus and proposes the `for_profile` inputs the rule table can't self-derive (homographs / known schema / vocabs); a gold self-verify accepts a proposal ONLY if it beats the deterministic baseline — so the LLM can never do worse.

## What
`erkgbench/substrate_suggest.py`:
- **`propose_corpus_flags`** — one JSON-mode LLM call reads a corpus sample → `CorpusFlags`; `_parse_flags` salvages messy JSON and defaults all-off on garbage (never raises → degrades to baseline).
- **`suggest_substrate_config`** — the review_config self-verify: score `for_profile(flags-off)` vs `for_profile(**flags)` via the reproducible `build_and_score_real` (#1380 reset); accept iff `_score` improves, else fall back to baseline. `entity_type_vocab` stamped only when `accepted AND expect_homographs`.
- **`suggest_substrate_config_unverified`** — thin no-gold MCP surface (returns the LLM perception, labeled unverified).
- Runner + `modal_bench` `suggest` mode (homograph engineered corpus, whole-corpus sampling).

## Smoke result (7B, homograph corpus) — validated + a clear finding
- **Guardrail proven (twice):** the LLM proposed F1-worse configs (incomplete-vocab `schema_canon` → F1 0.74→0.41; homograph+schema → 0.74→0.67); the self-verify **rejected both → deterministic baseline won.** The LLM cannot make the substrate worse.
- **Perception validated:** with whole-corpus sampling the 7B correctly detected homographs + the complete relation schema (all 5 relations) + entity types. (The initial miss was a 6-doc sampling confound.)
- **Finding:** the proposed homograph-safe config **raised precision 0.815 → 0.892** (the intended win) but F1 fell (recall cost), so the F1-based accept rejected it. **On a homograph corpus, F1 hides the precision win — the win is metric-gated, not perception-gated.** Top follow-on: a precision-aware accept metric.

13 pure box-safe tests (fake chat + fake build), ruff clean. Full verdict: `docs/superpowers/reports/2026-07-02-suggester-smoke-verdict.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)