### PR TITLE
perf(fuzzy_values): make rapidfuzz a hard dep + drop the pure-Python fallback

### DIFF
--- a/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
+++ b/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
@@ -15,13 +15,15 @@ a column's *distinct* values (a small set for the categorical columns it
 targets), with trigram + prefix blocking and a Levenshtein-ratio scorer.
 
 Native (``goldencheck[native]``) runs the blocking + pairwise edit distance in
-Rust -- pairwise Levenshtein is the part that is slow in Python, so this kernel
-genuinely beats the fallback. The pure-Python fallback (used when the ext is
-absent) computes the same clusters with the same algorithm via difflib.
+Rust. The Python fallback (used when the ext is absent) computes the same
+clusters with the same trigram/prefix blocking and the same ``1 - dist/maxlen``
+Levenshtein-ratio metric, scored with rapidfuzz's C Levenshtein (~38x over the
+old pure-Python DP), so the two paths agree.
 """
 from __future__ import annotations
 
 import polars as pl
+from rapidfuzz.distance import Levenshtein as _RFLevenshtein
 
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.models.finding import Finding, Severity
@@ -75,42 +77,15 @@ def _python_clusters(values: list[str], min_similarity: float) -> list[list[int]
             x = parent[x]
         return x
 
-    # Levenshtein-ratio, `1 - dist/maxlen`, identical to
-    # goldencheck_core::similarity so the fallback clusters match the native
-    # kernel exactly. rapidfuzz (C, ~38x faster) is used when importable and
-    # gives byte-identical ratios; goldencheck does not depend on it, but it is
-    # present whenever goldenmatch co-uses cell_quality (the survivorship
-    # bridge -- the hot path where this fallback ran unbatched). Pure-Python
-    # dynamic-programming Levenshtein is the dependency-free fallback-of-the-
-    # fallback (identical result, just slower).
-    try:
-        from rapidfuzz.distance import Levenshtein as _RFLev
-
-        def lev_ratio(a: str, b: str) -> float:
-            maxlen = max(len(a), len(b))
-            if maxlen == 0:
-                return 1.0
-            return 1.0 - _RFLev.distance(a, b) / maxlen
-    except ImportError:
-        def levenshtein(a: str, b: str) -> int:
-            if not a:
-                return len(b)
-            if not b:
-                return len(a)
-            prev = list(range(len(b) + 1))
-            for i, ca in enumerate(a):
-                cur = [i + 1]
-                for j, cb in enumerate(b):
-                    cost = 0 if ca == cb else 1
-                    cur.append(min(prev[j + 1] + 1, cur[j] + 1, prev[j] + cost))
-                prev = cur
-            return prev[len(b)]
-
-        def lev_ratio(a: str, b: str) -> float:
-            maxlen = max(len(a), len(b))
-            if maxlen == 0:
-                return 1.0
-            return 1.0 - levenshtein(a, b) / maxlen
+    def lev_ratio(a: str, b: str) -> float:
+        # `1 - dist/maxlen`, the identical metric to goldencheck_core::similarity,
+        # so this Python path clusters match the native kernel exactly. Backed by
+        # rapidfuzz's C Levenshtein (~38x over the old pure-Python DP); rapidfuzz
+        # is a goldencheck dependency (same pin as the rest of the suite).
+        maxlen = max(len(a), len(b))
+        if maxlen == 0:
+            return 1.0
+        return 1.0 - _RFLevenshtein.distance(a, b) / maxlen
 
     linked = False
     for i, j in candidates:

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -33,6 +33,10 @@ dependencies = [
     "openpyxl>=3.1",
     "textual>=1.0",
     "goldencheck-types",
+    # Fast C Levenshtein for the fuzzy_values / cell_quality Python path (the
+    # fallback when goldencheck-native is absent). Same pin as the rest of the
+    # suite (goldenmatch/goldenflow). ~38x over the pure-Python DP it replaced.
+    "rapidfuzz>=3.0",
 ]
 
 [project.urls]

--- a/packages/python/goldencheck/tests/profilers/test_fuzzy_values.py
+++ b/packages/python/goldencheck/tests/profilers/test_fuzzy_values.py
@@ -51,28 +51,40 @@ def test_native_and_python_agree(monkeypatch: pytest.MonkeyPatch) -> None:
     assert py == nat
 
 
-def test_rapidfuzz_and_pure_python_fallback_agree(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The Python fallback uses rapidfuzz's Levenshtein when importable (~38x
-    faster) and a pure-Python DP Levenshtein otherwise. Both use the identical
-    `1 - dist/maxlen` metric, so the resulting clusters must be byte-identical.
-    Forces the pure-Python branch by hiding rapidfuzz from the import machinery."""
-    import sys
-
+def test_python_clusters_rapidfuzz_metric() -> None:
+    """The Python path scores candidate pairs with rapidfuzz's Levenshtein
+    (`1 - dist/maxlen`) -- the identical metric to the native kernel. Verify it
+    groups near-duplicate variants and leaves distinct values apart."""
     from goldencheck.profilers.fuzzy_values import _python_clusters
 
