### PR TITLE
docs: REFUTE schema_canon self-harm (isolation ablation — it HELPS)

### DIFF
--- a/docs/superpowers/reports/2026-07-02-schema-canon-ablation-correction.md
+++ b/docs/superpowers/reports/2026-07-02-schema-canon-ablation-correction.md
@@ -1,0 +1,33 @@
+# schema_canon "self-harm" — REFUTED (correction)
+
+**Date:** 2026-07-02
+**Corrects:** the SP-C suggester smoke verdict (`2026-07-02-suggester-smoke-verdict.md`) follow-on #2, which listed "`schema_canon` self-harms even with a complete, correct vocab (drops recall)."
+
+## The finding was a misattribution
+
+The SP-C smoke's proposed config that lost recall (relational R 0.672 → 0.540) bundled **three** levers: `name_ci_type` + `entity_type_canon` + `schema_canon`. I attributed part of the recall loss to `schema_canon` **without isolating it** — a bundled-config delta read as a single-lever effect.
+
+## Isolation (systematic-debugging)
+
+**Box-safe (free):** the `RelationSchema` built from the LLM's proposed vocab (`acquired, located in, part of, works at, authored`) matches **all 18/18** distinct rendered predicate surfaces of the homograph engineered corpus (the vocab maps exactly onto the `_ENGINEERED_ALIASES` keys; the substring fallback even catches the homograph appositive-cue forms). So the schema drops **zero** gold predicates by construction.
+
+**Modal ablation (confirming):** homograph engineered corpus, ambiguity=0, `GOLDENGRAPH_LLM_SEED=42`, `name_ci` fixed — the ONLY difference is `schema_canon` + the complete vocab:
+
+| | baseline (`name_ci`) | +`schema_canon` |
+|---|---|---|
+| relational F1 | 0.7368 | **0.7823** (+0.045) |
+| relational recall | 0.6720 | **0.7426** (+0.071) |
+| relational precision | 0.8153 | 0.8264 |
+| **edge_recall** | 0.8849 | **0.8849 (identical)** |
+
+## Verdict
+
+**`schema_canon` does NOT self-harm — with the correct complete vocab it HELPS** (F1 +0.045, recall +0.071) and drops **zero** edges (`edge_recall` byte-identical). It canonicalizes predicate variants + fixes reverse-direction phrasings → a more consistent graph → better cross-doc clustering (consistent with the original SCHEMA_CANON arc win).
+
+**Corrected attribution of the SP-C recall drop:** it is **entirely `name_ci_type`** (the known type-jitter recall cost, #1335). `schema_canon` was actually *offsetting* it (+0.071 recall), so the bundled config's net recall loss means `name_ci_type`'s cost was even larger than the headline number suggested.
+
+## Lesson
+
+**Do not attribute a bundled-config delta to a single lever without isolating it.** The cheap box-safe schema check (predicates kept/dropped) should have preceded the claim. The self-verify guardrail was never at risk — the accepted config is genuinely good (the `name_ci_type` precision win is real; `schema_canon` is a bonus, not a harm). The one real follow-on left from the SP-C arc is **auto-beta** (perceive homographs/ambiguity → default beta<1, measured).
+
+(Data: `data/2026-07-02-schemacanon-ablation-{baseline,schemacanon}.md`.)

--- a/docs/superpowers/reports/data/2026-07-02-schemacanon-ablation-baseline.md
+++ b/docs/superpowers/reports/data/2026-07-02-schemacanon-ablation-baseline.md
@@ -1,0 +1,4933 @@
+[controller.run n_rows=278] t=0.0s: entry
+[controller.run n_rows=278] t=0.0s: _initial_config done
+[controller.run n_rows=278] t=0.0s: _take_sample done (sample.height=278)
+[controller.run n_rows=278] t=0.0s: compute_column_priors done
+[controller.run n_rows=278] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=278] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=278] t=0.1s: entering iteration loop
+[controller.run n_rows=278] t=0.1s: iter 0 start
+[controller.run n_rows=278] t=1.2s: iter 0 _run_pipeline_sample done in 1.1s
+[controller.run n_rows=278] t=1.2s: iter 1 start
+[controller.run n_rows=278] t=1.4s: iter 1 _run_pipeline_sample done in 0.2s
+[score_buckets] entry: prepared_df.height=278 n_buckets=68
+[score_buckets] t=0.00s: slim projection 6 -> 6 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 32 buckets
+[score_buckets] t=0.00s: 32 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.09s: bucket_score done in 0.09s, 41 blocks, 956 pairs
+[score_buckets] t=0.09s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.09s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.09s: partition_by(bucket) in 0.00s -> 30 buckets
+[score_buckets] t=0.09s: 30 non-empty buckets ready for scoring
+[score_buckets] t=0.09s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.17s: bucket_score done in 0.08s, 38 blocks, 1851 pairs
+[score_buckets] t=0.17s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.17s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.17s: partition_by(bucket) in 0.00s -> 29 buckets
+[score_buckets] t=0.17s: 29 non-empty buckets ready for scoring
+[score_buckets] t=0.17s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.25s: bucket_score done in 0.08s, 37 blocks, 1142 pairs
+[score_buckets] t=0.25s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.25s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.25s: partition_by(bucket) in 0.00s -> 1 buckets
+[score_buckets] t=0.25s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.25s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.26s: bucket_score done in 0.02s, 1 blocks, 4835 pairs
+[score_buckets] t=0.27s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.27s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.27s: partition_by(bucket) in 0.00s -> 1 buckets
+[score_buckets] t=0.27s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.27s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.28s: bucket_score done in 0.02s, 1 blocks, 4835 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.1s: entering iteration loop
+[controller.run n_rows=3] t=0.1s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.1s: compute_column_priors done
+[controller.run n_rows=3] t=0.1s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.1s: entering iteration loop
+[controller.run n_rows=3] t=0.1s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.2s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.1s: entering iteration loop
+[controller.run n_rows=2] t=0.1s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.1s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.1s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.0s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 3 start
+[controller.run n_rows=3] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.1s: entering iteration loop
+[controller.run n_rows=2] t=0.1s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[substrate] ambiguity=0.0: relational: F1=0.7368 R=0.6720 P=0.8153 | connectivity: edge_recall=0.8849 | coherence: comp=1 largest=1.000 | ER-F1(A)=0.5855 gap=-0.1513 provenance=1.000
+
+# Substrate-Quality Scoreboard (engineered)
+
+| ambiguity | ER-F1(A) | relational_F1(B) | relational_P | relational_R | edge_recall | A-B gap | components | largest-frac | provenance |
+|---|---|---|---|---|---|---|---|---|---|
+| 0.0 | 0.5855 | 0.7368 | 0.8153 | 0.6720 | 0.8849 | -0.1513 | 1 | 1.0000 | 1.0000 |
+
+A = resolver in isolation (clean gold surfaces); B = end-to-end build. **A-B gap = extraction-induced fragmentation.** On the engineered corpus the doc-id oracle IS the presence signal, so only the RELATIONAL (B) + connectivity(edge_recall) axes are reported here; the presence/connectivity-coverage split is a wiki-path (alias-bearing) metric.
+
+
+
+===== RESULTS_MD =====
+# Substrate-Quality Scoreboard (engineered)
+
+| ambiguity | ER-F1(A) | relational_F1(B) | relational_P | relational_R | edge_recall | A-B gap | components | largest-frac | provenance |
+|---|---|---|---|---|---|---|---|---|---|
+| 0.0 | 0.5855 | 0.7368 | 0.8153 | 0.6720 | 0.8849 | -0.1513 | 1 | 1.0000 | 1.0000 |
+
+A = resolver in isolation (clean gold surfaces); B = end-to-end build. **A-B gap = extraction-induced fragmentation.** On the engineered corpus the doc-id oracle IS the presence signal, so only the RELATIONAL (B) + connectivity(edge_recall) axes are reported here; the presence/connectivity-coverage split is a wiki-path (alias-bearing) metric.

