### PR TITLE
feat(erkgbench): SP-C beta-frontier report (auto-beta follow-on, honest shape)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-suggest-beta-frontier.md
+++ b/docs/superpowers/plans/2026-07-02-suggest-beta-frontier.md
@@ -1,0 +1,200 @@
+# SP-C Beta-Frontier Report Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `suggest_substrate_config` report the accept decision across a small beta sweep so the caller sees the precision/recall frontier and picks beta — a free recompute from the two scorecards already in hand.
+
+**Architecture:** One pure helper `_accept_frontier` (recomputes `_score(prop, beta) > _score(base, beta)` per beta), one additive `SuggestResult.accept_frontier` field, computed in `suggest_substrate_config` from the existing `base_sc`/`prop_sc`. The run's `accepted`/`config` (active-beta decision) are untouched. Runner prints the frontier + P/R.
+
+**Tech Stack:** Python stdlib, pytest. No Modal (the beta=1.0 + beta=0.5 SP-C runs already *are* the frontier).
+
+**Spec:** `docs/superpowers/specs/2026-07-02-suggest-beta-frontier-design.md`
+
+**Branch:** `feat/suggest-beta-frontier` (off `origin/main`; SP-C + F-beta both merged).
+
+---
+
+## Files
+
+- **Modify** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py` — add `_accept_frontier`; add `accept_frontier` field to `SuggestResult`; compute + pass it in `suggest_substrate_config`.
+- **Modify** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py` — print the frontier + baseline/proposed relational P/R (stdout + md).
+- **Modify (tests)** `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py` — append frontier tests.
+
+## Test runner (box-safe)
+
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD:/d/show_case/gg-local-llm/packages/python/goldengraph" PYTHONIOENCODING=utf-8 PYTHONUTF8=1 \
+  POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_substrate_suggest.py -q
+```
+
+## Ground-truth facts (verified)
+
+- `SuggestResult` is a frozen dataclass with 5 no-default fields: `config, flags, accepted, baseline_scorecard, proposed_scorecard`. The ONLY constructor call is `SuggestResult(winner, flags, accepted, base_sc, prop_sc)` (positional, substrate_suggest.py:118). No other `SuggestResult(...)` call sites in source or tests (tests build via `suggest_substrate_config`).
+- `_score(scorecard, *, beta=None)` (keyword-only beta) is imported from `substrate_tuner` — `_score(sc, beta=b)` is valid. On presence=None scorecards `_score` is relational-only (the test `_rel` helper builds presence=None).
+- Runner: `b, p = res.baseline_scorecard, res.proposed_scorecard` (line 47); `[suggest]` print (48-50); md block (51-57).
+- **Frontier arithmetic (reviewer-verified):** base P=0.8153/R=0.672/f1=0.7368, prop P=0.9323/R=0.545/f1=0.6885 → `{1.0: False, 0.5: True, 0.25: True}` (F_0.5: base 0.782, prop 0.816; F_0.25: base 0.805, prop 0.895).
+
+---
+
+### Task 1: `_accept_frontier` + `SuggestResult.accept_frontier` + wire
+
+**Files:**
+- Modify: `erkgbench/substrate_suggest.py`
+- Test: `tests/test_substrate_suggest.py`
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_substrate_suggest.py`:
+
+```python
+# --- SP-C beta-frontier report ------------------------------------------------------------------------
+def _relsc(p, r, f1):
+    """A presence=None scorecard with explicit relational P/R/F1 (so _score is relational-only)."""
+    return {"presence": None, "relational": {"f1": f1, "recall": r, "precision": p},
+            "connectivity": {"coverage": None, "f1": None, "edge_recall": 0.9},
+            "coherence": {"components": 1, "largest_fraction": 1.0}}
+
+
+def test_accept_frontier_flips_at_beta():
+    base = _relsc(0.8153, 0.672, 0.7368)     # SP-C smoke baseline
+    prop = _relsc(0.9323, 0.545, 0.6885)     # proposed homograph-safe config (beta=0.5 run)
+    assert ss._accept_frontier(base, prop) == {1.0: False, 0.5: True, 0.25: True}
+
+
+def test_accept_frontier_all_true_when_proposed_dominates():
+    base = _relsc(0.6, 0.6, 0.6)
+    prop = _relsc(0.9, 0.9, 0.9)             # better on both P and R
+    assert set(ss._accept_frontier(base, prop).values()) == {True}
+
+
+def test_accept_frontier_all_false_when_baseline_dominates():
+    base = _relsc(0.9, 0.9, 0.9)
+    prop = _relsc(0.6, 0.6, 0.6)             # worse on both
+    assert set(ss._accept_frontier(base, prop).values()) == {False}
+
+
+def test_suggest_result_carries_frontier():
+    # frontier is ADDITIVE: accepted/config unchanged, accept_frontier == _accept_frontier(base, prop)
+    docs = [_Doc("a"), _Doc("b")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.40, 0.70), chat=_fake_chat_homograph)
+    # at the default beta (1.0) the proposed (name_ci_type) scored 0.70 > baseline 0.40 -> accepted
+    assert res.accepted is True and res.config.xdoc_key == "name_ci_type"
+    assert res.accept_frontier == ss._accept_frontier(res.baseline_scorecard, res.proposed_scorecard)
+```
+
+(`_Doc`, `_short_profile`, `_bykey`, `_fake_chat_homograph` already exist in the file from the SP-C tests.)
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k "accept_frontier or carries_frontier"`. Expected: FAIL — no `_accept_frontier` / no `accept_frontier` field.
+
+- [ ] **Step 3: Implement** in `substrate_suggest.py`:
+
+Add the helper (after `propose_corpus_flags`, before `SuggestResult`):
+```python
+def _accept_frontier(base_sc, prop_sc, betas=(1.0, 0.5, 0.25)) -> dict:
+    """Accept decision (proposed beats baseline) at each beta, recomputed from the two scorecards
+    already in hand (no rebuild). beta<1 favors precision -> shows where a precision-improving-but-
+    F1-losing config flips to accepted. See the beta-frontier design doc."""
+    return {b: _score(prop_sc, beta=b) > _score(base_sc, beta=b) for b in betas}
+```
+
+Add the field to `SuggestResult` (6th, no default — all-non-default ordering preserved):
+```python
+@dataclass(frozen=True)
+class SuggestResult:
+    config: SubstrateConfig
+    flags: CorpusFlags
+    accepted: bool
+    baseline_scorecard: dict
+    proposed_scorecard: dict
+    accept_frontier: dict
+```
+
+In `suggest_substrate_config`, compute the frontier and pass it (keyword) to the constructor:
+```python
+    accepted = _score(prop_sc) > _score(base_sc)
+    frontier = _accept_frontier(base_sc, prop_sc)
+    winner = proposed if accepted else baseline
+    if accepted and flags.expect_homographs and flags.entity_type_vocab:
+        winner = replace(winner, entity_type_vocab=flags.entity_type_vocab)
+    return SuggestResult(winner, flags, accepted, base_sc, prop_sc, accept_frontier=frontier)
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k "accept_frontier or carries_frontier"`. Expected: PASS (4).
+
+- [ ] **Step 5: Run the WHOLE SP-C test file** (existing 13 + F-beta-adjacent + 4 new must all be green — the change is additive):
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD:/d/show_case/gg-local-llm/packages/python/goldengraph" PYTHONIOENCODING=utf-8 PYTHONUTF8=1 \
+  POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 /d/show_case/goldenmatch/.venv/Scripts/python.exe \
+  -m pytest tests/test_substrate_suggest.py -q      # 13 + 4 = 17 green
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py \
+        packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
+git commit -m "feat(erkgbench): SP-C accept_frontier (beta sweep, free recompute; accepted/config unchanged)"
+```
+
+---
+
+### Task 2: Runner prints the frontier + P/R
+
+**Files:**
+- Modify: `erkgbench/run_substrate_suggest.py` (the print + md block, ~lines 47-57)
+
+- [ ] **Step 1: Add the frontier line to stdout + md**
+
+After `b, p = res.baseline_scorecard, res.proposed_scorecard` (line 47), the print (48-50) becomes:
+```python
+    print(f"[suggest] accepted={res.accepted} flags={res.flags} "
+          f"baseline_F1={b['relational']['f1']:.4f} proposed_F1={p['relational']['f1']:.4f} "
+          f"winner_xdoc={res.config.xdoc_key} canon={res.config.entity_type_canon}", flush=True)
+    print(f"[suggest] accept_frontier={res.accept_frontier} | "
+          f"baseline P/R={b['relational']['precision']:.4f}/{b['relational']['recall']:.4f} "
+          f"proposed P/R={p['relational']['precision']:.4f}/{p['relational']['recall']:.4f} "
+          f"-> set GOLDENGRAPH_SUBSTRATE_SCORE_BETA to the lowest beta where accept flips True",
+          flush=True)
+```
+And add a frontier line to the `md` block (after the `- winner:` line):
+```python
+        f"- accept_frontier: `{res.accept_frontier}` (beta<1 favors precision)\n"
+        f"- baseline P/R: {b['relational']['precision']:.4f} / {b['relational']['recall']:.4f}  |  "
+        f"proposed P/R: {p['relational']['precision']:.4f} / {p['relational']['recall']:.4f}\n"
+```
+
+- [ ] **Step 2: Static-check** — box-safe parse + import:
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD:/d/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -c "import ast; ast.parse(open('erkgbench/run_substrate_suggest.py').read()); import erkgbench.run_substrate_suggest; print('ok')"
+```
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py
+git commit -m "feat(erkgbench): suggester runner prints the beta accept_frontier + P/R (pick beta from the frontier)"
+```
+
+---
+
+### Task 3: Finish
+
+- [ ] **Step 1: Full green** — `test_substrate_suggest.py` (17) + `test_substrate_tuner.py` (23, the F-beta `_score` is unchanged) box-safe. Confirm no regression.
+- [ ] **Step 2: Lint** — `ruff check` the three files; fix findings.
+- [ ] **Step 3: PR + arm** — push, open PR base `main`, arm `--auto`, STOP. (No Modal — the frontier is a pure recompute; the beta=1.0/0.5 SP-C runs already demonstrate `{1.0: False, 0.5: True}`.)
+- [ ] **Step 4: Memory** — append to `project_goldengraph_local_oss_llm_lane.md`: the auto-beta follow-on shipped as the beta-frontier report (both SP-C follow-ons now closed).
+
+---
+
+## Notes for the implementer
+
+- **Box-safe only.** `test_substrate_suggest.py` + `test_substrate_tuner.py`. No Modal.
+- **Additive only.** `accepted`/`config` behavior is unchanged; `accept_frontier` is informational. `test_suggest_result_carries_frontier` is the regression guard.
+- **`_relsc` builds presence=None** so `_score` is relational-only and the P/R-only frontier numbers reproduce exactly (a differing presence delta would shift the bool, per the spec note).
+- **Float keys 1.0/0.5/0.25** are exact in binary64 — no dict-key collision.

