### PR TITLE
feat(goldengraph): alias-injected STaRK ER-moat harness + verdict (inconclusive, confounded instrument)

### DIFF
--- a/docs/superpowers/plans/2026-07-03-goldengraph-stark-alias-moat.md
+++ b/docs/superpowers/plans/2026-07-03-goldengraph-stark-alias-moat.md
@@ -563,7 +563,7 @@ git commit -m "feat(goldengraph): stark_moat collapse-for-index/store (Python ed
 - Modify: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py`
 - Test: `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_alias_scoring.py`
 
-- [ ] **Step 1: Write the failing test** (pure — reuses `canon_rank` semantics against `metrics`)
+- [ ] **Step 1: Write the failing test** (pure — `_apply_id_map` semantics against `metrics`)
 
 ```python
 """SP-moat scoring: canon-mapped ranked list -> equivalence-class hit."""

--- a/docs/superpowers/plans/2026-07-03-goldengraph-stark-alias-moat.md
+++ b/docs/superpowers/plans/2026-07-03-goldengraph-stark-alias-moat.md
@@ -1,0 +1,699 @@
+# Alias-injected STaRK ER-moat experiment — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Corrupt a real STaRK KB with alias duplicates that fragment each gold entity's text + edges, then show goldenmatch's resolver recovers retrieval quality that ad-hoc exact-match dedup loses — the ER moat vanilla STaRK cannot show.
+
+**Architecture:** Reuse SP2/SP1 wholesale. A pure injector fragments gold entities into k variant-named alias nodes (split doc sentences + edges). A resolver clusters the aliases three ways (none / exact / goldenmatch). One Python clustering drives BOTH materializations: the `EntityIndex` (one merged-text embedding per cluster) and the store (a caller-side collapse to one node per cluster, edges remapped, then `bulk_load` the pre-merged graph — `bulk.py` unchanged). Scoring maps retrieved cluster ordinals → canonical originals (equivalence class) and reuses `stark_metrics`.
+
+**Tech Stack:** Python 3.12, `goldengraph_native.PyStore` (real store, box-loadable), `goldengraph.entity_index.EntityIndex`, `goldenmatch.dedupe_df` + `polars` (the `er` resolver), numpy, Modal (run only).
+
+**Spec:** `docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md`
+
+---
+
+## Ground truth confirmed
+
+- `goldengraph_native.PyStore` loads on the box (`append`/`as_of`/`history`/`snapshot`); `bulk_load` (`goldengraph/bulk.py`) is REUSED UNCHANGED — each collapsed cluster node passed as `(str(ordinal), name, typ)` gets `record_keys=[str(ordinal)]` (unique → passthrough, no store merge relied on).
+- `goldenmatch.dedupe_df(pl.DataFrame(...))` → `result.clusters` is a dict `{cluster_id: {"members": [row_indices], ...}}` (pattern already in `ingest.py::_gm_cluster` lines 210-229). Model the `er` resolver on it.
+- `as_of` mints view-local EntityIds in ascending StableId order, and StableIds are minted in **string-sorted record_key order**, so a store node's view-eid ≠ its ordinal. The ordinal rides through on `source_refs` (bulk_load sets `source_refs=[str(ordinal)]`); recover it exactly as SP2 recovered stark_id: `{int(e["source_refs"][0]): e["entity_id"] for e in slice.entities()}`.
+- `EntityIndex.build` filters `literal:`-typed + empty-name rows — a cluster whose merged doc is empty just drops from the index (unretrievable anyway; fine).
+- `stark_adapter.evaluate(index, slice, stark_to_eid, eid_to_stark, queries, embedder, *, arm, sample)` already maps view-eid↔the-id-on-source_refs. We add an `id_map` param so retrieved ids are canon-mapped before `metrics`.
+- Clean reference (recall@20 dense 0.261 / graph 0.213) is CITED from PR #1402, not re-run (there ordinal = stark_id, identity map).
+
+## File structure
+
+- **Create** `packages/python/goldengraph/goldengraph/stark_inject.py` — the corruption: `inject_aliases`, `_variants`. Pure + seeded rng. No store, no goldenmatch.
+- **Create** `packages/python/goldengraph/goldengraph/stark_moat.py` — the clustering→materialization: `build_clusters`, `collapse_for_index`, `collapse_for_store`, `canon_rank`. Pure except `collapse_for_store`'s consumer (bulk_load in the test).
+- **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_resolve.py` — `resolve_aliases` (none/exact/er). Lazy goldenmatch import.
+- **Modify** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py` — add `id_map=None` to `evaluate` (canon-map retrieved ids before scoring).
+- **Modify** `scripts/distill/modal_stark.py` — add `--inject` mode driver (integration).
+- **Tests:** `goldengraph/tests/test_stark_inject.py`, `goldengraph/tests/test_alias_materialize.py` (real PyStore), `er-kg-bench/tests/test_stark_resolve.py`, `er-kg-bench/tests/test_alias_scoring.py` (pure).
+
+## Box-safe test runners
+
+goldengraph (real PyStore, worktree goldenmatch shadow):
+```
+cd packages/python/goldengraph
+PYTHONPATH=/d/show_case/gg-local-llm/packages/python/goldenmatch POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/<file> -q
+```
+erkgbench:
+```
+cd packages/python/goldenmatch/benchmarks/er-kg-bench
+PYTHONPATH="$PWD:/d/show_case/gg-local-llm/packages/python/goldengraph" POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/<file> -q
+```
+Reference skills: @superpowers:test-driven-development, @superpowers:subagent-driven-development. Auth: benzsevern (`unset GH_TOKEN` before push). Fixtures: surname-diverse per the synthetic-fixture guidance (avoid blocking hangs in dedupe).
+
+---
+
+## Task 1: `inject_aliases` + `_variants` — the corruption
+
+**Files:**
+- Create: `packages/python/goldengraph/goldengraph/stark_inject.py`
+- Test: `packages/python/goldengraph/tests/test_stark_inject.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""SP-moat: alias injection fragments a gold entity into k variant-named nodes,
+splitting its doc + edges. Pure + seeded; no store, no goldenmatch."""
+from __future__ import annotations
+
+from goldengraph.stark_inject import _variants, inject_aliases
+
+# 3 nodes; N1 is the injection target. Docs are 3 sentences so k=3 splits cleanly.
+_NODES = [("1", "Interleukin 6", "gene"), ("2", "aspirin", "drug"), ("3", "fever", "effect")]
+_TEXTS = ["Interleukin 6 is a cytokine. It signals inflammation. It is a drug target.",
+          "aspirin doc.", "fever doc."]
+_EDGES = [("1", "associated_with", "3"), ("2", "treats", "3"), ("1", "targeted_by", "2")]
+
+
+def test_variants_returns_k_distinct():
+    vs = _variants("Interleukin 6", 3, seed=0)
+    assert len(vs) == 3 and len(set(vs)) == 3          # distinct (anti-rig for exact dedup)
+
+
+def test_target_fragmented_into_k_aliases_original_dropped():
+    nodes2, texts2, edges2, canon = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=0)
+    ids = {n[0] for n in nodes2}
+    assert "1" not in ids                               # original dropped
+    aliases = [i for i in ids if i.startswith("1#a")]
+    assert len(aliases) == 3                            # k aliases
+    assert {"2", "3"} <= ids                            # non-targets pass through
+
+
+def test_canon_maps_aliases_to_original_identity_elsewhere():
+    _, _, _, canon = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=0)
+    assert canon["2"] == "2" and canon["3"] == "3"      # identity for non-targets
+    assert all(canon[a] == "1" for a in canon if a.startswith("1#a"))
+
+
+def test_doc_sentences_partitioned_no_alias_has_full():
+    nodes2, texts2, _, _ = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=0)
+    txt = dict(zip([n[0] for n in nodes2], texts2))
+    alias_docs = [txt[i] for i in txt if i.startswith("1#a")]
+    joined = " ".join(alias_docs)
+    for sent in ["Interleukin 6 is a cytokine", "It signals inflammation", "It is a drug target"]:
+        assert sent in joined                           # union preserves every sentence
+    assert all(len(d) < len(_TEXTS[0]) for d in alias_docs)   # no alias has the full doc
+
+
+def test_edges_distributed_across_aliases():
+    _, _, edges2, _ = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=0)
+    # N1 had 2 incident edges (->3, N1 targeted_by 2); they land on DIFFERENT aliases
+    n1_edge_sources = {s for (s, _p, _o) in edges2 if s.startswith("1#a")}
+    n1_edge_objs = {o for (_s, _p, o) in edges2 if o.startswith("1#a")}
+    assert len(n1_edge_sources | n1_edge_objs) >= 2     # spread across >=2 aliases
+
+
+def test_both_target_edge_remaps_both_ends():
+    # inject BOTH endpoints of edge (1 -targeted_by-> 2): both must become aliases
+    _, _, edges2, _ = inject_aliases(_NODES, _TEXTS, _EDGES, {"1", "2"}, k=2, seed=0)
+    e = [(s, p, o) for (s, p, o) in edges2 if p == "targeted_by"][0]
+    assert e[0].startswith("1#a") and e[2].startswith("2#a")
+
+
+def test_determinism_same_seed():
+    a = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=7)
+    b = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=7)
+    assert a == b
+```
+
+- [ ] **Step 2: Run to verify failure** (box runner) → `ModuleNotFoundError: goldengraph.stark_inject`.
+
+- [ ] **Step 3: Implement**
+
+```python
+"""SP-moat: fragment gold entities into k alias nodes (variant names, split doc +
+edges) so dense retrieval degrades and only a real resolver recovers it. Pure +
+seeded (reproducible); no store, no goldenmatch here.
+See docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md.
+"""
+from __future__ import annotations
+
+import random
+
+
+def _variants(name: str, k: int, *, seed: int) -> list[str]:
+    """k DISTINCT surface forms of `name` (abbreviation / word-order / truncation /
+    punctuation-drop). Distinctness is load-bearing: if two variants collide, the
+    ad-hoc exact-match baseline would merge them for free and rig the comparison.
+    Falls back to a numbered suffix to guarantee k distinct forms."""
+    rng = random.Random(f"{seed}:{name}")
+    toks = name.split()
+    cands: list[str] = []
+
+    def _add(v: str) -> None:
+        v = v.strip()
+        if v and v not in cands:
+            cands.append(v)
+
+    _add(name)
+    if len(toks) > 1:
+        _add(" ".join(reversed(toks)))                       # word-order
+        _add("".join(t[0].upper() for t in toks))            # abbreviation/initials
+        _add(" ".join(toks[:-1]))                            # truncation
+    _add(name.replace("-", " ").replace(",", ""))            # punctuation-drop
+    _add(name.lower())
+    rng.shuffle(cands)
+    out = cands[:k]
+    j = 0
+    while len(out) < k:                                       # guarantee k distinct
+        cand = f"{name} ({j})"
+        if cand not in out:
+            out.append(cand)
+        j += 1
+    return out
+
+
+def _sentences(doc: str) -> list[str]:
+    return [s.strip() for s in doc.split(". ") if s.strip()]
+
+
+def inject_aliases(nodes, node_texts, edges, target_ids, *, k: int = 3, seed: int = 0):
+    """Fragment each entity in `target_ids` into k alias nodes. Returns
+    (nodes2, node_texts2, edges2, canon). See the spec / module docstring."""
+    target_ids = set(target_ids)
+    name_of = {n[0]: n[1] for n in nodes}
+    typ_of = {n[0]: n[2] for n in nodes}
+    text_of = dict(zip([n[0] for n in nodes], node_texts))
+
+    # alias ids + variant names per target; canon maps every id -> original
+    alias_ids: dict[str, list[str]] = {}
+    canon: dict[str, str] = {}
+    nodes2: list[tuple] = []
+    texts2: list[str] = []
+    for nid, name, typ in nodes:
+        if nid not in target_ids:
+            nodes2.append((nid, name, typ))
+            texts2.append(text_of[nid])
+            canon[nid] = nid
+            continue
+        vs = _variants(name, k, seed=seed)
+        ids = [f"{nid}#a{j}" for j in range(k)]
+        alias_ids[nid] = ids
+        sents = _sentences(text_of.get(nid, "")) or [name]
+        buckets: list[list[str]] = [[] for _ in range(k)]
+        for i, s in enumerate(sents):
+            buckets[i % k].append(s)                          # round-robin sentences
+        for j, aid in enumerate(ids):
+            nodes2.append((aid, vs[j], typ))
+            texts2.append(". ".join(buckets[j]))
+            canon[aid] = nid
+
+    # remap edges: an endpoint that is a target -> one of its aliases (round-robin by
+    # a per-target counter so its incident edges spread across aliases)
+    ctr: dict[str, int] = {}
+
+    def _remap(endpoint: str) -> str:
+        if endpoint not in target_ids:
+            return endpoint
+        ids = alias_ids[endpoint]
+        c = ctr.get(endpoint, 0)
+        ctr[endpoint] = c + 1
+        return ids[c % len(ids)]
+
+    edges2 = [(_remap(s), p, _remap(o)) for (s, p, o) in edges]
+    return nodes2, texts2, edges2, canon
+```
+
+- [ ] **Step 4: Run to verify pass** (box runner). Expected: 7 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /d/show_case/gg-local-llm && unset GH_TOKEN
+git add packages/python/goldengraph/goldengraph/stark_inject.py packages/python/goldengraph/tests/test_stark_inject.py
+git commit -m "feat(goldengraph): alias injection for STaRK ER-moat (fragment gold entity text+edges)"
+```
+
+---
+
+## Task 2: `resolve_aliases` — none / exact / goldenmatch
+
+**Files:**
+- Create: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_resolve.py`
+- Test: `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_stark_resolve.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""SP-moat resolver: cluster injected alias nodes 3 ways. `er` (goldenmatch) must
+merge variant surface forms of ONE entity that `exact` leaves split -- the moat in
+miniature. Surname-diverse fixture to avoid dedupe blocking hangs."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.stark_resolve import resolve_aliases  # noqa: E402
+
+
+def _clusters_as_sets(clusters):
+    return {frozenset(c) for c in clusters}
+
+
+# two entities: A has 3 variant surface forms, B has 1. Distinct real surnames.
+_ALIAS_NODES = [
+    ("A#a0", "Interleukin 6"), ("A#a1", "IL 6"), ("A#a2", "Interleukin-6"),
+    ("B#a0", "Metformin"),
+]
+
+
+def test_none_all_singletons():
+    cl = resolve_aliases(_ALIAS_NODES, "none")
+    assert _clusters_as_sets(cl) == {frozenset([i]) for i, _ in _ALIAS_NODES}
+
+
+def test_exact_merges_only_identical_names():
+    dup = _ALIAS_NODES + [("C#a0", "Metformin")]     # exact dup of B's name
+    cl = resolve_aliases(dup, "exact")
+    sets = _clusters_as_sets(cl)
+    assert frozenset(["B#a0", "C#a0"]) in sets        # identical names merge
+    assert frozenset(["A#a0"]) in sets                # variant forms stay split
+    assert frozenset(["A#a1"]) in sets
+
+
+def test_er_merges_variant_surface_forms():
+    cl = resolve_aliases(_ALIAS_NODES, "er")
+    sets = _clusters_as_sets(cl)
+    # the 3 IL-6 variants land in ONE cluster; Metformin stays separate
+    il6 = next(s for s in sets if "A#a0" in s)
+    assert {"A#a0", "A#a1", "A#a2"} <= set(il6)        # moat: er merges what exact can't
+    assert frozenset(["B#a0"]) in sets
+```
+
+- [ ] **Step 2: Run to verify failure** (erkgbench box runner) → module missing. (If `er` blocks/hangs, the fixture is too homogeneous — keep it tiny + surname-diverse.)
+
+- [ ] **Step 3: Implement**
+
+```python
+"""SP-moat resolver: cluster injected alias nodes. `none`/`exact` are pure; `er`
+routes through goldenmatch's zero-config dedupe (the suite's real ER engine) over
+the alias names -- the same call `ingest.py::_gm_cluster` uses. goldenmatch + polars
+import lazily so the pure paths need neither."""
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+def resolve_aliases(alias_nodes, method: str):
+    """`alias_nodes`: [(alias_id, name)] (injected set only). Returns clusters:
+    list[list[alias_id]]. method in {none, exact, er}."""
+    ids = [a for a, _ in alias_nodes]
+    if method == "none":
+        return [[i] for i in ids]
+    if method == "exact":
+        groups: dict[str, list[str]] = defaultdict(list)
+        for aid, name in alias_nodes:
+            groups[name.lower().strip()].append(aid)
+        return list(groups.values())
+    if method == "er":
+        import goldenmatch as gm
+        import polars as pl
+
+        if not alias_nodes:
+            return []
+        df = pl.DataFrame({"name": [name for _, name in alias_nodes]})
+        result = gm.dedupe_df(df)
+        seen: set[int] = set()
+        clusters: list[list[str]] = []
+        for info in result.clusters.values():
+            members = [int(x) for x in info["members"]]
+            seen.update(members)
+            clusters.append([ids[m] for m in members])
+        # dedupe_df only returns multi-member clusters; singletons are the rest
+        for i, aid in enumerate(ids):
+            if i not in seen:
+                clusters.append([aid])
+        return clusters
+    raise ValueError(f"unknown method {method!r} (none|exact|er)")
+```
+
+- [ ] **Step 4: Run to verify pass** (erkgbench box runner). If `er` returns singletons for all (dedupe found nothing), the fixture names may be too dissimilar for the zero-config threshold — nudge the variants closer (`IL-6` / `IL 6` / `Interleukin 6`) so the real engine merges them; that IS the behavior under test. Expected: 3 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_resolve.py packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_stark_resolve.py
+git commit -m "feat(erkgbench): STaRK alias resolver (none/exact/goldenmatch dedupe_df)"
+```
+
+---
+
+## Task 3: `build_clusters` + `canon_rank` — cluster ordinals + scoring map (pure)
+
+**Files:**
+- Create: `packages/python/goldengraph/goldengraph/stark_moat.py`
+- Test: `packages/python/goldengraph/tests/test_alias_scoring.py` (pure — lives in goldengraph tests; erkgbench's copy imports it too, see Task 5)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""SP-moat cluster assembly + canon scoring map (pure)."""
+from __future__ import annotations
+
+from goldengraph.stark_moat import build_clusters, canon_rank
+
+
+def test_build_clusters_targets_grouped_nontargets_singleton():
+    canon = {"1#a0": "1", "1#a1": "1", "2": "2"}
+    method_clusters = [["1#a0", "1#a1"]]               # resolver merged the two aliases
+    all_ids = ["1#a0", "1#a1", "2"]
+    ordinal_of, ord2canon = build_clusters(canon, method_clusters, all_ids)
+    assert ordinal_of["1#a0"] == ordinal_of["1#a1"]    # aliases share an ordinal
+    assert ordinal_of["2"] != ordinal_of["1#a0"]        # non-target its own ordinal
+    assert ord2canon[ordinal_of["1#a0"]] == "1"         # cluster -> canonical original
+    assert ord2canon[ordinal_of["2"]] == "2"
+
+
+def test_build_clusters_fragmented_all_singletons():
+    canon = {"1#a0": "1", "1#a1": "1"}
+    ordinal_of, ord2canon = build_clusters(canon, [["1#a0"], ["1#a1"]], ["1#a0", "1#a1"])
+    assert ordinal_of["1#a0"] != ordinal_of["1#a1"]     # fragmented -> distinct ordinals
+    assert ord2canon[ordinal_of["1#a0"]] == "1"         # both still map to original 1
+
+
+def test_canon_rank_maps_and_dedups_first_seen():
+    # retrieved ordinals -> canonical originals, dedup preserving order
+    ord2canon = {10: "1", 11: "1", 12: "2"}
+    assert canon_rank([12, 10, 11], ord2canon) == ["2", "1"]   # 11->1 is a dup of 10->1
+```
+
+- [ ] **Step 2: Run to verify failure** (goldengraph box runner).
+
+- [ ] **Step 3: Implement**
+
+```python
+"""SP-moat: turn a resolver's clusters into cluster-ordinal ids that drive BOTH
+materializations (index + store), plus the canon scoring map. The clustering is the
+single ER lever; the store's overlap-merge is NOT used (a batch reconciles only
+against already-stored entities, so same-batch aliases would never merge -- we
+collapse in Python instead). See the spec.
+"""
+from __future__ import annotations
+
+
+def build_clusters(canon, method_clusters, all_ids):
+    """`canon`: alias_id -> original id. `method_clusters`: resolver output over the
+    INJECTED aliases (list[list[alias_id]]). `all_ids`: every node id in the injected
+    graph (aliases + passthrough non-targets). Returns (ordinal_of, ord2canon):
+      ordinal_of: id -> cluster_ordinal (int, deterministic)
+      ord2canon:  cluster_ordinal -> canonical original id
+    Injected aliases group by `method_clusters`; every other id is its own singleton
+    cluster. Ordinals assigned in sorted order for determinism."""
+    ordinal_of: dict[str, int] = {}
+    ord2canon: dict[int, str] = {}
+    clustered: set[str] = set()
+    # deterministic order: sort clusters by their lexicographically smallest member
+    ordered = sorted((sorted(c) for c in method_clusters), key=lambda c: c[0])
+    ordinal = 0
+    for members in ordered:
+        for m in members:
+            ordinal_of[m] = ordinal
+            clustered.add(m)
+        # canonical = the original that the cluster's members map to (first by sort);
+        # a resolver error mixing two originals deterministically picks the smallest.
+        ord2canon[ordinal] = canon.get(members[0], members[0])
+        ordinal += 1
+    for nid in sorted(set(all_ids) - clustered):        # singletons (non-targets etc.)
+        ordinal_of[nid] = ordinal
+        ord2canon[ordinal] = canon.get(nid, nid)
+        ordinal += 1
+    return ordinal_of, ord2canon
+
+
+def canon_rank(retrieved_ordinals, ord2canon):
+    """Map retrieved cluster ordinals -> canonical original ids, dedup first-seen
+    (a later ordinal resolving to an already-seen original must not take a 2nd rank
+    slot -- it would understate recall@20)."""
+    seen: set = set()
+    out: list = []
+    for o in retrieved_ordinals:
+        c = ord2canon.get(o)
+        if c is not None and c not in seen:
+            seen.add(c)
+            out.append(c)
+    return out
+```
+
+- [ ] **Step 4: Run to verify pass** (goldengraph box runner). Expected: 3 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldengraph/goldengraph/stark_moat.py packages/python/goldengraph/tests/test_alias_scoring.py
+git commit -m "feat(goldengraph): stark_moat cluster ordinals + canon scoring map"
+```
+
+---
+
+## Task 4: `collapse_for_index` + `collapse_for_store` (+ real-PyStore materialize)
+
+**Files:**
+- Modify: `packages/python/goldengraph/goldengraph/stark_moat.py`
+- Test: `packages/python/goldengraph/tests/test_alias_materialize.py` (real PyStore)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""SP-moat materialization: one index entry + one store node per cluster; the store
+holds the PRE-MERGED graph (edges unioned by Python collapse, not store merge)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+ggn = pytest.importorskip("goldengraph_native")
+from goldengraph.bulk import bulk_load                       # noqa: E402
+from goldengraph.stark_moat import collapse_for_index, collapse_for_store  # noqa: E402
+
+_BIG = 1 << 62
+
+
+def _store():
+    from goldengraph_native import _native as gg
+    return gg.PyStore()
+
+
+def test_collapse_for_index_merges_docs_per_cluster():
+    nodes2 = [("1#a0", "IL6", "gene"), ("1#a1", "IL 6", "gene"), ("2", "aspirin", "drug")]
+    texts2 = ["sentence one", "sentence two", "aspirin doc"]
+    ordinal_of = {"1#a0": 0, "1#a1": 0, "2": 1}              # aliases merged into ord 0
+    ents = collapse_for_index(nodes2, texts2, ordinal_of)
+    by_ord = {e["entity_id"]: e for e in ents}
+    assert set(by_ord) == {0, 1}                             # one entry per cluster
+    assert "sentence one" in by_ord[0]["canonical_name"] and "sentence two" in by_ord[0]["canonical_name"]
+
+
+def test_collapse_for_store_unions_neighborhood():
+    # aliases 1#a0,1#a1 (cluster 0) each hold one edge to distinct neighbors 2,3
+    nodes2 = [("1#a0", "IL6", "gene"), ("1#a1", "IL 6", "gene"),
+              ("2", "aspirin", "drug"), ("3", "fever", "effect")]
+    edges2 = [("1#a0", "targets", "2"), ("1#a1", "assoc", "3")]
+    ordinal_of = {"1#a0": 0, "1#a1": 0, "2": 1, "3": 2}
+    coll_nodes, coll_edges = collapse_for_store(nodes2, edges2, ordinal_of)
+    assert len(coll_nodes) == 3                              # 3 clusters -> 3 nodes
+    store = _store()
+    bulk_load(store, coll_nodes, coll_edges)
+    g = store.as_of(_BIG, _BIG)
+    ord_to_eid = {int(e["source_refs"][0]): e["entity_id"] for e in g.entities()}
+    eid0 = ord_to_eid[0]                                     # view-eid != ordinal; map via source_refs
+    neighbors = {e["obj"] for e in g.query([eid0], 1)["edges"] if e["subj"] == eid0}
+    assert neighbors == {ord_to_eid[1], ord_to_eid[2]}      # UNIONED: both aliases' edges on cluster 0
+
+
+def test_collapse_drops_intra_cluster_self_loops():
+    nodes2 = [("1#a0", "IL6", "gene"), ("1#a1", "IL 6", "gene")]
+    edges2 = [("1#a0", "same", "1#a1")]                      # both ends in cluster 0
+    ordinal_of = {"1#a0": 0, "1#a1": 0}
+    _, coll_edges = collapse_for_store(nodes2, edges2, ordinal_of)
+    assert coll_edges == []                                  # self-loop dropped
+```
+
+- [ ] **Step 2: Run to verify failure** (goldengraph box runner) → functions missing.
+
+- [ ] **Step 3: Implement** (append to `stark_moat.py`)
+
+```python
+def collapse_for_index(nodes2, node_texts2, ordinal_of):
+    """One index entry per cluster: entity_id = ordinal, canonical_name = the joined
+    member docs (the MERGED text -- where dense-ER recovery happens), typ from the
+    first member. Docs joined in stable (ordinal, id) order."""
+    text_of = dict(zip([n[0] for n in nodes2], node_texts2))
+    typ_of = {n[0]: n[2] for n in nodes2}
+    members: dict[int, list[str]] = {}
+    for nid, _name, _typ in nodes2:
+        members.setdefault(ordinal_of[nid], []).append(nid)
+    out = []
+    for ordv, ids in sorted(members.items()):
+        ids_sorted = sorted(ids)
+        doc = " ".join(text_of.get(i, "") for i in ids_sorted).strip()
+        out.append({"entity_id": ordv, "canonical_name": doc, "typ": typ_of[ids_sorted[0]]})
+    return out
+
+
+def collapse_for_store(nodes2, edges2, ordinal_of):
+    """One store node per cluster (id = str(ordinal)) + edges remapped endpoint ->
+    its cluster ordinal, dropping intra-cluster self-loops. Feed to bulk_load
+    UNCHANGED -- each node's unique key = str(ordinal) => passthrough, so the store
+    holds exactly this pre-merged graph (no store-side merge)."""
+    name_of = {n[0]: n[1] for n in nodes2}
+    typ_of = {n[0]: n[2] for n in nodes2}
+    seen: dict[int, tuple] = {}
+    for nid, name, typ in nodes2:
+        ordv = ordinal_of[nid]
+        seen.setdefault(ordv, (str(ordv), name, typ))       # first member names the node
+    coll_nodes = [seen[o] for o in sorted(seen)]
+    coll_edges = []
+    for s, p, o in edges2:
+        so, oo = ordinal_of[s], ordinal_of[o]
+        if so == oo:
+            continue                                        # intra-cluster self-loop
+        coll_edges.append((str(so), p, str(oo)))
+    return coll_nodes, coll_edges
+```
+
+- [ ] **Step 4: Run to verify pass** (goldengraph box runner). Expected: 3 pass. The union test is the load-bearing graph-arm check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldengraph/goldengraph/stark_moat.py packages/python/goldengraph/tests/test_alias_materialize.py
+git commit -m "feat(goldengraph): stark_moat collapse-for-index/store (Python edge-union, bulk_load unchanged)"
+```
+
+---
+
+## Task 5: `evaluate(id_map=...)` — canon-mapped scoring + pure scoring test
+
+**Files:**
+- Modify: `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py`
+- Test: `packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_alias_scoring.py`
+
+- [ ] **Step 1: Write the failing test** (pure — reuses `canon_rank` semantics against `metrics`)
+
+```python
+"""SP-moat scoring: canon-mapped ranked list -> equivalence-class hit."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.stark_metrics import metrics                 # noqa: E402
+from erkgbench.stark_adapter import _apply_id_map           # noqa: E402
+
+
+def test_id_map_canon_then_hit_on_any_alias():
+    # retrieved cluster ordinals; ord2canon maps ords 10,11 -> gold entity 1
+    ranked = _apply_id_map([12, 10, 11], {10: 1, 11: 1, 12: 2})
+    assert ranked == [2, 1]                                  # dedup first-seen
+    m = metrics(ranked, {1})                                 # gold entity 1 retrieved via an alias
+    assert m["hit@5"] == 1.0 and m["recall@20"] == 1.0
+```
+
+- [ ] **Step 2: Run to verify failure** (erkgbench box runner) → `_apply_id_map` missing.
+
+- [ ] **Step 3: Implement** — add `_apply_id_map` + thread `id_map` through `evaluate`
+
+In `stark_adapter.py`, add:
+```python
+def _apply_id_map(retrieved, id_map):
+    """Map retrieved ids through `id_map` (cluster_ordinal -> canonical original),
+    dedup first-seen. `id_map=None` -> passthrough (dedup only)."""
+    seen, out = set(), []
+    for r in retrieved:
+        v = r if id_map is None else id_map.get(r)
+        if v is not None and v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out
+```
+Then in `evaluate(...)` add an `id_map=None` kwarg and replace each arm's
+`ranked = [...]` scoring input so the retrieved ids are passed through
+`_apply_id_map(ranked, id_map)` before `metrics(ranked, gold)`. The dense arm's
+`index.query` already returns ordinals; the graph arm's neighbor mapping already
+returns the-id-on-source_refs (the ordinal). So `id_map = ord2canon` for the moat,
+`id_map = None` for the clean/plain STaRK path (identity — unchanged behavior).
+
+- [ ] **Step 4: Run to verify pass** (erkgbench box runner) + re-run the existing `test_stark_metrics.py` to confirm no regression. Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_alias_scoring.py
+git commit -m "feat(erkgbench): evaluate(id_map=) for canon-equivalence moat scoring"
+```
+
+---
+
+## Task 6: Modal `--inject` driver (integration, run-only)
+
+**Files:**
+- Modify: `scripts/distill/modal_stark.py`
+
+Not box-TDD'd (needs HF + embed + Modal). Add an `inject: bool = False`, `k: int = 3`, `seed: int = 0` path to `_stark_impl` / `run_stark` / `main`.
+
+- [ ] **Step 1: Implement the `--inject` branch**
+
+Inside `_stark_impl`, when `inject`:
+1. `nodes, edges, queries, node_texts = load_stark_kb(kb, split="test", limit_queries=sample, with_text=True)`
+2. `target_ids = {str(g) for _q, gold in queries for g in gold}`  # sampled queries' gold entities
+3. `nodes2, texts2, edges2, canon = inject_aliases(nodes, node_texts, edges, target_ids, k=k, seed=seed)`
+4. `alias_nodes = [(nid, name) for nid, name, _typ in nodes2 if nid in canon and canon[nid] != nid]`  # injected aliases only
+5. For `method in ("none", "exact", "er")`:
+   - `clusters = resolve_aliases(alias_nodes, method)`
+   - `ordinal_of, ord2canon = build_clusters(canon, clusters, [n[0] for n in nodes2])`
+   - `index = EntityIndex.build(collapse_for_index(nodes2, texts2, ordinal_of), embedder, top_k=50)`
+   - `coll_nodes, coll_edges = collapse_for_store(nodes2, edges2, ordinal_of)`; `store = PyStore(); bulk_load(store, coll_nodes, coll_edges)`
+   - `slice = store.as_of(_BIG, _BIG)`; build `stark_to_eid`/`eid_to_stark` over `source_refs` (these are ordinals now)
+   - `gold_int = queries` unchanged (original stark ids as ints)
+   - for `arm in ("dense", "graph")`: `evaluate(index, slice, stark_to_eid, eid_to_stark, queries, embedder, arm=arm, id_map=ord2canon)`
+   - collect `row(method, arm)`
+6. Print a table: per (method × arm) recall@20/hit@1/hit@5/mrr, plus the **ER−adhoc** and **ER−fragmented** margins on dense recall@20. Cite the clean row from PR #1402 (dense 0.261 / graph 0.213) in the header — not re-run.
+7. Persist to `/cache/results/stark_{kb}_inject.md`.
+
+Imports inside the function (after the sys.path shim): `from goldengraph.stark_inject import inject_aliases`, `from goldengraph.stark_moat import build_clusters, collapse_for_index, collapse_for_store`, `from erkgbench.stark_resolve import resolve_aliases`.
+
+`main`/`run_stark` gain `--inject`, `--k`, `--seed`; result filename `stark_{kb}_inject.md`; SPAWNED line updated.
+
+- [ ] **Step 2: Run PRIME inject on Modal** (foreground through build to SPAWNED, then poll — bg pollers get killed):
+```
+export PYTHONIOENCODING=utf-8 PYTHONUTF8=1
+P=a99885f0-c5af-4ae1-9dc8-255cc60aa129
+export MODAL_TOKEN_ID=$(infisical.cmd secrets get MODAL_TOKEN_ID --projectId $P --env dev --plain)
+export MODAL_TOKEN_SECRET=$(infisical.cmd secrets get MODAL_TOKEN_SECRET --projectId $P --env dev --plain)
+modal run --detach scripts/distill/modal_stark.py --kb prime --sample 200 --inject --k 3 --spawn
+```
+No new pip deps → image cached → fast spawn. Then poll the volume for `stark_prime_inject.md` + crash-detect the app.
+
+- [ ] **Step 3: Verdict report** `docs/superpowers/reports/2026-07-03-stark-alias-moat.md`: the method×arm table, the ER−adhoc margin, and the honest call — **moat CONFIRMED** (ER-dense recovers recall@20 toward clean 0.261 while adhoc stays depressed) or **REFUTED/weak** (ER≈adhoc, or fragmented barely dropped from clean → injection too weak, note the knob to change). Either is publishable.
+
+- [ ] **Step 4: Commit** the driver + report.
+
+---
+
+## Wrap-up
+
+- [ ] `#1402` is MERGED, so rebase this branch onto main: `git fetch origin main && git rebase --onto origin/main <fulltext-branch-tip> feat/goldengraph-stark-alias-moat` (or plain `git rebase origin/main` if no overlap remains). Verify `git diff --stat origin/main HEAD` shows only the moat files.
+- [ ] Push (benzsevern), open PR, arm `gh pr merge --auto --squash`, STOP (no CI poll).
+- [ ] Update memory `project_stark_retrieval_scale.md`: the moat verdict (confirmed/refuted + the numbers), and what it means for the program.
+- [ ] Doc-surface sweep only if a new PUBLIC API surfaced (these are bench-internal modules — likely none).
+
+## Notes / risks
+
+- **The union test (Task 4) is load-bearing** — it proves the graph arm gets the merged neighborhood via the Python collapse (the store cannot merge same-batch aliases). Do not weaken it.
+- **`er` resolver on the real PRIME alias set** (a few thousand nodes) may be slow or over/under-merge at goldenmatch's zero-config threshold. That is itself a finding — record the cluster count vs the true target count. Keep the box fixture tiny + surname-diverse to avoid dedupe blocking hangs.
+- **If fragmented-dense barely drops from clean 0.261**, the injection is too weak (docs didn't fragment enough, or gold entities have short docs) — the experiment is inconclusive, not a moat refutation. The report must check the fragmented-vs-clean drop FIRST before interpreting ER−adhoc.
+- **`evaluate` id_map default None** keeps the plain STaRK path (Tasks from PR #1399/#1402) byte-identical — re-run `test_stark_metrics.py` to confirm no regression.

--- a/docs/superpowers/plans/2026-07-03-goldengraph-stark-alias-moat.md
+++ b/docs/superpowers/plans/2026-07-03-goldengraph-stark-alias-moat.md
@@ -24,11 +24,11 @@
 ## File structure
 
 - **Create** `packages/python/goldengraph/goldengraph/stark_inject.py` — the corruption: `inject_aliases`, `_variants`. Pure + seeded rng. No store, no goldenmatch.
-- **Create** `packages/python/goldengraph/goldengraph/stark_moat.py` — the clustering→materialization: `build_clusters`, `collapse_for_index`, `collapse_for_store`, `canon_rank`. Pure except `collapse_for_store`'s consumer (bulk_load in the test).
+- **Create** `packages/python/goldengraph/goldengraph/stark_moat.py` — the clustering→materialization: `build_clusters`, `collapse_for_index`, `collapse_for_store`. Pure except `collapse_for_store`'s consumer (bulk_load in the test). (No `canon_rank` — the single map+dedup helper is `_apply_id_map` in `stark_adapter`.)
 - **Create** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_resolve.py` — `resolve_aliases` (none/exact/er). Lazy goldenmatch import.
-- **Modify** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py` — add `id_map=None` to `evaluate` (canon-map retrieved ids before scoring).
+- **Modify** `packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py` — add `id_map=None` to `evaluate` + the `_apply_id_map` helper (canon-map retrieved ids before scoring).
 - **Modify** `scripts/distill/modal_stark.py` — add `--inject` mode driver (integration).
-- **Tests:** `goldengraph/tests/test_stark_inject.py`, `goldengraph/tests/test_alias_materialize.py` (real PyStore), `er-kg-bench/tests/test_stark_resolve.py`, `er-kg-bench/tests/test_alias_scoring.py` (pure).
+- **Tests (5 files):** `goldengraph/tests/test_stark_inject.py`, `goldengraph/tests/test_build_clusters.py` (build_clusters, pure), `goldengraph/tests/test_alias_materialize.py` (real PyStore), `er-kg-bench/tests/test_stark_resolve.py`, `er-kg-bench/tests/test_alias_scoring.py` (`_apply_id_map` + metrics, pure). The two "scoring"-ish tests live in separate roots and test different functions — no clash.
 
 ## Box-safe test runners
 
@@ -347,19 +347,21 @@ git commit -m "feat(erkgbench): STaRK alias resolver (none/exact/goldenmatch ded
 
 ---
 
-## Task 3: `build_clusters` + `canon_rank` — cluster ordinals + scoring map (pure)
+## Task 3: `build_clusters` — cluster ordinals + int canon map (pure)
 
 **Files:**
 - Create: `packages/python/goldengraph/goldengraph/stark_moat.py`
-- Test: `packages/python/goldengraph/tests/test_alias_scoring.py` (pure — lives in goldengraph tests; erkgbench's copy imports it too, see Task 5)
+- Test: `packages/python/goldengraph/tests/test_build_clusters.py` (pure)
 
 - [ ] **Step 1: Write the failing tests**
 
 ```python
-"""SP-moat cluster assembly + canon scoring map (pure)."""
+"""SP-moat cluster assembly + INT canon scoring map (pure). ord2canon values are
+INTS -- the original STaRK node ids -- so they match the int `gold` sets in
+stark_metrics. (A str->int mismatch here would make every method score ~0.)"""
 from __future__ import annotations
 
-from goldengraph.stark_moat import build_clusters, canon_rank
+from goldengraph.stark_moat import build_clusters
 
 
 def test_build_clusters_targets_grouped_nontargets_singleton():
@@ -369,21 +371,16 @@ def test_build_clusters_targets_grouped_nontargets_singleton():
     ordinal_of, ord2canon = build_clusters(canon, method_clusters, all_ids)
     assert ordinal_of["1#a0"] == ordinal_of["1#a1"]    # aliases share an ordinal
     assert ordinal_of["2"] != ordinal_of["1#a0"]        # non-target its own ordinal
-    assert ord2canon[ordinal_of["1#a0"]] == "1"         # cluster -> canonical original
-    assert ord2canon[ordinal_of["2"]] == "2"
+    assert ord2canon[ordinal_of["1#a0"]] == 1           # INT canonical original (matches int gold)
+    assert ord2canon[ordinal_of["2"]] == 2
+    assert all(isinstance(v, int) for v in ord2canon.values())
 
 
 def test_build_clusters_fragmented_all_singletons():
     canon = {"1#a0": "1", "1#a1": "1"}
     ordinal_of, ord2canon = build_clusters(canon, [["1#a0"], ["1#a1"]], ["1#a0", "1#a1"])
     assert ordinal_of["1#a0"] != ordinal_of["1#a1"]     # fragmented -> distinct ordinals
-    assert ord2canon[ordinal_of["1#a0"]] == "1"         # both still map to original 1
-
-
-def test_canon_rank_maps_and_dedups_first_seen():
-    # retrieved ordinals -> canonical originals, dedup preserving order
-    ord2canon = {10: "1", 11: "1", 12: "2"}
-    assert canon_rank([12, 10, 11], ord2canon) == ["2", "1"]   # 11->1 is a dup of 10->1
+    assert ord2canon[ordinal_of["1#a0"]] == 1           # both still map to original 1 (int)
 ```
 
 - [ ] **Step 2: Run to verify failure** (goldengraph box runner).
@@ -401,15 +398,17 @@ from __future__ import annotations
 
 
 def build_clusters(canon, method_clusters, all_ids):
-    """`canon`: alias_id -> original id. `method_clusters`: resolver output over the
-    INJECTED aliases (list[list[alias_id]]). `all_ids`: every node id in the injected
-    graph (aliases + passthrough non-targets). Returns (ordinal_of, ord2canon):
+    """`canon`: alias_id -> original id (STRING stark ids). `method_clusters`: resolver
+    output over the INJECTED aliases (list[list[alias_id]]). `all_ids`: every node id in
+    the injected graph (aliases + passthrough non-targets). Returns (ordinal_of, ord2canon):
       ordinal_of: id -> cluster_ordinal (int, deterministic)
-      ord2canon:  cluster_ordinal -> canonical original id
+      ord2canon:  cluster_ordinal -> canonical original id, **as INT** (STaRK node ids
+                  are integers; the int match is what makes scoring against the int
+                  `gold` sets work -- a str value here scores ~0 for every method).
     Injected aliases group by `method_clusters`; every other id is its own singleton
     cluster. Ordinals assigned in sorted order for determinism."""
     ordinal_of: dict[str, int] = {}
