### PR TITLE
perf(postgres): de-bridge goldenmatch_score — native score-core fast path (P1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,9 @@ jobs:
               # sketch-core is a path dep of the postgres crate (goldenmatch_lsh_pairs),
               # so a kernel change must rebuild + re-smoke this lane.
               - 'packages/rust/extensions/sketch-core/**'
+              # score-core is a path dep of the postgres crate (goldenmatch_score
+              # native fast path), so a kernel change must rebuild + re-smoke.
+              - 'packages/rust/extensions/score-core/**'
               - 'packages/rust/extensions/Cargo.toml'
             rust_cores:
               # ANY Rust extension change re-validates EVERY committed TS wasm
@@ -2775,6 +2778,18 @@ jobs:
                 'char', 3, 64, 16, 42);
               IF pd.n <> 1 OR pd.a <> 0 OR pd.b <> 1 THEN
                 RAISE EXCEPTION 'lsh_pairs: expected exactly (0,1), got n=% (%,%)', pd.n, pd.a, pd.b;
+              END IF;
+
+              -- goldenmatch_score native fast path: jaro_winkler over a near-dup
+              -- pair == 0.9125 (validated vs the Python reference); exact over an
+              -- identical pair == 1.0. Proves the score-core path (not the bridge)
+              -- and that it matches the reference.
+              IF abs(goldenmatch.goldenmatch_score('Acme Corporation', 'Acme Corp', 'jaro_winkler') - 0.9125) > 1e-9 THEN
+                RAISE EXCEPTION 'score jaro_winkler: expected 0.9125, got %',
+                  goldenmatch.goldenmatch_score('Acme Corporation', 'Acme Corp', 'jaro_winkler');
+              END IF;
+              IF goldenmatch.goldenmatch_score('abc', 'abc', 'exact') <> 1.0 THEN
+                RAISE EXCEPTION 'score exact: expected 1.0';
               END IF;
 
               -- record_fingerprint: stable across key order (fields sorted by name).

--- a/packages/rust/extensions/CLAUDE.md
+++ b/packages/rust/extensions/CLAUDE.md
@@ -38,7 +38,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 
 ### postgres/ (goldenmatch_pg)
 - pgrx 0.12.9 Postgres extension, standalone crate (not in workspace)
-- `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based
+- `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based. **`goldenmatch_score(a, b, scorer)` de-bridged (P1):** the four rapidfuzz-family scorers (jaro_winkler / levenshtein / token_sort / exact) now run native-direct over `score-core` (no embedded-CPython per row — matters for row-wise `WHERE goldenmatch_score(...) > t`); other scorers (soundex_match / ensemble) still fall back to the bridge. Same signature + results, so NO version bump (implementation-only change; the SQL is unchanged). `rust_pgrx` smoke asserts the native value (`jaro_winkler` == 0.9125, validated vs the Python reference).
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
 - `correction.rs` -- Learning Memory CRUD + tuning: `correction_add`, `correction_list`, plus `memory_learn` (force a MemoryLearner pass) and `memory_stats` (counts + learned adjustments). All wrap the bridge `goldenmatch_bridge::api::*`. `memory_learn` is REVOKEd from PUBLIC like `correction_add`; `memory_stats` is read-only status, left for PUBLIC.

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -36,6 +36,9 @@ goldenhnsw = { path = "../goldenhnsw" }
 # Pure-Rust MinHash + LSH sketch kernel (no pyo3) — goldenmatch_lsh_pairs calls
 # this native-direct, NOT through the embedded-CPython bridge.
 goldenmatch-sketch-core = { path = "../sketch-core" }
+# Pure-Rust string scorers (jaro-winkler / levenshtein / token-sort, no pyo3) —
+# goldenmatch_score fast-paths these native-direct instead of the CPython bridge.
+goldenmatch-score-core = { path = "../score-core" }
 serde_json = "1"
 
 [[bin]]