--- a/docs/superpowers/specs/2026-07-02-suggest-beta-frontier-design.md
+++ b/docs/superpowers/specs/2026-07-02-suggest-beta-frontier-design.md
@@ -1,0 +1,64 @@
+# SP-C Beta-Frontier Report — Design
+
+**Date:** 2026-07-02
+**Status:** design, pre-implementation
+**Follows:** SP-C suggester (#1384) + precision-aware F-beta `_score` (#1388). The auto-beta follow-on, resolved to the *report-the-frontier* option (make the precision/recall tradeoff visible; the user picks beta).
+
+## Problem
+
+The F-beta `_score` makes the accept metric precision-tunable, but the caller has no guidance on *which* beta to pick — the friction the auto-beta follow-on was meant to remove. Auto-*setting* beta on the LLM's homograph perception was rejected (it couples the metric to a fallible perception and hardcodes a corpus-dependent beta — the "assume, don't measure" anti-pattern). Instead: **report the accept decision across a small beta sweep so the caller sees the frontier and decides.**
+
+## Key property (why it's free)
+
+`beta` only changes the accept *comparison* of two **already-computed** scorecards. `suggest_substrate_config` already builds baseline + proposed once each and holds `base_sc` + `prop_sc` (each with `relational.precision`/`recall`/`f1`). So the frontier is a **pure recompute** — zero extra builds, zero Modal cost.
+
+## Non-goals
+
+- NOT auto-setting beta (rejected).
+- NOT changing the run's actual decision: `SuggestResult.accepted`/`.config` stay governed by the *active* beta (`GOLDENGRAPH_SUBSTRATE_SCORE_BETA`, default 1.0). The frontier is purely informational.
+- NOT touching `_score`, `for_profile`, `build_and_score_real`, or the self-verify guardrail.
+- No frontier on the no-gold MCP surface (`suggest_substrate_config_unverified`) — it has no scorecards to compare.
+
+## Design
+
+### 1. `_accept_frontier(base_sc, prop_sc, betas=(1.0, 0.5, 0.25)) -> dict[float, bool]`
+Pure helper in `substrate_suggest.py`:
+```python
+def _accept_frontier(base_sc, prop_sc, betas=(1.0, 0.5, 0.25)):
+    """Accept decision (proposed beats baseline) at each beta, recomputed from the two scorecards
+    already in hand. beta<1 favors precision -> shows where a precision-improving-but-F1-losing config
+    flips to accepted. Pure; no rebuild."""
+    return {b: _score(prop_sc, beta=b) > _score(base_sc, beta=b) for b in betas}
+```
+
+### 2. `SuggestResult` gains `accept_frontier: dict[float, bool]`
+Added as a field (frozen dataclass). `suggest_substrate_config` computes it from `base_sc`/`prop_sc` right after those are built:
+```python
+    frontier = _accept_frontier(base_sc, prop_sc)
+    ...
+    return SuggestResult(winner, flags, accepted, base_sc, prop_sc, accept_frontier=frontier)
+```
+`accepted` (the active-beta decision) and `config` (the winner at the active beta) are unchanged. On the homograph smoke's scorecards (baseline P=0.815/R=0.672, proposed P=0.932/R=0.545) the frontier is `{1.0: False, 0.5: True, 0.25: True}` — i.e. F1 rejects, beta≤0.5 accepts.
+
+### 3. Runner prints the frontier + the P/R deltas
+`run_substrate_suggest.py` adds a line: the `accept_frontier` dict + baseline/proposed `relational.precision`/`recall`, so a run reads (in effect): *"F1 (beta=1.0) rejects this; at beta≤0.5 it wins on precision 0.815→0.932. Set `GOLDENGRAPH_SUBSTRATE_SCORE_BETA` accordingly."* The markdown report gets the same.
+
+## Testing (TDD, box-safe, no Modal)
+
+`tests/test_substrate_suggest.py`:
+- `accept_frontier_flips_at_beta` — with the smoke scorecards (`_rel(0.8153, 0.672, 0.7368)` baseline, `_rel(0.9323, 0.545, 0.6885)` proposed via a small local scorecard helper), `_accept_frontier(base, prop)` returns `{1.0: False, 0.5: True, 0.25: True}`. The measured flip, unit-pinned.
+- `accept_frontier_all_true_when_proposed_dominates` — proposed better on BOTH P and R → every beta True.
+- `accept_frontier_all_false_when_baseline_dominates` — baseline better on both → every beta False.
+- `suggest_result_carries_frontier` — `suggest_substrate_config` (fake chat + fake build) returns a `SuggestResult` whose `accept_frontier` matches `_accept_frontier(base_sc, prop_sc)`, and whose `accepted`/`config` are UNCHANGED from before (the active-beta decision — regression guard that the frontier is purely additive).
+
+Existing 13 SP-C tests + the F-beta tests stay green (additive change).
+
+## Design choices flagged for review
+
+- **Default betas `(1.0, 0.5, 0.25)`** — includes the F1 default (1.0) so the frontier always shows the status-quo decision, plus two precision-favoring points that bracket the homograph flip (0.5 marginal, 0.25 clear). Env-overridable is YAGNI for now (the caller can call `_accept_frontier` with custom betas if needed).
+- **`accepted`/`config` unchanged** — the frontier informs, it does not decide. The run still returns the config for the *active* beta, so nothing about the shipped accept behavior changes.
+- **No new Modal run** — the beta=1.0 (`accepted=False`) and beta=0.5 (`accepted=True`) SP-C runs already *are* the frontier `{1.0: False, 0.5: True}`, measured on real data; the box tests pin the recompute to those P/R numbers.
+
+## Follow-ons
+
+- Surface the frontier in the no-gold MCP path via an *unsupervised* precision proxy (needs the deferred no-gold-verify work) — not now.

--- a/docs/superpowers/specs/2026-07-02-suggest-beta-frontier-design.md
+++ b/docs/superpowers/specs/2026-07-02-suggest-beta-frontier-design.md
@@ -21,6 +21,8 @@ The F-beta `_score` makes the accept metric precision-tunable, but the caller ha
 
 ## Design
 
+**Note on the presence term:** `_score = relational_F_beta + presence.coverage` (when presence not None). `beta` shifts ONLY the relational term; the presence term is beta-independent and appears equally in both `_score(prop)` and `_score(base)`. So on the engineered/homograph corpus (presence is `None` there → `_score` is relational-only) the P/R-only frontier numbers reproduce exactly. If two scorecards had *differing* presence, the accept bool at a given beta would also reflect that (beta-independent) presence delta — the flip logic is unchanged, but the shown P/R-only numbers assume equal-or-None presence (which the box-test `_rel` helper builds). Also: at `beta==1.0` `_score` uses the STORED `relational.f1` while `beta!=1.0` recomputes F_beta from P/R — they agree when the stored f1 == 2PR/(P+R) (it does for these scorecards); a latent edge inherited from `_score`, not introduced here.
+
 ### 1. `_accept_frontier(base_sc, prop_sc, betas=(1.0, 0.5, 0.25)) -> dict[float, bool]`
 Pure helper in `substrate_suggest.py`:
 ```python

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/run_substrate_suggest.py
@@ -48,12 +48,20 @@ def main() -> None:
     print(f"[suggest] accepted={res.accepted} flags={res.flags} "
           f"baseline_F1={b['relational']['f1']:.4f} proposed_F1={p['relational']['f1']:.4f} "
           f"winner_xdoc={res.config.xdoc_key} canon={res.config.entity_type_canon}", flush=True)
+    print(f"[suggest] accept_frontier={res.accept_frontier} | "
+          f"baseline P/R={b['relational']['precision']:.4f}/{b['relational']['recall']:.4f} "
+          f"proposed P/R={p['relational']['precision']:.4f}/{p['relational']['recall']:.4f} "
+          f"-> set GOLDENGRAPH_SUBSTRATE_SCORE_BETA to the lowest beta where accept flips True",
+          flush=True)
     md = (
         "# SP-C Suggester Smoke (homograph engineered)\n\n"
         f"- accepted: `{res.accepted}`  flags: `{res.flags}`\n"
         f"- baseline relational F1: {b['relational']['f1']:.4f} (P={b['relational']['precision']:.4f})\n"
         f"- proposed relational F1: {p['relational']['f1']:.4f} (P={p['relational']['precision']:.4f})\n"
         f"- winner: xdoc_key=`{res.config.xdoc_key}` entity_type_canon={res.config.entity_type_canon}\n"
+        f"- accept_frontier: `{res.accept_frontier}` (beta<1 favors precision)\n"
+        f"- baseline P/R: {b['relational']['precision']:.4f} / {b['relational']['recall']:.4f}  |  "
+        f"proposed P/R: {p['relational']['precision']:.4f} / {p['relational']['recall']:.4f}\n"
     )
     with open(args.out_md, "w", encoding="utf-8") as fh:
         fh.write(md)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/substrate_suggest.py
@@ -84,6 +84,13 @@ def propose_corpus_flags(sample_docs, *, chat) -> CorpusFlags:
     return _parse_flags(chat(_PROMPT.format(sample=sample)))
 
 
+def _accept_frontier(base_sc, prop_sc, betas=(1.0, 0.5, 0.25)) -> dict:
+    """Accept decision (proposed beats baseline) at each beta, recomputed from the two scorecards
+    already in hand (no rebuild). beta<1 favors precision -> shows where a precision-improving-but-
+    F1-losing config flips to accepted. See the beta-frontier design doc."""
+    return {b: _score(prop_sc, beta=b) > _score(base_sc, beta=b) for b in betas}
+
+
 @dataclass(frozen=True)
 class SuggestResult:
     config: SubstrateConfig
@@ -91,6 +98,7 @@ class SuggestResult:
     accepted: bool
     baseline_scorecard: dict
     proposed_scorecard: dict
+    accept_frontier: dict
 
 
 def suggest_substrate_config(docs, *, gold, qid_aliases, build_and_score, chat,
@@ -109,13 +117,14 @@ def suggest_substrate_config(docs, *, gold, qid_aliases, build_and_score, chat,
     base_sc = build_and_score(baseline, dataset)
     prop_sc = build_and_score(proposed, dataset)
     accepted = _score(prop_sc) > _score(base_sc)
+    frontier = _accept_frontier(base_sc, prop_sc)
     winner = proposed if accepted else baseline
     # Stamp entity_type_vocab ONLY on an accepted homograph winner (canon is on only via
     # expect_homographs; `accepted` alone does NOT imply it -- a schema-only proposal can be accepted
     # with canon off). Both terms required -> never dirties a canon-off config.
     if accepted and flags.expect_homographs and flags.entity_type_vocab:
         winner = replace(winner, entity_type_vocab=flags.entity_type_vocab)
-    return SuggestResult(winner, flags, accepted, base_sc, prop_sc)
+    return SuggestResult(winner, flags, accepted, base_sc, prop_sc, accept_frontier=frontier)
 
 
 def suggest_substrate_config_unverified(sample_texts, *, chat, sample_docs=6) -> dict:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_substrate_suggest.py
@@ -140,3 +140,39 @@ def test_mcp_unverified_returns_config_and_flag():
 def test_mcp_unverified_bad_read_is_baseline():
     out = ss.suggest_substrate_config_unverified(["doc"], chat=lambda p: "nope")
     assert out["config"] == for_profile(profile_corpus(["doc"]))  # baseline, no vocab
+
+
+# --- SP-C beta-frontier report ------------------------------------------------------------------------
+def _relsc(p, r, f1):
+    """A presence=None scorecard with explicit relational P/R/F1 (so _score is relational-only)."""
+    return {"presence": None, "relational": {"f1": f1, "recall": r, "precision": p},
+            "connectivity": {"coverage": None, "f1": None, "edge_recall": 0.9},
+            "coherence": {"components": 1, "largest_fraction": 1.0}}
+
+
+def test_accept_frontier_flips_at_beta():
+    base = _relsc(0.8153, 0.672, 0.7368)     # SP-C smoke baseline
+    prop = _relsc(0.9323, 0.545, 0.6885)     # proposed homograph-safe config (beta=0.5 run)
+    assert ss._accept_frontier(base, prop) == {1.0: False, 0.5: True, 0.25: True}
+
+
+def test_accept_frontier_all_true_when_proposed_dominates():
+    base = _relsc(0.6, 0.6, 0.6)
+    prop = _relsc(0.9, 0.9, 0.9)             # better on both P and R
+    assert set(ss._accept_frontier(base, prop).values()) == {True}
+
+
+def test_accept_frontier_all_false_when_baseline_dominates():
+    base = _relsc(0.9, 0.9, 0.9)
+    prop = _relsc(0.6, 0.6, 0.6)             # worse on both
+    assert set(ss._accept_frontier(base, prop).values()) == {False}
+
+
+def test_suggest_result_carries_frontier():
+    # frontier is ADDITIVE: accepted/config unchanged, accept_frontier == _accept_frontier(base, prop)
+    docs = [_Doc("a"), _Doc("b")]
+    res = ss.suggest_substrate_config(
+        docs, gold=[], qid_aliases=None, profile=_short_profile(),
+        build_and_score=_bykey(0.40, 0.70), chat=_fake_chat_homograph)
+    assert res.accepted is True and res.config.xdoc_key == "name_ci_type"
+    assert res.accept_frontier == ss._accept_frontier(res.baseline_scorecard, res.proposed_scorecard)


### PR DESCRIPTION
Resolves the auto-beta follow-on. Rather than auto-*setting* beta on the LLM's homograph perception (which couples the accept metric to a fallible perception + hardcodes a corpus-dependent beta — the "assume, don't measure" anti-pattern), `suggest_substrate_config` now **reports the accept decision across a beta sweep** so the caller sees the precision/recall frontier and picks.

## What
- **`_accept_frontier(base_sc, prop_sc, betas=(1.0, 0.5, 0.25))`** — pure recompute of `_score(prop, beta) > _score(base, beta)` per beta from the two scorecards already in hand. **Free** (no rebuild).
- **`SuggestResult.accept_frontier`** — additive; the run's `accepted`/`config` stay governed by the active env beta (behavior unchanged).
- **Runner prints the frontier + P/R**, so a run reads: *"F1 (beta=1.0) rejects this, but at beta≤0.5 it wins on precision 0.815→0.932 — set `GOLDENGRAPH_SUBSTRATE_SCORE_BETA` accordingly."*

## Why this shape
The self-verify guardrail already protects config choice at any beta; the only question was *how beta gets chosen*. Reporting the frontier removes the "what beta?" friction without the tool making a precision/recall value judgment on the user's behalf. Arc discipline applied to the metric choice: make the frontier visible, user decides.

## No Modal
The beta=1.0 (`accepted=False`) and beta=0.5 (`accepted=True`) SP-C runs already *are* the frontier `{1.0: False, 0.5: True}`; the box tests pin the recompute to those exact P/R numbers (reviewer-verified arithmetic). 4 box tests, 17 suggest + 23 tuner green, ruff clean.

Both SP-C follow-ons now closed (this + the schema_canon-self-harm refutation, #1393).

🤖 Generated with [Claude Code](https://claude.com/claude-code)