### PR TITLE
feat(goldengraph): STaRK bulk-load + feasibility spike (SP2)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-goldengraph-stark-bulkload.md
+++ b/docs/superpowers/plans/2026-07-02-goldengraph-stark-bulkload.md
@@ -493,7 +493,7 @@ def load_stark_kb(name: str):
     """Return (nodes, edges, queries). `name` in {"prime","amazon","mag"}.
     nodes: list of (stark_id:str, name:str, typ:str).
     edges: list of (subj_stark_id:str, predicate:str, obj_stark_id:str).
-    queries: list of (query_text:str, gold_stark_ids:set[str]).
+    queries: list of (query_text:str, gold_stark_ids:set[int]).  # ints -- match index/entity_id
 
     Uses the `stark_qa` package (SKB loader + QA split) when available; that is the
     canonical STaRK data path. The node's display name is title/name if present else
@@ -513,7 +513,7 @@ def load_stark_kb(name: str):
         for (s, r, o) in skb.get_tuples()   # (head, relation, tail)
     ]
     qa = load_qa(name)
-    queries = [(row["query"], {str(a) for a in row["answer_ids"]}) for row in qa]
+    queries = [(row["query"], {int(a) for a in row["answer_ids"]}) for row in qa]
     return nodes, edges, queries
 ```
 
@@ -522,10 +522,14 @@ NOTE for the implementer: the exact `stark_qa` API names (`load_skb`, `get_tuple
 - [ ] **Step 2: Implement `evaluate` (one arm over the query set)**
 
 ```python
-def evaluate(index, slice_graph, eid_to_stark, queries, embedder, *, arm: str,
-             sample: int | None = None) -> dict:
-    """Run one retrieval arm over `queries`, translate view-local ids -> stark ids
-    via `eid_to_stark`, return mean metrics + timing. `arm` in {"dense","graph"}."""
+def evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, *,
+             arm: str, sample: int | None = None) -> dict:
+    """Run one retrieval arm over `queries`, return mean metrics + timing. `arm` in
+    {"dense","graph"}. The index returns STARK ids (entity_id=int(stark_id) at build
+    time), so Arm A needs no translation and covers ALL nodes. Arm B walks the STORE
+    (as_of().query -- the thing under test), translating stark<->slice-local ids only
+    at the walk boundary. `stark_to_eid`/`eid_to_stark` cover edge-endpoint nodes
+    only, which is exactly the set that has neighbors."""
     from erkgbench.stark_metrics import dedup_first_seen, mean_metrics, metrics
 
     qs = queries[:sample] if sample else queries
@@ -533,16 +537,16 @@ def evaluate(index, slice_graph, eid_to_stark, queries, embedder, *, arm: str,
     for text, gold in qs:
         t0 = time.perf_counter()
         if arm == "dense":
-            local_ids = index.query(text, embedder, k=20)
+            ranked = index.query(text, embedder, k=20)               # stark ids already
         elif arm == "graph":
-            seeds = index.query(text, embedder, k=5)
-            neigh = [e["entity_id"] for e in _neighbors(slice_graph, seeds)]
-            local_ids = dedup_first_seen([*seeds, *neigh])
+            seeds = index.query(text, embedder, k=5)                 # stark ids
+            seed_eids = [stark_to_eid[s] for s in seeds if s in stark_to_eid]
+            nbr = [eid_to_stark[e["entity_id"]] for e in _neighbors(slice_graph, seed_eids)]
+            ranked = dedup_first_seen([*seeds, *nbr])
         else:
             raise ValueError(f"unknown arm {arm!r}")
         latencies.append(time.perf_counter() - t0)
-        ranked = [eid_to_stark[i] for i in local_ids if i in eid_to_stark]
-        per_query.append(metrics(ranked, gold))
+        per_query.append(metrics(ranked, gold))                      # gold: int stark ids
     agg = mean_metrics(per_query)
     lat = sorted(latencies)
     agg["latency_ms_mean"] = 1000 * sum(lat) / (len(lat) or 1)
@@ -551,13 +555,14 @@ def evaluate(index, slice_graph, eid_to_stark, queries, embedder, *, arm: str,
     return agg
 
 
-def _neighbors(slice_graph, seeds):
-    """1-hop neighbor entity dicts of `seeds` on the slice. `query(ids, 1)` returns
-    {'entities':[...], 'edges':[...]}; the entities are seeds ++ their neighbors."""
-    if not seeds:
+def _neighbors(slice_graph, seed_eids):
+    """1-hop neighbor entity dicts of `seed_eids` (view-local ids) on the slice.
+    `query(ids, 1)` returns {'entities':[...], 'edges':[...]}; entities are the seeds
+    ++ their neighbors, so drop the seeds themselves."""
+    if not seed_eids:
         return []
-    res = slice_graph.query(list(seeds), 1)
-    seed_set = set(seeds)
+    res = slice_graph.query(list(seed_eids), 1)
+    seed_set = set(seed_eids)
     return [e for e in res["entities"] if e["entity_id"] not in seed_set]
 ```
 
@@ -580,12 +585,13 @@ git commit -m "feat(erkgbench): STaRK HF loader + dense/graph arm evaluator"
 The function (runs on the Modal box):
 1. `nodes, edges, queries = load_stark_kb(kb)`  # `kb` default "prime"
 2. `store = goldengraph_native._native.PyStore()`; time `bulk_load(store, nodes, edges)` → **ingest wall + peak RSS**. On MemoryError (single-batch OOM), re-run with `chunk_edges` and RECORD the node/edge count at the ceiling — that is a finding, not a silent fallback.
-3. `slice_graph = store.as_of(_BIG, _BIG)`
-4. `eid_to_stark = {e["entity_id"]: e["source_refs"][0] for e in slice_graph.entities() if e["source_refs"]}`
-5. `index = EntityIndex.build(slice_graph.entities(), embedder)` → **index-build wall + peak RSS**
-6. `dense = evaluate(index, slice_graph, eid_to_stark, queries, embedder, arm="dense", sample=N)`
-7. `graph = evaluate(..., arm="graph", sample=N)`
-8. Print a numbers table: `n_nodes / n_edges / n_dropped_edges / n_batches`, ingest wall, index-build wall, per-query mean+p95 latency, peak RSS, and the dense-vs-graph metric rows.
+3. **Index over ALL nodes (not the slice — isolated nodes must stay in the dense baseline):**
+   `index = EntityIndex.build([{"entity_id": int(sid), "canonical_name": name, "typ": typ} for sid, name, typ in nodes], embedder)` → **index-build wall + peak RSS**. `entity_id=int(stark_id)` so `query()` returns stark ids directly.
+4. `slice_graph = store.as_of(_BIG, _BIG)`  (for the Arm-B store walk only)
+5. `stark_to_eid = {int(e["source_refs"][0]): e["entity_id"] for e in slice_graph.entities() if e["source_refs"]}`; `eid_to_stark = {v: k for k, v in stark_to_eid.items()}`
+6. `dense = evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, arm="dense", sample=N)`
+7. `graph = evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, arm="graph", sample=N)`
+8. Print a numbers table: `n_nodes / n_edges / n_dropped_edges / n_batches`, count of ISOLATED nodes (`n_nodes - len(stark_to_eid)`, the honesty caveat), ingest wall, index-build wall, per-query mean+p95 latency, peak RSS, and the dense-vs-graph metric rows.
 
 Embedder: a real goldenmatch embedding provider (`GoldenmatchEmbedder("local")` or a GPU provider on the box). PRIME first with a query `sample` (e.g. 200) to keep the first run cheap.
 
@@ -623,3 +629,4 @@ git commit -m "feat(bench): Modal STaRK feasibility entry + PRIME verdict"
 - **The parity test (Task 3) is load-bearing:** chunked and single-batch MUST produce identical graph state, or the OOM fallback silently changes results. Do not weaken it.
 - **`stark_qa` accessor names may drift** by version — the mapping contract is fixed; confirm the exact attribute names against the installed package when building Task 5.
 - **OOM at single-batch AMAZON is an expected possible finding**, not a failure — record the ceiling and switch to `chunk_edges`.
+- **`as_of()` surfaces edge-endpoint nodes only** (store.rs:412-432) — isolated nodes vanish from `slice_graph.entities()`. This is WHY the index is built over the full `nodes` list (Task 6 step 3), not the slice: a slice-built index would silently drop isolated nodes from the dense baseline and understate Recall@20. The Task 2/3 tests use all-connected fixtures so their slice-based assertions are unaffected; report the isolated-node count in the Task-6 verdict so the numbers stay honest.

--- a/docs/superpowers/plans/2026-07-02-goldengraph-stark-bulkload.md
+++ b/docs/superpowers/plans/2026-07-02-goldengraph-stark-bulkload.md
@@ -1,0 +1,625 @@
+# STaRK bulk-load + feasibility spike (SP2) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Load a pre-structured STaRK KB straight into the goldengraph store (no LLM extraction), retrieve over it two ways (dense vs graph-expanded), and produce honest at-scale numbers (ingest/index time, per-query latency, RAM, Hit@k/Recall@20/MRR).
+
+**Architecture:** A pure `bulk_load` maps `(nodes, edges)` to a `StoreBatch` dict and calls `store.append` (single batch by default; chunked fallback for OOM). A STaRK adapter downloads the KB from HuggingFace and reimplements the 4 IR metrics. Retrieval runs over ONE `as_of` slice in view-local id space; a `source_refs`-carried `eid_to_stark` map translates results back to stark ids for scoring. A Modal entry runs the whole thing on a big box, PRIME first.
+
+**Tech Stack:** Python 3.12, `goldengraph_native.PyStore` (real store — its append/as_of semantics are under test), `goldengraph.entity_index.EntityIndex` (SP1, on main), numpy, HuggingFace `datasets`/`stark-qa` (adapter only), Modal (run only).
+
+**Spec:** `docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md`
+
+---
+
+## Ground truth confirmed before planning
+
+- `goldengraph_native.PyStore` LOADS on the box (methods `append`, `as_of`, `history`, `snapshot`) — so `bulk_load` tests use a REAL store, not a stub.
+- `store.append(json_str)` takes a JSON `StoreBatch`; `store.as_of(valid_t, tx_t)` returns a `PyGraph` with `.entities()` (dicts: `entity_id`, `canonical_name`, `typ`, `members`, `surface_names`, `source_refs`) and `.query(ids, hops)` (returns `{"entities":[...], "edges":[{subj,predicate,obj,source_refs}]}`).
+- `store.snapshot()` returns canonical JSON with an `entities`/`edges`/`history`/`next_id` shape — `json.loads(snap)["history"]` is the merge/split event list (empty ⇒ pure passthrough).
+- StoreBatch dict shape (from `ingest.py::build_batch`): top-level `entities`/`edges`/`ingested_at`; entity `local_id`/`canonical_name`/`typ`/`surface_names`/`record_keys`/`source_refs`; edge `subj_local`/`predicate`/`obj_local`/`valid_from`/`valid_to`/`source_refs`.
+- `EntityIndex.build(entities, embedder, *, top_k=50)` filters `literal:`-typed + empty-name rows; `query(query, embedder, *, k)` needs `k <= top_k`.
+
+## File structure
+
+- **Create** `packages/python/goldengraph/goldengraph/bulk.py` — the `bulk_load` mapper. One responsibility: `(nodes, edges)` → `StoreBatch` dict(s) → `store.append`. No STaRK, no HF, no retrieval.
+- **Modify** `packages/python/goldengraph/goldengraph/__init__.py` — export `bulk_load`.
+- **Create** `packages/python/goldengraph/tests/test_bulk_load.py` — real-`PyStore` TDD for the mapper + store semantics.
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_metrics.py` — the 4 pure IR metrics + Arm-B dedup helper.
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/tests/test_stark_metrics.py` — pure box-safe metric tests.
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py` — HF loader + `evaluate` arm runner (integration-only, not in box suite).
+- **Create** `scripts/distill/modal_stark.py` — the Modal feasibility entry (run-only).
+
+## Box-safe test runners
+
+goldengraph mapper tests (real PyStore, worktree goldenmatch shadow):
+```
+cd packages/python/goldengraph
+PYTHONPATH=/d/show_case/gg-local-llm/packages/python/goldenmatch POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_bulk_load.py -q
+```
+metrics tests (pure python):
+```
+cd packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD:/d/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_stark_metrics.py -q
+```
+
+Reference skills: @superpowers:test-driven-development, @superpowers:subagent-driven-development. Auth/commit rules: benzsevern account (`unset GH_TOKEN` before push), squash-merge SOP, arm auto-merge and STOP.
+
+---
+
+## Task 1: `bulk_load` — nodes/edges → StoreBatch → store.append (single batch)
+
+**Files:**
+- Create: `packages/python/goldengraph/goldengraph/bulk.py`
+- Test: `packages/python/goldengraph/tests/test_bulk_load.py`
+
+- [ ] **Step 1: Write the failing test — single-batch load stores every node with its stark_id as a record_key**
+
+```python
+"""SP2 bulk_load: pre-structured KB -> StoreBatch -> real PyStore. Exercises the
+store's append/as_of semantics directly (that IS what is under test), so it needs
+goldengraph_native; skip cleanly if the wheel is absent."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+ggn = pytest.importorskip("goldengraph_native")
+from goldengraph.bulk import bulk_load  # noqa: E402
+
+_BIG = 1 << 62
+
+
+def _store():
+    from goldengraph_native import _native as gg
+    return gg.PyStore()
+
+
+# stark ids are strings; names/types are plain; one triangle A-B, A-C
+_NODES = [("s10", "Alice", "person"), ("s20", "Acme", "org"), ("s30", "Bob", "person")]
+_EDGES = [("s10", "works_at", "s20"), ("s10", "knows", "s30")]
+
+
+def test_single_batch_stores_all_nodes_with_stark_record_keys():
+    store = _store()
+    out = bulk_load(store, _NODES, _EDGES)
+    assert out == {"n_nodes": 3, "n_edges": 2, "n_dropped_edges": 0, "n_batches": 1}
+    snap = json.loads(store.snapshot())
+    # every node present, keyed by its stark id
+    keys = {tuple(e["record_keys"]) for e in snap["entities"].values()}
+    assert keys == {("s10",), ("s20",), ("s30",)}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the goldengraph box-safe runner above.
+Expected: FAIL — `ModuleNotFoundError: No module named 'goldengraph.bulk'` (or import error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""SP2: load a PRE-STRUCTURED knowledge base straight into the store, bypassing
+extract/resolve/link. STaRK-style KBs come with canonical node ids already, so
+each node's id IS its resolution: a unique `record_key` per node means the store's
+overlap-merge mints a fresh stable id for each with zero merges (see
+goldengraph-core/src/store.rs::append). Edges are co-batched with their endpoints
+because the store panics on an edge whose endpoint is absent from the same batch.
+See docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+
+def _entity(local_id: int, stark_id: str, name: str, typ: str) -> dict:
+    # record_keys=[stark_id] -> unique -> passthrough (no merge). source_refs=[stark_id]
+    # -> the stark id rides through as_of so retrieval can translate view-local ids back.
+    return {
+        "local_id": local_id,
+        "canonical_name": name,
+        "typ": typ,
+        "surface_names": [name],
+        "record_keys": [stark_id],
+        "source_refs": [stark_id],
+    }
+
+
+def _edge(subj_local: int, predicate: str, obj_local: int, at: int) -> dict:
+    return {
+        "subj_local": subj_local,
+        "predicate": predicate,
+        "obj_local": obj_local,
+        "valid_from": at,
+        "valid_to": None,
+        "source_refs": [],
+    }
+
+
+def bulk_load(store, nodes: Iterable, edges: Iterable, *, at: int = 1, chunk_edges: int | None = None) -> dict:
+    """Load `(nodes, edges)` into `store`. `nodes`: iterable of (stark_id, name, typ);
+    `edges`: iterable of (subj_stark_id, predicate, obj_stark_id). Returns
+    {n_nodes, n_edges, n_dropped_edges, n_batches}. See module docstring / spec."""
+    node_list = list(nodes)
+    id_to_local: dict[str, int] = {}
+    entities: list[dict] = []
+    for i, (stark_id, name, typ) in enumerate(node_list):
+        id_to_local[str(stark_id)] = i
+        entities.append(_entity(i, str(stark_id), name, typ))
+
+    edge_dicts: list[dict] = []
+    dropped = 0
+    for subj, predicate, obj in edges:
+        s = id_to_local.get(str(subj))
+        o = id_to_local.get(str(obj))
+        if s is None or o is None:
+            dropped += 1
+            continue
+        edge_dicts.append(_edge(s, predicate, o, at))
+
+    n_batches = _append_single(store, entities, edge_dicts, at)
+    return {
+        "n_nodes": len(entities),
+        "n_edges": len(edge_dicts),
+        "n_dropped_edges": dropped,
+        "n_batches": n_batches,
+    }
+
+
+def _append_single(store, entities: list[dict], edges: list[dict], at: int) -> int:
+    store.append(json.dumps({"entities": entities, "edges": edges, "ingested_at": at}))
+    return 1
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the goldengraph box-safe runner.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /d/show_case/gg-local-llm && unset GH_TOKEN
+git add packages/python/goldengraph/goldengraph/bulk.py packages/python/goldengraph/tests/test_bulk_load.py
+git commit -m "feat(goldengraph): bulk_load nodes+edges -> StoreBatch (single batch)"
+```
+
+---
+
+## Task 2: `bulk_load` — edges remap to correct stable-id pairs, passthrough, provenance
+
+**Files:**
+- Modify: `packages/python/goldengraph/tests/test_bulk_load.py`
+
+- [ ] **Step 1: Write the failing tests — edges land on the right entities, zero history, stark_id rides through**
+
+```python
+def _by_name(slice_graph):
+    return {e["canonical_name"]: e for e in slice_graph.entities()}
+
+
+def test_edges_remap_to_right_entity_pairs():
+    store = _store()
+    bulk_load(store, _NODES, _EDGES)
+    g = store.as_of(_BIG, _BIG)
+    ents = _by_name(g)
+    eid = {name: e["entity_id"] for name, e in ents.items()}
+    edges = {(e["subj"], e["predicate"], e["obj"]) for e in g.query(list(eid.values()), 1)["edges"]}
+    assert (eid["Alice"], "works_at", eid["Acme"]) in edges
+    assert (eid["Alice"], "knows", eid["Bob"]) in edges
+
+
+def test_passthrough_no_merges_or_splits():
+    store = _store()
+    bulk_load(store, _NODES, _EDGES)
+    assert json.loads(store.snapshot())["history"] == []   # distinct keys -> zero HistoryEvent
+
+
+def test_stark_id_rides_through_as_of():
+    # eid_to_stark (the Arm-B translation map) must be recoverable from the slice.
+    store = _store()
+    bulk_load(store, _NODES, _EDGES)
+    g = store.as_of(_BIG, _BIG)
+    for e in g.entities():
+        assert e["source_refs"] == [ {"Alice": "s10", "Acme": "s20", "Bob": "s30"}[e["canonical_name"]] ]
+
+
+def test_dangling_edge_dropped_and_counted():
+    store = _store()
+    out = bulk_load(store, _NODES, [("s10", "works_at", "s99")])  # s99 unknown
+    assert out["n_edges"] == 0 and out["n_dropped_edges"] == 1
+    # no edge landed
+    g = store.as_of(_BIG, _BIG)
+    assert g.query([e["entity_id"] for e in g.entities()], 1)["edges"] == []
+```
+
+- [ ] **Step 2: Run to verify they fail (or pass) against Task 1's implementation**
+
+Run the goldengraph box-safe runner.
+Expected: these should PASS with the Task 1 implementation (this task is the semantics lock — if any FAIL, the implementation is wrong, fix it, don't weaken the test). Note `store.as_of` uses `_BIG` for BOTH axes so all facts/entities are visible.
+
+- [ ] **Step 3: (only if a test failed) fix `bulk.py`**
+
+No new code expected. If `test_stark_id_rides_through_as_of` fails, verify `_entity` sets `source_refs=[stark_id]`. If edges are missing, verify endpoints are co-batched (they are, single batch).
+
+- [ ] **Step 4: Re-run — all green**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldengraph/tests/test_bulk_load.py
+git commit -m "test(goldengraph): lock bulk_load edge-remap, passthrough, provenance"
+```
+
+---
+
+## Task 3: `bulk_load` — chunked-edges fallback with store-state parity
+
+**Files:**
+- Modify: `packages/python/goldengraph/goldengraph/bulk.py`
+- Modify: `packages/python/goldengraph/tests/test_bulk_load.py`
+
+- [ ] **Step 1: Write the failing tests — chunked load yields the SAME store state, edge co-batching does not panic**
+
+```python
+def _canonical_state(store):
+    """Order-independent (entities, edges) view for parity comparison across batchings."""
+    g = store.as_of(_BIG, _BIG)
+    ents = {tuple(e["source_refs"]): (e["canonical_name"], e["typ"]) for e in g.entities()}
+    eid_to_stark = {e["entity_id"]: e["source_refs"][0] for e in g.entities()}
+    edges = sorted(
+        (eid_to_stark[e["subj"]], e["predicate"], eid_to_stark[e["obj"]])
+        for e in g.query(list(eid_to_stark), 1)["edges"]
+    )
+    return ents, edges
+
+
+def test_chunked_matches_single_batch_state():
+    a, b = _store(), _store()
+    out_single = bulk_load(a, _NODES, _EDGES)
+    out_chunk = bulk_load(b, _NODES, _EDGES, chunk_edges=1)   # 1 edge per batch
+    assert _canonical_state(a) == _canonical_state(b)          # identical final graph
+    assert out_chunk["n_batches"] == 1 + 2                     # nodes batch + 2 edge batches
+    assert out_single["n_batches"] == 1
+
+
+def test_chunked_edge_relists_endpoints_without_panic():
+    # The whole risk of chunking: an edge batch must re-list its endpoint entities or
+    # store.append panics on the missing local id. This asserts it lands the edge.
+    store = _store()
+    bulk_load(store, _NODES, _EDGES, chunk_edges=1)
+    g = store.as_of(_BIG, _BIG)
+    assert len(g.query([e["entity_id"] for e in g.entities()], 1)["edges"]) == 2
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run the goldengraph box-safe runner.
+Expected: FAIL — `chunk_edges` currently ignored (single batch), so `n_batches` is 1 not 3 (and, if the naive path were used, a KeyError/panic on missing endpoints).
+
+- [ ] **Step 3: Implement the chunked path**
+
+Add to `bulk.py` and route `bulk_load` through it when `chunk_edges` is set:
+
+```python
+def bulk_load(store, nodes, edges, *, at=1, chunk_edges=None):
+    # ... (unchanged node/edge building above) ...
+    if chunk_edges is None:
+        n_batches = _append_single(store, entities, edge_dicts, at)
+    else:
+        n_batches = _append_chunked(store, entities, edge_dicts, at, chunk_edges)
+    return {"n_nodes": len(entities), "n_edges": len(edge_dicts),
+            "n_dropped_edges": dropped, "n_batches": n_batches}
+
+
+def _append_chunked(store, entities: list[dict], edges: list[dict], at: int, chunk: int) -> int:
+    """Initial nodes-ONLY batch mints every stable id; then edge batches, each
+    re-listing ONLY the endpoint entities it references so the store's overlap-merge
+    (record_keys=[stark_id]) re-resolves them to the already-minted id (single
+    inheritor -> no merge, no new mint). Bounds peak JSON size vs one giant batch."""
+    if chunk < 1:
+        raise ValueError(f"chunk_edges must be >= 1, got {chunk}")
+    by_local = {e["local_id"]: e for e in entities}
+    store.append(json.dumps({"entities": entities, "edges": [], "ingested_at": at}))
+    n_batches = 1
+    for start in range(0, len(edges), chunk):
+        window = edges[start:start + chunk]
+        needed = {e["subj_local"] for e in window} | {e["obj_local"] for e in window}
+        batch_entities = [by_local[lid] for lid in sorted(needed)]
+        store.append(json.dumps({"entities": batch_entities, "edges": window, "ingested_at": at}))
+        n_batches += 1
+    return n_batches
+```
+
+- [ ] **Step 4: Run — all green (parity holds)**
+
+Run the goldengraph box-safe runner. Expected: PASS. The parity test is the load-bearing guard: chunked and single-batch must produce byte-equivalent graph state.
+
+- [ ] **Step 5: Export `bulk_load` and commit**
+
+Add to `packages/python/goldengraph/goldengraph/__init__.py`: `from .bulk import bulk_load` and add `"bulk_load"` to `__all__`.
+
+```bash
+git add packages/python/goldengraph/goldengraph/bulk.py packages/python/goldengraph/goldengraph/__init__.py packages/python/goldengraph/tests/test_bulk_load.py
+git commit -m "feat(goldengraph): bulk_load chunked-edges fallback (OOM escape), export"
+```
+
+---
+
+## Task 4: STaRK IR metrics (pure, box-safe)
+
+**Files:**
+- Create: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_metrics.py`
+- Create: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/tests/test_stark_metrics.py`
+
+- [ ] **Step 1: Write the failing tests — hand-worked rankings**
+
+```python
+"""SP2 STaRK IR metrics + Arm-B dedup: pure, no store/HF/Modal. Box-safe."""
+from erkgbench.stark_metrics import dedup_first_seen, metrics
+
+
+def test_hit_at_1_gold_in_first_position():
+    m = metrics(ranked_ids=[7, 3, 9], gold_ids={7})
+    assert m["hit@1"] == 1.0 and m["hit@5"] == 1.0
+    assert m["mrr"] == 1.0 and m["recall@20"] == 1.0
+
+
+def test_hit_at_5_not_at_1():
+    m = metrics(ranked_ids=[1, 2, 3, 4, 7], gold_ids={7})
+    assert m["hit@1"] == 0.0 and m["hit@5"] == 1.0
+    assert m["mrr"] == 1 / 5
+
+
+def test_gold_absent():
+    m = metrics(ranked_ids=[1, 2, 3], gold_ids={7})
+    assert m == {"hit@1": 0.0, "hit@5": 0.0, "recall@20": 0.0, "mrr": 0.0}
+
+
+def test_multi_gold_recall_partial():
+    # 2 of 3 gold in the top-20
+    m = metrics(ranked_ids=[10, 11, 99], gold_ids={10, 11, 42})
+    assert m["recall@20"] == 2 / 3
+    assert m["hit@1"] == 1.0 and m["mrr"] == 1.0
+
+
+def test_zero_gold_recall_is_none_sentinel():
+    # A query with no gold answers must NOT contribute to the recall mean.
+    m = metrics(ranked_ids=[1, 2], gold_ids=set())
+    assert m["recall@20"] is None      # caller skips None from the recall mean
+    assert m["hit@1"] == 0.0 and m["mrr"] == 0.0
+
+
+def test_dedup_first_seen_preserves_order_and_drops_repeats():
+    assert dedup_first_seen([5, 3, 5, 9, 3]) == [5, 3, 9]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run the metrics box-safe runner.
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement**
+
+```python
+"""Standard IR metrics for the STaRK retrieval spike. Definitions match STaRK
+(arXiv 2404.13207): Hit@k, Recall@20, MRR over a single query's ranked id list
+against its gold answer id set. Reimplemented (not STaRK's harness) -- ~30 lines,
+no dependency or retriever-API coupling. `recall@20` returns None on a zero-gold
+query so the caller can EXCLUDE it from the recall mean (never divide by zero)."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+_RECALL_K = 20
+
+
+def dedup_first_seen(ids: Iterable[int]) -> list[int]:
+    """De-duplicate preserving first-seen order (Arm-B ranks seeds ++ neighbors;
+    an undeduped repeat can push a distinct gold id past position 20)."""
+    seen: set[int] = set()
+    out: list[int] = []
+    for i in ids:
+        if i not in seen:
+            seen.add(i)
+            out.append(i)
+    return out
+
+
+def metrics(ranked_ids: list[int], gold_ids: set[int]) -> dict:
+    """One query's metrics. `ranked_ids`: rank-ordered retrieved ids (assumed already
+    deduped by the caller). `gold_ids`: the answer set."""
+    gold = set(gold_ids)
+    hit1 = 1.0 if ranked_ids[:1] and ranked_ids[0] in gold else 0.0
+    hit5 = 1.0 if gold & set(ranked_ids[:5]) else 0.0
+    mrr = 0.0
+    for rank, i in enumerate(ranked_ids, start=1):
+        if i in gold:
+            mrr = 1.0 / rank
+            break
+    recall = None if not gold else len(gold & set(ranked_ids[:_RECALL_K])) / len(gold)
+    return {"hit@1": hit1, "hit@5": hit5, "recall@20": recall, "mrr": mrr}
+
+
+def mean_metrics(per_query: list[dict]) -> dict:
+    """Aggregate per-query dicts. Recall averages only over non-None (has-gold)
+    queries; the rest average over all queries."""
+    n = len(per_query) or 1
+    rec = [m["recall@20"] for m in per_query if m["recall@20"] is not None]
+    return {
+        "hit@1": sum(m["hit@1"] for m in per_query) / n,
+        "hit@5": sum(m["hit@5"] for m in per_query) / n,
+        "mrr": sum(m["mrr"] for m in per_query) / n,
+        "recall@20": (sum(rec) / len(rec)) if rec else 0.0,
+        "n_queries": len(per_query),
+        "n_with_gold": len(rec),
+    }
+```
+
+- [ ] **Step 4: Run — all green** (create `erkgbench/tests/__init__.py` if the package needs it; mirror the existing tests dir layout).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_metrics.py packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/tests/test_stark_metrics.py
+git commit -m "feat(erkgbench): STaRK IR metrics (hit@k/recall@20/mrr) + arm-B dedup"
+```
+
+---
+
+## Task 5: STaRK adapter — HF loader + arm runner (integration-only)
+
+**Files:**
+- Create: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py`
+
+Not box-TDD'd (needs the HF download + a built native store + an embedder). Build it to a clear interface; it is exercised by the Modal run (Task 6). Keep the pure pieces (metrics, dedup) in Task 4 so they ARE tested.
+
+- [ ] **Step 1: Implement `load_stark_kb`**
+
+```python
+"""STaRK KB adapter: download a STaRK semi-structured KB from HuggingFace and map
+it to goldengraph's (nodes, edges) + a query set. Integration surface -- the pure
+metrics live in stark_metrics.py (box-tested). See the spec for the id-space model.
+"""
+from __future__ import annotations
+
+import time
+
+
+def load_stark_kb(name: str):
+    """Return (nodes, edges, queries). `name` in {"prime","amazon","mag"}.
+    nodes: list of (stark_id:str, name:str, typ:str).
+    edges: list of (subj_stark_id:str, predicate:str, obj_stark_id:str).
+    queries: list of (query_text:str, gold_stark_ids:set[str]).
+
+    Uses the `stark_qa` package (SKB loader + QA split) when available; that is the
+    canonical STaRK data path. The node's display name is title/name if present else
+    the first line of its text; typ is the STaRK node_type. Stark integer ids are
+    stringified so they slot straight into record_keys."""
+    from stark_qa import load_qa
+    from stark_qa.skb import load_skb
+
+    skb = load_skb(name)
+    nodes = []
+    for nid in skb.node_ids:
+        info = skb.get_node_info(nid)
+        display = str(info.get("name") or info.get("title") or "").strip()
+        nodes.append((str(nid), display, str(skb.node_type_dict[skb.node_types[nid]])))
+    edges = [
+        (str(s), str(skb.edge_type_dict[r]), str(o))
+        for (s, r, o) in skb.get_tuples()   # (head, relation, tail)
+    ]
+    qa = load_qa(name)
+    queries = [(row["query"], {str(a) for a in row["answer_ids"]}) for row in qa]
+    return nodes, edges, queries
+```
+
+NOTE for the implementer: the exact `stark_qa` API names (`load_skb`, `get_tuples`, `answer_ids`) must be confirmed against the installed package version at build time via `stark_qa`'s README/source — adapt the attribute names if they differ. The mapping CONTRACT (what each field must contain) is fixed; the accessor names are the only thing that may drift.
+
+- [ ] **Step 2: Implement `evaluate` (one arm over the query set)**
+
+```python
+def evaluate(index, slice_graph, eid_to_stark, queries, embedder, *, arm: str,
+             sample: int | None = None) -> dict:
+    """Run one retrieval arm over `queries`, translate view-local ids -> stark ids
+    via `eid_to_stark`, return mean metrics + timing. `arm` in {"dense","graph"}."""
+    from erkgbench.stark_metrics import dedup_first_seen, mean_metrics, metrics
+
+    qs = queries[:sample] if sample else queries
+    per_query, latencies = [], []
+    for text, gold in qs:
+        t0 = time.perf_counter()
+        if arm == "dense":
+            local_ids = index.query(text, embedder, k=20)
+        elif arm == "graph":
+            seeds = index.query(text, embedder, k=5)
+            neigh = [e["entity_id"] for e in _neighbors(slice_graph, seeds)]
+            local_ids = dedup_first_seen([*seeds, *neigh])
+        else:
+            raise ValueError(f"unknown arm {arm!r}")
+        latencies.append(time.perf_counter() - t0)
+        ranked = [eid_to_stark[i] for i in local_ids if i in eid_to_stark]
+        per_query.append(metrics(ranked, gold))
+    agg = mean_metrics(per_query)
+    lat = sorted(latencies)
+    agg["latency_ms_mean"] = 1000 * sum(lat) / (len(lat) or 1)
+    agg["latency_ms_p95"] = 1000 * lat[int(0.95 * (len(lat) - 1))] if lat else 0.0
+    agg["arm"] = arm
+    return agg
+
+
+def _neighbors(slice_graph, seeds):
+    """1-hop neighbor entity dicts of `seeds` on the slice. `query(ids, 1)` returns
+    {'entities':[...], 'edges':[...]}; the entities are seeds ++ their neighbors."""
+    if not seeds:
+        return []
+    res = slice_graph.query(list(seeds), 1)
+    seed_set = set(seeds)
+    return [e for e in res["entities"] if e["entity_id"] not in seed_set]
+```
+
+- [ ] **Step 3: Commit** (no box test — integration surface)
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
+git commit -m "feat(erkgbench): STaRK HF loader + dense/graph arm evaluator"
+```
+
+---
+
+## Task 6: Modal feasibility entry (run-only)
+
+**Files:**
+- Create: `scripts/distill/modal_stark.py` (model on `scripts/distill/modal_bench.py` — same `modal.App`, image with rust/maturin + `stark_qa` + the two packages, a cache Volume for the HF download, a `resource`/`tracemalloc` RSS sample).
+
+- [ ] **Step 1: Implement the entry**
+
+The function (runs on the Modal box):
+1. `nodes, edges, queries = load_stark_kb(kb)`  # `kb` default "prime"
+2. `store = goldengraph_native._native.PyStore()`; time `bulk_load(store, nodes, edges)` → **ingest wall + peak RSS**. On MemoryError (single-batch OOM), re-run with `chunk_edges` and RECORD the node/edge count at the ceiling — that is a finding, not a silent fallback.
+3. `slice_graph = store.as_of(_BIG, _BIG)`
+4. `eid_to_stark = {e["entity_id"]: e["source_refs"][0] for e in slice_graph.entities() if e["source_refs"]}`
+5. `index = EntityIndex.build(slice_graph.entities(), embedder)` → **index-build wall + peak RSS**
+6. `dense = evaluate(index, slice_graph, eid_to_stark, queries, embedder, arm="dense", sample=N)`
+7. `graph = evaluate(..., arm="graph", sample=N)`
+8. Print a numbers table: `n_nodes / n_edges / n_dropped_edges / n_batches`, ingest wall, index-build wall, per-query mean+p95 latency, peak RSS, and the dense-vs-graph metric rows.
+
+Embedder: a real goldenmatch embedding provider (`GoldenmatchEmbedder("local")` or a GPU provider on the box). PRIME first with a query `sample` (e.g. 200) to keep the first run cheap.
+
+- [ ] **Step 2: Run PRIME on Modal** (do NOT run in the box)
+
+Creds from Infisical dev project (never in literals):
+```
+P=a99885f0-c5af-4ae1-9dc8-255cc60aa129
+export MODAL_TOKEN_ID=$(infisical.cmd secrets get MODAL_TOKEN_ID --projectId $P --env dev --plain)
+export MODAL_TOKEN_SECRET=$(infisical.cmd secrets get MODAL_TOKEN_SECRET --projectId $P --env dev --plain)
+modal run --detach scripts/distill/modal_stark.py --kb prime --sample 200
+```
+`--detach` so it survives disconnect; poll status, don't foreground-loop.
+
+- [ ] **Step 3: Record the numbers** in a verdict report `docs/superpowers/reports/2026-07-02-stark-prime-feasibility.md` (ingest/index/latency/RAM + dense-vs-graph table + the honest verdict: did it run at PRIME scale, does the graph arm beat dense). AMAZON is the same entry `--kb amazon` ONLY if PRIME is clean.
+
+- [ ] **Step 4: Commit** the entry + report.
+
+```bash
+git add scripts/distill/modal_stark.py docs/superpowers/reports/2026-07-02-stark-prime-feasibility.md
+git commit -m "feat(bench): Modal STaRK feasibility entry + PRIME verdict"
+```
+
+---
+
+## Wrap-up
+
+- [ ] Push branch, open PR against main, arm `gh pr merge --auto --squash`, STOP (no CI poll loop). Auth: `GH_TOKEN=$(gh auth token --user benzsevern)` for `gh pr create`, `unset GH_TOKEN` before push.
+- [ ] Update memory `project_stark_retrieval_scale.md`: SP2 shipped, the PRIME numbers, the flat-vs-HNSW verdict, any OOM ceiling found.
+- [ ] Doc surfaces: `bulk_load` is a new public goldengraph export — sweep per @feedback_rollout_docs_sweep at PR time.
+
+## Notes / risks
+
+- **Metrics tests and mapper tests are the only box-TDD'd units.** The adapter + Modal entry are integration surfaces validated by the actual PRIME run — that is deliberate (the whole point is the at-scale numbers, which can't be produced on the box).
+- **The parity test (Task 3) is load-bearing:** chunked and single-batch MUST produce identical graph state, or the OOM fallback silently changes results. Do not weaken it.
+- **`stark_qa` accessor names may drift** by version — the mapping contract is fixed; confirm the exact attribute names against the installed package when building Task 5.
+- **OOM at single-batch AMAZON is an expected possible finding**, not a failure — record the ceiling and switch to `chunk_edges`.

--- a/docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md
@@ -94,47 +94,54 @@ so `append`'s overlap-merge re-resolves them to the id minted in the node batch
   - Hit@k = 1 if any gold id in the top-k, else 0 (mean over queries).
   - Recall@20 = |gold ∩ top-20| / |gold|.
   - MRR = 1 / rank of the first gold id (0 if none in the ranking).
-- `evaluate(index, slice_graph, eid_to_stark, queries, embedder, *, arm)` runs one
-  retrieval arm over the query set, translates each arm's view-local ids back to
-  stark ids via `eid_to_stark`, and returns the mean metric dict + timing.
+- `evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, *, arm)`
+  runs one retrieval arm over the query set and returns the mean metric dict +
+  timing. Arm A (dense) works directly in stark-id space (the index returns stark
+  ids); Arm B (graph) translates stark->slice-local at the walk boundary and back
+  (see §3).
 
-Node ids in STaRK are integers; the adapter stringifies them for `record_keys` /
-`source_refs`. The retrieval id space is NOT the stark id (see §3) -- it is the
-`as_of` slice's view-local `EntityId`, and a single `eid_to_stark` map recovered
-from the slice translates both arms' outputs to stark ids for scoring.
+Node ids in STaRK are integers; the adapter keeps them as ints for `entity_id` and
+gold, and stringifies them for `record_keys` / `source_refs` (opaque store keys).
 
 ### 3. Retrieval arms + measurement — driven from the adapter / a Modal entry
 
-**Id spaces (the correction that makes Arm B runnable).** There are THREE:
-the stark id (gold answers), the store's minted `StableId`, and the per-slice
+**Id spaces + the isolated-node honesty fix.** There are THREE id spaces: the
+stark id (gold answers, ints), the store's minted `StableId`, and the per-slice
 **view-local `EntityId`** that `as_of` assigns in ascending `StableId` order
-(store.rs:426-432; `embed.py::query` warns ids are slice-specific). Graph
-expansion (`as_of().query(seeds,1)`) only works in the view-local space, so the
-index MUST be built in that space, not on stark ids.
+(store.rs:426-432; `embed.py::query` warns ids are slice-specific). Critically,
+`as_of` builds its entity set from resolved EDGE ENDPOINTS only (store.rs:412-432)
+-- an **isolated** node (no edges) is absent from `slice_graph.entities()`. So the
+index MUST NOT be built from the slice: that would silently drop every isolated
+node from even the dense baseline, handicapping Arm A vs a real dense retriever and
+understating Recall@20 for isolated-node gold answers. A spike that cripples its
+own baseline is dishonest.
 
-Take ONE slice `slice_graph = store.as_of(BIG, BIG)`. Build `EntityIndex` over
-`slice_graph.entities()` (so `entity_id` = view-local `EntityId`,
-`canonical_name` = node name). Build `eid_to_stark = {e["entity_id"]:
-e["source_refs"][0] for e in slice_graph.entities() if e["source_refs"]}` from the
-SAME slice -- the stark id rides through on `source_refs` (lib.rs:79-80 exposes it;
-the loader stamps `source_refs=[stark_id]`). The map spans the FULL slice (a
-superset of the index's rows, which drop literal/empty-name nodes) so Arm B
-neighbors that are stored-but-unindexed still translate. The `if e["source_refs"]`
-guard keeps it robust to a source-ref-less node (a retrieved id with no mapping is
-simply skipped from the ranked list, never an `IndexError`). Both arms retrieve view-local ids and map to
-stark ids via `eid_to_stark` before `metrics(...)`.
+**Build the index over the FULL node list** (all N nodes, not the slice), with
+`entity_id = int(stark_id)` and `canonical_name = node name`. Then
+`index.query(...)` returns stark ids directly -- Arm A needs no translation and
+covers every node. Arm B still walks the **store** (the thing under test),
+translating only at the walk boundary:
 
-- **Arm A — dense baseline:** `index.query(q, embedder, k=20)` -> view-local ids
-  -> `eid_to_stark` -> compare gold. Pure vector retrieval; the graph contributes
+- `slice_graph = store.as_of(BIG, BIG)` (one slice).
+- `stark_to_eid = {int(e["source_refs"][0]): e["entity_id"] for e in slice_graph.entities() if e["source_refs"]}` and its inverse
+  `eid_to_stark = {v: k for k, v in stark_to_eid.items()}` (stark id rides through
+  on `source_refs`; lib.rs:79-80 exposes it; the loader stamps
+  `source_refs=[stark_id]`). These cover only edge-endpoint nodes -- exactly the
+  nodes that HAVE neighbors, which is all Arm B needs.
+
+- **Arm A — dense baseline:** `index.query(q, embedder, k=20)` -> stark ids ->
+  compare gold. Pure vector retrieval over ALL nodes; the graph contributes
   nothing. The "vectors alone" number.
-- **Arm B — graph-expanded:** `seeds = index.query(q, embedder, k=5)` (view-local),
-  then 1-hop expansion `slice_graph.query(seeds, 1)` on the SAME slice; rank
-  `seeds ++ neighbors` **deduped preserving first-seen order** (a neighbor equal to
-  a seed must not occupy a second rank slot -- an undeduped duplicate can push a
-  distinct gold id past position 20 and understate Recall@20), map via
-  `eid_to_stark`, compare gold. This is the graph's value-add -- answers reachable
-  by a relation but not textually near the query. (Equivalent to
-  `ask(entity_index=index)`, which already seeds + walks one slice.)
+- **Arm B — graph-expanded:** `seeds = index.query(q, embedder, k=5)` (stark ids);
+  `seed_eids = [stark_to_eid[s] for s in seeds if s in stark_to_eid]` (an isolated
+  seed has no slice eid -> no neighbors, correctly); 1-hop expansion
+  `slice_graph.query(seed_eids, 1)` on the store; neighbor eids -> stark via
+  `eid_to_stark`; rank `seeds ++ neighbor_stark_ids` **deduped preserving
+  first-seen order** (a neighbor equal to a seed must not occupy a second rank slot
+  -- an undeduped duplicate can push a distinct gold id past position 20 and
+  understate Recall@20); compare gold. This is the graph's value-add -- answers
+  reachable by a relation but not textually near the query, retrieved THROUGH the
+  store's `as_of`+`query`.
 
 Captured per run: ingest wall, `EntityIndex.build` wall, mean/95p per-query
 latency, peak RSS (via `resource`/`tracemalloc` or a Modal memory sample), and
@@ -156,14 +163,17 @@ PRIME first; AMAZON is the same entry with `--kb amazon` once PRIME is clean.
 STaRK HF download
   -> load_stark_kb(name) -> (nodes, edges, queries)
   -> bulk_load(store, nodes, edges)         # StoreBatch -> store.append  [MEASURE ingest, RAM]
-  -> slice_graph = store.as_of(BIG, BIG)    # one view-local id space
-  -> eid_to_stark = {e["entity_id"]: e["source_refs"][0] for e in slice_graph.entities()}
-  -> index = EntityIndex.build(slice_graph.entities(), embedder)  # embed names once [MEASURE build, RAM]
+  -> index = EntityIndex.build([{entity_id:int(sid),canonical_name:name,typ} for ALL nodes], embedder)  # [MEASURE build, RAM]
+  -> slice_graph = store.as_of(BIG, BIG)    # for the Arm-B store walk
+  -> stark_to_eid = {int(e["source_refs"][0]): e["entity_id"] for e in slice_graph.entities() if e["source_refs"]}
+     eid_to_stark = {v: k for k, v in stark_to_eid.items()}
   -> for q in queries:                                             [MEASURE latency]
-       Arm A: ids = index.query(q, embedder, k=20)
-       Arm B: seeds = index.query(q, embedder, k=5); ids = seeds ++ slice_graph.query(seeds,1) neighbors
-       ranked_stark = [eid_to_stark[i] for i in ids]
-       metrics(ranked_stark, gold) per arm
+       Arm A (dense): ranked = index.query(q, embedder, k=20)                 # stark ids already
+       Arm B (graph): seeds = index.query(q, embedder, k=5)
+                      seed_eids = [stark_to_eid[s] for s in seeds if s in stark_to_eid]
+                      nbr = [eid_to_stark[e["entity_id"]] for e in slice_graph.query(seed_eids,1) neighbors]
+                      ranked = dedup_first_seen(seeds ++ nbr)
+       metrics(ranked, gold) per arm     # gold is int stark ids
   -> numbers table
 ```
 

