### PR TITLE
feat(goldenflow): Wave A — SWIFT/ABA/IMEI identifier families (cross-surface)

### DIFF
--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,16 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-07-04 — GoldenFlow Wave A: SWIFT/ABA/IMEI identifier families
+- Extension of ADR [../decisions/0031-goldenflow-reference-mode-identifiers-wasm.md](../decisions/0031-goldenflow-reference-mode-identifiers-wasm.md)
+  (no new ADR needed) — three new owned checksummed/structural identifier
+  families: `swift_validate`/`swift_format` (SWIFT/BIC), `aba_validate` (US ABA
+  routing), `imei_validate` (IMEI Luhn). Same cross-surface pattern as Wave 0
+  (native + WASM/TS + pure-Python fallback, byte-parity to the goldenflow-core
+  Rust oracle), all `auto_apply=False`.
+- Registry moves 86 → **90**. Versions: goldenflow 1.5.0 / npm 0.5.0 /
+  goldenflow-native 0.3.0.
+
 ## 2026-07-03 — GoldenFlow Wave 0: core split + reference-mode + checksummed identifiers + cross-surface WASM
 - New ADR [../decisions/0031-goldenflow-reference-mode-identifiers-wasm.md](../decisions/0031-goldenflow-reference-mode-identifiers-wasm.md):
   GoldenFlow adopts the suite-standard `-core`/`-native`/`-wasm` layout — new

--- a/docs-site/goldenflow/overview.mdx
+++ b/docs-site/goldenflow/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "GoldenFlow overview"
-description: "Standardize, reshape, and normalize messy data with 86 built-in transforms across 11 categories."
+description: "Standardize, reshape, and normalize messy data with 90 built-in transforms across 11 categories."
 keywords: ["goldenflow", "transforms", "standardization", "normalization", "data cleaning"]
 ---
 
-GoldenFlow standardizes, reshapes, and normalizes messy data before it enters a pipeline. In zero-config mode it auto-detects quality issues and applies safe transforms. It ships 86 built-in transforms across 11 categories (text, phone, name, address, date, categorical, numeric, email, identifiers, and URLs), plus domain packs for healthcare, finance, ecommerce, people/HR, and real estate. The identifiers group includes checksummed validators/formatters for payment cards (Luhn), IBAN (mod-97), ISBN, EAN/UPC, and EU VAT, running on owned Rust kernels. It scores 100/100 on the DQBench transform benchmarks.
+GoldenFlow standardizes, reshapes, and normalizes messy data before it enters a pipeline. In zero-config mode it auto-detects quality issues and applies safe transforms. It ships 90 built-in transforms across 11 categories (text, phone, name, address, date, categorical, numeric, email, identifiers, and URLs), plus domain packs for healthcare, finance, ecommerce, people/HR, and real estate. The identifiers group includes checksummed/structural validators/formatters for payment cards (Luhn), IBAN (mod-97), ISBN, EAN/UPC, EU VAT, SWIFT/BIC, US ABA routing numbers, and IMEI, running on owned Rust kernels. It scores 100/100 on the DQBench transform benchmarks.
 
 <CardGroup cols={2}>
   <Card title="CLI reference" icon="terminal" href="/goldenflow/cli">
@@ -65,7 +65,7 @@ console.log(result.rows[0]);
 ## Key features
 
 - **Zero-config mode**: auto-detects column types and applies safe transforms.
-- **86 transforms** across 11 categories, including checksummed identifiers (payment card, IBAN, ISBN, EAN/UPC, EU VAT).
+- **90 transforms** across 11 categories, including checksummed/structural identifiers (payment card, IBAN, ISBN, EAN/UPC, EU VAT, SWIFT/BIC, ABA routing, IMEI).
 - **5 domain packs**: healthcare, finance, ecommerce, people/HR, real estate.
 - **Audit trail**: a JSON manifest of every transform, which rows changed, and before/after samples.
 - **Schema mapping**: auto-map columns between systems by name similarity and data profiling.

