### PR TITLE
fix(healer): skip O(distinct^2) goldencheck variant scan on the default advisory path

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
@@ -268,6 +268,8 @@ def _build_column_signals_batch(
     df: pl.DataFrame,
     config: Any,
     clusters: dict[int, dict],
+    *,
+    cheap: bool = False,
 ) -> pa.RecordBatch:
     """Build the column_signals Arrow batch from the df + config + run results.
 
@@ -348,10 +350,23 @@ def _build_column_signals_batch(
     collision_rates = _collision_rates(clusters, df)
 
     # -- variant_rate from goldencheck blocking_risk (fail-open: 0.0) --
-    try:
-        variant_risk = blocking_risk(df.select(data_cols)) or {}
-    except Exception:
-        variant_risk = {}
+    # `cheap` skips this scan entirely (variant_rate defaults to 0.0, the same
+    # value used when goldencheck is absent). goldencheck `blocking_risk` /
+    # `cell_quality` runs an O(distinct^2) pairwise fuzzy-variant comparison per
+    # string column; on moderate-cardinality categorical columns (~200-5000
+    # distinct: city/company/status/product) that is 350ms-950ms EACH, and the
+    # default advisory `dedupe_df` path was paying it on every run whose free
+    # headroom trigger fired (RED/YELLOW health -- the norm for messy production
+    # data, with the native kernel present). The default surface attaches raw,
+    # unverified candidates (ADR 0026's cheap tier), so the full-fidelity variant
+    # signal belongs to the opt-in verified paths (`suggest=`/`heal=`) only.
+    if cheap:
+        variant_risk: dict = {}
+    else:
+        try:
+            variant_risk = blocking_risk(df.select(data_cols)) or {}
+        except Exception:
+            variant_risk = {}
 
     # -- Assemble rows --
     rows_field: list[str] = []
@@ -554,15 +569,19 @@ def _parse_suggestions(raw_json: str) -> list[Suggestion]:
     return suggestions
 
 
-def _kernel_suggest(nm, df, config, scored_pairs, clusters, priors) -> list[Suggestion]:
+def _kernel_suggest(
+    nm, df, config, scored_pairs, clusters, priors, *, cheap: bool = False
+) -> list[Suggestion]:
     """Build the three Arrow batches from the PASSED-IN scored_pairs/clusters/df/
     config (no re-run), call the native ``suggest_config`` kernel, and parse the
     result.  FULL_DIST pair selection happens in the caller, which passes the
-    chosen pairs in as ``scored_pairs``."""
+    chosen pairs in as ``scored_pairs``.  ``cheap`` skips the expensive
+    full-frame goldencheck variant scan in the column-signals batch (default
+    advisory path); see ``_build_column_signals_batch``."""
     # -- Build Arrow batches --
     scored_pairs_batch = _build_scored_pairs_batch(scored_pairs)
     clusters_batch = _build_clusters_batch(clusters)
-    column_signals_batch = _build_column_signals_batch(df, config, clusters)
+    column_signals_batch = _build_column_signals_batch(df, config, clusters, cheap=cheap)
 
     config_json = json.dumps(_config_summary(config), default=str)
     priors_dict = priors if priors is not None else {"counts": {}}