--- a/docs/superpowers/reports/data/2026-07-02-schemacanon-ablation-schemacanon.md
+++ b/docs/superpowers/reports/data/2026-07-02-schemacanon-ablation-schemacanon.md
@@ -1,0 +1,5234 @@
+[controller.run n_rows=278] t=0.0s: entry
+[controller.run n_rows=278] t=0.0s: _initial_config done
+[controller.run n_rows=278] t=0.0s: _take_sample done (sample.height=278)
+[controller.run n_rows=278] t=0.1s: compute_column_priors done
+[controller.run n_rows=278] t=0.1s: promote_negative_evidence done
+[controller.run n_rows=278] t=0.1s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=278] t=0.1s: entering iteration loop
+[controller.run n_rows=278] t=0.1s: iter 0 start
+[controller.run n_rows=278] t=1.0s: iter 0 _run_pipeline_sample done in 1.0s
+[controller.run n_rows=278] t=1.0s: iter 1 start
+[controller.run n_rows=278] t=1.3s: iter 1 _run_pipeline_sample done in 0.2s
+[score_buckets] entry: prepared_df.height=278 n_buckets=68
+[score_buckets] t=0.00s: slim projection 6 -> 6 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.00s: partition_by(bucket) in 0.00s -> 32 buckets
+[score_buckets] t=0.00s: 32 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.13s: bucket_score done in 0.12s, 41 blocks, 956 pairs
+[score_buckets] t=0.13s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.13s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.13s: partition_by(bucket) in 0.00s -> 30 buckets
+[score_buckets] t=0.13s: 30 non-empty buckets ready for scoring
+[score_buckets] t=0.13s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.24s: bucket_score done in 0.11s, 38 blocks, 1851 pairs
+[score_buckets] t=0.24s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.24s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.24s: partition_by(bucket) in 0.00s -> 29 buckets
+[score_buckets] t=0.24s: 29 non-empty buckets ready for scoring
+[score_buckets] t=0.24s: starting bucket_score with max_workers=17 path=find_fuzzy_matches
+[score_buckets] t=0.35s: bucket_score done in 0.11s, 37 blocks, 1142 pairs
+[score_buckets] t=0.35s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.35s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.35s: partition_by(bucket) in 0.00s -> 1 buckets
+[score_buckets] t=0.35s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.35s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.37s: bucket_score done in 0.02s, 1 blocks, 4835 pairs
+[score_buckets] t=0.37s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.37s: bucketed (hash %% N) in 0.00s
+[score_buckets] t=0.37s: partition_by(bucket) in 0.00s -> 1 buckets
+[score_buckets] t=0.37s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.37s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.39s: bucket_score done in 0.01s, 1 blocks, 4835 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 6 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 2 start
+[controller.run n_rows=2] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 3 start
+[controller.run n_rows=2] t=0.1s: iter 3 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=3] t=0.0s: entry
+[controller.run n_rows=3] t=0.0s: _initial_config done
+[controller.run n_rows=3] t=0.0s: _take_sample done (sample.height=3)
+[controller.run n_rows=3] t=0.0s: compute_column_priors done
+[controller.run n_rows=3] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=3] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=3] t=0.0s: entering iteration loop
+[controller.run n_rows=3] t=0.0s: iter 0 start
+[controller.run n_rows=3] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 1 start
+[controller.run n_rows=3] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=3] t=0.1s: iter 2 start
+[controller.run n_rows=3] t=0.1s: iter 2 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=3 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=3 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 1 blocks, 1 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.01s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.01s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.01s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.1s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.01s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.1s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.01s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[controller.run n_rows=2] t=0.0s: entry
+[controller.run n_rows=2] t=0.0s: _initial_config done
+[controller.run n_rows=2] t=0.0s: _take_sample done (sample.height=2)
+[controller.run n_rows=2] t=0.0s: compute_column_priors done
+[controller.run n_rows=2] t=0.0s: promote_negative_evidence done
+[controller.run n_rows=2] t=0.0s: estimate_sparse_match_signal done (exact_cols=0)
+[controller.run n_rows=2] t=0.0s: entering iteration loop
+[controller.run n_rows=2] t=0.0s: iter 0 start
+[controller.run n_rows=2] t=0.0s: iter 0 _run_pipeline_sample done in 0.0s
+[controller.run n_rows=2] t=0.0s: iter 1 start
+[controller.run n_rows=2] t=0.1s: iter 1 _run_pipeline_sample done in 0.0s
+[score_buckets] entry: prepared_df.height=2 n_buckets=68
+[score_buckets] t=0.00s: slim projection 8 -> 7 cols
+[score_buckets._resolve_fast_path] declined: _resolve_score_pair_callable('ensemble') is None
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[score_buckets] t=0.00s: keyed (with_columns key_expr) in 0.00s
+[score_buckets] t=0.00s: small-block fast path (height=2 < n_buckets=68); skipping hash+partition_by. See #422.
+[score_buckets] t=0.00s: 1 non-empty buckets ready for scoring
+[score_buckets] t=0.00s: starting bucket_score with max_workers=1 path=find_fuzzy_matches
+[score_buckets] t=0.00s: bucket_score done in 0.00s, 0 blocks, 0 pairs
+[substrate] ambiguity=0.0: relational: F1=0.7823 R=0.7426 P=0.8264 | connectivity: edge_recall=0.8849 | coherence: comp=1 largest=1.000 | ER-F1(A)=0.5855 gap=-0.1968 provenance=1.000
+
+# Substrate-Quality Scoreboard (engineered)
+
+| ambiguity | ER-F1(A) | relational_F1(B) | relational_P | relational_R | edge_recall | A-B gap | components | largest-frac | provenance |
+|---|---|---|---|---|---|---|---|---|---|
+| 0.0 | 0.5855 | 0.7823 | 0.8264 | 0.7426 | 0.8849 | -0.1968 | 1 | 1.0000 | 1.0000 |
+
+A = resolver in isolation (clean gold surfaces); B = end-to-end build. **A-B gap = extraction-induced fragmentation.** On the engineered corpus the doc-id oracle IS the presence signal, so only the RELATIONAL (B) + connectivity(edge_recall) axes are reported here; the presence/connectivity-coverage split is a wiki-path (alias-bearing) metric.
+
+
+
+===== RESULTS_MD =====
+# Substrate-Quality Scoreboard (engineered)
+
+| ambiguity | ER-F1(A) | relational_F1(B) | relational_P | relational_R | edge_recall | A-B gap | components | largest-frac | provenance |
+|---|---|---|---|---|---|---|---|---|---|
+| 0.0 | 0.5855 | 0.7823 | 0.8264 | 0.7426 | 0.8849 | -0.1968 | 1 | 1.0000 | 1.0000 |
+
+A = resolver in isolation (clean gold surfaces); B = end-to-end build. **A-B gap = extraction-induced fragmentation.** On the engineered corpus the doc-id oracle IS the presence signal, so only the RELATIONAL (B) + connectivity(edge_recall) axes are reported here; the presence/connectivity-coverage split is a wiki-path (alias-bearing) metric.


### PR DESCRIPTION
Corrects the SP-C smoke verdict's follow-on #2 ("schema_canon self-harms even with a complete vocab"). That was a **misattribution** — the SP-C recall drop came from a config bundling `name_ci_type` + `entity_type_canon` + `schema_canon`, and I read part of it as schema_canon without isolating.

## Isolation
- **Box-safe:** the schema from the LLM's vocab keeps **18/18** rendered predicates (maps onto the alias table; substring fallback catches the homograph appositive cues).
- **Modal ablation** (homograph corpus, ambiguity 0, seed 42, `name_ci` fixed, only `schema_canon` differs):

| | baseline | +schema_canon |
|---|---|---|
| relational F1 | 0.7368 | **0.7823** |
| relational recall | 0.6720 | **0.7426** (+0.071) |
| **edge_recall** | 0.8849 | **0.8849 (identical, 0 dropped)** |

## Verdict
`schema_canon` with the correct vocab **HELPS** (F1 +0.045, recall +0.071) and drops zero edges. The SP-C recall drop is **entirely `name_ci_type`** (type-jitter, #1335); schema_canon was offsetting it. Docs-only correction. Lesson: isolate before attributing a bundled-config delta to one lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)