-    ord2canon: dict[int, str] = {}
+    ord2canon: dict[int, int] = {}
     clustered: set[str] = set()
     # deterministic order: sort clusters by their lexicographically smallest member
     ordered = sorted((sorted(c) for c in method_clusters), key=lambda c: c[0])
@@ -418,38 +417,24 @@ def build_clusters(canon, method_clusters, all_ids):
         for m in members:
             ordinal_of[m] = ordinal
             clustered.add(m)
-        # canonical = the original that the cluster's members map to (first by sort);
-        # a resolver error mixing two originals deterministically picks the smallest.
-        ord2canon[ordinal] = canon.get(members[0], members[0])
+        # canonical = the original the cluster's members map to (first by sort); a
+        # resolver error mixing two originals deterministically picks the smallest.
+        ord2canon[ordinal] = int(canon.get(members[0], members[0]))
         ordinal += 1
     for nid in sorted(set(all_ids) - clustered):        # singletons (non-targets etc.)
         ordinal_of[nid] = ordinal
-        ord2canon[ordinal] = canon.get(nid, nid)
+        ord2canon[ordinal] = int(canon.get(nid, nid))
         ordinal += 1
     return ordinal_of, ord2canon
-
-
-def canon_rank(retrieved_ordinals, ord2canon):
-    """Map retrieved cluster ordinals -> canonical original ids, dedup first-seen
-    (a later ordinal resolving to an already-seen original must not take a 2nd rank
-    slot -- it would understate recall@20)."""
-    seen: set = set()
-    out: list = []
-    for o in retrieved_ordinals:
-        c = ord2canon.get(o)
-        if c is not None and c not in seen:
-            seen.add(c)
-            out.append(c)
-    return out
 ```
 
-- [ ] **Step 4: Run to verify pass** (goldengraph box runner). Expected: 3 pass.
+- [ ] **Step 4: Run to verify pass** (goldengraph box runner). Expected: 2 pass.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add packages/python/goldengraph/goldengraph/stark_moat.py packages/python/goldengraph/tests/test_alias_scoring.py
-git commit -m "feat(goldengraph): stark_moat cluster ordinals + canon scoring map"
+git add packages/python/goldengraph/goldengraph/stark_moat.py packages/python/goldengraph/tests/test_build_clusters.py
+git commit -m "feat(goldengraph): stark_moat cluster ordinals + int canon scoring map"
 ```
 
 ---

