### PR TITLE
feat(goldenpipe): goldenpipe-native binding + pure==core parity gate (SP2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
       goldenprofile_native: ${{ steps.filter.outputs.goldenprofile_native }}
       analysis_native: ${{ steps.filter.outputs.analysis_native }}
       native_flow: ${{ steps.filter.outputs.native_flow }}
+      goldenpipe_native: ${{ steps.filter.outputs.goldenpipe_native }}
       goldenembed: ${{ steps.filter.outputs.goldenembed }}
       embed: ${{ steps.filter.outputs.embed }}
       goldenhnsw: ${{ steps.filter.outputs.goldenhnsw }}
@@ -517,6 +518,15 @@ jobs:
               - 'packages/python/goldenflow/tests/transforms/test_native_parity.py'
               - 'packages/python/goldenflow/tests/transforms/test_fastpath_parity.py'
               - 'packages/python/goldenflow/scripts/build_native.py'
+            goldenpipe_native:
+              # GoldenPipe planner kernel: the pyo3-free goldenpipe-core is the
+              # REFERENCE; this lane builds the goldenpipe-native abi3 wheel and
+              # runs the pure-Python==core parity gate (Leg A) + wheel==core (Leg B)
+              # under GOLDENPIPE_NATIVE=1. This is also goldenpipe-core's ONLY CI
+              # coverage (it had no consumer to hang a lane on before SP2).
+              - 'packages/rust/extensions/goldenpipe-core/**'
+              - 'packages/rust/extensions/goldenpipe-native/**'
+              - 'packages/python/goldenpipe/**'
             goldenembed:
               # Standalone Rust embedding runtime (char n-gram featurize + ONNX
               # inference via ort). Own workspace, not in the `rust` job's
@@ -2265,6 +2275,49 @@ jobs:
             packages/python/goldenflow/tests/transforms/test_phone.py \
             packages/python/goldenflow/tests/transforms/test_dates.py \
             -v
+
+  # goldenpipe planner kernel: pyo3-free goldenpipe-core is the REFERENCE. This lane
+  # is goldenpipe-core's ONLY CI coverage (it had no consumer to hang a lane on before
+  # SP2), and it runs the pure-Python==core parity gate (Leg A) + wheel==core (Leg B)
+  # under GOLDENPIPE_NATIVE=1. Parity-gate-only: the pure-Python planner stays the
+  # runtime; the core is the oracle it's proven against.
+  goldenpipe_native:
+    needs: changes
+    if: needs.changes.outputs.goldenpipe_native == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: |
+            packages/rust/extensions/goldenpipe-core
+            packages/rust/extensions/goldenpipe-native
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: fmt + clippy (goldenpipe-core + goldenpipe-native)
+        run: |
+          cargo fmt --check --manifest-path packages/rust/extensions/goldenpipe-core/Cargo.toml
+          cargo clippy --release --manifest-path packages/rust/extensions/goldenpipe-core/Cargo.toml -- -D warnings
+          cargo fmt --check --manifest-path packages/rust/extensions/goldenpipe-native/Cargo.toml
+          cargo clippy --release --manifest-path packages/rust/extensions/goldenpipe-native/Cargo.toml -- -D warnings
+      - name: goldenpipe-core unit + golden-vector tests (the SP1 kernel's CI home)
+        run: cargo test --manifest-path packages/rust/extensions/goldenpipe-core/Cargo.toml
+      - name: Build the native planner ext into the package (goldenpipe._native)
+        run: uv run python packages/python/goldenpipe/scripts/build_native.py
+      - name: Parity gate (Leg A pure==core + Leg B wheel==core)
+        env:
+          GOLDENPIPE_NATIVE: "1"
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: uv run pytest packages/python/goldenpipe/tests/core/ -v
 
   # goldenflow-native distribution smoke: build the SEPARATE maturin/abi3 wheel
   # and prove the runtime loads through the wheel path. Distinct from

--- a/docs/superpowers/plans/2026-07-04-goldenpipe-native-binding.md
+++ b/docs/superpowers/plans/2026-07-04-goldenpipe-native-binding.md
@@ -1,0 +1,633 @@
+# goldenpipe-native binding + parity gate (SP2) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `goldenpipe-native` abi3 wheel over the SP1 `goldenpipe-core` planner + a reference-mode loader, and make the core the Python REFERENCE via a pure-Python==core parity gate (the pure-Python planner stays the runtime — parity-gate-only).
+
+**Architecture:** Mirror goldenflow Wave 0a (#1405). A tiny pyo3 crate wraps the core's five `*_json` fns. A `_planner_json.py` helper puts the REAL pure-Python planner behind the same JSON interface so a parity test can replay the SP1 golden vectors through both and assert equal. No runtime routing; one additive `WiringError` change.
+
+**Tech Stack:** Rust (pyo3 abi3-py311, edition 2021), Python 3.11+ (pydantic, polars), maturin, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-04-goldenpipe-native-binding-design.md`
+
+---
+
+## Ground truth (confirmed by reading the code)
+
+- `resolver.py`: `WiringError(Exception)` is plain (no attrs). `PlannedStage{name, stage, spec: StageSpec, config: dict}`. `ExecutionPlan{stages: [PlannedStage]}`. Resolver auto-prepends load via `try: registry.get("load") except KeyError`. Serialize a PlannedStage → core `PlannedSpec`: `{name: p.name, use: p.spec.use, config: p.config, on_error: p.spec.on_error}` (+ `skip_if` iff `p.spec.skip_if` is set). `on_error` is already the string `"continue"`/`"abort"` (a `Literal`).
+- `registry.py`: `StageRegistry._stages: dict` keyed by `info.name` via `register()`. `get(name)` → `KeyError`. `list_all()` → `{name: StageInfo}`. NO `has()` method. To key by a `key != info.name` (SP1's `key` field), write `_stages[key] = stub` DIRECTLY.
+- `pipeline.py`: `Pipeline(config=None, registry=None, identity_opts=None)`; passing a non-None `registry` SKIPS `discover()`. `_auto_config(self)` reads `self._registry.list_all()` + `self._identity_opts` (an instance method — construct a stub-registry Pipeline).
+- `decisions.py`: three free fns `severity_gate`/`pii_router`/`row_count_gate(ctx) -> Decision|None`. No dispatch/unknown handling (the helper adds the name table + unknown→None).
+- SP1 golden vectors (the shared truth, already on main): `packages/rust/extensions/goldenpipe-core/tests/vectors/{resolve,apply_decision,evaluate_builtin,auto_config,skip_if}.json`, arrays of `{input, expected}` (some carry a `comment` the harness ignores).
+- Core JSON shapes (from SP1): PlannedSpec `{name,use,config,on_error}` (+skip_if if Some); Decision `{skip,abort,insert,reason}`; StageSpec `{use,needs,on_error,config}` (+name,skip_if if Some); PlanError `{kind:"wiring"|"unknown_stage",...}`; resolve envelope `{"ok":...}|{"err":...}`; evaluate None → JSON `null`.
+- Mirror targets: `packages/rust/extensions/native-flow/{Cargo.toml,src/lib.rs,pyproject.toml}`, `packages/python/goldenflow/goldenflow/core/_native_loader.py`, `.../scripts/build_native.py`, `tests/core/test_native_loader.py`.
+- `packages/python/goldenpipe/tests/` exists; NO `tests/core/` yet (create it). `goldenpipe/goldenpipe/core/` does NOT exist (create it + `__init__.py`).
+
+## File structure
+
+- Create `packages/rust/extensions/goldenpipe-native/{Cargo.toml, src/lib.rs, pyproject.toml}`
+- Create `packages/python/goldenpipe/goldenpipe/core/__init__.py`, `.../core/_native_loader.py`, `.../core/_planner_json.py`
+- Modify `packages/python/goldenpipe/goldenpipe/engine/resolver.py` (additive `WiringError` attrs)
+- Create `packages/python/goldenpipe/tests/core/__init__.py` (if the test dir needs it), `.../tests/core/test_native_loader.py`, `.../tests/core/test_planner_parity.py`
+- Create `packages/python/goldenpipe/scripts/build_native.py`
+- Modify `.github/workflows/ci.yml` (parity lane + paths-filter — Task 8)
+
+## Box runners
+
+Python (box-safe):
+```
+cd packages/python/goldenpipe
+POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 GOLDENPIPE_NATIVE=0 \
+  /d/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/core/ -q
+```
+(`POLARS_SKIP_CPU_CHECK=1` — goldenpipe imports polars via pipeline.py. `GOLDENPIPE_NATIVE=0` keeps Leg B skipped locally unless the wheel is present.)
+Rust wheel (box BEST-EFFORT, do NOT block SP2):
+```
+cd packages/rust/extensions/goldenpipe-native
+export PATH="/d/.rustup/toolchains/1.94.0-x86_64-pc-windows-msvc/bin:$PATH" CARGO_HOME=/d/.cargo
+maturin build   # or: /d/show_case/goldenmatch/.venv/Scripts/python.exe ../../../packages/python/goldenpipe/scripts/build_native.py
+```
+Reference skills: @superpowers:test-driven-development, @superpowers:subagent-driven-development. Auth: benzsevern (`unset GH_TOKEN` before push).
+
+---
+
+## Task 1: `goldenpipe-native` crate (the pyo3 shim over the core)
+
+**Files:** Create `packages/rust/extensions/goldenpipe-native/{Cargo.toml, src/lib.rs, pyproject.toml}`
+
+- [ ] **Step 1: `Cargo.toml`**
+
+```toml
+# Standalone workspace (empty [workspace]) so pyo3's `extension-module` feature isn't
+# unified with any sibling crate's features. Mirrors native-flow / goldenmatch's native.
+[workspace]
+
+[package]
+name = "goldenpipe-native"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Native binding for the GoldenPipe planner kernel (PyO3 extension module over goldenpipe-core)"
+
+[lib]
+# Produces _native.{so,dll,dylib}; the #[pymodule] is `_native` -> init PyInit__native.
+name = "_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+# abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
+# extension-module: don't link libpython (imported BY CPython).
+pyo3 = { version = ">=0.28, <0.29", features = ["extension-module", "abi3-py311"] }
+# The core is the single source of truth; this crate is a pure JSON-string marshaling
+# shim. No arrow (the planner is JSON, not columnar).
+goldenpipe-core = { path = "../goldenpipe-core" }
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+```
+
+- [ ] **Step 2: `src/lib.rs`**
+
+```rust
+//! `goldenpipe._native` / `goldenpipe_native._native` — the PyO3 binding for the
+//! GoldenPipe planner kernel. Pure marshaling shim: `&str` in -> goldenpipe-core
+//! json fn -> `String` out. The core owns all logic; the pure-Python planner is a
+//! non-authoritative fallback proven to reproduce these bytes (SP2 parity gate).
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn resolve_json(input: &str) -> String {
+    goldenpipe_core::json::resolve_json(input)
+}
+#[pyfunction]
+fn apply_decision_json(input: &str) -> String {
+    goldenpipe_core::json::apply_decision_json(input)
+}
+#[pyfunction]
+fn evaluate_builtin_json(input: &str) -> String {
+    goldenpipe_core::json::evaluate_builtin_json(input)
+}
+#[pyfunction]
+fn auto_config_json(input: &str) -> String {
+    goldenpipe_core::json::auto_config_json(input)
+}
+#[pyfunction]
+fn skip_if_falsy_json(input: &str) -> String {
+    goldenpipe_core::json::skip_if_falsy_json(input)
+}
+
+#[pymodule]
+fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_function(wrap_pyfunction!(resolve_json, m)?)?;
+    m.add_function(wrap_pyfunction!(apply_decision_json, m)?)?;
+    m.add_function(wrap_pyfunction!(evaluate_builtin_json, m)?)?;
+    m.add_function(wrap_pyfunction!(auto_config_json, m)?)?;
+    m.add_function(wrap_pyfunction!(skip_if_falsy_json, m)?)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 3: `pyproject.toml`** (mirror native-flow; separate `goldenpipe-native` wheel)
+
+```toml
+# goldenpipe-native — optional native binding for the GoldenPipe planner, shipped as a
+# SEPARATE maturin/abi3 package (mirrors goldenflow-native). `goldenpipe` stays pure
+# Python; `pip install goldenpipe[native]` pulls this; goldenpipe.core._native_loader
+# discovers it. Note: this exposes the core as the REFERENCE; it does not accelerate.
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "goldenpipe-native"
+version = "0.1.0"
+description = "Native binding (Rust/PyO3) for the goldenpipe planner kernel"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Ben Severn", email = "ben@bensevern.dev" }]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
+]
+
+[project.urls]
+Homepage = "https://github.com/benseverndev-oss/goldenmatch"
+
+[tool.maturin]
+python-source = "python"
+module-name = "goldenpipe_native._native"
+```
+Also create `packages/rust/extensions/goldenpipe-native/python/goldenpipe_native/__init__.py` (empty) and a one-line `README.md` so maturin's mixed layout resolves (mirror native-flow's `python/goldenflow_native/`).
+
+- [ ] **Step 4: Verify it compiles** (box best-effort):
+```
+cd packages/rust/extensions/goldenpipe-native && export PATH="/d/.rustup/toolchains/1.94.0-x86_64-pc-windows-msvc/bin:$PATH" CARGO_HOME=/d/.cargo
+maturin build 2>&1 | tail -5
+```
+Expected: a wheel builds (goldenpipe-native has only pyo3 + the serde-only core; no ort/arrow, so it should link on Windows/NTFS unlike goldenmatch-native). **If maturin/linking fails locally, SKIP** — the crate is validated in CI (Task 8); do NOT block SP2. `cargo build` alone may complain about linking libpython under `extension-module`; prefer `maturin build`.
+
+- [ ] **Step 5: Commit** `feat(goldenpipe-native): pyo3 binding crate over goldenpipe-core`
+
+---
+
+## Task 2: `_native_loader.py` + `core/` package + loader tests
+
+**Files:**
+- Create: `packages/python/goldenpipe/goldenpipe/core/__init__.py` (empty), `.../core/_native_loader.py`
+- Create: `packages/python/goldenpipe/tests/core/__init__.py` (empty), `.../tests/core/test_native_loader.py`
+
+- [ ] **Step 1: Write the failing loader tests** (`tests/core/test_native_loader.py`, mirror goldenflow's)
+
+```python
+from goldenpipe.core import _native_loader as L
+
+
+def test_planner_enabled_when_symbol_present(monkeypatch):
+    class FakeNative:
+        def resolve_json(self, s): ...
+    monkeypatch.setenv("GOLDENPIPE_NATIVE", "auto")
+    monkeypatch.setattr(L, "_native", FakeNative())
+    assert L.native_enabled("planner") is True
+
+
+def test_force_off(monkeypatch):
+    monkeypatch.setenv("GOLDENPIPE_NATIVE", "0")
+    monkeypatch.setattr(L, "_native", object())
+    assert L.native_enabled("planner") is False
+
+
+def test_require_raises_when_absent(monkeypatch):
+    monkeypatch.setenv("GOLDENPIPE_NATIVE", "1")
+    monkeypatch.setattr(L, "_native", None)
+    import pytest
+    with pytest.raises(RuntimeError):
+        L.native_enabled("planner")
+
+
+def test_auto_disabled_when_symbol_missing(monkeypatch):
+    class Bare:  # native present but no resolve_json symbol
+        pass
+    monkeypatch.setenv("GOLDENPIPE_NATIVE", "auto")
+    monkeypatch.setattr(L, "_native", Bare())
+    assert L.native_enabled("planner") is False
+```
+
+- [ ] **Step 2: Run** the box runner on `tests/core/test_native_loader.py` — FAIL (module missing).
+
+- [ ] **Step 3: Implement `_native_loader.py`** (mirror goldenflow, trimmed — one component `planner`, no `_FALLBACK_ONLY`)
+
+```python
+"""Loader + gate for the optional ``goldenpipe._native`` binding.
+
+Mirrors ``goldenflow.core._native_loader``. The binding (Rust/PyO3, built from
+``packages/rust/extensions/goldenpipe-native``) exposes ``goldenpipe-core`` — the
+REFERENCE planner kernel — to Python. It is NOT a runtime accelerator: the
+pure-Python planner stays the runtime; this loader exists so the parity gate can
+reach the kernel (and so a future reference-mode flip has the seam ready).
+
+``GOLDENPIPE_NATIVE`` env:
+- ``"0"``   -> force pure (never use native).
+- ``"1"``   -> require native; raise if not importable (the CI parity lane).
+- ``"auto"`` / unset -> native available iff the floor symbol exists. Default.
+
+Reachable two ways, tried in order (like goldenflow/goldenmatch):
+  1. ``goldenpipe._native``        — in-tree build (scripts/build_native.py).
+  2. ``goldenpipe_native._native`` — the separate ``goldenpipe-native`` abi3 wheel.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    import goldenpipe._native as _native  # type: ignore[import-not-found]
+except Exception:  # noqa: BLE001 - any import/load failure falls back below
+    try:
+        from goldenpipe_native import _native  # type: ignore[import-not-found]
+    except Exception:  # noqa: BLE001 - neither path available -> pure Python
+        _native = None
+
+# Floor symbols per component (wheel-skew safe: probe the actual module).
+_COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
+    "planner": ("resolve_json",),
+}
+
+
+def _has_symbol(component: str) -> bool:
+    if _native is None:
+        return False
+    syms = _COMPONENT_SYMBOLS.get(component)
+    if not syms:
+        return False
+    return any(hasattr(_native, s) for s in syms)
+
+
+def native_module() -> Any:
+    """The imported native module, or ``None``. Guard with ``native_enabled`` first."""
+    return _native
+
+
+def native_available() -> bool:
+    return _native is not None
+
+
+def native_enabled(component: str) -> bool:
+    mode = os.environ.get("GOLDENPIPE_NATIVE", "auto").lower()
+    if mode == "0":
+        return False
+    if mode == "1":
+        if _native is None:
+            raise RuntimeError(
+                "GOLDENPIPE_NATIVE=1 but goldenpipe._native is not built/importable"
+            )
+        return True
+    return _native is not None and _has_symbol(component)
+
+
+# Thin pass-throughs the parity test's Leg B calls (guard with native_enabled first).
+def resolve_json(input: str) -> str:
+    return _native.resolve_json(input)
+
+
+def apply_decision_json(input: str) -> str:
+    return _native.apply_decision_json(input)
+
+
+def evaluate_builtin_json(input: str) -> str:
+    return _native.evaluate_builtin_json(input)
+
+
+def auto_config_json(input: str) -> str:
+    return _native.auto_config_json(input)
+
+
+def skip_if_falsy_json(input: str) -> str:
+    return _native.skip_if_falsy_json(input)
+```
+
+- [ ] **Step 4: Run** the loader tests — 4 PASS.
+- [ ] **Step 5: Commit** `feat(goldenpipe): native-loader reference-mode gate (mirror goldenflow)`
+
+---
+
+## Task 3: `WiringError` structured attrs (additive)
+
+**Files:** Modify `packages/python/goldenpipe/goldenpipe/engine/resolver.py`
+- Test: `packages/python/goldenpipe/tests/core/test_wiring_error_attrs.py` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from goldenpipe.engine.resolver import WiringError
+
+
+def test_wiring_error_is_additive():
+    # legacy raise (message only) still works
+    e0 = WiringError("some message")
+    assert str(e0) == "some message"
+    assert e0.stage is None and e0.missing is None and e0.available is None
+    # structured raise carries attrs, message preserved
+    e1 = WiringError("msg", stage="s", missing="df", available=["a", "b"])
+    assert str(e1) == "msg"
+    assert (e1.stage, e1.missing, e1.available) == ("s", "df", ["a", "b"])
+```
+
+- [ ] **Step 2: Run** — FAIL (`WiringError` has no `.stage`).
+
+- [ ] **Step 3: Implement** — replace the `WiringError` class + the raise site in `resolver.py`
+
+```python
+class WiringError(Exception):
+    """Raised when a stage's consumes can't be satisfied. Carries OPTIONAL structured
+    attrs (stage/missing/available) for the parity helper; the message is unchanged and
+    the single-positional-message raise still works (existing consumers read str(e))."""
+
+    def __init__(self, message: str, *, stage: str | None = None,
+                 missing: str | None = None, available: list[str] | None = None) -> None:
+        super().__init__(message)
+        self.stage = stage
+        self.missing = missing
+        self.available = available
+```
+And at the raise site (currently `resolver.py:61-64`):
+```python
+                    raise WiringError(
+                        f"Stage '{name}' consumes '{dep}' but no prior stage "
+                        f"produces it. Available: {sorted(available_artifacts)}",
+                        stage=name, missing=dep, available=sorted(available_artifacts),
+                    )
+```
+
+- [ ] **Step 4: Run** the new test + the existing `tests/test_config.py`/any resolver test to confirm nothing broke (`str(e)` consumers unaffected). PASS.
+- [ ] **Step 5: Commit** `feat(goldenpipe): WiringError gains additive structured attrs`
+
+---
+
+## Task 4: `_planner_json.py` helper + Leg A parity gate (the deliverable)
+
+**Files:**
+- Create: `packages/python/goldenpipe/goldenpipe/core/_planner_json.py`
+- Create: `packages/python/goldenpipe/tests/core/test_planner_parity.py`
+
+- [ ] **Step 1: Write the Leg A parity harness** (`test_planner_parity.py`) — it drives the whole task
+
+```python
+"""SP2 Leg A: the pure-Python planner (via _planner_json) must reproduce the SP1
+golden vectors (the core's output) byte-for-byte. Box-safe, no wheel."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from goldenpipe.core import _planner_json as PJ
+
+# repo-relative: tests/core/ -> goldenpipe pkg -> python -> packages -> repo root (parents[4])
+_VECTORS = Path(__file__).resolve().parents[4] / "packages/rust/extensions/goldenpipe-core/tests/vectors"
+
+
+def _load(name: str) -> list[dict]:
+    return json.loads((_VECTORS / f"{name}.json").read_text())
+
+
+_CASES = [
+    ("resolve", PJ.resolve_json),
+    ("apply_decision", PJ.apply_decision_json),
+    ("evaluate_builtin", PJ.evaluate_builtin_json),
+    ("auto_config", PJ.auto_config_json),
+    ("skip_if", PJ.skip_if_falsy_json),
+]
+
+
+@pytest.mark.parametrize("name,fn", _CASES)
+def test_pure_python_matches_core_vectors(name, fn):
+    for i, case in enumerate(_load(name)):
+        got = json.loads(fn(json.dumps(case["input"])))
+        assert got == case["expected"], f"{name}[{i}] input={case['input']!r}"
+```
+
+- [ ] **Step 2: Run** — FAIL (no `_planner_json`).
+
+- [ ] **Step 3: Implement `_planner_json.py`** (calls the REAL planner; serializes to the core's shapes)
+
+```python
+"""The JSON face of the pure-Python planner — the SP2 parity surface (SHIPPED).
+
+Each ``*_json`` fn CALLS the real Resolver/Router/decisions/_auto_config and serializes
+to goldenpipe-core's exact JSON shapes, so the parity gate tests the actual planner
+(not a re-implementation). It does NOT run at pipeline runtime; ordering/validation/
+routing stay in the engine modules. Mirrors goldenpipe-core/src/json.rs.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from goldenpipe import decisions as _dec
+from goldenpipe.engine.resolver import Resolver, WiringError
+from goldenpipe.engine.router import Router
+from goldenpipe.models.config import PipelineConfig, StageSpec
+from goldenpipe.models.context import Decision, PipeContext
+from goldenpipe.models.stage import StageInfo
+
+
+class _Stub:
+    """A minimal Stage object carrying .info (all the planner reads)."""
+    def __init__(self, info: StageInfo) -> None:
+        self.info = info
+
+
+class _StubRegistry:
+    """Registry keyed EXPLICITLY (bypasses register()'s key-by-info.name) so
+    `key != info.name` vectors resolve. Provides get()/list_all()."""
+    def __init__(self) -> None:
+        self._stages: dict[str, Any] = {}
+
+    def add(self, key: str, info: StageInfo) -> None:
+        self._stages[key] = _Stub(info)
+
+    def get(self, name: str) -> Any:
+        if name not in self._stages:
+            raise KeyError(f"Stage '{name}' not found in registry")
+        return self._stages[name]
+
+    def list_all(self) -> dict[str, StageInfo]:
+        return {k: s.info for k, s in self._stages.items()}
+
+
+def _info(d: dict) -> StageInfo:
+    return StageInfo(name=d["name"], produces=list(d["produces"]), consumes=list(d["consumes"]))
+
+
+def _planned_to_dict(p: Any) -> dict:
+    out = {"name": p.name, "use": p.spec.use, "config": p.config or {}, "on_error": p.spec.on_error}
+    if p.spec.skip_if is not None:
+        out["skip_if"] = p.spec.skip_if
+    return out
+
+
+def resolve_json(input_str: str) -> str:
+    arg = json.loads(input_str)
+    reg = _StubRegistry()
+    for s in arg["stages"]:
+        reg.add(s["key"], _info(s))  # key by the registry KEY, not info.name
+    config = PipelineConfig(**arg["config"])
+    try:
+        plan = Resolver.resolve(config, reg)
+    except WiringError as e:
+        return json.dumps({"err": {"kind": "wiring", "stage": e.stage,
+                                   "missing": e.missing, "available": e.available}})
+    except KeyError:
+        # unknown `use`: the first configured stage whose use isn't registered
+        # (Resolver fails on the first such stage, in order).
+        for raw in config.stages:
+            use = raw if isinstance(raw, str) else raw.use
+            if use not in reg._stages:
+                return json.dumps({"err": {"kind": "unknown_stage", "use": use}})
+        raise  # unreachable
+    return json.dumps({"ok": {"stages": [_planned_to_dict(p) for p in plan.stages]}})
+
+
+def apply_decision_json(input_str: str) -> str:
+    arg = json.loads(input_str)
+    d = arg["decision"]
+    decision = Decision(skip=d.get("skip", []), abort=d.get("abort", False),
+                        insert=d.get("insert", []), reason=d.get("reason", ""))
+    remaining = []
+    from goldenpipe.engine.resolver import PlannedStage
+    for r in arg["remaining"]:
+        remaining.append(PlannedStage(name=r["name"], stage=None,
+                                      spec=StageSpec(use=r["use"]), config=r.get("config", {})))
+    reg = _StubRegistry()
+    for name in decision.insert:  # Router.get(name) for each inserted stage
+        reg.add(name, StageInfo(name=name, produces=[], consumes=[]))
+    ctx = PipeContext()
+    new_remaining = Router.apply(decision, remaining, ctx, reg)
+    out: dict = {"remaining": [_planned_to_dict(p) for p in new_remaining]}
+    note = ctx.reasoning.get("_router")
+    if note is not None:
+        out["router_note"] = note
+    return json.dumps(out)
+
+
+_BUILTINS = {
+    "severity_gate": _dec.severity_gate,
+    "pii_router": _dec.pii_router,
+    "row_count_gate": _dec.row_count_gate,
+}
+
+
+def evaluate_builtin_json(input_str: str) -> str:
+    arg = json.loads(input_str)
+    fn = _BUILTINS.get(arg["name"])
+    if fn is None:
+        return "null"
+    ctx = PipeContext(artifacts=arg.get("ctx", {}).get("artifacts", {}),
+                      metadata=arg.get("ctx", {}).get("metadata", {}))
+    d = fn(ctx)
+    if d is None:
+        return "null"
+    return json.dumps({"skip": d.skip, "abort": d.abort, "insert": d.insert, "reason": d.reason})
+
+
+def auto_config_json(input_str: str) -> str:
+    from goldenpipe.pipeline import Pipeline
+    arg = json.loads(input_str)
+    reg = _StubRegistry()
+    for name in arg["available"]:
+        reg.add(name, StageInfo(name=name, produces=[], consumes=[]))
+    p = Pipeline(registry=reg, identity_opts=arg.get("identity_opts"))
+    cfg = p._auto_config()
+    stages = []
+    for spec in cfg.stages:  # each is a StageSpec
+        stages.append({"use": spec.use, "needs": spec.needs,
+                       "on_error": spec.on_error, "config": spec.config})
+    return json.dumps({"pipeline": cfg.pipeline, "stages": stages, "decisions": cfg.decisions})
+
+
+def skip_if_falsy_json(input_str: str) -> str:
+    return json.dumps(not json.loads(input_str))
+```
+
+- [ ] **Step 4: Run** the Leg A parity test. Iterate until all 5 families pass. If a case fails, the fix is in `_planner_json` (make it faithfully match the core), NEVER in the fixture. Likely first failures + fixes:
+  - `auto_config` stage shape: confirm `StageSpec.on_error` serializes as the string (it's a `Literal`), and `spec.needs` is `[]`. If the core emitted `config` key order differently, the harness compares parsed dicts (order-insensitive) so it's fine.
+  - `apply_decision` inserted stage: `PlannedStage(config default {})` → `_planned_to_dict` emits `config:{}`, `on_error:"continue"`, `use:name`. Matches core.
+  - `resolve` `unknown_stage` empty-registry vector (`stages:[]`, config `["nope"]`): `Resolver.resolve` catches the load KeyError internally, then `registry.get("nope")` raises KeyError → helper derives `use:"nope"`. Confirm.
+  Expected end state: 5 parametrized cases PASS (all vectors).
+
+- [ ] **Step 5: Commit** `feat(goldenpipe): _planner_json helper + Leg A pure==core parity gate`
+
+---
+
+## Task 5: `build_native.py` + Leg B (wheel==core) parity
+
+**Files:**
+- Create: `packages/python/goldenpipe/scripts/build_native.py`
+- Modify: `packages/python/goldenpipe/tests/core/test_planner_parity.py` (add Leg B)
+
+- [ ] **Step 1: `build_native.py`** — mirror goldenflow's (cargo build + copy), with a Windows `.dll -> _native.pyd` branch
+
+Copy goldenflow's `scripts/build_native.py` structure verbatim, changing: `CRATE = REPO/"packages/rust/extensions/goldenpipe-native"`, `PKG = REPO/"packages/python/goldenpipe/goldenpipe"`, artifact `lib_native.so`/`.dylib` (Linux/mac) OR `_native.dll` (Windows) → `DEST = PKG/"_native.abi3.so"` (Linux/mac) / `PKG/"_native.pyd"` (Windows). Keep the atomic `os.replace` write and the `PYO3_PYTHON=sys.executable` env. (CI Linux is the canonical path; the Windows branch is box convenience.)
+
+- [ ] **Step 2: Add Leg B** to `test_planner_parity.py`
+
+```python
+from goldenpipe.core import _native_loader as NL
+
+
+@pytest.mark.parametrize("name,fn_name", [
+    ("resolve", "resolve_json"), ("apply_decision", "apply_decision_json"),
+    ("evaluate_builtin", "evaluate_builtin_json"), ("auto_config", "auto_config_json"),
+    ("skip_if", "skip_if_falsy_json"),
+])
+def test_native_wheel_matches_core_vectors(name, fn_name):
+    import os
+    if not NL.native_available():
+        if os.environ.get("GOLDENPIPE_NATIVE") == "1":
+            pytest.fail("GOLDENPIPE_NATIVE=1 but the native wheel is not importable")
+        pytest.skip("native wheel not built (Leg B is CI-primary)")
+    fn = getattr(NL, fn_name)
+    for i, case in enumerate(_load(name)):
+        got = json.loads(fn(json.dumps(case["input"])))
+        assert got == case["expected"], f"native {name}[{i}] input={case['input']!r}"
+```
+
+- [ ] **Step 3: Run** the full parity suite locally (`GOLDENPIPE_NATIVE=0` or unset) — Leg A PASS, Leg B SKIP (no wheel). If you got the wheel to build in Task 1, run once with the wheel importable (build_native.py) to see Leg B PASS too — best-effort.
+- [ ] **Step 4: Commit** `feat(goldenpipe): build_native.py + Leg B wheel parity (skip-guarded)`
+
+---
+
+## Task 6: CI parity lane
+
+**Files:** Modify `.github/workflows/ci.yml`
+
+- [ ] **Step 1:** Add a `dorny/paths-filter` output (e.g. `goldenpipe_native`) triggered by:
+  `packages/rust/extensions/goldenpipe-core/**`, `packages/rust/extensions/goldenpipe-native/**`, `packages/python/goldenpipe/**`, and `ci.yml` itself.
+- [ ] **Step 2:** Add a job gated on that output that: sets up Rust + Python 3.11, `maturin build`s the `goldenpipe-native` wheel + `pip install`s it, then runs
+  `GOLDENPIPE_NATIVE=1 POLARS_SKIP_CPU_CHECK=1 pytest packages/python/goldenpipe/tests/core/ -q`
+  (Leg A always + Leg B mandatory under `=1`). Mirror the existing goldenflow-native parity lane's shape. This is ALSO where goldenpipe-core gets its first CI coverage (the SP1 gap).
+- [ ] **Step 3:** Note in the PR that editing `ci.yml` forces all jobs to re-run (per CLAUDE.md); that's expected.
+- [ ] **Step 4: Commit** `ci(goldenpipe): GOLDENPIPE_NATIVE=1 parity lane (Leg A+B) + paths-filter`
+
+---
+
+## Wrap-up
+
+- [ ] Full box suite green: `pytest packages/python/goldenpipe/tests/core/ -q` (Leg A + loader + WiringError, Leg B skipped). Push branch, open PR against main, arm `gh pr merge --auto --squash`, STOP. Auth: `GH_TOKEN=$(gh auth token --user benzsevern)` for `gh pr create`; `unset GH_TOKEN` before push.
+- [ ] PR body: SP2 of goldenpipe→Rust; parity-gate-only (core=oracle, pure-Python stays runtime); the anti-drift value = Leg A locks Python to the core; SP3 (TS) is the drift-kill; the one additive WiringError change; box-verified Leg A, wheel/Leg B CI-primary.
+- [ ] Update memory `project_goldenpipe_core_cross_surface`: SP2 shipped, what it delivers, SP3 remaining.
+- [ ] `goldenpipe[native]` extra: if `packages/python/goldenpipe/pyproject.toml` has an extras table, add a `native = ["goldenpipe-native"]` extra (mirror goldenflow). Check before adding.
+
+## Notes / risks
+
+- **Leg A is the load-bearing gate** — it must call the REAL Resolver/Router/decisions (the helper is glue, not a re-impl). If a vector fails, fix `_planner_json` to match the core, never the fixture.
+- **WiringError change is additive** — optional kwargs, message unchanged; existing `str(e)` consumers (server.py/mcp/cli/test_resolver.py) unaffected.
+- **Wheel build is box best-effort** — goldenpipe-native has no heavy deps so it likely links on Windows, but if not, Leg B is CI-only; don't block SP2.
+- **`PipelineConfig(**arg["config"])`** relies on pydantic coercing bare-string stage entries to `str` and dict entries to `StageSpec` (union, StageSpec-first). Confirm in Task 4 Step 4; if pydantic mis-coerces a bare string, normalize entries explicitly before constructing.
+- **Scope stays SP2** — no runtime routing through the core; SP3 (TS/WASM) is separate.

--- a/docs/superpowers/plans/2026-07-04-goldenpipe-native-binding.md
+++ b/docs/superpowers/plans/2026-07-04-goldenpipe-native-binding.md
@@ -388,8 +388,9 @@ import pytest
 
 from goldenpipe.core import _planner_json as PJ
 
-# repo-relative: tests/core/ -> goldenpipe pkg -> python -> packages -> repo root (parents[4])
-_VECTORS = Path(__file__).resolve().parents[4] / "packages/rust/extensions/goldenpipe-core/tests/vectors"
+# repo-relative: test file is packages/python/goldenpipe/tests/core/test_planner_parity.py
+# parents: [0]=core [1]=tests [2]=goldenpipe [3]=python [4]=packages [5]=REPO ROOT.
+_VECTORS = Path(__file__).resolve().parents[5] / "packages/rust/extensions/goldenpipe-core/tests/vectors"
 
 
 def _load(name: str) -> list[dict]:
@@ -502,8 +503,11 @@ def apply_decision_json(input_str: str) -> str:
     remaining = []
     from goldenpipe.engine.resolver import PlannedStage
     for r in arg["remaining"]:
-        remaining.append(PlannedStage(name=r["name"], stage=None,
-                                      spec=StageSpec(use=r["use"]), config=r.get("config", {})))
+        # carry on_error/skip_if through the spec so a remaining stage that has them
+        # round-trips faithfully (the core's PlannedSpec round-trips both).
+        spec = StageSpec(use=r["use"], name=r.get("name"),
+                         on_error=r.get("on_error", "continue"), skip_if=r.get("skip_if"))
+        remaining.append(PlannedStage(name=r["name"], stage=None, spec=spec, config=r.get("config", {})))
     reg = _StubRegistry()
     for name in decision.insert:  # Router.get(name) for each inserted stage
         reg.add(name, StageInfo(name=name, produces=[], consumes=[]))

--- a/docs/superpowers/specs/2026-07-04-goldenpipe-native-binding-design.md
+++ b/docs/superpowers/specs/2026-07-04-goldenpipe-native-binding-design.md
@@ -99,6 +99,10 @@ re-implementation):
     a message. Add structured attributes `.stage`, `.missing`, `.available` (the message
     is unchanged) so the helper reads them directly instead of string-parsing. Additive,
     behavior-preserving, and it's the faithful way to map the wiring vector.
+    IMPLEMENTATION NOTE: keep it additive — set the attrs via OPTIONAL kwargs (do not
+    make them required positional; existing raises pass only the message), and set
+    `.available = sorted(available_artifacts)` (matches `resolver.py:63` + the core's
+    sorted `BTreeSet`).
 - **`apply_decision_json`** — parse `{decision, remaining}`. Reconstruct `PlannedStage`s
   from `remaining`, a `Decision`, a stub registry providing the `insert` names (Router
   calls `registry.get(name)` per insert), and a `PipeContext`. Call `Router.apply`,

--- a/docs/superpowers/specs/2026-07-04-goldenpipe-native-binding-design.md
+++ b/docs/superpowers/specs/2026-07-04-goldenpipe-native-binding-design.md
@@ -1,0 +1,146 @@
+# goldenpipe-native — Python binding + parity gate (SP2) — design
+
+**Program:** goldenpipe → Rust. SP1 (`goldenpipe-core`, PR #1418, merged) is the
+pyo3-free planner kernel + golden-vector fixtures. **SP2 makes the core the Python
+REFERENCE:** ship a `goldenpipe-native` abi3 wheel over the core + a reference-mode
+loader, and gate the pure-Python planner against the core with a parity test. **SP3
+(TS/WASM reroute — the actual Python↔TS drift-kill) is a separate spec.**
+
+## Scope decisions (locked in brainstorming)
+
+- **Parity-gate only, NOT reference-mode runtime.** The core is the ORACLE; the
+  pure-Python planner stays the Python RUNTIME (unchanged). We do NOT route
+  Resolver/Router/decisions through the core at runtime — the planner isn't
+  compute-bound, so marshaling JSON to Rust and back per pipeline would be a pure
+  tax for zero benefit. The anti-drift value is delivered by the **parity gate**
+  (pure-Python provably conforms to the core), not by making Python call Rust.
+  This is the honest reading of "Rust is the reference, source-of-truth not speed"
+  for a no-perf-win component.
+- **CI-primary, box best-effort.** The gate is authoritative in CI
+  (`GOLDENPIPE_NATIVE=1` lane, wheel built there). Try building the wheel locally
+  too — goldenpipe-native has NO heavy deps (pyo3 + the serde-only core; unlike the
+  ort-blocked goldenmatch native) so it likely links on the box — but SP2 does not
+  block on a local wheel build.
+
+## Components
+
+Mirror goldenflow's Wave 0a (`#1405`) exactly where it fits; goldenpipe is simpler
+(JSON string boundary, not Arrow columnar).
+
+### 1. `goldenpipe-native` crate — `packages/rust/extensions/goldenpipe-native/`
+
+Standalone `[workspace]` (empty) so pyo3's `extension-module` feature isn't unified
+with any other crate. `[lib] name = "_native", crate-type = ["cdylib"]` (produces
+`_native.so`/`.pyd`; the `#[pymodule]` init is `PyInit__native`).
+
+Deps: `pyo3 = { version = ">=0.28,<0.29", features = ["extension-module", "abi3-py311"] }`
++ `goldenpipe-core = { path = "../goldenpipe-core" }`. **No arrow** — the planner is
+JSON-in/JSON-out, not columnar.
+
+`src/lib.rs` — `#[pymodule] _native` exposing five thin string wrappers, each a
+`#[pyfunction] fn(input: &str) -> String` that delegates to `goldenpipe_core::json::*`:
+`resolve_json`, `apply_decision_json`, `evaluate_builtin_json`, `auto_config_json`,
+`skip_if_falsy_json`, plus `__version__ = env!("CARGO_PKG_VERSION")`. It is a pure
+marshaling shim: `&str` in → core fn → `String` out (release the GIL is unnecessary
+— the work is sub-microsecond; keep it a plain call). The core is the single source
+of truth; this crate adds zero logic.
+
+`pyproject.toml` (maturin build backend, like native-flow's) so it publishes as the
+separate `goldenpipe-native` abi3 wheel (`pip install goldenpipe[native]`).
+
+### 2. `goldenpipe/core/_native_loader.py` (new)
+
+Mirror `goldenflow/core/_native_loader.py`:
+- Reachable two ways, tried in order: `goldenpipe._native` (in-tree build via
+  `scripts/build_native.py`) → `goldenpipe_native._native` (the wheel).
+- `GOLDENPIPE_NATIVE` env: `"0"` force pure; `"1"` require native (raise if absent —
+  the CI parity lane); `"auto"`/unset → native available iff the floor symbol exists.
+- Component = `"planner"`, floor symbol `resolve_json` (wheel-skew-safe `_has_symbol`
+  probe). No `_FALLBACK_ONLY` (nothing wrong-spec here).
+- Public API: `native_module()`, `native_available()`, `native_enabled("planner")`,
+  and thin `resolve_json(...)`/etc. pass-throughs the parity test (and any future
+  reference-mode consumer) call — so the wheel is reachable through one module.
+
+Note the loader is SHIPPED but the runtime does NOT consume it yet (parity-gate-only
+scope). It exists so (a) the parity test can reach the wheel and (b) SP3-era or a
+future reference-mode flip has the seam ready. This matches the roadmap's
+"native = required artifact, reachable under a gate" without paying the runtime tax.
+
+### 3. `scripts/build_native.py`
+
+Mirror goldenflow's: `maturin build`/`develop` the `goldenpipe-native` crate into
+`goldenpipe/_native` for the in-tree path. Box-runnable if pyo3 links locally.
+
+## The parity gate (the SP2 deliverable — makes the core the reference)
+
+Reuse the SP1 golden vectors (`packages/rust/extensions/goldenpipe-core/tests/vectors/*.json`)
+as the shared truth — their `expected` IS the core's output. Two legs:
+
+- **Leg A — pure-Python == core (the anti-drift gate; box-safe, no wheel needed).**
+  A test replays each vector `input` through the PURE-PYTHON planner and asserts the
+  output equals the vector `expected`. This proves the Python planner conforms to the
+  core and CANNOT drift from it (a future Python change that diverges fails here). It
+  needs a small JSON-shaped adapter around the pure-Python planner:
+  - resolve: build a throwaway registry/stage-info from the vector's `stages`, run
+    `Resolver.resolve`, serialize the `ExecutionPlan` to the core's JSON shape
+    (`{name, use, config, on_error}` per stage; `{ok|err}` envelope).
+  - apply_decision / evaluate_builtin / auto_config / skip_if: call the pure-Python
+    `Router.apply` / `decisions.*` / `_auto_config` / `not artifact`, serialize to the
+    core's shape.
+  This adapter lives in the TEST (or a tiny `goldenpipe/core/_planner_json.py` helper
+  if cleaner) — it does NOT change the runtime planner. Runs in every CI lane +
+  locally, no wheel.
+- **Leg B — native wheel == core (validates the wheel/marshaling; CI-primary).**
+  With the wheel built (`GOLDENPIPE_NATIVE=1`), replay each vector `input` through the
+  native `_native.resolve_json(...)` etc. and assert == `expected`. Trivially true if
+  the wheel is the core, but catches build/version/marshaling breakage. Skips (not
+  fails) when the wheel is absent under `auto`; the `=1` CI lane makes it mandatory.
+
+Leg A is the load-bearing anti-drift value and is always-on. Leg B is the wheel smoke.
+
+## Loader unit tests
+
+Mirror `test_native_loader.py`: `native_enabled("planner")` True when a fake `_native`
+with `resolve_json` is present under `auto`; False under `"0"`; raises under `"1"` when
+`_native is None`; `_has_symbol` probes the floor symbol.
+
+## CI
+
+- Add a `GOLDENPIPE_NATIVE=1` parity lane (mirror goldenflow's) that builds the wheel
+  and runs Leg A + Leg B. Wire a `dorny/paths-filter` entry so a change to
+  `goldenpipe-core/**` OR `goldenpipe-native/**` OR the goldenpipe Python planner
+  re-triggers it — this is ALSO where goldenpipe-core finally gets its CI coverage
+  (the SP1 gap: the core had no consumer to hang a lane on; goldenpipe-native is that
+  consumer).
+- Leg A runs in the ordinary goldenpipe pytest lane (no wheel) too, so drift is caught
+  even on a doc-filtered run of the planner.
+
+## Error handling / edge
+
+- The wheel is optional: `_native = None` on any import failure → Leg B skips, runtime
+  unaffected (pure-Python), exactly like goldenflow.
+- Version skew: `_has_symbol` probes the actual module for `resolve_json` (not a
+  version string), so a stale wheel missing a symbol degrades gracefully.
+- The native wrappers never panic on bad JSON — the core's `*_json` already return a
+  `{"err":{"kind":"parse",...}}` envelope; the pyo3 layer just passes the `String`
+  through.
+
+## Testing summary (box posture)
+
+- Leg A parity (pure-Python == core fixtures): **box-safe**, always runs.
+- Loader unit tests: **box-safe** (pure Python, fake `_native`).
+- Wheel build + Leg B: **box best-effort** (goldenpipe-native has no heavy deps so it
+  likely links on Windows/NTFS via maturin; if it doesn't, Leg B is CI-only). Do not
+  block SP2 on the local wheel.
+- Rust: `goldenpipe-native` `cargo build` (needs a Python lib to link the
+  extension-module; `cargo build` alone may need `--no-default-features` juggling —
+  prefer `maturin build` as the real check).
+
+## Out of scope (SP2)
+
+- Any runtime routing of the Python planner through the core (parity-gate-only). A
+  future reference-mode flip is a separate, opt-in change if ever justified.
+- SP3 (TS/WASM reroute + the Python↔TS drift-kill) — separate spec.
+- Publishing the wheel to PyPI / release tags — SP2 lands the crate + build + CI gate;
+  the publish workflow follows the existing `goldenflow-native` pattern in a later step.
+- Touching Runner/registry/IO (host stays).

--- a/docs/superpowers/specs/2026-07-04-goldenpipe-native-binding-design.md
+++ b/docs/superpowers/specs/2026-07-04-goldenpipe-native-binding-design.md
@@ -74,22 +74,58 @@ Mirror goldenflow's: `maturin build`/`develop` the `goldenpipe-native` crate int
 ## The parity gate (the SP2 deliverable — makes the core the reference)
 
 Reuse the SP1 golden vectors (`packages/rust/extensions/goldenpipe-core/tests/vectors/*.json`)
-as the shared truth — their `expected` IS the core's output. Two legs:
+as the shared truth — their `expected` IS the core's output. Two legs, both replaying
+those vectors.
+
+### `goldenpipe/core/_planner_json.py` (new, SHIPPED helper) — the JSON face of the pure-Python planner
+
+Leg A is NOT "just serialize" — mapping the object/exception-based Python planner to
+the core's JSON shape needs real, specified glue. Put it in ONE helper with an explicit
+contract (five `*_json(input_str) -> output_str` fns that CALL the real
+Resolver/Router/decisions internally, so the gate tests the ACTUAL planner, not a
+re-implementation):
+
+- **`resolve_json`** — parse `{config, stages}`. Build a throwaway `StageRegistry` from
+  the vector's `StageInfo` objects, keying **by `StageInfo.key`** — `registry.register()`
+  keys by `info.name`, so for the `key != info.name` vectors the helper writes
+  `registry._stages[info.key] = _stub_stage(info)` directly (a stub Stage whose `.info`
+  carries the metadata). Call `Resolver.resolve(config, registry)`; on success serialize
+  `ExecutionPlan.stages -> [{name, use, config, on_error}]` as `{"ok": {...}}`. On
+  `WiringError` -> `{"err": {"kind":"wiring", stage, missing, available}}`; on the
+  unknown-`use` `KeyError` -> `{"err": {"kind":"unknown_stage", "use": <the first
+  config stage whose use ∉ registry>}}` (deterministic — Resolver fails on the first
+  such stage).
+  - **In-scope additive change to `resolver.py`:** `WiringError` currently carries only
+    a message. Add structured attributes `.stage`, `.missing`, `.available` (the message
+    is unchanged) so the helper reads them directly instead of string-parsing. Additive,
+    behavior-preserving, and it's the faithful way to map the wiring vector.
+- **`apply_decision_json`** — parse `{decision, remaining}`. Reconstruct `PlannedStage`s
+  from `remaining`, a `Decision`, a stub registry providing the `insert` names (Router
+  calls `registry.get(name)` per insert), and a `PipeContext`. Call `Router.apply`,
+  then serialize `{remaining: [{name,use,config,on_error}], router_note}` where
+  `router_note` is `ctx.reasoning.get("_router")` (Router writes it there; absent -> the
+  field is omitted, matching the core's `skip_serializing_if`).
+- **`evaluate_builtin_json`** — parse `{name, ctx}`. Dispatch a name table
+  `{"severity_gate": severity_gate, "pii_router": pii_router, "row_count_gate":
+  row_count_gate}`; **unknown name -> `None`** (the core's `_ => None`). Call the
+  `decisions.py` fn with a `PipeContext` built from `ctx.artifacts`/`ctx.metadata`;
+  serialize the returned `Decision` (or JSON `null`).
+- **`auto_config_json`** — parse `{available, identity_opts}`. `Pipeline._auto_config`
+  is an instance method reading `self._registry.list_all()` + `self._identity_opts`, so
+  construct a `Pipeline` with a stub registry whose `list_all()` returns `available` and
+  set `_identity_opts` (empty `{}` -> not-given, matching both sides), call
+  `_auto_config`, serialize the `PipelineConfig` to the core's shape.
+- **`skip_if_falsy_json`** — parse a bare JSON value; return `str(bool(not <value>))`
+  lowercased... i.e. Python `not artifact` -> the same truthy set the core pins.
+
+Leg A (below) asserts each helper fn == the vector `expected`. Because the helper calls
+the real Resolver/Router/decisions, a future runtime-planner change that diverges from
+the core fails the gate. The registry-construction / dispatch / envelope glue is helper
+concern, not planner logic — ordering, validation, and routing stay in the real modules.
 
 - **Leg A — pure-Python == core (the anti-drift gate; box-safe, no wheel needed).**
-  A test replays each vector `input` through the PURE-PYTHON planner and asserts the
-  output equals the vector `expected`. This proves the Python planner conforms to the
-  core and CANNOT drift from it (a future Python change that diverges fails here). It
-  needs a small JSON-shaped adapter around the pure-Python planner:
-  - resolve: build a throwaway registry/stage-info from the vector's `stages`, run
-    `Resolver.resolve`, serialize the `ExecutionPlan` to the core's JSON shape
-    (`{name, use, config, on_error}` per stage; `{ok|err}` envelope).
-  - apply_decision / evaluate_builtin / auto_config / skip_if: call the pure-Python
-    `Router.apply` / `decisions.*` / `_auto_config` / `not artifact`, serialize to the
-    core's shape.
-  This adapter lives in the TEST (or a tiny `goldenpipe/core/_planner_json.py` helper
-  if cleaner) — it does NOT change the runtime planner. Runs in every CI lane +
-  locally, no wheel.
+  Replay each vector `input` through the matching `_planner_json.*` fn and assert the
+  parsed output equals the vector `expected`. Runs in every CI lane + locally, no wheel.
 - **Leg B — native wheel == core (validates the wheel/marshaling; CI-primary).**
   With the wheel built (`GOLDENPIPE_NATIVE=1`), replay each vector `input` through the
   native `_native.resolve_json(...)` etc. and assert == `expected`. Trivially true if
@@ -143,4 +179,8 @@ with `resolve_json` is present under `auto`; False under `"0"`; raises under `"1
 - SP3 (TS/WASM reroute + the Python↔TS drift-kill) — separate spec.
 - Publishing the wheel to PyPI / release tags — SP2 lands the crate + build + CI gate;
   the publish workflow follows the existing `goldenflow-native` pattern in a later step.
-- Touching Runner/registry/IO (host stays).
+- Touching Runner/registry/IO (host stays). The ONLY runtime file SP2 modifies is
+  `engine/resolver.py`, and only ADDITIVELY: `WiringError` gains `.stage`/`.missing`/
+  `.available` attributes (message unchanged, no behavior change) so the parity helper
+  can read a structured error. The pure-Python planner runtime path is otherwise
+  untouched (parity-gate-only).

--- a/packages/python/goldenpipe/goldenpipe/core/__init__.py
+++ b/packages/python/goldenpipe/goldenpipe/core/__init__.py
@@ -1,0 +1,1 @@
+"""goldenpipe.core -- native-loader + planner-json parity surface (SP2)."""

--- a/packages/python/goldenpipe/goldenpipe/core/_native_loader.py
+++ b/packages/python/goldenpipe/goldenpipe/core/_native_loader.py
@@ -1,0 +1,87 @@
+"""Loader + gate for the optional ``goldenpipe._native`` binding.
+
+Mirrors ``goldenflow.core._native_loader``. The binding (Rust/PyO3, built from
+``packages/rust/extensions/goldenpipe-native``) exposes ``goldenpipe-core`` — the
+REFERENCE planner kernel — to Python. It is NOT a runtime accelerator: the
+pure-Python planner stays the runtime; this loader exists so the parity gate can
+reach the kernel (and so a future reference-mode flip has the seam ready).
+
+``GOLDENPIPE_NATIVE`` env:
+- ``"0"``   -> force pure (never use native).
+- ``"1"``   -> require native; raise if not importable (the CI parity lane).
+- ``"auto"`` / unset -> native available iff the floor symbol exists. Default.
+
+Reachable two ways, tried in order (like goldenflow/goldenmatch):
+  1. ``goldenpipe._native``        — in-tree build (scripts/build_native.py).
+  2. ``goldenpipe_native._native`` — the separate ``goldenpipe-native`` abi3 wheel.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    import goldenpipe._native as _native  # type: ignore[import-not-found]
+except Exception:  # noqa: BLE001 - any import/load failure falls back below
+    try:
+        from goldenpipe_native import _native  # type: ignore[import-not-found]
+    except Exception:  # noqa: BLE001 - neither path available -> pure Python
+        _native = None
+
+
+# Floor symbols per component (wheel-skew safe: probe the actual module).
+_COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
+    "planner": ("resolve_json",),
+}
+
+
+def _has_symbol(component: str) -> bool:
+    if _native is None:
+        return False
+    syms = _COMPONENT_SYMBOLS.get(component)
+    if not syms:
+        return False
+    return any(hasattr(_native, s) for s in syms)
+
+
+def native_module() -> Any:
+    """The imported native module, or ``None``. Guard with ``native_enabled`` first."""
+    return _native
+
+
+def native_available() -> bool:
+    return _native is not None
+
+
+def native_enabled(component: str) -> bool:
+    mode = os.environ.get("GOLDENPIPE_NATIVE", "auto").lower()
+    if mode == "0":
+        return False
+    if mode == "1":
+        if _native is None:
+            raise RuntimeError(
+                "GOLDENPIPE_NATIVE=1 but goldenpipe._native is not built/importable"
+            )
+        return True
+    return _native is not None and _has_symbol(component)
+
+
+# Thin pass-throughs the parity test's Leg B calls (guard with native_enabled first).
+def resolve_json(input: str) -> str:
+    return _native.resolve_json(input)
+
+
+def apply_decision_json(input: str) -> str:
+    return _native.apply_decision_json(input)
+
+
+def evaluate_builtin_json(input: str) -> str:
+    return _native.evaluate_builtin_json(input)
+
+
+def auto_config_json(input: str) -> str:
+    return _native.auto_config_json(input)
+
+
+def skip_if_falsy_json(input: str) -> str:
+    return _native.skip_if_falsy_json(input)

--- a/packages/python/goldenpipe/goldenpipe/core/_planner_json.py
+++ b/packages/python/goldenpipe/goldenpipe/core/_planner_json.py
@@ -1,0 +1,147 @@
+"""The JSON face of the pure-Python planner — the SP2 parity surface (SHIPPED).
+
+Each ``*_json`` fn CALLS the real Resolver/Router/decisions/_auto_config and serializes
+to goldenpipe-core's exact JSON shapes, so the parity gate tests the actual planner
+(not a re-implementation). It does NOT run at pipeline runtime; ordering/validation/
+routing stay in the engine modules. Mirrors goldenpipe-core/src/json.rs.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from goldenpipe import decisions as _dec
+from goldenpipe.engine.resolver import PlannedStage, Resolver, WiringError
+from goldenpipe.engine.router import Router
+from goldenpipe.models.config import PipelineConfig, StageSpec
+from goldenpipe.models.context import Decision, PipeContext
+from goldenpipe.models.stage import StageInfo
+
+
+class _Stub:
+    """A minimal Stage object carrying .info (all the planner reads)."""
+
+    def __init__(self, info: StageInfo) -> None:
+        self.info = info
+
+
+class _StubRegistry:
+    """Registry keyed EXPLICITLY (bypasses register()'s key-by-info.name) so
+    ``key != info.name`` vectors resolve. Provides get()/list_all()."""
+
+    def __init__(self) -> None:
+        self._stages: dict[str, Any] = {}
+
+    def add(self, key: str, info: StageInfo) -> None:
+        self._stages[key] = _Stub(info)
+
+    def get(self, name: str) -> Any:
+        if name not in self._stages:
+            raise KeyError(f"Stage '{name}' not found in registry")
+        return self._stages[name]
+
+    def list_all(self) -> dict[str, StageInfo]:
+        return {k: s.info for k, s in self._stages.items()}
+
+
+def _info(d: dict) -> StageInfo:
+    return StageInfo(name=d["name"], produces=list(d["produces"]), consumes=list(d["consumes"]))
+
+
+def _planned_to_dict(p: Any) -> dict:
+    out = {"name": p.name, "use": p.spec.use, "config": p.config or {}, "on_error": p.spec.on_error}
+    if p.spec.skip_if is not None:
+        out["skip_if"] = p.spec.skip_if
+    return out
+
+
+def resolve_json(input_str: str) -> str:
+    arg = json.loads(input_str)
+    reg = _StubRegistry()
+    for s in arg["stages"]:
+        reg.add(s["key"], _info(s))  # key by the registry KEY, not info.name
+    config = PipelineConfig(**arg["config"])
+    try:
+        plan = Resolver.resolve(config, reg)
+    except WiringError as e:
+        return json.dumps(
+            {"err": {"kind": "wiring", "stage": e.stage, "missing": e.missing, "available": e.available}}
+        )
+    except KeyError:
+        # unknown `use`: the first configured stage whose use isn't registered
+        # (Resolver fails on the first such stage, in order).
+        for raw in config.stages:
+            use = raw if isinstance(raw, str) else raw.use
+            if use not in reg._stages:
+                return json.dumps({"err": {"kind": "unknown_stage", "use": use}})
+        raise  # unreachable
+    return json.dumps({"ok": {"stages": [_planned_to_dict(p) for p in plan.stages]}})
+
+
+def apply_decision_json(input_str: str) -> str:
+    arg = json.loads(input_str)
+    d = arg["decision"]
+    decision = Decision(
+        skip=d.get("skip", []),
+        abort=d.get("abort", False),
+        insert=d.get("insert", []),
+        reason=d.get("reason", ""),
+    )
+    remaining = []
+    for r in arg["remaining"]:
+        # carry on_error/skip_if through the spec so a remaining stage that has them
+        # round-trips faithfully (the core's PlannedSpec round-trips both).
+        spec = StageSpec(
+            use=r["use"], name=r.get("name"), on_error=r.get("on_error", "continue"),
+            skip_if=r.get("skip_if"),
+        )
+        remaining.append(PlannedStage(name=r["name"], stage=None, spec=spec, config=r.get("config", {})))
+    reg = _StubRegistry()
+    for name in decision.insert:  # Router.get(name) for each inserted stage
+        reg.add(name, StageInfo(name=name, produces=[], consumes=[]))
+    ctx = PipeContext()
+    new_remaining = Router.apply(decision, remaining, ctx, reg)
+    out: dict = {"remaining": [_planned_to_dict(p) for p in new_remaining]}
+    note = ctx.reasoning.get("_router")
+    if note is not None:
+        out["router_note"] = note
+    return json.dumps(out)
+
+
+_BUILTINS = {
+    "severity_gate": _dec.severity_gate,
+    "pii_router": _dec.pii_router,
+    "row_count_gate": _dec.row_count_gate,
+}
+
+
+def evaluate_builtin_json(input_str: str) -> str:
+    arg = json.loads(input_str)
+    fn = _BUILTINS.get(arg["name"])
+    if fn is None:
+        return "null"
+    ctx_in = arg.get("ctx", {})
+    ctx = PipeContext(artifacts=ctx_in.get("artifacts", {}), metadata=ctx_in.get("metadata", {}))
+    d = fn(ctx)
+    if d is None:
+        return "null"
+    return json.dumps({"skip": d.skip, "abort": d.abort, "insert": d.insert, "reason": d.reason})
+
+
+def auto_config_json(input_str: str) -> str:
+    from goldenpipe.pipeline import Pipeline
+
+    arg = json.loads(input_str)
+    reg = _StubRegistry()
+    for name in arg["available"]:
+        reg.add(name, StageInfo(name=name, produces=[], consumes=[]))
+    p = Pipeline(registry=reg, identity_opts=arg.get("identity_opts"))
+    cfg = p._auto_config()
+    stages = []
+    for spec in cfg.stages:  # each is a StageSpec
+        stages.append({"use": spec.use, "needs": spec.needs, "on_error": spec.on_error, "config": spec.config})
+    return json.dumps({"pipeline": cfg.pipeline, "stages": stages, "decisions": cfg.decisions})
+
+
+def skip_if_falsy_json(input_str: str) -> str:
+    return json.dumps(not json.loads(input_str))

--- a/packages/python/goldenpipe/goldenpipe/engine/resolver.py
+++ b/packages/python/goldenpipe/goldenpipe/engine/resolver.py
@@ -9,7 +9,23 @@ from goldenpipe.models.config import PipelineConfig, StageSpec
 
 
 class WiringError(Exception):
-    """Raised when a stage's consumes can't be satisfied."""
+    """Raised when a stage's consumes can't be satisfied. Carries OPTIONAL structured
+    attrs (stage/missing/available) for the SP2 parity helper; the message is unchanged
+    and the single-positional-message raise still works (existing consumers read
+    ``str(e)``)."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        stage: str | None = None,
+        missing: str | None = None,
+        available: list[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.stage = stage
+        self.missing = missing
+        self.available = available
 
 
 @dataclass
@@ -60,7 +76,10 @@ class Resolver:
                 if dep not in available_artifacts:
                     raise WiringError(
                         f"Stage '{name}' consumes '{dep}' but no prior stage "
-                        f"produces it. Available: {sorted(available_artifacts)}"
+                        f"produces it. Available: {sorted(available_artifacts)}",
+                        stage=name,
+                        missing=dep,
+                        available=sorted(available_artifacts),
                     )
 
             plan.stages.append(PlannedStage(

--- a/packages/python/goldenpipe/scripts/build_native.py
+++ b/packages/python/goldenpipe/scripts/build_native.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Build the optional `goldenpipe._native` planner-kernel binding (in-tree dev).
+
+Compiles the PyO3 crate at `packages/rust/extensions/goldenpipe-native` (abi3)
+against the *current* interpreter and drops the artifact next to the goldenpipe
+package so `import goldenpipe._native` resolves — the first path tried by
+`goldenpipe.core._native_loader`. Mirrors goldenflow/goldenmatch's build_native.py.
+
+Run via the project interpreter:
+    python packages/python/goldenpipe/scripts/build_native.py
+
+Best-effort: prints a clear message and exits non-zero if cargo is missing or the
+build fails, never leaving a half-written artifact. GoldenPipe works fine without
+it (pure-Python planner); this only wires the native REFERENCE for the parity gate.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+# packages/python/goldenpipe/scripts/build_native.py -> repo root is 4 up.
+REPO = Path(__file__).resolve().parents[4]
+CRATE = REPO / "packages" / "rust" / "extensions" / "goldenpipe-native"
+PKG = REPO / "packages" / "python" / "goldenpipe" / "goldenpipe"
+
+
+def main() -> int:
+    if shutil.which("cargo") is None:
+        print("ERROR: cargo not found on PATH; cannot build the native ext.", file=sys.stderr)
+        return 1
+    if not CRATE.exists():
+        print(f"ERROR: native crate not found at {CRATE}", file=sys.stderr)
+        return 1
+
+    env = dict(os.environ)
+    env["PYO3_PYTHON"] = sys.executable
+
+    cmd = ["cargo", "build", "--release"]
+    if "--offline" in sys.argv:
+        cmd.append("--offline")
+    print(f"building: {' '.join(cmd)}  (PYO3_PYTHON={sys.executable})")
+    proc = subprocess.run(cmd, cwd=CRATE, env=env)
+    if proc.returncode != 0:
+        print("ERROR: cargo build failed.", file=sys.stderr)
+        return proc.returncode
+
+    rel = CRATE / "target" / "release"
+    # cdylib name is `_native`: _native.dll (win), lib_native.so (linux), lib_native.dylib (mac).
+    if (rel / "_native.dll").exists():
+        built, dest = rel / "_native.dll", PKG / "_native.pyd"
+    elif (rel / "lib_native.so").exists():
+        built, dest = rel / "lib_native.so", PKG / "_native.abi3.so"
+    elif (rel / "lib_native.dylib").exists():
+        built, dest = rel / "lib_native.dylib", PKG / "_native.abi3.so"
+    else:
+        print(f"ERROR: build artifact not found under {rel}", file=sys.stderr)
+        return 1
+
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    shutil.copy2(built, tmp)
+    os.replace(tmp, dest)  # atomic; never a half-written ext
+    print(f"installed: {dest}  (interpreter EXT_SUFFIX={sysconfig.get_config_var('EXT_SUFFIX')})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenpipe/tests/core/test_native_loader.py
+++ b/packages/python/goldenpipe/tests/core/test_native_loader.py
@@ -1,0 +1,31 @@
+from goldenpipe.core import _native_loader as L
+
+
+def test_planner_enabled_when_symbol_present(monkeypatch):
+    class FakeNative:
+        def resolve_json(self, s): ...
+    monkeypatch.setenv("GOLDENPIPE_NATIVE", "auto")
+    monkeypatch.setattr(L, "_native", FakeNative())
+    assert L.native_enabled("planner") is True
+
+
+def test_force_off(monkeypatch):
+    monkeypatch.setenv("GOLDENPIPE_NATIVE", "0")
+    monkeypatch.setattr(L, "_native", object())
+    assert L.native_enabled("planner") is False
+
+
+def test_require_raises_when_absent(monkeypatch):
+    import pytest
+    monkeypatch.setenv("GOLDENPIPE_NATIVE", "1")
+    monkeypatch.setattr(L, "_native", None)
+    with pytest.raises(RuntimeError):
+        L.native_enabled("planner")
+
+
+def test_auto_disabled_when_symbol_missing(monkeypatch):
+    class Bare:  # native present but no resolve_json symbol
+        pass
+    monkeypatch.setenv("GOLDENPIPE_NATIVE", "auto")
+    monkeypatch.setattr(L, "_native", Bare())
+    assert L.native_enabled("planner") is False

--- a/packages/python/goldenpipe/tests/core/test_planner_parity.py
+++ b/packages/python/goldenpipe/tests/core/test_planner_parity.py
@@ -1,0 +1,34 @@
+"""SP2 Leg A: the pure-Python planner (via _planner_json) must reproduce the SP1
+golden vectors (the core's output) byte-for-byte. Box-safe, no wheel."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from goldenpipe.core import _planner_json as PJ
+
+# repo-relative: test file is packages/python/goldenpipe/tests/core/test_planner_parity.py
+# parents: [0]=core [1]=tests [2]=goldenpipe [3]=python [4]=packages [5]=REPO ROOT.
+_VECTORS = Path(__file__).resolve().parents[5] / "packages/rust/extensions/goldenpipe-core/tests/vectors"
+
+
+def _load(name: str) -> list[dict]:
+    return json.loads((_VECTORS / f"{name}.json").read_text())
+
+
+_CASES = [
+    ("resolve", PJ.resolve_json),
+    ("apply_decision", PJ.apply_decision_json),
+    ("evaluate_builtin", PJ.evaluate_builtin_json),
+    ("auto_config", PJ.auto_config_json),
+    ("skip_if", PJ.skip_if_falsy_json),
+]
+
+
+@pytest.mark.parametrize("name,fn", _CASES)
+def test_pure_python_matches_core_vectors(name, fn):
+    for i, case in enumerate(_load(name)):
+        got = json.loads(fn(json.dumps(case["input"])))
+        assert got == case["expected"], f"{name}[{i}] input={case['input']!r}"

--- a/packages/python/goldenpipe/tests/core/test_planner_parity.py
+++ b/packages/python/goldenpipe/tests/core/test_planner_parity.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 from goldenpipe.core import _planner_json as PJ
 
 # repo-relative: test file is packages/python/goldenpipe/tests/core/test_planner_parity.py

--- a/packages/python/goldenpipe/tests/core/test_planner_parity.py
+++ b/packages/python/goldenpipe/tests/core/test_planner_parity.py
@@ -31,3 +31,30 @@ def test_pure_python_matches_core_vectors(name, fn):
     for i, case in enumerate(_load(name)):
         got = json.loads(fn(json.dumps(case["input"])))
         assert got == case["expected"], f"{name}[{i}] input={case['input']!r}"
+
+
+# --- Leg B: the native wheel reproduces the core (CI-primary; skip-guarded locally) ---
+from goldenpipe.core import _native_loader as NL  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "name,fn_name",
+    [
+        ("resolve", "resolve_json"),
+        ("apply_decision", "apply_decision_json"),
+        ("evaluate_builtin", "evaluate_builtin_json"),
+        ("auto_config", "auto_config_json"),
+        ("skip_if", "skip_if_falsy_json"),
+    ],
+)
+def test_native_wheel_matches_core_vectors(name, fn_name):
+    import os
+
+    if not NL.native_available():
+        if os.environ.get("GOLDENPIPE_NATIVE") == "1":
+            pytest.fail("GOLDENPIPE_NATIVE=1 but the native wheel is not importable")
+        pytest.skip("native wheel not built (Leg B is CI-primary)")
+    fn = getattr(NL, fn_name)
+    for i, case in enumerate(_load(name)):
+        got = json.loads(fn(json.dumps(case["input"])))
+        assert got == case["expected"], f"native {name}[{i}] input={case['input']!r}"

--- a/packages/python/goldenpipe/tests/core/test_wiring_error_attrs.py
+++ b/packages/python/goldenpipe/tests/core/test_wiring_error_attrs.py
@@ -1,0 +1,12 @@
+from goldenpipe.engine.resolver import WiringError
+
+
+def test_wiring_error_is_additive():
+    # legacy raise (message only) still works
+    e0 = WiringError("some message")
+    assert str(e0) == "some message"
+    assert e0.stage is None and e0.missing is None and e0.available is None
+    # structured raise carries attrs, message preserved
+    e1 = WiringError("msg", stage="s", missing="df", available=["a", "b"])
+    assert str(e1) == "msg"
+    assert (e1.stage, e1.missing, e1.available) == ("s", "df", ["a", "b"])

--- a/packages/rust/extensions/goldenpipe-core/src/config.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/config.rs
@@ -67,18 +67,29 @@ mod tests {
         v.iter().map(|s| s.to_string()).collect()
     }
     fn uses(cfg: &crate::model::PipelineConfig) -> Vec<String> {
-        cfg.stages.iter().map(|e| e.clone().into_spec().use_).collect()
+        cfg.stages
+            .iter()
+            .map(|e| e.clone().into_spec().use_)
+            .collect()
     }
 
     #[test]
     fn all_available_default_three() {
         let c = auto_config(
-            &avail(&["goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe"]),
+            &avail(&[
+                "goldencheck.scan",
+                "goldenflow.transform",
+                "goldenmatch.dedupe",
+            ]),
             None,
         );
         assert_eq!(
             uses(&c),
-            ["goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe"]
+            [
+                "goldencheck.scan",
+                "goldenflow.transform",
+                "goldenmatch.dedupe"
+            ]
         );
         assert_eq!(c.pipeline, "auto");
     }
@@ -97,7 +108,10 @@ mod tests {
             &avail(&["goldenmatch.dedupe", "goldenmatch.identity_resolve"]),
             Some(&opts),
         );
-        assert_eq!(uses(&c), ["goldenmatch.dedupe", "goldenmatch.identity_resolve"]);
+        assert_eq!(
+            uses(&c),
+            ["goldenmatch.dedupe", "goldenmatch.identity_resolve"]
+        );
     }
 
     #[test]

--- a/packages/rust/extensions/goldenpipe-core/src/decisions.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/decisions.rs
@@ -97,11 +97,14 @@ mod tests {
 
     #[test]
     fn row_count_gate_reason_bytes_match_python() {
-        let d = evaluate_builtin("row_count_gate", &ctx(r#"{"metadata":{"input_rows":1}}"#)).unwrap();
+        let d =
+            evaluate_builtin("row_count_gate", &ctx(r#"{"metadata":{"input_rows":1}}"#)).unwrap();
         assert_eq!(d.reason, "Only 1 row(s), skipping deduplication"); // byte-match f-string
         assert_eq!(d.skip, vec!["goldenmatch.dedupe"]);
         // >= 2 -> None; missing -> default 0 -> fires
-        assert!(evaluate_builtin("row_count_gate", &ctx(r#"{"metadata":{"input_rows":2}}"#)).is_none());
+        assert!(
+            evaluate_builtin("row_count_gate", &ctx(r#"{"metadata":{"input_rows":2}}"#)).is_none()
+        );
         let missing = evaluate_builtin("row_count_gate", &ctx(r#"{"metadata":{}}"#)).unwrap();
         assert_eq!(missing.reason, "Only 0 row(s), skipping deduplication"); // default 0 -> fires
     }

--- a/packages/rust/extensions/goldenpipe-core/src/json.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/json.rs
@@ -114,7 +114,10 @@ mod tests {
                 "stages":[{"key":"s","name":"s","produces":[],"consumes":["df"]}]}"#,
         );
         let cfg_str = out.split("\"config\":{").nth(1).unwrap();
-        assert!(cfg_str.starts_with("\"z\":1,\"a\":2,\"m\":3"), "got {cfg_str}");
+        assert!(
+            cfg_str.starts_with("\"z\":1,\"a\":2,\"m\":3"),
+            "got {cfg_str}"
+        );
     }
 
     #[test]

--- a/packages/rust/extensions/goldenpipe-core/src/model.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/model.rs
@@ -6,16 +6,12 @@ use serde_json::{Map, Value};
 
 pub type JsonMap = Map<String, Value>;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OnError {
+    #[default]
     Continue,
     Abort,
-}
-impl Default for OnError {
-    fn default() -> Self {
-        OnError::Continue
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/packages/rust/extensions/goldenpipe-core/src/resolve.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/resolve.rs
@@ -87,7 +87,10 @@ mod tests {
             info("goldenmatch.dedupe", &["clusters"], &["df", "findings"]),
         ];
         let plan = resolve(
-            &cfg(vec![name_entry("goldencheck.scan"), name_entry("goldenmatch.dedupe")]),
+            &cfg(vec![
+                name_entry("goldencheck.scan"),
+                name_entry("goldenmatch.dedupe"),
+            ]),
             &stages,
         )
         .unwrap();
@@ -123,7 +126,12 @@ mod tests {
     #[test]
     fn unknown_use_is_unknown_stage() {
         let err = resolve(&cfg(vec![name_entry("nope")]), &[]).unwrap_err();
-        assert_eq!(err, PlanError::UnknownStage { use_: "nope".into() });
+        assert_eq!(
+            err,
+            PlanError::UnknownStage {
+                use_: "nope".into()
+            }
+        );
     }
 
     #[test]

--- a/packages/rust/extensions/goldenpipe-core/src/router.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/router.rs
@@ -95,7 +95,10 @@ mod tests {
 
     #[test]
     fn skip_then_insert_combined() {
-        let r = apply_decision(&dec(&["a"], false, &["z"], "r"), &[planned("a"), planned("b")]);
+        let r = apply_decision(
+            &dec(&["a"], false, &["z"], "r"),
+            &[planned("a"), planned("b")],
+        );
         let names: Vec<_> = r.remaining.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, ["z", "b"]);
     }

--- a/packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs
+++ b/packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs
@@ -17,7 +17,10 @@ fn run(name: &str, f: fn(&str) -> String) {
     for (i, case) in load(name).into_iter().enumerate() {
         let input = serde_json::to_string(&case["input"]).unwrap();
         let got: Value = serde_json::from_str(&f(&input)).unwrap();
-        assert_eq!(got, case["expected"], "{name}[{i}] mismatch\n input={input}");
+        assert_eq!(
+            got, case["expected"],
+            "{name}[{i}] mismatch\n input={input}"
+        );
     }
 }
 

--- a/packages/rust/extensions/goldenpipe-native/Cargo.toml
+++ b/packages/rust/extensions/goldenpipe-native/Cargo.toml
@@ -1,0 +1,28 @@
+# Standalone workspace (empty [workspace]) so pyo3's `extension-module` feature isn't
+# unified with any sibling crate's features. Mirrors native-flow / goldenmatch's native.
+[workspace]
+
+[package]
+name = "goldenpipe-native"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Native binding for the GoldenPipe planner kernel (PyO3 extension module over goldenpipe-core)"
+
+[lib]
+# Produces _native.{so,dll,dylib}; the #[pymodule] is `_native` -> init PyInit__native.
+name = "_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+# abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
+# extension-module: don't link libpython (imported BY CPython).
+pyo3 = { version = ">=0.28, <0.29", features = ["extension-module", "abi3-py311"] }
+# The core is the single source of truth; this crate is a pure JSON-string marshaling
+# shim. No arrow (the planner is JSON, not columnar).
+goldenpipe-core = { path = "../goldenpipe-core" }
+
+[profile.release]
+opt-level = 3
+lto = "thin"

--- a/packages/rust/extensions/goldenpipe-native/README.md
+++ b/packages/rust/extensions/goldenpipe-native/README.md
@@ -1,0 +1,3 @@
+# goldenpipe-native
+
+Optional native (Rust/PyO3) binding exposing the pyo3-free `goldenpipe-core` planner kernel to Python. `pip install goldenpipe[native]`. Not an accelerator -- it makes the Rust core the reference the pure-Python planner is gated against.

--- a/packages/rust/extensions/goldenpipe-native/pyproject.toml
+++ b/packages/rust/extensions/goldenpipe-native/pyproject.toml
@@ -1,0 +1,28 @@
+# goldenpipe-native — optional native binding for the GoldenPipe planner, shipped as a
+# SEPARATE maturin/abi3 package (mirrors goldenflow-native). `goldenpipe` stays pure
+# Python; `pip install goldenpipe[native]` pulls this; goldenpipe.core._native_loader
+# discovers it. Note: this exposes the core as the REFERENCE; it does not accelerate.
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "goldenpipe-native"
+version = "0.1.0"
+description = "Native binding (Rust/PyO3) for the goldenpipe planner kernel"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Ben Severn", email = "ben@bensevern.dev" }]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
+]
+
+[project.urls]
+Homepage = "https://github.com/benseverndev-oss/goldenmatch"
+
+[tool.maturin]
+python-source = "python"
+module-name = "goldenpipe_native._native"

--- a/packages/rust/extensions/goldenpipe-native/python/goldenpipe_native/__init__.py
+++ b/packages/rust/extensions/goldenpipe-native/python/goldenpipe_native/__init__.py
@@ -1,0 +1,1 @@
+"""goldenpipe-native: PyO3 binding over goldenpipe-core. The compiled `_native` ext lands here."""

--- a/packages/rust/extensions/goldenpipe-native/src/lib.rs
+++ b/packages/rust/extensions/goldenpipe-native/src/lib.rs
@@ -1,0 +1,37 @@
+//! `goldenpipe._native` / `goldenpipe_native._native` — the PyO3 binding for the
+//! GoldenPipe planner kernel. Pure marshaling shim: `&str` in -> goldenpipe-core
+//! json fn -> `String` out. The core owns all logic; the pure-Python planner is a
+//! non-authoritative fallback proven to reproduce these bytes (SP2 parity gate).
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn resolve_json(input: &str) -> String {
+    goldenpipe_core::json::resolve_json(input)
+}
+#[pyfunction]
+fn apply_decision_json(input: &str) -> String {
+    goldenpipe_core::json::apply_decision_json(input)
+}
+#[pyfunction]
+fn evaluate_builtin_json(input: &str) -> String {
+    goldenpipe_core::json::evaluate_builtin_json(input)
+}
+#[pyfunction]
+fn auto_config_json(input: &str) -> String {
+    goldenpipe_core::json::auto_config_json(input)
+}
+#[pyfunction]
+fn skip_if_falsy_json(input: &str) -> String {
+    goldenpipe_core::json::skip_if_falsy_json(input)
+}
+
+#[pymodule]
+fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_function(wrap_pyfunction!(resolve_json, m)?)?;
+    m.add_function(wrap_pyfunction!(apply_decision_json, m)?)?;
+    m.add_function(wrap_pyfunction!(evaluate_builtin_json, m)?)?;
+    m.add_function(wrap_pyfunction!(auto_config_json, m)?)?;
+    m.add_function(wrap_pyfunction!(skip_if_falsy_json, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
SP2 of moving goldenpipe's planner to Rust. Makes the SP1 `goldenpipe-core` the Python REFERENCE: a `goldenpipe-native` abi3 wheel + reference-mode loader + a pure-Python==core parity gate.

## Scope (parity-gate-only — honest)
The core is the **oracle**; the pure-Python planner stays the **runtime** (no routing through the core — the planner isn't compute-bound, so marshaling JSON per pipeline would be a tax for zero benefit). The anti-drift value is the **gate**: the Python planner is provably locked to the core, and the core becomes the single reference SP3's TS will conform to (that's the actual drift-kill's foundation).

## What ships
- **`goldenpipe-native` crate** — pyo3 `_native` extension, 5 `fn(&str)->String` wrappers over the core's `*_json` (no arrow). **abi3 wheel builds clean on Windows** (no heavy deps).
- **`goldenpipe/core/_native_loader.py`** — `GOLDENPIPE_NATIVE` 0/1/auto gate (mirror goldenflow), floor-symbol probe. Shipped but the runtime doesn't consume it (parity-gate-only).
- **`goldenpipe/core/_planner_json.py`** — the JSON face of the pure-Python planner; it *calls* the real Resolver/Router/decisions, so the gate tests the actual planner.
- **`WiringError`** gains additive `.stage/.missing/.available` (message unchanged; confirmed non-regressing).
- **`scripts/build_native.py`** + the CI `goldenpipe_native` lane (`GOLDENPIPE_NATIVE=1`) — also `goldenpipe-core`'s first CI coverage (the SP1 gap), with fmt/clippy/cargo-test on the core.

## Tests
38 green locally: Leg A (pure==core, 5 vector families), **Leg B (wheel==core, ran green on the box under `GOLDENPIPE_NATIVE=1`)**, loader units, WiringError, + config/decisions regression. Both crates fmt+clippy-clean.

Two honesty flags carried from the spec (land at SP3): auto_config identity is a real TS behavior change; `evaluate_builtin` is a no-op vs today (prevents future drift). SP3 (TS/WASM reroute — the drift-kill) is the next slice.

Spec + plan: `docs/superpowers/{specs,plans}/2026-07-04-goldenpipe-native-binding*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)