--- a/docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md
@@ -115,19 +115,26 @@ index MUST be built in that space, not on stark ids.
 Take ONE slice `slice_graph = store.as_of(BIG, BIG)`. Build `EntityIndex` over
 `slice_graph.entities()` (so `entity_id` = view-local `EntityId`,
 `canonical_name` = node name). Build `eid_to_stark = {e["entity_id"]:
-e["source_refs"][0] for e in slice_graph.entities()}` from the SAME slice -- the
-stark id rides through on `source_refs` (lib.rs:79-80 exposes it; the loader
-stamps `source_refs=[stark_id]`). Both arms retrieve view-local ids and map to
+e["source_refs"][0] for e in slice_graph.entities() if e["source_refs"]}` from the
+SAME slice -- the stark id rides through on `source_refs` (lib.rs:79-80 exposes it;
+the loader stamps `source_refs=[stark_id]`). The map spans the FULL slice (a
+superset of the index's rows, which drop literal/empty-name nodes) so Arm B
+neighbors that are stored-but-unindexed still translate. The `if e["source_refs"]`
+guard keeps it robust to a source-ref-less node (a retrieved id with no mapping is
+simply skipped from the ranked list, never an `IndexError`). Both arms retrieve view-local ids and map to
 stark ids via `eid_to_stark` before `metrics(...)`.
 
 - **Arm A — dense baseline:** `index.query(q, embedder, k=20)` -> view-local ids
   -> `eid_to_stark` -> compare gold. Pure vector retrieval; the graph contributes
   nothing. The "vectors alone" number.
 - **Arm B — graph-expanded:** `seeds = index.query(q, embedder, k=5)` (view-local),
-  then 1-hop expansion `slice_graph.query(seeds, 1)` on the SAME slice; rank seeds
-  ++ their neighbor ids, map via `eid_to_stark`, compare gold. This is the graph's
-  value-add -- answers reachable by a relation but not textually near the query.
-  (Equivalent to `ask(entity_index=index)`, which already seeds + walks one slice.)
+  then 1-hop expansion `slice_graph.query(seeds, 1)` on the SAME slice; rank
+  `seeds ++ neighbors` **deduped preserving first-seen order** (a neighbor equal to
+  a seed must not occupy a second rank slot -- an undeduped duplicate can push a
+  distinct gold id past position 20 and understate Recall@20), map via
+  `eid_to_stark`, compare gold. This is the graph's value-add -- answers reachable
+  by a relation but not textually near the query. (Equivalent to
+  `ask(entity_index=index)`, which already seeds + walks one slice.)
 
 Captured per run: ingest wall, `EntityIndex.build` wall, mean/95p per-query
 latency, peak RSS (via `resource`/`tracemalloc` or a Modal memory sample), and

--- a/docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md
@@ -1,0 +1,183 @@
+# STaRK bulk-load + feasibility spike (SP2) — design
+
+**Program:** STaRK-scale retrieval. SP1 shipped `EntityIndex` (embed-once ANN
+retrieval reusing goldenmatch `ANNBlocker`; PR #1395, merged). SP2 answers one
+question: **does goldengraph's ingest + retrieve path run at STaRK scale, and
+what are the numbers?** (ingest time, `EntityIndex.build` time, per-query
+latency, peak RAM, retrieval Hit@1 / Hit@5 / Recall@20 / MRR).
+
+This is a **feasibility spike**: minimal build to get honest numbers, not a
+leaderboard entry. The ER moat is deliberately NOT exercised here — vanilla
+STaRK entities are pre-resolved with canonical ids, so this proves "structure
+loads + retrieves at scale," not "our ER beats ad-hoc dedup." Alias-injected
+STaRK (the moat experiment) is a later sub-project.
+
+## Decisions locked in brainstorming
+
+- **First target: STaRK-PRIME** (~130K nodes, biomedical — the smallest STaRK
+  KB). Fail-fast/cheap: validate loader + adapter + metrics + RAM end-to-end in
+  minutes, then run the SAME code on AMAZON (~1M) only if PRIME is clean.
+- **Single-batch load, measure.** One `StoreBatch` → one `append` (O(N)). If the
+  giant `json.dumps` OOMs, THAT is the finding and it motivates the `chunk_edges`
+  fallback. The chunk knob is built but off by default.
+- **Skip the resolver — direct id passthrough.** STaRK's canonical node ids ARE
+  the resolution. Each node gets `record_keys=[stark_id]` (globally unique), so
+  within one batch there is zero key-overlap → every node mints a fresh stable
+  id, no merges, no splits. Clean passthrough.
+- **Reuse STaRK data loading, reimplement the 4 metrics.** Their file format is
+  the fiddly part (reuse it); Hit@k / Recall@20 / MRR are ~30 trivial lines over
+  `(ranked_ids, gold_ids)` with no dependency or retriever-API coupling.
+
+## Load-bearing store constraints (from `goldengraph-core/src/store.rs`)
+
+These drove the decisions above and constrain the loader:
+
+1. **Edges must be co-batched with their endpoints.** `append` remaps each edge
+   via `local_to_stable[subj_local]` and **panics** if an endpoint is absent from
+   the same batch. There is no cross-batch edge. A chunked load must re-list an
+   edge's endpoint entities in that edge's batch.
+2. **`append` is O(stored) per call** — it rebuilds `key_to_stored` over every
+   currently-stored entity. So N small batches ≈ O(N × batches) (quadratic); one
+   batch is O(N). Single-batch is strictly cheapest on append cost; its only cost
+   is peak JSON-string memory (the thing the spike measures).
+3. **Unique record_key ⇒ passthrough.** With `record_keys=[stark_id]` and all ids
+   distinct, `overlaps` is empty for every batch entity, so all `assigned[i]`
+   mint fresh ids in `sorted_keys` order. No `HistoryEvent` is emitted. Verified
+   against the plurality-heir algorithm in `store.rs::append`.
+
+## Components
+
+### 1. `bulk_load` — `packages/python/goldengraph/goldengraph/bulk.py` (new)
+
+```python
+def bulk_load(store, nodes, edges, *, at: int = 1, chunk_edges: int | None = None) -> dict:
+    """Load a PRE-STRUCTURED KB straight into `store`, bypassing extract/resolve/link.
+
+    `nodes`: iterable of (stark_id: str, name: str, typ: str).
+    `edges`: iterable of (subj_stark_id: str, predicate: str, obj_stark_id: str).
+
+    Each node -> BatchEntity(local_id=positional index, canonical_name=name,
+    typ=typ, surface_names=[name], record_keys=[stark_id], source_refs=[]).
+    Each edge -> BatchEdge(subj_local, predicate, obj_local, valid_from=at,
+    valid_to=None, source_refs=[]). Edges whose endpoint stark_id is unknown are
+    dropped (counted). Returns {"n_nodes", "n_edges", "n_dropped_edges", "n_batches"}.
+
+    Default single batch (O(N) append). `chunk_edges=C` splits edges into batches
+    of <=C edges, each re-listing ONLY its endpoint entities (so the store's
+    local->stable remap resolves them to their already-minted ids via the unique
+    record_key). The fallback for when the single-batch JSON OOMs -- off by default."""
+```
+
+Responsibility: the node/edge → `StoreBatch` mapping and the `store.append`
+call(s). Nothing STaRK-specific and nothing about retrieval. Pure w.r.t. the
+data source — testable with a tiny in-memory `nodes`/`edges` list against a stub
+store.
+
+`local_id` is the node's positional index (`u32`; ~1M fits). A single
+`stark_id -> local_id` dict is built once so edges remap in O(1). In the chunked
+path, an edge-batch's endpoint entities carry the same `record_keys=[stark_id]`,
+so `append`'s overlap-merge re-resolves them to the id minted in the node batch
+(single inheritor → no merge, no new mint).
+
+### 2. STaRK adapter — `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py` (new)
+
+- `load_stark_kb(name)` → `(nodes, edges, queries)`. Downloads
+  `snap-stanford/stark` from HuggingFace (the `stark-qa` package / HF datasets),
+  maps its `(node_id, node_type, name|title, text)` and `(src, relation, dst)`
+  schema to the loader's `(stark_id, name, typ)` / `(subj, predicate, obj)`
+  tuples, and loads the eval split's `(query_text, gold_node_ids)` pairs.
+- `metrics(ranked_ids, gold_ids)` → `{hit@1, hit@5, recall@20, mrr}`.
+  Reimplemented, standard definitions:
+  - Hit@k = 1 if any gold id in the top-k, else 0 (mean over queries).
+  - Recall@20 = |gold ∩ top-20| / |gold|.
+  - MRR = 1 / rank of the first gold id (0 if none in the ranking).
+- `evaluate(index, store, queries, embedder, *, arm)` runs one retrieval arm over
+  the query set and returns the mean metric dict + timing.
+
+Node ids in STaRK are integers already; the adapter stringifies them for
+`record_keys` and keeps the int for `EntityIndex.entity_id` so `query()` returns
+ints directly comparable to gold.
+
+### 3. Retrieval arms + measurement — driven from the adapter / a Modal entry
+
+Build `EntityIndex` with `entity_id = the STaRK node id` and
+`canonical_name = node name` (so `query()` returns STaRK ids, sidestepping the
+`as_of` view-local id remap). Two arms:
+
+- **Arm A — dense baseline:** `EntityIndex.query(q, k=20)`. Pure vector
+  retrieval; the graph contributes nothing. This is the "vectors alone" number.
+- **Arm B — graph-expanded:** seeds from `EntityIndex` (k small, e.g. 5) then
+  1-hop neighborhood expansion via `ask(entity_index=index)` /
+  `store.as_of(∞,∞).query(seeds, 1)`, ranking seeds + their neighbors. This is
+  the graph's value-add — answers reachable by a relation but not textually near
+  the query.
+
+Captured per run: ingest wall, `EntityIndex.build` wall, mean/95p per-query
+latency, peak RSS (via `resource`/`tracemalloc` or a Modal memory sample), and
+the A-vs-B metric table. Flat (`IndexFlatIP`) is the default; HNSW
+(`IndexHNSWFlat`, a 1-line `ANNBlocker` swap) is a follow-up knob ONLY if flat
+per-query latency is measured too slow.
+
+### 4. Modal feasibility entry
+
+A `scripts/distill/modal_*` entry (or an extension of the existing
+`modal_bench.py`) that: downloads the KB on Modal's box, runs `bulk_load`, builds
+the index, runs both arms over a query sample, and prints the numbers table.
+`--detach --spawn` + poll; creds from Infisical dev project (never in literals).
+PRIME first; AMAZON is the same entry with `--kb amazon` once PRIME is clean.
+
+## Data flow
+
+```
+STaRK HF download
+  -> load_stark_kb(name) -> (nodes, edges, queries)
+  -> bulk_load(store, nodes, edges)         # StoreBatch -> store.append  [MEASURE ingest, RAM]
+  -> EntityIndex.build(nodes-as-entities)   # embed names once            [MEASURE build, RAM]
+  -> for q in queries:
+       Arm A: index.query(q, k=20)                                        [MEASURE latency]
+       Arm B: seeds=index.query(q,k=5); expand via store.as_of.query(seeds,1)
+  -> metrics(ranked, gold) per arm -> numbers table
+```
+
+## Error handling / honest-null posture
+
+- **OOM on single-batch append** (giant JSON): the expected first-run risk. Catch
+  it as a FINDING, report the node/edge count at which it broke, then re-run with
+  `chunk_edges`. Do not silently fall back — the ceiling is the result.
+- **Edge endpoint unknown** (dangling STaRK edge): drop + count, never crash.
+- **Empty / literal node names**: `EntityIndex.build` already filters these
+  (mirrors `seed_by_query`); the loader still stores them as nodes (they can be
+  edge endpoints), they are just not index-able seeds.
+- **Metric on zero gold**: Recall@20 undefined → skip that query from the Recall
+  mean (count skipped), never divide by zero.
+
+## Testing (box-safe, TDD)
+
+`packages/python/goldengraph/tests/test_bulk_load.py` (numpy/stub only, no HF,
+no Modal):
+- `bulk_load` single-batch: N nodes → N stored entities, each with its stark_id
+  as a record_key; edges remapped to the right stable-id pairs.
+- passthrough: distinct record_keys ⇒ zero `HistoryEvent` (no merges/splits).
+- dangling edge dropped + counted; return dict shape.
+- `chunk_edges=C`: same final store state as single-batch (endpoint re-listing
+  resolves to the same ids) — the parity guard for the fallback path.
+- edge co-batching: a chunk with an edge whose endpoint is re-listed does NOT
+  panic and lands the edge.
+
+`erkgbench/tests/test_stark_metrics.py`:
+- Hit@1/Hit@5/Recall@20/MRR against hand-worked rankings (gold in position 1, in
+  top-5 not top-1, absent; multi-gold recall; zero-gold skip).
+
+Adapter HF download + Modal run are integration-only (not in the box suite).
+
+Box-safe runner (worktree goldenmatch shadow, per SP1):
+`cd packages/python/goldengraph; PYTHONPATH=/d/show_case/gg-local-llm/packages/python/goldenmatch POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_bulk_load.py -q`
+
+## Out of scope (YAGNI / deferred)
+
+- Alias-injected STaRK (the ER moat experiment) — separate sub-project.
+- A native Rust bulk-append that bypasses reconciliation — only if the
+  Python single-batch + chunked paths BOTH prove infeasible at AMAZON scale
+  (measured, not assumed).
+- HNSW — a measured follow-up knob, not built up front.
+- MAG (~1.9M) — not a de-risking target; runnable later via the same entry.

--- a/docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md
@@ -57,15 +57,18 @@ def bulk_load(store, nodes, edges, *, at: int = 1, chunk_edges: int | None = Non
     `edges`: iterable of (subj_stark_id: str, predicate: str, obj_stark_id: str).
 
     Each node -> BatchEntity(local_id=positional index, canonical_name=name,
-    typ=typ, surface_names=[name], record_keys=[stark_id], source_refs=[]).
+    typ=typ, surface_names=[name], record_keys=[stark_id], source_refs=[stark_id]).
     Each edge -> BatchEdge(subj_local, predicate, obj_local, valid_from=at,
     valid_to=None, source_refs=[]). Edges whose endpoint stark_id is unknown are
     dropped (counted). Returns {"n_nodes", "n_edges", "n_dropped_edges", "n_batches"}.
 
-    Default single batch (O(N) append). `chunk_edges=C` splits edges into batches
-    of <=C edges, each re-listing ONLY its endpoint entities (so the store's
-    local->stable remap resolves them to their already-minted ids via the unique
-    record_key). The fallback for when the single-batch JSON OOMs -- off by default."""
+    Default single batch (O(N) append). `chunk_edges=C` emits an initial
+    nodes-ONLY batch first (mints every stable id), THEN splits edges into batches
+    of <=C edges, each re-listing ONLY its endpoint entities (the store's
+    overlap-merge re-resolves them to the id minted in the nodes batch via the
+    unique record_key -- single inheritor, no merge/mint). The fallback for when
+    the single-batch JSON OOMs -- off by default. `n_batches` counts every append
+    (1 for single-batch; 1 + ceil(n_edges/C) for chunked)."""
 ```
 
 Responsibility: the node/edge → `StoreBatch` mapping and the `store.append`
