### PR TITLE
feat(goldengraph): STaRK Case B (bridge fragmentation) + moat-arc conclusion

### DIFF
--- a/docs/superpowers/reports/2026-07-03-stark-bridge-moat.md
+++ b/docs/superpowers/reports/2026-07-03-stark-bridge-moat.md
@@ -1,0 +1,83 @@
+# Alias-injected STaRK, Case B (bridge fragmentation) — verdict (conclusive negative)
+
+**Question:** with the Case-A confound removed, does goldenmatch's resolver measurably
+recover STaRK retrieval quality that ad-hoc dedup loses?
+
+**Answer: no — directionally present but negligible (~1 question), and this
+concludes the STaRK moat arc.** The corrected instrument works (confound gone, dense
+control flat, ER mechanically merges what exact can't), but the retrieval moat is
++0.005 recall@20 (ER vs ad-hoc) — within noise. STaRK-PRIME is text-rich and
+dense-dominated, so the graph path is rarely the only route to an answer, so
+restoring a severed path rarely changes what is retrieved. Run on Modal (A10G,
+64GB), PRIME, 200 queries, k=3, bridge_cap=8, seed=0, Ollama `nomic-embed-text`.
+
+## Design (the correction to Case A)
+
+Case A (2026-07-03, PR #1407) fragmented the **gold answers** + scored by canonical
+equivalence — a confound: 3 aliases = 3 retrieval chances at the gold, so
+fragmentation *helped*. Case B fixes it: fragment the gold answers' **1-hop
+neighbors** (the BRIDGE), keep answers INTACT. Gold stays a single node (no
+equivalence inflation); fragmenting a neighbor splits its edges + text, severing the
+route a graph walk takes from a dense seed to the answer. Moat now reads on the
+**GRAPH arm**; **dense = control** (answers untouched → should stay flat).
+
+## Raw numbers
+
+```
+inject: targets=1639 neighbors  k=3  nodes 129375->132653 (aliases=4917)
+                          fragmented   adhoc     er        clean
+DENSE  recall@20            0.244      0.258     0.258     0.261     (ER-adhoc +0.000)
+GRAPH  recall@20            0.183      0.185     0.190     0.213     (ER-adhoc +0.005, ER-frag +0.007)
+ER clusters: 131099 (of 4917 aliases -> ~1554 merges); build ~1090-1240s/method.
+```
+
+## Reading
+
+1. **Confound removed — dense control is FLAT.** Dense recall@20 barely moves
+   (fragmented 0.244 → adhoc/er 0.258 ≈ clean 0.261). Fragmenting non-answer
+   neighbors adds a little index noise (the 0.244 dip) that resolution cleans up,
+   but there is no lottery-ticket inflation. The instrument is now correct.
+2. **The moat is in the RIGHT DIRECTION on the graph arm.** `ER > adhoc > fragmented`
+   (0.190 > 0.185 > 0.183): ER re-merges the severed bridge and the walk recovers a
+   bit where exact-match cannot. Direction confirms the mechanism.
+3. **...but the MAGNITUDE is negligible.** ER−adhoc = +0.005 recall@20 over 200
+   queries ≈ **one question**. Within noise. No condition recovers to the clean
+   graph number (0.213); best is er 0.190. Graph stays far below dense everywhere
+   (0.190 vs 0.258), consistent with every prior run: the naive 1-hop walk is weak.
+4. **ER mechanically works at scale** — ~1,554 alias merges (131,099 clusters vs
+   132,653 fragmented). The resolver does merge variant surface forms exact-match
+   leaves split; it just doesn't move the retrieval needle here.
+
+## Why the moat is invisible on STaRK retrieval (the root cause)
+
+For a severed bridge to matter, a query's answer must be reachable ONLY via the
+graph walk (dense misses it directly) AND the specific fragmented neighbor must be
+the bridge the walk needs. On text-rich STaRK-PRIME, dense answers most queries
+directly, so the graph path is load-bearing for only a small slice — and restoring
+it (what ER does) changes retrieval for that slice alone. This is the SAME root cause
+as the vanilla and full-text runs: STaRK retrieval is a text problem; structure (and
+therefore resolution-of-structure) is rarely the bottleneck.
+
+## Conclusion — the STaRK moat arc ends here (honestly)
+
+Across four runs the finding is consistent and now conclusive:
+
+| run | finding |
+|-----|---------|
+| vanilla (names) | graph "+39%" — a weak-baseline artifact |
+| full-text (fair dense) | graph delta INVERTS (−18%); dense is all you need |
+| alias, Case A | confounded instrument (equivalence scoring inflates fragmentation) |
+| alias, Case B | confound removed; moat directionally real but negligible (+0.005 ≈ 1q) |
+
+**goldenmatch's ER is not un-valuable — it demonstrably merges variant surface forms
+that exact-match can't (proven in the `stark_resolve` unit test AND at scale). It
+simply does not move RETRIEVAL on a text-rich, dense-dominated benchmark, because
+retrieval there does not depend on the resolved structure.** The moat lives where
+resolution is THE bottleneck — deduplication / entity-resolution tasks (the suite's
+actual home turf), not semi-structured retrieval. Recommend closing the STaRK
+program on this honest negative rather than chasing further injection knobs; the
+instrument is now sound and the signal is genuinely absent.
+
+Entry: `scripts/distill/modal_stark.py --kb prime --sample 200 --inject --bridge --k 3`.
+Harness (all box-TDD'd): `stark_inject` (+`bridge_targets`), `stark_resolve`,
+`stark_moat`, `evaluate(id_map=)`.

--- a/packages/python/goldengraph/goldengraph/stark_inject.py
+++ b/packages/python/goldengraph/goldengraph/stark_inject.py
@@ -45,6 +45,26 @@ def _sentences(doc: str) -> list[str]:
     return [s.strip() for s in doc.split(". ") if s.strip()]
 
 
+def bridge_targets(edges, gold_ids, *, cap: int = 8) -> set[str]:
+    """Case B target selector: the 1-hop neighbors of the gold answer entities, to be
+    fragmented while the answers themselves stay INTACT. Fragmenting the BRIDGE (not
+    the answer) severs the route a graph walk takes to reach the answer, without the
+    equivalence-scoring inflation that answer-fragmentation caused. Per gold, keep at
+    most `cap` neighbors (lexicographically smallest -- deterministic, bounds the
+    resolver run); never a gold answer itself."""
+    gold = {str(g) for g in gold_ids}
+    nbrs: dict[str, set[str]] = {}
+    for s, _p, o in edges:
+        if s in gold and o not in gold:
+            nbrs.setdefault(s, set()).add(o)
+        if o in gold and s not in gold:
+            nbrs.setdefault(o, set()).add(s)
+    out: set[str] = set()
+    for g, ns in nbrs.items():
+        out.update(sorted(ns)[:cap])
+    return out
+
+
 def inject_aliases(nodes, node_texts, edges, target_ids, *, k: int = 3, seed: int = 0):
     """Fragment each entity in `target_ids` into k alias nodes. Returns
     (nodes2, node_texts2, edges2, canon). See the spec / module docstring."""

--- a/packages/python/goldengraph/tests/test_bridge_targets.py
+++ b/packages/python/goldengraph/tests/test_bridge_targets.py
@@ -1,0 +1,29 @@
+"""Case B: fragment the BRIDGE (gold answers' 1-hop neighbors), keep answers intact.
+`bridge_targets` picks the neighbor ids to fragment -- deterministic, capped, and
+never a gold answer itself."""
+from __future__ import annotations
+
+from goldengraph.stark_inject import bridge_targets
+
+# answer A(=1) has neighbors 2,3,4,5; B(=9) has neighbor 3 (shared) and 8. 6 is unrelated.
+_EDGES = [("1", "r", "2"), ("3", "r", "1"), ("1", "r", "4"), ("1", "r", "5"),
+          ("9", "r", "3"), ("8", "r", "9"), ("6", "r", "7")]
+
+
+def test_bridge_targets_are_gold_neighbors_excluding_gold():
+    t = bridge_targets(_EDGES, {"1", "9"}, cap=10)
+    assert t == {"2", "3", "4", "5", "8"}              # neighbors of 1 or 9
+    assert "1" not in t and "9" not in t                # gold answers stay intact
+    assert "6" not in t and "7" not in t                # unrelated nodes untouched
+
+
+def test_bridge_targets_capped_per_gold_deterministic():
+    # cap=2 per gold: answer 1 keeps its 2 lexicographically-smallest neighbors
+    t = bridge_targets(_EDGES, {"1"}, cap=2)
+    assert t == {"2", "3"}                              # sorted neighbors of 1, first 2
+
+
+def test_bridge_targets_shared_neighbor_not_double_counted():
+    t = bridge_targets(_EDGES, {"1", "9"}, cap=10)
+    # 3 is a neighbor of BOTH 1 and 9 -> appears once
+    assert sorted(t) == ["2", "3", "4", "5", "8"]

--- a/scripts/distill/modal_stark.py
+++ b/scripts/distill/modal_stark.py
@@ -133,7 +133,8 @@ def _start_ollama(embed_model: str) -> str:
 
 
 def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int,
-                text_mode: str = "names", inject: bool = False, k: int = 3, seed: int = 0) -> str:
+                text_mode: str = "names", inject: bool = False, k: int = 3, seed: int = 0,
+                bridge: bool = False, bridge_cap: int = 8) -> str:
     import os
     import sys
     import time
@@ -153,9 +154,9 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int,
     from goldengraph_native import _native as ggn
 
     _BIG = 1 << 62
-    _title = f"# STaRK -- {kb} (sample={sample}, " + (f"INJECT k={k} seed={seed}" if inject
-                                                       else f"text_mode={text_mode}") + ")"
-    lines = [_title, ""]
+    _mode = (f"INJECT-{'BRIDGE' if bridge else 'ANSWER'} k={k} seed={seed}" if inject
+             else f"text_mode={text_mode}")
+    lines = [f"# STaRK -- {kb} (sample={sample}, {_mode})", ""]
 
     # 1. download + map. with_text builds the fair-baseline corpus (each node's intrinsic doc,
     #    add_rel=False -- NO relations). Injection needs the docs too (it fragments them).
@@ -167,7 +168,8 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int,
 
     if inject:
         return _run_moat(lines, nodes, edges, queries, node_texts, k, seed, kb,
-                         embed_model, base_url, ggn, EntityIndex, _BIG)
+                         embed_model, base_url, ggn, EntityIndex, _BIG,
+                         bridge=bridge, bridge_cap=bridge_cap)
 
     # 2. bulk_load -> store  [ingest wall + RSS]. Single batch; chunked on OOM.
     from goldengraph.bulk import bulk_load