--- a/docs/superpowers/reports/2026-07-03-stark-alias-moat.md
+++ b/docs/superpowers/reports/2026-07-03-stark-alias-moat.md
@@ -1,0 +1,85 @@
+# Alias-injected STaRK ER-moat — verdict (INCONCLUSIVE: confounded instrument)
+
+**Question:** does goldenmatch's resolver recover retrieval quality that ad-hoc
+exact-match dedup loses, on a real STaRK KB corrupted with alias duplicates?
+
+**Answer: inconclusive — the experiment as designed is CONFOUNDED.** Answer-entity
+fragmentation + canonical-equivalence scoring makes fragmentation *help* dense
+retrieval (more aliases = more chances at the gold), so "more resolution → lower
+recall" is a scoring artifact, not evidence about ER. The thesis is neither
+confirmed nor refuted; the instrument is wrong. Run on Modal (A10G, 64GB), PRIME,
+200 test queries, k=3, seed=0, Ollama `nomic-embed-text`.
+
+## Raw numbers
+
+```
+inject: targets=474 gold entities  k=3  nodes 129375->130323 (aliases=1422)
+[none  fragmented] clusters=130323  dense recall@20=0.365 hit@1=0.180 mrr=0.249 | graph 0.308
+[exact ad-hoc]     clusters=130041  dense recall@20=0.288 hit@1=0.115 mrr=0.180 | graph 0.221
+[er    goldenmatch]clusters=129420  dense recall@20=0.240 hit@1=0.045 mrr=0.109 | graph 0.224
+
+DENSE recall@20:  fragmented=0.365  adhoc=0.288  er=0.240  clean=0.261 (PR #1402)
+                  ER-adhoc=-0.048   ER-fragmented=-0.125   clean-fragmented=-0.104
+```
+
+## The confound (why this is inconclusive, not a refutation)
+
+The design fragmented each **gold answer entity** into k=3 alias nodes and scored by
+**canonical equivalence** (a hit = retrieving ANY alias of the gold entity). Under
+that scoring, splitting the gold into 3 nodes gives the dense retriever **3 separate
+embeddings competing for a top-20 slot instead of 1** — three lottery tickets. So
+fragmentation *raises* recall (0.365 vs clean 0.261, `clean-fragmented = -0.104`),
+and merging the aliases back *removes* tickets, *lowering* recall
+(fragmented 0.365 → adhoc 0.288 → er 0.240). The multiple-chances effect dominates
+the per-alias text-dilution the design assumed would hurt dense. The intended signal
+("fragmentation hurts, ER recovers") is inverted by the scoring, so the ER−adhoc
+margin (−0.048) says nothing about the moat.
+
+The build-in guard caught it: the report's rule "CHECK clean-fragmented FIRST — if
+not a real drop, inconclusive" fired exactly here (fragmentation *helped*).
+
+## What IS real underneath (secondary, swamped)
+
+- **ER mechanically works.** goldenmatch merged 903 of the ~948 possible alias
+  merges (129,420 clusters vs 130,323 fragmented singletons; 1422 aliases → ~519
+  clusters). The resolver does re-merge variant surface forms exact-match leaves
+  split — the `stark_resolve` unit test's "moat in miniature" holds at scale.
+- **`er` dense (0.240) slightly undershoots clean (0.261).** If ER re-merged the 3
+  aliases perfectly into the original node, `er` should ≈ clean. The ~0.02 shortfall
+  suggests the zero-config dedupe **over-merged** a few distinct entities with
+  similar names (474 targets, name-variants → some cross-entity collisions) — a real
+  ER-precision finding, but far too small to read against the scoring artifact.
+- **Graph ≤ dense in every condition** (0.308/0.221/0.224 vs 0.365/0.288/0.240),
+  consistent with PR #1402: the naive 1-hop walk doesn't help. The gap narrows under
+  `er` (0.224 vs 0.240) but nothing to hang a moat on.
+
+## Why the design was wrong, and the fix
+
+Fragmenting the **answer** entity is the mistake: the answer is exactly what you
+retrieve, so splitting it into equivalence-scored copies adds retrieval surface
+instead of removing it. To make fragmentation genuinely HURT, corrupt the **path to**
+the answer, not the answer:
+
+- **Case B (deferred in the spec, now the clear next cut): fragment BRIDGE / path
+  entities, keep gold answers intact.** A query reaches its answer by walking through
+  intermediate entities; fragment those so the seed connects to bridge-alias-1 while
+  the answer connects to bridge-alias-2 — the path is *severed*, and only ER
+  re-merging the bridge restores it. Gold ids stay single (no equivalence-scoring
+  inflation), and the effect lands on the GRAPH arm where structure is load-bearing.
+- **Alternative:** keep answer-fragmentation but score without alias-count reward —
+  e.g. designate ONE alias as the true answer and the other k−1 as **distractors**
+  (not gold-equivalent), so fragmentation adds noise, not chances.
+
+Either removes the multiple-chances confound. Case B is the sharper test and matches
+the original moat intuition (resolution restores a broken retrieval path).
+
+## Status
+
+The harness is sound and reusable (`stark_inject` / `stark_resolve` / `stark_moat` /
+`evaluate(id_map=)`, all box-TDD'd; the resolver + collapse mechanics verified). The
+NEGATIVE is about the experimental *instrument*, and the discipline caught it before
+it was mis-sold as a result. Next: re-run as **Case B (bridge fragmentation, gold
+intact)** — a new injection target selector + no equivalence scoring, reusing the
+same resolve/collapse/materialize path.
+
+Entry: `scripts/distill/modal_stark.py --kb prime --sample 200 --inject --k 3`.

--- a/docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md
@@ -202,10 +202,14 @@ are box-TDD-able; only the STaRK download + embed + Modal run is integration.
 
 `tests/test_alias_materialize.py` (real `PyStore`): the Python collapse builds one
 store node per cluster with edges remapped to `cluster_ordinal`; after `bulk_load`,
-`store.as_of(BIG,BIG).query([cluster_ordinal],1)` shows the UNIONED neighborhood
-(edges from all the cluster's aliases), and singleton/fragmented clusters keep the
-un-collapsed graph. Intra-cluster self-loops are dropped. This is the graph-arm
-edge-union check that the store's own merge can NOT provide in one batch.
+resolve the cluster's view-local eid FIRST (`eid = {int(e["source_refs"][0]):
+e["entity_id"] for e in slice.entities()}[ordinal]` — the store mints StableIds in
+string-sorted record_key order, so the view-eid ≠ the ordinal; the ordinal rides
+through on `source_refs` exactly as SP2 carried stark_id), then
+`slice.query([eid],1)` shows the UNIONED neighborhood (edges from all the cluster's
+aliases). Singleton/fragmented clusters keep the un-collapsed graph; intra-cluster
+self-loops are dropped. This is the graph-arm edge-union check that the store's own
+merge can NOT provide in one batch.
 
 `tests/test_alias_scoring.py` (pure): canon-mapped ranked list → a hit when any
 alias of the gold entity is retrieved; equivalence-class recall.

--- a/docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md
@@ -27,12 +27,26 @@ it never enters the store. So "resolution" acts in **two different places**:
 - **Dense arm** — ER must unify the TEXT: build one `EntityIndex` embedding per
   resolved cluster over the **concatenated member docs**. Merging in the store
   alone does nothing for dense retrieval.
-- **Graph arm** — ER unifies the EDGES: cluster-shared `record_keys` → the store's
-  overlap-merge unions the fragmented neighborhoods so the 1-hop walk can traverse
-  the whole entity.
+- **Graph arm** — ER unifies the EDGES **caller-side, in Python**: collapse the
+  alias graph to ONE node per resolved cluster and remap every edge endpoint to its
+  cluster's canonical id, then `bulk_load` the **pre-merged** graph. The store never
+  sees the aliases.
 
-So "ER-native ingest" is a **clustering step that feeds both** the index (merged
-text) and the store (merged edges), not just a record_key relabel.
+  > **Why not let the store merge via shared record_keys:** `store.rs::append`
+  > reconciles a batch only against ALREADY-STORED entities (`key_to_stored` is
+  > built from `self.entities`), never against siblings in the same batch. `bulk_load`
+  > issues all nodes in one batch, so N aliases sharing a key would each MINT a
+  > separate id — no union — and would also leave multiple current entities sharing
+  > one key (violating the store's one-key-one-entity invariant). And `bulk_load`
+  > hardcodes `record_keys=[stark_id]` (no shared-key lever). So the store-merge path
+  > does not work here; the Python collapse is the correct, simpler mechanism and
+  > needs no `bulk.py` change (each collapsed cluster-node keeps a unique key —
+  > exactly SP2's passthrough usage).
+
+So "ER-native ingest" is a **clustering step that feeds both materializations**: the
+index (one embedding per cluster over merged text) and the store (one node per
+cluster over merged edges). The clustering is the single ER lever; the store's
+overlap-merge is NOT used.
 
 ## Conditions (all on PRIME, over the full-text `get_doc_info` corpus)
 
@@ -102,26 +116,39 @@ ER mistake and is scored as such — not hidden).
 Given `clusters` (from a method) over the injected aliases + the pass-through
 non-target nodes as singletons:
 
-- **Index (dense):** one entry per cluster, `entity_id = int(hash-free cluster
-  ordinal)`, `canonical_name = " ".join(member docs)` (the merged text). Keep a
-  `cluster_ordinal -> canonical original id` map for scoring. Fragmented → each
-  alias is its own cluster → fragmented text embeddings.
-- **Store (graph):** `bulk_load` with `record_keys = [cluster_key]` shared within
-  a cluster (the store then unions the members' edges); non-target singletons keep
-  their unique key (passthrough, as SP2). The graph arm walks the merged
-  neighborhood.
+Both materializations are driven by the SAME `clusters`. Assign each cluster a
+`cluster_ordinal` (int) and pick its `canonical_id` = the `canon`-mapped original
+(all aliases in a true cluster share one original; a resolver error mixing two
+originals picks one deterministically and is scored as the real ER mistake it is).
 
-Reuses SP2's `bulk_load` unchanged (record_keys is the only lever) and the
-full-text `EntityIndex` build path.
+- **Index (dense):** one entry per cluster — `entity_id = cluster_ordinal`,
+  `canonical_name = " ".join(member docs)` (the merged text). Keep
+  `cluster_ordinal -> canonical_id` for scoring. Fragmented → each alias its own
+  cluster → fragmented text embeddings.
+- **Store (graph):** collapse to ONE node per cluster in Python — node id =
+  `cluster_ordinal`, and remap EVERY edge's endpoints from alias id → the cluster
+  each alias belongs to (`alias_id -> cluster_ordinal`), dropping intra-cluster
+  self-loops. Then `bulk_load(collapsed_nodes, collapsed_edges)` with the normal
+  unique per-node key (passthrough). The store thus holds the PRE-MERGED graph; the
+  1-hop walk traverses the unioned neighborhood with no store-side merge. Fragmented
+  → singleton clusters → the full un-collapsed alias graph.
+
+Reuses SP2's `bulk_load` **unchanged** (each collapsed node keeps a unique key) and
+the full-text `EntityIndex` build path. The only new code is the Python clustering
++ the two materializations built from it.
 
 ### 4. Canonical-equivalence scoring
 
-Both arms return retrieved ids (cluster ordinals for the index / stark ids for the
-graph). Map each retrieved id → its **canonical original id** via the cluster maps
-+ `canon`. A query's gold set (original stark ids) is compared against the
-canon-mapped ranked list, deduped first-seen. Reuse `stark_metrics.metrics`
-unchanged. So a retrieval "hits" iff it surfaces ANY node whose canonical original
-is a gold entity — well-defined even though the gold entity is split into k aliases.
+Both arms now operate in the SAME id space — `cluster_ordinal` (index `entity_id`
+= ordinal; store node id = ordinal; the graph slice's `source_refs` carry the
+ordinal for the stark↔slice-eid maps, exactly as SP2 carried stark_id). Map each
+retrieved `cluster_ordinal` → its **canonical original id** via
+`cluster_ordinal -> canonical_id`. A query's gold set (original stark ids) is
+compared against the canon-mapped ranked list, deduped first-seen. Reuse
+`stark_metrics.metrics` unchanged. So a retrieval "hits" iff it surfaces ANY node
+whose canonical original is a gold entity — well-defined even though the gold
+entity is split into k aliases. (For the CLEAN reference reuse, ordinal = stark id
+and the map is identity, so the numbers reconcile with PR #1402.)
 
 ## Data flow
 
@@ -131,11 +158,14 @@ gold_ids = union of sampled queries' gold sets
 nodes2,texts2,edges2,canon = inject_aliases(nodes,node_texts,edges, gold_ids, k=3, seed)
 for method in (none, exact, er):
     clusters = resolve_aliases(injected_alias_nodes, method)          # non-targets = singletons
-    index    = EntityIndex.build(one entry/cluster, canonical_name=joined docs)
-    store    = bulk_load(cluster-keyed nodes2, edges2)                # store unions edges per cluster
-    slice    = store.as_of(BIG,BIG); stark<->eid maps
+    ordinal_of = {alias_id -> cluster_ordinal};  ord2canon = {ordinal -> canonical_id}
+    index    = EntityIndex.build(one entry/cluster, entity_id=ordinal, canonical_name=joined docs)
+    coll_nodes = [one node per cluster, id=ordinal]
+    coll_edges = [(ordinal_of[s], pred, ordinal_of[o]) for (s,pred,o) in edges2 if s!=o cluster]
+    store    = bulk_load(coll_nodes, coll_edges)                      # PRE-MERGED graph (Python collapse)
+    slice    = store.as_of(BIG,BIG); ordinal<->eid maps
     for arm in (dense, graph):
-        ranked = evaluate(...)                    # ids -> canonical originals -> metrics vs gold
+        ranked = evaluate(...) -> [ord2canon[o] for o in retrieved]   # -> metrics vs gold
     -> row(method, arm)
 compare vs clean (PR #1402): does ER recover recall@20 that fragmented/adhoc lose?
 ```
@@ -169,6 +199,13 @@ are box-TDD-able; only the STaRK download + embed + Modal run is integration.
 - `none` → singletons; `exact` → merges only identical names; `er` → merges variant
   surface forms of one entity that `exact` leaves split (the moat in miniature),
   on a small fixture (goldenmatch dedupe available in CI; box run uses main .venv).
+
+`tests/test_alias_materialize.py` (real `PyStore`): the Python collapse builds one
+store node per cluster with edges remapped to `cluster_ordinal`; after `bulk_load`,
+`store.as_of(BIG,BIG).query([cluster_ordinal],1)` shows the UNIONED neighborhood
+(edges from all the cluster's aliases), and singleton/fragmented clusters keep the
+un-collapsed graph. Intra-cluster self-loops are dropped. This is the graph-arm
+edge-union check that the store's own merge can NOT provide in one batch.
 
 `tests/test_alias_scoring.py` (pure): canon-mapped ranked list → a hit when any
 alias of the gold entity is retrieved; equivalence-class recall.

--- a/docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md
+++ b/docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md
@@ -1,0 +1,194 @@
+# Alias-injected STaRK — the ER-moat experiment (design)
+
+**Program:** STaRK retrieval. **Goal:** show goldengraph's entity resolution earns
+its place on a REAL retrieval benchmark where vanilla STaRK cannot — by corrupting
+a real STaRK KB with duplicate/alias nodes so a strong dense baseline **collapses**,
+then showing **ER-native ingest recovers retrieval quality that ad-hoc dedup loses.**
+
+## Why (the motivating negative)
+
+PR #1402 proved that on **vanilla** STaRK-PRIME with a FAIR dense baseline (embed
+each node's intrinsic `get_doc_info(add_rel=False)` doc), the naive 1-hop graph
+walk does NOT earn its place: graph recall@20 0.213 vs dense 0.261 (−18%); the
+earlier names-mode "+39%" was a weak-baseline artifact. Honest conclusion: vanilla
+STaRK is **pre-resolved and text-rich**, so structure adds nothing over text — the
+ER moat is invisible there. This experiment builds the battlefield where
+**resolution is load-bearing**: alias noise fragments the text signal, dense
+degrades, and only a real resolver recovers it.
+
+## The load-bearing mechanism insight
+
+The store (`goldengraph-core/src/store.rs`) merges entities on `record_key`
+overlap: it unions `record_keys`, `surface_names`, `source_refs`, and remaps
+edges — but it has **NO description/text field**. A node's rich doc
+(`get_doc_info`) lives only in the adapter and is used to build the `EntityIndex`;
+it never enters the store. So "resolution" acts in **two different places**:
+
+- **Dense arm** — ER must unify the TEXT: build one `EntityIndex` embedding per
+  resolved cluster over the **concatenated member docs**. Merging in the store
+  alone does nothing for dense retrieval.
+- **Graph arm** — ER unifies the EDGES: cluster-shared `record_keys` → the store's
+  overlap-merge unions the fragmented neighborhoods so the 1-hop walk can traverse
+  the whole entity.
+
+So "ER-native ingest" is a **clustering step that feeds both** the index (merged
+text) and the store (merged edges), not just a record_key relabel.
+
+## Conditions (all on PRIME, over the full-text `get_doc_info` corpus)
+
+|            | dense                                   | graph (secondary)         |
+|------------|-----------------------------------------|---------------------------|
+| **clean**  | reuse PR #1402 (recall@20 0.261)         | reuse PR #1402 (0.213)    |
+| **fragmented** | each alias its own node (split text+edges) | "                     |
+| **ad-hoc** | merge by normalized-exact-name           | "                         |
+| **ER**     | merge by goldenmatch `dedupe_df`         | "                         |
+
+**Moat = ER recovers toward clean while ad-hoc does not** (ad-hoc's exact-string
+match cannot merge variant surface forms). Clean is already measured, so ONE new
+Modal run covers fragmented / ad-hoc / ER × dense / graph (6 cells).
+
+## Components
+
+### 1. `stark_inject.py` — the corruption (box-TDD'd)
+
+```python
+def inject_aliases(nodes, node_texts, edges, target_ids, *, k=3, seed=0):
+    """Fragment each entity in `target_ids` into `k` alias nodes.
+
+    nodes: [(stark_id:str, name:str, typ:str)]; node_texts: aligned docs;
+    edges: [(subj_id, pred, obj_id)]; target_ids: set[str] to fragment.
+
+    For each target entity E (id, name, doc, incident edges):
+      - mint k NEW alias ids (namespaced, e.g. f"{id}#a{j}"), each a deterministic
+        VARIANT surface name of E's name (seeded rng: abbreviation / word-order /
+        truncation / punctuation-drop -- mirrors engineered._render_mention);
+      - ROUND-ROBIN E's doc SENTENCES across the k aliases (each alias doc = its
+        slice -> no alias has the full text -> dense degrades);
+      - ROUND-ROBIN E's incident EDGES across the k aliases (each alias holds a
+        subset of the neighborhood -> the walk degrades); the endpoint that is
+        itself a target is remapped to one of ITS aliases (round-robin) too, so
+        fragmentation composes across an edge whose both ends are injected.
+      - drop the original node E (replaced by its aliases).
+
+    Returns (nodes', node_texts', edges', canon) where `canon: dict[str,str]`
+    maps every alias id -> E's ORIGINAL id (identity for untouched nodes)."""
+```
+
+Deterministic + seeded (reproducible). Non-target nodes pass through unchanged
+with `canon[id] = id`. Variant generation is a small pure helper
+`_variants(name, k, rng)` returning `k` distinct surface forms (fall back to
+`f"{name} ({j})"` if the name is too short to vary `k` ways, so aliases stay
+distinct — ad-hoc-exact must NOT accidentally merge them, or the baseline is
+rigged).
+
+### 2. `resolve_aliases(alias_nodes, method) -> clusters` (box-TDD'd)
+
+`alias_nodes`: `[(alias_id, name)]` for the injected set only (bounded, fast).
+Returns `clusters: list[list[str]]` (alias_ids per cluster).
+
+- `method="none"` — singletons (fragmented floor).
+- `method="exact"` — group by `name.lower().strip()` (ad-hoc dedup; only exact
+  duplicates merge, variant surface forms stay split).
+- `method="er"` — goldenmatch `dedupe_df` over the alias names (the real resolver;
+  fuzzy, merges variant surface forms). Lazy import; box-testable on a small
+  variant-name fixture. Runs over the injected alias set only.
+
+A cluster's **canonical id** = the `canon`-mapped original (all aliases in a true
+cluster share one original; a resolver error that mixes two originals is a real
+ER mistake and is scored as such — not hidden).
+
+### 3. Per-condition materialization
+
+Given `clusters` (from a method) over the injected aliases + the pass-through
+non-target nodes as singletons:
+
+- **Index (dense):** one entry per cluster, `entity_id = int(hash-free cluster
+  ordinal)`, `canonical_name = " ".join(member docs)` (the merged text). Keep a
+  `cluster_ordinal -> canonical original id` map for scoring. Fragmented → each
+  alias is its own cluster → fragmented text embeddings.
+- **Store (graph):** `bulk_load` with `record_keys = [cluster_key]` shared within
+  a cluster (the store then unions the members' edges); non-target singletons keep
+  their unique key (passthrough, as SP2). The graph arm walks the merged
+  neighborhood.
+
+Reuses SP2's `bulk_load` unchanged (record_keys is the only lever) and the
+full-text `EntityIndex` build path.
+
+### 4. Canonical-equivalence scoring
+
+Both arms return retrieved ids (cluster ordinals for the index / stark ids for the
+graph). Map each retrieved id → its **canonical original id** via the cluster maps
++ `canon`. A query's gold set (original stark ids) is compared against the
+canon-mapped ranked list, deduped first-seen. Reuse `stark_metrics.metrics`
+unchanged. So a retrieval "hits" iff it surfaces ANY node whose canonical original
+is a gold entity — well-defined even though the gold entity is split into k aliases.
+
+## Data flow
+
+```
+load_stark_kb(prime, with_text=True) -> nodes, edges, queries(gold ids), node_texts
+gold_ids = union of sampled queries' gold sets
+nodes2,texts2,edges2,canon = inject_aliases(nodes,node_texts,edges, gold_ids, k=3, seed)
+for method in (none, exact, er):
+    clusters = resolve_aliases(injected_alias_nodes, method)          # non-targets = singletons
+    index    = EntityIndex.build(one entry/cluster, canonical_name=joined docs)
+    store    = bulk_load(cluster-keyed nodes2, edges2)                # store unions edges per cluster
+    slice    = store.as_of(BIG,BIG); stark<->eid maps
+    for arm in (dense, graph):
+        ranked = evaluate(...)                    # ids -> canonical originals -> metrics vs gold
+    -> row(method, arm)
+compare vs clean (PR #1402): does ER recover recall@20 that fragmented/adhoc lose?
+```
+
+## What proves / refutes the moat
+
+- **Moat CONFIRMED** if, on the fragmented KB, `ER-dense recall@20` recovers
+  toward the clean 0.261 while `adhoc-dense` and `fragmented-dense` stay
+  depressed — i.e. `ER > adhoc` by a real margin. (Secondary: same shape on the
+  graph arm.)
+- **Moat REFUTED / weak** if ER ≈ adhoc (the resolver merges nothing the exact
+  match doesn't) or fragmented-dense barely drops (text fragmentation didn't hurt
+  — injection too weak). Either is an honest, publishable result and tells us the
+  injection/knobs to change.
+
+## Testing (box-safe, TDD)
+
+Real `PyStore` loads on the box, so injection/resolution/materialization/scoring
+are box-TDD-able; only the STaRK download + embed + Modal run is integration.
+
+`tests/test_stark_inject.py`:
+- k aliases minted per target; original dropped; non-targets pass through; `canon`
+  maps aliases→original and is identity elsewhere.
+- doc sentences partitioned across aliases (union = original, no alias = full).
+- edges distributed across aliases; an edge with both ends injected remaps both.
+- variant names are distinct (ad-hoc-exact would NOT merge them) — the anti-rigging
+  guard.
+- determinism: same seed → identical output.
+
+`tests/test_resolve_aliases.py`:
+- `none` → singletons; `exact` → merges only identical names; `er` → merges variant
+  surface forms of one entity that `exact` leaves split (the moat in miniature),
+  on a small fixture (goldenmatch dedupe available in CI; box run uses main .venv).
+
+`tests/test_alias_scoring.py` (pure): canon-mapped ranked list → a hit when any
+alias of the gold entity is retrieved; equivalence-class recall.
+
+Box runner: `cd packages/python/goldengraph`… (goldengraph inject/score) and
+`cd …/er-kg-bench` for resolve/scoring, per the SP2 shadow-PYTHONPATH pattern.
+
+## Modal integration
+
+Extend `scripts/distill/modal_stark.py` with an `--inject` mode (`k`, `seed`):
+load PRIME full-text, inject over the sample's gold ids, run the 3 methods × 2 arms,
+print a table (recall@20/hit@k/mrr per cell + the ER−adhoc margin), persist to
+`stark_prime_inject.md`. Same detach+spawn+poll harness. PRIME only, one setting.
+
+## Scope / YAGNI
+
+- **In:** PRIME, sample 200, k=3, one injection setting, 3 methods × 2 arms + reuse
+  clean; dense is the primary read, graph secondary.
+- **Deferred:** background-injection rate + ambiguity-dial sweep; AMAZON/MAG;
+  routing ER through the full goldengraph resolve()/profile-link pipeline (this cut
+  uses goldenmatch `dedupe_df`); real-alias sources (UMLS synonyms). A smarter
+  graph arm (dense-ranked/degree-capped expansion) stays out — the naive walk is
+  the honest secondary read.

--- a/packages/python/goldengraph/goldengraph/stark_inject.py
+++ b/packages/python/goldengraph/goldengraph/stark_inject.py
@@ -1,0 +1,90 @@
+"""SP-moat: fragment gold entities into k alias nodes (variant names, split doc +
+edges) so dense retrieval degrades and only a real resolver recovers it. Pure +
+seeded (reproducible); no store, no goldenmatch here.
+
+See docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md.
+"""
+from __future__ import annotations
+
+import random
+
+
+def _variants(name: str, k: int, *, seed: int) -> list[str]:
+    """k DISTINCT surface forms of `name` (abbreviation / word-order / truncation /
+    punctuation-drop). Distinctness is load-bearing: if two variants collide, the
+    ad-hoc exact-match baseline would merge them for free and rig the comparison.
+    Falls back to a numbered suffix to guarantee k distinct forms."""
+    rng = random.Random(f"{seed}:{name}")
+    toks = name.split()
+    cands: list[str] = []
+
+    def _add(v: str) -> None:
+        v = v.strip()
+        if v and v not in cands:
+            cands.append(v)
+
+    _add(name)
+    if len(toks) > 1:
+        _add(" ".join(reversed(toks)))                       # word-order
+        _add("".join(t[0].upper() for t in toks))            # abbreviation/initials
+        _add(" ".join(toks[:-1]))                            # truncation
+    _add(name.replace("-", " ").replace(",", ""))            # punctuation-drop
+    _add(name.lower())
+    rng.shuffle(cands)
+    out = cands[:k]
+    j = 0
+    while len(out) < k:                                       # guarantee k distinct
+        cand = f"{name} ({j})"
+        if cand not in out:
+            out.append(cand)
+        j += 1
+    return out
+
+
+def _sentences(doc: str) -> list[str]:
+    return [s.strip() for s in doc.split(". ") if s.strip()]
+
+
+def inject_aliases(nodes, node_texts, edges, target_ids, *, k: int = 3, seed: int = 0):
+    """Fragment each entity in `target_ids` into k alias nodes. Returns
+    (nodes2, node_texts2, edges2, canon). See the spec / module docstring."""
+    target_ids = set(target_ids)
+    text_of = dict(zip([n[0] for n in nodes], node_texts))
+
+    # alias ids + variant names per target; canon maps every id -> original
+    alias_ids: dict[str, list[str]] = {}
+    canon: dict[str, str] = {}
+    nodes2: list[tuple] = []
+    texts2: list[str] = []
+    for nid, name, typ in nodes:
+        if nid not in target_ids:
+            nodes2.append((nid, name, typ))
+            texts2.append(text_of[nid])
+            canon[nid] = nid
+            continue
+        vs = _variants(name, k, seed=seed)
+        ids = [f"{nid}#a{j}" for j in range(k)]
+        alias_ids[nid] = ids
+        sents = _sentences(text_of.get(nid, "")) or [name]
+        buckets: list[list[str]] = [[] for _ in range(k)]
+        for i, s in enumerate(sents):
+            buckets[i % k].append(s)                          # round-robin sentences
+        for j, aid in enumerate(ids):
+            nodes2.append((aid, vs[j], typ))
+            texts2.append(". ".join(buckets[j]))
+            canon[aid] = nid
+
+    # remap edges: an endpoint that is a target -> one of its aliases (round-robin by
+    # a per-target counter so its incident edges spread across aliases)
+    ctr: dict[str, int] = {}
+
+    def _remap(endpoint: str) -> str:
+        if endpoint not in target_ids:
+            return endpoint
+        ids = alias_ids[endpoint]
+        c = ctr.get(endpoint, 0)
+        ctr[endpoint] = c + 1
+        return ids[c % len(ids)]
+
+    edges2 = [(_remap(s), p, _remap(o)) for (s, p, o) in edges]
+    return nodes2, texts2, edges2, canon

--- a/packages/python/goldengraph/goldengraph/stark_moat.py
+++ b/packages/python/goldengraph/goldengraph/stark_moat.py
@@ -1,0 +1,38 @@
+"""SP-moat: turn a resolver's clusters into cluster-ordinal ids that drive BOTH
+materializations (index + store), plus the int canon scoring map. The clustering is
+the single ER lever; the store's overlap-merge is NOT used (a batch reconciles only
+against already-stored entities, so same-batch aliases would never merge -- we
+collapse in Python instead). See the spec.
+"""
+from __future__ import annotations
+
+
+def build_clusters(canon, method_clusters, all_ids):
+    """`canon`: alias_id -> original id (STRING stark ids). `method_clusters`: resolver
+    output over the INJECTED aliases (list[list[alias_id]]). `all_ids`: every node id in
+    the injected graph (aliases + passthrough non-targets). Returns (ordinal_of, ord2canon):
+      ordinal_of: id -> cluster_ordinal (int, deterministic)
+      ord2canon:  cluster_ordinal -> canonical original id, **as INT** (STaRK node ids
+                  are integers; the int match is what makes scoring against the int
+                  `gold` sets work -- a str value here scores ~0 for every method).
+    Injected aliases group by `method_clusters`; every other id is its own singleton
+    cluster. Ordinals assigned in sorted order for determinism."""
+    ordinal_of: dict[str, int] = {}
+    ord2canon: dict[int, int] = {}
+    clustered: set[str] = set()
+    # deterministic order: sort clusters by their lexicographically smallest member
+    ordered = sorted((sorted(c) for c in method_clusters), key=lambda c: c[0])
+    ordinal = 0
+    for members in ordered:
+        for m in members:
+            ordinal_of[m] = ordinal
+            clustered.add(m)
+        # canonical = the original the cluster's members map to (first by sort); a
+        # resolver error mixing two originals deterministically picks the smallest.
+        ord2canon[ordinal] = int(canon.get(members[0], members[0]))
+        ordinal += 1
+    for nid in sorted(set(all_ids) - clustered):        # singletons (non-targets etc.)
+        ordinal_of[nid] = ordinal
+        ord2canon[ordinal] = int(canon.get(nid, nid))
+        ordinal += 1
+    return ordinal_of, ord2canon

--- a/packages/python/goldengraph/goldengraph/stark_moat.py
+++ b/packages/python/goldengraph/goldengraph/stark_moat.py
@@ -36,3 +36,39 @@ def build_clusters(canon, method_clusters, all_ids):
         ord2canon[ordinal] = int(canon.get(nid, nid))
         ordinal += 1
     return ordinal_of, ord2canon
+
+
+def collapse_for_index(nodes2, node_texts2, ordinal_of):
+    """One index entry per cluster: entity_id = ordinal, canonical_name = the joined
+    member docs (the MERGED text -- where dense-ER recovery happens), typ from the
+    first member. Docs joined in stable (ordinal, id) order."""
+    text_of = dict(zip([n[0] for n in nodes2], node_texts2))
+    typ_of = {n[0]: n[2] for n in nodes2}
+    members: dict[int, list[str]] = {}
+    for nid, _name, _typ in nodes2:
+        members.setdefault(ordinal_of[nid], []).append(nid)
+    out = []
+    for ordv, ids in sorted(members.items()):
+        ids_sorted = sorted(ids)
+        doc = " ".join(text_of.get(i, "") for i in ids_sorted).strip()
+        out.append({"entity_id": ordv, "canonical_name": doc, "typ": typ_of[ids_sorted[0]]})
+    return out
+
+
+def collapse_for_store(nodes2, edges2, ordinal_of):
+    """One store node per cluster (id = str(ordinal)) + edges remapped endpoint ->
+    its cluster ordinal, dropping intra-cluster self-loops. Feed to bulk_load
+    UNCHANGED -- each node's unique key = str(ordinal) => passthrough, so the store
+    holds exactly this pre-merged graph (no store-side merge)."""
+    seen: dict[int, tuple] = {}
+    for nid, name, typ in nodes2:
+        ordv = ordinal_of[nid]
+        seen.setdefault(ordv, (str(ordv), name, typ))       # first member names the node
+    coll_nodes = [seen[o] for o in sorted(seen)]
+    coll_edges = []
+    for s, p, o in edges2:
+        so, oo = ordinal_of[s], ordinal_of[o]
+        if so == oo:
+            continue                                        # intra-cluster self-loop
+        coll_edges.append((str(so), p, str(oo)))
+    return coll_nodes, coll_edges

--- a/packages/python/goldengraph/tests/test_alias_materialize.py
+++ b/packages/python/goldengraph/tests/test_alias_materialize.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 ggn = pytest.importorskip("goldengraph_native")
-from goldengraph.bulk import bulk_load                       # noqa: E402
+from goldengraph.bulk import bulk_load  # noqa: E402
 from goldengraph.stark_moat import collapse_for_index, collapse_for_store  # noqa: E402
 
 _BIG = 1 << 62

--- a/packages/python/goldengraph/tests/test_alias_materialize.py
+++ b/packages/python/goldengraph/tests/test_alias_materialize.py
@@ -1,0 +1,52 @@
+"""SP-moat materialization: one index entry + one store node per cluster; the store
+holds the PRE-MERGED graph (edges unioned by Python collapse, not store merge)."""
+from __future__ import annotations
+
+import pytest
+
+ggn = pytest.importorskip("goldengraph_native")
+from goldengraph.bulk import bulk_load                       # noqa: E402
+from goldengraph.stark_moat import collapse_for_index, collapse_for_store  # noqa: E402
+
+_BIG = 1 << 62
+
+
+def _store():
+    from goldengraph_native import _native as gg
+
+    return gg.PyStore()
+
+
+def test_collapse_for_index_merges_docs_per_cluster():
+    nodes2 = [("1#a0", "IL6", "gene"), ("1#a1", "IL 6", "gene"), ("2", "aspirin", "drug")]
+    texts2 = ["sentence one", "sentence two", "aspirin doc"]
+    ordinal_of = {"1#a0": 0, "1#a1": 0, "2": 1}              # aliases merged into ord 0
+    ents = collapse_for_index(nodes2, texts2, ordinal_of)
+    by_ord = {e["entity_id"]: e for e in ents}
+    assert set(by_ord) == {0, 1}                             # one entry per cluster
+    assert "sentence one" in by_ord[0]["canonical_name"] and "sentence two" in by_ord[0]["canonical_name"]
+
+
+def test_collapse_for_store_unions_neighborhood():
+    # aliases 1#a0,1#a1 (cluster 0) each hold one edge to distinct neighbors 2,3
+    nodes2 = [("1#a0", "IL6", "gene"), ("1#a1", "IL 6", "gene"),
+              ("2", "aspirin", "drug"), ("3", "fever", "effect")]
+    edges2 = [("1#a0", "targets", "2"), ("1#a1", "assoc", "3")]
+    ordinal_of = {"1#a0": 0, "1#a1": 0, "2": 1, "3": 2}
+    coll_nodes, coll_edges = collapse_for_store(nodes2, edges2, ordinal_of)
+    assert len(coll_nodes) == 3                              # 3 clusters -> 3 nodes
+    store = _store()
+    bulk_load(store, coll_nodes, coll_edges)
+    g = store.as_of(_BIG, _BIG)
+    ord_to_eid = {int(e["source_refs"][0]): e["entity_id"] for e in g.entities()}
+    eid0 = ord_to_eid[0]                                     # view-eid != ordinal; map via source_refs
+    neighbors = {e["obj"] for e in g.query([eid0], 1)["edges"] if e["subj"] == eid0}
+    assert neighbors == {ord_to_eid[1], ord_to_eid[2]}      # UNIONED: both aliases' edges on cluster 0
+
+
+def test_collapse_drops_intra_cluster_self_loops():
+    nodes2 = [("1#a0", "IL6", "gene"), ("1#a1", "IL 6", "gene")]
+    edges2 = [("1#a0", "same", "1#a1")]                      # both ends in cluster 0
+    ordinal_of = {"1#a0": 0, "1#a1": 0}
+    _, coll_edges = collapse_for_store(nodes2, edges2, ordinal_of)
+    assert coll_edges == []                                  # self-loop dropped

--- a/packages/python/goldengraph/tests/test_build_clusters.py
+++ b/packages/python/goldengraph/tests/test_build_clusters.py
@@ -1,0 +1,25 @@
+"""SP-moat cluster assembly + INT canon scoring map (pure). ord2canon values are
+INTS -- the original STaRK node ids -- so they match the int `gold` sets in
+stark_metrics. (A str->int mismatch here would make every method score ~0.)"""
+from __future__ import annotations
+
+from goldengraph.stark_moat import build_clusters
+
+
+def test_build_clusters_targets_grouped_nontargets_singleton():
+    canon = {"1#a0": "1", "1#a1": "1", "2": "2"}
+    method_clusters = [["1#a0", "1#a1"]]               # resolver merged the two aliases
+    all_ids = ["1#a0", "1#a1", "2"]
+    ordinal_of, ord2canon = build_clusters(canon, method_clusters, all_ids)
+    assert ordinal_of["1#a0"] == ordinal_of["1#a1"]    # aliases share an ordinal
+    assert ordinal_of["2"] != ordinal_of["1#a0"]        # non-target its own ordinal
+    assert ord2canon[ordinal_of["1#a0"]] == 1           # INT canonical original (matches int gold)
+    assert ord2canon[ordinal_of["2"]] == 2
+    assert all(isinstance(v, int) for v in ord2canon.values())
+
+
+def test_build_clusters_fragmented_all_singletons():
+    canon = {"1#a0": "1", "1#a1": "1"}
+    ordinal_of, ord2canon = build_clusters(canon, [["1#a0"], ["1#a1"]], ["1#a0", "1#a1"])
+    assert ordinal_of["1#a0"] != ordinal_of["1#a1"]     # fragmented -> distinct ordinals
+    assert ord2canon[ordinal_of["1#a0"]] == 1           # both still map to original 1 (int)

--- a/packages/python/goldengraph/tests/test_stark_inject.py
+++ b/packages/python/goldengraph/tests/test_stark_inject.py
@@ -1,0 +1,62 @@
+"""SP-moat: alias injection fragments a gold entity into k variant-named nodes,
+splitting its doc + edges. Pure + seeded; no store, no goldenmatch."""
+from __future__ import annotations
+
+from goldengraph.stark_inject import _variants, inject_aliases
+
+# 3 nodes; N1 is the injection target. Docs are 3 sentences so k=3 splits cleanly.
+_NODES = [("1", "Interleukin 6", "gene"), ("2", "aspirin", "drug"), ("3", "fever", "effect")]
+_TEXTS = ["Interleukin 6 is a cytokine. It signals inflammation. It is a drug target.",
+          "aspirin doc.", "fever doc."]
+_EDGES = [("1", "associated_with", "3"), ("2", "treats", "3"), ("1", "targeted_by", "2")]
+
+
+def test_variants_returns_k_distinct():
+    vs = _variants("Interleukin 6", 3, seed=0)
+    assert len(vs) == 3 and len(set(vs)) == 3          # distinct (anti-rig for exact dedup)
+
+
+def test_target_fragmented_into_k_aliases_original_dropped():
+    nodes2, texts2, edges2, canon = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=0)
+    ids = {n[0] for n in nodes2}
+    assert "1" not in ids                               # original dropped
+    aliases = [i for i in ids if i.startswith("1#a")]
+    assert len(aliases) == 3                            # k aliases
+    assert {"2", "3"} <= ids                            # non-targets pass through
+
+
+def test_canon_maps_aliases_to_original_identity_elsewhere():
+    _, _, _, canon = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=0)
+    assert canon["2"] == "2" and canon["3"] == "3"      # identity for non-targets
+    assert all(canon[a] == "1" for a in canon if a.startswith("1#a"))
+
+
+def test_doc_sentences_partitioned_no_alias_has_full():
+    nodes2, texts2, _, _ = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=0)
+    txt = dict(zip([n[0] for n in nodes2], texts2))
+    alias_docs = [txt[i] for i in txt if i.startswith("1#a")]
+    joined = " ".join(alias_docs)
+    for sent in ["Interleukin 6 is a cytokine", "It signals inflammation", "It is a drug target"]:
+        assert sent in joined                           # union preserves every sentence
+    assert all(len(d) < len(_TEXTS[0]) for d in alias_docs)   # no alias has the full doc
+
+
+def test_edges_distributed_across_aliases():
+    _, _, edges2, _ = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=0)
+    # N1 had 2 incident edges (->3, N1 targeted_by 2); they land on DIFFERENT aliases
+    n1_edge_sources = {s for (s, _p, _o) in edges2 if s.startswith("1#a")}
+    n1_edge_objs = {o for (_s, _p, o) in edges2 if o.startswith("1#a")}
+    assert len(n1_edge_sources | n1_edge_objs) >= 2     # spread across >=2 aliases
+
+
+def test_both_target_edge_remaps_both_ends():
+    # inject BOTH endpoints of edge (1 -targeted_by-> 2): both must become aliases
+    _, _, edges2, _ = inject_aliases(_NODES, _TEXTS, _EDGES, {"1", "2"}, k=2, seed=0)
+    e = [(s, p, o) for (s, p, o) in edges2 if p == "targeted_by"][0]
+    assert e[0].startswith("1#a") and e[2].startswith("2#a")
+
+
+def test_determinism_same_seed():
+    a = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=7)
+    b = inject_aliases(_NODES, _TEXTS, _EDGES, {"1"}, k=3, seed=7)
+    assert a == b

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_adapter.py
@@ -107,14 +107,30 @@ def load_stark_kb(name: str, *, split: str = "test", limit_queries: int | None =
     return nodes, edges, queries, node_texts
 
 
+def _apply_id_map(retrieved, id_map):
+    """Map retrieved ids through ``id_map`` (cluster_ordinal -> canonical original id),
+    dedup first-seen. ``id_map=None`` -> identity passthrough (dedup only). Used by the
+    alias-moat scoring: retrieved ordinals -> canonical originals so a hit is
+    equivalence-class (any alias of the gold entity counts)."""
+    seen, out = set(), []
+    for r in retrieved:
+        v = r if id_map is None else id_map.get(r)
+        if v is not None and v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out
+
+
 def evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, *,
-             arm: str, sample: int | None = None) -> dict:
+             arm: str, sample: int | None = None, id_map=None) -> dict:
     """Run one retrieval arm over ``queries``, return mean metrics + timing. ``arm``
-    in {"dense","graph"}. The index returns STARK ids (entity_id=int(stark_id) at
-    build time), so Arm A needs no translation and covers ALL nodes. Arm B walks the
-    STORE (``as_of().query`` -- the thing under test), translating stark<->slice-local
-    ids only at the walk boundary. ``stark_to_eid``/``eid_to_stark`` cover edge-endpoint
-    nodes only, which is exactly the set that has neighbors."""
+    in {"dense","graph"}. The index returns the id it was BUILT with (plain STaRK:
+    entity_id=int(stark_id); alias-moat: entity_id=cluster_ordinal), so Arm A needs no
+    translation of THAT id and covers ALL nodes. Arm B walks the STORE (``as_of().query``
+    -- the thing under test), translating that-id<->slice-local only at the walk
+    boundary. ``id_map`` (alias-moat: cluster_ordinal -> canonical original id) maps the
+    retrieved ids to the scoring space before ``metrics``; ``None`` = plain STaRK
+    (identity), keeping the pre-moat path byte-identical."""
     from erkgbench.stark_metrics import dedup_first_seen, mean_metrics, metrics
 
     qs = queries[:sample] if sample else queries
@@ -122,16 +138,16 @@ def evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder, 
     for text, gold in qs:
         t0 = time.perf_counter()
         if arm == "dense":
-            ranked = index.query(text, embedder, k=20)  # stark ids already
+            ranked = index.query(text, embedder, k=20)  # ids already (stark id or ordinal)
         elif arm == "graph":
-            seeds = index.query(text, embedder, k=5)  # stark ids
+            seeds = index.query(text, embedder, k=5)
             seed_eids = [stark_to_eid[s] for s in seeds if s in stark_to_eid]
             nbr = [eid_to_stark[e["entity_id"]] for e in _neighbors(slice_graph, seed_eids)]
             ranked = dedup_first_seen([*seeds, *nbr])
         else:
             raise ValueError(f"unknown arm {arm!r}")
         latencies.append(time.perf_counter() - t0)
-        per_query.append(metrics(ranked, gold))  # gold: int stark ids
+        per_query.append(metrics(_apply_id_map(ranked, id_map), gold))  # gold: int originals
     agg = mean_metrics(per_query)
     lat = sorted(latencies)
     agg["latency_ms_mean"] = 1000 * sum(lat) / (len(lat) or 1)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_resolve.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_resolve.py
@@ -1,0 +1,41 @@
+"""SP-moat resolver: cluster injected alias nodes. `none`/`exact` are pure; `er`
+routes through goldenmatch's zero-config dedupe (the suite's real ER engine) over
+the alias names -- the same call ``ingest.py::_gm_cluster`` uses. goldenmatch +
+polars import lazily so the pure paths need neither.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+def resolve_aliases(alias_nodes, method: str):
+    """`alias_nodes`: [(alias_id, name)] (injected set only). Returns clusters:
+    list[list[alias_id]]. method in {none, exact, er}."""
+    ids = [a for a, _ in alias_nodes]
+    if method == "none":
+        return [[i] for i in ids]
+    if method == "exact":
+        groups: dict[str, list[str]] = defaultdict(list)
+        for aid, name in alias_nodes:
+            groups[name.lower().strip()].append(aid)
+        return list(groups.values())
+    if method == "er":
+        import goldenmatch as gm
+        import polars as pl
+
+        if not alias_nodes:
+            return []
+        df = pl.DataFrame({"name": [name for _, name in alias_nodes]})
+        result = gm.dedupe_df(df)
+        seen: set[int] = set()
+        clusters: list[list[str]] = []
+        for info in result.clusters.values():
+            members = [int(x) for x in info["members"]]
+            seen.update(members)
+            clusters.append([ids[m] for m in members])
+        # dedupe_df only returns multi-member clusters; singletons are the rest
+        for i, aid in enumerate(ids):
+            if i not in seen:
+                clusters.append([aid])
+        return clusters
+    raise ValueError(f"unknown method {method!r} (none|exact|er)")

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_alias_scoring.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_alias_scoring.py
@@ -1,0 +1,24 @@
+"""SP-moat scoring: canon-mapped ranked list -> equivalence-class hit."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.stark_adapter import _apply_id_map  # noqa: E402
+from erkgbench.stark_metrics import metrics  # noqa: E402
+
+
+def test_id_map_canon_then_hit_on_any_alias():
+    # retrieved cluster ordinals; ord2canon maps ords 10,11 -> gold entity 1
+    ranked = _apply_id_map([12, 10, 11], {10: 1, 11: 1, 12: 2})
+    assert ranked == [2, 1]                                  # dedup first-seen
+    m = metrics(ranked, {1})                                 # gold entity 1 retrieved via an alias
+    assert m["hit@5"] == 1.0 and m["recall@20"] == 1.0
+
+
+def test_id_map_none_is_passthrough_dedup():
+    assert _apply_id_map([5, 3, 5, 9], None) == [5, 3, 9]    # dedup first-seen, no mapping

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_stark_resolve.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_stark_resolve.py
@@ -1,0 +1,56 @@
+"""SP-moat resolver: cluster injected alias nodes 3 ways. `er` (goldenmatch) must
+merge variant surface forms of ONE entity that `exact` leaves split -- the moat in
+miniature. Surname-diverse fixture to avoid dedupe blocking hangs."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.stark_resolve import resolve_aliases  # noqa: E402
+
+
+def _clusters_as_sets(clusters):
+    return {frozenset(c) for c in clusters}
+
+
+# two entities: A has 3 variant surface forms, B has 1. Distinct real surnames.
+_ALIAS_NODES = [
+    ("A#a0", "Interleukin 6"), ("A#a1", "IL 6"), ("A#a2", "Interleukin-6"),
+    ("B#a0", "Metformin"),
+]
+
+
+def test_none_all_singletons():
+    cl = resolve_aliases(_ALIAS_NODES, "none")
+    assert _clusters_as_sets(cl) == {frozenset([i]) for i, _ in _ALIAS_NODES}
+
+
+def test_exact_merges_only_identical_names():
+    dup = _ALIAS_NODES + [("C#a0", "Metformin")]     # exact dup of B's name
+    cl = resolve_aliases(dup, "exact")
+    sets = _clusters_as_sets(cl)
+    assert frozenset(["B#a0", "C#a0"]) in sets        # identical names merge
+    assert frozenset(["A#a0"]) in sets                # variant forms stay split
+    assert frozenset(["A#a1"]) in sets
+
+
+def test_er_merges_variant_surface_forms():
+    # The moat in miniature: `exact` leaves all 3 A-variants as 3 singletons (distinct
+    # names); `er` merges at least some of them into a multi-alias cluster that exact
+    # cannot -- WITHOUT conflating A with B. (The real engine may not merge EVERY
+    # variant -- e.g. an abbreviation form -- which is an honest resolver-limit finding,
+    # not a unit-test target; we assert it recovers MORE than exact does, and never
+    # over-merges across entities.)
+    a_ids = {"A#a0", "A#a1", "A#a2"}
+    exact_a = [s for s in _clusters_as_sets(resolve_aliases(_ALIAS_NODES, "exact")) if s & a_ids]
+    er_sets = _clusters_as_sets(resolve_aliases(_ALIAS_NODES, "er"))
+    er_a = [s for s in er_sets if s & a_ids]
+    assert len(exact_a) == 3                            # exact: every A-variant a singleton
+    assert len(er_a) < 3                               # er merges >=2 A-variants exact left split
+    il6 = next(s for s in er_a if "A#a0" in s)
+    assert len(il6 & a_ids) >= 2 and not (il6 - a_ids)  # multi-A cluster, no cross-entity merge
+    assert frozenset(["B#a0"]) in er_sets              # B stays separate (no over-merge)