@@ -91,26 +94,40 @@ so `append`'s overlap-merge re-resolves them to the id minted in the node batch
   - Hit@k = 1 if any gold id in the top-k, else 0 (mean over queries).
   - Recall@20 = |gold ∩ top-20| / |gold|.
   - MRR = 1 / rank of the first gold id (0 if none in the ranking).
-- `evaluate(index, store, queries, embedder, *, arm)` runs one retrieval arm over
-  the query set and returns the mean metric dict + timing.
+- `evaluate(index, slice_graph, eid_to_stark, queries, embedder, *, arm)` runs one
+  retrieval arm over the query set, translates each arm's view-local ids back to
+  stark ids via `eid_to_stark`, and returns the mean metric dict + timing.
 
-Node ids in STaRK are integers already; the adapter stringifies them for
-`record_keys` and keeps the int for `EntityIndex.entity_id` so `query()` returns
-ints directly comparable to gold.
+Node ids in STaRK are integers; the adapter stringifies them for `record_keys` /
+`source_refs`. The retrieval id space is NOT the stark id (see §3) -- it is the
+`as_of` slice's view-local `EntityId`, and a single `eid_to_stark` map recovered
+from the slice translates both arms' outputs to stark ids for scoring.
 
 ### 3. Retrieval arms + measurement — driven from the adapter / a Modal entry
 
