### PR TITLE
feat(goldenflow): Wave D sweep pt1 — url/numeric/categorical owned kernels

### DIFF
--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,27 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-07-04 -- GoldenFlow Wave D sweep (part 1): url, numeric, categorical migrated to owned kernels
+- Three more existing transform families migrated to the owned-kernel
+  pattern (not new additions -- registry stays at 92): `url_normalize` /
+  `url_extract_domain`; the numeric parsers `currency_strip` /
+  `percentage_normalize` / `to_integer` / `comma_decimal` /
+  `scientific_to_decimal` plus the numeric-array ops `round` / `clamp` /
+  `abs_value` / `fill_zero`; and the categorical family `boolean_normalize` /
+  `gender_standardize` / `null_standardize` (fully owned) plus
+  `category_standardize` / `category_from_file` (logic/data split -- the
+  caller-supplied variant->canonical mapping stays in Python/TS, only the
+  shared key-derivation is a Rust kernel). Same cross-surface pattern as
+  prior waves (native + WASM/TS + pure-Python fallback), Rust is the
+  reference implementation.
+- **Behavior change (reference-mode, resolved in Rust's favor):** numeric
+  `round` now uses round-half-away-from-zero (was Python's round-half-to-even
+  banker's rounding); the five numeric string parsers return null on
+  unparseable input on both Python and TS (TS parsers previously passed
+  through unparsed input).
+- Versions: goldenflow 1.7.0 -> 1.8.0 / npm 0.7.0 -> 0.8.0 / goldenflow-native
+  0.5.0 -> 0.6.0.
+
 ## 2026-07-04 — GoldenFlow Wave D1: email transform family migrated to owned kernels
 - The email transform family (`email_lowercase`, `email_normalize`,
   `email_extract_domain`, `email_validate`) is now backed by owned Rust

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.8.0 (2026-07-04)
+
+Wave D (sweep, part 1): the url, numeric, and categorical transform families are now backed by owned Rust kernels in `goldenflow-core` (native + WASM/TS + pure-Python fallback), Rust is the reference implementation.
+
+- **Behavior change (reference-mode, resolved in Rust's favor):** numeric `round` now uses round-half-away-from-zero (e.g. 2.5 -> 3), replacing Python's round-half-to-even (banker's rounding). Numeric parsers (`currency_strip`/`percentage_normalize`/`to_integer`/`comma_decimal`/`scientific_to_decimal`) return null on unparseable input (value-parity with the kernel). TS numeric parsers now return null on parse failure (was pass-through).
+- url/categorical outputs unchanged for well-formed inputs.
+
 ## 1.7.0 (2026-07-04)
 
 Wave D1: the email transform family (`email_lowercase`, `email_normalize`, `email_extract_domain`, `email_validate`) is now backed by owned Rust kernels in `goldenflow-core`, cross-surface (native + WASM/TS + pure-Python fallback), byte-parity to the Rust oracle. This wave migrated existing transforms to the owned-kernel pattern; it did not add new transforms. `email_lowercase`/`email_extract_domain` moved from a vectorized Polars expression to native-first dispatch (the pure-Python fallback runs per-row when the native wheel is absent). Outputs are unchanged for well-formed inputs.

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -211,6 +211,30 @@ package. Loader discover order in `goldenflow/core/_native_loader.py`:
   pattern as the email family above (existing transforms migrated, not new
   additions). Both wired via the single `"url"` `_native_loader` component
   (floor symbol `url_normalize_arrow`).
+- **Numeric family migrated to owned kernels (Wave D4) -- VALUE parity, not
+  string parity.** `currency_strip`/`percentage_normalize`/`to_integer`
+  (mode stays `"expr"`, dispatched via `pl.col(column).map_batches(...)` so
+  the public `func(column) -> Expr` signature is unchanged) and
+  `comma_decimal`/`scientific_to_decimal`/`round`/`clamp`/`abs_value`/
+  `fill_zero` (mode `"series"`) now dispatch native-first through
+  goldenflow-core (`currency_strip_arrow` et al.), all wired via the single
+  `"numeric"` `_native_loader` component (floor symbol
+  `currency_strip_arrow`). This family outputs floats/ints, so the
+  byte-parity harness compares by VALUE: the 5 string->number PARSERS
+  (currency_strip/percentage_normalize/to_integer/comma_decimal/
+  scientific_to_decimal) live in the shared
+  `tests/parity/identifiers_corpus.jsonl` corpus with a numeric-aware
+  `_assert_value_parity` helper in `test_identifiers_parity.py` (exact float
+  equality preferred, 1e-9 epsilon only as a documented last resort); the 4
+  numeric-ARRAY ops (round/clamp/abs_value/fill_zero) take a NUMERIC column
+  as input rather than a string, so they don't fit that string-keyed corpus
+  and instead live in `test_numeric_kernels.py` with pinned-vector native +
+  fallback asserts. **Locked rounding rule:** `round` is round-half-away-
+  from-zero via multiply/round/divide (`(x * 10^n + 0.5).floor() / 10^n` for
+  `x >= 0`, mirrored `ceil` for negative) -- the goldenflow-core
+  `round_f64` kernel is the source of truth; this is deliberately NOT
+  Python's builtin `round()` (round-half-to-even) nor naive `Math.round`
+  (rounds half toward +Infinity, not away from zero) in TS.
 - **Byte-parity harness (cross-surface oracle = goldenflow-core).**
   `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` (mirrored
   byte-identical into `packages/typescript/goldenflow/tests/parity/`) is the

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -205,6 +205,12 @@ package. Loader discover order in `goldenflow/core/_native_loader.py`:
   `email_normalize`, `email_extract_domain`, `email_validate` now dispatch
   native-first through goldenflow-core, same cross-surface pattern as
   identifiers/names above (existing transforms migrated, not new additions).
+- **URL family migrated to owned kernels (Wave D2):** `url_normalize`,
+  `url_extract_domain` now dispatch native-first through goldenflow-core
+  (`url_normalize_arrow`/`url_extract_domain_arrow`), same cross-surface
+  pattern as the email family above (existing transforms migrated, not new
+  additions). Both wired via the single `"url"` `_native_loader` component
+  (floor symbol `url_normalize_arrow`).
 - **Byte-parity harness (cross-surface oracle = goldenflow-core).**
   `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` (mirrored
   byte-identical into `packages/typescript/goldenflow/tests/parity/`) is the

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -235,6 +235,21 @@ package. Loader discover order in `goldenflow/core/_native_loader.py`:
   `round_f64` kernel is the source of truth; this is deliberately NOT
   Python's builtin `round()` (round-half-to-even) nor naive `Math.round`
   (rounds half toward +Infinity, not away from zero) in TS.
+- **Categorical family migrated to owned kernels (Wave D5) -- LOGIC/DATA
+  split for the mapping transforms.** `boolean_normalize`/
+  `gender_standardize`/`null_standardize` are fully owned (fixed in-crate
+  lookup tables) and dispatch native-first through goldenflow-core
+  (`boolean_normalize_arrow` et al.), same cross-surface pattern as the
+  email/url families. `category_standardize`/`category_from_file` apply a
+  CALLER-SUPPLIED variant->canonical mapping (a function param, or loaded
+  from a CSV/YAML file at runtime) -- that mapping is runtime DATA, not
+  logic, so goldenflow-core does NOT own a dict-lookup kernel for it.
+  Instead, goldenflow-core owns `category_normalize_key` (the shared
+  trim+lowercase key-derivation both mapping transforms use before their
+  lookup); the dict-lookup-with-fallback loop stays in Python/TS. All 4
+  kernels wired via the single `"categorical"` `_native_loader` component
+  (floor symbol `boolean_normalize_arrow`). `null_standardize` stays
+  `auto_apply=True`.
 - **Byte-parity harness (cross-surface oracle = goldenflow-core).**
   `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` (mirrored
   byte-identical into `packages/typescript/goldenflow/tests/parity/`) is the

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -101,6 +101,11 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # url: normalize/extract_domain -- floor symbol only (url_normalize_arrow),
     # locale-free, region-free.
     "url": ("url_normalize_arrow",),
+    # numeric: string->number parsers (currency/percentage/to_integer/
+    # comma_decimal/scientific_to_decimal) + numeric-array ops (round/clamp/
+    # abs_value/fill_zero) -- floor symbol only (currency_strip_arrow),
+    # locale-free, region-free.
+    "numeric": ("currency_strip_arrow",),
 }
 
 # Components whose only native path is intentionally non-authoritative (the

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -106,6 +106,11 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # abs_value/fill_zero) -- floor symbol only (currency_strip_arrow),
     # locale-free, region-free.
     "numeric": ("currency_strip_arrow",),
+    # categorical: boolean_normalize/gender_standardize/null_standardize +
+    # the shared category_normalize_key (used by category_standardize/
+    # category_from_file's runtime-data mapping lookup) -- floor symbol only
+    # (boolean_normalize_arrow), locale-free, region-free.
+    "categorical": ("boolean_normalize_arrow",),
 }
 
 # Components whose only native path is intentionally non-authoritative (the

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -98,6 +98,9 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # email: lowercase/normalize/extract_domain/validate -- floor symbol only
     # (email_validate_arrow), locale-free, region-free.
     "email": ("email_validate_arrow",),
+    # url: normalize/extract_domain -- floor symbol only (url_normalize_arrow),
+    # locale-free, region-free.
+    "url": ("url_normalize_arrow",),
 }
 
 # Components whose only native path is intentionally non-authoritative (the

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -412,3 +412,33 @@ def email_extract_domain_native() -> Callable[[pl.Series], pl.Series] | None:
 
 def email_validate_native() -> Callable[[pl.Series], pl.Series] | None:
     return _email_kernel_runner("email_validate_arrow")
+
+
+def _url_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for URL kernel function ``attr`` if
+    native ``url`` is enabled and the dependencies are importable; else
+    ``None``. Like the other identifier runners -- no region/gating args,
+    scheme/domain normalization and domain extraction are locale-free."""
+    if not native_enabled("url"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def url_normalize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _url_kernel_runner("url_normalize_arrow")
+
+
+def url_extract_domain_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _url_kernel_runner("url_extract_domain_arrow")

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -539,3 +539,42 @@ def abs_value_native() -> Callable[[pl.Series], pl.Series] | None:
 
 def fill_zero_native() -> Callable[[pl.Series], pl.Series] | None:
     return _numeric_array_kernel_runner("fill_zero_arrow")
+
+
+def _categorical_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for categorical kernel function ``attr``
+    if native ``categorical`` is enabled and the dependencies are
+    importable; else ``None``. Like the other identifier runners -- no
+    region/gating args, the fixed lookup tables (boolean/gender/null) and
+    the key-normalization step are locale-free."""
+    if not native_enabled("categorical"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def boolean_normalize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _categorical_kernel_runner("boolean_normalize_arrow")
+
+
+def gender_standardize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _categorical_kernel_runner("gender_standardize_arrow")
+
+
+def null_standardize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _categorical_kernel_runner("null_standardize_arrow")
+
+
+def category_normalize_key_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _categorical_kernel_runner("category_normalize_key_arrow")

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -442,3 +442,100 @@ def url_normalize_native() -> Callable[[pl.Series], pl.Series] | None:
 
 def url_extract_domain_native() -> Callable[[pl.Series], pl.Series] | None:
     return _url_kernel_runner("url_extract_domain_arrow")
+
+
+def _as_f64_series(s: pl.Series) -> pl.Series:
+    """Ensure a Float64 series for the numeric-array-op Arrow bridge (round/
+    clamp/abs/fill_zero). Mirrors ``_as_str_series`` -- an all-null column is
+    Null-dtype, whose ``.to_arrow()`` the kernels reject."""
+    return s if s.dtype == pl.Float64 else s.cast(pl.Float64, strict=False)
+
+
+def _numeric_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for a numeric STRING-PARSER kernel function
+    ``attr`` (currency/percentage/to_integer/comma_decimal/
+    scientific_to_decimal) if native ``numeric`` is enabled and the
+    dependencies are importable; else ``None``. No region/gating args --
+    these parsers are locale-free (except comma_decimal's EU-format
+    detection, which is baked into the kernel itself)."""
+    if not native_enabled("numeric"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def currency_strip_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_kernel_runner("currency_strip_arrow")
+
+
+def percentage_normalize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_kernel_runner("percentage_normalize_arrow")
+
+
+def to_integer_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_kernel_runner("to_integer_arrow")
+
+
+def comma_decimal_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_kernel_runner("comma_decimal_arrow")
+
+
+def scientific_to_decimal_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_kernel_runner("scientific_to_decimal_arrow")
+
+
+def _numeric_array_kernel_runner(
+    attr: str, **kwargs: float | int
+) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for a numeric ARRAY-OP kernel function
+    ``attr`` (round/clamp/abs_value/fill_zero) if native ``numeric`` is
+    enabled and the dependencies are importable; else ``None``. Unlike the
+    string-parser runners, these read/write Float64 (not Utf8) Arrow arrays
+    and may carry params (``n`` for round, ``min_val``/``max_val`` for
+    clamp) forwarded as kwargs to the kernel call."""
+    if not native_enabled("numeric"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_f64_series(s).to_arrow(), **kwargs))
+
+    return run
+
+
+def round_native(n: int = 2) -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_array_kernel_runner("round_arrow", n=n)
+
+
+def clamp_native(
+    min_val: float = 0.0, max_val: float = 1.0
+) -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_array_kernel_runner(
+        "clamp_arrow", min_val=min_val, max_val=max_val
+    )
+
+
+def abs_value_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_array_kernel_runner("abs_value_arrow")
+
+
+def fill_zero_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _numeric_array_kernel_runner("fill_zero_arrow")

--- a/packages/python/goldenflow/goldenflow/transforms/categorical.py
+++ b/packages/python/goldenflow/goldenflow/transforms/categorical.py
@@ -3,55 +3,124 @@ from __future__ import annotations
 import polars as pl
 
 from goldenflow.transforms import register_transform
+from goldenflow.transforms._native import (
+    boolean_normalize_native,
+    category_normalize_key_native,
+    gender_standardize_native,
+    null_standardize_native,
+)
 
 _TRUE_VALUES = {"yes", "y", "1", "true", "t"}
 _FALSE_VALUES = {"no", "n", "0", "false", "f"}
 _NULL_VALUES = {"n/a", "null", "none", "na", "nil", "nan", "-", ""}
+
+# Pure-Python reference for goldenflow-core's ``categorical`` kernel. MUST
+# reproduce the Rust kernel byte-for-byte (asserted by
+# tests/transforms/test_identifiers_parity.py over
+# tests/parity/identifiers_corpus.jsonl).
+#
+# NOTE on the mapping-based transforms (``category_standardize`` /
+# ``category_from_file``): the caller-supplied variant->canonical mapping is
+# RUNTIME DATA (a function param, or loaded from a CSV/YAML file), not logic,
+# so goldenflow-core does NOT own it -- there is no dict lookup kernel. What
+# IS owned is ``category_normalize_key`` (the shared trim+lowercase key
+# derivation used before any lookup, fixed or caller-supplied); the two
+# mapping transforms below call it to derive the lookup key, then keep the
+# dict-lookup-with-fallback loop in pure Python.
+
+
+def _category_normalize_key_py(val: str) -> str:
+    return val.strip().lower()
+
+
+def _boolean_normalize_py(val: str | None) -> bool | None:
+    if val is None:
+        return None
+    v = _category_normalize_key_py(val)
+    if v in _TRUE_VALUES:
+        return True
+    if v in _FALSE_VALUES:
+        return False
+    return None
+
+
+def _gender_standardize_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    _map = {"male": "M", "m": "M", "female": "F", "f": "F"}
+    return _map.get(_category_normalize_key_py(val), val)
+
+
+def _null_standardize_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    if _category_normalize_key_py(val) in _NULL_VALUES:
+        return None
+    return val
+
+
+def _category_normalize_key_series(series: pl.Series) -> pl.Series:
+    """Vectorized key-normalization shared by ``category_standardize`` and
+    ``category_from_file``. Native-first (goldenflow-core's
+    ``categorical::category_normalize_key`` kernel); the pure-Python fallback
+    below is the byte-exact reference this kernel replicates."""
+    native = category_normalize_key_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(
+        lambda v: None if v is None else _category_normalize_key_py(v),
+        return_dtype=pl.Utf8,
+    )
 
 
 @register_transform(
     name="boolean_normalize", input_types=["boolean", "string"], auto_apply=False, priority=50, mode="series"
 )
 def boolean_normalize(series: pl.Series) -> pl.Series:
-    def _norm(val: str | None) -> bool | None:
-        if val is None:
-            return None
-        v = val.strip().lower()
-        if v in _TRUE_VALUES:
-            return True
-        if v in _FALSE_VALUES:
-            return False
-        return None
+    """Parse loose boolean-ish strings (yes/no/y/n/1/0/true/false/t/f).
 
-    return series.map_elements(_norm, return_dtype=pl.Boolean)
+    Native-first (goldenflow-core's ``categorical::boolean_normalize``
+    kernel); the pure-Python fallback below is the byte-exact reference this
+    kernel replicates.
+    """
+    native = boolean_normalize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_boolean_normalize_py, return_dtype=pl.Boolean)
 
 
 @register_transform(
     name="gender_standardize", input_types=["string"], auto_apply=False, priority=50, mode="series"
 )
 def gender_standardize(series: pl.Series) -> pl.Series:
-    _map = {"male": "M", "m": "M", "female": "F", "f": "F"}
+    """Standardize gender strings to ``M``/``F``; anything else passes
+    through unchanged.
 
-    def _std(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return _map.get(val.strip().lower(), val)
-
-    return series.map_elements(_std, return_dtype=pl.Utf8)
+    Native-first (goldenflow-core's ``categorical::gender_standardize``
+    kernel); the pure-Python fallback below is the byte-exact reference this
+    kernel replicates.
+    """
+    native = gender_standardize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_gender_standardize_py, return_dtype=pl.Utf8)
 
 
 @register_transform(
     name="null_standardize", input_types=["string"], auto_apply=True, priority=80, mode="series"
 )
 def null_standardize(series: pl.Series) -> pl.Series:
