### PR TITLE
feat(goldengraph): EntityIndex — embed-once ANN retrieval (STaRK-scale prerequisite, SP1)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-goldengraph-entity-index.md
+++ b/docs/superpowers/plans/2026-07-02-goldengraph-entity-index.md
@@ -1,0 +1,362 @@
+# GoldenGraph Entity Index (SP1) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the STaRK-scale retrieval blocker — embed each entity name ONCE into a persisted ANN index (reusing goldenmatch's `ANNBlocker`) so `seed_by_query` stops re-embedding all N names on every query.
+
+**Architecture:** New `EntityIndex` owns the L2-normalized embedding array + `entity_id`↔row map, wrapping `ANNBlocker` (FAISS flat + numpy fallback). `query` embeds only the query. `seed_by_query`/`ask` gain an opt-in `index=`/`entity_index=` param (default `None` = today's behavior). Box-tested on the numpy fallback with stub embedders.
+
+**Tech Stack:** Python, numpy, pytest. Reuses `goldenmatch.core.ann_blocker.ANNBlocker`.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-goldengraph-entity-index-design.md`
+
+**Branch:** `feat/goldengraph-entity-index` (off `origin/main`; goldengraph already deps goldenmatch).
+
+---
+
+## Files
+
+- **Create** `packages/python/goldengraph/goldengraph/entity_index.py` — `EntityIndex`.
+- **Modify** `packages/python/goldengraph/goldengraph/embed.py` — `seed_by_query` gains `index=None`.
+- **Modify** `packages/python/goldengraph/goldengraph/answer.py` — `ask` gains `entity_index=None`, threaded to `seed_by_query`.
+- **Create** `packages/python/goldengraph/tests/test_entity_index.py` — box-safe tests (numpy fallback, stub embedders).
+
+## Test runner (box-safe)
+
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldengraph
+PYTHONIOENCODING=utf-8 PYTHONUTF8=1 POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_entity_index.py -q
+```
+
+## Ground-truth facts (verified)
+
+- `ANNBlocker(top_k=…)`; `build_index(embeddings)` (stores `_corpus` on the numpy path); `query_one(vec) -> list[(neighbor_row, score)]` **rank-ordered, capped at `top_k`, filtered to row >= 0**. `_HAS_FAISS` (module flag) selects faiss vs the numpy `_np_search` — tests force `_HAS_FAISS=False` for hermetic runs. `IndexFlatIP` does NOT normalize internally → callers pass L2-normalized vectors.
+- `seed_by_query(slice_graph, query, embedder, *, k=5)` (embed.py:66) filters entities: `typ` NOT startswith `"literal:"` AND non-empty stripped `canonical_name`. `Embedder` = Protocol `embed(texts) -> np.ndarray`. The embedder batches internally (seed_by_query passes all names in one `embed()` call).
+- `ask()` (answer.py) calls `seeds = seed_by_query(slice_graph, query, embedder, k=k)` at line 323. Only source caller of `seed_by_query`.
+
+---
+
+### Task 1: `EntityIndex.build` + `query` (+ filter + k contract)
+
+**Files:**
+- Create: `goldengraph/entity_index.py`
+- Test: `tests/test_entity_index.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_entity_index.py`:
+
+```python
+"""SP1 EntityIndex: embed-once ANN retrieval over entity names (box-safe, numpy fallback)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import goldenmatch.core.ann_blocker as _ab
+from goldengraph.entity_index import EntityIndex
+
+
+@pytest.fixture(autouse=True)
+def _force_numpy_fallback(monkeypatch):
+    # Hermetic: never depend on faiss being installed; numpy fallback gives the same neighbor set.
+    monkeypatch.setattr(_ab, "_HAS_FAISS", False)
+
+
+_VECS = {"apple": [1.0, 0.0, 0.0], "banana": [0.0, 1.0, 0.0], "cherry": [0.0, 0.0, 1.0]}
+
+
+class _StubEmbedder:
+    """Deterministic: known name -> its axis vector, unknown -> zero. Counts embed() calls."""
+    def __init__(self):
+        self.calls = 0
+
+    def embed(self, texts):
+        self.calls += 1
+        return np.array([_VECS.get(str(t).strip().lower(), [0.0, 0.0, 0.0]) for t in texts], dtype=float)
+
+
+def _ent(eid, name, typ="thing"):
+    return {"entity_id": eid, "canonical_name": name, "typ": typ}
+
+
+def test_build_and_query_topk():
+    idx = EntityIndex.build([_ent(0, "apple"), _ent(1, "banana"), _ent(2, "cherry")], _StubEmbedder())
+    assert idx.query("banana", _StubEmbedder(), k=1) == [1]
+    assert idx.query("apple", _StubEmbedder(), k=1) == [0]
+
+
+def test_query_maps_rows_to_entity_ids():
+    # non-contiguous ids: apple is row 0 but entity_id 5 -> query must return 5, not 0
+    idx = EntityIndex.build([_ent(5, "apple"), _ent(1, "banana"), _ent(99, "cherry")], _StubEmbedder())
+    assert idx.query("apple", _StubEmbedder(), k=1) == [5]
+    assert idx.query("cherry", _StubEmbedder(), k=1) == [99]
+
+
+def test_build_filters_literals_and_empty():
+    ents = [_ent(0, "apple"), _ent(1, "2024-01-01", typ="literal:date"), _ent(2, "  ")]
+    idx = EntityIndex.build(ents, _StubEmbedder())
+    assert len(idx) == 1                      # only "apple"
+    assert idx.query("apple", _StubEmbedder(), k=1) == [0]
+
+
+def test_query_embeds_query_only():
+    idx = EntityIndex.build([_ent(0, "apple"), _ent(1, "banana")], _StubEmbedder())
+    emb = _StubEmbedder()
+    idx.query("apple", emb, k=1)
+    assert emb.calls == 1                      # ONE embed (the query), NOT N -- the anti-regression
+    idx.query("banana", emb, k=1)
+    assert emb.calls == 2                      # one more, still per-query O(1)
+
+
+def test_query_rejects_k_above_capacity():
+    idx = EntityIndex.build([_ent(0, "apple")], _StubEmbedder(), top_k=50)
+    with pytest.raises(ValueError):
+        idx.query("apple", _StubEmbedder(), k=100)
+
+
+def test_empty_index_returns_empty():
+    idx = EntityIndex.build([_ent(0, "  ", typ="literal:x")], _StubEmbedder())
+    assert len(idx) == 0 and idx.query("apple", _StubEmbedder(), k=5) == []
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe. Expected: `ModuleNotFoundError: goldengraph.entity_index`.
+
+- [ ] **Step 3: Implement** — create `goldengraph/entity_index.py`:
+
+```python
+"""SP1: a persisted ANN index over entity canonical-name embeddings, keyed by entity_id.
+
+Embed each entity name ONCE (batched by the embedder), keep an ANNBlocker (FAISS IndexFlatIP + numpy
+fallback) over the L2-normalized vectors, and answer per-query top-k WITHOUT re-embedding the corpus --
+the fix for seed_by_query's O(N)-embed-per-query blocker. EntityIndex OWNS the embedding array, so
+persistence is backend-agnostic (np.save) and nothing reaches into ANNBlocker internals.
+See docs/superpowers/specs/2026-07-02-goldengraph-entity-index-design.md.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _l2(mat: np.ndarray) -> np.ndarray:
+    mat = np.asarray(mat, dtype=np.float32)
+    if mat.ndim == 1:
+        return mat / (np.linalg.norm(mat) + 1e-12)
+    return mat / (np.linalg.norm(mat, axis=1, keepdims=True) + 1e-12)
+
+
+class EntityIndex:
+    def __init__(self, corpus: np.ndarray, row_to_entity_id, top_k: int, dim: int):
+        self._corpus = np.asarray(corpus, dtype=np.float32)
+        self._row_to_entity_id = [int(x) for x in row_to_entity_id]
+        self._top_k = int(top_k)
+        self._dim = int(dim)
+        self._blocker = None
+        self._build_blocker()
+
+    def _build_blocker(self) -> None:
+        from goldenmatch.core.ann_blocker import ANNBlocker  # lazy: keep import off the hot path
+        self._blocker = ANNBlocker(top_k=self._top_k)
+        if len(self._row_to_entity_id):
+            self._blocker.build_index(self._corpus)
+
+    @classmethod
+    def build(cls, entities, embedder, *, top_k: int = 50) -> "EntityIndex":
+        """Filter to real entity nodes (typ not 'literal:*', non-empty name -- mirrors seed_by_query),
+        embed all names ONCE, L2-normalize, index. `top_k` = index capacity (max neighbors per query)."""
+        ids, names = [], []
+        for e in entities:
+            typ = str(e.get("typ", ""))
+            name = str(e.get("canonical_name", "")).strip()
+            if typ.startswith("literal:") or not name:
+                continue
+            ids.append(int(e["entity_id"]))
+            names.append(name)
+        if not names:
+            return cls(np.zeros((0, 1), dtype=np.float32), [], top_k, 1)
+        vecs = _l2(np.asarray(embedder.embed(names), dtype=np.float32))
+        return cls(vecs, ids, top_k, vecs.shape[1])
+
+    def query(self, query: str, embedder, *, k: int = 5) -> list[int]:
+        """Embed the QUERY only, ANN top-k, map rows->entity_ids. Requires k <= top_k."""
+        if k > self._top_k:
+            raise ValueError(f"k={k} exceeds index top_k={self._top_k}; rebuild with a larger top_k")
+        if not self._row_to_entity_id:
+            return []
+        q = _l2(np.asarray(embedder.embed([query]), dtype=np.float32)[0])
+        rows = self._blocker.query_one(q)   # [(row, score)] rank-ordered, capped at top_k
+        return [self._row_to_entity_id[r] for r, _ in rows[:k]]
+
+    def __len__(self) -> int:
+        return len(self._row_to_entity_id)
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe. Expected: PASS (6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldengraph/goldengraph/entity_index.py \
+        packages/python/goldengraph/tests/test_entity_index.py
+git commit -m "feat(goldengraph): EntityIndex build+query (embed-once ANN over entity names, k<=top_k) (SP1 task 1)"
+```
+
+---
+
+### Task 2: `save` / `load` (backend-agnostic)
+
+**Files:**
+- Modify: `goldengraph/entity_index.py`
+- Test: `tests/test_entity_index.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_save_load_roundtrip(tmp_path):
+    ents = [_ent(5, "apple"), _ent(1, "banana"), _ent(99, "cherry")]
+    idx = EntityIndex.build(ents, _StubEmbedder())
+    idx.save(str(tmp_path / "idx"))
+    loaded = EntityIndex.load(str(tmp_path / "idx"))
+    assert len(loaded) == 3
+    assert loaded.query("cherry", _StubEmbedder(), k=1) == [99]   # same top-k after reload
+```
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k save_load`. Expected: FAIL — no `save`.
+
+- [ ] **Step 3: Implement** — add to `EntityIndex` (`import json`, `import os` at module top):
+
+```python
+    def save(self, path: str) -> None:
+        """Backend-agnostic: np.save the (normalized) corpus + row_to_entity_id + a meta.json. NO
+        faiss.write_index -- EntityIndex owns the array, so load rebuilds the ANNBlocker from it."""
+        os.makedirs(path, exist_ok=True)
+        np.save(os.path.join(path, "corpus.npy"), self._corpus)
+        np.save(os.path.join(path, "row_to_entity_id.npy"),
+                np.asarray(self._row_to_entity_id, dtype=np.int64))
+        with open(os.path.join(path, "meta.json"), "w", encoding="utf-8") as fh:
+            json.dump({"top_k": self._top_k, "dim": self._dim}, fh)
+
+    @classmethod
+    def load(cls, path: str) -> "EntityIndex":
+        corpus = np.load(os.path.join(path, "corpus.npy"))
+        ids = np.load(os.path.join(path, "row_to_entity_id.npy")).tolist()
+        with open(os.path.join(path, "meta.json"), encoding="utf-8") as fh:
+            meta = json.load(fh)
+        return cls(corpus, ids, meta["top_k"], meta["dim"])
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k save_load`. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldengraph/goldengraph/entity_index.py \
+        packages/python/goldengraph/tests/test_entity_index.py
+git commit -m "feat(goldengraph): EntityIndex save/load (backend-agnostic np.save, no faiss internals) (SP1 task 2)"
+```
+
+---
+
+### Task 3: `seed_by_query(index=)` seam + `ask(entity_index=)` threading
+
+**Files:**
+- Modify: `goldengraph/embed.py` (`seed_by_query`, line 66)
+- Modify: `goldengraph/answer.py` (`ask`, line 323)
+- Test: `tests/test_entity_index.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_seed_by_query_uses_index_when_given():
+    from goldengraph.embed import seed_by_query
+
+    # a minimal PyGraph-like stub exposing .entities()
+    class _Graph:
+        def __init__(self, ents):
+            self._e = ents
+        def entities(self):
+            return self._e
+
+    ents = [_ent(0, "apple"), _ent(1, "banana")]
+    idx = EntityIndex.build(ents, _StubEmbedder())
+    emb = _StubEmbedder()
+    seeds = seed_by_query(_Graph(ents), "apple", emb, k=1, index=idx)
+    assert seeds == [0]
+    assert emb.calls == 1          # ONLY the query embedded (via the index), graph NOT re-embedded
+
+
+def test_seed_by_query_none_preserves_current_path():
+    from goldengraph.embed import seed_by_query
+
+    class _Graph:
+        def __init__(self, ents):
+            self._e = ents
+        def entities(self):
+            return self._e
+
+    ents = [_ent(0, "apple"), _ent(1, "banana")]
+    emb = _StubEmbedder()
+    seeds = seed_by_query(_Graph(ents), "apple", emb, k=1)   # index=None -> current re-embed path
+    assert seeds == [0]
+    assert emb.calls == 1          # current path embeds [query]+names in ONE call (embedder batches)
+```
+
+(Note: the current `seed_by_query` embeds `[query] + names` in a single `embed()` call, so `emb.calls == 1` on BOTH paths — the difference at scale is N names embedded vs 0. The index path is validated by `test_query_embeds_query_only` counting; here we assert behavior parity + correct seeds.)
+
+- [ ] **Step 2: Run to verify it fails** — box-safe `-k "seed_by_query"`. Expected: FAIL — `seed_by_query() got an unexpected keyword argument 'index'`.
+
+- [ ] **Step 3: Implement** — in `embed.py`, change `seed_by_query`'s signature + add the index branch at the top of the body:
+
+```python
+def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5, index=None) -> list[int]:
+    # (docstring unchanged; add:) `index` (an EntityIndex): when given, query the prebuilt index
+    # instead of re-embedding every entity name -- the O(1)-embed-per-query path for scale.
+    if index is not None:
+        return index.query(query, embedder, k=k)
+    # ... existing body unchanged ...
+```
+
+In `answer.py`: add `entity_index=None` to `ask`'s keyword args, and thread it at line 323:
+```python
+    seeds = seed_by_query(slice_graph, query, embedder, k=k, index=entity_index)
+```
+
+- [ ] **Step 4: Run to verify passes** — box-safe `-k "seed_by_query"`, then the WHOLE file:
+```bash
+cd /d/show_case/gg-local-llm/packages/python/goldengraph
+PYTHONIOENCODING=utf-8 PYTHONUTF8=1 POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_entity_index.py -q   # 9 green
+```
+Also run the existing goldengraph retrieval/answer tests to confirm the `seed_by_query`/`ask` signature change is back-compat (default None):
+```bash
+... -m pytest tests/test_chain_retrieval.py tests/test_asof_mode.py -q   # or the relevant answer/retrieve tests
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldengraph/goldengraph/embed.py \
+        packages/python/goldengraph/goldengraph/answer.py \
+        packages/python/goldengraph/tests/test_entity_index.py
+git commit -m "feat(goldengraph): seed_by_query/ask opt-in index= (EntityIndex path, back-compat None) (SP1 task 3)"
+```
+
+---
+
+### Task 4: Finish
+
+- [ ] **Step 1: Full green** — `tests/test_entity_index.py` (9) + a sanity run of the existing goldengraph answer/retrieval tests (back-compat). Use the box-safe command; if a test needs the native store, note it (the EntityIndex tests do NOT).
+- [ ] **Step 2: Lint** — `ruff check` the three files; fix findings.
+- [ ] **Step 3: PR + arm** — push, open PR base `main`, arm `--auto`, STOP. (No Modal — SP1 is pure/box-safe; the STaRK feasibility run is SP2.)
+- [ ] **Step 4: Memory** — note SP1 EntityIndex shipped in `project_goldengraph_local_oss_llm_lane.md` (or the STaRK program memory); SP2 = `StoreBatch` bulk-loader + STaRK-AMAZON feasibility run is next.
+
+---
+
+## Notes for the implementer
+
+- **Box-safe only.** `tests/test_entity_index.py`. The `_force_numpy_fallback` fixture makes it faiss-independent. Do NOT run the full suite or Modal.
+- **`ANNBlocker` import is lazy** (inside `_build_blocker`) so a plain `import goldengraph.entity_index` doesn't pull goldenmatch's ANN stack onto the import path.
+- **`query` embeds the QUERY only** — the one property that matters. `test_query_embeds_query_only` is the anti-regression; don't let a refactor reintroduce corpus embedding in `query`.
+- **Back-compat:** `seed_by_query(..., index=None)` and `ask(..., entity_index=None)` default to today's behavior; the only source caller (`ask` @ 323) passes the new kwarg. Verify existing answer/retrieval tests stay green.
+- **`k <= top_k`** is a hard contract (`query_one` caps at `top_k`); `query` raises rather than silently truncating.

--- a/docs/superpowers/specs/2026-07-02-goldengraph-entity-index-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-entity-index-design.md
@@ -1,0 +1,80 @@
+# GoldenGraph Entity Index (ANN-Indexed Retrieval) — Design (SP1)
+
+**Date:** 2026-07-02
+**Status:** design, pre-implementation
+**Sub-project:** SP1 of the STaRK-scale retrieval prerequisite (SP2 = `StoreBatch` bulk-loader + STaRK-AMAZON feasibility run). Prerequisite to test goldengraph on a structure-load-bearing benchmark (rebut the MuSiQue "graph inert" finding).
+
+## Problem
+
+`seed_by_query` (`goldengraph/embed.py:66`) — the query→seed-entity retrieval step — **re-embeds ALL entity canonical-names on EVERY query** (`embedder.embed([query] + names)`, then a brute-force cosine). That is O(N) *embedding calls* per query over the network/model. At STaRK-AMAZON scale (~1M+ nodes) a single query re-embeds a million names → minutes-to-hours per query. Node embeddings are never persisted. This is the hard blocker for any at-scale retrieval; the Rust store + BFS neighborhood already scale.
+
+## Insight / reuse
+
+The catastrophe is the per-query *embedding*, not the O(N) dot-products. The repo already has a FAISS index: `goldenmatch/core/ann_blocker.py::ANNBlocker` (`build_index(embeddings)`, `query_one(vec) -> [(row, score)]`, numpy all-pairs fallback when faiss absent). So SP1 is a **reuse + re-seam**: embed each node's name **once**, build an `ANNBlocker` over those vectors, and make the per-query path query the prebuilt index instead of re-embedding. `ANNBlocker` uses `IndexFlatIP` (exact flat, O(N) SIMD dot-products/query — ~ms at 1M, fine for the spike; `IndexHNSWFlat` is a later one-line swap if latency demands).
+
+## Non-goals
+
+- No approximate (HNSW/IVF) index tuning — flat FAISS for the spike; index-type is a measured SP2 finding.
+- No bulk-KB-loader, no STaRK adapter, no Modal run (SP2).
+- No change to the Rust store (embeddings live in a **sidecar**, keyed by `entity_id` — the store is a JSON-boundary graph; vectors never cross it).
+- No change to `ask()`'s existing default behavior — the indexed path is opt-in via a passed index.
+
+## Architecture
+
+New module `goldengraph/entity_index.py`:
+
+### `EntityIndex`
+```python
+class EntityIndex:
+    """A persisted ANN index over entity canonical-name embeddings, keyed by entity_id. Built ONCE
+    (embed all names in batches), queried per-request without re-embedding the corpus. Wraps
+    goldenmatch's ANNBlocker (FAISS IndexFlatIP + numpy fallback)."""
+
+    @classmethod
+    def build(cls, entities, embedder, *, top_k=20) -> "EntityIndex":
+        # entities: iterable of {"entity_id", "canonical_name", "typ", ...} (e.g. slice_graph.entities()).
+        # Filter to real entity nodes (typ not startswith "literal:", non-empty name) -- same rule as
+        # seed_by_query. Embed all names ONCE (batched via embedder.embed), L2-normalize,
+        # ANNBlocker.build_index. Keep row_to_entity_id: list[int] parallel to the corpus rows.
+
+    def query(self, query: str, embedder, *, k=5) -> list[int]:
+        # embed the QUERY only (one call), ANNBlocker.query_one, map rows -> entity_ids, top-k, dedup.
+
+    def save(self, path) -> None: ...   # faiss.write_index (or np.save the corpus) + np.save row_to_entity_id
+    @classmethod
+    def load(cls, path) -> "EntityIndex": ...
+    def __len__(self) -> int: ...
+```
+- **Filtering** mirrors `seed_by_query`: skip `typ` starting `literal:` and empty/whitespace names (embedding a bare value 400s the provider batch — the exact bug seed_by_query documents).
+- **Normalization:** L2-normalize both corpus and query so `IndexFlatIP` inner product == cosine (ANNBlocker's contract).
+- **Persistence:** `save`/`load` so SP2 doesn't re-embed 1M names every run (the expensive part). FAISS path = `faiss.write_index`; numpy-fallback path = `np.save` the corpus; both + `np.save(row_to_entity_id)`. A small `meta.json` records which backend + dim.
+
+### Retrieval seam
+`seed_by_query(slice_graph, query, embedder, *, k=5, index=None)` gains an optional `index`:
+- `index is not None` → return `index.query(query, embedder, k=k)` (NO corpus re-embed).
+- `index is None` → the current re-embed path, unchanged (fine for small graphs / back-compat).
+
+`ask(..., entity_index=None)` threads it: passes `index=entity_index` to `seed_by_query`. Default `None` → today's behavior. The STaRK harness (SP2) builds the `EntityIndex` once and passes it to every `ask`.
+
+## Testing (TDD, box-safe — numpy fallback, stub embedder)
+
+`packages/python/goldengraph/tests/test_entity_index.py` (no faiss needed — `ANNBlocker` falls back to numpy; a `_StubEmbedder` returns deterministic vectors):
+- `build_and_query_topk` — 4 entities with distinct stub vectors; `query` returns the nearest entity_ids in order.
+- `query_maps_rows_to_entity_ids` — non-contiguous entity_ids (e.g. 5, 1, 99) → `query` returns entity_ids, not row indices.
+- `build_filters_literals_and_empty` — a `literal:`-typed node and an empty-name node are excluded from the index (mirrors seed_by_query).
+- `query_embeds_query_only` — a counting stub embedder: `build` embeds N names once; each `query` makes exactly ONE embed call (the query), NOT N (the anti-regression for the whole sub-project).
+- `save_load_roundtrip` — `build` → `save` → `load` → `query` returns the same top-k (numpy-backend path; the faiss path is exercised in SP2/CI where faiss is installed).
+- `empty_index_returns_empty` — no eligible entities → `query` returns `[]`.
+- `seed_by_query_uses_index_when_given` — `seed_by_query(graph, q, emb, index=idx)` calls `idx.query` and does NOT re-embed the graph (counting stub confirms one embed call); `index=None` preserves the current path.
+
+## Design choices flagged for review
+
+- **Reuse `ANNBlocker`, don't add hnswlib.** The FAISS `IndexFlatIP` + numpy fallback already exists; box tests run on the fallback. Flat-vs-approximate is a measured SP2 call, not a design commitment.
+- **Sidecar, keyed by entity_id.** Embeddings never enter the Rust store's JSON boundary (millions × 768-dim would be absurd). The index is a separate artifact.
+- **`query` embeds the query only.** This single property is the entire point — the `query_embeds_query_only` test is the load-bearing regression guard.
+- **Cross-package dep:** `goldengraph` importing `goldenmatch.core.ann_blocker`. goldengraph already depends on goldenmatch (the resolver). Acceptable; if the import is heavy, import `ANNBlocker` lazily inside `EntityIndex.build`.
+
+## Follow-ons (SP2)
+
+- `StoreBatch` bulk-loader (map a pre-structured KB's nodes+edges → `StoreBatch` → `store.append`, bypassing extraction).
+- STaRK-AMAZON adapter + Modal feasibility run: ingest time, `EntityIndex.build` time, per-query latency, RAM; the flat-vs-HNSW verdict.

--- a/docs/superpowers/specs/2026-07-02-goldengraph-entity-index-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-entity-index-design.md
@@ -28,26 +28,35 @@ New module `goldengraph/entity_index.py`:
 class EntityIndex:
     """A persisted ANN index over entity canonical-name embeddings, keyed by entity_id. Built ONCE
     (embed all names in batches), queried per-request without re-embedding the corpus. Wraps
-    goldenmatch's ANNBlocker (FAISS IndexFlatIP + numpy fallback)."""
+    goldenmatch's ANNBlocker (FAISS IndexFlatIP + numpy fallback). EntityIndex OWNS the L2-normalized
+    embedding array (`self._corpus`) + `self._row_to_entity_id`; ANNBlocker is a rebuildable view over
+    that array, so nothing reaches into ANNBlocker's private state."""
 
     @classmethod
-    def build(cls, entities, embedder, *, top_k=20) -> "EntityIndex":
+    def build(cls, entities, embedder, *, top_k=50) -> "EntityIndex":
         # entities: iterable of {"entity_id", "canonical_name", "typ", ...} (e.g. slice_graph.entities()).
         # Filter to real entity nodes (typ not startswith "literal:", non-empty name) -- same rule as
-        # seed_by_query. Embed all names ONCE (batched via embedder.embed), L2-normalize,
-        # ANNBlocker.build_index. Keep row_to_entity_id: list[int] parallel to the corpus rows.
+        # seed_by_query. Embed all names ONCE (batched via embedder.embed), L2-normalize -> self._corpus.
+        # Keep row_to_entity_id: list[int] parallel to the corpus rows. Construct ANNBlocker(top_k=top_k)
+        # and build_index(self._corpus). `top_k` is the index CAPACITY (max neighbors any query can ask).
 
     def query(self, query: str, embedder, *, k=5) -> list[int]:
-        # embed the QUERY only (one call), ANNBlocker.query_one, map rows -> entity_ids, top-k, dedup.
+        # embed the QUERY only (one call), ANNBlocker.query_one -> [(row, score)], map rows->entity_ids,
+        # take the top k. REQUIRES k <= top_k (query_one caps at the construction-time top_k); raise
+        # ValueError if k > self._top_k rather than silently truncate.
 
-    def save(self, path) -> None: ...   # faiss.write_index (or np.save the corpus) + np.save row_to_entity_id
+    def save(self, path) -> None:
+        # Backend-agnostic (identical on faiss + numpy): np.save the corpus + row_to_entity_id, write a
+        # meta.json (dim, top_k). NO faiss.write_index (that would reach into ANNBlocker._index).
     @classmethod
-    def load(cls, path) -> "EntityIndex": ...
+    def load(cls, path) -> "EntityIndex":
+        # np.load corpus + row_to_entity_id, read meta, ANNBlocker(top_k).build_index(corpus).
     def __len__(self) -> int: ...
 ```
 - **Filtering** mirrors `seed_by_query`: skip `typ` starting `literal:` and empty/whitespace names (embedding a bare value 400s the provider batch — the exact bug seed_by_query documents).
-- **Normalization:** L2-normalize both corpus and query so `IndexFlatIP` inner product == cosine (ANNBlocker's contract).
-- **Persistence:** `save`/`load` so SP2 doesn't re-embed 1M names every run (the expensive part). FAISS path = `faiss.write_index`; numpy-fallback path = `np.save` the corpus; both + `np.save(row_to_entity_id)`. A small `meta.json` records which backend + dim.
+- **Normalization:** L2-normalize the corpus (in `build`) and the query (in `query`) so `IndexFlatIP` inner product == cosine (`ANNBlocker` does NOT normalize internally; the numpy fallback ranks by raw IP, so normalized inputs make both paths return cosine ranking identically).
+- **`k <= top_k` contract:** `ANNBlocker.query_one` returns at most the construction-time `top_k`; `query` validates `k <= self._top_k` and raises `ValueError` otherwise (no silent truncation). `build` defaults `top_k=50` (ample retrieval capacity); raise it for larger-recall runs.
+- **`EntityIndex` owns the array:** `save`/`load` operate on `self._corpus` (the normalized embeddings `EntityIndex` computed) — backend-agnostic, no `faiss.write_index`, no private-attr access. `load` rebuilds the `ANNBlocker` from the saved corpus. This is why SP2 can skip re-embedding 1M names every run.
 
 ### Retrieval seam
 `seed_by_query(slice_graph, query, embedder, *, k=5, index=None)` gains an optional `index`:
@@ -62,7 +71,8 @@ class EntityIndex:
 - `build_and_query_topk` — 4 entities with distinct stub vectors; `query` returns the nearest entity_ids in order.
 - `query_maps_rows_to_entity_ids` — non-contiguous entity_ids (e.g. 5, 1, 99) → `query` returns entity_ids, not row indices.
 - `build_filters_literals_and_empty` — a `literal:`-typed node and an empty-name node are excluded from the index (mirrors seed_by_query).
-- `query_embeds_query_only` — a counting stub embedder: `build` embeds N names once; each `query` makes exactly ONE embed call (the query), NOT N (the anti-regression for the whole sub-project).
+- `query_embeds_query_only` — a counting stub embedder: after `build`, each `query` makes exactly ONE `embed()` call (the query), NOT N (the anti-regression for the whole sub-project). Count ONLY query-phase calls — `build` may make >1 `embed()` call (the embedder batches at `_MAX_EMBED_BATCH`), so don't assert a total across build+query.
+- `query_rejects_k_above_capacity` — `query(k=100)` on an index built with `top_k=50` raises `ValueError` (no silent truncation).
 - `save_load_roundtrip` — `build` → `save` → `load` → `query` returns the same top-k (numpy-backend path; the faiss path is exercised in SP2/CI where faiss is installed).
 - `empty_index_returns_empty` — no eligible entities → `query` returns `[]`.
 - `seed_by_query_uses_index_when_given` — `seed_by_query(graph, q, emb, index=idx)` calls `idx.query` and does NOT re-embed the graph (counting stub confirms one embed call); `index=None` preserves the current path.

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -257,6 +257,7 @@ def ask(
     query_classifier: object | None = None,
     query_schema: object | None = None,
     provenance_out: set | None = None,
+    entity_index: object | None = None,
 ) -> str:
     """Answer `query` against `store` as-of `(valid_t, tx_t)`.
 
@@ -320,7 +321,7 @@ def ask(
         return synthesize_global(query, views, llm)
     if mode not in ("local", "hybrid"):
         raise ValueError(f"mode must be 'local', 'hybrid', or 'global', got {mode!r}")
-    seeds = seed_by_query(slice_graph, query, embedder, k=k)
+    seeds = seed_by_query(slice_graph, query, embedder, k=k, index=entity_index)
     _retrieve = _retrieve_local_bridged if _bridge_enabled() else _retrieve_local
     subgraph = _retrieve(slice_graph, seeds, max_hops=hops, node_budget=node_budget)
     # Hand the synthesis the seed entity NAMES (the query-relevant anchors) so the

--- a/packages/python/goldengraph/goldengraph/embed.py
+++ b/packages/python/goldengraph/goldengraph/embed.py
@@ -63,10 +63,15 @@ class GoldenmatchEmbedder:
         return np.vstack(parts)
 
 
-def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5) -> list[int]:
+def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5, index=None) -> list[int]:
     """Top-`k` entity ids in `slice_graph` (a `PyGraph` from `as_of`) nearest the
     query by cosine over canonical-name embeddings. Tie-break: ascending
     `entity_id` (deterministic — stub/zero vectors tie often).
+
+    When `index` (a `goldengraph.entity_index.EntityIndex` built once over the graph) is
+    given, query the PREBUILT index -- embeds ONLY the query, not every entity name -- the
+    O(1)-embed-per-query path for scale. `index=None` (default) keeps the re-embed path below
+    (fine for small graphs; back-compat).
 
     Only real ENTITY nodes are seed candidates: literal-attribute value leaves
     (`typ` starts with ``literal:``, from GOLDENGRAPH_LITERAL_ATTRS) are excluded --
@@ -75,6 +80,8 @@ def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5) ->
     risks an empty/over-long input that 400s the WHOLE provider batch. Empty /
     whitespace names are dropped for the same reason (a provider rejects an empty
     input). Without this, a literal-attrs run 400s on every answer at seed time."""
+    if index is not None:
+        return index.query(query, embedder, k=k)
     ents = [
         e
         for e in slice_graph.entities()

--- a/packages/python/goldengraph/goldengraph/entity_index.py
+++ b/packages/python/goldengraph/goldengraph/entity_index.py
@@ -1,0 +1,90 @@
+"""SP1: a persisted ANN index over entity canonical-name embeddings, keyed by entity_id.
+
+Embed each entity name ONCE (batched by the embedder), keep an ANNBlocker (FAISS IndexFlatIP + numpy
+fallback) over the L2-normalized vectors, and answer per-query top-k WITHOUT re-embedding the corpus --
+the fix for seed_by_query's O(N)-embed-per-query blocker. EntityIndex OWNS the embedding array, so
+persistence is backend-agnostic (np.save) and nothing reaches into ANNBlocker internals.
+See docs/superpowers/specs/2026-07-02-goldengraph-entity-index-design.md.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import numpy as np
+
+
+def _l2(mat: np.ndarray) -> np.ndarray:
+    mat = np.asarray(mat, dtype=np.float32)
+    if mat.ndim == 1:
+        return mat / (np.linalg.norm(mat) + 1e-12)
+    return mat / (np.linalg.norm(mat, axis=1, keepdims=True) + 1e-12)
+
+
+class EntityIndex:
+    def __init__(self, corpus: np.ndarray, row_to_entity_id, top_k: int, dim: int):
+        self._corpus = np.asarray(corpus, dtype=np.float32)
+        self._row_to_entity_id = [int(x) for x in row_to_entity_id]
+        self._top_k = int(top_k)
+        self._dim = int(dim)
+        self._blocker = None
+        self._build_blocker()
+
+    def _build_blocker(self) -> None:
+        from goldenmatch.core.ann_blocker import ANNBlocker  # lazy: keep import off the hot path
+
+        self._blocker = ANNBlocker(top_k=self._top_k)
+        if len(self._row_to_entity_id):
+            self._blocker.build_index(self._corpus)
+
+    @classmethod
+    def build(cls, entities, embedder, *, top_k: int = 50) -> EntityIndex:
+        """Filter to real entity nodes (typ not 'literal:*', non-empty name -- mirrors seed_by_query),
+        embed all names ONCE, L2-normalize, index. `top_k` = index capacity (max neighbors per query)."""
+        ids, names = [], []
+        for e in entities:
+            typ = str(e.get("typ", ""))
+            name = str(e.get("canonical_name", "")).strip()
+            if typ.startswith("literal:") or not name:
+                continue
+            ids.append(int(e["entity_id"]))
+            names.append(name)
+        if not names:
+            return cls(np.zeros((0, 1), dtype=np.float32), [], top_k, 1)
+        vecs = _l2(np.asarray(embedder.embed(names), dtype=np.float32))
+        return cls(vecs, ids, top_k, vecs.shape[1])
+
+    def query(self, query: str, embedder, *, k: int = 5) -> list[int]:
+        """Embed the QUERY only, ANN top-k, map rows->entity_ids. Requires k <= top_k.
+
+        NOTE (SP2 callers): the returned entity_ids are those of the graph slice the index was BUILT
+        from. entity_ids are slice-specific (see embed.py); do not reuse an index across a different
+        `as_of` slice or the ids may not resolve there."""
+        if k > self._top_k:
+            raise ValueError(f"k={k} exceeds index top_k={self._top_k}; rebuild with a larger top_k")
+        if not self._row_to_entity_id:
+            return []
+        q = _l2(np.asarray(embedder.embed([query]), dtype=np.float32)[0])
+        rows = self._blocker.query_one(q)   # [(row, score)] rank-ordered, capped at top_k
+        return [self._row_to_entity_id[r] for r, _ in rows[:k]]
+
+    def save(self, path: str) -> None:
+        """Backend-agnostic: np.save the (normalized) corpus + row_to_entity_id + a meta.json. NO
+        faiss.write_index -- EntityIndex owns the array, so load rebuilds the ANNBlocker from it."""
+        os.makedirs(path, exist_ok=True)
+        np.save(os.path.join(path, "corpus.npy"), self._corpus)
+        np.save(os.path.join(path, "row_to_entity_id.npy"),
+                np.asarray(self._row_to_entity_id, dtype=np.int64))
+        with open(os.path.join(path, "meta.json"), "w", encoding="utf-8") as fh:
+            json.dump({"top_k": self._top_k, "dim": self._dim}, fh)
+
+    @classmethod
+    def load(cls, path: str) -> EntityIndex:
+        corpus = np.load(os.path.join(path, "corpus.npy"))
+        ids = np.load(os.path.join(path, "row_to_entity_id.npy")).tolist()
+        with open(os.path.join(path, "meta.json"), encoding="utf-8") as fh:
+            meta = json.load(fh)
+        return cls(corpus, ids, meta["top_k"], meta["dim"])
+
+    def __len__(self) -> int:
+        return len(self._row_to_entity_id)

--- a/packages/python/goldengraph/tests/test_entity_index.py
+++ b/packages/python/goldengraph/tests/test_entity_index.py
@@ -1,0 +1,110 @@
+"""SP1 EntityIndex: embed-once ANN retrieval over entity names (box-safe, numpy fallback)."""
+from __future__ import annotations
+
+import goldenmatch.core.ann_blocker as _ab
+import numpy as np
+import pytest
+from goldengraph.entity_index import EntityIndex
+
+
+@pytest.fixture(autouse=True)
+def _force_numpy_fallback(monkeypatch):
+    # Hermetic: never depend on faiss being installed; numpy fallback gives the same neighbor set.
+    monkeypatch.setattr(_ab, "_HAS_FAISS", False)
+
+
+_VECS = {"apple": [1.0, 0.0, 0.0], "banana": [0.0, 1.0, 0.0], "cherry": [0.0, 0.0, 1.0]}
+
+
+class _StubEmbedder:
+    """Deterministic: known name -> its axis vector, unknown -> zero. Counts embed() calls."""
+    def __init__(self):
+        self.calls = 0
+
+    def embed(self, texts):
+        self.calls += 1
+        return np.array([_VECS.get(str(t).strip().lower(), [0.0, 0.0, 0.0]) for t in texts], dtype=float)
+
+
+def _ent(eid, name, typ="thing"):
+    return {"entity_id": eid, "canonical_name": name, "typ": typ}
+
+
+# --- Task 1: build + query ----------------------------------------------------------------------------
+def test_build_and_query_topk():
+    idx = EntityIndex.build([_ent(0, "apple"), _ent(1, "banana"), _ent(2, "cherry")], _StubEmbedder())
+    assert idx.query("banana", _StubEmbedder(), k=1) == [1]
+    assert idx.query("apple", _StubEmbedder(), k=1) == [0]
+
+
+def test_query_maps_rows_to_entity_ids():
+    idx = EntityIndex.build([_ent(5, "apple"), _ent(1, "banana"), _ent(99, "cherry")], _StubEmbedder())
+    assert idx.query("apple", _StubEmbedder(), k=1) == [5]
+    assert idx.query("cherry", _StubEmbedder(), k=1) == [99]
+
+
+def test_build_filters_literals_and_empty():
+    ents = [_ent(0, "apple"), _ent(1, "2024-01-01", typ="literal:date"), _ent(2, "  ")]
+    idx = EntityIndex.build(ents, _StubEmbedder())
+    assert len(idx) == 1
+    assert idx.query("apple", _StubEmbedder(), k=1) == [0]
+
+
+def test_query_embeds_query_only():
+    idx = EntityIndex.build([_ent(0, "apple"), _ent(1, "banana")], _StubEmbedder())
+    emb = _StubEmbedder()
+    idx.query("apple", emb, k=1)
+    assert emb.calls == 1                      # ONE embed (the query), NOT N -- the anti-regression
+    idx.query("banana", emb, k=1)
+    assert emb.calls == 2
+
+
+def test_query_rejects_k_above_capacity():
+    idx = EntityIndex.build([_ent(0, "apple")], _StubEmbedder(), top_k=50)
+    with pytest.raises(ValueError):
+        idx.query("apple", _StubEmbedder(), k=100)
+
+
+def test_empty_index_returns_empty():
+    idx = EntityIndex.build([_ent(0, "  ", typ="literal:x")], _StubEmbedder())
+    assert len(idx) == 0 and idx.query("apple", _StubEmbedder(), k=5) == []
+
+
+# --- Task 2: save / load ------------------------------------------------------------------------------
+def test_save_load_roundtrip(tmp_path):
+    ents = [_ent(5, "apple"), _ent(1, "banana"), _ent(99, "cherry")]
+    idx = EntityIndex.build(ents, _StubEmbedder())
+    idx.save(str(tmp_path / "idx"))
+    loaded = EntityIndex.load(str(tmp_path / "idx"))
+    assert len(loaded) == 3
+    assert loaded.query("cherry", _StubEmbedder(), k=1) == [99]
+
+
+# --- Task 3: seed_by_query seam -----------------------------------------------------------------------
+class _Graph:
+    def __init__(self, ents):
+        self._e = ents
+
+    def entities(self):
+        return self._e
+
+
+def test_seed_by_query_uses_index_when_given():
+    from goldengraph.embed import seed_by_query
+
+    ents = [_ent(0, "apple"), _ent(1, "banana")]
+    idx = EntityIndex.build(ents, _StubEmbedder())
+    emb = _StubEmbedder()
+    seeds = seed_by_query(_Graph(ents), "apple", emb, k=1, index=idx)
+    assert seeds == [0]
+    assert emb.calls == 1                      # ONLY the query embedded (via the index)
+
+
+def test_seed_by_query_none_preserves_current_path():
+    from goldengraph.embed import seed_by_query
+
+    ents = [_ent(0, "apple"), _ent(1, "banana")]
+    emb = _StubEmbedder()
+    seeds = seed_by_query(_Graph(ents), "apple", emb, k=1)   # index=None -> current re-embed path
+    assert seeds == [0]
+    assert emb.calls == 1                      # current path embeds [query]+names in ONE call


### PR DESCRIPTION
First of two prerequisites for testing goldengraph on a structure-load-bearing benchmark (STaRK). Fixes the actual at-scale retrieval blocker: `seed_by_query` re-embeds ALL N entity names on EVERY query (O(N) embedding calls) — infeasible at ~1M+ nodes.

## What
New `goldengraph/entity_index.py`:
- **`EntityIndex`** — embed every entity canonical-name **once**, own the L2-normalized array + `entity_id`↔row map, wrap goldenmatch's existing **`ANNBlocker`** (FAISS `IndexFlatIP` + numpy fallback — reuse, no new dep). `query(text)` embeds **only the query** → top-k entity_ids (`k <= top_k` contract). `save`/`load` are backend-agnostic `np.save` (no faiss internals) so SP2 never re-embeds a million names twice.
- **Retrieval seam** — `seed_by_query(..., index=None)` + `ask(..., entity_index=None)`: opt-in, fully back-compat (default `None` = today's re-embed path; only source caller is `answer.py:323`).

## Scope / honesty
- Flat FAISS for the feasibility spike (~ms/query at 1M; `IndexHNSWFlat` is a measured SP2 swap if latency demands). Embeddings sidecar — never in the Rust store's JSON boundary.
- 9 box-safe tests (numpy-fallback fixture → no faiss needed; stub embedders). The load-bearing one is `query_embeds_query_only` — the anti-regression proving each query embeds once, not N times. Back-compat verified (existing chain-retrieval tests green). ruff clean.

SP2 (next): `StoreBatch` bulk-loader for a pre-structured KB + STaRK-AMAZON adapter + Modal feasibility run (ingest/index-build time, query latency, RAM, flat-vs-HNSW verdict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)