-Build `EntityIndex` with `entity_id = the STaRK node id` and
-`canonical_name = node name` (so `query()` returns STaRK ids, sidestepping the
-`as_of` view-local id remap). Two arms:
+**Id spaces (the correction that makes Arm B runnable).** There are THREE:
+the stark id (gold answers), the store's minted `StableId`, and the per-slice
+**view-local `EntityId`** that `as_of` assigns in ascending `StableId` order
+(store.rs:426-432; `embed.py::query` warns ids are slice-specific). Graph
+expansion (`as_of().query(seeds,1)`) only works in the view-local space, so the
+index MUST be built in that space, not on stark ids.
 
-- **Arm A — dense baseline:** `EntityIndex.query(q, k=20)`. Pure vector
-  retrieval; the graph contributes nothing. This is the "vectors alone" number.
-- **Arm B — graph-expanded:** seeds from `EntityIndex` (k small, e.g. 5) then
-  1-hop neighborhood expansion via `ask(entity_index=index)` /
-  `store.as_of(∞,∞).query(seeds, 1)`, ranking seeds + their neighbors. This is
-  the graph's value-add — answers reachable by a relation but not textually near
-  the query.
+Take ONE slice `slice_graph = store.as_of(BIG, BIG)`. Build `EntityIndex` over
+`slice_graph.entities()` (so `entity_id` = view-local `EntityId`,
+`canonical_name` = node name). Build `eid_to_stark = {e["entity_id"]:
+e["source_refs"][0] for e in slice_graph.entities()}` from the SAME slice -- the
+stark id rides through on `source_refs` (lib.rs:79-80 exposes it; the loader
+stamps `source_refs=[stark_id]`). Both arms retrieve view-local ids and map to
+stark ids via `eid_to_stark` before `metrics(...)`.
+
+- **Arm A — dense baseline:** `index.query(q, embedder, k=20)` -> view-local ids
+  -> `eid_to_stark` -> compare gold. Pure vector retrieval; the graph contributes
+  nothing. The "vectors alone" number.
+- **Arm B — graph-expanded:** `seeds = index.query(q, embedder, k=5)` (view-local),
+  then 1-hop expansion `slice_graph.query(seeds, 1)` on the SAME slice; rank seeds
+  ++ their neighbor ids, map via `eid_to_stark`, compare gold. This is the graph's
+  value-add -- answers reachable by a relation but not textually near the query.
+  (Equivalent to `ask(entity_index=index)`, which already seeds + walks one slice.)
 
 Captured per run: ingest wall, `EntityIndex.build` wall, mean/95p per-query
 latency, peak RSS (via `resource`/`tracemalloc` or a Modal memory sample), and
