### PR TITLE
chore(release): goldencheck 1.4.1

### DIFF
--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [1.4.1] - 2026-07-02
+
+### Changed
+- **Fuzzy-values / `cell_quality` Python path is ~38x faster.** The near-duplicate value profiler's non-native Levenshtein path now uses `rapidfuzz` (a new dependency, the same pin the rest of the suite uses) instead of a pure-Python dynamic-programming loop. Byte-identical clusters (same `1 - dist/maxlen` metric, pinned against a reference DP), so the native kernel and the Python path still agree; the pure-Python fallback is retired. Measured 1757ms → 46ms on 110k candidate pairs — this is the path GoldenMatch's quality-weighted survivorship hits via `cell_quality`. (#1386, #1387)
+
 ## [1.4.0] - 2026-06-24
 
 ### Added

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "1.4.0"
+version = "1.4.1"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump for the rapidfuzz fuzzy_values / cell_quality perf work (#1386, #1387). Bumps pyproject + __init__ + CHANGELOG. After merge, a `goldencheck-v1.4.1` GitHub Release publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)