--- a/scripts/distill/modal_stark.py
+++ b/scripts/distill/modal_stark.py
@@ -133,7 +133,7 @@ def _start_ollama(embed_model: str) -> str:
 
 
 def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int,
-                text_mode: str = "names") -> str:
+                text_mode: str = "names", inject: bool = False, k: int = 3, seed: int = 0) -> str:
     import os
     import sys
     import time
@@ -153,15 +153,21 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int,
     from goldengraph_native import _native as ggn
 
     _BIG = 1 << 62
-    lines = [f"# STaRK feasibility -- {kb} (sample={sample}, text_mode={text_mode})", ""]
+    _title = f"# STaRK -- {kb} (sample={sample}, " + (f"INJECT k={k} seed={seed}" if inject
+                                                       else f"text_mode={text_mode}") + ")"
+    lines = [_title, ""]
 
     # 1. download + map. with_text builds the fair-baseline corpus (each node's intrinsic doc,
-    #    add_rel=False -- NO relations, so the graph walk stays the only structural signal).
+    #    add_rel=False -- NO relations). Injection needs the docs too (it fragments them).
     t = time.perf_counter()
     nodes, edges, queries, node_texts = load_stark_kb(
-        kb, split="test", limit_queries=sample, with_text=(text_mode == "full"))
+        kb, split="test", limit_queries=sample, with_text=(text_mode == "full" or inject))
     lines.append(f"load_stark_kb: {time.perf_counter() - t:.1f}s  "
                  f"nodes={len(nodes)} edges={len(edges)} queries={len(queries)}")