-    # A moderate set with clear near-duplicate variant groups + distractors.
     values = [
-        "Acme Corp", "Acme Corporation", "Acme Corp.",
-        "Globex Inc", "Globex Incorporated",
-        "Initech", "Umbrella", "Wonka",
+        "Acme Corp", "Acme Corporation", "Acme Corp.",   # one variant group
+        "Globex Inc", "Globex Incorporated",             # another
+        "Initech", "Umbrella", "Wonka",                  # distinct distractors
     ]
+    clusters = _python_clusters(values, 0.82)
+    grouped = {tuple(sorted(values[i] for i in c)) for c in clusters}
 
-    rf_clusters = _python_clusters(values, 0.82)  # rapidfuzz present (venv has it)
+    # The near-identical spellings cluster; the unrelated names never join one.
+    assert any({"Acme Corp", "Acme Corp."} <= set(g) for g in grouped)
+    assert all("Wonka" not in g for g in grouped)
 
-    # Hide rapidfuzz.distance so `from rapidfuzz.distance import Levenshtein` raises.
-    monkeypatch.setitem(sys.modules, "rapidfuzz.distance", None)
-    py_clusters = _python_clusters(values, 0.82)  # forced pure-Python
 
-    assert rf_clusters == py_clusters
-    # And the fallback actually found the near-dup groups (not a trivial [] == []).
-    assert rf_clusters, "expected at least one near-duplicate cluster"
+def test_rapidfuzz_ratio_matches_reference_levenshtein() -> None:
+    """Lock the metric: rapidfuzz's `1 - dist/maxlen` equals a plain DP
+    Levenshtein ratio, so clustering can't drift from the native kernel."""
+    from rapidfuzz.distance import Levenshtein as RL
+
+    def dp(a: str, b: str) -> int:
+        prev = list(range(len(b) + 1))
+        for i, ca in enumerate(a):
+            cur = [i + 1]
+            for j, cb in enumerate(b):
+                cur.append(min(prev[j + 1] + 1, cur[j] + 1, prev[j] + (ca != cb)))
+            prev = cur
+        return prev[len(b)]
+
+    for a, b in [("acme corp", "acme corp."), ("globex inc", "globex incorporated"),
+                 ("initech", "wonka"), ("", "x"), ("same", "same")]:
+        m = max(len(a), len(b)) or 1
+        assert abs((1 - RL.distance(a, b) / m) - (1 - dp(a, b) / m)) < 1e-9


### PR DESCRIPTION
Follow-up to #1386. That PR added rapidfuzz as an *optional* fast path (try/except with a pure-Python DP fallback). This commits to it, per review: make `rapidfuzz>=3.0` a real goldencheck dependency (the same pin goldenmatch and goldenflow already carry) and use `rapidfuzz.distance.Levenshtein` unconditionally in the fuzzy_values / cell_quality Python path. Drops the import dance and the pure-Python DP.

- **Metric unchanged** (`1 - dist/maxlen`) → clusters still byte-identical to the native kernel. `test_rapidfuzz_ratio_matches_reference_levenshtein` pins the ratio against a reference DP so it can't drift.
- rapidfuzz is already in the workspace `uv.lock`; CI's non-frozen `uv sync --all-packages` re-resolves the new `goldencheck -> rapidfuzz` edge.
- Measured **1757ms → 46ms (38x)** on 110k candidate pairs, byte-identical output. 10 fuzzy/cell_quality tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)