--- a/docs/superpowers/plans/2026-07-04-goldenflow-wave-a-validation-identifiers-plan.md
+++ b/docs/superpowers/plans/2026-07-04-goldenflow-wave-a-validation-identifiers-plan.md
@@ -1,0 +1,72 @@
+# GoldenFlow Wave A — validation/identifier families (SWIFT, ABA, IMEI) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add three new owned checksummed/structural identifier families — **SWIFT/BIC**, **ABA routing number**, **IMEI** — across every surface (native, WASM/TS, pure-Python fallback), byte-identical to the Rust oracle, reusing the Wave 0b/0c machinery.
+
+**Architecture:** Same as 0b/0c. Kernels in `goldenflow-core/src/identifiers/<family>.rs`; Arrow shims in `native-flow`; wasm-bindgen exports in `goldenflow-wasm`; Python transforms + fallback in `transforms/identifiers.py`; TS transforms + fallback in `src/core/transforms/identifiers.ts`; loader `_COMPONENT_SYMBOLS` entries; corpus rows in the shared `identifiers_corpus.jsonl` (Python) byte-copied to TS. The existing `native_flow`, `wasm_flow`, `rust` (goldenflow-core clippy), and `python_goldenflow*` CI lanes already cover all of this — no CI changes needed beyond the corpus staying in sync (already guarded).
+
+**Depends on:** Wave 0 (merged). Branch off `origin/main`.
+
+**Environment (Windows box):** Rust `cargo test`/`cargo-clippy clippy` (from the goldenflow-core dir) are the local gate. Python: `ruff`/`py_compile` + ONE targeted parity pytest with `POLARS_SKIP_CPU_CHECK=1` via `.venv/Scripts/python.exe`; kill python after. TS: no local typecheck/vitest (OOM) — CI gate. Do NOT build the native wheel (CI validates native). Prefer `x.is_multiple_of(n)` over `x % n == 0` (clippy).
+
+**Reference:** the merged Wave 0b plan (`docs/superpowers/plans/2026-07-02-goldenflow-identifier-kernels-plan-0b.md`) is the canonical per-family pattern; the merged 0c plan is the TS/wasm pattern. Read the existing `luhn.rs`/`iban.rs` + `identifiers.ts` cc/iban functions as live templates.
+
+---
+
+## Family specs (the kernels are the oracle — lock a rule, make all surfaces match)
+
+### SWIFT/BIC — `swift.rs`: `swift_validate(&str)->bool`, `swift_format(&str)->Option<String>`
+- Normalize: uppercase + strip spaces (NOT `-`/`.` — BICs don't use them; but strip spaces only, or reuse `strip_sep`? Use uppercase + remove ASCII spaces only, to avoid stripping a `-` that would make an invalid BIC pass. Decide: strip spaces only).
+- Structure: length 8 OR 11. `[0:4]` letters A-Z (institution). `[4:6]` letters A-Z (ISO-3166 country — structural A-Z, not a country-set lookup). `[6:8]` alphanumeric A-Z/0-9 (location). If length 11, `[8:11]` alphanumeric (branch). No checksum (BIC has none).
+- `swift_format` → the normalized uppercase value if valid, else None.
+- Vectors: valid `DEUTDEFF`, `DEUTDEFF500`, `NEDSZAJJXXX`, lowercase `deutdeff`→valid (normalized); invalid `DEUTDEFF5` (len 9), `DEUT1EFF` (digit in institution), `12345678` (digits in bank/country).
+
+### ABA routing — `aba.rs`: `aba_validate(&str)->bool`
+- Normalize: `strip_sep` (space/-/.); must be exactly 9 ASCII digits.
+- Checksum: `3*(d0+d3+d6) + 7*(d1+d4+d7) + 1*(d2+d5+d8)`, valid iff `sum.is_multiple_of(10)`.
+- Vectors: valid `011000015`, `021000021`, `122105155`; invalid `011000016` (bad check), `12345` (length), `01100001a` (non-digit).
+
+### IMEI — `imei.rs`: `imei_validate(&str)->bool`
+- Normalize: `strip_sep`; exactly 15 ASCII digits; Luhn check.
+- **Reuse Luhn:** change `luhn.rs`'s `fn luhn_ok` to `pub(crate) fn luhn_ok` and call `super::luhn::luhn_ok` from `imei.rs` (DRY — one Luhn impl). The Python/TS fallbacks similarly reuse their existing `_luhn_ok`/luhn helper.
+- Vectors: valid `490154203237518`, `356938035643809`; invalid `490154203237519` (bad Luhn), `12345` (length).
+
+Component/loader keys: `swift` → `("swift_validate_arrow",)`, `aba` → `("aba_validate_arrow",)`, `imei` → `("imei_validate_arrow",)`. Transforms (all `auto_apply=False`): `swift_validate`, `swift_format`, `aba_validate`, `imei_validate`.
+
+---
+
+## Task 1: SWIFT/BIC — full stack (native side)
+**Files:** `goldenflow-core/src/identifiers/{mod.rs,swift.rs}`, `native-flow/src/identifiers.rs`+`lib.rs`, `goldenflow-wasm/src/lib.rs`, `transforms/_native.py`, `transforms/identifiers.py`, `core/_native_loader.py`, `scripts/gen_identifiers_corpus.py`, corpus, `tests/transforms/test_identifiers*.py`.
+- [ ] Kernel TDD (red): write `swift.rs` test module with the vectors → `cargo test identifiers::swift` fails. Add `pub mod swift;` to mod.rs.
+- [ ] Implement `swift_validate`/`swift_format`; `cargo test` green + `cargo-clippy clippy -- -D warnings` (from goldenflow-core dir) + `cargo fmt --check`.
+- [ ] Arrow shims `swift_validate_arrow` (map_str_to_bool) + `swift_format_arrow` (map_str_to_str) in native-flow + register in lib.rs; `cargo build --release` (native-flow).
+- [ ] wasm exports `swift_validate`/`swift_format` in `goldenflow-wasm/src/lib.rs`; `cargo build --target wasm32-unknown-unknown --release`.
+- [ ] Python: `_native.py` `_swift_kernel_runner` + native helpers; `identifiers.py` `swift_validate`/`swift_format` transforms (`auto_apply=False`, priority 50) + byte-identical pure-Python fallback. `_native_loader.py` add `"swift"` to `_COMPONENT_SYMBOLS`.
+- [ ] Corpus: extend `gen_identifiers_corpus.py` (`_CASES` + fn maps) with swift rows; regenerate + `--check`. Extend `test_identifiers_parity.py` `_TRANSFORMS`/`_NATIVE_FLOOR_SYMBOL`. Append swift unit cases to `test_identifiers.py`. Run the fallback parity file once (`-k "not native"`) → green.
+- [ ] Commit `feat(goldenflow): owned SWIFT/BIC identifier kernel (structural, cross-surface native side)`.
+
+## Task 2: ABA routing — full stack (native side)
+- [ ] Same pattern as Task 1 for `aba.rs` (`aba_validate` only): kernel TDD, shim `aba_validate_arrow`, wasm export `aba_validate`, Python transform+fallback, loader `"aba"`, corpus rows, tests. clippy/fmt/cargo test green; fallback parity green. Commit `feat(goldenflow): owned ABA routing kernel (checksum)`.
+
+## Task 3: IMEI — full stack (native side), reusing Luhn
+- [ ] Make `luhn.rs::luhn_ok` `pub(crate)`. Implement `imei.rs::imei_validate` calling `super::luhn::luhn_ok`. Same pattern: kernel TDD, shim `imei_validate_arrow`, wasm export `imei_validate`, Python transform+fallback (reuse the existing `_luhn_ok` py helper), loader `"imei"`, corpus rows, tests. clippy/fmt/cargo test green; fallback parity green. Commit `feat(goldenflow): owned IMEI kernel (Luhn, reuses luhn_ok)`.
+
+## Task 4: TS transforms (all three families) + corpus sync
+**Files:** `packages/typescript/goldenflow/src/core/transforms/identifiers.ts`, `packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl`.
+- [ ] Add pure-TS `swiftValidateTs/swiftFormatTs/abaValidateTs/imeiValidateTs` (byte-identical to the Python fallbacks) + the wasm-dispatch wrappers `swiftValidate/swiftFormat/abaValidate/imeiValidate` (mirror the cc/iban dispatch idiom via `getFlowWasmBackend()`), register them, and add the exports (`*Ts`) that the parity test imports. Extend the `FlowWasmBackend` interface in `src/core/wasm/backend.ts` + the loader glue mapping with the 4 new methods.
+- [ ] Byte-copy the updated `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` → the TS copy (`cmp` IDENTICAL). Extend `tests/parity/identifiers.parity.test.ts`'s `PURE_TS_FN`/`_TRANSFORMS` maps with the 4 new transforms.
+- [ ] Commit `feat(goldenflow-js): SWIFT/ABA/IMEI pure-TS transforms + wasm dispatch + corpus sync`.
+
+## Task 5: docs + version bump + PR
+- [ ] Version bump: goldenflow py 1.4.0→1.5.0 (pyproject + `__init__` + server.json, all 3), npm 0.4.0→0.5.0, goldenflow-native 0.2.0→0.3.0 (Cargo.toml + pyproject + `__init__` fallback + Cargo.lock). CHANGELOG entries. (Version-consistency CI gate requires the 3 goldenflow spots match.)
+- [ ] Docs: goldenflow CLAUDE.md + README transform list/count (86→90), Identifiers section (+ swift/aba/imei), docs-site if it enumerates; context-network updates.log entry. Get authoritative count via the registry command. (Follow `.claude/doc-surfaces.md`.)
+- [ ] `pnpm install --lockfile-only` if any package.json changed (it shouldn't this wave — no new deps — but run it if it did).
+- [ ] Push, open PR `feat(goldenflow): Wave A — SWIFT/ABA/IMEI identifier families (cross-surface)`, arm `--auto --squash`.
+
+---
+
+## Guardrails
+- Kernels are the oracle; Python + TS fallbacks must match byte-for-byte (corpus parity enforces). Run `cargo-clippy clippy` FROM the goldenflow-core dir (not native-flow — it skips the path-dep).
+- Sequential Tasks 1-3 (shared files: mod.rs, identifiers.py, _native_loader.py, corpus). Task 4 is TS-only. No CI changes needed (lanes exist; corpus sync-check + goldenflow-core clippy already wired).
+- `auto_apply=False` on all four transforms. No new deps → no lockfile churn expected.

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.5.0 (2026-07-04)
+
+Wave A of the identifier-kernel program: three new owned checksummed/structural identifier families (SWIFT/BIC, ABA routing, IMEI), cross-surface (native + WASM/TS + pure-Python fallback), byte-parity to the Rust oracle. No breaking changes; existing transform outputs are unchanged.
+
+### Added
+
+- `swift_validate` / `swift_format`: validate and format SWIFT/BIC bank identifier codes (8 or 11 characters, structural bank/country/location/branch code checks).
+- `aba_validate`: validate US ABA routing numbers via the standard weighted checksum.
+- `imei_validate`: validate mobile-device IMEI numbers via the Luhn checksum.
+- All four transforms are `auto_apply=False` (request them explicitly in a config), native-first with pure-Python fallbacks proven byte-identical to the `goldenflow-core` Rust oracle, and available on the TypeScript/WASM surface via `enableWasm()`.
+
 ## 1.4.0 (2026-07-03)
 
 Wave 0 of the identifier-kernel + WASM cross-surface program: owned Rust kernels for GoldenFlow's transform engine, a reference-mode native loader, 10 new checksummed-identifier transforms, a byte-parity harness, and an opt-in WASM/TS acceleration surface. No breaking changes; existing transform outputs are unchanged.

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -187,6 +187,13 @@ package. Loader discover order in `goldenflow/core/_native_loader.py`:
   checksum bounded to DE + IT this wave). Each has a pure-Python reference in
   `transforms/identifiers.py` and a pure-TS fallback, both proven byte-identical
   to the goldenflow-core Rust oracle via a committed corpus.
+- **4 more checksummed/structural identifier kernels (Wave A, all
+  `auto_apply=False`, native-first):** `swift_validate`/`swift_format` (SWIFT/BIC
+  bank codes, 8 or 11 chars, structural bank/country/location/branch checks),
+  `aba_validate` (US ABA routing number weighted checksum), `imei_validate`
+  (mobile-device IMEI Luhn checksum). Same pattern as Wave 0: pure-Python
+  reference + pure-TS fallback, both byte-identical to the goldenflow-core Rust
+  oracle via the same committed corpus.
 - **Byte-parity harness (cross-surface oracle = goldenflow-core).**
   `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` (mirrored
   byte-identical into `packages/typescript/goldenflow/tests/parity/`) is the
@@ -446,7 +453,7 @@ result.manifest.records     # list[TransformRecord]
 result.manifest.created_at  # str
 ```
 
-### Available transforms (86)
+### Available transforms (90)
 **Text:** strip, lowercase, uppercase, title_case, normalize_unicode, normalize_quotes, collapse_whitespace, truncate, remove_punctuation, remove_html_tags, remove_urls, remove_digits, remove_emojis, fix_mojibake, normalize_line_endings, extract_numbers, pad_left, pad_right
 **Phone:** phone_e164, phone_national, phone_digits, phone_validate, phone_country_code
 **Name:** split_name, split_name_reverse, strip_titles, strip_suffixes, name_proper, initial_expand, nickname_standardize, merge_name
@@ -455,7 +462,7 @@ result.manifest.created_at  # str
 **Categorical:** category_auto_correct, category_standardize, category_from_file, boolean_normalize, gender_standardize, null_standardize
 **Numeric:** currency_strip, percentage_normalize, round, clamp, to_integer, abs_value, fill_zero, comma_decimal, scientific_to_decimal
 **Email:** email_lowercase, email_normalize, email_extract_domain, email_validate
-**Identifiers:** ssn_format, ssn_mask, ein_format, cc_validate, cc_format, cc_mask, iban_validate, iban_format, isbn_validate, isbn_normalize, ean_validate, vat_validate, vat_format
+**Identifiers:** ssn_format, ssn_mask, ein_format, cc_validate, cc_format, cc_mask, iban_validate, iban_format, isbn_validate, isbn_normalize, ean_validate, vat_validate, vat_format, swift_validate, swift_format, aba_validate, imei_validate
 **URL:** url_normalize, url_extract_domain
 
 ### Zero-config vs Configured — when to use which

--- a/packages/python/goldenflow/README.md
+++ b/packages/python/goldenflow/README.md
@@ -333,7 +333,7 @@ goldenflow transform listings.csv --domain real_estate
 
 ---
 
-## Transform Library (86 transforms)
+## Transform Library (90 transforms)
 
 ### Text Transforms (18)
 | Transform | What It Does |
@@ -431,7 +431,7 @@ goldenflow transform listings.csv --domain real_estate
 | `email_extract_domain` | user@example.com -> example.com |
 | `email_validate` | Flag invalid email format |
 
-### Identifier Transforms (13)
+### Identifier Transforms (17)
 | Transform | What It Does |
 |-----------|-------------|
 | `ssn_format` | Normalize to XXX-XX-XXXX |
@@ -447,10 +447,15 @@ goldenflow transform listings.csv --domain real_estate
 | `ean_validate` | Validate an EAN-8/UPC-A/EAN-13 via its GTIN mod-10 checksum |
 | `vat_validate` | Validate an EU VAT number (structural all 27 prefixes; checksum DE + IT) |
 | `vat_format` | Normalize a valid EU VAT to compact uppercase; null if invalid |
+| `swift_validate` | Validate a SWIFT/BIC bank code (8 or 11 chars; structural bank/country/location/branch checks) |
+| `swift_format` | Normalize a valid SWIFT/BIC to uppercase; null if invalid |
+| `aba_validate` | Validate a US ABA routing number via its weighted checksum |
+| `imei_validate` | Validate a mobile-device IMEI via the Luhn checksum |
 
-The checksummed identifiers (cc/iban/isbn/ean/vat) run on owned Rust kernels
-(native-first with pure-Python fallbacks proven byte-identical), and are
-opt-in (`auto_apply=False`) — request them explicitly in a config.
+The checksummed/structural identifiers (cc/iban/isbn/ean/vat/swift/aba/imei) run
+on owned Rust kernels (native-first with pure-Python fallbacks proven
+byte-identical), and are opt-in (`auto_apply=False`) — request them explicitly
+in a config.
 
 ### URL Transforms (2)
 | Transform | What It Does |
@@ -577,7 +582,7 @@ result.manifest  # renders transform audit trail
 
 ## TypeScript / JavaScript
 
-GoldenFlow has a full TypeScript port with feature parity — same 86 transforms, same engine, same config format. The core is **edge-safe** (runs in browsers, Cloudflare Workers, Vercel Edge) with a Node layer for file I/O and CLI. Pure-TS is the default; an opt-in `enableWasm()` routes the checksummed-identifier transforms through a WASM kernel (see below).
+GoldenFlow has a full TypeScript port with feature parity — same 90 transforms, same engine, same config format. The core is **edge-safe** (runs in browsers, Cloudflare Workers, Vercel Edge) with a Node layer for file I/O and CLI. Pure-TS is the default; an opt-in `enableWasm()` routes the checksummed-identifier transforms through a WASM kernel (see below).
 
 ### Install
 
@@ -862,7 +867,7 @@ dqbench run goldenflow
 | | GoldenFlow | pandas scripts | [Great Expectations](https://greatexpectations.io/) | [dbt](https://www.getdbt.com/) | [Dataprep.Clean](https://docs.dataprep.ai/user_guide/clean/) |
 |---|---|---|---|---|---|
 | Zero-config transforms | Yes (auto-detect) | No | No (validation only) | No (SQL transforms) | Partial |
-| 86 built-in transforms (11 categories) | Yes | Manual | No (validator, not transformer) | Via SQL | ~30 cleaners |
+| 90 built-in transforms (11 categories) | Yes | Manual | No (validator, not transformer) | Via SQL | ~30 cleaners |
 | Domain packs (healthcare, finance...) | 5 built-in | No | No | No | No |
 | Schema mapping | Auto + manual | Manual | No | Via ref/source | No |
 | Audit trail (manifest) | Automatic JSON | Manual | No | Via logs | No |

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -86,6 +86,9 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # aba: US ABA routing number (weighted checksum) -- floor symbol only,
     # region-free.
     "aba": ("aba_validate_arrow",),
+    # imei: IMEI (Luhn checksum, reuses the same luhn_ok as cc) -- floor
+    # symbol only, region-free.
+    "imei": ("imei_validate_arrow",),
 }
 
 # Components whose only native path is intentionally non-authoritative (the

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -83,6 +83,9 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # only -- see the CHECKSUM COVERAGE note in transforms/identifiers.py) --
     # floor symbol only, region-free.
     "vat": ("vat_validate_arrow",),
+    # aba: US ABA routing number (weighted checksum) -- floor symbol only,
+    # region-free.
+    "aba": ("aba_validate_arrow",),
 }
 
 # Components whose only native path is intentionally non-authoritative (the

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -76,6 +76,9 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     "isbn": ("isbn_validate_arrow",),
     # ean: EAN/UPC (GTIN mod-10) identifiers -- floor symbol only, region-free.
     "ean": ("ean_validate_arrow",),
+    # swift: SWIFT/BIC (ISO 9362, structural only -- no checksum) --
+    # floor symbol only, region-free.
+    "swift": ("swift_validate_arrow",),
     # vat: EU VAT identifiers (structural, all prefixes; checksum for DE/IT
     # only -- see the CHECKSUM COVERAGE note in transforms/identifiers.py) --
     # floor symbol only, region-free.

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -231,6 +231,36 @@ def ean_validate_native() -> Callable[[pl.Series], pl.Series] | None:
     return _ean_kernel_runner("ean_validate_arrow")
 
 
+def _swift_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for SWIFT/BIC kernel function ``attr`` if
+    native ``swift`` is enabled and the dependencies are importable; else
+    ``None``. Like the other identifier runners -- no region/gating args,
+    SWIFT/BIC validation is purely structural (no checksum)."""
+    if not native_enabled("swift"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def swift_validate_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _swift_kernel_runner("swift_validate_arrow")
+
+
+def swift_format_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _swift_kernel_runner("swift_format_arrow")
+
+
 def _vat_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
     """Build a whole-series runner for EU VAT kernel function ``attr`` if
     native ``vat`` is enabled and the dependencies are importable; else

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -316,3 +316,29 @@ def _aba_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
 
 def aba_validate_native() -> Callable[[pl.Series], pl.Series] | None:
     return _aba_kernel_runner("aba_validate_arrow")
+
+
+def _imei_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for IMEI kernel function ``attr`` if
+    native ``imei`` is enabled and the dependencies are importable; else
+    ``None``. Like the other identifier runners -- no region/gating args,
+    the Luhn checksum is region-free."""
+    if not native_enabled("imei"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def imei_validate_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _imei_kernel_runner("imei_validate_arrow")

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -290,3 +290,29 @@ def vat_validate_native() -> Callable[[pl.Series], pl.Series] | None:
 
 def vat_format_native() -> Callable[[pl.Series], pl.Series] | None:
     return _vat_kernel_runner("vat_format_arrow")
+
+
+def _aba_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for ABA routing-number kernel function
+    ``attr`` if native ``aba`` is enabled and the dependencies are
+    importable; else ``None``. Like the other identifier runners -- no
+    region/gating args, the checksum is region-free."""
+    if not native_enabled("aba"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def aba_validate_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _aba_kernel_runner("aba_validate_arrow")

--- a/packages/python/goldenflow/goldenflow/transforms/identifiers.py
+++ b/packages/python/goldenflow/goldenflow/transforms/identifiers.py
@@ -14,6 +14,8 @@ from goldenflow.transforms._native import (
     iban_validate_native,
     isbn_normalize_native,
     isbn_validate_native,
+    swift_format_native,
+    swift_validate_native,
     vat_format_native,
     vat_validate_native,
 )
@@ -398,6 +400,82 @@ def ean_validate(series: pl.Series) -> pl.Series:
     if native is not None:
         return native(series)
     return series.map_elements(_ean_validate_py, return_dtype=pl.Boolean)
+
+
+# --- SWIFT/BIC (ISO 9362, structural only) identifiers ----------------------
+#
+# Pure-Python reference for goldenflow-core's ``identifiers::swift`` kernel.
+# MUST reproduce the Rust kernel byte-for-byte (asserted by
+# tests/transforms/test_identifiers_parity.py over
+# tests/parity/identifiers_corpus.jsonl) -- same normalize (uppercase + strip
+# ASCII spaces ONLY, NOT '-'/'.'), same structural length/charset checks. No
+# checksum exists for BIC.
+
+
+def _swift_normalize(val: str) -> str:
+    """Uppercase + remove ASCII spaces only -- mirrors Rust ``normalize``.
+    Unlike the other identifiers here, '-'/'.' are NOT stripped: a
+    well-formed BIC never contains them, and silently stripping them could
+    let a malformed value pass structural validation."""
+    return val.replace(" ", "").upper()
+
+
+def _swift_validate_py(val: str | None) -> bool | None:
+    if val is None:
+        return None
+    t = _swift_normalize(val)
+    length = len(t)
+    if length not in (8, 11):
+        return False
+    if not all(c.isascii() and c.isalpha() for c in t[0:4]):
+        return False
+    if not all(c.isascii() and c.isalpha() for c in t[4:6]):
+        return False
+    if not all(c.isascii() and c.isalnum() for c in t[6:8]):
+        return False
+    if length == 11 and not all(c.isascii() and c.isalnum() for c in t[8:11]):
+        return False
+    return True
+
+
+def _swift_format_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    if not _swift_validate_py(val):
+        return None
+    return _swift_normalize(val)
+
+
+@register_transform(
+    name="swift_validate",
+    input_types=["identifier", "string"],
+    auto_apply=False,
+    priority=50,
+    mode="series",
+)
+def swift_validate(series: pl.Series) -> pl.Series:
+    """Validate a SWIFT/BIC code via structural checks (length 8/11 +
+    per-segment charset). No checksum exists for BIC."""
+    native = swift_validate_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_swift_validate_py, return_dtype=pl.Boolean)
+
+
+@register_transform(
+    name="swift_format",
+    input_types=["identifier", "string"],
+    auto_apply=False,
+    priority=50,
+    mode="series",
+)
+def swift_format(series: pl.Series) -> pl.Series:
+    """Normalize a valid SWIFT/BIC code to uppercase (spaces stripped);
+    ``null`` for invalid input."""
+    native = swift_format_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_swift_format_py, return_dtype=pl.Utf8)
 
 
 # --- EU VAT identifiers (bounded scope) -------------------------------------

--- a/packages/python/goldenflow/goldenflow/transforms/identifiers.py
+++ b/packages/python/goldenflow/goldenflow/transforms/identifiers.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
+    aba_validate_native,
     cc_format_native,
     cc_mask_native,
     cc_validate_native,
@@ -716,3 +717,39 @@ def ein_format(series: pl.Series) -> pl.Series:
         return f"{digits[:2]}-{digits[2:]}"
 
     return series.map_elements(_format, return_dtype=pl.Utf8)
+
+
+# --- ABA routing number (US bank routing transit number) --------------------
+#
+# Pure-Python reference for goldenflow-core's ``identifiers::aba`` kernel.
+# MUST reproduce the Rust kernel byte-for-byte (asserted by
+# tests/transforms/test_identifiers_parity.py over
+# tests/parity/identifiers_corpus.jsonl) -- same separator strip, same
+# 9-digit length gate, same weighted checksum.
+
+
+def _aba_validate_py(val: str | None) -> bool | None:
+    if val is None:
+        return None
+    t = _cc_strip_sep(val)
+    if len(t) != 9 or not t.isascii() or not t.isdigit():
+        return False
+    d = [ord(c) - ord("0") for c in t]
+    total = 3 * (d[0] + d[3] + d[6]) + 7 * (d[1] + d[4] + d[7]) + (d[2] + d[5] + d[8])
+    return total % 10 == 0
+
+
+@register_transform(
+    name="aba_validate",
+    input_types=["identifier", "string"],
+    auto_apply=False,
+    priority=50,
+    mode="series",
+)
+def aba_validate(series: pl.Series) -> pl.Series:
+    """Validate a US ABA bank routing number: exactly 9 digits plus the
+    standard weighted checksum."""
+    native = aba_validate_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_aba_validate_py, return_dtype=pl.Boolean)

--- a/packages/python/goldenflow/goldenflow/transforms/identifiers.py
+++ b/packages/python/goldenflow/goldenflow/transforms/identifiers.py
@@ -13,6 +13,7 @@ from goldenflow.transforms._native import (
     ean_validate_native,
     iban_format_native,
     iban_validate_native,
+    imei_validate_native,
     isbn_normalize_native,
     isbn_validate_native,
     swift_format_native,
@@ -753,3 +754,37 @@ def aba_validate(series: pl.Series) -> pl.Series:
     if native is not None:
         return native(series)
     return series.map_elements(_aba_validate_py, return_dtype=pl.Boolean)
+
+
+# --- IMEI (International Mobile Equipment Identity) --------------------------
+#
+# Pure-Python reference for goldenflow-core's ``identifiers::imei`` kernel.
+# MUST reproduce the Rust kernel byte-for-byte (asserted by
+# tests/transforms/test_identifiers_parity.py over
+# tests/parity/identifiers_corpus.jsonl) -- same separator strip, same
+# 15-digit length gate, same Luhn checksum (reuses ``_luhn_ok``, the same
+# helper the ``cc`` family uses -- one Luhn implementation for both).
+
+
+def _imei_validate_py(val: str | None) -> bool | None:
+    if val is None:
+        return None
+    t = _cc_strip_sep(val)
+    if len(t) != 15 or not t.isascii() or not t.isdigit():
+        return False
+    return _luhn_ok(t)
+
+
+@register_transform(
+    name="imei_validate",
+    input_types=["identifier", "string"],
+    auto_apply=False,
+    priority=50,
+    mode="series",
+)
+def imei_validate(series: pl.Series) -> pl.Series:
+    """Validate an IMEI: exactly 15 digits plus the Luhn checksum."""
+    native = imei_validate_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_imei_validate_py, return_dtype=pl.Boolean)

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.4.0"
+version = "1.5.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -37,6 +37,8 @@ from goldenflow.transforms.identifiers import (  # noqa: E402
     _iban_validate_py,
     _isbn_normalize_py,
     _isbn_validate_py,
+    _swift_format_py,
+    _swift_validate_py,
     _vat_format_py,
     _vat_validate_py,
 )
@@ -147,6 +149,28 @@ _CASES: list[tuple[str, str | None]] = [
     ("ean_validate", "40063813339a1"),  # non-digit
     ("ean_validate", ""),  # empty
     ("ean_validate", None),  # null
+    # --- swift_validate: valid ---
+    ("swift_validate", "DEUTDEFF"),  # 8-char, valid
+    ("swift_validate", "DEUTDEFF500"),  # 11-char, valid
+    ("swift_validate", "NEDSZAJJXXX"),  # 11-char, valid, all-alpha branch
+    ("swift_validate", "deutdeff"),  # lowercase -> valid, normalized
+    ("swift_validate", "deu tdeff"),  # embedded space stripped -> valid
+    # --- swift_validate: invalid ---
+    ("swift_validate", "DEUTDEFF5"),  # 9 chars, bad length
+    ("swift_validate", "DEUT1EFF"),  # digit in institution code
+    ("swift_validate", "1234DEFF"),  # digits in institution code
+    ("swift_validate", "DEUTDE-FF"),  # hyphen not stripped -> bad length/charset
+    ("swift_validate", ""),  # empty
+    ("swift_validate", None),  # null
+    # --- swift_format: valid ---
+    ("swift_format", "deutdeff"),  # -> DEUTDEFF
+    ("swift_format", "DEUTDEFF500"),
+    ("swift_format", "ne dsz ajj xxx"),  # spaced -> NEDSZAJJXXX
+    # --- swift_format: invalid -> null ---
+    ("swift_format", "DEUTDEFF5"),
+    ("swift_format", "1234DEFF"),
+    ("swift_format", ""),
+    ("swift_format", None),
     # --- vat_validate: valid, checksummed (DE, IT) ---
     ("vat_validate", "DE136695976"),  # DE, checksum ok
     ("vat_validate", "de 136 695 976"),  # DE, lowercase + spaced
@@ -192,6 +216,8 @@ _PY_FN = {
     "isbn_validate": _isbn_validate_py,
     "isbn_normalize": _isbn_normalize_py,
     "ean_validate": _ean_validate_py,
+    "swift_validate": _swift_validate_py,
+    "swift_format": _swift_format_py,
     "vat_validate": _vat_validate_py,
     "vat_format": _vat_format_py,
 }
@@ -205,6 +231,8 @@ _NATIVE_ARROW_FN = {
     "isbn_validate": "isbn_validate_arrow",
     "isbn_normalize": "isbn_normalize_arrow",
     "ean_validate": "ean_validate_arrow",
+    "swift_validate": "swift_validate_arrow",
+    "swift_format": "swift_format_arrow",
     "vat_validate": "vat_validate_arrow",
     "vat_format": "vat_format_arrow",
 }

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from goldenflow.core._native_loader import native_available, native_module  # noqa: E402
 from goldenflow.transforms.identifiers import (  # noqa: E402
+    _aba_validate_py,
     _cc_format_py,
     _cc_mask_py,
     _cc_validate_py,
@@ -196,6 +197,17 @@ _CASES: list[tuple[str, str | None]] = [
     ("vat_format", "ZZ123"),  # unknown prefix
     ("vat_format", ""),
     ("vat_format", None),
+    # --- aba_validate: valid ---
+    ("aba_validate", "011000015"),  # valid checksum
+    ("aba_validate", "021000021"),  # valid checksum
+    ("aba_validate", "122105155"),  # valid checksum
+    ("aba_validate", "011-000-015"),  # dashed, still valid
+    # --- aba_validate: invalid ---
+    ("aba_validate", "011000016"),  # bad checksum
+    ("aba_validate", "12345"),  # wrong length
+    ("aba_validate", "01100001a"),  # non-digit
+    ("aba_validate", ""),  # empty
+    ("aba_validate", None),  # null
     # --- astral-plane / non-ASCII char edge cases (UTF-16-vs-codepoint length
     # gate insurance -- Python `len()` counts codepoints, JS `.length` counts
     # UTF-16 code units, so an astral-plane char (surrogate pair) counts as 1
@@ -220,6 +232,7 @@ _PY_FN = {
     "swift_format": _swift_format_py,
     "vat_validate": _vat_validate_py,
     "vat_format": _vat_format_py,
+    "aba_validate": _aba_validate_py,
 }
 
 _NATIVE_ARROW_FN = {
@@ -235,6 +248,7 @@ _NATIVE_ARROW_FN = {
     "swift_format": "swift_format_arrow",
     "vat_validate": "vat_validate_arrow",
     "vat_format": "vat_format_arrow",
+    "aba_validate": "aba_validate_arrow",
 }
 
 

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -36,6 +36,7 @@ from goldenflow.transforms.identifiers import (  # noqa: E402
     _ean_validate_py,
     _iban_format_py,
     _iban_validate_py,
+    _imei_validate_py,
     _isbn_normalize_py,
     _isbn_validate_py,
     _swift_format_py,
@@ -208,6 +209,16 @@ _CASES: list[tuple[str, str | None]] = [
     ("aba_validate", "01100001a"),  # non-digit
     ("aba_validate", ""),  # empty
     ("aba_validate", None),  # null
+    # --- imei_validate: valid ---
+    ("imei_validate", "490154203237518"),  # valid Luhn
+    ("imei_validate", "356938035643809"),  # valid Luhn
+    ("imei_validate", "49-0154-203237518"),  # dashed, still valid
+    # --- imei_validate: invalid ---
+    ("imei_validate", "490154203237519"),  # bad Luhn
+    ("imei_validate", "12345"),  # wrong length
+    ("imei_validate", "49015420323751a"),  # non-digit
+    ("imei_validate", ""),  # empty
+    ("imei_validate", None),  # null
     # --- astral-plane / non-ASCII char edge cases (UTF-16-vs-codepoint length
     # gate insurance -- Python `len()` counts codepoints, JS `.length` counts
     # UTF-16 code units, so an astral-plane char (surrogate pair) counts as 1
@@ -233,6 +244,7 @@ _PY_FN = {
     "vat_validate": _vat_validate_py,
     "vat_format": _vat_format_py,
     "aba_validate": _aba_validate_py,
+    "imei_validate": _imei_validate_py,
 }
 
 _NATIVE_ARROW_FN = {
@@ -249,6 +261,7 @@ _NATIVE_ARROW_FN = {
     "vat_validate": "vat_validate_arrow",
     "vat_format": "vat_format_arrow",
     "aba_validate": "aba_validate_arrow",
+    "imei_validate": "imei_validate_arrow",
 }
 
 

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -84,6 +84,24 @@
 {"transform": "ean_validate", "input": "40063813339a1", "expected": false}
 {"transform": "ean_validate", "input": "", "expected": false}
 {"transform": "ean_validate", "input": null, "expected": null}
+{"transform": "swift_validate", "input": "DEUTDEFF", "expected": true}
+{"transform": "swift_validate", "input": "DEUTDEFF500", "expected": true}
+{"transform": "swift_validate", "input": "NEDSZAJJXXX", "expected": true}
+{"transform": "swift_validate", "input": "deutdeff", "expected": true}
+{"transform": "swift_validate", "input": "deu tdeff", "expected": true}
+{"transform": "swift_validate", "input": "DEUTDEFF5", "expected": false}
+{"transform": "swift_validate", "input": "DEUT1EFF", "expected": false}
+{"transform": "swift_validate", "input": "1234DEFF", "expected": false}
+{"transform": "swift_validate", "input": "DEUTDE-FF", "expected": false}
+{"transform": "swift_validate", "input": "", "expected": false}
+{"transform": "swift_validate", "input": null, "expected": null}
+{"transform": "swift_format", "input": "deutdeff", "expected": "DEUTDEFF"}
+{"transform": "swift_format", "input": "DEUTDEFF500", "expected": "DEUTDEFF500"}
+{"transform": "swift_format", "input": "ne dsz ajj xxx", "expected": "NEDSZAJJXXX"}
+{"transform": "swift_format", "input": "DEUTDEFF5", "expected": null}
+{"transform": "swift_format", "input": "1234DEFF", "expected": null}
+{"transform": "swift_format", "input": "", "expected": null}
+{"transform": "swift_format", "input": null, "expected": null}
 {"transform": "vat_validate", "input": "DE136695976", "expected": true}
 {"transform": "vat_validate", "input": "de 136 695 976", "expected": true}
 {"transform": "vat_validate", "input": "IT00743110157", "expected": true}

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -122,6 +122,15 @@
 {"transform": "vat_format", "input": "ZZ123", "expected": null}
 {"transform": "vat_format", "input": "", "expected": null}
 {"transform": "vat_format", "input": null, "expected": null}
+{"transform": "aba_validate", "input": "011000015", "expected": true}
+{"transform": "aba_validate", "input": "021000021", "expected": true}
+{"transform": "aba_validate", "input": "122105155", "expected": true}
+{"transform": "aba_validate", "input": "011-000-015", "expected": true}
+{"transform": "aba_validate", "input": "011000016", "expected": false}
+{"transform": "aba_validate", "input": "12345", "expected": false}
+{"transform": "aba_validate", "input": "01100001a", "expected": false}
+{"transform": "aba_validate", "input": "", "expected": false}
+{"transform": "aba_validate", "input": null, "expected": null}
 {"transform": "cc_validate", "input": "424242424242😀2", "expected": false}
 {"transform": "iban_validate", "input": "DE89370400440532😀13000", "expected": false}
 {"transform": "vat_validate", "input": "DE13669597😀", "expected": false}

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -131,6 +131,14 @@
 {"transform": "aba_validate", "input": "01100001a", "expected": false}
 {"transform": "aba_validate", "input": "", "expected": false}
 {"transform": "aba_validate", "input": null, "expected": null}
+{"transform": "imei_validate", "input": "490154203237518", "expected": true}
+{"transform": "imei_validate", "input": "356938035643809", "expected": true}
+{"transform": "imei_validate", "input": "49-0154-203237518", "expected": true}
+{"transform": "imei_validate", "input": "490154203237519", "expected": false}
+{"transform": "imei_validate", "input": "12345", "expected": false}
+{"transform": "imei_validate", "input": "49015420323751a", "expected": false}
+{"transform": "imei_validate", "input": "", "expected": false}
+{"transform": "imei_validate", "input": null, "expected": null}
 {"transform": "cc_validate", "input": "424242424242😀2", "expected": false}
 {"transform": "iban_validate", "input": "DE89370400440532😀13000", "expected": false}
 {"transform": "vat_validate", "input": "DE13669597😀", "expected": false}

--- a/packages/python/goldenflow/tests/transforms/test_identifiers.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers.py
@@ -13,6 +13,8 @@ from goldenflow.transforms.identifiers import (
     isbn_validate,
     ssn_format,
     ssn_mask,
+    swift_format,
+    swift_validate,
     vat_format,
     vat_validate,
 )
@@ -26,6 +28,8 @@ IDENTIFIER_TRANSFORM_NAMES = [
     "isbn_validate",
     "isbn_normalize",
     "ean_validate",
+    "swift_validate",
+    "swift_format",
     "vat_validate",
     "vat_format",
 ]
@@ -254,6 +258,49 @@ def test_ean_validate_valid_and_invalid():
     assert result[5] is False
     assert result[6] is False
     assert result[7] is None
+
+
+# --- SWIFT/BIC (ISO 9362, structural only) identifiers ----------------------
+
+
+def test_swift_validate_valid_and_invalid():
+    s = pl.Series(
+        "swift",
+        [
+            "DEUTDEFF",  # 8-char, valid
+            "DEUTDEFF500",  # 11-char, valid
+            "deutdeff",  # lowercase -> valid
+            "DEUTDEFF5",  # bad length
+            "DEUT1EFF",  # digit in institution
+            "",  # empty
+            None,  # null
+        ],
+    )
+    result = swift_validate(s)
+    assert result[0] is True
+    assert result[1] is True
+    assert result[2] is True
+    assert result[3] is False
+    assert result[4] is False
+    assert result[5] is False
+    assert result[6] is None
+
+
+def test_swift_format_normalizes_and_nulls_invalid():
+    s = pl.Series(
+        "swift",
+        [
+            "deutdeff",  # -> DEUTDEFF
+            "DEUTDEFF500",
+            "DEUTDEFF5",  # invalid -> null
+            None,
+        ],
+    )
+    result = swift_format(s)
+    assert result[0] == "DEUTDEFF"
+    assert result[1] == "DEUTDEFF500"
+    assert result[2] is None
+    assert result[3] is None
 
 
 # --- EU VAT identifiers (bounded scope: structural for all, checksum DE/IT) --

--- a/packages/python/goldenflow/tests/transforms/test_identifiers.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers.py
@@ -2,6 +2,7 @@ import goldenflow
 import polars as pl
 from goldenflow.transforms import registry
 from goldenflow.transforms.identifiers import (
+    aba_validate,
     cc_format,
     cc_mask,
     cc_validate,
@@ -32,6 +33,7 @@ IDENTIFIER_TRANSFORM_NAMES = [
     "swift_format",
     "vat_validate",
     "vat_format",
+    "aba_validate",
 ]
 
 
@@ -354,6 +356,34 @@ def test_vat_format_normalizes_and_nulls_invalid():
     assert result[2] is None
     assert result[3] is None
     assert result[4] is None
+
+
+# --- ABA routing number (US bank routing transit number) --------------------
+
+
+def test_aba_validate_valid_and_invalid():
+    s = pl.Series(
+        "aba",
+        [
+            "011000015",  # valid checksum
+            "021000021",  # valid checksum
+            "122105155",  # valid checksum
+            "011000016",  # bad checksum
+            "12345",  # wrong length
+            "01100001a",  # non-digit
+            "",  # empty
+            None,  # null
+        ],
+    )
+    result = aba_validate(s)
+    assert result[0] is True
+    assert result[1] is True
+    assert result[2] is True
+    assert result[3] is False
+    assert result[4] is False
+    assert result[5] is False
+    assert result[6] is False
+    assert result[7] is None
 
 
 # --- Registration + zero-config posture --------------------------------------

--- a/packages/python/goldenflow/tests/transforms/test_identifiers.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers.py
@@ -10,6 +10,7 @@ from goldenflow.transforms.identifiers import (
     ein_format,
     iban_format,
     iban_validate,
+    imei_validate,
     isbn_normalize,
     isbn_validate,
     ssn_format,
@@ -34,6 +35,7 @@ IDENTIFIER_TRANSFORM_NAMES = [
     "vat_validate",
     "vat_format",
     "aba_validate",
+    "imei_validate",
 ]
 
 
@@ -384,6 +386,32 @@ def test_aba_validate_valid_and_invalid():
     assert result[5] is False
     assert result[6] is False
     assert result[7] is None
+
+
+# --- IMEI (International Mobile Equipment Identity) --------------------------
+
+
+def test_imei_validate_valid_and_invalid():
+    s = pl.Series(
+        "imei",
+        [
+            "490154203237518",  # valid Luhn
+            "356938035643809",  # valid Luhn
+            "490154203237519",  # bad Luhn
+            "12345",  # wrong length
+            "49015420323751a",  # non-digit
+            "",  # empty
+            None,  # null
+        ],
+    )
+    result = imei_validate(s)
+    assert result[0] is True
+    assert result[1] is True
+    assert result[2] is False
+    assert result[3] is False
+    assert result[4] is False
+    assert result[5] is False
+    assert result[6] is None
 
 
 # --- Registration + zero-config posture --------------------------------------

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -21,6 +21,7 @@ from goldenflow.transforms.identifiers import (
     ean_validate,
     iban_format,
     iban_validate,
+    imei_validate,
     isbn_normalize,
     isbn_validate,
     swift_format,
@@ -45,6 +46,7 @@ _TRANSFORMS = {
     "vat_validate": vat_validate,
     "vat_format": vat_format,
     "aba_validate": aba_validate,
+    "imei_validate": imei_validate,
 }
 
 # Floor native symbol per transform's component -- used to skip a row when the
@@ -64,6 +66,7 @@ _NATIVE_FLOOR_SYMBOL = {
     "vat_validate": "vat_validate_arrow",
     "vat_format": "vat_validate_arrow",
     "aba_validate": "aba_validate_arrow",
+    "imei_validate": "imei_validate_arrow",
 }
 
 

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -22,6 +22,8 @@ from goldenflow.transforms.identifiers import (
     iban_validate,
     isbn_normalize,
     isbn_validate,
+    swift_format,
+    swift_validate,
     vat_format,
     vat_validate,
 )
@@ -37,6 +39,8 @@ _TRANSFORMS = {
     "isbn_validate": isbn_validate,
     "isbn_normalize": isbn_normalize,
     "ean_validate": ean_validate,
+    "swift_validate": swift_validate,
+    "swift_format": swift_format,
     "vat_validate": vat_validate,
     "vat_format": vat_format,
 }
@@ -53,6 +57,8 @@ _NATIVE_FLOOR_SYMBOL = {
     "isbn_validate": "isbn_validate_arrow",
     "isbn_normalize": "isbn_validate_arrow",
     "ean_validate": "ean_validate_arrow",
+    "swift_validate": "swift_validate_arrow",
+    "swift_format": "swift_validate_arrow",
     "vat_validate": "vat_validate_arrow",
     "vat_format": "vat_validate_arrow",
 }

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -14,6 +14,7 @@ import polars as pl
 import pytest
 from goldenflow.core._native_loader import native_available
 from goldenflow.transforms.identifiers import (
+    aba_validate,
     cc_format,
     cc_mask,
     cc_validate,
@@ -43,6 +44,7 @@ _TRANSFORMS = {
     "swift_format": swift_format,
     "vat_validate": vat_validate,
     "vat_format": vat_format,
+    "aba_validate": aba_validate,
 }
 
 # Floor native symbol per transform's component -- used to skip a row when the
@@ -61,6 +63,7 @@ _NATIVE_FLOOR_SYMBOL = {
     "swift_format": "swift_validate_arrow",
     "vat_validate": "vat_validate_arrow",
     "vat_format": "vat_validate_arrow",
+    "aba_validate": "aba_validate_arrow",
 }
 
 

--- a/packages/rust/extensions/goldenflow-core/src/identifiers/aba.rs
+++ b/packages/rust/extensions/goldenflow-core/src/identifiers/aba.rs
@@ -1,0 +1,37 @@
+//! ABA routing number (US bank routing transit number) checksum validation.
+//! Structural: exactly 9 ASCII digits. Checksum per the standard ABA formula.
+
+use super::strip_sep;
+
+/// True if `s` normalizes to exactly 9 ASCII digits and passes the ABA
+/// routing-number checksum: `3*(d0+d3+d6) + 7*(d1+d4+d7) + 1*(d2+d5+d8)`
+/// is a multiple of 10.
+pub fn aba_validate(s: &str) -> bool {
+    let t = strip_sep(s);
+    if t.len() != 9 || !t.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    let d: Vec<u32> = t.bytes().map(|b| (b - b'0') as u32).collect();
+    let sum = 3 * (d[0] + d[3] + d[6]) + 7 * (d[1] + d[4] + d[7]) + (d[2] + d[5] + d[8]);
+    sum.is_multiple_of(10)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_aba_numbers() {
+        assert!(aba_validate("011000015"));
+        assert!(aba_validate("021000021"));
+        assert!(aba_validate("122105155"));
+    }
+
+    #[test]
+    fn invalid_aba_numbers() {
+        assert!(!aba_validate("011000016")); // bad checksum
+        assert!(!aba_validate("12345")); // wrong length
+        assert!(!aba_validate("01100001a")); // non-digit
+        assert!(!aba_validate("")); // empty
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/identifiers/imei.rs
+++ b/packages/rust/extensions/goldenflow-core/src/identifiers/imei.rs
@@ -1,0 +1,33 @@
+//! IMEI (International Mobile Equipment Identity) checksum validation.
+//! Structural: exactly 15 ASCII digits. Checksum: Luhn (reuses the shared
+//! `luhn::luhn_ok` -- one Luhn implementation for both `cc` and `imei`).
+
+use super::strip_sep;
+
+/// True if `s` normalizes to exactly 15 ASCII digits and passes the Luhn
+/// checksum.
+pub fn imei_validate(s: &str) -> bool {
+    let t = strip_sep(s);
+    if t.len() != 15 || !t.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    super::luhn::luhn_ok(&t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_imei_numbers() {
+        assert!(imei_validate("490154203237518"));
+        assert!(imei_validate("356938035643809"));
+    }
+
+    #[test]
+    fn invalid_imei_numbers() {
+        assert!(!imei_validate("490154203237519")); // bad Luhn
+        assert!(!imei_validate("12345")); // wrong length
+        assert!(!imei_validate("")); // empty
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/identifiers/luhn.rs
+++ b/packages/rust/extensions/goldenflow-core/src/identifiers/luhn.rs
@@ -1,7 +1,7 @@
 use super::strip_sep;
 
 /// Luhn checksum over an all-ASCII-digit string. Caller guarantees digits.
-fn luhn_ok(digits: &str) -> bool {
+pub(crate) fn luhn_ok(digits: &str) -> bool {
     let mut sum = 0u32;
     let mut dbl = false;
     for c in digits.bytes().rev() {

--- a/packages/rust/extensions/goldenflow-core/src/identifiers/mod.rs
+++ b/packages/rust/extensions/goldenflow-core/src/identifiers/mod.rs
@@ -4,6 +4,7 @@
 pub mod aba;
 pub mod ean;
 pub mod iban;
+pub mod imei;
 pub mod isbn;
 pub mod luhn;
 pub mod swift;

--- a/packages/rust/extensions/goldenflow-core/src/identifiers/mod.rs
+++ b/packages/rust/extensions/goldenflow-core/src/identifiers/mod.rs
@@ -1,6 +1,7 @@
 //! Owned checksummed-identifier kernels (pyo3-free). validate -> bool,
 //! canonicalize -> Option<String>. These are the reference implementations;
 //! the Python/TS fallbacks must reproduce their bytes exactly (byte-parity harness).
+pub mod aba;
 pub mod ean;
 pub mod iban;
 pub mod isbn;

--- a/packages/rust/extensions/goldenflow-core/src/identifiers/mod.rs
+++ b/packages/rust/extensions/goldenflow-core/src/identifiers/mod.rs
@@ -5,6 +5,7 @@ pub mod ean;
 pub mod iban;
 pub mod isbn;
 pub mod luhn;
+pub mod swift;
 pub mod vat;
 
 /// Remove ASCII spaces, '-' and '.' — the separators identifiers tolerate.

--- a/packages/rust/extensions/goldenflow-core/src/identifiers/swift.rs
+++ b/packages/rust/extensions/goldenflow-core/src/identifiers/swift.rs
@@ -1,0 +1,82 @@
+//! SWIFT/BIC (ISO 9362) structural validation. No checksum exists for BIC --
+//! validity is purely structural: 8 or 11 chars, institution (4 letters) +
+//! country (2 letters) + location (2 alnum) + optional branch (3 alnum).
+
+/// Normalize: uppercase + remove ASCII spaces only. Unlike other identifiers
+/// in this module, `-`/`.` are NOT stripped -- a well-formed BIC never
+/// contains them, and silently stripping them could let a malformed value
+/// pass structural validation.
+fn normalize(s: &str) -> String {
+    s.chars()
+        .filter(|c| *c != ' ')
+        .collect::<String>()
+        .to_ascii_uppercase()
+}
+
+fn is_alpha_upper(c: char) -> bool {
+    c.is_ascii_uppercase()
+}
+
+fn is_alnum_upper(c: char) -> bool {
+    c.is_ascii_uppercase() || c.is_ascii_digit()
+}
+
+/// True if `s` is a structurally valid SWIFT/BIC code (length 8 or 11).
+pub fn swift_validate(s: &str) -> bool {
+    let t = normalize(s);
+    let chars: Vec<char> = t.chars().collect();
+    let len = chars.len();
+    if len != 8 && len != 11 {
+        return false;
+    }
+    if !chars[0..4].iter().all(|&c| is_alpha_upper(c)) {
+        return false;
+    }
+    if !chars[4..6].iter().all(|&c| is_alpha_upper(c)) {
+        return false;
+    }
+    if !chars[6..8].iter().all(|&c| is_alnum_upper(c)) {
+        return false;
+    }
+    if len == 11 && !chars[8..11].iter().all(|&c| is_alnum_upper(c)) {
+        return false;
+    }
+    true
+}
+
+/// Normalized uppercase form of a valid SWIFT/BIC; `None` if invalid.
+pub fn swift_format(s: &str) -> Option<String> {
+    if !swift_validate(s) {
+        return None;
+    }
+    Some(normalize(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_swift_codes() {
+        assert!(swift_validate("DEUTDEFF"));
+        assert!(swift_validate("DEUTDEFF500"));
+        assert!(swift_validate("NEDSZAJJXXX"));
+        assert!(swift_validate("deutdeff"));
+    }
+
+    #[test]
+    fn invalid_swift_codes() {
+        assert!(!swift_validate("DEUTDEFF5")); // len 9
+        assert!(!swift_validate("DEUT1EFF")); // digit in institution
+        assert!(!swift_validate("1234DEFF")); // digits in institution
+        assert!(!swift_validate("")); // empty
+    }
+
+    #[test]
+    fn format_valid_and_invalid() {
+        assert_eq!(swift_format("deutdeff").as_deref(), Some("DEUTDEFF"));
+        assert_eq!(swift_format("DEUTDEFF500").as_deref(), Some("DEUTDEFF500"));
+        assert_eq!(swift_format("DEUTDEFF5"), None);
+        assert_eq!(swift_format(""), None);
+    }
+}

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -12,7 +12,7 @@
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use goldenflow_core::identifiers::{ean, iban, isbn, luhn, vat};
+    use goldenflow_core::identifiers::{ean, iban, isbn, luhn, swift, vat};
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
@@ -53,6 +53,16 @@ mod wasm {
     #[wasm_bindgen]
     pub fn ean_validate(s: &str) -> bool {
         ean::ean_validate(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn swift_validate(s: &str) -> bool {
+        swift::swift_validate(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn swift_format(s: &str) -> Option<String> {
+        swift::swift_format(s)
     }
 
     #[wasm_bindgen]

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -12,7 +12,7 @@
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use goldenflow_core::identifiers::{ean, iban, isbn, luhn, swift, vat};
+    use goldenflow_core::identifiers::{aba, ean, iban, isbn, luhn, swift, vat};
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
@@ -63,6 +63,11 @@ mod wasm {
     #[wasm_bindgen]
     pub fn swift_format(s: &str) -> Option<String> {
         swift::swift_format(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn aba_validate(s: &str) -> bool {
+        aba::aba_validate(s)
     }
 
     #[wasm_bindgen]

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -12,7 +12,7 @@
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use goldenflow_core::identifiers::{aba, ean, iban, isbn, luhn, swift, vat};
+    use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
@@ -68,6 +68,11 @@ mod wasm {
     #[wasm_bindgen]
     pub fn aba_validate(s: &str) -> bool {
         aba::aba_validate(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn imei_validate(s: &str) -> bool {
+        imei::imei_validate(s)
     }
 
     #[wasm_bindgen]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.2.0"
+version = "0.3.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.2.0"
+    __version__ = "0.3.0"

--- a/packages/rust/extensions/native-flow/src/identifiers.rs
+++ b/packages/rust/extensions/native-flow/src/identifiers.rs
@@ -3,7 +3,7 @@
 use crate::util::{map_str_to_bool, map_str_to_str};
 use arrow::array::ArrayData;
 use arrow::pyarrow::PyArrowType;
-use goldenflow_core::identifiers::{ean, iban, isbn, luhn, vat};
+use goldenflow_core::identifiers::{ean, iban, isbn, luhn, swift, vat};
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -76,6 +76,27 @@ pub fn ean_validate_arrow(
     Ok(PyArrowType(map_str_to_bool(py, array.0, |s| {
         Some(ean::ean_validate(s))
     })?))
+}
+
+#[pyfunction]
+pub fn swift_validate_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_bool(py, array.0, |s| {
+        Some(swift::swift_validate(s))
+    })?))
+}
+#[pyfunction]
+pub fn swift_format_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(
+        py,
+        array.0,
+        swift::swift_format,
+    )?))
 }
 
 #[pyfunction]

--- a/packages/rust/extensions/native-flow/src/identifiers.rs
+++ b/packages/rust/extensions/native-flow/src/identifiers.rs
@@ -3,7 +3,7 @@
 use crate::util::{map_str_to_bool, map_str_to_str};
 use arrow::array::ArrayData;
 use arrow::pyarrow::PyArrowType;
-use goldenflow_core::identifiers::{ean, iban, isbn, luhn, swift, vat};
+use goldenflow_core::identifiers::{aba, ean, iban, isbn, luhn, swift, vat};
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -97,6 +97,16 @@ pub fn swift_format_arrow(
         array.0,
         swift::swift_format,
     )?))
+}
+
+#[pyfunction]
+pub fn aba_validate_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_bool(py, array.0, |s| {
+        Some(aba::aba_validate(s))
+    })?))
 }
 
 #[pyfunction]

--- a/packages/rust/extensions/native-flow/src/identifiers.rs
+++ b/packages/rust/extensions/native-flow/src/identifiers.rs
@@ -3,7 +3,7 @@
 use crate::util::{map_str_to_bool, map_str_to_str};
 use arrow::array::ArrayData;
 use arrow::pyarrow::PyArrowType;
-use goldenflow_core::identifiers::{aba, ean, iban, isbn, luhn, swift, vat};
+use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -106,6 +106,16 @@ pub fn aba_validate_arrow(
 ) -> PyResult<PyArrowType<ArrayData>> {
     Ok(PyArrowType(map_str_to_bool(py, array.0, |s| {
         Some(aba::aba_validate(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn imei_validate_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_bool(py, array.0, |s| {
+        Some(imei::imei_validate(s))
     })?))
 }
 

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -34,5 +34,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(identifiers::swift_format_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(identifiers::vat_validate_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(identifiers::vat_format_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(identifiers::aba_validate_arrow, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -35,5 +35,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(identifiers::vat_validate_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(identifiers::vat_format_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(identifiers::aba_validate_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(identifiers::imei_validate_arrow, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -30,6 +30,8 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(identifiers::isbn_validate_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(identifiers::isbn_normalize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(identifiers::ean_validate_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(identifiers::swift_validate_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(identifiers::swift_format_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(identifiers::vat_validate_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(identifiers::vat_format_arrow, m)?)?;
     Ok(())

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/core/transforms/identifiers.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/identifiers.ts
@@ -636,6 +636,158 @@ registerTransform(
 );
 
 // ---------------------------------------------------------------------------
+// SWIFT/BIC identifiers
+//
+// Pure-TS reference for goldenflow-core's `identifiers::swift` kernel. MUST
+// reproduce the Rust/Python kernel byte-for-byte -- normalize is uppercase +
+// remove ASCII spaces ONLY (unlike `ccStripSep`, '-'/'.' are NOT stripped: a
+// well-formed BIC never contains them, and silently stripping them could let
+// a malformed value pass structural validation). Structural-only (no
+// checksum exists for BIC): length 8 or 11, [0:4] alpha, [4:6] alpha, [6:8]
+// alnum, [8:11] alnum if present.
+// ---------------------------------------------------------------------------
+
+/** Uppercase + remove ASCII spaces only -- mirrors Rust/Python `_swift_normalize`. */
+function swiftNormalize(val: string): string {
+  return val.replace(/ /g, "").toUpperCase();
+}
+
+function swiftValidateTs(val: string): boolean {
+  const t = swiftNormalize(val);
+  const length = t.length;
+  if (length !== 8 && length !== 11) return false;
+  for (let i = 0; i < 4; i++) {
+    if (!isAsciiAlphaChar(t[i] ?? "")) return false;
+  }
+  for (let i = 4; i < 6; i++) {
+    if (!isAsciiAlphaChar(t[i] ?? "")) return false;
+  }
+  for (let i = 6; i < 8; i++) {
+    if (!isAsciiAlnumChar(t[i] ?? "")) return false;
+  }
+  if (length === 11) {
+    for (let i = 8; i < 11; i++) {
+      if (!isAsciiAlnumChar(t[i] ?? "")) return false;
+    }
+  }
+  return true;
+}
+
+function swiftFormatTs(val: string): string | undefined {
+  if (!swiftValidateTs(val)) return undefined;
+  return swiftNormalize(val);
+}
+
+function swiftValidate(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapToBool(values, backend ? (s) => backend.swiftValidate(s) : swiftValidateTs);
+}
+
+registerTransform(
+  {
+    name: "swift_validate",
+    inputTypes: ["identifier", "string"],
+    autoApply: false,
+    priority: 50,
+    mode: "series",
+  },
+  swiftValidate,
+);
+
+function swiftFormat(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapToStringOrNull(
+    values,
+    backend ? (s) => backend.swiftFormat(s) : swiftFormatTs,
+  );
+}
+
+registerTransform(
+  {
+    name: "swift_format",
+    inputTypes: ["identifier", "string"],
+    autoApply: false,
+    priority: 50,
+    mode: "series",
+  },
+  swiftFormat,
+);
+
+// ---------------------------------------------------------------------------
+// ABA routing number (US bank routing transit number)
+//
+// Pure-TS reference for goldenflow-core's `identifiers::aba` kernel. MUST
+// reproduce the Rust/Python kernel byte-for-byte -- same separator strip
+// (reuses `ccStripSep`), same 9-digit length gate, same weighted checksum.
+// ---------------------------------------------------------------------------
+
+function abaValidateTs(val: string): boolean {
+  const t = ccStripSep(val);
+  if (t.length !== 9) return false;
+  for (const c of t) {
+    if (!isAsciiDigitChar(c)) return false;
+  }
+  const d: number[] = [];
+  for (const c of t) d.push(c.charCodeAt(0) - 48);
+  const total =
+    3 * ((d[0] ?? 0) + (d[3] ?? 0) + (d[6] ?? 0)) +
+    7 * ((d[1] ?? 0) + (d[4] ?? 0) + (d[7] ?? 0)) +
+    1 * ((d[2] ?? 0) + (d[5] ?? 0) + (d[8] ?? 0));
+  return total % 10 === 0;
+}
+
+function abaValidate(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapToBool(values, backend ? (s) => backend.abaValidate(s) : abaValidateTs);
+}
+
+registerTransform(
+  {
+    name: "aba_validate",
+    inputTypes: ["identifier", "string"],
+    autoApply: false,
+    priority: 50,
+    mode: "series",
+  },
+  abaValidate,
+);
+
+// ---------------------------------------------------------------------------
+// IMEI (International Mobile Equipment Identity)
+//
+// Pure-TS reference for goldenflow-core's `identifiers::imei` kernel. MUST
+// reproduce the Rust/Python kernel byte-for-byte -- same separator strip
+// (reuses `ccStripSep`), same 15-digit length gate, same Luhn checksum
+// (reuses `luhnOk`, the same helper the `cc` family uses -- one Luhn
+// implementation for both).
+// ---------------------------------------------------------------------------
+
+function imeiValidateTs(val: string): boolean {
+  const t = ccStripSep(val);
+  if (t.length !== 15) return false;
+  for (const c of t) {
+    if (!isAsciiDigitChar(c)) return false;
+  }
+  return luhnOk(t);
+}
+
+function imeiValidate(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapToBool(values, backend ? (s) => backend.imeiValidate(s) : imeiValidateTs);
+}
+
+registerTransform(
+  {
+    name: "imei_validate",
+    inputTypes: ["identifier", "string"],
+    autoApply: false,
+    priority: 50,
+    mode: "series",
+  },
+  imeiValidate,
+);
+
+// ---------------------------------------------------------------------------
 // ssn_format (series, ssn|string, 50)
 // ---------------------------------------------------------------------------
 
@@ -708,4 +860,8 @@ export {
   eanValidateTs,
   vatValidateTs,
   vatFormatTs,
+  swiftValidateTs,
+  swiftFormatTs,
+  abaValidateTs,
+  imeiValidateTs,
 };

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -3,9 +3,9 @@
  * node:* here.
  *
  * The active backend (if any) is consulted by the identifier transforms
- * (cc/iban/isbn/ean/vat) for the 10 covered functions; everything else stays
- * pure-TS. Mirrors goldenmatch's `setScorerBackend(null)` module-singleton
- * pattern for test isolation.
+ * (cc/iban/isbn/ean/vat/swift/aba/imei) for the 14 covered functions;
+ * everything else stays pure-TS. Mirrors goldenmatch's
+ * `setScorerBackend(null)` module-singleton pattern for test isolation.
  */
 
 /**
@@ -29,6 +29,10 @@ export interface FlowWasmBackend {
   eanValidate(s: string): boolean;
   vatValidate(s: string): boolean;
   vatFormat(s: string): string | undefined;
+  swiftValidate(s: string): boolean;
+  swiftFormat(s: string): string | undefined;
+  abaValidate(s: string): boolean;
+  imeiValidate(s: string): boolean;
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -51,6 +51,10 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     ean_validate: (s: string) => boolean;
     vat_validate: (s: string) => boolean;
     vat_format: (s: string) => string | undefined;
+    swift_validate: (s: string) => boolean;
+    swift_format: (s: string) => string | undefined;
+    aba_validate: (s: string) => boolean;
+    imei_validate: (s: string) => boolean;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -65,5 +69,9 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     eanValidate: (s) => glue.ean_validate(s),
     vatValidate: (s) => glue.vat_validate(s),
     vatFormat: (s) => glue.vat_format(s),
+    swiftValidate: (s) => glue.swift_validate(s),
+    swiftFormat: (s) => glue.swift_format(s),
+    abaValidate: (s) => glue.aba_validate(s),
+    imeiValidate: (s) => glue.imei_validate(s),
   };
 }

--- a/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
@@ -31,6 +31,10 @@ import {
   eanValidateTs,
   vatValidateTs,
   vatFormatTs,
+  swiftValidateTs,
+  swiftFormatTs,
+  abaValidateTs,
+  imeiValidateTs,
 } from "../../src/core/transforms/identifiers.js";
 import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
 import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
@@ -62,6 +66,10 @@ const PURE_TS_FN: Record<string, (s: string) => boolean | string | undefined> = 
   ean_validate: eanValidateTs,
   vat_validate: vatValidateTs,
   vat_format: vatFormatTs,
+  swift_validate: swiftValidateTs,
+  swift_format: swiftFormatTs,
+  aba_validate: abaValidateTs,
+  imei_validate: imeiValidateTs,
 };
 
 /** Same transform set, dispatched through the wasm backend's method of the
@@ -79,6 +87,10 @@ function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boo
     ean_validate: (s) => backend.eanValidate(s),
     vat_validate: (s) => backend.vatValidate(s),
     vat_format: (s) => backend.vatFormat(s),
+    swift_validate: (s) => backend.swiftValidate(s),
+    swift_format: (s) => backend.swiftFormat(s),
+    aba_validate: (s) => backend.abaValidate(s),
+    imei_validate: (s) => backend.imeiValidate(s),
   };
   const fn = map[transform];
   if (!fn) throw new Error(`no wasm dispatch for transform ${transform}`);

--- a/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -84,6 +84,24 @@
 {"transform": "ean_validate", "input": "40063813339a1", "expected": false}
 {"transform": "ean_validate", "input": "", "expected": false}
 {"transform": "ean_validate", "input": null, "expected": null}
+{"transform": "swift_validate", "input": "DEUTDEFF", "expected": true}
+{"transform": "swift_validate", "input": "DEUTDEFF500", "expected": true}
+{"transform": "swift_validate", "input": "NEDSZAJJXXX", "expected": true}
+{"transform": "swift_validate", "input": "deutdeff", "expected": true}
+{"transform": "swift_validate", "input": "deu tdeff", "expected": true}
+{"transform": "swift_validate", "input": "DEUTDEFF5", "expected": false}
+{"transform": "swift_validate", "input": "DEUT1EFF", "expected": false}
+{"transform": "swift_validate", "input": "1234DEFF", "expected": false}
+{"transform": "swift_validate", "input": "DEUTDE-FF", "expected": false}
+{"transform": "swift_validate", "input": "", "expected": false}
+{"transform": "swift_validate", "input": null, "expected": null}
+{"transform": "swift_format", "input": "deutdeff", "expected": "DEUTDEFF"}
+{"transform": "swift_format", "input": "DEUTDEFF500", "expected": "DEUTDEFF500"}
+{"transform": "swift_format", "input": "ne dsz ajj xxx", "expected": "NEDSZAJJXXX"}
+{"transform": "swift_format", "input": "DEUTDEFF5", "expected": null}
+{"transform": "swift_format", "input": "1234DEFF", "expected": null}
+{"transform": "swift_format", "input": "", "expected": null}
+{"transform": "swift_format", "input": null, "expected": null}
 {"transform": "vat_validate", "input": "DE136695976", "expected": true}
 {"transform": "vat_validate", "input": "de 136 695 976", "expected": true}
 {"transform": "vat_validate", "input": "IT00743110157", "expected": true}
@@ -104,6 +122,23 @@
 {"transform": "vat_format", "input": "ZZ123", "expected": null}
 {"transform": "vat_format", "input": "", "expected": null}
 {"transform": "vat_format", "input": null, "expected": null}
+{"transform": "aba_validate", "input": "011000015", "expected": true}
+{"transform": "aba_validate", "input": "021000021", "expected": true}
+{"transform": "aba_validate", "input": "122105155", "expected": true}
+{"transform": "aba_validate", "input": "011-000-015", "expected": true}
+{"transform": "aba_validate", "input": "011000016", "expected": false}
+{"transform": "aba_validate", "input": "12345", "expected": false}
+{"transform": "aba_validate", "input": "01100001a", "expected": false}
+{"transform": "aba_validate", "input": "", "expected": false}
+{"transform": "aba_validate", "input": null, "expected": null}
+{"transform": "imei_validate", "input": "490154203237518", "expected": true}
+{"transform": "imei_validate", "input": "356938035643809", "expected": true}
+{"transform": "imei_validate", "input": "49-0154-203237518", "expected": true}
+{"transform": "imei_validate", "input": "490154203237519", "expected": false}
+{"transform": "imei_validate", "input": "12345", "expected": false}
+{"transform": "imei_validate", "input": "49015420323751a", "expected": false}
+{"transform": "imei_validate", "input": "", "expected": false}
+{"transform": "imei_validate", "input": null, "expected": null}
 {"transform": "cc_validate", "input": "424242424242😀2", "expected": false}
 {"transform": "iban_validate", "input": "DE89370400440532😀13000", "expected": false}
 {"transform": "vat_validate", "input": "DE13669597😀", "expected": false}


### PR DESCRIPTION
## What

Wave A of the post-0 program: three new owned checksummed/structural identifier families, added across **every surface** (native, WASM/TS, pure-Python fallback) byte-identical to the Rust oracle, reusing the Wave 0b/0c machinery.

| Family | Transforms | Kernel |
|---|---|---|
| SWIFT/BIC | `swift_validate`, `swift_format` | structural (len 8/11, institution/country/location/branch) |
| ABA routing | `aba_validate` | 3-7-1 weighted mod-10 checksum |
| IMEI | `imei_validate` | Luhn over 15 digits (reuses `luhn_ok`) |

- Kernels in `goldenflow-core/src/identifiers/{swift,aba,imei}.rs`; `luhn.rs::luhn_ok` promoted to `pub(crate)` so IMEI reuses it (one Luhn impl). Arrow shims + wasm-bindgen exports + Python/TS transforms + fallbacks, all `auto_apply=False`.
- Corpus extended (one oracle, byte-copied to TS, `cmp`-enforced); the existing `native_flow` / `wasm_flow` / `goldenflow-core` clippy / parity CI lanes cover it with no CI changes.
- Versions: goldenflow 1.5.0, npm 0.5.0, goldenflow-native 0.3.0. Transform count 86 → 90. Docs updated (extends ADR 0031).

## Verification

26 Rust unit tests + 166 Python parity/unit tests green; clippy (from the goldenflow-core dir) + fmt clean; wasm32 build clean. Native + TS/wasm parity run in CI (box OOMs on local TS). Checksums independently re-derived in review (ABA, IMEI Luhn); byte-parity fallbacks verified line-by-line.

## Scope

Extends Wave 0's identifier surface. email/url validation hardening folds into the upcoming Wave D full sweep. Wave C (i18n addresses) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)