@@ -799,7 +818,14 @@ def suggest_from_result(result, df, *, priors=None, verify=False) -> list[Sugges
         diag = _diagnostic_scored_pairs(MatchEngine.from_dataframe(df), df, config)
         if diag is not None:
             pairs_for_kernel = diag
-    suggestions = _kernel_suggest(nm, df, config, pairs_for_kernel, clusters, priors)
+    # The default advisory path (verify=False) is ADR 0026's "cheap raw
+    # candidates" tier: skip the expensive full-frame goldencheck variant scan
+    # (`cheap=True`). The opt-in verified paths (`suggest=`/`heal=`) keep full
+    # fidelity. This is the fix for the production slowdown -- the variant scan is
+    # O(distinct^2) per moderate-cardinality column and was paid on every default run.
+    suggestions = _kernel_suggest(
+        nm, df, config, pairs_for_kernel, clusters, priors, cheap=not verify
+    )
     if not (verify and _verify_enabled_by_env()) or not suggestions:
         return suggestions
     from goldenmatch.tui.engine import MatchEngine

--- a/packages/python/goldenmatch/tests/test_dedupe_suggest_wiring.py
+++ b/packages/python/goldenmatch/tests/test_dedupe_suggest_wiring.py
@@ -55,3 +55,54 @@ def test_heal_true_returns_healed(monkeypatch):
     res = dedupe_df(_df(), heal=True)
     assert res.config == "HEALED_CFG"
     assert res.heal_trail and res.heal_trail[0]["id"] == "h" and res.heal_trail[0]["verified"] is True
+
+
+# ── Production slowdown regression: the default path must not run the O(distinct^2)
+#    goldencheck variant scan (blocking_risk). Fake the native kernel so the REAL
+#    signal-build path executes even without the wheel; record any blocking_risk call.
+
+
+class _FakeKernel:
+    def suggest_config(self, *args):
+        return "[]"          # valid-empty -> _parse_suggestions returns []
+
+
+def _record_blocking_risk(monkeypatch):
+    """Patch the SOURCE (blocking_risk is a function-local import inside
+    _build_column_signals_batch, so the adapter attribute can't be patched)."""
+    calls = {"n": 0}
+
+    def _rec(df, *a, **k):
+        calls["n"] += 1
+        return {}
+
+    monkeypatch.setattr("goldenmatch.core.quality.blocking_risk", _rec)
+    return calls
+
+
+def test_default_dedupe_df_does_not_call_blocking_risk(monkeypatch):
+    """The default advisory `dedupe_df` path must NOT run goldencheck's
+    O(distinct^2) fuzzy-variant scan — it was the production slowdown (350ms-950ms
+    per moderate-cardinality column, on every run whose free trigger fired)."""
+    import goldenmatch.core.suggest.adapter as adapter
+    import goldenmatch.core.suggest.surface as surf
+
+    # Force the free trigger to fire and fake the kernel so the real signal build runs.
+    monkeypatch.setattr(surf, "headroom_signal", lambda r: surf.HeadroomReason("dip"))
+    monkeypatch.setattr(adapter, "_require_kernel", lambda: _FakeKernel())
+    calls = _record_blocking_risk(monkeypatch)
+
+    res = dedupe_df(_df())
+    assert calls["n"] == 0, "default dedupe_df must not run the goldencheck variant scan"
+    assert res.suggestions == []
+
+
+def test_suggest_true_still_computes_variant_signal(monkeypatch):
+    """The opt-in verified path keeps full fidelity — it DOES compute variant_rate."""
+    import goldenmatch.core.suggest.adapter as adapter
+
+    monkeypatch.setattr(adapter, "_require_kernel", lambda: _FakeKernel())
+    calls = _record_blocking_risk(monkeypatch)
+
+    dedupe_df(_df(), suggest=True)   # verify=True -> full signal build
+    assert calls["n"] >= 1, "suggest=True must still compute the variant signal"

--- a/packages/python/goldenmatch/tests/test_suggest_adapter.py
+++ b/packages/python/goldenmatch/tests/test_suggest_adapter.py
@@ -376,3 +376,37 @@ def test_arrow_batch_helpers():
     csb = _build_column_signals_batch(df, config, clusters)
     assert csb.schema.equals(_COLUMN_SIGNALS_SCHEMA)
     assert csb.num_rows >= 1  # at least one column
+
+
+# ── cheap-signal gate (production slowdown fix) ──────────────────────────────
+
+def test_build_column_signals_cheap_skips_blocking_risk(monkeypatch):
+    """`cheap=True` (the default advisory path) must NOT call goldencheck
+    blocking_risk — that O(distinct^2) scan was the production slowdown.
+    variant_rate falls back to 0.0, exactly as when goldencheck is absent."""
+    from goldenmatch.core.suggest.adapter import (
+        _build_column_signals_batch,
+    )
+
+    calls = {"n": 0}
+
+    def _rec(df, *a, **k):
+        calls["n"] += 1
+        return {}
+
+    # blocking_risk is a function-local import inside the builder -> patch the source.
+    monkeypatch.setattr("goldenmatch.core.quality.blocking_risk", _rec)
+
+    df = _make_df().with_row_index("__row_id__").with_columns(
+        pl.col("__row_id__").cast(pl.Int64)
+    )
+    config = _make_config()
+
+    # cheap=True -> no scan, variant_rate all 0.0
+    batch = _build_column_signals_batch(df, config, {}, cheap=True)
+    assert calls["n"] == 0
+    assert all(v == 0.0 for v in batch.column("variant_rate").to_pylist())
+
+    # cheap=False (opt-in verified path) -> scan runs
+    _build_column_signals_batch(df, config, {}, cheap=False)
+    assert calls["n"] == 1


### PR DESCRIPTION
## Production slowdown: root cause

The healer is default-on in `dedupe_df` (ADR 0026). After each run, if the free headroom trigger fires (**RED/YELLOW health — the norm for messy production data**, with the native kernel present), it builds column signals via `_build_column_signals_batch`, which ran goldencheck `blocking_risk` (`cell_quality`) over the **full frame**.

That scan is an **O(distinct²) pairwise fuzzy-variant comparison per string column**. Measured post-warmup (N=20k):

| distinct values | time |
|---|---|
| 200 | 350 ms |
| 500 | 430 ms |
| **1000** | **950 ms** |
| 5000+ | 11 ms |

The cost peaks on **moderate-cardinality categorical columns** (~200–5000 distinct: city/company/status/product) — goldencheck caps the analysis above ~5000 distinct, so high-cardinality free text is actually the *fast* case (the opposite of what the old code comment claimed). Production frames carry several such columns, so the healer stacked multiple seconds onto every dedupe.

**Invisible in dev:** clean/test data commits GREEN (trigger never fires); many dev installs lack the native wheel (kernel absent → the whole surface no-ops).

## Fix
Thread `cheap` through `suggest_from_result` → `_kernel_suggest` → `_build_column_signals_batch`. The **default advisory path** (`verify=False`) sets `cheap=True` and skips the variant scan (`variant_rate` falls back to `0.0` — the same value used when goldencheck is absent). The **opt-in verified paths** (`suggest=True` / `heal=True`) keep the full-fidelity scan. This makes the code match ADR 0026's own two-stage cost model: cheap raw candidates by default, expensive verified work only on explicit opt-in.

**Measured (40k rows, 4 moderate-cardinality string cols): default signal build 2220ms → 16.7ms (133x, −2.2s per dedupe).**

Instant production mitigation without waiting for this deploy: `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`.

## Tests
- `test_default_dedupe_df_does_not_call_blocking_risk` — fakes the native kernel so the *real* signal-build path runs even without the wheel, forces the trigger, asserts `blocking_risk` is untouched on the default path.
- `test_suggest_true_still_computes_variant_signal` — `suggest=True` still scans.
- `test_build_column_signals_cheap_skips_blocking_risk` — direct gate unit test.
- 41 suggest-surface tests unchanged, ruff clean.

## Follow-up
The underlying O(distinct²) in goldencheck `cell_quality` is worth a bounded-distinct fix so every caller benefits (separate cross-package change — investigating next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)