+
+    if inject:
+        return _run_moat(lines, nodes, edges, queries, node_texts, k, seed, kb,
+                         embed_model, base_url, ggn, EntityIndex, _BIG)
 
     # 2. bulk_load -> store  [ingest wall + RSS]. Single batch; chunked on OOM.
     from goldengraph.bulk import bulk_load
@@ -233,19 +239,92 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int,
     return text
 
 
+def _run_moat(lines, nodes, edges, queries, node_texts, k, seed, kb,
+              embed_model, base_url, ggn, EntityIndex, _BIG):
+    """The ER-moat experiment: fragment the sampled queries' gold entities into k
+    alias nodes (split doc + edges), then compare 3 resolution conditions x 2 arms.
+    Moat = ER-dense recovers recall@20 toward clean while ad-hoc stays depressed.
+    See docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md."""
+    import os
+    import time
+
+    from erkgbench.stark_adapter import evaluate
+    from erkgbench.stark_resolve import resolve_aliases
+    from goldengraph.bulk import bulk_load
+    from goldengraph.stark_inject import inject_aliases
+    from goldengraph.stark_moat import build_clusters, collapse_for_index, collapse_for_store
+
+    # fragment ONLY the sampled queries' gold entities (controlled, guaranteed signal)
+    target_ids = {str(g) for _q, gold in queries for g in gold}
+    t = time.perf_counter()
+    nodes2, texts2, edges2, canon = inject_aliases(nodes, node_texts, edges, target_ids, k=k, seed=seed)
+    alias_nodes = [(nid, name) for nid, name, _typ in nodes2 if canon.get(nid) != nid]
+    all_ids = [n[0] for n in nodes2]
+    lines.append(f"inject: {time.perf_counter() - t:.1f}s  targets={len(target_ids)} k={k}  "
+                 f"nodes {len(nodes)}->{len(nodes2)} (aliases={len(alias_nodes)})  "
+                 f"edges {len(edges)}->{len(edges2)}")
+    lines.append("clean reference (PR #1402, no injection): dense recall@20=0.261 mrr=0.151 ; "
+                 "graph recall@20=0.213 mrr=0.150")
+
+    embedder = _OllamaEmbedder(embed_model, base_url)
+    rows = []
+    for method in ("none", "exact", "er"):
+        tc = time.perf_counter()
+        clusters = resolve_aliases(alias_nodes, method)
+        ordinal_of, ord2canon = build_clusters(canon, clusters, all_ids)
+        n_clusters = len(set(ordinal_of.values()))
+        index = EntityIndex.build(collapse_for_index(nodes2, texts2, ordinal_of), embedder, top_k=50)
+        coll_nodes, coll_edges = collapse_for_store(nodes2, edges2, ordinal_of)
+        store = ggn.PyStore()
+        bulk_load(store, coll_nodes, coll_edges)
+        slice_graph = store.as_of(_BIG, _BIG)
+        stark_to_eid = {int(e["source_refs"][0]): e["entity_id"]
+                        for e in slice_graph.entities() if e["source_refs"]}
+        eid_to_stark = {v: kk for kk, v in stark_to_eid.items()}
+        lines.append(f"\n[{method}] clusters={n_clusters} (of {len(alias_nodes)} aliases + "
+                     f"{len(all_ids) - len(alias_nodes)} passthrough)  build={time.perf_counter() - tc:.1f}s "
+                     f"peak_rss={_peak_rss_gb():.2f}GB")
+        for arm in ("dense", "graph"):
+            r = evaluate(index, slice_graph, stark_to_eid, eid_to_stark, queries, embedder,
+                         arm=arm, id_map=ord2canon)
+            rows.append((method, arm, r))
+            lines.append(f"  [{method}/{arm}] hit@1={r['hit@1']:.3f} hit@5={r['hit@5']:.3f} "
+                         f"recall@20={r['recall@20']:.3f} mrr={r['mrr']:.3f} "
+                         f"lat_mean={r['latency_ms_mean']:.1f}ms")
+
+    dr = {m: r["recall@20"] for (m, a, r) in rows if a == "dense"}
+    lines.append(f"\nDENSE recall@20:  fragmented={dr['none']:.3f}  adhoc={dr['exact']:.3f}  "
+                 f"er={dr['er']:.3f}  clean=0.261   |   ER-adhoc={dr['er'] - dr['exact']:+.3f}   "
+                 f"ER-fragmented={dr['er'] - dr['none']:+.3f}   clean-fragmented={0.261 - dr['none']:+.3f}")
+    lines.append("\nMOAT read: (1) CHECK clean-fragmented FIRST -- if ~0 the injection was too weak "
+                 "(inconclusive, not a refutation). (2) ER recovers recall@20 toward clean while adhoc "
+                 "stays depressed (ER-adhoc > 0) => MOAT CONFIRMED. ER~=adhoc => resolver merged nothing "
+                 "exact didn't.")
+    text = "\n".join(lines)
+    print(text, flush=True)
+    os.makedirs("/cache/results", exist_ok=True)
+    pathlib.Path(f"/cache/results/stark_{kb}_inject.md").write_text(text)
+    cache.commit()
+    return text
+
+
 @app.function(image=image, gpu="A10G", volumes={"/cache": cache}, timeout=10800, memory=65536)
 def run_stark(kb: str = "prime", sample: int = 200, embed_model: str = "nomic-embed-text",
-              chunk_edges: int = 0, text_mode: str = "names") -> str:
-    return _stark_impl(kb, sample, embed_model, chunk_edges, text_mode)
+              chunk_edges: int = 0, text_mode: str = "names",
+              inject: bool = False, k: int = 3, seed: int = 0) -> str:
+    return _stark_impl(kb, sample, embed_model, chunk_edges, text_mode, inject, k, seed)
 
 
 @app.local_entrypoint()
 def main(kb: str = "prime", sample: int = 200, embed_model: str = "nomic-embed-text",
-         chunk_edges: int = 0, text_mode: str = "names", spawn: bool = False) -> None:
+         chunk_edges: int = 0, text_mode: str = "names", inject: bool = False,
+         k: int = 3, seed: int = 0, spawn: bool = False) -> None:
+    tag = "inject" if inject else text_mode
     if spawn:
         call = run_stark.spawn(kb=kb, sample=sample, embed_model=embed_model,
-                               chunk_edges=chunk_edges, text_mode=text_mode)
-        print(f"SPAWNED call_id={call.object_id} -> results/stark_{kb}_{text_mode}.md on gg-bench-cache")
+                               chunk_edges=chunk_edges, text_mode=text_mode, inject=inject, k=k, seed=seed)
+        print(f"SPAWNED call_id={call.object_id} -> results/stark_{kb}_{tag}.md on gg-bench-cache")
         return
     print("\n===== RESULT =====\n" + run_stark.remote(
-        kb=kb, sample=sample, embed_model=embed_model, chunk_edges=chunk_edges, text_mode=text_mode))
+        kb=kb, sample=sample, embed_model=embed_model, chunk_edges=chunk_edges,
+        text_mode=text_mode, inject=inject, k=k, seed=seed))


