### PR TITLE
chore(release): goldenmatch 2.8.0

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,8 +6,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-07-02
+
+### Added
+- **Identity audit log: claim-authority tier + claim-lifecycle operations.** Events now carry a categorical `ClaimType` (`observation` / `inference` / `verified` / `directive`) — orthogonal to the numeric `trust` — plus a typed `EvidenceRef` and a `previous_claim_id` chain, so a reviewer can tell "an agent inferred this at 0.8" from "a tool verified this at 0.8". New lifecycle ops `promote_claim` / `amend_claim` / `revoke_claim` make an agent inference *becoming* durable shared truth an explicit, auditable event. All additive/nullable — the tamper-evidence hash stays byte-identical for pre-existing events. SQLite `v4→v5` migration + Postgres/Mongo + Alembic 0004. (#1383)
+
 ### Changed
 - **`goldenmatch dedupe <file>` is now non-interactive by default.** A bare `goldenmatch dedupe customers.csv` runs auto-config, writes golden records (a timestamped `*_golden.csv` in the current directory), and prints a summary — so the advertised "CSV in, 30 seconds, CSV out" is what actually happens. The interactive review TUI is now opt-in via **`--tui`** (previously it opened by default). `--no-tui` is still accepted as a no-op for back-compat. When no explicit output flag is given on the auto-config path, golden records are written by default (use `--output-all` / `--output-dir` to control, `--tui` to review). An explicit `--config` run keeps its exact prior behavior.
+- **Input validation on the `dedupe` CLI + ingest (break-it review).** A Windows-1252 / Latin-1 CSV is no longer silently lossy-decoded into replacement chars — non-UTF-8 files are detected, decoded as cp1252, and warned about (so `José Muñoz` survives instead of becoming mojibake in the golden record); explicit `--encoding cp1252`/`latin-1` now works too. `--anomaly-sensitivity` is validated + case-normalized (a miscased `Low` no longer silently inverts to the most-sensitive behavior); an unknown `--backend` is rejected instead of silently dropped; `--format` is validated at parse time (not after the whole run); structured non-tabular inputs (`.json`/`.xml`/`.yaml`) get a clear message; `--chunk-size`/`--preview-size` reject non-positive values. (#1390)
+
+### Fixed
+- **Config-suggestion "healer" production slowdown.** The default `dedupe_df` advisory path no longer runs the O(distinct²) goldencheck variant scan (`cell_quality`) over the full frame on every run whose free trigger fired — the scan is reserved for the opt-in `suggest=`/`heal=` paths. Instant mitigation without upgrading: `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`. (#1385)
+
+### Performance
+- **Golden-stage quality-weighting scan scoped to cluster members.** `goldencheck.cell_quality` runs only over rows that actually get a golden record (multi-member, non-oversized cluster members) instead of the entire collected frame — much cheaper on real data, since singletons never consume a quality weight. (#1389)
+- **Throughput tier skips golden-record survivorship.** Lifts the 100k+ corpus ceiling for the `dedupe_df(throughput=...)` path, which consumes clusters, not canonical records. (#1382)
 
 ## [2.7.0] - 2026-07-02
 

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "2.7.0"
+version = "2.8.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump for this session's goldenmatch work. Bumps pyproject + __init__ + CHANGELOG (`## [2.8.0]`). After merge, pushing tag `v2.8.0` fires publish-goldenmatch.yml -> PyPI + GitHub Release (notes auto-extracted from the CHANGELOG section).

Included: claim-authority tier (#1383), config-healer production slowdown fix (#1385), golden quality-scan scoping (#1389), throughput golden skip (#1382), break-it input validation (#1390), CLI non-interactive default.

**Ordering:** queues behind #1390 so the release includes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)