### PR TITLE
fix(goldengraph): SP2 verdict report + Modal-run deps missed by #1399 squash

### DIFF
--- a/docs/superpowers/reports/2026-07-02-stark-prime-feasibility.md
+++ b/docs/superpowers/reports/2026-07-02-stark-prime-feasibility.md
@@ -1,0 +1,86 @@
+# STaRK-PRIME feasibility spike (SP2) — verdict
+
+**Question:** does goldengraph's ingest + retrieve path run at STaRK scale, and
+does the graph earn its place over a pure-dense baseline?
+
+**Answer: YES on both, at PRIME scale.** Ingest + retrieve runs cleanly on
+129,375 nodes / 8.1M edges; the 1-hop graph walk lifts recall@20 +39% and MRR
++17% over dense-only. Run on Modal (A10G, 64GB), `snap-stanford/stark` PRIME,
+200 test queries, Ollama `nomic-embed-text`.
+
+## Raw numbers
+
+```
+load_stark_kb: 40.6s  nodes=129375 edges=8100498 queries=200
+bulk_load:     38.1s  {n_nodes:129375, n_edges:8100498, n_dropped_edges:0, n_batches:1}  peak_rss=10.93GB
+EntityIndex.build: 852.5s  indexed=129375  peak_rss=10.99GB
+slice: endpoint_nodes=129375  isolated_nodes=0
+peak_rss_final=10.99GB
+
+[dense] hit@1=0.035 hit@5=0.145 recall@20=0.144 mrr=0.077  lat_mean=237.9ms lat_p95=321.9ms
+[graph] hit@1=0.035 hit@5=0.145 recall@20=0.200 mrr=0.090  lat_mean=575.9ms lat_p95=2529.6ms
+```
+
+## Findings
+
+### 1. Feasibility: single-batch ingest scales to PRIME (no OOM)
+`bulk_load` loaded 129K nodes + **8.1M edges in ONE `StoreBatch`** (`n_batches=1`)
+in 38.1s at 10.9GB peak RSS. The OOM ceiling the spike was designed to find was
+**not hit** — the chunked-edges fallback was unnecessary at this scale. Zero
+dropped edges (every STaRK endpoint resolved). Total peak RSS across the whole
+run stayed at ~11GB.
+
+### 2. The graph arm beats dense on recall/MRR
+| arm | hit@1 | hit@5 | recall@20 | MRR | lat_mean | lat_p95 |
+|-----|-------|-------|-----------|-----|----------|---------|
+| dense (vectors only) | 0.035 | 0.145 | 0.144 | 0.077 | 238ms | 322ms |
+| graph (seeds + 1-hop) | 0.035 | 0.145 | **0.200** | **0.090** | 576ms | 2530ms |
+
+The 1-hop store walk (`as_of().query(seeds, 1)`) recovers answers reachable by a
+relation but not textually near the query: **recall@20 +39%** (0.144→0.200),
+**MRR +17%** (0.077→0.090). hit@1/hit@5 are identical — the top of the ranking is
+dominated by the dense seeds; the graph contributes answers deeper in the list,
+which is exactly where recall@20 and MRR reward it. This is the graph earning its
+place through the store's retrieval path (not a Python side-structure).
+
+### 3. Embedding is the build bottleneck
+`EntityIndex.build` was 852.5s of the ~890s total non-query time — embedding 129K
+node names via Ollama `nomic-embed-text` (batches of 256). The store ingest (38s)
+and the graph walk (per-query) are cheap by comparison. Any scale-up work should
+target the embedding throughput first (batch size, a faster/GPU-native embedder),
+not the store.
+
+### 4. Latency: graph walk costs p95, not mean
+Dense is a flat ~238ms/query (one query embed + ANN). Graph adds a 1-hop walk:
+mean 576ms but p95 2530ms — high-degree PRIME nodes (biomedical hubs) blow up the
+neighbor set. A neighbor cap or degree-aware expansion is the obvious lever if
+graph-arm latency ever matters.
+
+## Honest caveats
+
+- **Not leaderboard-comparable.** `EntityIndex` embeds node **names only**, not
+  STaRK's full node text. Absolute numbers are low (hit@1 3.5%) for that reason.
+  A real dense retriever on full text scores far higher. This spike is an
+  **internal A-vs-B** (our dense vs our dense+graph); the **delta** is the signal,
+  and it is positive. Making Arm A competitive with STaRK's leaderboard would mean
+  embedding full node text — a separate, larger change.
+- **isolated_nodes=0 here.** PRIME is edge-dense (every node is an endpoint), so
+  the isolated-node honesty fix (index over the full node list, not the `as_of`
+  slice) didn't bite on PRIME — but it is load-bearing for sparser KBs and stays
+  in the design.
+- **ER moat NOT exercised.** Vanilla STaRK is pre-resolved; this proves "structure
+  loads + retrieves at scale," not "our ER beats ad-hoc dedup." Alias-injected
+  STaRK is the deferred moat experiment.
+
+## Next
+
+- **AMAZON** (~1M nodes) is the next scale rung — same entry (`--kb amazon`). The
+  single-batch JSON at ~1M nodes / more edges is where the OOM ceiling may finally
+  appear; the `chunk_edges` fallback is wired and parity-tested for exactly that.
+- If pursued as a real benchmark: embed full node text (not names) for a fair
+  dense baseline, and add a degree cap to the graph walk.
+
+Entry: `scripts/distill/modal_stark.py` (`modal run --detach ... --kb prime --sample 200 --spawn`).
+Eight Modal-harness fixes were needed to get `stark_qa` importable without its
+retrieval-baseline dependency tree (see the PR #1399 commit history); the
+box-tested `bulk_load` + metrics code was unchanged throughout.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
@@ -33,6 +33,24 @@ def load_stark_kb(name: str, *, split: str = "test", limit_queries: int | None =
 
     Node/gold ids stay INTS for retrieval+scoring; ids are stringified only for the
     store's opaque ``record_keys`` (done inside ``bulk_load``)."""
+    # stark_qa is installed --no-deps (its FULL tree pulls the colbert/gritlm/mteb retrieval
+    # baselines -- what we replace -- and pip can't resolve them). Its package __init__ imports
+    # load_model -> stark_qa.models -> those baselines at top level, so seed lightweight MagicMock
+    # stand-ins for the heavy backends: we only call the SKB/QA DATA loaders, never a model.
+    import sys
+    from unittest.mock import MagicMock
+
+    # `stark_qa/__init__` does `from .load_model import load_model`, dragging in the WHOLE
+    # retrieval-baseline + evaluator branch (colbert/gritlm/mteb/torchmetrics/faiss/...). We never
+    # call a stark model (we reimplement retrieval + metrics), and load_skb/load_qa don't depend on
+    # it, so stub the branch WHOLESALE -- one move instead of chasing each transitive dep.
+    for _mod in ("stark_qa.load_model", "stark_qa.models"):
+        sys.modules.setdefault(_mod, MagicMock())
+    # The SKB branch (load_skb) DOES load: skb/__init__ eagerly imports amazon+mag, whose modules
+    # pull text-cleaning libs at top level. Stub just those (we read raw node data, not the cleaners).
+    for _m in ("nltk", "nltk.corpus", "nltk.stem", "nltk.tokenize", "bs4", "langchain",
+               "langchain.text_splitter", "langchain_text_splitters", "langdetect", "unidecode"):
+        sys.modules.setdefault(_m, MagicMock())
     from stark_qa import load_qa, load_skb
 
     skb = load_skb(name)

--- a/scripts/distill/modal_stark.py
+++ b/scripts/distill/modal_stark.py
@@ -35,7 +35,17 @@ image = (
     .apt_install("curl", "build-essential", "pkg-config", "libssl-dev", "git", "zstd")
     .run_commands("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
     .env({"PATH": "/root/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"})
-    .pip_install("maturin", "goldenmatch", "numpy", "openai", "stark-qa")
+    .pip_install("maturin", "goldenmatch", "numpy", "openai")
+    # STaRK data deps only. stark-qa's FULL tree drags in the retrieval-model baselines
+    # (colbert-ai/gritlm/mteb/wandb) -- exactly what goldengraph replaces -- and pip backtracks
+    # forever resolving them. Install the SKB/QA DATA loaders with --no-deps + just what they need:
+    # torch (SKB edge tensors), pandas/hf_hub/gdown (download+parse), PyTDC (PRIME's tdc.resource),
+    # ogb (skb/__init__ eagerly imports amazon+mag which need ogb.utils.url regardless of --kb);
+    # torch_geometric (base SKB knowledge_base.py uses torch_geometric.utils -- pure-Python, no
+    # torch-scatter/sparse C++ ext needed for is_undirected/to_undirected).
+    .pip_install("torch", "pandas", "huggingface_hub", "gdown", "requests", "PyTDC", "ogb",
+                 "torch_geometric")
+    .pip_install("stark-qa", extra_options="--no-deps")
     .run_commands("curl -fsSL https://ollama.com/install.sh | sh")
     .add_local_dir(str(REPO / "packages/rust"), "/repo/packages/rust", ignore=["**/target/**"])
     .add_local_dir(str(REPO / "packages/python/goldengraph"), "/repo/packages/python/goldengraph",
@@ -130,7 +140,12 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int) -> str
     _build_native_and_install()
     base_url = _start_ollama(embed_model)
     os.environ["POLARS_SKIP_CPU_CHECK"] = "1"
-    sys.path.insert(0, _BENCH)
+    # `pip install -e` ran in a SUBPROCESS; its .pth is only read at interpreter startup, so this
+    # already-running process can't import the editable packages. Put the (flat-layout) src roots on
+    # sys.path directly -- the native wheel installs into site-packages so it imports fine.
+    for _p in ("/repo/packages/python/goldengraph", "/repo/packages/python/goldenmatch", _BENCH):
+        if _p not in sys.path:
+            sys.path.insert(0, _p)
 
     from erkgbench.stark_adapter import evaluate, load_stark_kb
     from goldengraph.entity_index import EntityIndex


### PR DESCRIPTION
Follow-up to #1399. Its auto-merge squash fired before three files landed on the branch:

- **`docs/.../2026-07-02-stark-prime-feasibility.md`** — the PRIME verdict (129K nodes / 8.1M edges: single-batch ingest 38s/10.9GB no OOM; graph arm recall@20 +39% / MRR +17% over dense).
- **`stark_adapter.py`** — the wholesale stub of `stark_qa.load_model`/`models` + `langdetect` mock (so `import stark_qa` works headless without the colbert/gritlm/mteb tree).
- **`modal_stark.py`** — `ogb` + `torch_geometric` image deps.

Without these, the Modal entry on main can't import `stark_qa`. Integration + docs only; the box-tested `bulk_load` + metrics already merged in #1399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)