### PR TITLE
perf(golden): scope the quality-weighting cell_quality scan to cluster members

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2227,6 +2227,28 @@ def _run_dedupe_pipeline(
             _clusters_cache.append(d)
         return _clusters_cache[0]
 
+    def _golden_member_row_ids() -> list[int]:
+        """``__row_id__`` of members of multi-member, non-oversized clusters --
+        the only rows survivorship builds a golden record for (singletons and
+        oversized clusters never are). Read from whichever cluster representation
+        is populated, WITHOUT materializing the full cluster dict on the
+        frames-out path."""
+        if cluster_frames is not None:
+            keep = cluster_frames.metadata.filter(
+                (pl.col("size") > 1) & (~pl.col("oversized"))
+            )["cluster_id"].to_list()
+            return cluster_frames.assignments.filter(
+                pl.col("cluster_id").is_in(keep)
+            )["member_id"].to_list()
+        return [
+            mid
+            for info in clusters.values()
+            if isinstance(info, dict)
+            and info.get("size", 0) > 1
+            and not info.get("oversized")
+            for mid in info.get("members", [])
+        ]
+
     if cluster_frames is not None:
         # Stats from frame aggregates (no dict materialization). Matches the
         # dict path's len(clusters) / size>1 / oversized counts exactly.
@@ -2310,13 +2332,29 @@ def _run_dedupe_pipeline(
     # documented no-op until now.
     quality_scores = None
     if not _skip_golden and getattr(golden_rules, "quality_weighting", False):
-        from goldenmatch.core.quality import compute_quality_scores
-        with stage("golden_quality_scores"):
-            quality_scores = compute_quality_scores(collected_df)
-        if quality_scores:
-            logger.info(
-                "GoldenCheck quality weighting: %d penalized cell(s)", len(quality_scores)
-            )
+        # Scope the goldencheck.cell_quality scan (full-frame O(N) value counts +
+        # O(distinct^2) fuzzy variant detection per string column) to just the
+        # rows that will actually get a golden record -- members of multi-member,
+        # non-oversized clusters -- instead of the entire collected frame. On a
+        # typical dedupe that is a fraction of N with far fewer distinct values,
+        # so the scan is much cheaper, and singleton rows never consume a quality
+        # weight anyway. When nothing multi-member clustered, the scan is skipped
+        # entirely. Variant detection is now judged relative to the cluster
+        # members (the values survivorship actually compares), which is the
+        # relevant universe; scoped so cell_quality is not paid over the whole
+        # frame on every default dedupe.
+        _member_ids = _golden_member_row_ids()
+        if _member_ids:
+            from goldenmatch.core.quality import compute_quality_scores
+            with stage("golden_quality_scores"):
+                quality_scores = compute_quality_scores(
+                    collected_df.filter(pl.col("__row_id__").is_in(_member_ids))
+                )
+            if quality_scores:
+                logger.info(
+                    "GoldenCheck quality weighting: %d penalized cell(s)",
+                    len(quality_scores),
+                )
 
     # Golden-record construction was the hidden N²-shaped stage that the
     # bench harness surfaced at 11K rows (36% of wall before this rewrite):

--- a/packages/python/goldenmatch/tests/test_quality_weighting.py
+++ b/packages/python/goldenmatch/tests/test_quality_weighting.py
@@ -109,3 +109,35 @@ def test_dedupe_df_pipeline_runs_with_quality_weighting() -> None:
     # wiring/no-crash guard (the flip itself is locked by the test above).
     assert golden.height == 1
     assert golden["state"][0] in ("California", "Californa")
+
+
+def test_quality_scan_scoped_to_cluster_members(monkeypatch):
+    """The golden-stage cell_quality scan must run only over rows that get a
+    golden record (multi-member, non-oversized cluster members), NOT the whole
+    frame -- a singleton row never consumes a quality weight. Regression for the
+    full-frame scan that ran on every default dedupe."""
+    import goldenmatch.core.quality as q
+    from goldenmatch import dedupe_df
+
+    seen: dict[str, int] = {}
+    orig = q.compute_quality_scores
+
+    def _recording(df):
+        seen["height"] = df.height
+        return orig(df)
+
+    monkeypatch.setattr(q, "compute_quality_scores", _recording)
+
+    # 2 exact-email duplicate pairs (4 member rows) + 4 unique singletons.
+    df = pl.DataFrame({
+        "name": ["Ann Lee", "Ann Lee", "Bob Ray", "Bob Ray",
+                 "Cy Xu", "Dee Fo", "Ed Gu", "Fi Ho"],
+        "email": ["a@x.com", "a@x.com", "b@y.com", "b@y.com",
+                  "c@z.com", "d@w.com", "e@v.com", "f@u.com"],
+    })
+    res = dedupe_df(df)
+
+    # The dup pairs must have clustered, and the scan must have seen ONLY the
+    # 4 member rows -- not all 8 (which is what the pre-fix full-frame scan did).
+    assert res.clusters, "expected the exact-email dup pairs to cluster"
+    assert seen.get("height") == 4


### PR DESCRIPTION
The healer-class sibling you asked me to take (#1). The golden stage ran `goldencheck.cell_quality` over the **entire collected frame** on every default dedupe (`quality_weighting=True` by default) — full-frame O(N) value counts + O(distinct²) fuzzy variant detection per string column, the same cost profile as the config-healer scan.

## Fix
Quality-weighted survivorship only applies to rows that get a golden record — members of multi-member, non-oversized clusters. Singletons never consume a quality weight. Scope the scan to those member rows (`_golden_member_row_ids` — reads the frames `metadata`/`assignments` on the frames-out path or the `clusters` dict otherwise, **without** materializing the full dict), and skip it entirely when nothing multi-member clustered.

On a typical dedupe the member subset is a fraction of N with far fewer distinct values, so the scan is much cheaper. Variant detection is now judged relative to the cluster members — the values survivorship actually compares — which is the relevant universe (a small, defensible semantic refinement; all existing quality/golden tests pass unchanged).

Complements: healer default-path skip (#1385) + rapidfuzz kernel speedup (#1386/#1387).

## Tests
- `test_quality_scan_scoped_to_cluster_members` — 8-row frame (2 dup pairs + 4 singletons); asserts the scan receives **4** member rows, not all 8.
- Existing `test_quality_weighting` + `test_golden` + `test_golden_partition_perf` unchanged (32 tests pass), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)