### PR TITLE
feat(goldengraph): STaRK fair-baseline follow-up (graph delta inverts on fair dense)

### DIFF
--- a/docs/superpowers/reports/2026-07-02-stark-prime-feasibility.md
+++ b/docs/superpowers/reports/2026-07-02-stark-prime-feasibility.md
@@ -3,10 +3,19 @@
 **Question:** does goldengraph's ingest + retrieve path run at STaRK scale, and
 does the graph earn its place over a pure-dense baseline?
 
-**Answer: YES on both, at PRIME scale.** Ingest + retrieve runs cleanly on
-129,375 nodes / 8.1M edges; the 1-hop graph walk lifts recall@20 +39% and MRR
-+17% over dense-only. Run on Modal (A10G, 64GB), `snap-stanford/stark` PRIME,
-200 test queries, Ollama `nomic-embed-text`.
+**Answers.** Feasibility: **YES** — ingest + retrieve runs cleanly on 129,375
+nodes / 8.1M edges. Does the graph earn its place: **NO on vanilla PRIME once the
+dense baseline is FAIR.** The initial "graph +39% recall@20" held only against a
+name-only dense baseline; when dense embeds each node's intrinsic description, it
+nearly doubles and the naive 1-hop walk provides no net benefit (recall@20 −18%).
+See "Fair-baseline follow-up" below — this is the load-bearing correction, and it
+redirects to the ER-moat experiment (alias-injected STaRK). Run on Modal (A10G,
+64GB), `snap-stanford/stark` PRIME, 200 test queries, Ollama `nomic-embed-text`.
+
+> The "names-mode" numbers below (§Raw numbers / §Findings 1-4) are the FIRST run
+> and are superseded on the retrieval-quality question by the fair-baseline
+> follow-up. They remain valid for FEASIBILITY (ingest/RAM/scale) and as the
+> weak-baseline half of the A/B.
 
 ## Raw numbers
 