@@ -240,10 +242,15 @@ def _stark_impl(kb: str, sample: int, embed_model: str, chunk_edges: int,
 
 
 def _run_moat(lines, nodes, edges, queries, node_texts, k, seed, kb,
-              embed_model, base_url, ggn, EntityIndex, _BIG):
-    """The ER-moat experiment: fragment the sampled queries' gold entities into k
-    alias nodes (split doc + edges), then compare 3 resolution conditions x 2 arms.
-    Moat = ER-dense recovers recall@20 toward clean while ad-hoc stays depressed.
+              embed_model, base_url, ggn, EntityIndex, _BIG, bridge=False, bridge_cap=8):
+    """The ER-moat experiment: fragment entities into k alias nodes (split doc + edges),
+    then compare 3 resolution conditions x 2 arms. Two injection targets:
+      - default (Case A): fragment the sampled queries' GOLD ANSWER entities. CONFOUNDED
+        -- equivalence scoring gives dense k retrieval chances at the gold (see the
+        2026-07-03 verdict); fragmentation HELPS, inverting the signal.
+      - bridge=True (Case B): fragment the gold answers' 1-HOP NEIGHBORS, answers INTACT.
+        No equivalence inflation (gold single); severs the graph WALK's route to the
+        answer -> moat is read on the GRAPH arm, dense = flat control.
     See docs/superpowers/specs/2026-07-02-goldengraph-stark-alias-moat-design.md."""
     import os
     import time
@@ -251,11 +258,14 @@ def _run_moat(lines, nodes, edges, queries, node_texts, k, seed, kb,
     from erkgbench.stark_adapter import evaluate
     from erkgbench.stark_resolve import resolve_aliases
     from goldengraph.bulk import bulk_load
-    from goldengraph.stark_inject import inject_aliases
+    from goldengraph.stark_inject import bridge_targets, inject_aliases
     from goldengraph.stark_moat import build_clusters, collapse_for_index, collapse_for_store
 
-    # fragment ONLY the sampled queries' gold entities (controlled, guaranteed signal)
-    target_ids = {str(g) for _q, gold in queries for g in gold}
+    gold_ids = {str(g) for _q, gold in queries for g in gold}
+    if bridge:
+        target_ids = bridge_targets(edges, gold_ids, cap=bridge_cap)   # Case B: fragment the BRIDGE
+    else:
+        target_ids = gold_ids                                          # Case A: fragment the ANSWER
     t = time.perf_counter()
     nodes2, texts2, edges2, canon = inject_aliases(nodes, node_texts, edges, target_ids, k=k, seed=seed)
     alias_nodes = [(nid, name) for nid, name, _typ in nodes2 if canon.get(nid) != nid]
@@ -293,17 +303,29 @@ def _run_moat(lines, nodes, edges, queries, node_texts, k, seed, kb,
                          f"lat_mean={r['latency_ms_mean']:.1f}ms")
 
     dr = {m: r["recall@20"] for (m, a, r) in rows if a == "dense"}
+    gr = {m: r["recall@20"] for (m, a, r) in rows if a == "graph"}
     lines.append(f"\nDENSE recall@20:  fragmented={dr['none']:.3f}  adhoc={dr['exact']:.3f}  "
-                 f"er={dr['er']:.3f}  clean=0.261   |   ER-adhoc={dr['er'] - dr['exact']:+.3f}   "
-                 f"ER-fragmented={dr['er'] - dr['none']:+.3f}   clean-fragmented={0.261 - dr['none']:+.3f}")
-    lines.append("\nMOAT read: (1) CHECK clean-fragmented FIRST -- if ~0 the injection was too weak "
-                 "(inconclusive, not a refutation). (2) ER recovers recall@20 toward clean while adhoc "
-                 "stays depressed (ER-adhoc > 0) => MOAT CONFIRMED. ER~=adhoc => resolver merged nothing "
-                 "exact didn't.")
+                 f"er={dr['er']:.3f}  clean=0.261   |   ER-adhoc={dr['er'] - dr['exact']:+.3f}")
+    lines.append(f"GRAPH recall@20:  fragmented={gr['none']:.3f}  adhoc={gr['exact']:.3f}  "
+                 f"er={gr['er']:.3f}  clean=0.213   |   ER-adhoc={gr['er'] - gr['exact']:+.3f}   "
+                 f"ER-fragmented={gr['er'] - gr['none']:+.3f}")
+    if bridge:
+        lines.append("\nMOAT read (Case B, bridge-fragmented, answers INTACT): the moat lives on the "
+                     "GRAPH arm (dense = control, should stay ~flat since answers aren't touched). "
+                     "MOAT CONFIRMED iff graph ER-fragmented > 0 AND graph ER-adhoc > 0 -- ER re-merges "
+                     "the severed bridge so the walk reaches the answer, where exact-match can't. If "
+                     "graph stays flat across none/exact/er, the 1-hop walk doesn't route through the "
+                     "fragmented bridge on these queries (structure not load-bearing here) -> honest "
+                     "conclusion that vanilla STaRK can't stage the moat.")
+    else:
+        lines.append("\nMOAT read (Case A, answer-fragmented): CONFOUNDED -- equivalence scoring gives "
+                     "dense k chances at the gold, so fragmentation HELPS (clean-fragmented "
+                     f"={0.261 - dr['none']:+.3f}). Use Case B (bridge) instead.")
     text = "\n".join(lines)
     print(text, flush=True)
     os.makedirs("/cache/results", exist_ok=True)
-    pathlib.Path(f"/cache/results/stark_{kb}_inject.md").write_text(text)
+    _suffix = "bridge" if bridge else "inject"
+    pathlib.Path(f"/cache/results/stark_{kb}_{_suffix}.md").write_text(text)
     cache.commit()
     return text
 
@@ -311,20 +333,24 @@ def _run_moat(lines, nodes, edges, queries, node_texts, k, seed, kb,
 @app.function(image=image, gpu="A10G", volumes={"/cache": cache}, timeout=10800, memory=65536)
 def run_stark(kb: str = "prime", sample: int = 200, embed_model: str = "nomic-embed-text",
               chunk_edges: int = 0, text_mode: str = "names",
-              inject: bool = False, k: int = 3, seed: int = 0) -> str:
-    return _stark_impl(kb, sample, embed_model, chunk_edges, text_mode, inject, k, seed)
+              inject: bool = False, k: int = 3, seed: int = 0,
+              bridge: bool = False, bridge_cap: int = 8) -> str:
+    return _stark_impl(kb, sample, embed_model, chunk_edges, text_mode, inject, k, seed,
+                       bridge, bridge_cap)
 
 
 @app.local_entrypoint()
 def main(kb: str = "prime", sample: int = 200, embed_model: str = "nomic-embed-text",
          chunk_edges: int = 0, text_mode: str = "names", inject: bool = False,
-         k: int = 3, seed: int = 0, spawn: bool = False) -> None:
-    tag = "inject" if inject else text_mode
+         k: int = 3, seed: int = 0, bridge: bool = False, bridge_cap: int = 8,
+         spawn: bool = False) -> None:
+    tag = ("bridge" if bridge else "inject") if inject else text_mode
     if spawn:
         call = run_stark.spawn(kb=kb, sample=sample, embed_model=embed_model,
-                               chunk_edges=chunk_edges, text_mode=text_mode, inject=inject, k=k, seed=seed)
+                               chunk_edges=chunk_edges, text_mode=text_mode, inject=inject, k=k,
+                               seed=seed, bridge=bridge, bridge_cap=bridge_cap)
         print(f"SPAWNED call_id={call.object_id} -> results/stark_{kb}_{tag}.md on gg-bench-cache")
         return
     print("\n===== RESULT =====\n" + run_stark.remote(
         kb=kb, sample=sample, embed_model=embed_model, chunk_edges=chunk_edges,
-        text_mode=text_mode, inject=inject, k=k, seed=seed))
+        text_mode=text_mode, inject=inject, k=k, seed=seed, bridge=bridge, bridge_cap=bridge_cap))


### PR DESCRIPTION
Follow-up to #1407 (which shipped the harness + the Case A *confounded* verdict). Case B removes the confound and concludes the STaRK moat arc.

## Design fix
Case A fragmented gold **answers** + equivalence scoring → 3 aliases = 3 retrieval chances → fragmentation *helped* (confounded). Case B fragments the answers' **1-hop neighbors** (`bridge_targets`, capped), keeps answers **intact**: gold stays single (no inflation), and severing a neighbor breaks the graph walk's *route* to the answer. Moat reads on the **GRAPH arm**; **dense = control**.

## Result: conclusive negative
```
                fragmented  adhoc   er      clean
DENSE recall@20   0.244     0.258   0.258   0.261   (ER-adhoc +0.000  -- control FLAT)
GRAPH recall@20   0.183     0.185   0.190   0.213   (ER-adhoc +0.005, ER-frag +0.007)
```
- **Confound gone** — dense control flat (answers intact).
- **Moat directionally real** on the graph arm: `ER > adhoc > fragmented` (0.190 > 0.185 > 0.183) — ER re-merges the severed bridge where exact-match can't.
- **...but negligible** — ER−adhoc = +0.005 recall@20 over 200 queries ≈ **1 question**, within noise. ER mechanically works (~1,554 merges), but doesn't move retrieval.

**Root cause (consistent across all 4 runs):** STaRK-PRIME is text-rich + dense-dominated, so the graph path is load-bearing for only a small query slice → restoring it rarely changes retrieval.

## Conclusion
goldenmatch ER is not un-valuable — it demonstrably merges variant surface forms exact-match can't (unit test + at scale) — it just doesn't move **retrieval** on a benchmark where retrieval doesn't depend on resolved structure. The moat lives where resolution is *the* bottleneck (dedup / entity-resolution), not semi-structured retrieval. **Recommend closing the STaRK program on this honest negative.** Full write-up: `docs/.../2026-07-03-stark-bridge-moat.md`.

`bridge_targets` is box-TDD'd; the rest reuses the #1407 harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)