--- a/packages/rust/extensions/postgres/src/quick.rs
+++ b/packages/rust/extensions/postgres/src/quick.rs
@@ -144,6 +144,14 @@ pub fn goldenmatch_match_pairs(
 /// Score two strings using a named similarity algorithm.
 ///
 /// Supported scorers: jaro_winkler, levenshtein, exact, token_sort, soundex_match
+///
+/// The four rapidfuzz-family scorers (jaro_winkler / levenshtein / token_sort /
+/// exact) run **native-direct** over the pyo3-free `score-core` kernel — no
+/// embedded-CPython round-trip per row, which matters for `WHERE
+/// goldenmatch_score(...) > t` over a large table. `score-core` IS the reference
+/// the Python path uses, so results are unchanged. Any other scorer
+/// (soundex_match / ensemble / future) falls back to the bridge, so nothing is
+/// lost.
 #[pg_extern]
 pub fn goldenmatch_score(
     value_a: String,
@@ -152,6 +160,20 @@ pub fn goldenmatch_score(
 ) -> f64 {
     let scorer_name = scorer.unwrap_or_else(|| "jaro_winkler".to_string());
 
+    // Native fast path: score-core's scorer ids (0=jw, 1=lev, 2=token_sort,
+    // 3=exact) match the bridge's named scorers byte-for-algorithm.
+    let native_id = match scorer_name.as_str() {
+        "jaro_winkler" => Some(0u8),
+        "levenshtein" => Some(1),
+        "token_sort" => Some(2),
+        "exact" => Some(3),
+        _ => None,
+    };
+    if let Some(id) = native_id {
+        return goldenmatch_score_core::score_one(id, &value_a, &value_b);
+    }
+
+    // Bridge fallback for scorers score-core doesn't implement.
     match goldenmatch_bridge::api::score_strings(&value_a, &value_b, &scorer_name) {
         Ok(score) => score,
         Err(e) => pgrx::error!("goldenmatch: {}", e),


### PR DESCRIPTION
## What and why

Roadmap **P1** (`docs/design/2026-07-04-cross-surface-parity-roadmap.md`, #1414): make the matching math native on SQL.

On audit the picture was more specific than the roadmap's one-liner: `goldenmatch_score(a, b, scorer)` **already exists** on both SQL surfaces — but the **Postgres** one round-trips through the **embedded-CPython bridge** (`goldenmatch_bridge::api::score_strings`) on *every call*. That's the real gap: `WHERE goldenmatch_score(a.name, b.name, 'jaro_winkler') > 0.9` over a large table pays a CPython call per row. (DuckDB's is an in-process Python UDF — not the embedded-CPython problem — so it's fine as-is.)

## Changes

- **`quick.rs`** — `goldenmatch_score` fast-paths the four rapidfuzz-family scorers (`jaro_winkler` / `levenshtein` / `token_sort` / `exact`) **native-direct** over the pyo3-free `score-core` kernel (scorer ids 0..3). Other scorers (`soundex_match` / `ensemble` / future) still fall back to the bridge, so nothing is lost.
- `score-core` **is** the reference the Python path uses — verified `score_strings == score_field == score-core` for these four (`jaro_winkler('Acme Corporation','Acme Corp') = 0.9125` on both) — so results are **unchanged**.
- **No version bump.** Same signature, same results ⇒ the SQL declaration is identical; only the C function body changes. `pgrx_sql_sync` stays 61==61.
- `postgres/Cargo.toml`: `score-core` path dep. `rust_pgrx` filter gains `score-core`; its psql smoke asserts the native value (`jaro_winkler == 0.9125`, `exact == 1.0`).

## Testing

- pgrx is CI-only (needs libclang/`PGRX_HOME`), so the native path is exercised by the `rust_pgrx` smoke. Locally: `cargo fmt` clean; `score_one` symbol present; `ci.yml` valid YAML; `pgrx_sql_sync` green (no new function); reference value `0.9125` confirmed against the Python scorer (`score_strings`/`score_field` agree to <1e-12).

## Scope note
This is a **de-bridge / perf** change, not a new surface — the function was already exposed, just bridge-backed on Postgres. It's the correctly-scoped P1 (score native on SQL). The roadmap's P1 checkbox can be ticked; a follow-up could route DuckDB through the native wheel for byte-identity with Postgres, but its current in-process Python path is already fast.

## Checklist
- [x] Lint clean (cargo fmt)
- [ ] CHANGELOG — N/A (no signature/behavior change; perf only)
- [x] No secrets/tokens committed
- [x] Docs / `CLAUDE.md` updated (postgres `quick.rs` note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_