### PR TITLE
feat(goldenflow): Wave D1 — email family owned kernels (cross-surface)

### DIFF
--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,14 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-07-04 — GoldenFlow Wave D1: email transform family migrated to owned kernels
+- The email transform family (`email_lowercase`, `email_normalize`,
+  `email_extract_domain`, `email_validate`) is now backed by owned Rust
+  kernels in `goldenflow-core`, cross-surface (native + WASM/TS +
+  pure-Python fallback), byte-parity to the Rust oracle. Existing transforms
+  migrated to native-first dispatch, not new additions -- registry stays at
+  92. Versions: goldenflow 1.7.0 / npm 0.7.0 / goldenflow-native 0.5.0.
+
 ## 2026-07-04 — GoldenFlow Wave B: name_transliterate + name_script i18n name kernels
 - Extension of ADR [../decisions/0031-goldenflow-reference-mode-identifiers-wasm.md](../decisions/0031-goldenflow-reference-mode-identifiers-wasm.md)
   (no new ADR needed) — two new owned i18n name kernels: `name_transliterate`

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0 (2026-07-04)
+
+Wave D1: the email transform family (`email_lowercase`, `email_normalize`, `email_extract_domain`, `email_validate`) is now backed by owned Rust kernels in `goldenflow-core`, cross-surface (native + WASM/TS + pure-Python fallback), byte-parity to the Rust oracle. This wave migrated existing transforms to the owned-kernel pattern; it did not add new transforms. `email_lowercase`/`email_extract_domain` moved from a vectorized Polars expression to native-first dispatch (the pure-Python fallback runs per-row when the native wheel is absent). Outputs are unchanged for well-formed inputs.
+
 ## 1.6.0 (2026-07-04)
 
 Wave B of the i18n-name-kernel program: two new owned name kernels for cross-script identity matching, cross-surface (native + WASM/TS + pure-Python), byte-parity to the Rust oracle. No breaking changes; existing transform outputs are unchanged.

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -201,6 +201,10 @@ package. Loader discover order in `goldenflow/core/_native_loader.py`:
   detection via Unicode code point ranges). Same cross-surface pattern as
   Waves 0/A: native + WASM/TS + pure-Python fallback, all byte-identical to
   the goldenflow-core Rust oracle.
+- **Email family migrated to owned kernels (Wave D1):** `email_lowercase`,
+  `email_normalize`, `email_extract_domain`, `email_validate` now dispatch
+  native-first through goldenflow-core, same cross-surface pattern as
+  identifiers/names above (existing transforms migrated, not new additions).
 - **Byte-parity harness (cross-surface oracle = goldenflow-core).**
   `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` (mirrored
   byte-identical into `packages/typescript/goldenflow/tests/parity/`) is the

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -95,6 +95,9 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # name_script: Unicode-range script detection -- floor symbol only,
     # locale-free.
     "name_script": ("name_script_arrow",),
+    # email: lowercase/normalize/extract_domain/validate -- floor symbol only
+    # (email_validate_arrow), locale-free, region-free.
+    "email": ("email_validate_arrow",),
 }
 
 # Components whose only native path is intentionally non-authoritative (the

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -374,3 +374,41 @@ def name_transliterate_native() -> Callable[[pl.Series], pl.Series] | None:
 
 def name_script_native() -> Callable[[pl.Series], pl.Series] | None:
     return _name_kernel_runner("name_script", "name_script_arrow")
+
+
+def _email_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for email kernel function ``attr`` if
+    native ``email`` is enabled and the dependencies are importable; else
+    ``None``. Like the other identifier runners -- no region/gating args,
+    lowercase/normalize/domain-extract/validate are all locale-free."""
+    if not native_enabled("email"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def email_lowercase_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _email_kernel_runner("email_lowercase_arrow")
+
+
+def email_normalize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _email_kernel_runner("email_normalize_arrow")
+
+
+def email_extract_domain_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _email_kernel_runner("email_extract_domain_arrow")
+
+
+def email_validate_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _email_kernel_runner("email_validate_arrow")

--- a/packages/python/goldenflow/goldenflow/transforms/email.py
+++ b/packages/python/goldenflow/goldenflow/transforms/email.py
@@ -5,8 +5,64 @@ import re
 import polars as pl
 
 from goldenflow.transforms import register_transform
+from goldenflow.transforms._native import (
+    email_extract_domain_native,
+    email_lowercase_native,
+    email_normalize_native,
+    email_validate_native,
+)
 
 _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+# Pure-Python reference for goldenflow-core's ``email`` kernel. MUST reproduce
+# the Rust kernel byte-for-byte (asserted by
+# tests/transforms/test_identifiers_parity.py over
+# tests/parity/identifiers_corpus.jsonl).
+
+
+def _email_lowercase_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return val.strip().lower()
+
+
+def _email_normalize_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    original = val
+    val = val.strip().lower()
+    if not val or "@" not in val:
+        return original  # preserve invalid values
+    local, domain = val.rsplit("@", 1)
+    # Strip +tag
+    local = local.split("+")[0]
+    # Strip dots from Gmail local part
+    if domain in ("gmail.com", "googlemail.com"):
+        local = local.replace(".", "")
+    return f"{local}@{domain}"
+
+
+def _email_extract_domain_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    v = val.strip()
+    idx = v.rfind("@")
+    if idx == -1:
+        return None
+    domain = v[idx + 1 :]
+    if not domain:
+        return None
+    return domain.lower()
+
+
+def _email_validate_py(val: str | None) -> bool | None:
+    if val is None:
+        return None
+    val = val.strip()
+    if not val:
+        return False
+    return bool(_EMAIL_PATTERN.match(val))
 
 
 @register_transform(
@@ -14,16 +70,19 @@ _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
     input_types=["email", "string"],
     auto_apply=False,
     priority=55,
-    mode="expr",
+    mode="series",
 )
-def email_lowercase(column: str) -> pl.Expr:
-    """Lowercase the entire email address.
+def email_lowercase(series: pl.Series) -> pl.Series:
+    """Lowercase the entire email address (trim + lowercase).
 
-    Native Polars: strip then to_lowercase. Drops the per-row Python UDF
-    (previously map_elements). Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    Native-first (goldenflow-core's ``email::email_lowercase`` kernel); the
+    pure-Python fallback below is the byte-exact reference this kernel
+    replicates.
     """