@@ -132,11 +149,15 @@ PRIME first; AMAZON is the same entry with `--kb amazon` once PRIME is clean.
 STaRK HF download
   -> load_stark_kb(name) -> (nodes, edges, queries)
   -> bulk_load(store, nodes, edges)         # StoreBatch -> store.append  [MEASURE ingest, RAM]
-  -> EntityIndex.build(nodes-as-entities)   # embed names once            [MEASURE build, RAM]
-  -> for q in queries:
-       Arm A: index.query(q, k=20)                                        [MEASURE latency]
-       Arm B: seeds=index.query(q,k=5); expand via store.as_of.query(seeds,1)
-  -> metrics(ranked, gold) per arm -> numbers table
+  -> slice_graph = store.as_of(BIG, BIG)    # one view-local id space
+  -> eid_to_stark = {e["entity_id"]: e["source_refs"][0] for e in slice_graph.entities()}
+  -> index = EntityIndex.build(slice_graph.entities(), embedder)  # embed names once [MEASURE build, RAM]
+  -> for q in queries:                                             [MEASURE latency]
+       Arm A: ids = index.query(q, embedder, k=20)
+       Arm B: seeds = index.query(q, embedder, k=5); ids = seeds ++ slice_graph.query(seeds,1) neighbors
+       ranked_stark = [eid_to_stark[i] for i in ids]
+       metrics(ranked_stark, gold) per arm
+  -> numbers table
 ```
 
 ## Error handling / honest-null posture
@@ -158,6 +179,8 @@ no Modal):
 - `bulk_load` single-batch: N nodes → N stored entities, each with its stark_id
   as a record_key; edges remapped to the right stable-id pairs.
 - passthrough: distinct record_keys ⇒ zero `HistoryEvent` (no merges/splits).
+- stark_id rides through: after load, `store.as_of(BIG,BIG).entities()` each carry
+  `source_refs == [stark_id]`, so `eid_to_stark` is recoverable (the Arm-B id map).
 - dangling edge dropped + counted; return dict shape.
 - `chunk_edges=C`: same final store state as single-batch (endpoint re-listing
   resolves to the same ids) — the parity guard for the fallback path.

--- a/packages/python/goldengraph/goldengraph/__init__.py
+++ b/packages/python/goldengraph/goldengraph/__init__.py
@@ -8,6 +8,7 @@ duplicate surface forms across documents collapse into one durable entity.
 __version__ = "0.1.0"
 
 from .answer import ask, to_cypher
+from .bulk import bulk_load
 from .embed import Embedder, GoldenmatchEmbedder, seed_by_query
 from .extract import Extraction, Mention, Relationship, extract, parse_extraction
 from .ingest import build_batch, ingest
@@ -32,6 +33,7 @@ __all__ = [
     "ResolvedEntity",
     "resolve",
     "build_batch",
+    "bulk_load",
     "ingest",
     # SP4c — retrieval + synthesis + query
     "Embedder",

--- a/packages/python/goldengraph/goldengraph/bulk.py
+++ b/packages/python/goldengraph/goldengraph/bulk.py
@@ -1,0 +1,104 @@
+"""SP2: load a PRE-STRUCTURED knowledge base straight into the store, bypassing
+extract/resolve/link. STaRK-style KBs come with canonical node ids already, so
+each node's id IS its resolution: a unique ``record_key`` per node means the
+store's overlap-merge mints a fresh stable id for each with zero merges (see
+``goldengraph-core/src/store.rs::append``). Edges are co-batched with their
+endpoints because the store panics on an edge whose endpoint is absent from the
+same batch.
+
+See docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+
+def _entity(local_id: int, stark_id: str, name: str, typ: str) -> dict:
+    # record_keys=[stark_id] -> unique -> passthrough (no merge). source_refs=[stark_id]
+    # -> the stark id rides through as_of so retrieval can translate view-local ids back.
+    return {
+        "local_id": local_id,
+        "canonical_name": name,
+        "typ": typ,
+        "surface_names": [name],
+        "record_keys": [stark_id],
+        "source_refs": [stark_id],
+    }
+
+
+def _edge(subj_local: int, predicate: str, obj_local: int, at: int) -> dict:
+    return {
+        "subj_local": subj_local,
+        "predicate": predicate,
+        "obj_local": obj_local,
+        "valid_from": at,
+        "valid_to": None,
+        "source_refs": [],
+    }
+
+
+def bulk_load(
+    store,
+    nodes: Iterable,
+    edges: Iterable,
+    *,
+    at: int = 1,
+    chunk_edges: int | None = None,
+) -> dict:
+    """Load ``(nodes, edges)`` into ``store``. ``nodes``: iterable of
+    ``(stark_id, name, typ)``; ``edges``: iterable of
+    ``(subj_stark_id, predicate, obj_stark_id)``. Returns
+    ``{n_nodes, n_edges, n_dropped_edges, n_batches}``. See module docstring / spec."""
+    node_list = list(nodes)
+    id_to_local: dict[str, int] = {}
+    entities: list[dict] = []
+    for i, (stark_id, name, typ) in enumerate(node_list):
+        id_to_local[str(stark_id)] = i
+        entities.append(_entity(i, str(stark_id), name, typ))
+
+    edge_dicts: list[dict] = []
+    dropped = 0
+    for subj, predicate, obj in edges:
+        s = id_to_local.get(str(subj))
+        o = id_to_local.get(str(obj))
+        if s is None or o is None:
+            dropped += 1
+            continue
+        edge_dicts.append(_edge(s, predicate, o, at))
+
+    if chunk_edges is None:
+        n_batches = _append_single(store, entities, edge_dicts, at)
+    else:
+        n_batches = _append_chunked(store, entities, edge_dicts, at, chunk_edges)
+
+    return {
+        "n_nodes": len(entities),
+        "n_edges": len(edge_dicts),
+        "n_dropped_edges": dropped,
+        "n_batches": n_batches,
+    }
+
+
+def _append_single(store, entities: list[dict], edges: list[dict], at: int) -> int:
+    store.append(json.dumps({"entities": entities, "edges": edges, "ingested_at": at}))
+    return 1
+
+
+def _append_chunked(store, entities: list[dict], edges: list[dict], at: int, chunk: int) -> int:
+    """Initial nodes-ONLY batch mints every stable id; then edge batches, each
+    re-listing ONLY the endpoint entities it references so the store's overlap-merge
+    (record_keys=[stark_id]) re-resolves them to the already-minted id (single
+    inheritor -> no merge, no new mint). Bounds peak JSON size vs one giant batch."""
+    if chunk < 1:
+        raise ValueError(f"chunk_edges must be >= 1, got {chunk}")
+    by_local = {e["local_id"]: e for e in entities}
+    store.append(json.dumps({"entities": entities, "edges": [], "ingested_at": at}))
+    n_batches = 1
+    for start in range(0, len(edges), chunk):
+        window = edges[start : start + chunk]
+        needed = {e["subj_local"] for e in window} | {e["obj_local"] for e in window}
+        batch_entities = [by_local[lid] for lid in sorted(needed)]
+        store.append(json.dumps({"entities": batch_entities, "edges": window, "ingested_at": at}))
+        n_batches += 1
+    return n_batches

--- a/packages/python/goldengraph/tests/test_bulk_load.py
+++ b/packages/python/goldengraph/tests/test_bulk_load.py
@@ -1,0 +1,103 @@
+"""SP2 bulk_load: pre-structured KB -> StoreBatch -> real PyStore. Exercises the
+store's append/as_of semantics directly (that IS what is under test), so it needs
+goldengraph_native; skip cleanly if the wheel is absent."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+ggn = pytest.importorskip("goldengraph_native")
+from goldengraph.bulk import bulk_load  # noqa: E402
+
+_BIG = 1 << 62
+
+
+def _store():
+    from goldengraph_native import _native as gg
+
+    return gg.PyStore()
+
+
+# stark ids are strings; names/types are plain; one triangle A-B, A-C
+_NODES = [("s10", "Alice", "person"), ("s20", "Acme", "org"), ("s30", "Bob", "person")]
+_EDGES = [("s10", "works_at", "s20"), ("s10", "knows", "s30")]
+
+
+def test_single_batch_stores_all_nodes_with_stark_record_keys():
+    store = _store()
+    out = bulk_load(store, _NODES, _EDGES)
+    assert out == {"n_nodes": 3, "n_edges": 2, "n_dropped_edges": 0, "n_batches": 1}
+    snap = json.loads(store.snapshot())
+    # every node present, keyed by its stark id
+    keys = {tuple(e["record_keys"]) for e in snap["entities"].values()}
+    assert keys == {("s10",), ("s20",), ("s30",)}
+
+
+def _by_name(slice_graph):
+    return {e["canonical_name"]: e for e in slice_graph.entities()}
+
+
+def test_edges_remap_to_right_entity_pairs():
+    store = _store()
+    bulk_load(store, _NODES, _EDGES)
+    g = store.as_of(_BIG, _BIG)
+    ents = _by_name(g)
+    eid = {name: e["entity_id"] for name, e in ents.items()}
+    edges = {(e["subj"], e["predicate"], e["obj"]) for e in g.query(list(eid.values()), 1)["edges"]}
+    assert (eid["Alice"], "works_at", eid["Acme"]) in edges
+    assert (eid["Alice"], "knows", eid["Bob"]) in edges
+
+
+def test_passthrough_no_merges_or_splits():
+    store = _store()
+    bulk_load(store, _NODES, _EDGES)
+    assert json.loads(store.snapshot())["history"] == []  # distinct keys -> zero HistoryEvent
+
+
+def test_stark_id_rides_through_as_of():
+    # eid_to_stark (the Arm-B translation map) must be recoverable from the slice.
+    store = _store()
+    bulk_load(store, _NODES, _EDGES)
+    g = store.as_of(_BIG, _BIG)
+    want = {"Alice": "s10", "Acme": "s20", "Bob": "s30"}
+    for e in g.entities():
+        assert e["source_refs"] == [want[e["canonical_name"]]]
+
+
+def test_dangling_edge_dropped_and_counted():
+    store = _store()
+    out = bulk_load(store, _NODES, [("s10", "works_at", "s99")])  # s99 unknown
+    assert out["n_edges"] == 0 and out["n_dropped_edges"] == 1
+    g = store.as_of(_BIG, _BIG)
+    assert g.query([e["entity_id"] for e in g.entities()], 1)["edges"] == []
+
+
+def _canonical_state(store):
+    """Order-independent (entities, edges) view for parity comparison across batchings."""
+    g = store.as_of(_BIG, _BIG)
+    ents = {tuple(e["source_refs"]): (e["canonical_name"], e["typ"]) for e in g.entities()}
+    eid_to_stark = {e["entity_id"]: e["source_refs"][0] for e in g.entities()}
+    edges = sorted(
+        (eid_to_stark[e["subj"]], e["predicate"], eid_to_stark[e["obj"]])
+        for e in g.query(list(eid_to_stark), 1)["edges"]
+    )
+    return ents, edges
+
+
+def test_chunked_matches_single_batch_state():
+    a, b = _store(), _store()
+    out_single = bulk_load(a, _NODES, _EDGES)
+    out_chunk = bulk_load(b, _NODES, _EDGES, chunk_edges=1)  # 1 edge per batch
+    assert _canonical_state(a) == _canonical_state(b)  # identical final graph
+    assert out_chunk["n_batches"] == 1 + 2  # nodes batch + 2 edge batches
+    assert out_single["n_batches"] == 1
+
+
+def test_chunked_edge_relists_endpoints_without_panic():
+    # The whole risk of chunking: an edge batch must re-list its endpoint entities or
+    # store.append panics on the missing local id. This asserts it lands the edge.
+    store = _store()
+    bulk_load(store, _NODES, _EDGES, chunk_edges=1)
+    g = store.as_of(_BIG, _BIG)
+    assert len(g.query([e["entity_id"] for e in g.entities()], 1)["edges"]) == 2

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
@@ -1,0 +1,114 @@
+"""STaRK KB adapter: download a STaRK semi-structured KB from HuggingFace and map
+it to goldengraph's ``(nodes, edges)`` + a query set. Integration surface -- the
+pure metrics live in ``stark_metrics.py`` (box-tested); this module is exercised by
+the Modal feasibility run, not the box suite.
+
+STaRK API (snap-stanford/stark, ``stark_qa`` package):
+- ``skb = load_skb(name)``: node ids are ``0..len(skb)-1``; ``skb.node_info[nid]``
+  is a dict ``{'id','type','name'|'title','source',...}``; ``skb.get_node_type_by_id(nid)``
+  gives the type string; edges are ``skb.edge_index`` (2xE LongTensor) +
+  ``skb.edge_types`` (E LongTensor), decoded via ``skb.get_edge_type_by_id(tid)``.
+- ``qa = load_qa(name)``: ``qa.get_idx_split()`` -> {'train','val','test',...} of
+  LongTensor indices; ``qa[idx]`` -> ``(query, q_id, answer_ids, meta)`` with
+  ``answer_ids`` a python list of ints.
+
+See docs/superpowers/specs/2026-07-02-goldengraph-stark-bulkload-design.md.
+"""
+from __future__ import annotations
+
+import time
+
+
+def _node_name(info: dict) -> str:
+    # PRIME/MAG use 'name'; AMAZON uses 'title'. Fall back through both.
+    return str(info.get("name") or info.get("title") or "").strip()
+
+
+def load_stark_kb(name: str, *, split: str = "test", limit_queries: int | None = None):
+    """Return ``(nodes, edges, queries)`` for a STaRK KB.
+
+    nodes: list of ``(stark_id: str, name: str, typ: str)``.
+    edges: list of ``(subj_stark_id: str, predicate: str, obj_stark_id: str)``.
+    queries: list of ``(query_text: str, gold_stark_ids: set[int])`` from ``split``.
+
+    Node/gold ids stay INTS for retrieval+scoring; ids are stringified only for the
+    store's opaque ``record_keys`` (done inside ``bulk_load``)."""
+    from stark_qa import load_qa, load_skb
+
+    skb = load_skb(name)
+    n_nodes = len(skb)
+    nodes = []
+    for nid in range(n_nodes):
+        info = skb.node_info[nid]
+        nodes.append((str(nid), _node_name(info), str(skb.get_node_type_by_id(nid))))
+
+    # Real edges live in edge_index (2xE) + edge_types (E); get_tuples() is only the
+    # SCHEMA (type-triples), not instances. Materialize once as python lists (fast),
+    # decode each relation-type id once via a cache.
+    ei = skb.edge_index.tolist()  # [[heads...], [tails...]]
+    et = skb.edge_types.tolist()
+    rel_cache: dict[int, str] = {}
+
+    def _rel(tid: int) -> str:
+        r = rel_cache.get(tid)
+        if r is None:
+            r = str(skb.get_edge_type_by_id(tid))
+            rel_cache[tid] = r
+        return r
+
+    heads, tails = ei[0], ei[1]
+    edges = [(str(heads[i]), _rel(et[i]), str(tails[i])) for i in range(len(heads))]
+
+    qa = load_qa(name)
+    idx = qa.get_idx_split()[split].tolist()
+    if limit_queries:
+        idx = idx[:limit_queries]
+    queries = []
+    for i in idx:
+        query, _q_id, answer_ids, _meta = qa[i]
+        queries.append((query, {int(a) for a in answer_ids}))
+    return nodes, edges, queries
+
+
+def evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, *,
+             arm: str, sample: int | None = None) -> dict:
+    """Run one retrieval arm over ``queries``, return mean metrics + timing. ``arm``
+    in {"dense","graph"}. The index returns STARK ids (entity_id=int(stark_id) at
+    build time), so Arm A needs no translation and covers ALL nodes. Arm B walks the
+    STORE (``as_of().query`` -- the thing under test), translating stark<->slice-local
+    ids only at the walk boundary. ``stark_to_eid``/``eid_to_stark`` cover edge-endpoint
+    nodes only, which is exactly the set that has neighbors."""
+    from erkgbench.stark_metrics import dedup_first_seen, mean_metrics, metrics
+
+    qs = queries[:sample] if sample else queries
+    per_query, latencies = [], []
+    for text, gold in qs:
+        t0 = time.perf_counter()
+        if arm == "dense":
+            ranked = index.query(text, embedder, k=20)  # stark ids already
+        elif arm == "graph":
+            seeds = index.query(text, embedder, k=5)  # stark ids
+            seed_eids = [stark_to_eid[s] for s in seeds if s in stark_to_eid]
+            nbr = [eid_to_stark[e["entity_id"]] for e in _neighbors(slice_graph, seed_eids)]
+            ranked = dedup_first_seen([*seeds, *nbr])
+        else:
+            raise ValueError(f"unknown arm {arm!r}")
+        latencies.append(time.perf_counter() - t0)
+        per_query.append(metrics(ranked, gold))  # gold: int stark ids
+    agg = mean_metrics(per_query)
+    lat = sorted(latencies)
+    agg["latency_ms_mean"] = 1000 * sum(lat) / (len(lat) or 1)
+    agg["latency_ms_p95"] = 1000 * lat[int(0.95 * (len(lat) - 1))] if lat else 0.0
+    agg["arm"] = arm
+    return agg
+
+
+def _neighbors(slice_graph, seed_eids):
+    """1-hop neighbor entity dicts of ``seed_eids`` (view-local ids) on the slice.
+    ``query(ids, 1)`` returns ``{'entities':[...], 'edges':[...]}``; entities are the
+    seeds ++ their neighbors, so drop the seeds themselves."""
+    if not seed_eids:
+        return []
+    res = slice_graph.query(list(seed_eids), 1)
+    seed_set = set(seed_eids)
+    return [e for e in res["entities"] if e["entity_id"] not in seed_set]

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_metrics.py
@@ -1,0 +1,55 @@
+"""Standard IR metrics for the STaRK retrieval spike. Definitions match STaRK
+(arXiv 2404.13207): Hit@k, Recall@20, MRR over a single query's ranked id list
+against its gold answer id set. Reimplemented (not STaRK's harness) -- ~30 lines,
+no dependency or retriever-API coupling. ``recall@20`` returns ``None`` on a
+zero-gold query so the caller can EXCLUDE it from the recall mean (never divide by
+zero).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+_RECALL_K = 20
+
+
+def dedup_first_seen(ids: Iterable[int]) -> list[int]:
+    """De-duplicate preserving first-seen order (Arm-B ranks seeds ++ neighbors; an
+    undeduped repeat can push a distinct gold id past position 20)."""
+    seen: set[int] = set()
+    out: list[int] = []
+    for i in ids:
+        if i not in seen:
+            seen.add(i)
+            out.append(i)
+    return out
+
+
+def metrics(ranked_ids: list[int], gold_ids: set[int]) -> dict:
+    """One query's metrics. ``ranked_ids``: rank-ordered retrieved ids (assumed
+    already deduped by the caller). ``gold_ids``: the answer set. ``recall@20`` is
+    ``None`` when there is no gold (caller skips it from the recall mean)."""
+    gold = set(gold_ids)
+    hit1 = 1.0 if ranked_ids[:1] and ranked_ids[0] in gold else 0.0
+    hit5 = 1.0 if gold & set(ranked_ids[:5]) else 0.0
+    mrr = 0.0
+    for rank, i in enumerate(ranked_ids, start=1):
+        if i in gold:
+            mrr = 1.0 / rank
+            break
+    recall = None if not gold else len(gold & set(ranked_ids[:_RECALL_K])) / len(gold)
+    return {"hit@1": hit1, "hit@5": hit5, "recall@20": recall, "mrr": mrr}
+
+
+def mean_metrics(per_query: list[dict]) -> dict:
+    """Aggregate per-query dicts. Recall averages only over non-None (has-gold)
+    queries; the rest average over all queries."""
+    n = len(per_query) or 1
+    rec = [m["recall@20"] for m in per_query if m["recall@20"] is not None]
+    return {
+        "hit@1": sum(m["hit@1"] for m in per_query) / n,
+        "hit@5": sum(m["hit@5"] for m in per_query) / n,
+        "mrr": sum(m["mrr"] for m in per_query) / n,
+        "recall@20": (sum(rec) / len(rec)) if rec else 0.0,
+        "n_queries": len(per_query),
+        "n_with_gold": len(rec),
+    }

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_stark_metrics.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_stark_metrics.py
@@ -1,0 +1,62 @@
+"""SP2 STaRK IR metrics + Arm-B dedup: pure, no store/HF/Modal. Box-safe."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.stark_metrics import dedup_first_seen, mean_metrics, metrics  # noqa: E402
+
+
+def test_hit_at_1_gold_in_first_position():
+    m = metrics(ranked_ids=[7, 3, 9], gold_ids={7})
+    assert m["hit@1"] == 1.0 and m["hit@5"] == 1.0
+    assert m["mrr"] == 1.0 and m["recall@20"] == 1.0
+
+
+def test_hit_at_5_not_at_1():
+    m = metrics(ranked_ids=[1, 2, 3, 4, 7], gold_ids={7})
+    assert m["hit@1"] == 0.0 and m["hit@5"] == 1.0
+    assert m["mrr"] == 1 / 5
+
+
+def test_gold_absent():
+    m = metrics(ranked_ids=[1, 2, 3], gold_ids={7})
+    assert m == {"hit@1": 0.0, "hit@5": 0.0, "recall@20": 0.0, "mrr": 0.0}
+
+
+def test_multi_gold_recall_partial():
+    # 2 of 3 gold in the top-20
+    m = metrics(ranked_ids=[10, 11, 99], gold_ids={10, 11, 42})
+    assert m["recall@20"] == 2 / 3
+    assert m["hit@1"] == 1.0 and m["mrr"] == 1.0
+
+
+def test_zero_gold_recall_is_none_sentinel():
+    # A query with no gold answers must NOT contribute to the recall mean.
+    m = metrics(ranked_ids=[1, 2], gold_ids=set())
+    assert m["recall@20"] is None  # caller skips None from the recall mean
+    assert m["hit@1"] == 0.0 and m["mrr"] == 0.0
+
+
+def test_empty_ranked_is_all_zero():
+    m = metrics(ranked_ids=[], gold_ids={7})
+    assert m == {"hit@1": 0.0, "hit@5": 0.0, "recall@20": 0.0, "mrr": 0.0}
+
+
+def test_dedup_first_seen_preserves_order_and_drops_repeats():
+    assert dedup_first_seen([5, 3, 5, 9, 3]) == [5, 3, 9]
+
+
+def test_mean_metrics_skips_none_recall():
+    per_query = [
+        {"hit@1": 1.0, "hit@5": 1.0, "recall@20": 0.5, "mrr": 1.0},
+        {"hit@1": 0.0, "hit@5": 0.0, "recall@20": None, "mrr": 0.0},  # zero-gold query
+    ]
+    agg = mean_metrics(per_query)
+    assert agg["hit@1"] == 0.5  # averaged over ALL queries
+    assert agg["recall@20"] == 0.5  # averaged over the ONE has-gold query only
+    assert agg["n_queries"] == 2 and agg["n_with_gold"] == 1

--- a/scripts/distill/modal_stark.py
+++ b/scripts/distill/modal_stark.py
@@ -1,0 +1,220 @@
+"""SP2 STaRK feasibility spike INSIDE a Modal function -- does goldengraph's ingest +
+retrieve path run at STaRK scale, and what are the numbers?
+
+Downloads a STaRK KB (PRIME first -- smallest, ~130K nodes), bulk-loads it into the
+native store (single batch; chunked fallback on OOM), builds an EntityIndex over ALL
+nodes, and runs two retrieval arms over a query sample:
+  Arm A (dense)  -- EntityIndex.query, pure vectors, covers every node.
+  Arm B (graph)  -- seeds + 1-hop walk THROUGH the store's as_of().query.
+Reports: n_nodes/n_edges/n_dropped/n_batches/n_isolated, ingest wall, index-build
+wall, per-query latency, peak RSS, and the dense-vs-graph metric table.
+
+The ER moat is NOT exercised (vanilla STaRK is pre-resolved) -- this proves
+"structure loads + retrieves at scale," the honest scope. See the spec.
+
+AUTH (Modal creds in Infisical, project a99885f0-c5af-4ae1-9dc8-255cc60aa129, env dev):
+    $P = "a99885f0-c5af-4ae1-9dc8-255cc60aa129"
+    $env:MODAL_TOKEN_ID     = (infisical.cmd secrets get MODAL_TOKEN_ID     --projectId $P --env dev --plain)
+    $env:MODAL_TOKEN_SECRET = (infisical.cmd secrets get MODAL_TOKEN_SECRET --projectId $P --env dev --plain)
+    pip install modal
+    modal run --detach scripts/distill/modal_stark.py --kb prime --sample 200
+    # then: modal volume get gg-bench-cache results/stark_prime.md .
+"""
+from __future__ import annotations
+
+import pathlib
+
+import modal
+
+_parents = pathlib.Path(__file__).resolve().parents
+REPO = _parents[2] if len(_parents) > 2 else _parents[0]
+app = modal.App("gg-stark")
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("curl", "build-essential", "pkg-config", "libssl-dev", "git", "zstd")
+    .run_commands("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+    .env({"PATH": "/root/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"})
+    .pip_install("maturin", "goldenmatch", "numpy", "openai", "stark-qa")
+    .run_commands("curl -fsSL https://ollama.com/install.sh | sh")
+    .add_local_dir(str(REPO / "packages/rust"), "/repo/packages/rust", ignore=["**/target/**"])
+    .add_local_dir(str(REPO / "packages/python/goldengraph"), "/repo/packages/python/goldengraph",
+                   ignore=["**/__pycache__/**", "**/*.pyc"])
+    .add_local_dir(str(REPO / "packages/python/goldenmatch"), "/repo/packages/python/goldenmatch",
+                   ignore=["**/__pycache__/**", "**/.venv/**", "**/target/**", "**/*.pyc"])
+)
+
+cache = modal.Volume.from_name("gg-bench-cache", create_if_missing=True)
+_BENCH = "/repo/packages/python/goldenmatch/benchmarks/er-kg-bench"
+
+
+def _peak_rss_gb() -> float:
+    """Process high-water RSS in GB (monotonic). Linux ru_maxrss is in KB."""
+    import resource
+
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (1024 * 1024)
+
+
+class _OllamaEmbedder:
+    """Minimal Embedder: batched embeddings via the local Ollama OpenAI-compatible
+    endpoint. `.embed(texts) -> np.ndarray`. Self-contained (no goldenmatch provider
+    wiring) so the spike measures a clean name-embedding path."""
+
+    def __init__(self, model: str, base_url: str, batch: int = 256):
+        from openai import OpenAI
+
+        self._cli = OpenAI(api_key="ollama", base_url=base_url)
+        self._model = model
+        self._batch = batch
+
+    def embed(self, texts):
+        import numpy as np
+
+        texts = [t if str(t).strip() else " " for t in texts]  # Ollama 400s on empty input
+        out = []
+        for i in range(0, len(texts), self._batch):
+            chunk = texts[i : i + self._batch]
+            resp = self._cli.embeddings.create(model=self._model, input=chunk)
+            out.extend(d.embedding for d in resp.data)
+        return np.asarray(out, dtype=float)
+
+
+def _build_native_and_install():
+    """Build the goldengraph-native wheel (cached on the Volume) + install the two
+    packages editable. Mirrors modal_bench._bench_impl step 1 (clean+force-reinstall
+    so a source change always lands)."""
+    import os
+    import subprocess
+
+    wheels = "/cache/wheels"
+    os.makedirs(wheels, exist_ok=True)
+    cache.reload()
+    if not any(f.endswith(".whl") for f in os.listdir(wheels)):
+        print("building goldengraph-native wheel (first run) ...", flush=True)
+        subprocess.run(["cargo", "clean", "--manifest-path",
+                        "/repo/packages/rust/extensions/goldengraph-native/Cargo.toml"], check=False)
+        subprocess.run(["maturin", "build", "--release", "-m",
+                        "/repo/packages/rust/extensions/goldengraph-native/Cargo.toml",
+                        "--out", wheels], check=True)
+        cache.commit()
+    subprocess.run(f"pip install --no-deps --force-reinstall {wheels}/*.whl", shell=True, check=True)
+    subprocess.run(["pip", "install", "--no-deps", "-e", "/repo/packages/python/goldengraph"], check=True)
+    subprocess.run(["pip", "install", "--no-deps", "-e", "/repo/packages/python/goldenmatch"], check=True)
+
+
+def _start_ollama(embed_model: str) -> str:
+    import os
+    import subprocess
+    import time
+    import urllib.request
+
+    os.environ["OLLAMA_MODELS"] = "/cache/ollama"
+    os.makedirs("/cache/ollama", exist_ok=True)
+    subprocess.Popen(["ollama", "serve"])
+    for _ in range(60):
+        try:
+            urllib.request.urlopen("http://localhost:11434/api/version", timeout=2)
+            break
+        except Exception:
+            time.sleep(1)
+    subprocess.run(["ollama", "pull", embed_model], check=True)
+    cache.commit()
+    return "http://localhost:11434/v1"
+
+
+def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int) -> str:
+    import os
+    import sys
+    import time
+
+    _build_native_and_install()
+    base_url = _start_ollama(embed_model)
+    os.environ["POLARS_SKIP_CPU_CHECK"] = "1"
+    sys.path.insert(0, _BENCH)
+
+    from erkgbench.stark_adapter import evaluate, load_stark_kb
+    from goldengraph.entity_index import EntityIndex
+    from goldengraph_native import _native as ggn
+
+    _BIG = 1 << 62
+    lines = [f"# STaRK feasibility -- {kb} (sample={sample})", ""]
+
+    # 1. download + map
+    t = time.perf_counter()
+    nodes, edges, queries = load_stark_kb(kb, split="test", limit_queries=sample)
+    lines.append(f"load_stark_kb: {time.perf_counter() - t:.1f}s  "
+                 f"nodes={len(nodes)} edges={len(edges)} queries={len(queries)}")
+
+    # 2. bulk_load -> store  [ingest wall + RSS]. Single batch; chunked on OOM.
+    from goldengraph.bulk import bulk_load
+
+    store = ggn.PyStore()
+    t = time.perf_counter()
+    ce = chunk_edges or None
+    try:
+        stats = bulk_load(store, nodes, edges, chunk_edges=ce)
+    except MemoryError:
+        fallback = 500_000
+        lines.append(f"** single-batch OOM at nodes={len(nodes)} edges={len(edges)} "
+                     f"-> retry chunk_edges={fallback} (FINDING) **")
+        store = ggn.PyStore()
+        stats = bulk_load(store, nodes, edges, chunk_edges=fallback)
+    ingest_s = time.perf_counter() - t
+    lines.append(f"bulk_load: {ingest_s:.1f}s  {stats}  peak_rss={_peak_rss_gb():.2f}GB")
+
+    # 3. index over ALL nodes (entity_id=int(stark_id) -> query returns stark ids; isolated
+    #    nodes stay in the dense baseline). [index-build wall + RSS]
+    embedder = _OllamaEmbedder(embed_model, base_url)
+    index_entities = [{"entity_id": int(sid), "canonical_name": name, "typ": typ}
+                      for sid, name, typ in nodes]
+    t = time.perf_counter()
+    index = EntityIndex.build(index_entities, embedder, top_k=50)
+    build_s = time.perf_counter() - t
+    lines.append(f"EntityIndex.build: {build_s:.1f}s  indexed={len(index)}  peak_rss={_peak_rss_gb():.2f}GB")
+
+    # 4. slice + stark<->slice-eid maps (edge-endpoint nodes only)
+    slice_graph = store.as_of(_BIG, _BIG)
+    stark_to_eid = {int(e["source_refs"][0]): e["entity_id"]
+                    for e in slice_graph.entities() if e["source_refs"]}
+    eid_to_stark = {v: k for k, v in stark_to_eid.items()}
+    n_isolated = len(nodes) - len(stark_to_eid)
+    lines.append(f"slice: endpoint_nodes={len(stark_to_eid)}  isolated_nodes={n_isolated} "
+                 f"(absent from as_of -- dense still covers them via the full-node index)")
+
+    # 5. both arms
+    for arm in ("dense", "graph"):
+        r = evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, arm=arm)
+        lines.append(
+            f"\n[{arm}] hit@1={r['hit@1']:.3f} hit@5={r['hit@5']:.3f} "
+            f"recall@20={r['recall@20']:.3f} mrr={r['mrr']:.3f}  "
+            f"lat_mean={r['latency_ms_mean']:.1f}ms lat_p95={r['latency_ms_p95']:.1f}ms "
+            f"(n={r['n_queries']}, with_gold={r['n_with_gold']})"
+        )
+
+    lines.append(f"\npeak_rss_final={_peak_rss_gb():.2f}GB")
+    lines.append("\nNOTE: EntityIndex embeds node NAMES (not STaRK full node text), so absolute "
+                 "numbers are NOT leaderboard-comparable; the dense-vs-graph DELTA is the signal.")
+    text = "\n".join(lines)
+    print(text, flush=True)
+
+    os.makedirs("/cache/results", exist_ok=True)
+    pathlib.Path(f"/cache/results/stark_{kb}.md").write_text(text)
+    cache.commit()
+    return text
+
+
+@app.function(image=image, gpu="A10G", volumes={"/cache": cache}, timeout=10800, memory=65536)
+def run_stark(kb: str = "prime", sample: int = 200, embed_model: str = "nomic-embed-text",
+              chunk_edges: int = 0) -> str:
+    return _stark_impl(kb, sample, embed_model, chunk_edges)
+
+
+@app.local_entrypoint()
+def main(kb: str = "prime", sample: int = 200, embed_model: str = "nomic-embed-text",
+         chunk_edges: int = 0, spawn: bool = False) -> None:
+    if spawn:
+        call = run_stark.spawn(kb=kb, sample=sample, embed_model=embed_model, chunk_edges=chunk_edges)
+        print(f"SPAWNED call_id={call.object_id} -> results/stark_{kb}.md on gg-bench-cache")
+        return
+    print("\n===== RESULT =====\n" + run_stark.remote(
+        kb=kb, sample=sample, embed_model=embed_model, chunk_edges=chunk_edges))


### PR DESCRIPTION
## What

SP2 of the STaRK-scale program: load a **pre-structured** KB straight into the goldengraph store (no LLM extraction), retrieve over it two ways, and produce honest at-scale numbers. Prereq SP1 (EntityIndex, #1395) already merged.

- **`goldengraph/bulk.py::bulk_load`** — maps `(nodes, edges)` → `StoreBatch` → `store.append`, bypassing extract/resolve/link. Unique `record_keys=[stark_id]` ⇒ passthrough (zero merges); `source_refs=[stark_id]` rides through `as_of` for retrieval id translation; edges co-batched with endpoints. Single batch by default (O(N) append); `chunk_edges` fallback (byte-parity with single-batch) for the OOM ceiling.
- **`erkgbench/stark_metrics.py`** — pure Hit@1/Hit@5/Recall@20/MRR + Arm-B dedup. Reimplemented (no STaRK-harness coupling).
- **`erkgbench/stark_adapter.py`** — HF `stark_qa` loader (real API: `node_info` names, `edge_index`/`edge_types`, QA test split) + a two-arm evaluator.
- **`scripts/distill/modal_stark.py`** — the Modal feasibility entry (PRIME first).

## Id-space correctness (the load-bearing bit)

Three id spaces: stark id / minted `StableId` / `as_of` view-local `EntityId`. `as_of` surfaces **edge-endpoint nodes only**, so the index is built over the **full node list** (`entity_id=int(stark_id)`) — a slice-built index would silently drop isolated nodes from the **dense baseline** and understate Recall@20. Arm A returns stark ids directly (covers all nodes); Arm B walks the **store** (`as_of().query`) via stark↔slice-eid maps at the walk boundary. Both reviewed and fixed pre-merge.

## Tests

- `tests/test_bulk_load.py` — 7 tests vs a **real `PyStore`** (append/as_of semantics are what's under test): single-batch, edge-remap, passthrough (zero HistoryEvent), provenance ride-through, dangling-drop, chunked-parity, edge co-batching.
- `tests/test_stark_metrics.py` — 8 pure box-safe metric tests.
- Adapter + Modal entry are integration-only (validated by the PRIME run, ruff+compile clean).

Vanilla STaRK is pre-resolved, so this proves "structure loads + retrieves at scale," **not** the ER moat (alias-injected STaRK is deferred).

Spec + plan: `docs/superpowers/{specs,plans}/2026-07-02-goldengraph-stark-bulkload*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)