-    def _std(val: str | None) -> str | None:
-        if val is None:
-            return None
-        if val.strip().lower() in _NULL_VALUES:
-            return None
-        return val
+    """Map null-sentinel strings (n/a, null, none, na, nil, nan, -, empty) to
+    a real null; anything else passes through unchanged.
 
-    return series.map_elements(_std, return_dtype=pl.Utf8)
+    Native-first (goldenflow-core's ``categorical::null_standardize``
+    kernel); the pure-Python fallback below is the byte-exact reference this
+    kernel replicates.
+    """
+    native = null_standardize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_null_standardize_py, return_dtype=pl.Utf8)
 
 
 @register_transform(
@@ -64,7 +133,13 @@ def null_standardize(series: pl.Series) -> pl.Series:
 def category_standardize(
     series: pl.Series, mapping: dict[str, list[str]] | None = None
 ) -> pl.Series:
-    """Map variant values to canonical values. mapping: {canonical: [variant1, variant2, ...]}"""
+    """Map variant values to canonical values. mapping: {canonical: [variant1, variant2, ...]}
+
+    The mapping is runtime DATA supplied by the caller, so the dict lookup
+    stays in Python; only the key-normalization step (trim+lowercase) is
+    native-first via goldenflow-core's ``categorical::category_normalize_key``
+    kernel.
+    """
     if not mapping:
         return series
     lookup: dict[str, str] = {}
@@ -72,12 +147,13 @@ def category_standardize(
         for v in variants:
             lookup[v.lower()] = canonical
 
-    def _std(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return lookup.get(val.strip().lower(), val)
-
-    return series.map_elements(_std, return_dtype=pl.Utf8)
+    keys = _category_normalize_key_series(series).to_list()
+    originals = series.to_list()
+    result = [
+        (lookup.get(key, original) if original is not None else None)
+        for key, original in zip(keys, originals)
+    ]
+    return pl.Series(series.name, result, dtype=pl.Utf8)
 
 
 @register_transform(
@@ -91,7 +167,12 @@ def category_from_file(
     series: pl.Series, lookup_path: str | None = None
 ) -> pl.Series:
     """Load mapping from a CSV/YAML file and standardize values.
-    CSV must have columns: variant, canonical."""
+    CSV must have columns: variant, canonical.
+
+    Same native/Python split as ``category_standardize``: the file-loaded
+    mapping is runtime data (Python-only); only key-normalization is
+    native-first.
+    """
     if not lookup_path:
         return series
     from pathlib import Path
@@ -113,9 +194,10 @@ def category_from_file(
     else:
         return series
 
-    def _std(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return mapping.get(val.strip().lower(), val)
-
-    return series.map_elements(_std, return_dtype=pl.Utf8)
+    keys = _category_normalize_key_series(series).to_list()
+    originals = series.to_list()
+    result = [
+        (mapping.get(key, original) if original is not None else None)
+        for key, original in zip(keys, originals)
+    ]
+    return pl.Series(series.name, result, dtype=pl.Utf8)

--- a/packages/python/goldenflow/goldenflow/transforms/numeric.py
+++ b/packages/python/goldenflow/goldenflow/transforms/numeric.py
@@ -1,8 +1,132 @@
 from __future__ import annotations
 
+import math
+
 import polars as pl
 
 from goldenflow.transforms import register_transform
+from goldenflow.transforms._native import (
+    abs_value_native,
+    clamp_native,
+    comma_decimal_native,
+    currency_strip_native,
+    fill_zero_native,
+    percentage_normalize_native,
+    round_native,
+    scientific_to_decimal_native,
+    to_integer_native,
+)
+
+# Pure-Python reference for goldenflow-core's ``numeric`` kernel. MUST
+# reproduce the Rust kernel VALUE-for-VALUE (asserted by
+# tests/transforms/test_identifiers_parity.py / test_numeric_kernels.py over
+# tests/parity/identifiers_corpus.jsonl). This family outputs floats/ints, so
+# parity is by VALUE, not string repr.
+
+
+def _currency_strip_py(val: str | None) -> float | None:
+    if val is None:
+        return None
+    filtered = "".join(c for c in str(val) if c.isdigit() or c in ".-")
+    try:
+        return float(filtered)
+    except ValueError:
+        return None
+
+
+def _percentage_normalize_py(val: str | None) -> float | None:
+    if val is None:
+        return None
+    v = str(val).strip()
+    v = v.rstrip("%")
+    v = v.strip()
+    try:
+        return float(v) / 100.0
+    except ValueError:
+        return None
+
+
+def _to_integer_py(val: str | None) -> int | None:
+    if val is None:
+        return None
+    try:
+        return int(float(str(val).strip()))
+    except ValueError:
+        return None
+
+
+def _comma_decimal_py(val: str | None) -> float | None:
+    if val is None:
+        return None
+    v = str(val).strip()
+    if "," not in v:
+        try:
+            return float(v)
+        except ValueError:
+            return None
+    v = v.replace(".", "").replace(",", ".")
+    try:
+        return float(v)
+    except ValueError:
+        return None
+
+
+def _scientific_to_decimal_py(val: str | None) -> float | None:
+    if val is None:
+        return None
+    try:
+        return float(str(val).strip())
+    except ValueError:
+        return None
+
+
+def _round_f64_py(x: float, n: int) -> float:
+    """Round-half-away-from-zero at the n-th decimal, via multiply/round/
+    divide -- the SAME formula as goldenflow-core's ``round_f64`` kernel.
+    Deliberately NOT Python's builtin ``round()`` (round-half-to-even)."""
+    factor = 10.0**n
+    scaled = x * factor
+    rounded = math.floor(scaled + 0.5) if scaled >= 0 else math.ceil(scaled - 0.5)
+    return rounded / factor
+
+
+def _clamp_f64_py(x: float, min_val: float, max_val: float) -> float:
+    if x < min_val:
+        return min_val
+    if x > max_val:
+        return max_val
+    return x
+
+
+def _abs_f64_py(x: float) -> float:
+    return abs(x)
+
+
+def _currency_strip_series(series: pl.Series) -> pl.Series:
+    native = currency_strip_native()
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Utf8, strict=False).map_elements(
+        _currency_strip_py, return_dtype=pl.Float64
+    )
+
+
+def _percentage_normalize_series(series: pl.Series) -> pl.Series:
+    native = percentage_normalize_native()
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Utf8, strict=False).map_elements(
+        _percentage_normalize_py, return_dtype=pl.Float64
+    )
+
+
+def _to_integer_series(series: pl.Series) -> pl.Series:
+    native = to_integer_native()
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Utf8, strict=False).map_elements(
+        _to_integer_py, return_dtype=pl.Int64
+    )
 
 
 @register_transform(
@@ -11,17 +135,12 @@ from goldenflow.transforms import register_transform
 def currency_strip(column: str) -> pl.Expr:
     """Strip currency symbols and thousand separators, return numeric.
 
-    Native Polars: cast to Utf8, regex-strip non-numeric chars, cast to
-    Float64 (strict=False yields null on failure, matching the old
-    try/except). Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    Native-first (goldenflow-core's ``numeric::currency_strip`` kernel),
+    dispatched via ``map_batches`` so the transform keeps its original
+    ``expr``-mode signature; the pure-Python fallback is the value-exact
+    reference this kernel replicates.
     """
-    return (
-        pl.col(column)
-        .cast(pl.Utf8, strict=False)
-        .str.replace_all(r"[^\d.\-]", "")
-        .cast(pl.Float64, strict=False)
-    )
+    return pl.col(column).map_batches(_currency_strip_series, return_dtype=pl.Float64)
 
 
 @register_transform(
@@ -34,32 +153,49 @@ def currency_strip(column: str) -> pl.Expr:
 def percentage_normalize(column: str) -> pl.Expr:
     """Strip trailing %, parse to float, divide by 100.
 
-    Native Polars: cast to Utf8, strip whitespace + trailing %, cast to
-    Float64 (null on failure), then divide. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    Native-first (goldenflow-core's ``numeric::percentage_normalize``
+    kernel), dispatched via ``map_batches``; the pure-Python fallback is the
+    value-exact reference this kernel replicates.
     """
-    return (
-        pl.col(column)
-        .cast(pl.Utf8, strict=False)
-        .str.strip_chars()
-        .str.replace(r"%+$", "")
-        .cast(pl.Float64, strict=False)
-        / 100.0
-    )
+    return pl.col(column).map_batches(_percentage_normalize_series, return_dtype=pl.Float64)
 
 
 @register_transform(
     name="round", input_types=["numeric"], auto_apply=False, priority=40, mode="series"
 )
 def round_values(series: pl.Series, n: int = 2) -> pl.Series:
-    return series.round(n)
+    """Round to n decimal places (round-half-away-from-zero, see the
+    goldenflow-core ``round_f64`` kernel doc for why this deliberately isn't
+    the language builtin ``round()``).
+
+    Native-first; the pure-Python fallback below is the value-exact
+    reference this kernel replicates.
+    """
+    native = round_native(n)
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Float64, strict=False).map_elements(
+        lambda x: None if x is None else _round_f64_py(x, n), return_dtype=pl.Float64
+    )
 
 
 @register_transform(
     name="clamp", input_types=["numeric"], auto_apply=False, priority=40, mode="series"
 )
 def clamp(series: pl.Series, min_val: float = 0.0, max_val: float = 1.0) -> pl.Series:
-    return series.clip(min_val, max_val)
+    """Clip values into [min_val, max_val].
+
+    Native-first (goldenflow-core's ``numeric::clamp_f64`` kernel); the
+    pure-Python fallback below is the value-exact reference this kernel
+    replicates.
+    """
+    native = clamp_native(min_val, max_val)
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Float64, strict=False).map_elements(
+        lambda x: None if x is None else _clamp_f64_py(x, min_val, max_val),
+        return_dtype=pl.Float64,
+    )
 
 
 @register_transform(
@@ -72,16 +208,11 @@ def clamp(series: pl.Series, min_val: float = 0.0, max_val: float = 1.0) -> pl.S
 def to_integer(column: str) -> pl.Expr:
     """Parse string to integer, truncating any decimal part.
 
-    Native Polars: cast via Float64 (truncation matches the old int(float(val))
-    semantics) then Int64. strict=False yields null on parse failure, matching
-    the old try/except. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    Native-first (goldenflow-core's ``numeric::to_integer`` kernel),
+    dispatched via ``map_batches``; the pure-Python fallback is the
+    value-exact reference this kernel replicates.
     """
-    return (
-        pl.col(column)
-        .cast(pl.Float64, strict=False)
-        .cast(pl.Int64, strict=False)
-    )
+    return pl.col(column).map_batches(_to_integer_series, return_dtype=pl.Int64)
 
 
 @register_transform(
@@ -92,8 +223,18 @@ def to_integer(column: str) -> pl.Expr:
     mode="series",
 )
 def abs_value(series: pl.Series) -> pl.Series:
-    """Return the absolute value."""
-    return series.abs()
+    """Return the absolute value.
+
+    Native-first (goldenflow-core's ``numeric::abs_f64`` kernel); the
+    pure-Python fallback below is the value-exact reference this kernel
+    replicates.
+    """
+    native = abs_value_native()
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Float64, strict=False).map_elements(
+        lambda x: None if x is None else _abs_f64_py(x), return_dtype=pl.Float64
+    )
 
 
 @register_transform(
@@ -104,8 +245,16 @@ def abs_value(series: pl.Series) -> pl.Series:
     mode="series",
 )
 def fill_zero(series: pl.Series) -> pl.Series:
-    """Replace null values with 0."""
-    return series.fill_null(0)
+    """Replace null values with 0.
+
+    Native-first (goldenflow-core's ``numeric::fill_zero`` kernel); the
+    pure-Python fallback below is the value-exact reference this kernel
+    replicates.
+    """
+    native = fill_zero_native()
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Float64, strict=False).fill_null(0.0)
 
 
 @register_transform(
@@ -116,26 +265,18 @@ def fill_zero(series: pl.Series) -> pl.Series:
     mode="series",
 )
 def comma_decimal(series: pl.Series) -> pl.Series:
-    """Convert European decimal format (1.234,56) to float (1234.56)."""
+    """Convert European decimal format (1.234,56) to float (1234.56).
 
-    def _convert(val: str | None) -> float | None:
-        if val is None:
-            return None
-        v = str(val).strip()
-        if "," not in v:
-            # No comma present — parse as-is (US format or plain number)
-            try:
-                return float(v)
-            except ValueError:
-                return None
-        # European format: dots are thousands, comma is decimal
-        v = v.replace(".", "").replace(",", ".")
-        try:
-            return float(v)
-        except ValueError:
-            return None
-
-    return series.map_elements(_convert, return_dtype=pl.Float64)
+    Native-first (goldenflow-core's ``numeric::comma_decimal`` kernel); the
+    pure-Python fallback below is the value-exact reference this kernel
+    replicates.
+    """
+    native = comma_decimal_native()
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Utf8, strict=False).map_elements(
+        _comma_decimal_py, return_dtype=pl.Float64
+    )
 
 
 @register_transform(
@@ -146,14 +287,15 @@ def comma_decimal(series: pl.Series) -> pl.Series:
     mode="series",
 )
 def scientific_to_decimal(series: pl.Series) -> pl.Series:
-    """Convert scientific notation (1.5e3) to decimal (1500.0)."""
+    """Convert scientific notation (1.5e3) to decimal (1500.0).
 
-    def _convert(val: str | None) -> float | None:
-        if val is None:
-            return None
-        try:
-            return float(str(val).strip())
-        except ValueError:
-            return None
-
-    return series.map_elements(_convert, return_dtype=pl.Float64)
+    Native-first (goldenflow-core's ``numeric::scientific_to_decimal``
+    kernel); the pure-Python fallback below is the value-exact reference
+    this kernel replicates.
+    """
+    native = scientific_to_decimal_native()
+    if native is not None:
+        return native(series)
+    return series.cast(pl.Utf8, strict=False).map_elements(
+        _scientific_to_decimal_py, return_dtype=pl.Float64
+    )

--- a/packages/python/goldenflow/goldenflow/transforms/url.py
+++ b/packages/python/goldenflow/goldenflow/transforms/url.py
@@ -5,8 +5,62 @@ import re
 import polars as pl
 
 from goldenflow.transforms import register_transform
+from goldenflow.transforms._native import (
+    url_extract_domain_native,
+    url_normalize_native,
+)
 
 _SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
+
+
+# Pure-Python reference for goldenflow-core's ``url`` kernel. MUST reproduce
+# the Rust kernel byte-for-byte (asserted by
+# tests/transforms/test_identifiers_parity.py over
+# tests/parity/identifiers_corpus.jsonl).
+
+
+def _url_normalize_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    val = val.strip()
+    if not val:
+        return None
+    # Add scheme if missing
+    if not _SCHEME_RE.match(val):
+        val = "https://" + val
+    # Split scheme from rest
+    scheme_end = val.index("://") + 3
+    scheme = val[:scheme_end].lower()
+    rest = val[scheme_end:]
+    # Lowercase the domain (everything before first /)
+    slash_idx = rest.find("/")
+    if slash_idx == -1:
+        domain = rest.lower()
+        path = ""
+    else:
+        domain = rest[:slash_idx].lower()
+        path = rest[slash_idx:]
+    # Strip trailing slash (but not if path is just "/")
+    result = scheme + domain + path
+    if result.endswith("/") and len(result) > scheme_end + len(domain) + 1:
+        result = result.rstrip("/")
+    elif result.endswith("/") and path == "/":
+        result = result[:-1]
+    return result
+
+
+def _url_extract_domain_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    val = val.strip()
+    if not val:
+        return None
+    # Strip scheme
+    if "://" in val:
+        val = val.split("://", 1)[1]
+    # Take everything before the first /
+    domain = val.split("/", 1)[0]
+    return domain.lower() if domain else None
 
 
 @register_transform(
@@ -17,38 +71,16 @@ _SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
     mode="series",
 )
 def url_normalize(series: pl.Series) -> pl.Series:
-    """Normalize URLs: ensure scheme, lowercase domain, strip trailing slash."""
+    """Normalize URLs: ensure scheme, lowercase domain, strip trailing slash.
 
-    def _norm(val: str | None) -> str | None:
-        if val is None:
-            return None
-        val = val.strip()
-        if not val:
-            return None
-        # Add scheme if missing
-        if not _SCHEME_RE.match(val):
-            val = "https://" + val
-        # Split scheme from rest
-        scheme_end = val.index("://") + 3
-        scheme = val[:scheme_end].lower()
-        rest = val[scheme_end:]
-        # Lowercase the domain (everything before first /)
-        slash_idx = rest.find("/")
-        if slash_idx == -1:
-            domain = rest.lower()
-            path = ""
-        else:
-            domain = rest[:slash_idx].lower()
-            path = rest[slash_idx:]
-        # Strip trailing slash (but not if path is just "/")
-        result = scheme + domain + path
-        if result.endswith("/") and len(result) > scheme_end + len(domain) + 1:
-            result = result.rstrip("/")
-        elif result.endswith("/") and path == "/":
-            result = result[:-1]
-        return result
-
-    return series.map_elements(_norm, return_dtype=pl.Utf8)
+    Native-first (goldenflow-core's ``url::url_normalize`` kernel); the
+    pure-Python fallback below is the byte-exact reference this kernel
+    replicates.
+    """
+    native = url_normalize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_url_normalize_py, return_dtype=pl.Utf8)
 
 
 @register_transform(
@@ -59,19 +91,13 @@ def url_normalize(series: pl.Series) -> pl.Series:
     mode="series",
 )
 def url_extract_domain(series: pl.Series) -> pl.Series:
-    """Extract domain from a URL."""
+    """Extract domain from a URL.
 
-    def _domain(val: str | None) -> str | None:
-        if val is None:
-            return None
-        val = val.strip()
-        if not val:
-            return None
-        # Strip scheme
-        if "://" in val:
-            val = val.split("://", 1)[1]
-        # Take everything before the first /
-        domain = val.split("/", 1)[0]
-        return domain.lower() if domain else None
-
-    return series.map_elements(_domain, return_dtype=pl.Utf8)
+    Native-first (goldenflow-core's ``url::url_extract_domain`` kernel); the
+    pure-Python fallback below is the byte-exact reference this kernel
+    replicates.
+    """
+    native = url_extract_domain_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_url_extract_domain_py, return_dtype=pl.Utf8)

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.7.0"
+version = "1.8.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -54,6 +54,13 @@ from goldenflow.transforms.names import (  # noqa: E402
     _name_script_py,
     _name_transliterate_py,
 )