-    return pl.col(column).str.strip_chars().str.to_lowercase()
+    native = email_lowercase_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_email_lowercase_py, return_dtype=pl.Utf8)
 
 
 @register_transform(
@@ -34,24 +93,16 @@ def email_lowercase(column: str) -> pl.Expr:
     mode="series",
 )
 def email_normalize(series: pl.Series) -> pl.Series:
-    """Normalize email: lowercase, strip +tags, strip dots from Gmail local part."""
+    """Normalize email: lowercase, strip +tags, strip dots from Gmail local part.
 
-    def _normalize(val: str | None) -> str | None:
-        if val is None:
-            return None
-        original = val
-        val = val.strip().lower()
-        if not val or "@" not in val:
-            return original  # preserve invalid values
-        local, domain = val.rsplit("@", 1)
-        # Strip +tag
-        local = local.split("+")[0]
-        # Strip dots from Gmail local part
-        if domain in ("gmail.com", "googlemail.com"):
-            local = local.replace(".", "")
-        return f"{local}@{domain}"
-
-    return series.map_elements(_normalize, return_dtype=pl.Utf8)
+    Native-first (goldenflow-core's ``email::email_normalize`` kernel); the
+    pure-Python fallback below is the byte-exact reference this kernel
+    replicates.
+    """
+    native = email_normalize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_email_normalize_py, return_dtype=pl.Utf8)
 
 
 @register_transform(
@@ -59,22 +110,19 @@ def email_normalize(series: pl.Series) -> pl.Series:
     input_types=["email"],
     auto_apply=False,
     priority=40,
-    mode="expr",
+    mode="series",
 )
-def email_extract_domain(column: str) -> pl.Expr:
+def email_extract_domain(series: pl.Series) -> pl.Series:
     """Extract the lowercased domain from an email address.
 
-    Native Polars: strip → regex extract after '@' → lowercase. Inputs
-    without '@' (or None) yield None via Polars's native null propagation.
-    Spec docs/superpowers/specs/2026-05-15-map-elements-attack-design.md
-    Tier 1.
+    Native-first (goldenflow-core's ``email::email_extract_domain`` kernel);
+    the pure-Python fallback below is the byte-exact reference this kernel
+    replicates. Inputs without '@' (or None) yield None.
     """
-    return (
-        pl.col(column)
-        .str.strip_chars()
-        .str.extract(r"@([^@]+)$", 1)
-        .str.to_lowercase()
-    )
+    native = email_extract_domain_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_email_extract_domain_py, return_dtype=pl.Utf8)
 
 
 @register_transform(
@@ -85,14 +133,13 @@ def email_extract_domain(column: str) -> pl.Expr:
     mode="series",
 )
 def email_validate(series: pl.Series) -> pl.Series:
-    """Validate email format. Returns True/False/None."""
+    """Validate email format. Returns True/False/None.
 
-    def _validate(val: str | None) -> bool | None:
-        if val is None:
-            return None
-        val = val.strip()
-        if not val:
-            return False
-        return bool(_EMAIL_PATTERN.match(val))
-
-    return series.map_elements(_validate, return_dtype=pl.Boolean)
+    Native-first (goldenflow-core's ``email::email_validate`` kernel); the
+    pure-Python fallback below is the byte-exact reference this kernel
+    replicates.
+    """
+    native = email_validate_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_email_validate_py, return_dtype=pl.Boolean)

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.6.0"
+version = "1.7.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -28,6 +28,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from goldenflow.core._native_loader import native_available, native_module  # noqa: E402
+from goldenflow.transforms.email import (  # noqa: E402
+    _email_extract_domain_py,
+    _email_lowercase_py,
+    _email_normalize_py,
+    _email_validate_py,
+)
 from goldenflow.transforms.identifiers import (  # noqa: E402
     _aba_validate_py,
     _cc_format_py,
@@ -260,6 +266,42 @@ _CASES: list[tuple[str, str | None]] = [
     ("name_script", "123"),  # digits only -> Common
     ("name_script", ""),  # empty -> Unknown
     ("name_script", None),  # null
+    # --- email_lowercase ---
+    ("email_lowercase", " John@X.COM "),  # leading/trailing whitespace
+    ("email_lowercase", "A@B.com"),  # already lower domain
+    ("email_lowercase", "ADMIN@EXAMPLE.COM"),  # all-caps
+    ("email_lowercase", ""),  # empty
+    ("email_lowercase", None),  # null
+    # --- email_normalize ---
+    ("email_normalize", "John.Doe+tag@Gmail.com"),  # gmail dot-strip + tag-strip
+    ("email_normalize", "a+b@x.com"),  # non-gmail: tag stripped, dots kept (none here)
+    ("email_normalize", "notanemail"),  # no '@' -> preserved verbatim
+    ("email_normalize", "A@B.com"),  # simple lowercase
+    ("email_normalize", "j.o.h.n@googlemail.com"),  # googlemail dot-strip
+    ("email_normalize", "user+spam@example.com"),  # non-gmail tag-strip only
+    ("email_normalize", ""),  # empty -> preserved
+    ("email_normalize", "   "),  # whitespace-only -> preserved verbatim
+    ("email_normalize", None),  # null
+    # --- email_extract_domain ---
+    ("email_extract_domain", "x@Foo.COM"),  # mixed-case domain -> lowercased
+    ("email_extract_domain", "noat"),  # no '@' -> None
+    ("email_extract_domain", "trailing@"),  # nothing after '@' -> None
+    ("email_extract_domain", "admin@sub.domain.org"),  # multi-label domain
+    ("email_extract_domain", "a@b@c.com"),  # multiple '@' -> domain after LAST
+    ("email_extract_domain", ""),  # empty -> None
+    ("email_extract_domain", None),  # null
+    # --- email_validate ---
+    ("email_validate", "a@b.co"),  # valid
+    ("email_validate", "valid@example.com"),  # valid
+    ("email_validate", "also.valid+tag@sub.example.co.uk"),  # valid, multi-label
+    ("email_validate", "a@b"),  # no dot in domain -> false
+    ("email_validate", "a b@c.com"),  # whitespace in local -> false
+    ("email_validate", "a@@b.com"),  # two '@' -> false
+    ("email_validate", "@no-local.com"),  # empty local -> false
+    ("email_validate", "no-domain@"),  # empty domain -> false
+    ("email_validate", ""),  # empty -> false
+    ("email_validate", "   "),  # whitespace-only -> false
+    ("email_validate", None),  # null
 ]
 
 _PY_FN = {
@@ -279,6 +321,10 @@ _PY_FN = {
     "imei_validate": _imei_validate_py,
     "name_transliterate": _name_transliterate_py,
     "name_script": _name_script_py,
+    "email_lowercase": _email_lowercase_py,
+    "email_normalize": _email_normalize_py,
+    "email_extract_domain": _email_extract_domain_py,
+    "email_validate": _email_validate_py,
 }
 
 _NATIVE_ARROW_FN = {
@@ -298,6 +344,10 @@ _NATIVE_ARROW_FN = {
     "imei_validate": "imei_validate_arrow",
     "name_transliterate": "name_transliterate_arrow",
     "name_script": "name_script_arrow",
+    "email_lowercase": "email_lowercase_arrow",
+    "email_normalize": "email_normalize_arrow",
+    "email_extract_domain": "email_extract_domain_arrow",
+    "email_validate": "email_validate_arrow",
 }
 
 

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -168,3 +168,35 @@
 {"transform": "name_script", "input": "123", "expected": "Common"}
 {"transform": "name_script", "input": "", "expected": "Unknown"}
 {"transform": "name_script", "input": null, "expected": null}
+{"transform": "email_lowercase", "input": " John@X.COM ", "expected": "john@x.com"}
+{"transform": "email_lowercase", "input": "A@B.com", "expected": "a@b.com"}
+{"transform": "email_lowercase", "input": "ADMIN@EXAMPLE.COM", "expected": "admin@example.com"}
+{"transform": "email_lowercase", "input": "", "expected": ""}
+{"transform": "email_lowercase", "input": null, "expected": null}
+{"transform": "email_normalize", "input": "John.Doe+tag@Gmail.com", "expected": "johndoe@gmail.com"}
+{"transform": "email_normalize", "input": "a+b@x.com", "expected": "a@x.com"}
+{"transform": "email_normalize", "input": "notanemail", "expected": "notanemail"}
+{"transform": "email_normalize", "input": "A@B.com", "expected": "a@b.com"}
+{"transform": "email_normalize", "input": "j.o.h.n@googlemail.com", "expected": "john@googlemail.com"}
+{"transform": "email_normalize", "input": "user+spam@example.com", "expected": "user@example.com"}
+{"transform": "email_normalize", "input": "", "expected": ""}
+{"transform": "email_normalize", "input": "   ", "expected": "   "}
+{"transform": "email_normalize", "input": null, "expected": null}
+{"transform": "email_extract_domain", "input": "x@Foo.COM", "expected": "foo.com"}
+{"transform": "email_extract_domain", "input": "noat", "expected": null}
+{"transform": "email_extract_domain", "input": "trailing@", "expected": null}
+{"transform": "email_extract_domain", "input": "admin@sub.domain.org", "expected": "sub.domain.org"}
+{"transform": "email_extract_domain", "input": "a@b@c.com", "expected": "c.com"}
+{"transform": "email_extract_domain", "input": "", "expected": null}
+{"transform": "email_extract_domain", "input": null, "expected": null}
+{"transform": "email_validate", "input": "a@b.co", "expected": true}
+{"transform": "email_validate", "input": "valid@example.com", "expected": true}
+{"transform": "email_validate", "input": "also.valid+tag@sub.example.co.uk", "expected": true}
+{"transform": "email_validate", "input": "a@b", "expected": false}
+{"transform": "email_validate", "input": "a b@c.com", "expected": false}
+{"transform": "email_validate", "input": "a@@b.com", "expected": false}
+{"transform": "email_validate", "input": "@no-local.com", "expected": false}
+{"transform": "email_validate", "input": "no-domain@", "expected": false}
+{"transform": "email_validate", "input": "", "expected": false}
+{"transform": "email_validate", "input": "   ", "expected": false}
+{"transform": "email_validate", "input": null, "expected": null}

--- a/packages/python/goldenflow/tests/transforms/test_email.py
+++ b/packages/python/goldenflow/tests/transforms/test_email.py
@@ -7,18 +7,9 @@ from goldenflow.transforms.email import (
 )
 
 
-def _apply_expr(func, column: str, data: list) -> list:
-    """Helper to apply an expr-mode transform to test data."""
-    df = pl.DataFrame({column: data})
-    expr = func(column)
-    return df.select(expr.alias(column))[column].to_list()
-
-
 def test_email_lowercase():
-    result = _apply_expr(
-        email_lowercase, "e",
-        ["John.DOE@Gmail.Com", "ADMIN@EXAMPLE.COM", None],
-    )
+    s = pl.Series("e", ["John.DOE@Gmail.Com", "ADMIN@EXAMPLE.COM", None])
+    result = email_lowercase(s)
     assert result[0] == "john.doe@gmail.com"
     assert result[1] == "admin@example.com"
     assert result[2] is None
@@ -53,10 +44,10 @@ def test_email_normalize_preserves_none_and_invalid():
 
 
 def test_email_extract_domain():
-    result = _apply_expr(
-        email_extract_domain, "e",
-        ["user@example.com", "admin@sub.domain.org", None, "invalid"],
+    s = pl.Series(
+        "e", ["user@example.com", "admin@sub.domain.org", None, "invalid"]
     )
+    result = email_extract_domain(s)
     assert result[0] == "example.com"
     assert result[1] == "sub.domain.org"
     assert result[2] is None
@@ -64,15 +55,18 @@ def test_email_extract_domain():
 
 
 def test_email_validate():
-    s = pl.Series("e", [
-        "valid@example.com",
-        "also.valid+tag@sub.example.co.uk",
-        "missing-at-sign",
-        "@no-local.com",
-        "no-domain@",
-        None,
-        "",
-    ])
+    s = pl.Series(
+        "e",
+        [
+            "valid@example.com",
+            "also.valid+tag@sub.example.co.uk",
+            "missing-at-sign",
+            "@no-local.com",
+            "no-domain@",
+            None,
+            "",
+        ],
+    )
     result = email_validate(s)
     assert result[0] is True
     assert result[1] is True

--- a/packages/python/goldenflow/tests/transforms/test_email_kernels.py
+++ b/packages/python/goldenflow/tests/transforms/test_email_kernels.py
@@ -1,0 +1,73 @@
+"""Direct behavioral unit tests for the owned email kernels (Wave D1).
+
+Complements the byte-parity harness in ``test_identifiers_parity.py`` (which
+sweeps the committed ``tests/parity/identifiers_corpus.jsonl`` corpus against
+both the pure-Python fallback and the native path) with a small set of
+readable, self-documenting assertions pinned to the exact vectors used to
+design the ``goldenflow-core::email`` Rust kernel.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenflow.transforms.email import (
+    email_extract_domain,
+    email_lowercase,
+    email_normalize,
+    email_validate,
+)
+
+
+def _one(fn, value):
+    return fn(pl.Series("v", [value])).to_list()[0]
+
+
+def test_lowercase_trims_and_lowercases():
+    assert _one(email_lowercase, " John@X.COM ") == "john@x.com"
+
+
+def test_normalize_strips_gmail_dots_and_plus_tag():
+    assert _one(email_normalize, "John.Doe+tag@Gmail.com") == "johndoe@gmail.com"
+
+
+def test_normalize_strips_plus_tag_on_non_gmail():
+    assert _one(email_normalize, "a+b@x.com") == "a@x.com"
+
+
+def test_normalize_preserves_invalid_input_verbatim():
+    assert _one(email_normalize, "notanemail") == "notanemail"
+
+
+def test_normalize_lowercases_simple_address():
+    assert _one(email_normalize, "A@B.com") == "a@b.com"
+
+
+def test_extract_domain_lowercases_and_uses_last_at():
+    assert _one(email_extract_domain, "x@Foo.COM") == "foo.com"
+
+
+def test_extract_domain_none_without_at():
+    assert _one(email_extract_domain, "noat") is None
+
+
+def test_validate_valid_address():
+    assert _one(email_validate, "a@b.co") is True
+
+
+def test_validate_false_without_dot_in_domain():
+    assert _one(email_validate, "a@b") is False
+
+
+def test_validate_false_on_internal_whitespace():
+    assert _one(email_validate, "a b@c.com") is False
+
+
+def test_validate_false_on_double_at():
+    assert _one(email_validate, "a@@b.com") is False
+
+
+def test_validate_false_on_empty_string():
+    assert _one(email_validate, "") is False
+
+
+def test_validate_null_propagates():
+    assert _one(email_validate, None) is None

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -13,6 +13,12 @@ from pathlib import Path
 import polars as pl
 import pytest
 from goldenflow.core._native_loader import native_available
+from goldenflow.transforms.email import (
+    email_extract_domain,
+    email_lowercase,
+    email_normalize,
+    email_validate,
+)
 from goldenflow.transforms.identifiers import (
     aba_validate,
     cc_format,
@@ -50,6 +56,10 @@ _TRANSFORMS = {
     "imei_validate": imei_validate,
     "name_transliterate": name_transliterate,
     "name_script": name_script,
+    "email_lowercase": email_lowercase,
+    "email_normalize": email_normalize,
+    "email_extract_domain": email_extract_domain,
+    "email_validate": email_validate,
 }
 
 # Floor native symbol per transform's component -- used to skip a row when the
@@ -72,6 +82,12 @@ _NATIVE_FLOOR_SYMBOL = {
     "imei_validate": "imei_validate_arrow",
     "name_transliterate": "name_transliterate_arrow",
     "name_script": "name_script_arrow",
+    # email: all 4 transforms are wired via the single "email" component
+    # (floor symbol email_validate_arrow), region-free/locale-free.
+    "email_lowercase": "email_validate_arrow",
+    "email_normalize": "email_validate_arrow",
+    "email_extract_domain": "email_validate_arrow",
+    "email_validate": "email_validate_arrow",
 }
 
 

--- a/packages/rust/extensions/goldenflow-core/src/email.rs
+++ b/packages/rust/extensions/goldenflow-core/src/email.rs
@@ -1,0 +1,139 @@
+//! Owned email kernels (pyo3-free): lowercase, normalize (Gmail dot-strip +
+//! `+tag` strip), domain extraction, and format validation. These are the
+//! reference implementations; the Python/TS fallbacks must reproduce their
+//! bytes exactly (byte-parity harness, `tests/parity/identifiers_corpus.jsonl`).
+//!
+//! Deliberately NOT using a `regex` crate dependency (mirrors the
+//! checksummed-identifier kernels' no-regex policy for cross-surface parity
+//! guarantees) -- `email_validate` hand-rolls the equivalent of
+//! `^[^@\s]+@[^@\s]+\.[^@\s]+$` via byte/char scanning.
+
+/// Trim ASCII/Unicode whitespace and lowercase the whole address.
+/// Always returns a `String` -- there is no "invalid input" for lowercasing.
+pub fn email_lowercase(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+
+/// Normalize an email address: lowercase, strip a `+tag` from the local
+/// part, and strip dots from the local part for Gmail/Googlemail domains.
+///
+/// Preserves the ORIGINAL (untrimmed) input verbatim when the trimmed +
+/// lowercased value is empty or has no `@` -- mirrors the Python reference's
+/// "preserve invalid values" behavior. Always returns a `String`.
+pub fn email_normalize(s: &str) -> String {
+    let v = s.trim().to_lowercase();
+    if v.is_empty() || !v.contains('@') {
+        return s.to_string();
+    }
+    // Split on the LAST '@' (mirrors Python's `rsplit("@", 1)`).
+    let idx = v.rfind('@').expect("checked contains('@') above");
+    let local = &v[..idx];
+    let domain = &v[idx + 1..];
+    let local = local.split('+').next().unwrap_or("");
+    let local = if domain == "gmail.com" || domain == "googlemail.com" {
+        local.replace('.', "")
+    } else {
+        local.to_string()
+    };
+    format!("{local}@{domain}")
+}
+
+/// Extract the lowercased domain after the LAST `@`. `None` if there is no
+/// `@`, or nothing follows it (mirrors the regex `@([^@]+)$`).
+pub fn email_extract_domain(s: &str) -> Option<String> {
+    let t = s.trim();
+    let idx = t.rfind('@')?;
+    let domain = &t[idx + 1..];
+    if domain.is_empty() {
+        return None;
+    }
+    Some(domain.to_lowercase())
+}
+
+/// Validate email format against the hand-rolled equivalent of
+/// `^[^@\s]+@[^@\s]+\.[^@\s]+$`: exactly one `@`; a non-empty,
+/// whitespace-free local part; a non-empty, whitespace-free domain part
+/// containing a `.` that is neither the first nor the last character.
+/// Empty (after trim) input is `Some(false)`, never `None` -- there is no
+/// null-propagation case for a non-null input.
+pub fn email_validate(s: &str) -> Option<bool> {
+    let t = s.trim();
+    if t.is_empty() {
+        return Some(false);
+    }
+    if t.matches('@').count() != 1 {
+        return Some(false);
+    }
+    let idx = t.find('@').expect("checked exactly one '@' above");
+    let local = &t[..idx];
+    let domain = &t[idx + 1..];
+    if local.is_empty() || local.chars().any(char::is_whitespace) {
+        return Some(false);
+    }
+    if domain.is_empty() || domain.chars().any(char::is_whitespace) {
+        return Some(false);
+    }
+    // domain must contain a '.' that is neither the first nor last byte, i.e.
+    // there's >=1 byte on each side (mirrors `[^@\s]+\.[^@\s]+` fully
+    // consuming the domain -- already guaranteed @/whitespace-free above).
+    let has_valid_dot = domain
+        .char_indices()
+        .any(|(i, c)| c == '.' && i != 0 && i + 1 != domain.len());
+    Some(has_valid_dot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lowercase() {
+        assert_eq!(email_lowercase(" John@X.COM "), "john@x.com");
+        assert_eq!(email_lowercase("A@B.com"), "a@b.com");
+    }
+
+    #[test]
+    fn normalize() {
+        assert_eq!(
+            email_normalize("John.Doe+tag@Gmail.com"),
+            "johndoe@gmail.com"
+        );
+        assert_eq!(email_normalize("a+b@x.com"), "a@x.com");
+        assert_eq!(email_normalize("notanemail"), "notanemail");
+        assert_eq!(email_normalize("A@B.com"), "a@b.com");
+        assert_eq!(
+            email_normalize("j.o.h.n@googlemail.com"),
+            "john@googlemail.com"
+        );
+        assert_eq!(email_normalize(""), "");
+        assert_eq!(email_normalize("  "), "  ");
+    }
+
+    #[test]
+    fn extract_domain() {
+        assert_eq!(
+            email_extract_domain("x@Foo.COM"),
+            Some("foo.com".to_string())
+        );
+        assert_eq!(email_extract_domain("noat"), None);
+        assert_eq!(email_extract_domain("trailing@"), None);
+        assert_eq!(email_extract_domain("a@b@c.com"), Some("c.com".to_string()));
+    }
+
+    #[test]
+    fn validate() {
+        assert_eq!(email_validate("a@b.co"), Some(true));
+        assert_eq!(email_validate("a@b"), Some(false));
+        assert_eq!(email_validate("a b@c.com"), Some(false));
+        assert_eq!(email_validate("a@@b.com"), Some(false));
+        assert_eq!(email_validate(""), Some(false));
+        assert_eq!(email_validate("   "), Some(false));
+        assert_eq!(email_validate("@no-local.com"), Some(false));
+        assert_eq!(email_validate("no-domain@"), Some(false));
+        assert_eq!(email_validate("valid@example.com"), Some(true));
+        assert_eq!(
+            email_validate("also.valid+tag@sub.example.co.uk"),
+            Some(true)
+        );
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! surface (`goldenflow-wasm`) are thin marshaling shims over these functions.
 //! The pure-Python / pure-TS transform paths are non-authoritative fallbacks
 //! that must reproduce these bytes (asserted by the byte-parity harness).
+pub mod email;
 pub mod identifiers;
 pub mod names;
 pub mod phone;

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -12,9 +12,30 @@
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
+    use goldenflow_core::email;
     use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
     use goldenflow_core::names;
     use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    pub fn email_lowercase(s: &str) -> String {
+        email::email_lowercase(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn email_normalize(s: &str) -> String {
+        email::email_normalize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn email_extract_domain(s: &str) -> Option<String> {
+        email::email_extract_domain(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn email_validate(s: &str) -> Option<bool> {
+        email::email_validate(s)
+    }
 
     #[wasm_bindgen]
     pub fn cc_validate(s: &str) -> bool {

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.4.0"
+version = "0.5.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.4.0"
+    __version__ = "0.5.0"

--- a/packages/rust/extensions/native-flow/src/email.rs
+++ b/packages/rust/extensions/native-flow/src/email.rs
@@ -1,0 +1,51 @@
+//! Arrow shims over goldenflow_core::email. Bytes in, kernel per element,
+//! bytes out; GIL released. All logic lives in the core.
+use crate::util::{map_str_to_bool, map_str_to_str};
+use arrow::array::ArrayData;
+use arrow::pyarrow::PyArrowType;
+use goldenflow_core::email;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn email_lowercase_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(email::email_lowercase(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn email_normalize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(email::email_normalize(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn email_extract_domain_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(
+        py,
+        array.0,
+        email::email_extract_domain,
+    )?))
+}
+
+#[pyfunction]
+pub fn email_validate_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_bool(
+        py,
+        array.0,
+        email::email_validate,
+    )?))
+}

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -11,6 +11,7 @@
 
 use pyo3::prelude::*;
 
+mod email;
 mod identifiers;
 mod names;
 mod phone;
@@ -19,6 +20,10 @@ mod util;
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_function(wrap_pyfunction!(email::email_lowercase_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(email::email_normalize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(email::email_extract_domain_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(email::email_validate_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(phone::phone_e164_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(phone::phone_national_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(phone::phone_country_code_arrow, m)?)?;

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/core/transforms/email.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/email.ts
@@ -1,101 +1,223 @@
 /**
  * Email transforms — ported from goldenflow/transforms/email.py
  * Side-effect module: registers 4 email transforms on import.
+ *
+ * Owned-kernel family (D1 wave): each transform is a byte-for-byte port of
+ * the Python pure-TS reference (`_email_lowercase_py` et al. in
+ * `goldenflow/transforms/email.py`), which is itself proven byte-identical
+ * to the Rust `goldenflow-core::email` kernels (parity corpus in
+ * `tests/parity/identifiers_corpus.jsonl`). Each transform dispatches to the
+ * opt-in WASM backend (`FlowWasmBackend`, a thin wasm-bindgen shim over the
+ * SAME Rust kernel) when `enableWasm()` has succeeded; otherwise it runs the
+ * pure-TS implementation below. Pure-TS is the default.
  */
 
 import type { ColumnValue } from "../types.js";
 import { registerTransform } from "./registry.js";
+import { getFlowWasmBackend, type FlowWasmBackend } from "../wasm/backend.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Simple but practical email regex (RFC 5321 simplified). */
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-/** Gmail-like domains where dots in the local part are ignored. */
-const GMAIL_DOMAINS = new Set(["gmail.com", "googlemail.com"]);
-
-// ---------------------------------------------------------------------------
-// email_lowercase (55, email|string)
-// ---------------------------------------------------------------------------
-
-function emailLowercase(values: readonly ColumnValue[]): ColumnValue[] {
+/** Map a string column through a string-returning fn; nulls and non-strings
+ * pass through unchanged (mirrors polars `map_elements` on an Optional[str]
+ * input -- `None` in, `None` out). */
+function mapStrings(
+  values: readonly ColumnValue[],
+  fn: (s: string) => string,
+): ColumnValue[] {
   return values.map((v) => {
     if (v === null || typeof v !== "string") return v;
-    return v.toLowerCase();
+    return fn(v);
   });
 }
 
+/** Map a string column through a boolean-returning fn; nulls and non-strings
+ * pass through unchanged. */
+function mapToBool(
+  values: readonly ColumnValue[],
+  fn: (s: string) => boolean,
+): ColumnValue[] {
+  return values.map((v) => {
+    if (v === null || typeof v !== "string") return v;
+    return fn(v);
+  });
+}
+
+/** Map a string column through a fn returning `string | undefined` (the Rust
+ * `Option<String>` -- `undefined` mirrors `None`); nulls and non-strings pass
+ * through unchanged, `undefined` maps to `null` in the output column. */
+function mapToStringOrNull(
+  values: readonly ColumnValue[],
+  fn: (s: string) => string | undefined,
+): ColumnValue[] {
+  return values.map((v) => {
+    if (v === null || typeof v !== "string") return v;
+    const r = fn(v);
+    return r === undefined ? null : r;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// email_lowercase (series, email|string, 55)
+//
+// Pure-TS reference for goldenflow-core's `email::email_lowercase` kernel.
+// Trim + lowercase the whole address. No invalid-input case.
+// ---------------------------------------------------------------------------
+
+function emailLowercaseTs(val: string): string {
+  return val.trim().toLowerCase();
+}
+
+function emailLowercase(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.emailLowercase(s) : emailLowercaseTs);
+}
+
 registerTransform(
-  { name: "email_lowercase", inputTypes: ["email", "string"], priority: 55, mode: "series" },
+  {
+    name: "email_lowercase",
+    inputTypes: ["email", "string"],
+    autoApply: false,
+    priority: 55,
+    mode: "series",
+  },
   emailLowercase,
 );
 
 // ---------------------------------------------------------------------------
-// email_normalize (50, email)
+// email_normalize (series, email, 50)
+//
+// Pure-TS reference for goldenflow-core's `email::email_normalize` kernel.
+// Lowercase, strip a `+tag` from the local part, and strip dots from the
+// local part for Gmail/Googlemail domains. Preserves the ORIGINAL input
+// verbatim when the trimmed + lowercased value is empty or has no `@`.
 // ---------------------------------------------------------------------------
 
+function emailNormalizeTs(val: string): string {
+  const original = val;
+  const v = val.trim().toLowerCase();
+  if (v === "" || !v.includes("@")) return original;
+  const atIdx = v.lastIndexOf("@"); // rsplit("@", 1)
+  let local = v.slice(0, atIdx);
+  const domain = v.slice(atIdx + 1);
+  local = local.split("+")[0] ?? "";
+  if (domain === "gmail.com" || domain === "googlemail.com") {
+    local = local.replace(/\./g, "");
+  }
+  return `${local}@${domain}`;
+}
+
 function emailNormalize(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null || typeof v !== "string") return v;
-    const lowered = v.toLowerCase().trim();
-    const atIdx = lowered.lastIndexOf("@");
-    if (atIdx === -1) return lowered;
-
-    let local = lowered.slice(0, atIdx);
-    const domain = lowered.slice(atIdx + 1);
-
-    // Strip +tags (e.g. user+tag@gmail.com -> user@gmail.com)
-    const plusIdx = local.indexOf("+");
-    if (plusIdx !== -1) {
-      local = local.slice(0, plusIdx);
-    }
-
-    // Strip dots for Gmail-like domains
-    if (GMAIL_DOMAINS.has(domain)) {
-      local = local.replace(/\./g, "");
-    }
-
-    return `${local}@${domain}`;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.emailNormalize(s) : emailNormalizeTs);
 }
 
 registerTransform(
-  { name: "email_normalize", inputTypes: ["email"], priority: 50, mode: "series" },
+  {
+    name: "email_normalize",
+    inputTypes: ["email"],
+    autoApply: false,
+    priority: 50,
+    mode: "series",
+  },
   emailNormalize,
 );
 
 // ---------------------------------------------------------------------------
-// email_extract_domain (40, email)
+// email_extract_domain (series, email, 40)
+//
+// Pure-TS reference for goldenflow-core's `email::email_extract_domain`
+// kernel. Lowercased domain after the LAST `@`; `undefined` (-> null) if
+// there is no `@`, or nothing follows it.
 // ---------------------------------------------------------------------------
 
+function emailExtractDomainTs(val: string): string | undefined {
+  const v = val.trim();
+  const idx = v.lastIndexOf("@");
+  if (idx === -1) return undefined;
+  const domain = v.slice(idx + 1);
+  if (domain === "") return undefined;
+  return domain.toLowerCase();
+}
+
 function emailExtractDomain(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null || typeof v !== "string") return v;
-    const atIdx = v.lastIndexOf("@");
-    if (atIdx === -1) return null;
-    return v.slice(atIdx + 1).toLowerCase();
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapToStringOrNull(
+    values,
+    backend ? (s) => backend.emailExtractDomain(s) : emailExtractDomainTs,
+  );
 }
 
 registerTransform(
-  { name: "email_extract_domain", inputTypes: ["email"], priority: 40, mode: "series" },
+  {
+    name: "email_extract_domain",
+    inputTypes: ["email"],
+    autoApply: false,
+    priority: 40,
+    mode: "series",
+  },
   emailExtractDomain,
 );
 
 // ---------------------------------------------------------------------------
-// email_validate (60, email|string)
+// email_validate (series, email|string, 60)
+//
+// Pure-TS reference for goldenflow-core's `email::email_validate` kernel.
+// Hand-rolled equivalent of `^[^@\s]+@[^@\s]+\.[^@\s]+$` (deliberately no
+// regex, mirroring the identifier kernels' no-regex parity policy): exactly
+// one `@`; a non-empty, whitespace-free local part; a non-empty,
+// whitespace-free domain part containing a `.` that is neither the first nor
+// the last character. Empty (after trim) input is `false`.
 // ---------------------------------------------------------------------------
 
+function hasWhitespace(s: string): boolean {
+  for (const c of s) {
+    if (/\s/.test(c)) return true;
+  }
+  return false;
+}
+
+function emailValidateTs(val: string): boolean {
+  const t = val.trim();
+  if (t === "") return false;
+  const atCount = t.split("@").length - 1;
+  if (atCount !== 1) return false;
+  const idx = t.indexOf("@");
+  const local = t.slice(0, idx);
+  const domain = t.slice(idx + 1);
+  if (local === "" || hasWhitespace(local)) return false;
+  if (domain === "" || hasWhitespace(domain)) return false;
+  for (let i = 0; i < domain.length; i++) {
+    if (domain[i] === "." && i !== 0 && i !== domain.length - 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function emailValidate(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null || typeof v !== "string") return v;
-    return EMAIL_RE.test(v.trim());
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapToBool(values, backend ? (s) => backend.emailValidate(s) : emailValidateTs);
 }
 
 registerTransform(
-  { name: "email_validate", inputTypes: ["email", "string"], priority: 60, mode: "series" },
+  {
+    name: "email_validate",
+    inputTypes: ["email", "string"],
+    autoApply: false,
+    priority: 60,
+    mode: "series",
+  },
   emailValidate,
 );
+
+// ---------------------------------------------------------------------------
+// Pure-TS single-value exports (cross-surface byte-parity harness)
+//
+// Bypass the wasm-dispatch wrappers above so a parity test can assert the
+// pure-TS path independently of whatever backend is currently registered.
+// ---------------------------------------------------------------------------
+
+export { emailLowercaseTs, emailNormalizeTs, emailExtractDomainTs, emailValidateTs };

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -3,8 +3,9 @@
  * node:* here.
  *
  * The active backend (if any) is consulted by the identifier transforms
- * (cc/iban/isbn/ean/vat/swift/aba/imei) for the 14 covered functions, plus
- * the i18n-name transforms (name_transliterate/name_script); everything
+ * (cc/iban/isbn/ean/vat/swift/aba/imei) for the 14 covered functions, the
+ * i18n-name transforms (name_transliterate/name_script), and the email
+ * transforms (email_lowercase/normalize/extract_domain/validate); everything
  * else stays pure-TS. Mirrors goldenmatch's `setScorerBackend(null)`
  * module-singleton pattern for test isolation.
  */
@@ -36,6 +37,10 @@ export interface FlowWasmBackend {
   imeiValidate(s: string): boolean;
   nameTransliterate(s: string): string;
   nameScript(s: string): string;
+  emailLowercase(s: string): string;
+  emailNormalize(s: string): string;
+  emailExtractDomain(s: string): string | undefined;
+  emailValidate(s: string): boolean;
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -57,6 +57,10 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     imei_validate: (s: string) => boolean;
     name_transliterate: (s: string) => string;
     name_script: (s: string) => string;
+    email_lowercase: (s: string) => string;
+    email_normalize: (s: string) => string;
+    email_extract_domain: (s: string) => string | undefined;
+    email_validate: (s: string) => boolean | undefined;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -77,5 +81,9 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     imeiValidate: (s) => glue.imei_validate(s),
     nameTransliterate: (s) => glue.name_transliterate(s),
     nameScript: (s) => glue.name_script(s),
+    emailLowercase: (s) => glue.email_lowercase(s),
+    emailNormalize: (s) => glue.email_normalize(s),
+    emailExtractDomain: (s) => glue.email_extract_domain(s),
+    emailValidate: (s) => glue.email_validate(s) ?? false,
   };
 }

--- a/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
@@ -37,6 +37,12 @@ import {
   imeiValidateTs,
 } from "../../src/core/transforms/identifiers.js";
 import { nameTransliterateTs, nameScriptTs } from "../../src/core/transforms/names.js";
+import {
+  emailLowercaseTs,
+  emailNormalizeTs,
+  emailExtractDomainTs,
+  emailValidateTs,
+} from "../../src/core/transforms/email.js";
 import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
 import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
 
@@ -73,6 +79,10 @@ const PURE_TS_FN: Record<string, (s: string) => boolean | string | undefined> = 
   imei_validate: imeiValidateTs,
   name_transliterate: nameTransliterateTs,
   name_script: nameScriptTs,
+  email_lowercase: emailLowercaseTs,
+  email_normalize: emailNormalizeTs,
+  email_extract_domain: emailExtractDomainTs,
+  email_validate: emailValidateTs,
 };
 
 /** Same transform set, dispatched through the wasm backend's method of the
@@ -96,6 +106,10 @@ function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boo
     imei_validate: (s) => backend.imeiValidate(s),
     name_transliterate: (s) => backend.nameTransliterate(s),
     name_script: (s) => backend.nameScript(s),
+    email_lowercase: (s) => backend.emailLowercase(s),
+    email_normalize: (s) => backend.emailNormalize(s),
+    email_extract_domain: (s) => backend.emailExtractDomain(s),
+    email_validate: (s) => backend.emailValidate(s),
   };
   const fn = map[transform];
   if (!fn) throw new Error(`no wasm dispatch for transform ${transform}`);

--- a/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -168,3 +168,35 @@
 {"transform": "name_script", "input": "123", "expected": "Common"}
 {"transform": "name_script", "input": "", "expected": "Unknown"}
 {"transform": "name_script", "input": null, "expected": null}
+{"transform": "email_lowercase", "input": " John@X.COM ", "expected": "john@x.com"}
+{"transform": "email_lowercase", "input": "A@B.com", "expected": "a@b.com"}
+{"transform": "email_lowercase", "input": "ADMIN@EXAMPLE.COM", "expected": "admin@example.com"}
+{"transform": "email_lowercase", "input": "", "expected": ""}
+{"transform": "email_lowercase", "input": null, "expected": null}
+{"transform": "email_normalize", "input": "John.Doe+tag@Gmail.com", "expected": "johndoe@gmail.com"}
+{"transform": "email_normalize", "input": "a+b@x.com", "expected": "a@x.com"}
+{"transform": "email_normalize", "input": "notanemail", "expected": "notanemail"}
+{"transform": "email_normalize", "input": "A@B.com", "expected": "a@b.com"}
+{"transform": "email_normalize", "input": "j.o.h.n@googlemail.com", "expected": "john@googlemail.com"}
+{"transform": "email_normalize", "input": "user+spam@example.com", "expected": "user@example.com"}
+{"transform": "email_normalize", "input": "", "expected": ""}
+{"transform": "email_normalize", "input": "   ", "expected": "   "}
+{"transform": "email_normalize", "input": null, "expected": null}
+{"transform": "email_extract_domain", "input": "x@Foo.COM", "expected": "foo.com"}
+{"transform": "email_extract_domain", "input": "noat", "expected": null}
+{"transform": "email_extract_domain", "input": "trailing@", "expected": null}
+{"transform": "email_extract_domain", "input": "admin@sub.domain.org", "expected": "sub.domain.org"}
+{"transform": "email_extract_domain", "input": "a@b@c.com", "expected": "c.com"}
+{"transform": "email_extract_domain", "input": "", "expected": null}
+{"transform": "email_extract_domain", "input": null, "expected": null}
+{"transform": "email_validate", "input": "a@b.co", "expected": true}
+{"transform": "email_validate", "input": "valid@example.com", "expected": true}
+{"transform": "email_validate", "input": "also.valid+tag@sub.example.co.uk", "expected": true}
+{"transform": "email_validate", "input": "a@b", "expected": false}
+{"transform": "email_validate", "input": "a b@c.com", "expected": false}
+{"transform": "email_validate", "input": "a@@b.com", "expected": false}
+{"transform": "email_validate", "input": "@no-local.com", "expected": false}
+{"transform": "email_validate", "input": "no-domain@", "expected": false}
+{"transform": "email_validate", "input": "", "expected": false}
+{"transform": "email_validate", "input": "   ", "expected": false}
+{"transform": "email_validate", "input": null, "expected": null}


### PR DESCRIPTION
## What

Wave D1 (first family of the full owned-kernel sweep): the **email** transform family — `email_lowercase`, `email_normalize`, `email_extract_domain`, `email_validate` — now computed by owned `goldenflow-core` kernels, byte-identical across native / WASM-TS / pure-Python.

- Logic ported to `goldenflow-core/src/email.rs` (validate hand-rolls `^[^@\s]+@[^@\s]+\.[^@\s]+$` — no regex dep, parity-safe). Arrow shims + wasm exports + Python/TS dispatch (native-first, existing pure-Python/TS as the byte-matched fallback).
- `email_lowercase`/`email_extract_domain` moved from vectorized Polars-expr to native-first dispatch (the "kernels I control, not Polars" posture) — outputs unchanged for well-formed inputs; the reference is the Rust kernel, corpus-enforced across all three surfaces.
- No new transforms (migration, not addition) → transform count unchanged (92). Versions goldenflow 1.7.0 / npm 0.7.0 / native 0.5.0.

## Verification

33 Rust unit tests + 222 Python parity/unit tests green; clippy/fmt clean; wasm32 builds. TS logic verified line-by-line vs Python (normalize preserve-original + gmail dot-strip, hand-rolled validate); corpus `cmp` IDENTICAL (202 rows). TS typecheck/parity run in CI.

## Sweep sequence

D1 email → D2 url → D3 text → D4 numeric → D5 categorical → D6 names-remainder → D7 address (simple, US) → D8 dates (separate spike, measure chrono-vs-dateutil parity first). i18n addresses (Wave C) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)