@@ -84,3 +93,65 @@ Entry: `scripts/distill/modal_stark.py` (`modal run --detach ... --kb prime --sa
 Eight Modal-harness fixes were needed to get `stark_qa` importable without its
 retrieval-baseline dependency tree (see the PR #1399 commit history); the
 box-tested `bulk_load` + metrics code was unchanged throughout.
+
+---
+
+## Fair-baseline follow-up (the load-bearing correction)
+
+**Motivation.** The names-mode "graph +39% recall@20" came against a dense baseline
+that embeds only node NAMES — it cannot see a node's description, so it misses
+answers the 1-hop walk then recovers. That is a handicapped baseline. The honest
+test: embed each node's INTRINSIC document (`get_doc_info(add_rel=False)` = name +
+description, NO relations, so the graph walk stays the ONLY structural signal) and
+ask whether the graph delta SURVIVES. Same run (`--text-mode full`), same PRIME,
+same 200 queries, same machine.
+
+| metric | names-dense | names-graph | **text-dense** | **text-graph** |
+|--------|-------------|-------------|----------------|----------------|
+| hit@1 | 0.035 | 0.035 | **0.085** | 0.085 |
+| hit@5 | 0.145 | 0.145 | **0.230** | 0.230 |
+| recall@20 | 0.144 | 0.200 (+39%) | **0.261** | 0.213 (**−18%**) |
+| MRR | 0.077 | 0.090 (+17%) | **0.151** | 0.150 (flat) |
+
+(text run: load 44.2s, bulk_load 34.8s @ 11.0GB, EntityIndex.build 1123s — longer
+docs embed slower than names; peak RSS 11.3GB.)
+
+**Finding 1 — a fair dense baseline is far stronger.** Embedding the intrinsic doc
+nearly doubles dense: recall@20 0.144→0.261 (+81%), hit@1 0.035→0.085 (2.4x), MRR
+0.077→0.151 (~2x). The name-only baseline was badly handicapped.
+
+**Finding 2 — the graph delta does not survive; it INVERTS.** Against fair dense,
+the naive 1-hop walk gives **no net benefit and hurts recall@20 (−18%: 0.213 vs
+0.261)**; MRR is flat. hit@1/hit@5 identical (the top-5 seeds are unchanged). So
+the earlier +39% was **entirely a weak-baseline artifact**.
+
+**Mechanism.** The graph arm ranks `top-5 seeds ++ all their 1-hop neighbors`
+(deduped). When dense is strong, the top-20 dense hits are already good; flooding
+in unranked neighbors after only 5 seeds displaces good dense hits at ranks 6-20
+with structurally-adjacent-but-irrelevant nodes → recall@20 drops. First-hit rank
+is unchanged → MRR flat, hit@1/5 unchanged.
+
+**Conclusion.** On **vanilla** STaRK-PRIME, with a fair dense baseline, the graph
+walk does **not** earn its place. This is expected and honest: vanilla STaRK is
+**pre-resolved and text-rich**, so structure adds nothing over strong text. It does
+NOT refute the program thesis — it sharpens it. The graph's value must be shown
+where text retrieval BREAKS: the **ER-moat experiment (alias-injected STaRK)** —
+inject alias/duplicate noise so the text signal fragments and dense collapses, and
+resolved-graph structure is the only way to recover the answer. This negative is
+the strongest argument for running the moat experiment next.
+
+**Caveat on the graph arm itself.** The 1-hop expansion here is naive (top-5 seeds,
+unranked neighbor flood). A smarter arm — rank neighbors by dense score, expand only
+when dense confidence is low, or cap by degree — might not hurt. But the clean
+finding stands: naive structural expansion does not beat strong dense on vanilla,
+pre-resolved, text-rich STaRK.
+
+## Revised next step
+
+- **NOT the AMAZON scale rung** (it would only re-run the same weak-vs-fair question
+  at 10x cost). Scale/OOM is an engineering data point available anytime.
+- **The ER-moat experiment: alias-injected STaRK.** Corrupt a real STaRK KB with
+  duplicate/alias nodes (mirror the homograph injection), run ad-hoc-dedup vs
+  ER-native ingest, and measure whether resolved-graph retrieval recovers quality
+  that fragmented-text dense loses. That is the battlefield where the graph is the
+  only way to win — the test vanilla STaRK cannot provide.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
@@ -24,12 +24,18 @@ def _node_name(info: dict) -> str:
     return str(info.get("name") or info.get("title") or "").strip()
 
 
-def load_stark_kb(name: str, *, split: str = "test", limit_queries: int | None = None):
-    """Return ``(nodes, edges, queries)`` for a STaRK KB.
+def load_stark_kb(name: str, *, split: str = "test", limit_queries: int | None = None,
+                  with_text: bool = False):
+    """Return ``(nodes, edges, queries, node_texts)`` for a STaRK KB.
 
     nodes: list of ``(stark_id: str, name: str, typ: str)``.
     edges: list of ``(subj_stark_id: str, predicate: str, obj_stark_id: str)``.
     queries: list of ``(query_text: str, gold_stark_ids: set[int])`` from ``split``.
+    node_texts: ``None`` unless ``with_text`` -- then a list aligned to ``nodes`` of each
+      node's INTRINSIC document (``get_doc_info(add_rel=False)`` = name + description, NO
+      relations). This is the fair-baseline embedding corpus: with relations excluded, the
+      graph WALK stays the only structural signal, so text-dense vs text-graph is a clean
+      test of whether the graph earns its place over strong text retrieval.
 
     Node/gold ids stay INTS for retrieval+scoring; ids are stringified only for the
     store's opaque ``record_keys`` (done inside ``bulk_load``)."""
@@ -60,6 +66,19 @@ def load_stark_kb(name: str, *, split: str = "test", limit_queries: int | None =
         info = skb.node_info[nid]
         nodes.append((str(nid), _node_name(info), str(skb.get_node_type_by_id(nid))))
 
+    # Fair-baseline corpus: each node's intrinsic doc (name + description, add_rel=False so NO
+    # relations leak into the dense vector). compact=True keeps it embedder-context-sized. Fail-soft
+    # per node -> fall back to the name (an unrenderable node must not sink the whole load).
+    node_texts = None
+    if with_text:
+        node_texts = []
+        for nid in range(n_nodes):
+            try:
+                txt = str(skb.get_doc_info(nid, add_rel=False, compact=True)).strip()
+            except Exception:
+                txt = ""
+            node_texts.append(txt or nodes[nid][1])
+
     # Real edges live in edge_index (2xE) + edge_types (E); get_tuples() is only the
     # SCHEMA (type-triples), not instances. Materialize once as python lists (fast),
     # decode each relation-type id once via a cache.
@@ -85,7 +104,7 @@ def load_stark_kb(name: str, *, split: str = "test", limit_queries: int | None =
     for i in idx:
         query, _q_id, answer_ids, _meta = qa[i]
         queries.append((query, {int(a) for a in answer_ids}))
-    return nodes, edges, queries
+    return nodes, edges, queries, node_texts
 
 
 def evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, *,

--- a/scripts/distill/modal_stark.py
+++ b/scripts/distill/modal_stark.py
@@ -132,7 +132,8 @@ def _start_ollama(embed_model: str) -> str:
     return "http://localhost:11434/v1"
 
 
-def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int) -> str:
+def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int,
+                text_mode: str = "names") -> str:
     import os
     import sys
     import time
@@ -152,11 +153,13 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int) -> str
     from goldengraph_native import _native as ggn
 
     _BIG = 1 << 62
-    lines = [f"# STaRK feasibility -- {kb} (sample={sample})", ""]
+    lines = [f"# STaRK feasibility -- {kb} (sample={sample}, text_mode={text_mode})", ""]
 
-    # 1. download + map
+    # 1. download + map. with_text builds the fair-baseline corpus (each node's intrinsic doc,
+    #    add_rel=False -- NO relations, so the graph walk stays the only structural signal).
     t = time.perf_counter()
-    nodes, edges, queries = load_stark_kb(kb, split="test", limit_queries=sample)
+    nodes, edges, queries, node_texts = load_stark_kb(
+        kb, split="test", limit_queries=sample, with_text=(text_mode == "full"))
     lines.append(f"load_stark_kb: {time.perf_counter() - t:.1f}s  "
                  f"nodes={len(nodes)} edges={len(edges)} queries={len(queries)}")
 
@@ -178,10 +181,16 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int) -> str
     lines.append(f"bulk_load: {ingest_s:.1f}s  {stats}  peak_rss={_peak_rss_gb():.2f}GB")
 
     # 3. index over ALL nodes (entity_id=int(stark_id) -> query returns stark ids; isolated
-    #    nodes stay in the dense baseline). [index-build wall + RSS]
+    #    nodes stay in the dense baseline). names mode embeds the node NAME; full mode embeds the
+    #    node's intrinsic DOC (fair dense baseline). canonical_name is just the index's embed text
+    #    here -- the store keeps the real name, so display/walk are unaffected. [build wall + RSS]
     embedder = _OllamaEmbedder(embed_model, base_url)
-    index_entities = [{"entity_id": int(sid), "canonical_name": name, "typ": typ}
-                      for sid, name, typ in nodes]
+    if text_mode == "full":
+        corpus = [(node_texts[i] or name) for i, (sid, name, typ) in enumerate(nodes)]
+    else:
+        corpus = [name for sid, name, typ in nodes]
+    index_entities = [{"entity_id": int(sid), "canonical_name": corpus[i], "typ": typ}
+                      for i, (sid, name, typ) in enumerate(nodes)]
     t = time.perf_counter()
     index = EntityIndex.build(index_entities, embedder, top_k=50)
     build_s = time.perf_counter() - t
@@ -207,29 +216,36 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int) -> str
         )
 
     lines.append(f"\npeak_rss_final={_peak_rss_gb():.2f}GB")
-    lines.append("\nNOTE: EntityIndex embeds node NAMES (not STaRK full node text), so absolute "
-                 "numbers are NOT leaderboard-comparable; the dense-vs-graph DELTA is the signal.")
+    if text_mode == "full":
+        lines.append("\nNOTE: EntityIndex embeds each node's INTRINSIC doc (name+description, "
+                     "add_rel=False -- NO relations), so the graph walk is the only structural "
+                     "signal. Compare vs the names-mode run: does the graph delta SURVIVE a strong "
+                     "dense baseline? Still not STaRK-leaderboard (their docs add relations).")
+    else:
+        lines.append("\nNOTE: EntityIndex embeds node NAMES (not full node text), so absolute "
+                     "numbers are NOT leaderboard-comparable; the dense-vs-graph DELTA is the signal.")
     text = "\n".join(lines)
     print(text, flush=True)
 
     os.makedirs("/cache/results", exist_ok=True)
-    pathlib.Path(f"/cache/results/stark_{kb}.md").write_text(text)
+    pathlib.Path(f"/cache/results/stark_{kb}_{text_mode}.md").write_text(text)
     cache.commit()
     return text
 
 
 @app.function(image=image, gpu="A10G", volumes={"/cache": cache}, timeout=10800, memory=65536)
 def run_stark(kb: str = "prime", sample: int = 200, embed_model: str = "nomic-embed-text",
-              chunk_edges: int = 0) -> str:
-    return _stark_impl(kb, sample, embed_model, chunk_edges)
+              chunk_edges: int = 0, text_mode: str = "names") -> str:
+    return _stark_impl(kb, sample, embed_model, chunk_edges, text_mode)
 
 
 @app.local_entrypoint()
 def main(kb: str = "prime", sample: int = 200, embed_model: str = "nomic-embed-text",
-         chunk_edges: int = 0, spawn: bool = False) -> None:
+         chunk_edges: int = 0, text_mode: str = "names", spawn: bool = False) -> None:
     if spawn:
-        call = run_stark.spawn(kb=kb, sample=sample, embed_model=embed_model, chunk_edges=chunk_edges)
-        print(f"SPAWNED call_id={call.object_id} -> results/stark_{kb}.md on gg-bench-cache")
+        call = run_stark.spawn(kb=kb, sample=sample, embed_model=embed_model,
+                               chunk_edges=chunk_edges, text_mode=text_mode)
+        print(f"SPAWNED call_id={call.object_id} -> results/stark_{kb}_{text_mode}.md on gg-bench-cache")
         return
     print("\n===== RESULT =====\n" + run_stark.remote(
-        kb=kb, sample=sample, embed_model=embed_model, chunk_edges=chunk_edges))
+        kb=kb, sample=sample, embed_model=embed_model, chunk_edges=chunk_edges, text_mode=text_mode))


### PR DESCRIPTION
Follow-up to #1399/#1400. Tests whether the PRIME "graph +39% recall@20" survives a **fair** dense baseline, or was an artifact of the name-only baseline.

**Change:** `--text-mode full` embeds each node's intrinsic doc (`get_doc_info(add_rel=False)` = name + description, NO relations, so the 1-hop walk stays the only structural signal), instead of the node name.

**Result (PRIME, 200 queries, same machine):**

| metric | names-dense | names-graph | text-dense | text-graph |
|--------|-------------|-------------|------------|------------|
| recall@20 | 0.144 | 0.200 (+39%) | **0.261** | 0.213 (**−18%**) |
| MRR | 0.077 | 0.090 (+17%) | **0.151** | 0.150 (flat) |
| hit@1 | 0.035 | 0.035 | **0.085** | 0.085 |

- Fair dense nearly doubles vs names (recall@20 +81%, hit@1 2.4x).
- The graph delta **inverts** — the naive 1-hop flood hurts recall@20 by −18%. The +39% was a weak-baseline artifact.

**Honest conclusion:** on vanilla (pre-resolved, text-rich) STaRK-PRIME the graph does not earn its place once dense is fair. This is expected and sharpens the case for the **ER-moat experiment (alias-injected STaRK)** — where text retrieval breaks and resolved-graph structure is the only recovery. Integration + docs only; box-tested `bulk_load`/metrics unchanged.

Full write-up in the updated `docs/.../2026-07-02-stark-prime-feasibility.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)