+from goldenflow.transforms.numeric import (  # noqa: E402
+    _comma_decimal_py,
+    _currency_strip_py,
+    _percentage_normalize_py,
+    _scientific_to_decimal_py,
+    _to_integer_py,
+)
 from goldenflow.transforms.url import (  # noqa: E402
     _url_extract_domain_py,
     _url_normalize_py,
@@ -328,6 +335,48 @@ _CASES: list[tuple[str, str | None]] = [
     ("url_extract_domain", ""),  # empty -> None
     ("url_extract_domain", "   "),  # whitespace-only -> None
     ("url_extract_domain", None),  # null
+    # --- currency_strip (string->float; VALUE parity, not repr) ---
+    ("currency_strip", "$1,234.56"),  # strip $ and comma
+    ("currency_strip", "-$42.00"),  # negative, dollar sign
+    ("currency_strip", "USD 100"),  # strip letters + space
+    ("currency_strip", "0.50"),  # plain decimal
+    ("currency_strip", "free"),  # no numeric chars -> null
+    ("currency_strip", ""),  # empty -> null
+    ("currency_strip", None),  # null
+    # --- percentage_normalize (string->float) ---
+    ("percentage_normalize", "85%"),
+    ("percentage_normalize", "100%"),
+    ("percentage_normalize", "0.5%"),
+    ("percentage_normalize", " 12.5 % "),  # whitespace around number and %
+    ("percentage_normalize", "50"),  # no % sign
+    ("percentage_normalize", "abc%"),  # non-numeric -> null
+    ("percentage_normalize", ""),  # empty -> null
+    ("percentage_normalize", None),  # null
+    # --- to_integer (string->int, truncating) ---
+    ("to_integer", "42"),
+    ("to_integer", "3.7"),  # truncates
+    ("to_integer", "-3.7"),  # truncates toward zero
+    ("to_integer", "100"),
+    ("to_integer", "abc"),  # non-numeric -> null
+    ("to_integer", ""),  # empty -> null
+    ("to_integer", None),  # null
+    # --- comma_decimal (string->float, EU format) ---
+    ("comma_decimal", "1.234,56"),  # EU format
+    ("comma_decimal", "99,99"),  # EU format, no thousands sep
+    ("comma_decimal", "1.000,00"),  # EU format with thousands sep
+    ("comma_decimal", "1.5"),  # US format (no comma) -> parsed as-is
+    ("comma_decimal", "100"),  # plain integer
+    ("comma_decimal", "abc"),  # non-numeric -> null
+    ("comma_decimal", ""),  # empty -> null
+    ("comma_decimal", None),  # null
+    # --- scientific_to_decimal (string->float) ---
+    ("scientific_to_decimal", "1.5e3"),
+    ("scientific_to_decimal", "2.0E-4"),
+    ("scientific_to_decimal", "3.14e0"),
+    ("scientific_to_decimal", "100"),  # plain number, no exponent
+    ("scientific_to_decimal", "abc"),  # non-numeric -> null
+    ("scientific_to_decimal", ""),  # empty -> null
+    ("scientific_to_decimal", None),  # null
 ]
 
 _PY_FN = {
@@ -353,6 +402,11 @@ _PY_FN = {
     "email_validate": _email_validate_py,
     "url_normalize": _url_normalize_py,
     "url_extract_domain": _url_extract_domain_py,
+    "currency_strip": _currency_strip_py,
+    "percentage_normalize": _percentage_normalize_py,
+    "to_integer": _to_integer_py,
+    "comma_decimal": _comma_decimal_py,
+    "scientific_to_decimal": _scientific_to_decimal_py,
 }
 
 _NATIVE_ARROW_FN = {
@@ -378,6 +432,11 @@ _NATIVE_ARROW_FN = {
     "email_validate": "email_validate_arrow",
     "url_normalize": "url_normalize_arrow",
     "url_extract_domain": "url_extract_domain_arrow",
+    "currency_strip": "currency_strip_arrow",
+    "percentage_normalize": "percentage_normalize_arrow",
+    "to_integer": "to_integer_arrow",
+    "comma_decimal": "comma_decimal_arrow",
+    "scientific_to_decimal": "scientific_to_decimal_arrow",
 }
 
 

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -28,6 +28,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from goldenflow.core._native_loader import native_available, native_module  # noqa: E402
+from goldenflow.transforms.categorical import (  # noqa: E402
+    _boolean_normalize_py,
+    _category_normalize_key_py,
+    _gender_standardize_py,
+    _null_standardize_py,
+)
 from goldenflow.transforms.email import (  # noqa: E402
     _email_extract_domain_py,
     _email_lowercase_py,
@@ -377,6 +383,54 @@ _CASES: list[tuple[str, str | None]] = [
     ("scientific_to_decimal", "abc"),  # non-numeric -> null
     ("scientific_to_decimal", ""),  # empty -> null
     ("scientific_to_decimal", None),  # null
+    # --- boolean_normalize (string->bool) ---
+    ("boolean_normalize", "Yes"),
+    ("boolean_normalize", "Y"),
+    ("boolean_normalize", "1"),
+    ("boolean_normalize", "True"),
+    ("boolean_normalize", " true "),  # whitespace around a recognized token
+    ("boolean_normalize", "T"),
+    ("boolean_normalize", "No"),
+    ("boolean_normalize", "N"),
+    ("boolean_normalize", "0"),
+    ("boolean_normalize", "False"),
+    ("boolean_normalize", "f"),
+    ("boolean_normalize", "maybe"),  # unrecognized -> null
+    ("boolean_normalize", ""),  # empty -> null
+    ("boolean_normalize", None),  # null
+    # --- gender_standardize (string->string, passthrough on no match) ---
+    ("gender_standardize", "Male"),
+    ("gender_standardize", "male"),
+    ("gender_standardize", "M"),
+    ("gender_standardize", "m"),
+    ("gender_standardize", "Female"),
+    ("gender_standardize", "female"),
+    ("gender_standardize", "F"),
+    ("gender_standardize", "f"),
+    ("gender_standardize", "Nonbinary"),  # no match -> passthrough UNCHANGED
+    ("gender_standardize", ""),  # empty -> passthrough (empty string)
+    ("gender_standardize", None),  # null
+    # --- null_standardize (string->string|null) ---
+    ("null_standardize", "N/A"),
+    ("null_standardize", "NULL"),
+    ("null_standardize", "none"),
+    ("null_standardize", ""),
+    ("null_standardize", "  "),  # trims to empty -> null
+    ("null_standardize", "null"),
+    ("null_standardize", "NA"),
+    ("null_standardize", "nil"),
+    ("null_standardize", "nan"),
+    ("null_standardize", "-"),
+    ("null_standardize", "actual value"),  # no match -> passthrough UNCHANGED
+    ("null_standardize", None),  # null
+    # --- category_normalize_key (string->string, shared key-derivation for
+    # the mapping-based transforms category_standardize/category_from_file --
+    # always trim+lowercase, never fails) ---
+    ("category_normalize_key", "  Yes  "),
+    ("category_normalize_key", "USA"),
+    ("category_normalize_key", "MiXeD Case"),
+    ("category_normalize_key", ""),
+    ("category_normalize_key", None),  # null
 ]
 
 _PY_FN = {
@@ -407,6 +461,10 @@ _PY_FN = {
     "to_integer": _to_integer_py,
     "comma_decimal": _comma_decimal_py,
     "scientific_to_decimal": _scientific_to_decimal_py,
+    "boolean_normalize": _boolean_normalize_py,
+    "gender_standardize": _gender_standardize_py,
+    "null_standardize": _null_standardize_py,
+    "category_normalize_key": lambda v: None if v is None else _category_normalize_key_py(v),
 }
 
 _NATIVE_ARROW_FN = {
@@ -437,6 +495,10 @@ _NATIVE_ARROW_FN = {
     "to_integer": "to_integer_arrow",
     "comma_decimal": "comma_decimal_arrow",
     "scientific_to_decimal": "scientific_to_decimal_arrow",
+    "boolean_normalize": "boolean_normalize_arrow",
+    "gender_standardize": "gender_standardize_arrow",
+    "null_standardize": "null_standardize_arrow",
+    "category_normalize_key": "category_normalize_key_arrow",
 }
 
 

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -54,6 +54,10 @@ from goldenflow.transforms.names import (  # noqa: E402
     _name_script_py,
     _name_transliterate_py,
 )
+from goldenflow.transforms.url import (  # noqa: E402
+    _url_extract_domain_py,
+    _url_normalize_py,
+)
 
 CORPUS_PATH = Path(__file__).resolve().parent.parent / "tests" / "parity" / "identifiers_corpus.jsonl"
 
@@ -302,6 +306,28 @@ _CASES: list[tuple[str, str | None]] = [
     ("email_validate", ""),  # empty -> false
     ("email_validate", "   "),  # whitespace-only -> false
     ("email_validate", None),  # null
+    # --- url_normalize ---
+    ("url_normalize", "Example.COM/Path/"),  # no scheme -> prepend https, lowercase domain
+    ("url_normalize", "http://X.com/"),  # trailing slash, path == "/" -> strip one
+    ("url_normalize", "https://a.com"),  # no trailing slash -> unchanged
+    ("url_normalize", "https://a.com/x/"),  # path beyond root -> strip all trailing slashes
+    ("url_normalize", "https://a.com/x//"),  # multiple trailing slashes -> strip all
+    ("url_normalize", "HTTPS://Foo.com"),  # uppercase scheme -> lowercased
+    ("url_normalize", "HtTp://Foo.com"),  # mixed-case scheme -> lowercased
+    ("url_normalize", "EXAMPLE.com"),  # no scheme, no path -> https prepended
+    ("url_normalize", " example.com "),  # leading/trailing whitespace -> trimmed
+    ("url_normalize", "http://sub.Domain.ORG/Path/More"),  # multi-label domain, mixed-case path
+    ("url_normalize", ""),  # empty -> None
+    ("url_normalize", "   "),  # whitespace-only -> None
+    ("url_normalize", None),  # null
+    # --- url_extract_domain ---
+    ("url_extract_domain", "https://Foo.com/x"),  # mixed-case domain -> lowercased
+    ("url_extract_domain", "bar.com"),  # no scheme -> domain as-is (lowercased)
+    ("url_extract_domain", "http://sub.domain.org/path/more"),  # multi-label domain
+    ("url_extract_domain", "HTTPS://EXAMPLE.COM"),  # all-caps, no path
+    ("url_extract_domain", ""),  # empty -> None
+    ("url_extract_domain", "   "),  # whitespace-only -> None
+    ("url_extract_domain", None),  # null
 ]
 
 _PY_FN = {
@@ -325,6 +351,8 @@ _PY_FN = {
     "email_normalize": _email_normalize_py,
     "email_extract_domain": _email_extract_domain_py,
     "email_validate": _email_validate_py,
+    "url_normalize": _url_normalize_py,
+    "url_extract_domain": _url_extract_domain_py,
 }
 
 _NATIVE_ARROW_FN = {
@@ -348,6 +376,8 @@ _NATIVE_ARROW_FN = {
     "email_normalize": "email_normalize_arrow",
     "email_extract_domain": "email_extract_domain_arrow",
     "email_validate": "email_validate_arrow",
+    "url_normalize": "url_normalize_arrow",
+    "url_extract_domain": "url_extract_domain_arrow",
 }
 
 

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -200,3 +200,23 @@
 {"transform": "email_validate", "input": "", "expected": false}
 {"transform": "email_validate", "input": "   ", "expected": false}
 {"transform": "email_validate", "input": null, "expected": null}
+{"transform": "url_normalize", "input": "Example.COM/Path/", "expected": "https://example.com/Path"}
+{"transform": "url_normalize", "input": "http://X.com/", "expected": "http://x.com"}
+{"transform": "url_normalize", "input": "https://a.com", "expected": "https://a.com"}
+{"transform": "url_normalize", "input": "https://a.com/x/", "expected": "https://a.com/x"}
+{"transform": "url_normalize", "input": "https://a.com/x//", "expected": "https://a.com/x"}
+{"transform": "url_normalize", "input": "HTTPS://Foo.com", "expected": "https://foo.com"}
+{"transform": "url_normalize", "input": "HtTp://Foo.com", "expected": "http://foo.com"}
+{"transform": "url_normalize", "input": "EXAMPLE.com", "expected": "https://example.com"}
+{"transform": "url_normalize", "input": " example.com ", "expected": "https://example.com"}
+{"transform": "url_normalize", "input": "http://sub.Domain.ORG/Path/More", "expected": "http://sub.domain.org/Path/More"}
+{"transform": "url_normalize", "input": "", "expected": null}
+{"transform": "url_normalize", "input": "   ", "expected": null}
+{"transform": "url_normalize", "input": null, "expected": null}
+{"transform": "url_extract_domain", "input": "https://Foo.com/x", "expected": "foo.com"}
+{"transform": "url_extract_domain", "input": "bar.com", "expected": "bar.com"}
+{"transform": "url_extract_domain", "input": "http://sub.domain.org/path/more", "expected": "sub.domain.org"}
+{"transform": "url_extract_domain", "input": "HTTPS://EXAMPLE.COM", "expected": "example.com"}
+{"transform": "url_extract_domain", "input": "", "expected": null}
+{"transform": "url_extract_domain", "input": "   ", "expected": null}
+{"transform": "url_extract_domain", "input": null, "expected": null}

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -257,3 +257,45 @@
 {"transform": "scientific_to_decimal", "input": "abc", "expected": null}
 {"transform": "scientific_to_decimal", "input": "", "expected": null}
 {"transform": "scientific_to_decimal", "input": null, "expected": null}
+{"transform": "boolean_normalize", "input": "Yes", "expected": true}
+{"transform": "boolean_normalize", "input": "Y", "expected": true}
+{"transform": "boolean_normalize", "input": "1", "expected": true}
+{"transform": "boolean_normalize", "input": "True", "expected": true}
+{"transform": "boolean_normalize", "input": " true ", "expected": true}
+{"transform": "boolean_normalize", "input": "T", "expected": true}
+{"transform": "boolean_normalize", "input": "No", "expected": false}
+{"transform": "boolean_normalize", "input": "N", "expected": false}
+{"transform": "boolean_normalize", "input": "0", "expected": false}
+{"transform": "boolean_normalize", "input": "False", "expected": false}
+{"transform": "boolean_normalize", "input": "f", "expected": false}
+{"transform": "boolean_normalize", "input": "maybe", "expected": null}
+{"transform": "boolean_normalize", "input": "", "expected": null}
+{"transform": "boolean_normalize", "input": null, "expected": null}
+{"transform": "gender_standardize", "input": "Male", "expected": "M"}
+{"transform": "gender_standardize", "input": "male", "expected": "M"}
+{"transform": "gender_standardize", "input": "M", "expected": "M"}
+{"transform": "gender_standardize", "input": "m", "expected": "M"}
+{"transform": "gender_standardize", "input": "Female", "expected": "F"}
+{"transform": "gender_standardize", "input": "female", "expected": "F"}
+{"transform": "gender_standardize", "input": "F", "expected": "F"}
+{"transform": "gender_standardize", "input": "f", "expected": "F"}
+{"transform": "gender_standardize", "input": "Nonbinary", "expected": "Nonbinary"}
+{"transform": "gender_standardize", "input": "", "expected": ""}
+{"transform": "gender_standardize", "input": null, "expected": null}
+{"transform": "null_standardize", "input": "N/A", "expected": null}
+{"transform": "null_standardize", "input": "NULL", "expected": null}
+{"transform": "null_standardize", "input": "none", "expected": null}
+{"transform": "null_standardize", "input": "", "expected": null}
+{"transform": "null_standardize", "input": "  ", "expected": null}
+{"transform": "null_standardize", "input": "null", "expected": null}
+{"transform": "null_standardize", "input": "NA", "expected": null}
+{"transform": "null_standardize", "input": "nil", "expected": null}
+{"transform": "null_standardize", "input": "nan", "expected": null}
+{"transform": "null_standardize", "input": "-", "expected": null}
+{"transform": "null_standardize", "input": "actual value", "expected": "actual value"}
+{"transform": "null_standardize", "input": null, "expected": null}
+{"transform": "category_normalize_key", "input": "  Yes  ", "expected": "yes"}
+{"transform": "category_normalize_key", "input": "USA", "expected": "usa"}
+{"transform": "category_normalize_key", "input": "MiXeD Case", "expected": "mixed case"}
+{"transform": "category_normalize_key", "input": "", "expected": ""}
+{"transform": "category_normalize_key", "input": null, "expected": null}

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -220,3 +220,40 @@
 {"transform": "url_extract_domain", "input": "", "expected": null}
 {"transform": "url_extract_domain", "input": "   ", "expected": null}
 {"transform": "url_extract_domain", "input": null, "expected": null}
+{"transform": "currency_strip", "input": "$1,234.56", "expected": 1234.56}
+{"transform": "currency_strip", "input": "-$42.00", "expected": -42.0}
+{"transform": "currency_strip", "input": "USD 100", "expected": 100.0}
+{"transform": "currency_strip", "input": "0.50", "expected": 0.5}
+{"transform": "currency_strip", "input": "free", "expected": null}
+{"transform": "currency_strip", "input": "", "expected": null}
+{"transform": "currency_strip", "input": null, "expected": null}
+{"transform": "percentage_normalize", "input": "85%", "expected": 0.85}
+{"transform": "percentage_normalize", "input": "100%", "expected": 1.0}
+{"transform": "percentage_normalize", "input": "0.5%", "expected": 0.005}
+{"transform": "percentage_normalize", "input": " 12.5 % ", "expected": 0.125}
+{"transform": "percentage_normalize", "input": "50", "expected": 0.5}
+{"transform": "percentage_normalize", "input": "abc%", "expected": null}
+{"transform": "percentage_normalize", "input": "", "expected": null}
+{"transform": "percentage_normalize", "input": null, "expected": null}
+{"transform": "to_integer", "input": "42", "expected": 42}
+{"transform": "to_integer", "input": "3.7", "expected": 3}
+{"transform": "to_integer", "input": "-3.7", "expected": -3}
+{"transform": "to_integer", "input": "100", "expected": 100}
+{"transform": "to_integer", "input": "abc", "expected": null}
+{"transform": "to_integer", "input": "", "expected": null}
+{"transform": "to_integer", "input": null, "expected": null}
+{"transform": "comma_decimal", "input": "1.234,56", "expected": 1234.56}
+{"transform": "comma_decimal", "input": "99,99", "expected": 99.99}
+{"transform": "comma_decimal", "input": "1.000,00", "expected": 1000.0}
+{"transform": "comma_decimal", "input": "1.5", "expected": 1.5}
+{"transform": "comma_decimal", "input": "100", "expected": 100.0}
+{"transform": "comma_decimal", "input": "abc", "expected": null}
+{"transform": "comma_decimal", "input": "", "expected": null}
+{"transform": "comma_decimal", "input": null, "expected": null}
+{"transform": "scientific_to_decimal", "input": "1.5e3", "expected": 1500.0}
+{"transform": "scientific_to_decimal", "input": "2.0E-4", "expected": 0.0002}
+{"transform": "scientific_to_decimal", "input": "3.14e0", "expected": 3.14}
+{"transform": "scientific_to_decimal", "input": "100", "expected": 100.0}
+{"transform": "scientific_to_decimal", "input": "abc", "expected": null}
+{"transform": "scientific_to_decimal", "input": "", "expected": null}
+{"transform": "scientific_to_decimal", "input": null, "expected": null}

--- a/packages/python/goldenflow/tests/transforms/test_categorical_kernels.py
+++ b/packages/python/goldenflow/tests/transforms/test_categorical_kernels.py
@@ -1,0 +1,127 @@
+"""Direct tests for the owned categorical kernels (Wave D5):
+boolean_normalize / gender_standardize / null_standardize +
+category_normalize_key.
+
+The four string-input kernels are ALSO covered by the shared
+``tests/parity/identifiers_corpus.jsonl`` byte-parity harness in
+``test_identifiers_parity.py`` (both fallback and native paths, corpus-wide).
+This file adds:
+  - a small readable pinned-vector sanity check (mirrors
+    ``test_numeric_kernels.py``'s pattern) for the three registered
+    transforms,
+  - coverage that ``category_standardize``/``category_from_file`` -- whose
+    runtime-data mapping application can't fit the string-keyed corpus --
+    still resolve correctly when their key-normalization step runs through
+    the native kernel path (``category_normalize_key_native``).
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenflow.core._native_loader import native_available, native_module
+from goldenflow.transforms.categorical import (
+    _category_normalize_key_series,
+    boolean_normalize,
+    category_from_file,
+    category_standardize,
+    gender_standardize,
+    null_standardize,
+)
+
+_VECTORS = {
+    "boolean_normalize": (
+        boolean_normalize,
+        ["Yes", "Y", "1", "True", "No", "N", "0", "False", "maybe", None],
+        [True, True, True, True, False, False, False, False, None, None],
+    ),
+    "gender_standardize": (
+        gender_standardize,
+        ["Male", "m", "Female", "f", "Nonbinary", None],
+        ["M", "M", "F", "F", "Nonbinary", None],
+    ),
+    "null_standardize": (
+        null_standardize,
+        ["N/A", "null", "  ", "actual value", None],
+        [None, None, None, "actual value", None],
+    ),
+}
+
+
+def test_fallback_matches_expected(monkeypatch):
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
+    for name, (fn, values, expected) in _VECTORS.items():
+        result = fn(pl.Series("v", values)).to_list()
+        assert result == expected, f"{name}: fallback mismatch"
+
+
+_NATIVE_FLOOR_SYMBOL = {
+    "boolean_normalize": "boolean_normalize_arrow",
+    "gender_standardize": "gender_standardize_arrow",
+    "null_standardize": "null_standardize_arrow",
+}
+
+
+def test_native_matches_expected(monkeypatch):
+    if not native_available():
+        import pytest
+
+        pytest.skip("goldenflow-native not built/importable")
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
+    nm = native_module()
+    for name, (fn, values, expected) in _VECTORS.items():
+        floor_symbol = _NATIVE_FLOOR_SYMBOL[name]
+        if not hasattr(nm, floor_symbol):
+            continue  # wheel skew: installed native predates this kernel
+        result = fn(pl.Series("v", values)).to_list()
+        assert result == expected, f"{name}: native mismatch"
+
+
+def test_category_normalize_key_fallback(monkeypatch):
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
+    result = _category_normalize_key_series(
+        pl.Series("v", ["  Yes  ", "USA", "MiXeD Case", "", None])
+    ).to_list()
+    assert result == ["yes", "usa", "mixed case", "", None]
+
+
+def test_category_standardize_uses_key_kernel(monkeypatch):
+    """category_standardize's dict lookup must still resolve correctly
+    whichever path (native/fallback) derives the normalized key."""
+    mapping = {"US": ["USA", "United States", "U.S.A."]}
+    s = pl.Series("c", ["USA", "  united states  ", "Canada", None])
+
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
+    result_fallback = category_standardize(s, mapping=mapping).to_list()
+    assert result_fallback == ["US", "US", "Canada", None]
+
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
+    result_auto = category_standardize(s, mapping=mapping).to_list()
+    assert result_auto == result_fallback
+
+
+def test_category_from_file_uses_key_kernel(monkeypatch, tmp_path):
+    lookup = tmp_path / "countries.csv"
+    lookup.write_text("variant,canonical\nUSA,US\nUnited States,US\n")
+    s = pl.Series("c", ["USA", "  United States  ", "Canada", None])
+
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
+    result_fallback = category_from_file(s, lookup_path=str(lookup)).to_list()
+    assert result_fallback == ["US", "US", "Canada", None]
+
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
+    result_auto = category_from_file(s, lookup_path=str(lookup)).to_list()
+    assert result_auto == result_fallback
+
+
+def test_boolean_normalize_null_propagates():
+    result = boolean_normalize(pl.Series("v", ["yes", None])).to_list()
+    assert result[1] is None
+
+
+def test_gender_standardize_null_propagates():
+    result = gender_standardize(pl.Series("v", ["m", None])).to_list()
+    assert result[1] is None
+
+
+def test_null_standardize_null_propagates():
+    result = null_standardize(pl.Series("v", ["x", None])).to_list()
+    assert result[1] is None

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -36,6 +36,7 @@ from goldenflow.transforms.identifiers import (
     vat_validate,
 )
 from goldenflow.transforms.names import name_script, name_transliterate
+from goldenflow.transforms.url import url_extract_domain, url_normalize
 
 _CORPUS_PATH = Path(__file__).parent.parent / "parity" / "identifiers_corpus.jsonl"
 
@@ -60,6 +61,8 @@ _TRANSFORMS = {
     "email_normalize": email_normalize,
     "email_extract_domain": email_extract_domain,
     "email_validate": email_validate,
+    "url_normalize": url_normalize,
+    "url_extract_domain": url_extract_domain,
 }
 
 # Floor native symbol per transform's component -- used to skip a row when the
@@ -88,6 +91,10 @@ _NATIVE_FLOOR_SYMBOL = {
     "email_normalize": "email_validate_arrow",
     "email_extract_domain": "email_validate_arrow",
     "email_validate": "email_validate_arrow",
+    # url: both transforms are wired via the single "url" component (floor
+    # symbol url_normalize_arrow), region-free/locale-free.
+    "url_normalize": "url_normalize_arrow",
+    "url_extract_domain": "url_normalize_arrow",
 }
 
 

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -13,6 +13,12 @@ from pathlib import Path
 import polars as pl
 import pytest
 from goldenflow.core._native_loader import native_available
+from goldenflow.transforms.categorical import (
+    _category_normalize_key_series,
+    boolean_normalize,
+    gender_standardize,
+    null_standardize,
+)
 from goldenflow.transforms.email import (
     email_extract_domain,
     email_lowercase,
@@ -111,6 +117,10 @@ _TRANSFORMS = {
     "to_integer": to_integer,
     "comma_decimal": comma_decimal,
     "scientific_to_decimal": scientific_to_decimal,
+    "boolean_normalize": boolean_normalize,
+    "gender_standardize": gender_standardize,
+    "null_standardize": null_standardize,
+    "category_normalize_key": _category_normalize_key_series,
 }
 
 # Floor native symbol per transform's component -- used to skip a row when the
@@ -151,6 +161,14 @@ _NATIVE_FLOOR_SYMBOL = {
     "to_integer": "currency_strip_arrow",
     "comma_decimal": "currency_strip_arrow",
     "scientific_to_decimal": "currency_strip_arrow",
+    # categorical: boolean_normalize/gender_standardize/null_standardize +
+    # category_normalize_key are all wired via the single "categorical"
+    # component (floor symbol boolean_normalize_arrow), region-free/
+    # locale-free.
+    "boolean_normalize": "boolean_normalize_arrow",
+    "gender_standardize": "boolean_normalize_arrow",
+    "null_standardize": "boolean_normalize_arrow",
+    "category_normalize_key": "boolean_normalize_arrow",
 }
 
 

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -36,9 +36,52 @@ from goldenflow.transforms.identifiers import (
     vat_validate,
 )
 from goldenflow.transforms.names import name_script, name_transliterate
+from goldenflow.transforms.numeric import _currency_strip_series as currency_strip
+from goldenflow.transforms.numeric import _percentage_normalize_series as percentage_normalize
+from goldenflow.transforms.numeric import _to_integer_series as to_integer
+from goldenflow.transforms.numeric import (
+    comma_decimal,
+    scientific_to_decimal,
+)
 from goldenflow.transforms.url import url_extract_domain, url_normalize
 
 _CORPUS_PATH = Path(__file__).parent.parent / "parity" / "identifiers_corpus.jsonl"
+
+# Transforms in this family output floats/ints -- parity is compared by
+# VALUE (numeric), not string repr / exact object equality, since a
+# byte-identical value could arrive as `2.0` vs `2` after a JSON round-trip.
+_NUMERIC_TRANSFORMS = frozenset(
+    {
+        "currency_strip",
+        "percentage_normalize",
+        "to_integer",
+        "comma_decimal",
+        "scientific_to_decimal",
+    }
+)
+
+
+def _assert_value_parity(transform: str, actual: object, expected: object) -> None:
+    """Numeric-aware equality for the numeric family; exact equality for
+    everything else. Both `None` -> pass. Prefer EXACT float equality (the
+    same IEEE754 parse ops on both sides should produce bit-identical
+    results) over a fuzzy epsilon -- only fall back to a tiny epsilon if
+    exact equality genuinely doesn't hold, which would indicate a real
+    cross-surface drift worth investigating, not paper over it."""
+    if transform not in _NUMERIC_TRANSFORMS:
+        assert actual == expected
+        return
+    if actual is None or expected is None:
+        assert actual == expected
+        return
+    if actual == expected:
+        return
+    # Both are numeric at this point (float or int) -- fall back to a tiny
+    # epsilon ONLY to absorb a genuine last-bit float discrepancy, never to
+    # mask a real logic divergence.
+    assert abs(float(actual) - float(expected)) < 1e-9, (
+        f"{transform}: {actual!r} != {expected!r} (beyond float epsilon)"
+    )
 
 _TRANSFORMS = {
     "cc_validate": cc_validate,
@@ -63,6 +106,11 @@ _TRANSFORMS = {
     "email_validate": email_validate,
     "url_normalize": url_normalize,
     "url_extract_domain": url_extract_domain,
+    "currency_strip": currency_strip,
+    "percentage_normalize": percentage_normalize,
+    "to_integer": to_integer,
+    "comma_decimal": comma_decimal,
+    "scientific_to_decimal": scientific_to_decimal,
 }
 
 # Floor native symbol per transform's component -- used to skip a row when the
@@ -95,6 +143,14 @@ _NATIVE_FLOOR_SYMBOL = {
     # symbol url_normalize_arrow), region-free/locale-free.
     "url_normalize": "url_normalize_arrow",
     "url_extract_domain": "url_normalize_arrow",
+    # numeric: all 5 string-parser transforms are wired via the single
+    # "numeric" component (floor symbol currency_strip_arrow), region-free/
+    # locale-free.
+    "currency_strip": "currency_strip_arrow",
+    "percentage_normalize": "currency_strip_arrow",
+    "to_integer": "currency_strip_arrow",
+    "comma_decimal": "currency_strip_arrow",
+    "scientific_to_decimal": "currency_strip_arrow",
 }
 
 
@@ -119,7 +175,7 @@ def test_identifiers_fallback_parity(row, monkeypatch):
     monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
     transform = _TRANSFORMS[row["transform"]]
     result = transform(pl.Series("v", [row["input"]]))
-    assert result.to_list()[0] == row["expected"]
+    _assert_value_parity(row["transform"], result.to_list()[0], row["expected"])
 
 
 @pytest.mark.parametrize("row", _CORPUS, ids=_IDS)
@@ -140,4 +196,4 @@ def test_identifiers_native_parity(row, monkeypatch):
     monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
     transform = _TRANSFORMS[row["transform"]]
     result = transform(pl.Series("v", [row["input"]]))
-    assert result.to_list()[0] == row["expected"]
+    _assert_value_parity(row["transform"], result.to_list()[0], row["expected"])

--- a/packages/python/goldenflow/tests/transforms/test_numeric_kernels.py
+++ b/packages/python/goldenflow/tests/transforms/test_numeric_kernels.py
@@ -1,0 +1,110 @@
+"""Direct value-parity tests for the owned numeric-ARRAY-op kernels (Wave D4):
+round / clamp / abs_value / fill_zero.
+
+These four transforms take a NUMERIC column (not a string column) as input,
+so they don't fit the shared string-keyed
+``tests/parity/identifiers_corpus.jsonl`` harness in
+``test_identifiers_parity.py`` (which feeds every row through a length-1
+Arrow *string* array). Instead this file directly asserts both the
+pure-Python fallback (``GOLDENFLOW_NATIVE=0``) and the native path (when
+built/importable) against the goldenflow-core Rust kernel's VALUES,
+mirroring ``test_url_kernels.py``'s "small readable pinned-vector" pattern.
+
+The 5 string->number PARSER transforms (currency_strip, percentage_normalize,
+to_integer, comma_decimal, scientific_to_decimal) DO fit the shared corpus
+(their input is a string) and are covered there instead, with numeric-value
+comparison (see ``_assert_value_parity`` in ``test_identifiers_parity.py``).
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenflow.core._native_loader import native_available, native_module
+from goldenflow.transforms.numeric import abs_value, clamp, fill_zero, round_values
+
+_VECTORS = {
+    "round_default_n2": (round_values, [2.345, -2.345, 1234.0, 0.005], {}, [2.35, -2.35, 1234.0, 0.01]),
+    "round_n0": (
+        round_values,
+        [2.4, 2.5, -2.5],
+        {"n": 0},
+        [2.0, 3.0, -3.0],
+    ),
+    "round_negative_n": (
+        round_values,
+        [1234.0, -1250.0],
+        {"n": -2},
+        [1200.0, -1300.0],
+    ),
+    "clamp_default": (
+        clamp,
+        [-5.0, 0.0, 0.5, 1.5],
+        {},
+        [0.0, 0.0, 0.5, 1.0],
+    ),
+    "clamp_custom_bounds": (
+        clamp,
+        [-5.0, 0.0, 50.0, 150.0],
+        {"min_val": 0.0, "max_val": 100.0},
+        [0.0, 0.0, 50.0, 100.0],
+    ),
+    "abs_value": (
+        abs_value,
+        [-5.0, 3.0, -0.5, 0.0],
+        {},
+        [5.0, 3.0, 0.5, 0.0],
+    ),
+    "fill_zero": (
+        fill_zero,
+        [1.0, None, 3.0, None],
+        {},
+        [1.0, 0.0, 3.0, 0.0],
+    ),
+}
+
+
+def test_fallback_matches_expected(monkeypatch):
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
+    for name, (fn, values, kwargs, expected) in _VECTORS.items():
+        result = fn(pl.Series("v", values), **kwargs).to_list()
+        assert result == expected, f"{name}: fallback mismatch"
+
+
+_NATIVE_FLOOR_SYMBOL = {
+    "round_default_n2": "round_arrow",
+    "round_n0": "round_arrow",
+    "round_negative_n": "round_arrow",
+    "clamp_default": "clamp_arrow",
+    "clamp_custom_bounds": "clamp_arrow",
+    "abs_value": "abs_value_arrow",
+    "fill_zero": "fill_zero_arrow",
+}
+
+
+def test_native_matches_expected(monkeypatch):
+    if not native_available():
+        import pytest
+
+        pytest.skip("goldenflow-native not built/importable")
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
+    nm = native_module()
+    for name, (fn, values, kwargs, expected) in _VECTORS.items():
+        floor_symbol = _NATIVE_FLOOR_SYMBOL[name]
+        if not hasattr(nm, floor_symbol):
+            continue  # wheel skew: installed native predates this kernel
+        result = fn(pl.Series("v", values), **kwargs).to_list()
+        assert result == expected, f"{name}: native mismatch"
+
+
+def test_round_null_propagates():
+    result = round_values(pl.Series("v", [1.0, None, 2.5])).to_list()
+    assert result[1] is None
+
+
+def test_clamp_null_propagates():
+    result = clamp(pl.Series("v", [0.5, None])).to_list()
+    assert result[1] is None
+
+
+def test_abs_value_null_propagates():
+    result = abs_value(pl.Series("v", [-1.0, None])).to_list()
+    assert result[1] is None

--- a/packages/python/goldenflow/tests/transforms/test_url_kernels.py
+++ b/packages/python/goldenflow/tests/transforms/test_url_kernels.py
@@ -1,0 +1,68 @@
+"""Direct behavioral unit tests for the owned URL kernels (Wave D2).
+
+Complements the byte-parity harness in ``test_identifiers_parity.py`` (which
+sweeps the committed ``tests/parity/identifiers_corpus.jsonl`` corpus against
+both the pure-Python fallback and the native path) with a small set of
+readable, self-documenting assertions pinned to the exact vectors used to
+design the ``goldenflow-core::url`` Rust kernel.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenflow.transforms.url import url_extract_domain, url_normalize
+
+
+def _one(fn, value):
+    return fn(pl.Series("v", [value])).to_list()[0]
+
+
+def test_normalize_adds_scheme_and_lowercases_domain():
+    assert _one(url_normalize, "Example.COM/Path/") == "https://example.com/Path"
+
+
+def test_normalize_strips_single_trailing_slash_when_path_is_root():
+    assert _one(url_normalize, "http://X.com/") == "http://x.com"
+
+
+def test_normalize_leaves_no_trailing_slash_unchanged():
+    assert _one(url_normalize, "https://a.com") == "https://a.com"
+
+
+def test_normalize_strips_all_trailing_slashes_when_path_has_more():
+    assert _one(url_normalize, "https://a.com/x/") == "https://a.com/x"
+    assert _one(url_normalize, "https://a.com/x//") == "https://a.com/x"
+
+
+def test_normalize_case_insensitive_scheme_detection():
+    assert _one(url_normalize, "HTTPS://Foo.com") == "https://foo.com"
+    assert _one(url_normalize, "HtTp://Foo.com") == "http://foo.com"
+
+
+def test_normalize_empty_and_whitespace_are_none():
+    assert _one(url_normalize, "") is None
+    assert _one(url_normalize, "   ") is None
+
+
+def test_normalize_null_propagates():
+    assert _one(url_normalize, None) is None
+
+
+def test_extract_domain_strips_scheme_and_lowercases():
+    assert _one(url_extract_domain, "https://Foo.com/x") == "foo.com"
+
+
+def test_extract_domain_no_scheme():
+    assert _one(url_extract_domain, "bar.com") == "bar.com"
+
+
+def test_extract_domain_multi_label():
+    assert _one(url_extract_domain, "http://sub.domain.org/path/more") == "sub.domain.org"
+
+
+def test_extract_domain_empty_and_whitespace_are_none():
+    assert _one(url_extract_domain, "") is None
+    assert _one(url_extract_domain, "   ") is None
+
+
+def test_extract_domain_null_propagates():
+    assert _one(url_extract_domain, None) is None

--- a/packages/rust/extensions/goldenflow-core/src/categorical.rs
+++ b/packages/rust/extensions/goldenflow-core/src/categorical.rs
@@ -1,0 +1,138 @@
+//! Owned categorical kernels (pyo3-free): boolean normalization, gender
+//! standardization, null-sentinel standardization, and the shared
+//! key-normalization step used by the two mapping-based transforms
+//! (`category_standardize` / `category_from_file`).
+//!
+//! **Split between owned LOGIC and runtime DATA (load-bearing design
+//! decision, see the goldenflow D5 wave):** `category_standardize` and
+//! `category_from_file` apply a caller-supplied variant->canonical mapping
+//! (a dict built from a function param, or loaded from a CSV/YAML file at
+//! runtime). That mapping is DATA, not logic, and has no sensible Rust
+//! representation shared across Python/TS/WASM call sites -- so this crate
+//! does NOT own the dict lookup. What IS shared, deterministic logic is the
+//! NORMALIZATION applied to a raw value before it's used as a lookup key
+//! (`category_normalize_key`, below) -- identical to what `null_standardize`
+//! and `gender_standardize` do internally before their own (fixed, in-crate)
+//! lookups. Owning that one function keeps the key-derivation byte-identical
+//! across surfaces while the mapping-application loop stays in
+//! Python/TS, where it belongs.
+//!
+//! These are the reference implementations; the Python/TS fallbacks must
+//! reproduce their bytes exactly (byte-parity harness,
+//! `tests/parity/identifiers_corpus.jsonl`).
+
+const TRUE_VALUES: &[&str] = &["yes", "y", "1", "true", "t"];
+const FALSE_VALUES: &[&str] = &["no", "n", "0", "false", "f"];
+const NULL_VALUES: &[&str] = &["n/a", "null", "none", "na", "nil", "nan", "-", ""];
+
+/// Trim + lowercase -- the shared key-normalization step used before any of
+/// this module's lookups (fixed in-crate maps for `gender_standardize`/
+/// `null_standardize`, and the caller-supplied mapping for
+/// `category_standardize`/`category_from_file`).
+pub fn category_normalize_key(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+
+/// Parse a loose boolean-ish string. `Some(true)`/`Some(false)` on a
+/// recognized token (case/whitespace-insensitive); `None` for anything else
+/// (including empty string).
+pub fn boolean_normalize(s: &str) -> Option<bool> {
+    let key = category_normalize_key(s);
+    if TRUE_VALUES.contains(&key.as_str()) {
+        Some(true)
+    } else if FALSE_VALUES.contains(&key.as_str()) {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Standardize a gender string to `"M"`/`"F"` via a fixed lookup
+/// (`male`/`m` -> `M`, `female`/`f` -> `F`); any other value passes through
+/// UNCHANGED (the original string, not the normalized key) -- mirrors the
+/// Python `dict.get(key, val)` fallback semantics.
+pub fn gender_standardize(s: &str) -> String {
+    let key = category_normalize_key(s);
+    match key.as_str() {
+        "male" | "m" => "M".to_string(),
+        "female" | "f" => "F".to_string(),
+        _ => s.to_string(),
+    }
+}
+
+/// Map a null-sentinel string (`n/a`, `null`, `none`, `na`, `nil`, `nan`,
+/// `-`, or empty, case/whitespace-insensitive) to `None`; any other value
+/// passes through as `Some(original)` -- mirrors the Python
+/// `None if key in NULL_VALUES else val` semantics.
+pub fn null_standardize(s: &str) -> Option<String> {
+    let key = category_normalize_key(s);
+    if NULL_VALUES.contains(&key.as_str()) {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_normalize_key_basic() {
+        assert_eq!(category_normalize_key("  Yes  "), "yes");
+        assert_eq!(category_normalize_key("USA"), "usa");
+        assert_eq!(category_normalize_key(""), "");
+        assert_eq!(category_normalize_key("MiXeD Case"), "mixed case");
+    }
+
+    #[test]
+    fn boolean_normalize_basic() {
+        assert_eq!(boolean_normalize("Yes"), Some(true));
+        assert_eq!(boolean_normalize("Y"), Some(true));
+        assert_eq!(boolean_normalize("1"), Some(true));
+        assert_eq!(boolean_normalize("True"), Some(true));
+        assert_eq!(boolean_normalize("true"), Some(true));
+        assert_eq!(boolean_normalize(" t "), Some(true));
+        assert_eq!(boolean_normalize("No"), Some(false));
+        assert_eq!(boolean_normalize("N"), Some(false));
+        assert_eq!(boolean_normalize("0"), Some(false));
+        assert_eq!(boolean_normalize("false"), Some(false));
+        assert_eq!(boolean_normalize("f"), Some(false));
+        assert_eq!(boolean_normalize("maybe"), None);
+        assert_eq!(boolean_normalize(""), None);
+    }
+
+    #[test]
+    fn gender_standardize_basic() {
+        assert_eq!(gender_standardize("Male"), "M");
+        assert_eq!(gender_standardize("male"), "M");
+        assert_eq!(gender_standardize("M"), "M");
+        assert_eq!(gender_standardize("m"), "M");
+        assert_eq!(gender_standardize("Female"), "F");
+        assert_eq!(gender_standardize("female"), "F");
+        assert_eq!(gender_standardize("F"), "F");
+        assert_eq!(gender_standardize("f"), "F");
+        // Unrecognized: passes through UNCHANGED (original, not lowercased).
+        assert_eq!(gender_standardize("Nonbinary"), "Nonbinary");
+        assert_eq!(gender_standardize(""), "");
+    }
+
+    #[test]
+    fn null_standardize_basic() {
+        assert_eq!(null_standardize("N/A"), None);
+        assert_eq!(null_standardize("NULL"), None);
+        assert_eq!(null_standardize("none"), None);
+        assert_eq!(null_standardize(""), None);
+        assert_eq!(null_standardize("  "), None); // trims to empty
+        assert_eq!(null_standardize("null"), None);
+        assert_eq!(null_standardize("NA"), None);
+        assert_eq!(null_standardize("nil"), None);
+        assert_eq!(null_standardize("nan"), None);
+        assert_eq!(null_standardize("-"), None);
+        // Passes through UNCHANGED (original, not lowercased).
+        assert_eq!(
+            null_standardize("actual value"),
+            Some("actual value".to_string())
+        );
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-core/src/lib.rs
@@ -10,3 +10,4 @@ pub mod identifiers;
 pub mod names;
 pub mod phone;
 pub mod text;
+pub mod url;

--- a/packages/rust/extensions/goldenflow-core/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-core/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod email;
 pub mod identifiers;
 pub mod names;
+pub mod numeric;
 pub mod phone;
 pub mod text;
 pub mod url;

--- a/packages/rust/extensions/goldenflow-core/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! surface (`goldenflow-wasm`) are thin marshaling shims over these functions.
 //! The pure-Python / pure-TS transform paths are non-authoritative fallbacks
 //! that must reproduce these bytes (asserted by the byte-parity harness).
+pub mod categorical;
 pub mod email;
 pub mod identifiers;
 pub mod names;

--- a/packages/rust/extensions/goldenflow-core/src/numeric.rs
+++ b/packages/rust/extensions/goldenflow-core/src/numeric.rs
@@ -1,0 +1,176 @@
+//! Owned numeric kernels (pyo3-free): string->number parsers (currency,
+//! percentage, integer-truncation, EU comma-decimal, scientific notation) and
+//! numeric-array ops (round, clamp, abs, fill-null-with-zero). These are the
+//! reference implementations; the Python/TS fallbacks must reproduce their
+//! VALUES exactly (byte/value-parity harness -- numeric comparison, not
+//! string repr, since this family outputs floats/ints).
+//!
+//! Deliberately NOT using a `regex` crate dependency (mirrors the other
+//! goldenflow-core kernels' no-regex policy) -- `currency_strip` hand-filters
+//! chars instead of `[^\d.\-]` regex-replace.
+
+/// Strip everything except ASCII digits, `.`, and `-`, then parse as `f64`.
+/// `None` on parse failure (mirrors Polars `cast(Float64, strict=False)`
+/// null-on-failure semantics).
+pub fn currency_strip(s: &str) -> Option<f64> {
+    let filtered: String = s
+        .chars()
+        .filter(|c| c.is_ascii_digit() || *c == '.' || *c == '-')
+        .collect();
+    filtered.parse::<f64>().ok()
+}
+
+/// Trim whitespace, strip trailing `%` character(s), trim again (in case
+/// removing `%` exposes more whitespace), parse as `f64`, and divide by 100.
+/// `None` on parse failure.
+pub fn percentage_normalize(s: &str) -> Option<f64> {
+    let trimmed = s.trim();
+    let stripped = trimmed.trim_end_matches('%');
+    let stripped = stripped.trim();
+    stripped.parse::<f64>().ok().map(|v| v / 100.0)
+}
+
+/// Parse a string to `f64` then truncate toward zero to `i64` (mirrors the
+/// old `int(float(val))` semantics / Polars `cast(Float64).cast(Int64)`,
+/// both strict=False). `None` on parse failure.
+pub fn to_integer(s: &str) -> Option<i64> {
+    s.trim().parse::<f64>().ok().map(|v| v as i64)
+}
+
+/// Convert a European decimal format (`1.234,56`) to a plain `f64`
+/// (`1234.56`). If the (trimmed) input has no comma, parse as-is (US format
+/// or a plain number). `None` on parse failure.
+pub fn comma_decimal(s: &str) -> Option<f64> {
+    let trimmed = s.trim();
+    if !trimmed.contains(',') {
+        return trimmed.parse::<f64>().ok();
+    }
+    let converted = trimmed.replace('.', "").replace(',', ".");
+    converted.parse::<f64>().ok()
+}
+
+/// Convert scientific notation (`1.5e3`) to a plain `f64` (`1500.0`). Trims
+/// whitespace first; `None` on parse failure. Rust's `f64::from_str` already
+/// accepts scientific notation, so this is just a trimmed parse.
+pub fn scientific_to_decimal(s: &str) -> Option<f64> {
+    s.trim().parse::<f64>().ok()
+}
+
+/// Round-half-away-from-zero at the `n`-th decimal place, computed via
+/// multiply/round/divide (the KERNEL is the source of truth for this
+/// rounding rule -- Python's fallback and TS's fallback must replicate this
+/// exact formula, not their language's built-in `round()`, since e.g.
+/// Python's `round()` uses round-half-to-even). `n` may be negative (rounds
+/// to the left of the decimal point).
+pub fn round_f64(x: f64, n: i32) -> f64 {
+    let factor = 10f64.powi(n);
+    let scaled = x * factor;
+    let rounded = if scaled >= 0.0 {
+        (scaled + 0.5).floor()
+    } else {
+        (scaled - 0.5).ceil()
+    };
+    rounded / factor
+}
+
+/// Clamp `x` into `[min_val, max_val]`.
+pub fn clamp_f64(x: f64, min_val: f64, max_val: f64) -> f64 {
+    if x < min_val {
+        min_val
+    } else if x > max_val {
+        max_val
+    } else {
+        x
+    }
+}
+
+/// Absolute value.
+pub fn abs_f64(x: f64) -> f64 {
+    x.abs()
+}
+
+/// Replace a null value with `0.0`; a present value passes through
+/// unchanged. Operates on `Option<f64>` since this is fundamentally a
+/// null-handling op, not a value transform.
+pub fn fill_zero(x: Option<f64>) -> f64 {
+    x.unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn currency_strip_basic() {
+        assert_eq!(currency_strip("$1,234.56"), Some(1234.56));
+        assert_eq!(currency_strip("-$42.00"), Some(-42.0));
+        assert_eq!(currency_strip("USD 100"), Some(100.0));
+        assert_eq!(currency_strip(""), None);
+        assert_eq!(currency_strip("abc"), None);
+    }
+
+    #[test]
+    fn percentage_normalize_basic() {
+        assert_eq!(percentage_normalize("50%"), Some(0.5));
+        assert_eq!(percentage_normalize(" 12.5 % "), Some(0.125));
+        assert_eq!(percentage_normalize("100"), Some(1.0));
+        assert_eq!(percentage_normalize("abc%"), None);
+        assert_eq!(percentage_normalize(""), None);
+    }
+
+    #[test]
+    fn to_integer_basic() {
+        assert_eq!(to_integer("42"), Some(42));
+        assert_eq!(to_integer("42.9"), Some(42));
+        assert_eq!(to_integer("-3.5"), Some(-3));
+        assert_eq!(to_integer("abc"), None);
+        assert_eq!(to_integer(""), None);
+    }
+
+    #[test]
+    fn comma_decimal_basic() {
+        assert_eq!(comma_decimal("1.234,56"), Some(1234.56));
+        assert_eq!(comma_decimal("1234.56"), Some(1234.56));
+        assert_eq!(comma_decimal("42"), Some(42.0));
+        assert_eq!(comma_decimal("abc,de"), None);
+        assert_eq!(comma_decimal(""), None);
+    }
+
+    #[test]
+    fn scientific_to_decimal_basic() {
+        assert_eq!(scientific_to_decimal("1.5e3"), Some(1500.0));
+        assert_eq!(scientific_to_decimal(" 2E-2 "), Some(0.02));
+        assert_eq!(scientific_to_decimal("abc"), None);
+        assert_eq!(scientific_to_decimal(""), None);
+    }
+
+    #[test]
+    fn round_f64_basic() {
+        assert_eq!(round_f64(2.345, 2), 2.35);
+        // 2.005 is not exactly representable; its nearest f64 is slightly
+        // ABOVE 2.005, so *100 rounds up (a real float-representation
+        // quirk, not a bug -- Python's `float("2.005")` has the same value).
+        assert_eq!(round_f64(2.005, 2), 2.01);
+        assert_eq!(round_f64(-2.345, 2), -2.35);
+        assert_eq!(round_f64(1234.0, -2), 1200.0);
+    }
+
+    #[test]
+    fn clamp_f64_basic() {
+        assert_eq!(clamp_f64(0.5, 0.0, 1.0), 0.5);
+        assert_eq!(clamp_f64(-0.5, 0.0, 1.0), 0.0);
+        assert_eq!(clamp_f64(1.5, 0.0, 1.0), 1.0);
+    }
+
+    #[test]
+    fn abs_f64_basic() {
+        assert_eq!(abs_f64(-3.5), 3.5);
+        assert_eq!(abs_f64(3.5), 3.5);
+    }
+
+    #[test]
+    fn fill_zero_basic() {
+        assert_eq!(fill_zero(None), 0.0);
+        assert_eq!(fill_zero(Some(5.0)), 5.0);
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/url.rs
+++ b/packages/rust/extensions/goldenflow-core/src/url.rs
@@ -1,0 +1,171 @@
+//! Owned URL kernels (pyo3-free): normalize (scheme/domain-lowercase +
+//! trailing-slash strip) and domain extraction. These are the reference
+//! implementations; the Python/TS fallbacks must reproduce their bytes
+//! exactly (byte-parity harness, `tests/parity/identifiers_corpus.jsonl`).
+//!
+//! Deliberately NOT using a `regex` crate dependency (mirrors the other
+//! goldenflow-core kernels' no-regex policy for cross-surface parity
+//! guarantees) -- the `^https?://` scheme check is hand-rolled via an
+//! ASCII-case-insensitive prefix compare.
+
+/// Case-insensitive check for a leading `http://` or `https://` scheme
+/// (mirrors the Python reference's `re.compile(r"^https?://", re.IGNORECASE)`).
+fn has_scheme(s: &str) -> bool {
+    let lower = s.to_ascii_lowercase();
+    lower.starts_with("https://") || lower.starts_with("http://")
+}
+
+/// Normalize a URL: ensure a scheme, lowercase the scheme + domain, keep the
+/// path as-is, and strip a trailing slash (unless the path IS just `/`, in
+/// which case exactly one trailing slash is dropped). `None` for empty
+/// (post-trim) input. Always `Some` otherwise.
+pub fn url_normalize(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut val = trimmed.to_string();
+    if !has_scheme(&val) {
+        val = format!("https://{val}");
+    }
+    // Split scheme from rest -- guaranteed present after the prepend above.
+    let scheme_idx = val.find("://").expect("scheme guaranteed present");
+    let scheme_end = scheme_idx + 3;
+    let scheme = val[..scheme_end].to_lowercase();
+    let rest = &val[scheme_end..];
+    // Lowercase the domain (everything before the first '/').
+    let (domain, path) = match rest.find('/') {
+        None => (rest.to_lowercase(), String::new()),
+        Some(slash_idx) => (
+            rest[..slash_idx].to_lowercase(),
+            rest[slash_idx..].to_string(),
+        ),
+    };
+    let mut result = format!("{scheme}{domain}{path}");
+    // Strip trailing slash (but not if path is just "/").
+    if result.ends_with('/') {
+        let scheme_len = scheme.chars().count(); // ASCII scheme: chars == byte offset.
+        let domain_len = domain.chars().count();
+        let result_len = result.chars().count();
+        if result_len > scheme_len + domain_len + 1 {
+            result = result.trim_end_matches('/').to_string();
+        } else if path == "/" {
+            result.pop();
+        }
+    }
+    Some(result)
+}
+
+/// Extract the lowercased domain from a URL: strip an optional `scheme://`
+/// prefix, then take everything before the first `/`. `None` for empty
+/// (post-trim) input or an empty domain.
+pub fn url_extract_domain(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let after_scheme = match trimmed.find("://") {
+        Some(idx) => &trimmed[idx + 3..],
+        None => trimmed,
+    };
+    let domain = after_scheme.split('/').next().unwrap_or("");
+    if domain.is_empty() {
+        None
+    } else {
+        Some(domain.to_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_adds_scheme_and_lowercases_domain() {
+        assert_eq!(
+            url_normalize("Example.COM/Path/"),
+            Some("https://example.com/Path".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_strips_single_trailing_slash_when_path_is_root() {
+        assert_eq!(
+            url_normalize("http://X.com/"),
+            Some("http://x.com".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_leaves_no_trailing_slash_unchanged() {
+        assert_eq!(
+            url_normalize("https://a.com"),
+            Some("https://a.com".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_strips_all_trailing_slashes_when_path_has_more() {
+        assert_eq!(
+            url_normalize("https://a.com/x/"),
+            Some("https://a.com/x".to_string())
+        );
+        assert_eq!(
+            url_normalize("https://a.com/x//"),
+            Some("https://a.com/x".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_case_insensitive_scheme_detection() {
+        assert_eq!(
+            url_normalize("HTTPS://Foo.com"),
+            Some("https://foo.com".to_string())
+        );
+        assert_eq!(
+            url_normalize("HtTp://Foo.com"),
+            Some("http://foo.com".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_empty_and_whitespace() {
+        assert_eq!(url_normalize(""), None);
+        assert_eq!(url_normalize("   "), None);
+    }
+
+    #[test]
+    fn normalize_no_path() {
+        assert_eq!(
+            url_normalize("EXAMPLE.com"),
+            Some("https://example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_domain_strips_scheme_and_lowercases() {
+        assert_eq!(
+            url_extract_domain("https://Foo.com/x"),
+            Some("foo.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_domain_no_scheme() {
+        assert_eq!(url_extract_domain("bar.com"), Some("bar.com".to_string()));
+    }
+
+    #[test]
+    fn extract_domain_empty() {
+        assert_eq!(url_extract_domain(""), None);
+        assert_eq!(url_extract_domain("   "), None);
+    }
+
+    #[test]
+    fn extract_domain_multi_at_scheme() {
+        assert_eq!(
+            url_extract_domain("http://sub.domain.org/path/more"),
+            Some("sub.domain.org".to_string())
+        );
+    }
+}

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -15,6 +15,7 @@ mod wasm {
     use goldenflow_core::email;
     use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
     use goldenflow_core::names;
+    use goldenflow_core::url;
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
@@ -115,5 +116,15 @@ mod wasm {
     #[wasm_bindgen]
     pub fn name_script(s: &str) -> String {
         names::name_script(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn url_normalize(s: &str) -> Option<String> {
+        url::url_normalize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn url_extract_domain(s: &str) -> Option<String> {
+        url::url_extract_domain(s)
     }
 }

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -12,6 +12,7 @@
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
+    use goldenflow_core::categorical;
     use goldenflow_core::email;
     use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
     use goldenflow_core::names;
@@ -172,5 +173,25 @@ mod wasm {
     #[wasm_bindgen]
     pub fn fill_zero(x: Option<f64>) -> f64 {
         numeric::fill_zero(x)
+    }
+
+    #[wasm_bindgen]
+    pub fn boolean_normalize(s: &str) -> Option<bool> {
+        categorical::boolean_normalize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn gender_standardize(s: &str) -> String {
+        categorical::gender_standardize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn null_standardize(s: &str) -> Option<String> {
+        categorical::null_standardize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn category_normalize_key(s: &str) -> String {
+        categorical::category_normalize_key(s)
     }
 }

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -15,6 +15,7 @@ mod wasm {
     use goldenflow_core::email;
     use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
     use goldenflow_core::names;
+    use goldenflow_core::numeric;
     use goldenflow_core::url;
     use wasm_bindgen::prelude::*;
 
@@ -126,5 +127,50 @@ mod wasm {
     #[wasm_bindgen]
     pub fn url_extract_domain(s: &str) -> Option<String> {
         url::url_extract_domain(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn currency_strip(s: &str) -> Option<f64> {
+        numeric::currency_strip(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn percentage_normalize(s: &str) -> Option<f64> {
+        numeric::percentage_normalize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn to_integer(s: &str) -> Option<i64> {
+        numeric::to_integer(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn comma_decimal(s: &str) -> Option<f64> {
+        numeric::comma_decimal(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn scientific_to_decimal(s: &str) -> Option<f64> {
+        numeric::scientific_to_decimal(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn round_value(x: f64, n: i32) -> f64 {
+        numeric::round_f64(x, n)
+    }
+
+    #[wasm_bindgen]
+    pub fn clamp_value(x: f64, min_val: f64, max_val: f64) -> f64 {
+        numeric::clamp_f64(x, min_val, max_val)
+    }
+
+    #[wasm_bindgen]
+    pub fn abs_value(x: f64) -> f64 {
+        numeric::abs_f64(x)
+    }
+
+    #[wasm_bindgen]
+    pub fn fill_zero(x: Option<f64>) -> f64 {
+        numeric::fill_zero(x)
     }
 }

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.5.0"
+version = "0.6.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.5.0"
+    __version__ = "0.6.0"

--- a/packages/rust/extensions/native-flow/src/categorical.rs
+++ b/packages/rust/extensions/native-flow/src/categorical.rs
@@ -1,0 +1,56 @@
+//! Arrow shims over goldenflow_core::categorical. Bytes in, kernel per
+//! element, bytes out; GIL released. All logic lives in the core.
+//!
+//! `category_normalize_key_arrow` is the ONLY symbol needed by the two
+//! mapping-based transforms (`category_standardize` / `category_from_file`)
+//! -- it accelerates the key-normalization step; the dict lookup itself
+//! stays in Python since the mapping is runtime data, not a kernel input.
+use crate::util::{map_str_to_bool, map_str_to_str};
+use arrow::array::ArrayData;
+use arrow::pyarrow::PyArrowType;
+use goldenflow_core::categorical;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn boolean_normalize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_bool(
+        py,
+        array.0,
+        categorical::boolean_normalize,
+    )?))
+}
+
+#[pyfunction]
+pub fn gender_standardize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(categorical::gender_standardize(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn null_standardize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(
+        py,
+        array.0,
+        categorical::null_standardize,
+    )?))
+}
+
+#[pyfunction]
+pub fn category_normalize_key_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(categorical::category_normalize_key(s))
+    })?))
+}

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -15,6 +15,7 @@ mod email;
 mod identifiers;
 mod names;
 mod phone;
+mod url;
 mod util;
 
 #[pymodule]
@@ -44,5 +45,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(identifiers::imei_validate_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(names::name_transliterate_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(names::name_script_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(url::url_normalize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(url::url_extract_domain_arrow, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -11,6 +11,7 @@
 
 use pyo3::prelude::*;
 
+mod categorical;
 mod email;
 mod identifiers;
 mod names;
@@ -57,5 +58,12 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(numeric::clamp_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(numeric::abs_value_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(numeric::fill_zero_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(categorical::boolean_normalize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(categorical::gender_standardize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(categorical::null_standardize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        categorical::category_normalize_key_arrow,
+        m
+    )?)?;
     Ok(())
 }

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -14,6 +14,7 @@ use pyo3::prelude::*;
 mod email;
 mod identifiers;
 mod names;
+mod numeric;
 mod phone;
 mod url;
 mod util;
@@ -47,5 +48,14 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(names::name_script_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(url::url_normalize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(url::url_extract_domain_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::currency_strip_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::percentage_normalize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::to_integer_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::comma_decimal_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::scientific_to_decimal_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::round_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::clamp_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::abs_value_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(numeric::fill_zero_arrow, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/native-flow/src/numeric.rs
+++ b/packages/rust/extensions/native-flow/src/numeric.rs
@@ -1,0 +1,112 @@
+//! Arrow shims over goldenflow_core::numeric. Bytes/floats in, kernel per
+//! element, floats out; GIL released. All logic lives in the core.
+use crate::util::{map_f64_to_f64, map_str_to_f64, map_str_to_i64};
+use arrow::array::ArrayData;
+use arrow::pyarrow::PyArrowType;
+use goldenflow_core::numeric;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn currency_strip_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_f64(
+        py,
+        array.0,
+        numeric::currency_strip,
+    )?))
+}
+
+#[pyfunction]
+pub fn percentage_normalize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_f64(
+        py,
+        array.0,
+        numeric::percentage_normalize,
+    )?))
+}
+
+#[pyfunction]
+pub fn to_integer_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_i64(
+        py,
+        array.0,
+        numeric::to_integer,
+    )?))
+}
+
+#[pyfunction]
+pub fn comma_decimal_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_f64(
+        py,
+        array.0,
+        numeric::comma_decimal,
+    )?))
+}
+
+#[pyfunction]
+pub fn scientific_to_decimal_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_f64(
+        py,
+        array.0,
+        numeric::scientific_to_decimal,
+    )?))
+}
+
+#[pyfunction]
+#[pyo3(signature = (array, n=2))]
+pub fn round_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+    n: i32,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_f64_to_f64(py, array.0, |v| {
+        v.map(|x| numeric::round_f64(x, n))
+    })?))
+}
+
+#[pyfunction]
+#[pyo3(signature = (array, min_val=0.0, max_val=1.0))]
+pub fn clamp_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+    min_val: f64,
+    max_val: f64,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_f64_to_f64(py, array.0, |v| {
+        v.map(|x| numeric::clamp_f64(x, min_val, max_val))
+    })?))
+}
+
+#[pyfunction]
+pub fn abs_value_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_f64_to_f64(py, array.0, |v| {
+        v.map(numeric::abs_f64)
+    })?))
+}
+
+#[pyfunction]
+pub fn fill_zero_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_f64_to_f64(py, array.0, |v| {
+        Some(numeric::fill_zero(v))
+    })?))
+}

--- a/packages/rust/extensions/native-flow/src/url.rs
+++ b/packages/rust/extensions/native-flow/src/url.rs
@@ -1,0 +1,27 @@
+//! Arrow shims over goldenflow_core::url. Bytes in, kernel per element, bytes
+//! out; GIL released. All logic lives in the core.
+use crate::util::map_str_to_str;
+use arrow::array::ArrayData;
+use arrow::pyarrow::PyArrowType;
+use goldenflow_core::url;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn url_normalize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, url::url_normalize)?))
+}
+
+#[pyfunction]
+pub fn url_extract_domain_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(
+        py,
+        array.0,
+        url::url_extract_domain,
+    )?))
+}

--- a/packages/rust/extensions/native-flow/src/url.rs
+++ b/packages/rust/extensions/native-flow/src/url.rs
@@ -11,7 +11,11 @@ pub fn url_normalize_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, url::url_normalize)?))
+    Ok(PyArrowType(map_str_to_str(
+        py,
+        array.0,
+        url::url_normalize,
+    )?))
 }
 
 #[pyfunction]

--- a/packages/rust/extensions/native-flow/src/util.rs
+++ b/packages/rust/extensions/native-flow/src/util.rs
@@ -5,8 +5,8 @@
 //! Interface. Each mapper releases the GIL around the compute loop.
 
 use arrow::array::{
-    make_array, Array, ArrayData, BooleanBuilder, Int64Builder, LargeStringArray, StringArray,
-    StringBuilder,
+    make_array, Array, ArrayData, BooleanBuilder, Float64Array, Float64Builder, Int64Builder,
+    LargeStringArray, StringArray, StringBuilder,
 };
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -77,5 +77,48 @@ where
             None => builder.append_null(),
         })
     })?;
+    Ok(builder.finish().into_data())
+}
+
+pub fn map_str_to_f64<F>(py: Python, data: ArrayData, f: F) -> PyResult<ArrayData>
+where
+    F: Fn(&str) -> Option<f64> + Sync,
+{
+    let len = make_array(data.clone()).len();
+    let mut builder = Float64Builder::with_capacity(len);
+    py.detach(|| -> PyResult<()> {
+        for_each_str(&data, |_, v| match v.and_then(&f) {
+            Some(out) => builder.append_value(out),
+            None => builder.append_null(),
+        })
+    })?;
+    Ok(builder.finish().into_data())
+}
+
+/// Apply `f` over each element of a Float64 array, receiving `None` for a
+/// null slot and `Some(x)` otherwise; `f` returns `None` to emit a null,
+/// `Some(out)` to emit a value. Unlike the string mappers, `f` sees the
+/// null-ness itself (some numeric ops, like `fill_zero`, act ON nulls rather
+/// than passing them through untouched).
+pub fn map_f64_to_f64<F>(py: Python, data: ArrayData, f: F) -> PyResult<ArrayData>
+where
+    F: Fn(Option<f64>) -> Option<f64> + Sync,
+{
+    let arr = make_array(data.clone());
+    let a = arr
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .ok_or_else(|| PyTypeError::new_err("expected an Arrow Float64 array"))?;
+    let len = a.len();
+    let mut builder = Float64Builder::with_capacity(len);
+    py.detach(|| {
+        for i in 0..len {
+            let v = if a.is_null(i) { None } else { Some(a.value(i)) };
+            match f(v) {
+                Some(out) => builder.append_value(out),
+                None => builder.append_null(),
+            }
+        }
+    });
     Ok(builder.finish().into_data())
 }

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/core/transforms/categorical.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/categorical.ts
@@ -1,25 +1,64 @@
 /**
  * Categorical transforms — ported from goldenflow/transforms/categorical.py
  * Side-effect module: registers 5 categorical transforms on import.
+ *
+ * Owned-kernel family (D5 wave): boolean_normalize/gender_standardize/
+ * null_standardize are byte-for-byte ports of the Python pure-TS reference
+ * (`_boolean_normalize_py` et al. in `goldenflow/transforms/categorical.py`),
+ * which is itself proven byte-identical to the Rust
+ * `goldenflow-core::categorical` kernels (parity corpus in
+ * `tests/parity/identifiers_corpus.jsonl`). Each dispatches to the opt-in
+ * WASM backend (`FlowWasmBackend`) when `enableWasm()` has succeeded;
+ * otherwise it runs the pure-TS implementation below. Pure-TS is the
+ * default.
+ *
+ * `category_standardize`/`category_from_file` apply a caller-supplied
+ * variant->canonical mapping -- that mapping is runtime DATA, not logic, so
+ * it has no kernel; only the shared key-normalization step
+ * (`categoryNormalizeKeyTs`, trim+lowercase) is native-first. The dict
+ * lookup itself stays pure TS.
  */
 
 import type { ColumnValue } from "../types.js";
 import { registerTransform } from "./registry.js";
+import { getFlowWasmBackend, type FlowWasmBackend } from "../wasm/backend.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Shared key-normalization step (trim+lowercase) -- pure-TS reference for
+ * goldenflow-core's `categorical::category_normalize_key` kernel. Used
+ * directly by boolean/gender/null below, and by the mapping-based
+ * transforms to derive their runtime-data lookup key. */
+function categoryNormalizeKeyTs(s: string): string {
+  return s.trim().toLowerCase();
+}
 
 // ---------------------------------------------------------------------------
 // boolean_normalize (series, boolean|string, 50)
+//
+// Pure-TS reference for goldenflow-core's `categorical::boolean_normalize`
+// kernel.
 // ---------------------------------------------------------------------------
 
 const TRUTHY = new Set(["yes", "y", "1", "true", "t"]);
 const FALSY = new Set(["no", "n", "0", "false", "f"]);
 
+function booleanNormalizeTs(s: string): boolean | undefined {
+  const key = categoryNormalizeKeyTs(s);
+  if (TRUTHY.has(key)) return true;
+  if (FALSY.has(key)) return false;
+  return undefined;
+}
+
 function booleanNormalize(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
   return values.map((v) => {
     if (v === null) return null;
-    const s = String(v).trim().toLowerCase();
-    if (TRUTHY.has(s)) return true;
-    if (FALSY.has(s)) return false;
-    return v;
+    const s = String(v);
+    const r = backend ? backend.booleanNormalize(s) : booleanNormalizeTs(s);
+    return r === undefined ? null : r;
   });
 }
 
@@ -30,16 +69,24 @@ registerTransform(
 
 // ---------------------------------------------------------------------------
 // gender_standardize (series, string, 50)
+//
+// Pure-TS reference for goldenflow-core's `categorical::gender_standardize`
+// kernel. Unrecognized values pass through UNCHANGED (the original string).
 // ---------------------------------------------------------------------------
 
+function genderStandardizeTs(s: string): string {
+  const key = categoryNormalizeKeyTs(s);
+  if (key === "male" || key === "m") return "M";
+  if (key === "female" || key === "f") return "F";
+  return s;
+}
+
 function genderStandardize(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
   return values.map((v) => {
     if (v === null) return null;
     if (typeof v !== "string") return v;
-    const s = v.trim().toLowerCase();
-    if (s === "male" || s === "m") return "M";
-    if (s === "female" || s === "f") return "F";
-    return v;
+    return backend ? backend.genderStandardize(v) : genderStandardizeTs(v);
   });
 }
 
@@ -50,19 +97,28 @@ registerTransform(
 
 // ---------------------------------------------------------------------------
 // null_standardize (series, string, 80, auto_apply)
+//
+// Pure-TS reference for goldenflow-core's `categorical::null_standardize`
+// kernel. Unrecognized values pass through UNCHANGED (the original string).
 // ---------------------------------------------------------------------------
 
 const NULL_VARIANTS = new Set([
   "n/a", "null", "none", "na", "nil", "nan", "-", "",
 ]);
 
+function nullStandardizeTs(s: string): string | undefined {
+  const key = categoryNormalizeKeyTs(s);
+  if (NULL_VARIANTS.has(key)) return undefined;
+  return s;
+}
+
 function nullStandardize(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
   return values.map((v) => {
     if (v === null) return null;
     if (typeof v !== "string") return v;
-    const s = v.trim().toLowerCase();
-    if (NULL_VARIANTS.has(s)) return null;
-    return v;
+    const r = backend ? backend.nullStandardize(v) : nullStandardizeTs(v);
+    return r === undefined ? null : r;
   });
 }
 
@@ -74,6 +130,10 @@ registerTransform(
 // ---------------------------------------------------------------------------
 // category_standardize (series, string, 45, param: mapping=null)
 // Mapping format: { canonical: [variant1, variant2, ...], ... }
+//
+// The mapping is runtime DATA supplied by the caller, so the dict lookup
+// stays pure TS; only the key-normalization step is native-first via
+// `categoryNormalizeKeyTs`/the WASM backend's `categoryNormalizeKey`.
 // ---------------------------------------------------------------------------
 
 function categoryStandardize(
@@ -96,10 +156,11 @@ function categoryStandardize(
     lookup.set(canonical.toLowerCase(), canonical);
   }
 
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
   return values.map((v) => {
     if (v === null) return null;
     if (typeof v !== "string") return v;
-    const key = v.trim().toLowerCase();
+    const key = backend ? backend.categoryNormalizeKey(v) : categoryNormalizeKeyTs(v);
     return lookup.get(key) ?? v;
   });
 }
@@ -128,3 +189,17 @@ registerTransform(
   { name: "category_from_file", inputTypes: ["string"], priority: 45, mode: "series" },
   categoryFromFile,
 );
+
+// ---------------------------------------------------------------------------
+// Pure-TS single-value exports (cross-surface byte-parity harness)
+//
+// Bypass the wasm-dispatch wrappers above so a parity test can assert the
+// pure-TS path independently of whatever backend is currently registered.
+// ---------------------------------------------------------------------------
+
+export {
+  categoryNormalizeKeyTs,
+  booleanNormalizeTs,
+  genderStandardizeTs,
+  nullStandardizeTs,
+};

--- a/packages/typescript/goldenflow/src/core/transforms/numeric.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/numeric.ts
@@ -1,24 +1,83 @@
 /**
  * Numeric transforms — ported from goldenflow/transforms/numeric.py
  * Side-effect module: registers 9 numeric transforms on import.
+ *
+ * Owned-kernel family (D4 wave): each transform is a value-for-value port of
+ * the Python pure-TS reference (`_currency_strip_py` et al. in
+ * `goldenflow/transforms/numeric.py`), which is itself proven value-identical
+ * to the Rust `goldenflow-core::numeric` kernels (parity corpus in
+ * `tests/parity/identifiers_corpus.jsonl` for the string->number parsers;
+ * `test_numeric_kernels.py` for the numeric-array ops). This family outputs
+ * floats/ints, so parity is by VALUE, not string repr. Each transform
+ * dispatches to the opt-in WASM backend (`FlowWasmBackend`) when
+ * `enableWasm()` has succeeded; otherwise it runs the pure-TS implementation
+ * below. Pure-TS is the default.
  */
 
 import type { ColumnValue } from "../types.js";
 import { registerTransform } from "./registry.js";
+import { getFlowWasmBackend, type FlowWasmBackend } from "../wasm/backend.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Stringify a column value the way Polars' `cast(Utf8, strict=False)` would
+ * for a numeric column feeding a string-parser transform: numbers become
+ * their decimal repr, strings pass through unchanged. */
+function toInputString(v: ColumnValue): string | null {
+  if (v === null) return null;
+  return typeof v === "string" ? v : String(v);
+}
+
+/** Map a column through a string->number|undefined parser fn (the Rust
+ * `Option<f64>`/`Option<i64>` -- `undefined` mirrors `None`); null passes
+ * through, `undefined` maps to `null` in the output column. */
+function mapParser(
+  values: readonly ColumnValue[],
+  fn: (s: string) => number | undefined,
+): ColumnValue[] {
+  return values.map((v) => {
+    const s = toInputString(v);
+    if (s === null) return null;
+    const r = fn(s);
+    return r === undefined ? null : r;
+  });
+}
+
+/** Map a column of numbers through a numeric-array-op fn; non-null,
+ * non-numeric values are coerced via `Number()` (NaN passes through as
+ * null, matching "not really numeric input" gracefully). */
+function mapNumericOp(
+  values: readonly ColumnValue[],
+  fn: (x: number) => number,
+): ColumnValue[] {
+  return values.map((v) => {
+    if (v === null) return null;
+    const num = typeof v === "number" ? v : Number(v);
+    if (Number.isNaN(num)) return null;
+    return fn(num);
+  });
+}
 
 // ---------------------------------------------------------------------------
 // currency_strip (series, string|numeric, 50)
+//
+// Pure-TS reference for goldenflow-core's `numeric::currency_strip` kernel.
+// Strip everything except ASCII digits, `.`, and `-`, then parse as a
+// number. `undefined` (-> null) on parse failure.
 // ---------------------------------------------------------------------------
 
+function currencyStripTs(s: string): number | undefined {
+  const filtered = s.replace(/[^0-9.\-]/g, "");
+  if (filtered === "") return undefined;
+  const n = Number(filtered);
+  return Number.isNaN(n) ? undefined : n;
+}
+
 function currencyStrip(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null) return null;
-    if (typeof v === "number") return v;
-    const cleaned = String(v).replace(/[^0-9.\-]/g, "");
-    if (cleaned === "" || cleaned === "-") return v;
-    const n = Number(cleaned);
-    return isNaN(n) ? v : n;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapParser(values, backend ? (s) => backend.currencyStrip(s) : currencyStripTs);
 }
 
 registerTransform(
@@ -28,16 +87,27 @@ registerTransform(
 
 // ---------------------------------------------------------------------------
 // percentage_normalize (series, string|numeric, 50)
+//
+// Pure-TS reference for goldenflow-core's `numeric::percentage_normalize`
+// kernel. Trim, strip trailing `%`, trim again, parse as a number, divide by
+// 100. `undefined` (-> null) on parse failure.
 // ---------------------------------------------------------------------------
 
+function percentageNormalizeTs(s: string): number | undefined {
+  let v = s.trim();
+  v = v.replace(/%+$/, "");
+  v = v.trim();
+  if (v === "") return undefined;
+  const n = Number(v);
+  return Number.isNaN(n) ? undefined : n / 100;
+}
+
 function percentageNormalize(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null) return null;
-    if (typeof v === "number") return v / 100;
-    const s = String(v).replace(/%/g, "").trim();
-    const n = Number(s);
-    return isNaN(n) ? v : n / 100;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapParser(
+    values,
+    backend ? (s) => backend.percentageNormalize(s) : percentageNormalizeTs,
+  );
 }
 
 registerTransform(
@@ -47,21 +117,26 @@ registerTransform(
 
 // ---------------------------------------------------------------------------
 // round (series, numeric, 40, param: n=2)
+//
+// Round-half-away-from-zero at the n-th decimal, via multiply/round/divide
+// -- the SAME formula as goldenflow-core's `round_f64` kernel. Deliberately
+// NOT `Math.round` (which rounds half toward +Infinity, not away from zero).
 // ---------------------------------------------------------------------------
 
-function roundTransform(
-  values: readonly ColumnValue[],
-  n: unknown = 2,
-): ColumnValue[] {
-  const decimals = typeof n === "number" ? n : Number(n) || 2;
-  const factor = Math.pow(10, decimals);
+function roundValueTs(x: number, n: number): number {
+  const factor = Math.pow(10, n);
+  const scaled = x * factor;
+  const rounded = scaled >= 0 ? Math.floor(scaled + 0.5) : Math.ceil(scaled - 0.5);
+  return rounded / factor;
+}
 
-  return values.map((v) => {
-    if (v === null) return null;
-    const num = typeof v === "number" ? v : Number(v);
-    if (isNaN(num)) return v;
-    return Math.round(num * factor) / factor;
-  });
+function roundTransform(values: readonly ColumnValue[], n: unknown = 2): ColumnValue[] {
+  const decimals = typeof n === "number" ? n : Number(n) || 2;
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapNumericOp(
+    values,
+    backend ? (x) => backend.roundValue(x, decimals) : (x) => roundValueTs(x, decimals),
+  );
 }
 
 registerTransform(
@@ -73,20 +148,20 @@ registerTransform(
 // clamp (series, numeric, 40, params: min_val=0, max_val=1)
 // ---------------------------------------------------------------------------
 
-function clamp(
-  values: readonly ColumnValue[],
-  minVal: unknown = 0,
-  maxVal: unknown = 1,
-): ColumnValue[] {
+function clampValueTs(x: number, minVal: number, maxVal: number): number {
+  if (x < minVal) return minVal;
+  if (x > maxVal) return maxVal;
+  return x;
+}
+
+function clamp(values: readonly ColumnValue[], minVal: unknown = 0, maxVal: unknown = 1): ColumnValue[] {
   const lo = typeof minVal === "number" ? minVal : Number(minVal) || 0;
   const hi = typeof maxVal === "number" ? maxVal : Number(maxVal) || 1;
-
-  return values.map((v) => {
-    if (v === null) return null;
-    const num = typeof v === "number" ? v : Number(v);
-    if (isNaN(num)) return v;
-    return Math.min(hi, Math.max(lo, num));
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapNumericOp(
+    values,
+    backend ? (x) => backend.clampValue(x, lo, hi) : (x) => clampValueTs(x, lo, hi),
+  );
 }
 
 registerTransform(
@@ -96,15 +171,22 @@ registerTransform(
 
 // ---------------------------------------------------------------------------
 // to_integer (series, string|numeric, 45)
+//
+// Pure-TS reference for goldenflow-core's `numeric::to_integer` kernel.
+// Parse as a number, truncate toward zero. `undefined` (-> null) on parse
+// failure.
 // ---------------------------------------------------------------------------
 
+function toIntegerTs(s: string): number | undefined {
+  const trimmed = s.trim();
+  if (trimmed === "") return undefined;
+  const n = Number(trimmed);
+  return Number.isNaN(n) ? undefined : Math.trunc(n);
+}
+
 function toInteger(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null) return null;
-    const num = Number(v);
-    if (isNaN(num)) return v;
-    return Math.trunc(num);
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapParser(values, backend ? (s) => backend.toInteger(s) : toIntegerTs);
 }
 
 registerTransform(
@@ -117,12 +199,8 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function absValue(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null) return null;
-    const num = typeof v === "number" ? v : Number(v);
-    if (isNaN(num)) return v;
-    return Math.abs(num);
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapNumericOp(values, backend ? (x) => backend.absValue(x) : Math.abs);
 }
 
 registerTransform(
@@ -135,7 +213,11 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function fillZero(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => (v === null ? 0 : v));
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return values.map((v) => {
+    if (v !== null) return v;
+    return backend ? backend.fillZero(undefined) : 0;
+  });
 }
 
 registerTransform(
@@ -145,18 +227,28 @@ registerTransform(
 
 // ---------------------------------------------------------------------------
 // comma_decimal (series, string|numeric, 48) — European "1.234,56" -> 1234.56
+//
+// Pure-TS reference for goldenflow-core's `numeric::comma_decimal` kernel.
+// If the (trimmed) input has no comma, parse as-is; else treat dots as
+// thousands separators and the comma as the decimal point. `undefined`
+// (-> null) on parse failure.
 // ---------------------------------------------------------------------------
 
+function commaDecimalTs(s: string): number | undefined {
+  const trimmed = s.trim();
+  if (!trimmed.includes(",")) {
+    if (trimmed === "") return undefined;
+    const n = Number(trimmed);
+    return Number.isNaN(n) ? undefined : n;
+  }
+  const converted = trimmed.replace(/\./g, "").replace(",", ".");
+  const n = Number(converted);
+  return Number.isNaN(n) ? undefined : n;
+}
+
 function commaDecimal(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null) return null;
-    if (typeof v === "number") return v;
-    const s = String(v);
-    // European format: dots as thousands separators, comma as decimal
-    const converted = s.replace(/\./g, "").replace(",", ".");
-    const n = Number(converted);
-    return isNaN(n) ? v : n;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapParser(values, backend ? (s) => backend.commaDecimal(s) : commaDecimalTs);
 }
 
 registerTransform(
@@ -166,17 +258,44 @@ registerTransform(
 
 // ---------------------------------------------------------------------------
 // scientific_to_decimal (series, string|numeric, 45)
+//
+// Pure-TS reference for goldenflow-core's `numeric::scientific_to_decimal`
+// kernel. Trim, parse as a number. `undefined` (-> null) on parse failure.
 // ---------------------------------------------------------------------------
 
+function scientificToDecimalTs(s: string): number | undefined {
+  const trimmed = s.trim();
+  if (trimmed === "") return undefined;
+  const n = Number(trimmed);
+  return Number.isNaN(n) ? undefined : n;
+}
+
 function scientificToDecimal(values: readonly ColumnValue[]): ColumnValue[] {
-  return values.map((v) => {
-    if (v === null) return null;
-    const n = Number(v);
-    return isNaN(n) ? v : n;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapParser(
+    values,
+    backend ? (s) => backend.scientificToDecimal(s) : scientificToDecimalTs,
+  );
 }
 
 registerTransform(
   { name: "scientific_to_decimal", inputTypes: ["string", "numeric"], priority: 45, mode: "series" },
   scientificToDecimal,
 );
+
+// ---------------------------------------------------------------------------
+// Pure-TS single-value exports (cross-surface byte/value-parity harness)
+//
+// Bypass the wasm-dispatch wrappers above so a parity test can assert the
+// pure-TS path independently of whatever backend is currently registered.
+// ---------------------------------------------------------------------------
+
+export {
+  currencyStripTs,
+  percentageNormalizeTs,
+  toIntegerTs,
+  commaDecimalTs,
+  scientificToDecimalTs,
+  roundValueTs,
+  clampValueTs,
+};

--- a/packages/typescript/goldenflow/src/core/transforms/url.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/url.ts
@@ -1,22 +1,36 @@
 /**
  * URL transforms — ported from goldenflow/transforms/url.py
  * Side-effect module: registers 2 URL transforms on import.
+ *
+ * Owned-kernel family (D2 wave): each transform is a byte-for-byte port of
+ * the Python pure-TS reference (`_url_normalize_py` et al. in
+ * `goldenflow/transforms/url.py`), which is itself proven byte-identical to
+ * the Rust `goldenflow-core::url` kernels (parity corpus in
+ * `tests/parity/identifiers_corpus.jsonl`). Each transform dispatches to the
+ * opt-in WASM backend (`FlowWasmBackend`, a thin wasm-bindgen shim over the
+ * SAME Rust kernel) when `enableWasm()` has succeeded; otherwise it runs the
+ * pure-TS implementation below. Pure-TS is the default.
  */
 
 import type { ColumnValue } from "../types.js";
 import { registerTransform } from "./registry.js";
+import { getFlowWasmBackend, type FlowWasmBackend } from "../wasm/backend.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function mapStrings(
+/** Map a string column through a fn returning `string | undefined` (the Rust
+ * `Option<String>` -- `undefined` mirrors `None`); nulls and non-strings pass
+ * through unchanged, `undefined` maps to `null` in the output column. */
+function mapToStringOrNull(
   values: readonly ColumnValue[],
-  fn: (s: string) => string | null,
+  fn: (s: string) => string | undefined,
 ): ColumnValue[] {
   return values.map((v) => {
     if (v === null || typeof v !== "string") return v;
-    return fn(v);
+    const r = fn(v);
+    return r === undefined ? null : r;
   });
 }
 
@@ -24,73 +38,115 @@ const _SCHEME_RE = /^https?:\/\//i;
 
 // ---------------------------------------------------------------------------
 // url_normalize (series, url|string, 50)
+//
+// Pure-TS reference for goldenflow-core's `url::url_normalize` kernel. Ensure
+// a scheme, lowercase the scheme + domain, keep the path as-is, and strip a
+// trailing slash (unless the path IS just "/", in which case exactly one
+// trailing slash is dropped). `undefined` (-> null) for empty (post-trim)
+// input.
 // ---------------------------------------------------------------------------
 
+function urlNormalizeTs(s: string): string | undefined {
+  let val = s.trim();
+  if (!val) return undefined;
+
+  // Add scheme if missing
+  if (!_SCHEME_RE.test(val)) {
+    val = "https://" + val;
+  }
+
+  // Split scheme from rest
+  const schemeEnd = val.indexOf("://") + 3;
+  const scheme = val.slice(0, schemeEnd).toLowerCase();
+  const rest = val.slice(schemeEnd);
+
+  // Lowercase the domain (everything before first /)
+  const slashIdx = rest.indexOf("/");
+  let domain: string;
+  let path: string;
+  if (slashIdx === -1) {
+    domain = rest.toLowerCase();
+    path = "";
+  } else {
+    domain = rest.slice(0, slashIdx).toLowerCase();
+    path = rest.slice(slashIdx);
+  }
+
+  // Strip trailing slash (but not if path is just "/")
+  let result = scheme + domain + path;
+  if (result.endsWith("/") && result.length > schemeEnd + domain.length + 1) {
+    result = result.replace(/\/+$/, "");
+  } else if (result.endsWith("/") && path === "/") {
+    result = result.slice(0, -1);
+  }
+
+  return result;
+}
+
 function urlNormalize(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    let val = s.trim();
-    if (!val) return null;
-
-    // Add scheme if missing
-    if (!_SCHEME_RE.test(val)) {
-      val = "https://" + val;
-    }
-
-    // Split scheme from rest
-    const schemeEnd = val.indexOf("://") + 3;
-    const scheme = val.slice(0, schemeEnd).toLowerCase();
-    const rest = val.slice(schemeEnd);
-
-    // Lowercase the domain (everything before first /)
-    const slashIdx = rest.indexOf("/");
-    let domain: string;
-    let path: string;
-    if (slashIdx === -1) {
-      domain = rest.toLowerCase();
-      path = "";
-    } else {
-      domain = rest.slice(0, slashIdx).toLowerCase();
-      path = rest.slice(slashIdx);
-    }
-
-    // Strip trailing slash
-    let result = scheme + domain + path;
-    if (result.endsWith("/") && result.length > schemeEnd + domain.length + 1) {
-      result = result.replace(/\/+$/, "");
-    } else if (result.endsWith("/") && path === "/") {
-      result = result.slice(0, -1);
-    }
-
-    return result;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapToStringOrNull(values, backend ? (s) => backend.urlNormalize(s) : urlNormalizeTs);
 }
 
 registerTransform(
-  { name: "url_normalize", inputTypes: ["url", "string"], priority: 50, mode: "series" },
+  {
+    name: "url_normalize",
+    inputTypes: ["url", "string"],
+    autoApply: false,
+    priority: 50,
+    mode: "series",
+  },
   urlNormalize,
 );
 
 // ---------------------------------------------------------------------------
 // url_extract_domain (series, url|string, 40)
+//
+// Pure-TS reference for goldenflow-core's `url::url_extract_domain` kernel.
+// Strip an optional `scheme://` prefix, then take everything before the
+// first `/`. `undefined` (-> null) for empty (post-trim) input or an empty
+// domain.
 // ---------------------------------------------------------------------------
 
+function urlExtractDomainTs(s: string): string | undefined {
+  let val = s.trim();
+  if (!val) return undefined;
+
+  // Strip scheme
+  const schemeIdx = val.indexOf("://");
+  if (schemeIdx !== -1) {
+    val = val.slice(schemeIdx + 3);
+  }
+
+  // Take everything before the first /
+  const domain = val.split("/", 1)[0]!;
+  return domain ? domain.toLowerCase() : undefined;
+}
+
 function urlExtractDomain(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    let val = s.trim();
-    if (!val) return null;
-
-    // Strip scheme
-    if (val.includes("://")) {
-      val = val.split("://", 2)[1]!;
-    }
-
-    // Take everything before the first /
-    const domain = val.split("/", 1)[0]!;
-    return domain ? domain.toLowerCase() : null;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapToStringOrNull(
+    values,
+    backend ? (s) => backend.urlExtractDomain(s) : urlExtractDomainTs,
+  );
 }
 
 registerTransform(
-  { name: "url_extract_domain", inputTypes: ["url", "string"], priority: 40, mode: "series" },
+  {
+    name: "url_extract_domain",
+    inputTypes: ["url", "string"],
+    autoApply: false,
+    priority: 40,
+    mode: "series",
+  },
   urlExtractDomain,
 );
+
+// ---------------------------------------------------------------------------
+// Pure-TS single-value exports (cross-surface byte-parity harness)
+//
+// Bypass the wasm-dispatch wrappers above so a parity test can assert the
+// pure-TS path independently of whatever backend is currently registered.
+// ---------------------------------------------------------------------------
+
+export { urlNormalizeTs, urlExtractDomainTs };

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -5,10 +5,12 @@
  * The active backend (if any) is consulted by the identifier transforms
  * (cc/iban/isbn/ean/vat/swift/aba/imei) for the 14 covered functions, the
  * i18n-name transforms (name_transliterate/name_script), the email
- * transforms (email_lowercase/normalize/extract_domain/validate), and the
- * URL transforms (url_normalize/extract_domain); everything else stays
- * pure-TS. Mirrors goldenmatch's `setScorerBackend(null)` module-singleton
- * pattern for test isolation.
+ * transforms (email_lowercase/normalize/extract_domain/validate), the URL
+ * transforms (url_normalize/extract_domain), and the categorical transforms
+ * (boolean_normalize/gender_standardize/null_standardize/
+ * category_normalize_key); everything else stays pure-TS. Mirrors
+ * goldenmatch's `setScorerBackend(null)` module-singleton pattern for test
+ * isolation.
  */
 
 /**
@@ -53,6 +55,10 @@ export interface FlowWasmBackend {
   clampValue(x: number, minVal: number, maxVal: number): number;
   absValue(x: number): number;
   fillZero(x: number | undefined): number;
+  booleanNormalize(s: string): boolean | undefined;
+  genderStandardize(s: string): string;
+  nullStandardize(s: string): string | undefined;
+  categoryNormalizeKey(s: string): string;
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -44,6 +44,15 @@ export interface FlowWasmBackend {
   emailValidate(s: string): boolean;
   urlNormalize(s: string): string | undefined;
   urlExtractDomain(s: string): string | undefined;
+  currencyStrip(s: string): number | undefined;
+  percentageNormalize(s: string): number | undefined;
+  toInteger(s: string): number | undefined;
+  commaDecimal(s: string): number | undefined;
+  scientificToDecimal(s: string): number | undefined;
+  roundValue(x: number, n: number): number;
+  clampValue(x: number, minVal: number, maxVal: number): number;
+  absValue(x: number): number;
+  fillZero(x: number | undefined): number;
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -4,10 +4,11 @@
  *
  * The active backend (if any) is consulted by the identifier transforms
  * (cc/iban/isbn/ean/vat/swift/aba/imei) for the 14 covered functions, the
- * i18n-name transforms (name_transliterate/name_script), and the email
- * transforms (email_lowercase/normalize/extract_domain/validate); everything
- * else stays pure-TS. Mirrors goldenmatch's `setScorerBackend(null)`
- * module-singleton pattern for test isolation.
+ * i18n-name transforms (name_transliterate/name_script), the email
+ * transforms (email_lowercase/normalize/extract_domain/validate), and the
+ * URL transforms (url_normalize/extract_domain); everything else stays
+ * pure-TS. Mirrors goldenmatch's `setScorerBackend(null)` module-singleton
+ * pattern for test isolation.
  */
 
 /**
@@ -41,6 +42,8 @@ export interface FlowWasmBackend {
   emailNormalize(s: string): string;
   emailExtractDomain(s: string): string | undefined;
   emailValidate(s: string): boolean;
+  urlNormalize(s: string): string | undefined;
+  urlExtractDomain(s: string): string | undefined;
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -63,6 +63,15 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     email_validate: (s: string) => boolean | undefined;
     url_normalize: (s: string) => string | undefined;
     url_extract_domain: (s: string) => string | undefined;
+    currency_strip: (s: string) => number | undefined;
+    percentage_normalize: (s: string) => number | undefined;
+    to_integer: (s: string) => number | undefined;
+    comma_decimal: (s: string) => number | undefined;
+    scientific_to_decimal: (s: string) => number | undefined;
+    round_value: (x: number, n: number) => number;
+    clamp_value: (x: number, minVal: number, maxVal: number) => number;
+    abs_value: (x: number) => number;
+    fill_zero: (x: number | undefined) => number;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -89,5 +98,14 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     emailValidate: (s) => glue.email_validate(s) ?? false,
     urlNormalize: (s) => glue.url_normalize(s),
     urlExtractDomain: (s) => glue.url_extract_domain(s),
+    currencyStrip: (s) => glue.currency_strip(s),
+    percentageNormalize: (s) => glue.percentage_normalize(s),
+    toInteger: (s) => glue.to_integer(s),
+    commaDecimal: (s) => glue.comma_decimal(s),
+    scientificToDecimal: (s) => glue.scientific_to_decimal(s),
+    roundValue: (x, n) => glue.round_value(x, n),
+    clampValue: (x, minVal, maxVal) => glue.clamp_value(x, minVal, maxVal),
+    absValue: (x) => glue.abs_value(x),
+    fillZero: (x) => glue.fill_zero(x),
   };
 }

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -61,6 +61,8 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     email_normalize: (s: string) => string;
     email_extract_domain: (s: string) => string | undefined;
     email_validate: (s: string) => boolean | undefined;
+    url_normalize: (s: string) => string | undefined;
+    url_extract_domain: (s: string) => string | undefined;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -85,5 +87,7 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     emailNormalize: (s) => glue.email_normalize(s),
     emailExtractDomain: (s) => glue.email_extract_domain(s),
     emailValidate: (s) => glue.email_validate(s) ?? false,
+    urlNormalize: (s) => glue.url_normalize(s),
+    urlExtractDomain: (s) => glue.url_extract_domain(s),
   };
 }

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -72,6 +72,10 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     clamp_value: (x: number, minVal: number, maxVal: number) => number;
     abs_value: (x: number) => number;
     fill_zero: (x: number | undefined) => number;
+    boolean_normalize: (s: string) => boolean | undefined;
+    gender_standardize: (s: string) => string;
+    null_standardize: (s: string) => string | undefined;
+    category_normalize_key: (s: string) => string;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -107,5 +111,9 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     clampValue: (x, minVal, maxVal) => glue.clamp_value(x, minVal, maxVal),
     absValue: (x) => glue.abs_value(x),
     fillZero: (x) => glue.fill_zero(x),
+    booleanNormalize: (s) => glue.boolean_normalize(s),
+    genderStandardize: (s) => glue.gender_standardize(s),
+    nullStandardize: (s) => glue.null_standardize(s),
+    categoryNormalizeKey: (s) => glue.category_normalize_key(s),
   };
 }

--- a/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
@@ -44,6 +44,12 @@ import {
   emailValidateTs,
 } from "../../src/core/transforms/email.js";
 import { urlNormalizeTs, urlExtractDomainTs } from "../../src/core/transforms/url.js";
+import {
+  categoryNormalizeKeyTs,
+  booleanNormalizeTs,
+  genderStandardizeTs,
+  nullStandardizeTs,
+} from "../../src/core/transforms/categorical.js";
 import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
 import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
 
@@ -86,6 +92,10 @@ const PURE_TS_FN: Record<string, (s: string) => boolean | string | undefined> = 
   email_validate: emailValidateTs,
   url_normalize: urlNormalizeTs,
   url_extract_domain: urlExtractDomainTs,
+  boolean_normalize: booleanNormalizeTs,
+  gender_standardize: genderStandardizeTs,
+  null_standardize: nullStandardizeTs,
+  category_normalize_key: categoryNormalizeKeyTs,
 };
 
 /** Same transform set, dispatched through the wasm backend's method of the
@@ -115,6 +125,10 @@ function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boo
     email_validate: (s) => backend.emailValidate(s),
     url_normalize: (s) => backend.urlNormalize(s),
     url_extract_domain: (s) => backend.urlExtractDomain(s),
+    boolean_normalize: (s) => backend.booleanNormalize(s),
+    gender_standardize: (s) => backend.genderStandardize(s),
+    null_standardize: (s) => backend.nullStandardize(s),
+    category_normalize_key: (s) => backend.categoryNormalizeKey(s),
   };
   const fn = map[transform];
   if (!fn) throw new Error(`no wasm dispatch for transform ${transform}`);

--- a/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
@@ -45,6 +45,13 @@ import {
 } from "../../src/core/transforms/email.js";
 import { urlNormalizeTs, urlExtractDomainTs } from "../../src/core/transforms/url.js";
 import {
+  currencyStripTs,
+  percentageNormalizeTs,
+  toIntegerTs,
+  commaDecimalTs,
+  scientificToDecimalTs,
+} from "../../src/core/transforms/numeric.js";
+import {
   categoryNormalizeKeyTs,
   booleanNormalizeTs,
   genderStandardizeTs,
@@ -56,7 +63,7 @@ import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/ba
 interface CorpusRow {
   transform: string;
   input: string | null;
-  expected: boolean | string | null;
+  expected: boolean | string | number | null;
 }
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -69,7 +76,7 @@ const rows: CorpusRow[] = readFileSync(corpusPath, "utf8")
 /** Pure-TS single-value functions, keyed by the corpus's `transform` name.
  * Each takes the raw `string` input (null rows are short-circuited before
  * calling into these -- the fns below don't accept null). */
-const PURE_TS_FN: Record<string, (s: string) => boolean | string | undefined> = {
+const PURE_TS_FN: Record<string, (s: string) => boolean | string | number | undefined> = {
   cc_validate: ccValidateTs,
   cc_format: ccFormatTs,
   cc_mask: ccMaskTs,
@@ -96,13 +103,18 @@ const PURE_TS_FN: Record<string, (s: string) => boolean | string | undefined> = 
   gender_standardize: genderStandardizeTs,
   null_standardize: nullStandardizeTs,
   category_normalize_key: categoryNormalizeKeyTs,
+  currency_strip: currencyStripTs,
+  percentage_normalize: percentageNormalizeTs,
+  to_integer: toIntegerTs,
+  comma_decimal: commaDecimalTs,
+  scientific_to_decimal: scientificToDecimalTs,
 };
 
 /** Same transform set, dispatched through the wasm backend's method of the
  * same name (the `FlowWasmBackend` interface intentionally mirrors these
  * names -- see `src/core/wasm/backend.ts`). */
-function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boolean | string | undefined {
-  const map: Record<string, (s: string) => boolean | string | undefined> = {
+function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boolean | string | number | undefined {
+  const map: Record<string, (s: string) => boolean | string | number | undefined> = {
     cc_validate: (s) => backend.ccValidate(s),
     cc_format: (s) => backend.ccFormat(s),
     cc_mask: (s) => backend.ccMask(s),
@@ -129,16 +141,24 @@ function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boo
     gender_standardize: (s) => backend.genderStandardize(s),
     null_standardize: (s) => backend.nullStandardize(s),
     category_normalize_key: (s) => backend.categoryNormalizeKey(s),
+    currency_strip: (s) => backend.currencyStrip(s),
+    percentage_normalize: (s) => backend.percentageNormalize(s),
+    to_integer: (s) => backend.toInteger(s),
+    comma_decimal: (s) => backend.commaDecimal(s),
+    scientific_to_decimal: (s) => backend.scientificToDecimal(s),
   };
   const fn = map[transform];
   if (!fn) throw new Error(`no wasm dispatch for transform ${transform}`);
   return fn;
 }
 
-/** Normalize a raw fn result (`boolean | string | undefined`) and a corpus
- * `expected` (`boolean | string | null`) onto the same shape so `undefined`
- * (Rust `Option::None` / no-match) and `null` (Python `None`) compare equal. */
-function normalize(v: boolean | string | undefined | null): boolean | string | null {
+/** Normalize a raw fn result (`boolean | string | number | undefined`) and a
+ * corpus `expected` (`boolean | string | number | null`) onto the same shape so
+ * `undefined` (Rust `Option::None` / no-match) and `null` (Python `None`)
+ * compare equal. Numeric transforms (currency/percentage/…) compare by VALUE:
+ * `toEqual` does structural number equality, so identical IEEE-754 results from
+ * the Rust kernel and the pure-TS parser match without string-repr coupling. */
+function normalize(v: boolean | string | number | undefined | null): boolean | string | number | null {
   return v === undefined ? null : v;
 }
 

--- a/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
@@ -43,6 +43,7 @@ import {
   emailExtractDomainTs,
   emailValidateTs,
 } from "../../src/core/transforms/email.js";
+import { urlNormalizeTs, urlExtractDomainTs } from "../../src/core/transforms/url.js";
 import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
 import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
 
@@ -83,6 +84,8 @@ const PURE_TS_FN: Record<string, (s: string) => boolean | string | undefined> = 
   email_normalize: emailNormalizeTs,
   email_extract_domain: emailExtractDomainTs,
   email_validate: emailValidateTs,
+  url_normalize: urlNormalizeTs,
+  url_extract_domain: urlExtractDomainTs,
 };
 
 /** Same transform set, dispatched through the wasm backend's method of the
@@ -110,6 +113,8 @@ function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boo
     email_normalize: (s) => backend.emailNormalize(s),
     email_extract_domain: (s) => backend.emailExtractDomain(s),
     email_validate: (s) => backend.emailValidate(s),
+    url_normalize: (s) => backend.urlNormalize(s),
+    url_extract_domain: (s) => backend.urlExtractDomain(s),
   };
   const fn = map[transform];
   if (!fn) throw new Error(`no wasm dispatch for transform ${transform}`);

--- a/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -200,3 +200,23 @@
 {"transform": "email_validate", "input": "", "expected": false}
 {"transform": "email_validate", "input": "   ", "expected": false}
 {"transform": "email_validate", "input": null, "expected": null}
+{"transform": "url_normalize", "input": "Example.COM/Path/", "expected": "https://example.com/Path"}
+{"transform": "url_normalize", "input": "http://X.com/", "expected": "http://x.com"}
+{"transform": "url_normalize", "input": "https://a.com", "expected": "https://a.com"}
+{"transform": "url_normalize", "input": "https://a.com/x/", "expected": "https://a.com/x"}
+{"transform": "url_normalize", "input": "https://a.com/x//", "expected": "https://a.com/x"}
+{"transform": "url_normalize", "input": "HTTPS://Foo.com", "expected": "https://foo.com"}
+{"transform": "url_normalize", "input": "HtTp://Foo.com", "expected": "http://foo.com"}
+{"transform": "url_normalize", "input": "EXAMPLE.com", "expected": "https://example.com"}
+{"transform": "url_normalize", "input": " example.com ", "expected": "https://example.com"}
+{"transform": "url_normalize", "input": "http://sub.Domain.ORG/Path/More", "expected": "http://sub.domain.org/Path/More"}
+{"transform": "url_normalize", "input": "", "expected": null}
+{"transform": "url_normalize", "input": "   ", "expected": null}
+{"transform": "url_normalize", "input": null, "expected": null}
+{"transform": "url_extract_domain", "input": "https://Foo.com/x", "expected": "foo.com"}
+{"transform": "url_extract_domain", "input": "bar.com", "expected": "bar.com"}
+{"transform": "url_extract_domain", "input": "http://sub.domain.org/path/more", "expected": "sub.domain.org"}
+{"transform": "url_extract_domain", "input": "HTTPS://EXAMPLE.COM", "expected": "example.com"}
+{"transform": "url_extract_domain", "input": "", "expected": null}
+{"transform": "url_extract_domain", "input": "   ", "expected": null}
+{"transform": "url_extract_domain", "input": null, "expected": null}

--- a/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -257,3 +257,45 @@
 {"transform": "scientific_to_decimal", "input": "abc", "expected": null}
 {"transform": "scientific_to_decimal", "input": "", "expected": null}
 {"transform": "scientific_to_decimal", "input": null, "expected": null}
+{"transform": "boolean_normalize", "input": "Yes", "expected": true}
+{"transform": "boolean_normalize", "input": "Y", "expected": true}
+{"transform": "boolean_normalize", "input": "1", "expected": true}
+{"transform": "boolean_normalize", "input": "True", "expected": true}
+{"transform": "boolean_normalize", "input": " true ", "expected": true}
+{"transform": "boolean_normalize", "input": "T", "expected": true}
+{"transform": "boolean_normalize", "input": "No", "expected": false}
+{"transform": "boolean_normalize", "input": "N", "expected": false}
+{"transform": "boolean_normalize", "input": "0", "expected": false}
+{"transform": "boolean_normalize", "input": "False", "expected": false}
+{"transform": "boolean_normalize", "input": "f", "expected": false}
+{"transform": "boolean_normalize", "input": "maybe", "expected": null}
+{"transform": "boolean_normalize", "input": "", "expected": null}
+{"transform": "boolean_normalize", "input": null, "expected": null}
+{"transform": "gender_standardize", "input": "Male", "expected": "M"}
+{"transform": "gender_standardize", "input": "male", "expected": "M"}
+{"transform": "gender_standardize", "input": "M", "expected": "M"}
+{"transform": "gender_standardize", "input": "m", "expected": "M"}
+{"transform": "gender_standardize", "input": "Female", "expected": "F"}
+{"transform": "gender_standardize", "input": "female", "expected": "F"}
+{"transform": "gender_standardize", "input": "F", "expected": "F"}
+{"transform": "gender_standardize", "input": "f", "expected": "F"}
+{"transform": "gender_standardize", "input": "Nonbinary", "expected": "Nonbinary"}
+{"transform": "gender_standardize", "input": "", "expected": ""}
+{"transform": "gender_standardize", "input": null, "expected": null}
+{"transform": "null_standardize", "input": "N/A", "expected": null}
+{"transform": "null_standardize", "input": "NULL", "expected": null}
+{"transform": "null_standardize", "input": "none", "expected": null}
+{"transform": "null_standardize", "input": "", "expected": null}
+{"transform": "null_standardize", "input": "  ", "expected": null}
+{"transform": "null_standardize", "input": "null", "expected": null}
+{"transform": "null_standardize", "input": "NA", "expected": null}
+{"transform": "null_standardize", "input": "nil", "expected": null}
+{"transform": "null_standardize", "input": "nan", "expected": null}
+{"transform": "null_standardize", "input": "-", "expected": null}
+{"transform": "null_standardize", "input": "actual value", "expected": "actual value"}
+{"transform": "null_standardize", "input": null, "expected": null}
+{"transform": "category_normalize_key", "input": "  Yes  ", "expected": "yes"}
+{"transform": "category_normalize_key", "input": "USA", "expected": "usa"}
+{"transform": "category_normalize_key", "input": "MiXeD Case", "expected": "mixed case"}
+{"transform": "category_normalize_key", "input": "", "expected": ""}
+{"transform": "category_normalize_key", "input": null, "expected": null}

--- a/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -220,3 +220,40 @@
 {"transform": "url_extract_domain", "input": "", "expected": null}
 {"transform": "url_extract_domain", "input": "   ", "expected": null}
 {"transform": "url_extract_domain", "input": null, "expected": null}
+{"transform": "currency_strip", "input": "$1,234.56", "expected": 1234.56}
+{"transform": "currency_strip", "input": "-$42.00", "expected": -42.0}
+{"transform": "currency_strip", "input": "USD 100", "expected": 100.0}
+{"transform": "currency_strip", "input": "0.50", "expected": 0.5}
+{"transform": "currency_strip", "input": "free", "expected": null}
+{"transform": "currency_strip", "input": "", "expected": null}
+{"transform": "currency_strip", "input": null, "expected": null}
+{"transform": "percentage_normalize", "input": "85%", "expected": 0.85}
+{"transform": "percentage_normalize", "input": "100%", "expected": 1.0}
+{"transform": "percentage_normalize", "input": "0.5%", "expected": 0.005}
+{"transform": "percentage_normalize", "input": " 12.5 % ", "expected": 0.125}
+{"transform": "percentage_normalize", "input": "50", "expected": 0.5}
+{"transform": "percentage_normalize", "input": "abc%", "expected": null}
+{"transform": "percentage_normalize", "input": "", "expected": null}
+{"transform": "percentage_normalize", "input": null, "expected": null}
+{"transform": "to_integer", "input": "42", "expected": 42}
+{"transform": "to_integer", "input": "3.7", "expected": 3}
+{"transform": "to_integer", "input": "-3.7", "expected": -3}
+{"transform": "to_integer", "input": "100", "expected": 100}
+{"transform": "to_integer", "input": "abc", "expected": null}
+{"transform": "to_integer", "input": "", "expected": null}
+{"transform": "to_integer", "input": null, "expected": null}
+{"transform": "comma_decimal", "input": "1.234,56", "expected": 1234.56}
+{"transform": "comma_decimal", "input": "99,99", "expected": 99.99}
+{"transform": "comma_decimal", "input": "1.000,00", "expected": 1000.0}
+{"transform": "comma_decimal", "input": "1.5", "expected": 1.5}
+{"transform": "comma_decimal", "input": "100", "expected": 100.0}
+{"transform": "comma_decimal", "input": "abc", "expected": null}
+{"transform": "comma_decimal", "input": "", "expected": null}
+{"transform": "comma_decimal", "input": null, "expected": null}
+{"transform": "scientific_to_decimal", "input": "1.5e3", "expected": 1500.0}
+{"transform": "scientific_to_decimal", "input": "2.0E-4", "expected": 0.0002}
+{"transform": "scientific_to_decimal", "input": "3.14e0", "expected": 3.14}
+{"transform": "scientific_to_decimal", "input": "100", "expected": 100.0}
+{"transform": "scientific_to_decimal", "input": "abc", "expected": null}
+{"transform": "scientific_to_decimal", "input": "", "expected": null}
+{"transform": "scientific_to_decimal", "input": null, "expected": null}


### PR DESCRIPTION
## What

Wave D sweep (part 1): three transform families migrated to owned `goldenflow-core` kernels — Rust is the source of truth, the language surfaces (Python/WASM-TS/pure-Python fallback) fall out of it.

- **url** — `url_normalize`, `url_extract_domain` (subtle trailing-slash logic ported exactly).
- **numeric** — `currency_strip`, `percentage_normalize`, `to_integer`, `comma_decimal`, `scientific_to_decimal` (string→number parsers, **value-parity**), plus `round`/`clamp`/`abs_value`/`fill_zero` numeric-array kernels. Added `map_str_to_f64`/`map_f64_to_f64` Arrow mappers + a numeric-comparison mode in the parity harness.
- **categorical** — `boolean_normalize`, `gender_standardize`, `null_standardize` (explicit-map kernels) + `category_normalize_key` (owned key-normalization; the runtime mapping stays data).

Migration, not addition → transform count unchanged (92). Versions goldenflow 1.8.0 / npm 0.8.0 / native 0.6.0.

## Behavior change (reference-mode, resolved in Rust's favor)

- `round` now uses **round-half-away-from-zero** (2.5 → 3), replacing Python's banker's rounding. Numeric parsers return **null on unparseable input** (value-parity with the kernel); the TS parsers likewise (was pass-through). Documented in CHANGELOG.

## Verification

53 Rust unit tests; 502 Python parity/unit tests green; clippy/fmt clean; wasm32 builds; corpus `cmp` IDENTICAL across every family. TS/wasm parity runs in CI.

## Sweep status

Done: email (merged) + url/numeric/categorical (here). Remaining families are the harder shapes — names-remainder + address (incl. dataframe-mode `split_name`/`split_address` → struct kernels), text (Unicode ops via explicit maps), `category_auto_correct` (fuzzy), and dates (separate spike). Those follow as further sweep PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)