### PR DESCRIPTION
The ER-moat experiment: corrupt real STaRK-PRIME with alias duplicates, then compare 3 resolution conditions (none/exact/goldenmatch) × 2 arms, scoring by canonical equivalence.

## Result: inconclusive — the instrument is confounded (honest negative)

```
DENSE recall@20:  fragmented=0.365  adhoc=0.288  er=0.240  clean=0.261 (PR #1402)
```

Fragmentation *raised* recall (0.365 > clean) and *more* resolution *lowered* it — the opposite of the hypothesis. **The confound:** fragmenting the gold answer into k=3 aliases + equivalence scoring (hit = any alias) gives dense **3 lottery tickets** at the gold instead of 1, so fragmentation helps and merging removes chances. The multiple-chances effect swamps the per-alias text dilution. The built-in `clean−fragmented` guard fired (−0.104 = fragmentation helped → inconclusive).

Real underneath (swamped): ER mechanically works (merged 903/948 aliases); `er` dense (0.240) slightly undershoots clean (0.261), hinting the zero-config dedupe over-merges a few similar-named entities; graph ≤ dense everywhere (naive walk still unhelpful, per #1402).

**Verdict: moat neither confirmed nor refuted — the instrument is wrong, not the thesis.** Fix = **Case B** (deferred in the spec): fragment *bridge/path* entities and keep gold answers intact, so fragmentation severs the *route* to the answer (no equivalence-scoring inflation), landing the effect on the graph arm. Reuses this same resolve/collapse/materialize harness.

## What ships

Full harness, all box-TDD'd (25 tests): `stark_inject` (fragment), `stark_resolve` (none/exact/`dedupe_df`), `stark_moat` (cluster ordinals + int canon + Python collapse-for-index/store), `evaluate(id_map=)` (canon-equivalence scoring, `id_map=None` keeps the plain STaRK path byte-identical), `modal_stark --inject`. Two review passes caught real bugs pre-code (store can't merge same-batch aliases → Python collapse; str/int scoring mismatch → int canon).

The negative is about the experimental *instrument*; the discipline caught it before it was mis-sold. Spec + plan + verdict under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)