### PR TITLE
feat(goldenflow): Wave D — address-simple owned kernels (cross-surface)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-goldenflow-wave-d-address-simple-plan.md
+++ b/docs/superpowers/plans/2026-07-04-goldenflow-wave-d-address-simple-plan.md
@@ -1,0 +1,144 @@
+# Wave D address-simple — owned goldenflow-core kernels (cross-surface)
+
+**Program:** GoldenFlow owned-kernel + cross-surface (Rust-is-the-reference).
+**Predecessors:** Wave 0 (identifiers), A (swift/aba/imei), B (name_transliterate/
+name_script), D1 email, D-sweep-pt1 (url/numeric/categorical, #1426), names-remainder
+(#1431 — this branch stacks on it).
+**Thesis (Ben, 2026-07-04, locked):** commit fully — ALL transforms become owned
+Rust kernels; language surfaces fall out of Rust; kernel = spec under reference-mode.
+No "keep it Python" escape hatches. Migration (not addition), so the transform count
+stays 92 and version bumps are minor.
+
+## Scope: the 8 `address` transforms (US-simple; i18n stays Wave C deferred)
+
+| transform | mode | auto_apply | shape | owned kernel |
+|---|---|---|---|---|
+| `address_standardize` | expr | False | string→string | `address::address_standardize` |
+| `address_expand` | expr | False | string→string | `address::address_expand` |
+| `state_abbreviate` | expr | False | string→string | `address::state_abbreviate` |
+| `state_expand` | expr | False | string→string | `address::state_expand` |
+| `zip_normalize` | expr | **True** | string→string | `address::zip_normalize` |
+| `country_standardize` | series | False | string→string (dict) | `address::country_standardize` |
+| `unit_normalize` | series | False | string→string | `address::unit_normalize` |
+| `split_address` | dataframe | False | 1 col → (street,city,state,zip) | `address::split_address` |
+
+All 8 are US-scoped: US street-suffix map, US state map, US ZIP, a bounded country
+lookup, US unit designators. i18n addresses remain Wave C (deferred).
+
+## Two shape-buckets, two parity mechanisms (both have precedent)
+
+### Bucket 1 — scalar `string→string` → the existing string corpus
+`address_standardize`, `address_expand`, `state_abbreviate`, `state_expand`,
+`zip_normalize`, `country_standardize`, `unit_normalize` all reduce to a scalar
+`(&str)->Option<String>`. They fit `tests/parity/identifiers_corpus.jsonl` exactly,
+like every prior scalar family. No corpus-shape change needed.
+
+- **`address_standardize`/`address_expand`:** currently `mode="expr"` — a chain of
+  case-insensitive **word-boundary** regex replaces, one per (full,abbr) pair. Keep
+  `mode="expr"` and the public `func(column)->Expr` signature by dispatching through
+  `pl.col(column).map_batches(...)` when native (the trick strip_titles/currency_strip
+  used). **Hand-roll the word-boundary replace in Rust — NO regex dep** (JS/Python/Rust
+  regex `\b` + replace-all semantics differ → parity hazard; email.rs set the no-regex
+  precedent). `\b{word}\b` = the match must be bounded by non-word chars (`[A-Za-z0-9_]`)
+  on both sides; case-insensitive compare; preserve the surrounding text. The `_STREET_ABBREV`
+  map (15 entries) is in-crate data replicated to TS. **Order matters** (dict iteration
+  order = insertion order in py3.7+; replicate that ordering in the Rust Vec and the TS
+  array). Note `"Way"→"Way"` is an identity entry — preserve it (harmless, keeps parity).
+- **`state_abbreviate`:** 3-way fallback — (1) 2-char input that upper-cases to a valid
+  abbreviation → uppercase; (2) full name (case-insensitive) → the `_STATES_LOWER` lookup;
+  (3) neither → **original column value unchanged** (NOT the stripped value — the Polars
+  `.otherwise(pl.col(column))` returns the raw input). Kernel must replicate that: strip
+  for the tests, but the fallback returns the ORIGINAL. 51 states incl DC.
+- **`state_expand`:** strip → upper → `_STATES_REVERSE` lookup, default = **original
+  column value** (again the raw, un-stripped input on no-match).
+- **`zip_normalize`** (**auto_apply=True** — user-visible): strip → take first `-`-split
+  segment → if all-digits (`^\d+$`) zero-pad to width 5 (`zfill(5)`), else return the
+  base segment unchanged. Note zfill only left-pads; a >5-digit all-digit base is returned
+  as-is. Empty base → zfill→"00000"? Check: `"".zfill(5)=="00000"` but base after strip of
+  empty is "" and `"^\d+$"` does NOT match empty → returns "" unchanged. Pin this in corpus.
+- **`country_standardize`:** the `_COUNTRIES` map (~60 entries) → in-crate data replicated
+  to TS. Key = `val.strip().lower()`, fallback = original value. (Same shape as
+  nickname_standardize from names.)
+- **`unit_normalize`:** strip → apply 3 anchored prefix substitutions in order:
+  `^(?:Apt|Apartment)\.?\s+`→`"Unit "`, `^(?:Ste|Suite)\.?\s+`→`"Ste "`, `^#\s*`→`"Unit "`,
+  case-insensitive. Anchored at start only (`^`), applied sequentially to the result.
+  Hand-roll (no regex): match a known prefix token (case-insensitive) optionally followed
+  by `.`, then `\s+` (or for `#`, `\s*`), replace with the target. Sequential application
+  matters — pin a corpus row where two could chain.
+
+### Bucket 2 — multi-output / dataframe → dedicated pinned-vector parity
+`split_address` (1 col → 4 cols: street/city/state/zip) does NOT fit a string→scalar
+corpus. Follow the **split_name precedent** (`test_name_kernels.py`): extend it (or add
+`test_address_kernels.py`) with pinned input→output vectors on BOTH the native path and
+the pure-Python fallback, plus a TS unit test. The kernel is the per-row scalar:
+- `split_address(&str) -> (Option, Option, Option, Option)` — hand-rolled parse of
+  `"street, city, state zip"`: the Python regex is
+  `^(.+?),\s*(.+?),\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)$` (non-greedy first two captures,
+  2-letter state, 5-or-9 ZIP). On match → (street, city, state, zip). On no-match →
+  **(whole_input, None, None, None)** (street = the raw value, others null). None → all None.
+  Hand-roll: the non-greedy `.+?,` means split on the FIRST comma for street, the SECOND
+  for city; then the remainder must be `<2 alpha> <5 or 5-4 digits>`. Implement as: find
+  first comma → street; find next comma → city; trim remainder; the tail must match
+  `[A-Za-z]{2}\s+\d{5}(-\d{4})?` anchored+full → state+zip; any structural miss → no-match
+  fallback. Pin +4 ZIP, no-match, null, and extra-comma cases.
+
+## New plumbing (the genuinely new part): 1→4 array marshaling
+names-remainder added `map_str_to_str_pair` (1→2) and `zip_str_to_str` (2→1).
+`split_address` needs **1→4**: add `map_str_to_str_quad(arr) -> (arr, arr, arr, arr)`
+to `native-flow/src/util.rs`, and `split_address_arrow(arr) -> (arr, arr, arr, arr)`.
+- `_native.py`: `split_address_native()` returns `Callable[[Series], tuple[Series×4]]`;
+  the dataframe-mode `split_address` builds street/city/state/zip from the quad.
+- wasm: `split_address(&str) -> Vec<Option<String>>` (4-element `[street,city,state,zip]`);
+  TS unpacks. Keep it a 4-element array (simplest marshaling, mirrors split_name's 2-elem).
+
+## Cross-surface fan-out (established migration recipe)
+For each kernel: **goldenflow-core** (pure Rust + `#[cfg(test)]` tests) → **native-flow**
+`*_arrow` shim → **`_native.py`** `*_native()` runner → **Python transform** imports the
+runner + keeps a byte-matched `_*_py` reference → **goldenflow-wasm** export → **TS**
+pure-fallback + wasm dispatch → **`_native_loader`** `_COMPONENT_SYMBOLS["address"]`
+(floor symbol `address_standardize_arrow`) → **corpus/parity**.
+
+New crate module: `goldenflow-core/src/address.rs` (+ `pub mod address;` in lib.rs) and
+`native-flow/src/address.rs` (+ registration in native-flow lib.rs). New TS
+`src/core/transforms/address.ts`. wasm exports appended to goldenflow-wasm lib.rs.
+
+## Tasks (each TDD, two-stage reviewed, sequential — shared lib.rs/loader/corpus)
+1. **goldenflow-core `address.rs`** (pyo3-free, LOCALLY TESTABLE via `cargo test`): 8
+   kernels — the 7 scalar + `split_address` tuple — one-for-one ports of `address.py`,
+   in-crate `_STREET_ABBREV`/`_STATES`/`_COUNTRIES` data, hand-rolled word-boundary +
+   anchored-prefix + split parsing (NO regex dep). Unit tests covering the pinned vectors
+   + fallback (no-match returns original) + Unicode/edge cases. Load-bearing novel piece.
+2. **native-flow shim** `address.rs`: `*_arrow` pyfunctions incl. `map_str_to_str_quad` +
+   `split_address_arrow` (4-tuple). Register in native-flow lib.rs.
+3. **`_native.py` runners** + Python transforms migrated native-first with byte-matched
+   `_*_py` references; `_native_loader` `address` component (floor `address_standardize_arrow`).
+   `mode="expr"` transforms keep the `func(column)->Expr` API via `map_batches`.
+4. **goldenflow-wasm** exports + TS `address.ts` + backend/loader wiring + pure-TS ports
+   (in-crate maps replicated to TS char-for-char).
+5. **Corpus + parity**: scalar rows appended to `identifiers_corpus.jsonl` (regen via
+   `scripts/gen_identifiers_corpus.py`, sync-check to TS copy); `test_address_kernels.py`
+   (or extend test_name_kernels) + TS unit test for `split_address`.
+6. **Versions + docs**: goldenflow 1.10.0 / npm 0.10.0 / native 0.8.0; CHANGELOG;
+   `goldenflow/CLAUDE.md` address-family note (count stays 92; migration).
+
+## Landmines
+- **zip_normalize is `auto_apply=True`** — a zero-config regression is user-visible. Kernel
+  MUST reproduce the strip→first-segment→conditional-zfill byte-for-byte. Pin the "already
+  5", "+4 stripped", ">5 all-digit returned as-is", "non-numeric passthrough", empty cases.
+- **state_abbreviate / state_expand fallback returns the ORIGINAL (un-stripped) value** on
+  no-match, not the stripped one. Easy to get wrong — pin a `"  xx  "`-style no-match row.
+- **Word-boundary hand-roll** (address_standardize/expand): `\b` semantics — a match inside
+  a longer word must NOT replace (`"Streets"` must not become `"Sts"`). Test that. Case-
+  insensitive match but the REPLACEMENT is the canonical-cased abbr. Dict ordering preserved.
+- **No regex dep** — hand-roll word-boundary, anchored-prefix, and the split parse. JS/Py/Rust
+  regex engines differ on `\b`/greedy/`replace_all`; hand-rolling is the parity guarantee.
+- **P-series overlap:** #1423 (P-series SQL de-bridge) adds `goldenflow-core::text` kernels;
+  does NOT touch `address`, so no collision — but expect the lib.rs module-list conflict on
+  rebase; keep both modules.
+- **CI-only TS gate** (box OOMs): statically verify `corpus == PURE_TS_FN == wasm map` keys
+  BEFORE push (the D-sweep numeric bug was invisible locally).
+
+## Base / merge
+Stacked on `feat/goldenflow-wave-d-names` (#1431). After #1431 squash-merges,
+`git rebase --onto origin/main <names-tip> feat/goldenflow-wave-d-address`, then open the
+PR + arm auto-merge (squash).

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.10.0 (2026-07-04)
+
+Wave D (address-simple): the eight US-address transforms are now backed by owned Rust kernels in `goldenflow-core` (native + WASM/TS + pure-Python fallback), Rust is the reference implementation. This wave migrated existing transforms to the owned-kernel pattern; it did not add new transforms (count unchanged).
+
+- Migrated: `address_standardize`, `address_expand`, `state_abbreviate`, `state_expand`, `zip_normalize`, `country_standardize`, `unit_normalize` (scalar), and `split_address` (multi-output: one column in, `street`/`city`/`state`/`zip` out — four Arrow arrays natively, a 1->4 marshaling shape). The scalar seven fit the string->scalar parity corpus; `split_address` is covered by a pinned-vector test.
+- **Behavior change (reference-mode, resolved in Rust's favor):** the street-suffix, unit-prefix, and `split_address` parsing are now hand-rolled with ASCII word-boundary semantics (no regex engine) for byte-identical output across Rust/Python/JS. `address_standardize`/`address_expand`/`state_abbreviate`/`state_expand`/`zip_normalize` moved from vectorized Polars expressions to native-first dispatch (the pure-Python fallback runs per-row when the native wheel is absent). Outputs are unchanged for well-formed US-address inputs.
+
 ## 1.9.0 (2026-07-04)
 
 Wave D (names-remainder): the eight remaining `name` transforms are now backed by owned Rust kernels in `goldenflow-core` (native + WASM/TS + pure-Python fallback), Rust is the reference implementation. This wave migrated existing transforms to the owned-kernel pattern; it did not add new transforms (count unchanged).

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -267,6 +267,26 @@ package. Loader discover order in `goldenflow/core/_native_loader.py`:
   scalar transforms live in the shared corpus; the 3 multi-output ones (they
   don't fit a string->scalar row) get pinned-vector `tests/transforms/
   test_name_kernels.py` (native + fallback), the numeric-array-op precedent.
+- **Address-simple family migrated to owned kernels (Wave D address) -- a
+  1->4 marshaling SHAPE.** The 8 US-address transforms now dispatch
+  native-first through goldenflow-core (`address_standardize`/`address_expand`/
+  `state_abbreviate`/`state_expand`/`zip_normalize`/`country_standardize`/
+  `unit_normalize` scalar; `split_address` multi-OUTPUT 1->4), all wired via
+  the single `"address"` `_native_loader` component (floor symbol
+  `address_standardize_arrow`). `zip_normalize` stays `auto_apply=True`; the
+  rest `auto_apply=False`. **New arrow marshaling** in `native-flow/src/util.rs`:
+  `map_str_to_str_quad` (1 array -> `street`+`city`+`state`+`zip`, where the
+  last three may be null on a present row); the wasm `split_address` returns a
+  4-element `[street,city,state,zip]` JS array (nullable city/state/zip). The
+  five `mode="expr"` transforms (standardize/expand/state_*/zip) keep their
+  `func(column)->Expr` signature via `map_batches` (numeric/names precedent).
+  **NO regex dep:** the word-boundary street-suffix replace, the anchored
+  unit-prefix subs, and the `split_address` grammar (non-greedy + backtracking
+  city group) are hand-rolled with ASCII word-char semantics in Rust AND the
+  Python/TS fallbacks -- JS/Py/Rust regex `\b`/greedy/`replace_all` differ, so
+  hand-rolling is the parity guarantee (email.rs precedent). US-scoped; i18n
+  addresses stay Wave C (deferred). The 7 scalar transforms live in the shared
+  corpus; `split_address` gets pinned-vector `test_address_kernels.py`.
 - **Byte-parity harness (cross-surface oracle = goldenflow-core).**
   `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` (mirrored
   byte-identical into `packages/typescript/goldenflow/tests/parity/`) is the

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.9.0"
+__version__ = "1.10.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -116,6 +116,11 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # split_name_reverse (pair) + merge_name (two-input) -- floor symbol only
     # (strip_titles_arrow), locale-free.
     "names_ext": ("strip_titles_arrow",),
+    # address: the US-address family -- address_standardize/address_expand/
+    # state_abbreviate/state_expand/zip_normalize/country_standardize/
+    # unit_normalize (scalar) + split_address (1->4 quad) -- floor symbol only
+    # (address_standardize_arrow), US-scoped/locale-free.
+    "address": ("address_standardize_arrow",),
 }
 
 # Components whose only native path is intentionally non-authoritative (the

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -475,6 +475,89 @@ def merge_name_native() -> Callable[[pl.Series, pl.Series], pl.Series] | None:
     return run
 
 
+def _address_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for a scalar address kernel function ``attr``
+    (address_standardize/address_expand/state_abbreviate/state_expand/
+    zip_normalize/country_standardize/unit_normalize) if native ``address`` is
+    enabled and importable; else ``None``. Single string array in, one out.
+    The in-crate street/state/country tables are locale-free (US-scoped)."""
+    if not native_enabled("address"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def address_standardize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _address_kernel_runner("address_standardize_arrow")
+
+
+def address_expand_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _address_kernel_runner("address_expand_arrow")
+
+
+def state_abbreviate_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _address_kernel_runner("state_abbreviate_arrow")
+
+
+def state_expand_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _address_kernel_runner("state_expand_arrow")
+
+
+def zip_normalize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _address_kernel_runner("zip_normalize_arrow")
+
+
+def country_standardize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _address_kernel_runner("country_standardize_arrow")
+
+
+def unit_normalize_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _address_kernel_runner("unit_normalize_arrow")
+
+
+def split_address_native() -> (
+    Callable[[pl.Series], tuple[pl.Series, pl.Series, pl.Series, pl.Series]] | None
+):
+    """Build a runner for the multi-output split_address kernel: one string
+    array in, a QUAD of arrays (street, city, state, zip) out. ``None`` when
+    native ``address`` is off or unbuilt."""
+    if not native_enabled("address"):
+        return None
+    nm = native_module()
+    attr = "split_address_arrow"
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(
+        s: pl.Series,
+    ) -> tuple[pl.Series, pl.Series, pl.Series, pl.Series]:
+        street_arr, city_arr, state_arr, zip_arr = func(_as_str_series(s).to_arrow())
+        return (
+            pl.from_arrow(street_arr),
+            pl.from_arrow(city_arr),
+            pl.from_arrow(state_arr),
+            pl.from_arrow(zip_arr),
+        )
+
+    return run
+
+
 def _email_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
     """Build a whole-series runner for email kernel function ``attr`` if
     native ``email`` is enabled and the dependencies are importable; else

--- a/packages/python/goldenflow/goldenflow/transforms/address.py
+++ b/packages/python/goldenflow/goldenflow/transforms/address.py
@@ -1,18 +1,31 @@
 from __future__ import annotations
 
-import re
-
 import polars as pl
 
 from goldenflow.transforms import register_transform
+from goldenflow.transforms._native import (
+    address_expand_native,
+    address_standardize_native,
+    country_standardize_native,
+    split_address_native,
+    state_abbreviate_native,
+    state_expand_native,
+    unit_normalize_native,
+    zip_normalize_native,
+)
 
+# In-crate data mirror: these tables are replicated char-for-char in
+# goldenflow-core/src/address.rs and the TS port. They are the shared DATA the
+# owned kernels look up; the pure-Python fallbacks below reproduce the Rust
+# kernels byte-for-byte (kernel = spec under reference-mode), asserted over
+# tests/parity/identifiers_corpus.jsonl (scalar transforms) and
+# tests/transforms/test_address_kernels.py (split_address).
 _STREET_ABBREV = {
     "Street": "St", "Avenue": "Ave", "Boulevard": "Blvd", "Drive": "Dr",
     "Lane": "Ln", "Road": "Rd", "Court": "Ct", "Place": "Pl",
     "Circle": "Cir", "Trail": "Trl", "Way": "Way", "Parkway": "Pkwy",
     "Highway": "Hwy", "Terrace": "Ter", "Square": "Sq",
 }
-_STREET_EXPAND = {v: k for k, v in _STREET_ABBREV.items()}
 
 _STATES = {
     "Alabama": "AL", "Alaska": "AK", "Arizona": "AZ", "Arkansas": "AR",
@@ -31,143 +44,6 @@ _STATES = {
 }
 _STATES_REVERSE = {v: k for k, v in _STATES.items()}
 _STATES_LOWER = {k.lower(): v for k, v in _STATES.items()}
-
-
-@register_transform(
-    name="address_standardize", input_types=["address"], auto_apply=False, priority=50, mode="expr"
-)
-def address_standardize(column: str) -> pl.Expr:
-    """Replace full street suffixes (Street, Avenue...) with abbreviations.
-
-    Native Polars: chain of case-insensitive word-boundary regex replaces.
-    One `str.replace_all` per (full, abbr) pair. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    expr = pl.col(column)
-    for full, abbr in _STREET_ABBREV.items():
-        expr = expr.str.replace_all(rf"(?i)\b{full}\b", abbr)
-    return expr
-
-
-@register_transform(
-    name="address_expand", input_types=["address"], auto_apply=False, priority=50, mode="expr"
-)
-def address_expand(column: str) -> pl.Expr:
-    """Replace street abbreviations (St, Ave...) with full forms.
-
-    Native Polars: chain of case-insensitive word-boundary regex replaces.
-    Spec docs/superpowers/specs/2026-05-15-map-elements-attack-design.md
-    Tier 1.
-    """
-    expr = pl.col(column)
-    for abbr, full in _STREET_EXPAND.items():
-        expr = expr.str.replace_all(rf"(?i)\b{abbr}\b", full)
-    return expr
-
-
-@register_transform(
-    name="state_abbreviate", input_types=["state", "string"], auto_apply=False, priority=50, mode="expr"
-)
-def state_abbreviate(column: str) -> pl.Expr:
-    """Normalize state name to 2-letter abbreviation.
-
-    Three-way fallback:
-      1. 2-letter input that's a valid abbreviation -> uppercase it.
-      2. Full name (case-insensitive) -> look up in _STATES_LOWER.
-      3. Neither matched -> return original column value unchanged.
-
-    Native Polars: `replace_strict` with `default=...` provides the
-    not-matched fallback; combined with `when/then` to handle the
-    2-letter-already-valid case. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    cleaned = pl.col(column).str.strip_chars()
-    upper = cleaned.str.to_uppercase()
-    is_valid_2letter = (cleaned.str.len_chars() == 2) & upper.is_in(
-        list(_STATES_REVERSE.keys())
-    )
-    # Lower-cased lookup; default to a sentinel that means "not in dict".
-    matched_full = cleaned.str.to_lowercase().replace_strict(
-        _STATES_LOWER, default=None, return_dtype=pl.Utf8,
-    )
-    return (
-        pl.when(is_valid_2letter).then(upper)
-        .when(matched_full.is_not_null()).then(matched_full)
-        .otherwise(pl.col(column))
-    )
-
-
-@register_transform(
-    name="state_expand", input_types=["state", "string"], auto_apply=False, priority=50, mode="expr"
-)
-def state_expand(column: str) -> pl.Expr:
-    """Expand 2-letter state abbreviation to full name.
-
-    Native Polars: `replace_strict` with the dict, default=original value
-    for unmatched inputs. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    return (
-        pl.col(column)
-        .str.strip_chars()
-        .str.to_uppercase()
-        .replace_strict(
-            _STATES_REVERSE, default=pl.col(column), return_dtype=pl.Utf8,
-        )
-    )
-
-
-@register_transform(
-    name="zip_normalize", input_types=["zip"], auto_apply=True, priority=55, mode="expr"
-)
-def zip_normalize(column: str) -> pl.Expr:
-    """Normalize US ZIP to 5-digit form. Strip +4, zero-pad if all-digits,
-    preserve invalid inputs unchanged.
-
-    Native Polars: strip + take first segment before '-' + check all-digits
-    via regex contains, then conditionally zfill. Spec Tier 2 (auto_apply=True
-    transform; was firing per-row Python on every dedupe iteration).
-    """
-    base = pl.col(column).str.strip_chars().str.split("-").list.first()
-    return (
-        pl.when(base.str.contains(r"^\d+$"))
-        .then(base.str.zfill(5))
-        .otherwise(base)
-    )
-
-
-@register_transform(
-    name="split_address", input_types=["address"], auto_apply=False, priority=45, mode="dataframe"
-)
-def split_address(df: pl.DataFrame, column: str) -> pl.DataFrame:
-    """Parse 'street, city, state zip' into separate columns."""
-    streets, cities, states, zips = [], [], [], []
-    pattern = re.compile(r"^(.+?),\s*(.+?),\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)$")
-    for val in df[column].to_list():
-        if val is None:
-            streets.append(None)
-            cities.append(None)
-            states.append(None)
-            zips.append(None)
-            continue
-        m = pattern.match(val.strip())
-        if m:
-            streets.append(m.group(1))
-            cities.append(m.group(2))
-            states.append(m.group(3))
-            zips.append(m.group(4))
-        else:
-            streets.append(val)
-            cities.append(None)
-            states.append(None)
-            zips.append(None)
-    return df.with_columns(
-        pl.Series("street", streets),
-        pl.Series("city", cities),
-        pl.Series("state", states),
-        pl.Series("zip", zips),
-    )
-
 
 _COUNTRIES: dict[str, str] = {
     "united states": "US", "united states of america": "US", "usa": "US", "us": "US",
@@ -204,6 +80,218 @@ _COUNTRIES: dict[str, str] = {
 }
 
 
+# --- shared low-level helpers (mirror goldenflow-core/src/address.rs) ---------
+
+
+def _ascii_lower(c: str) -> str:
+    """ASCII-only lowercase (Rust ``eq_ignore_ascii_case`` semantics): fold
+    ``A-Z`` only, leave everything else (incl. non-ASCII) untouched."""
+    return chr(ord(c) + 32) if "A" <= c <= "Z" else c
+
+
+def _is_word_char(c: str) -> bool:
+    r"""``\w`` = ASCII ``[A-Za-z0-9_]`` (matches the Rust kernel, NOT Python's
+    Unicode-aware ``\w``)."""
+    return ("a" <= c <= "z") or ("A" <= c <= "Z") or ("0" <= c <= "9") or c == "_"
+
+
+def _is_ascii_alpha(c: str) -> bool:
+    return ("a" <= c <= "z") or ("A" <= c <= "Z")
+
+
+def _is_ascii_digit(c: str) -> bool:
+    return "0" <= c <= "9"
+
+
+def _replace_word_bounded(s: str, needle: str, rep: str) -> str:
+    """Case-insensitive, word-boundary-delimited replace-all -- byte-identical to
+    ``address.rs::replace_word_bounded``. ``needle`` is a non-empty ASCII word."""
+    nlen = len(needle)
+    hlen = len(s)
+    out: list[str] = []
+    i = 0
+    while i < hlen:
+        replaced = False
+        if i + nlen <= hlen and all(
+            _ascii_lower(s[i + k]) == _ascii_lower(needle[k]) for k in range(nlen)
+        ):
+            left_ok = i == 0 or not _is_word_char(s[i - 1])
+            right_idx = i + nlen
+            right_ok = right_idx >= hlen or not _is_word_char(s[right_idx])
+            if left_ok and right_ok:
+                out.append(rep)
+                i += nlen
+                replaced = True
+        if not replaced:
+            out.append(s[i])
+            i += 1
+    return "".join(out)
+
+
+# --- address_standardize / address_expand ------------------------------------
+
+
+def _address_standardize_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    out = val
+    for full, abbr in _STREET_ABBREV.items():
+        out = _replace_word_bounded(out, full, abbr)
+    return out
+
+
+def _address_standardize_series(series: pl.Series) -> pl.Series:
+    native = address_standardize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_address_standardize_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="address_standardize", input_types=["address"], auto_apply=False, priority=50, mode="expr"
+)
+def address_standardize(column: str) -> pl.Expr:
+    """Replace full street suffixes (Street, Avenue...) with abbreviations.
+
+    Native-first (goldenflow-core's ``address::address_standardize`` kernel),
+    dispatched via ``map_batches`` so the transform keeps its ``expr``-mode
+    signature; the pure-Python fallback is the byte-exact reference.
+    """
+    return pl.col(column).map_batches(_address_standardize_series, return_dtype=pl.Utf8)
+
+
+def _address_expand_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    out = val
+    for full, abbr in _STREET_ABBREV.items():
+        out = _replace_word_bounded(out, abbr, full)
+    return out
+
+
+def _address_expand_series(series: pl.Series) -> pl.Series:
+    native = address_expand_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_address_expand_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="address_expand", input_types=["address"], auto_apply=False, priority=50, mode="expr"
+)
+def address_expand(column: str) -> pl.Expr:
+    """Replace street abbreviations (St, Ave...) with full forms.
+
+    Native-first (goldenflow-core's ``address::address_expand`` kernel); the
+    pure-Python fallback is the byte-exact reference.
+    """
+    return pl.col(column).map_batches(_address_expand_series, return_dtype=pl.Utf8)
+
+
+# --- state_abbreviate / state_expand -----------------------------------------
+
+
+def _state_abbreviate_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    cleaned = val.strip()
+    upper = cleaned.upper()
+    if len(cleaned) == 2 and upper in _STATES_REVERSE:
+        return upper
+    abbr = _STATES_LOWER.get(cleaned.lower())
+    if abbr is not None:
+        return abbr
+    return val
+
+
+def _state_abbreviate_series(series: pl.Series) -> pl.Series:
+    native = state_abbreviate_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_state_abbreviate_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="state_abbreviate", input_types=["state", "string"], auto_apply=False, priority=50,
+    mode="expr",
+)
+def state_abbreviate(column: str) -> pl.Expr:
+    """Normalize state name to a 2-letter abbreviation (unmatched -> original).
+
+    Native-first (goldenflow-core's ``address::state_abbreviate`` kernel); the
+    pure-Python fallback is the byte-exact reference.
+    """
+    return pl.col(column).map_batches(_state_abbreviate_series, return_dtype=pl.Utf8)
+
+
+def _state_expand_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    full = _STATES_REVERSE.get(val.strip().upper())
+    return full if full is not None else val
+
+
+def _state_expand_series(series: pl.Series) -> pl.Series:
+    native = state_expand_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_state_expand_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="state_expand", input_types=["state", "string"], auto_apply=False, priority=50,
+    mode="expr",
+)
+def state_expand(column: str) -> pl.Expr:
+    """Expand a 2-letter state abbreviation to its full name (unmatched -> original).
+
+    Native-first (goldenflow-core's ``address::state_expand`` kernel); the
+    pure-Python fallback is the byte-exact reference.
+    """
+    return pl.col(column).map_batches(_state_expand_series, return_dtype=pl.Utf8)
+
+
+# --- zip_normalize -----------------------------------------------------------
+
+
+def _zip_normalize_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    base = val.strip().split("-", 1)[0]
+    if base and all(_is_ascii_digit(c) for c in base):
+        return base.zfill(5)
+    return base
+
+
+def _zip_normalize_series(series: pl.Series) -> pl.Series:
+    native = zip_normalize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_zip_normalize_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="zip_normalize", input_types=["zip"], auto_apply=True, priority=55, mode="expr"
+)
+def zip_normalize(column: str) -> pl.Expr:
+    """Normalize a US ZIP to 5-digit form (strip +4, zero-pad all-digit, preserve
+    invalid inputs).
+
+    Native-first (goldenflow-core's ``address::zip_normalize`` kernel); the
+    pure-Python fallback is the byte-exact reference.
+    """
+    return pl.col(column).map_batches(_zip_normalize_series, return_dtype=pl.Utf8)
+
+
+# --- country_standardize -----------------------------------------------------
+
+
+def _country_standardize_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return _COUNTRIES.get(val.strip().lower(), val)
+
+
 @register_transform(
     name="country_standardize",
     input_types=["country", "string"],
@@ -212,22 +300,52 @@ _COUNTRIES: dict[str, str] = {
     mode="series",
 )
 def country_standardize(series: pl.Series) -> pl.Series:
-    """Normalize country names to ISO 3166-1 alpha-2 codes."""
+    """Normalize country names to ISO 3166-1 alpha-2 codes.
 
-    def _std(val: str | None) -> str | None:
-        if val is None:
-            return None
-        lookup = val.strip().lower()
-        return _COUNTRIES.get(lookup, val)
+    Native-first (goldenflow-core's ``address::country_standardize`` kernel,
+    whose lookup table is an in-crate copy of ``_COUNTRIES``); the pure-Python
+    fallback is the byte-exact reference.
+    """
+    native = country_standardize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_country_standardize_py, return_dtype=pl.Utf8)
 
-    return series.map_elements(_std, return_dtype=pl.Utf8)
+
+# --- unit_normalize ----------------------------------------------------------
 
 
-_UNIT_PATTERNS = [
-    (re.compile(r"^(?:Apt|Apartment)\.?\s+", re.IGNORECASE), "Unit "),
-    (re.compile(r"^(?:Ste|Suite)\.?\s+", re.IGNORECASE), "Ste "),
-    (re.compile(r"^#\s*", re.IGNORECASE), "Unit "),
-]
+def _ci_startswith(s: str, prefix: str) -> bool:
+    if len(s) < len(prefix):
+        return False
+    return all(_ascii_lower(s[i]) == _ascii_lower(prefix[i]) for i in range(len(prefix)))
+
+
+def _sub_leading_token(s: str, tokens: tuple[str, ...], rep: str) -> str:
+    for tok in tokens:
+        if _ci_startswith(s, tok):
+            rest = s[len(tok):]
+            after_dot = rest[1:] if rest.startswith(".") else rest
+            after_ws = after_dot.lstrip()
+            if len(after_ws) < len(after_dot):
+                return rep + after_ws
+    return s
+
+
+def _sub_leading_hash(s: str) -> str:
+    if s.startswith("#"):
+        return "Unit " + s[1:].lstrip()
+    return s
+
+
+def _unit_normalize_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    result = val.strip()
+    result = _sub_leading_token(result, ("Apt", "Apartment"), "Unit ")
+    result = _sub_leading_token(result, ("Ste", "Suite"), "Ste ")
+    result = _sub_leading_hash(result)
+    return result
 
 
 @register_transform(
@@ -238,14 +356,111 @@ _UNIT_PATTERNS = [
     mode="series",
 )
 def unit_normalize(series: pl.Series) -> pl.Series:
-    """Normalize unit/apartment/suite designations."""
+    """Normalize unit/apartment/suite designations.
 
-    def _norm(val: str | None) -> str | None:
-        if val is None:
-            return None
-        result = val.strip()
-        for pattern, replacement in _UNIT_PATTERNS:
-            result = pattern.sub(replacement, result)
-        return result
+    Native-first (goldenflow-core's ``address::unit_normalize`` kernel); the
+    pure-Python fallback is the byte-exact reference.
+    """
+    native = unit_normalize_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_unit_normalize_py, return_dtype=pl.Utf8)
 
-    return series.map_elements(_norm, return_dtype=pl.Utf8)
+
+# --- split_address (multi-output dataframe) ----------------------------------
+
+
+def _is_zip(s: str) -> bool:
+    if len(s) == 5:
+        return all(_is_ascii_digit(c) for c in s)
+    if len(s) == 10:
+        return (
+            all(_is_ascii_digit(c) for c in s[:5])
+            and s[5] == "-"
+            and all(_is_ascii_digit(c) for c in s[6:10])
+        )
+    return False
+
+
+def _parse_state_zip_tail(rem: str) -> tuple[str, str] | None:
+    after_ws = rem.lstrip()
+    if len(after_ws) < 2 or not (_is_ascii_alpha(after_ws[0]) and _is_ascii_alpha(after_ws[1])):
+        return None
+    state = after_ws[:2]
+    rest = after_ws[2:]
+    zipc = rest.lstrip()
+    if len(zipc) == len(rest):
+        return None  # no whitespace between state and ZIP -> `\s+` failed
+    if _is_zip(zipc):
+        return state, zipc
+    return None
+
+
+def _try_parse_address(t: str) -> tuple[str, str, str, str] | None:
+    c1 = t.find(",")
+    if c1 == -1:
+        return None
+    group1 = t[:c1]
+    if group1 == "":
+        return None
+    after1_ws = t[c1 + 1:].lstrip()
+    search = 0
+    while True:
+        c2 = after1_ws.find(",", search)
+        if c2 == -1:
+            break
+        group2 = after1_ws[:c2]
+        if group2 != "":
+            tail = _parse_state_zip_tail(after1_ws[c2 + 1:])
+            if tail is not None:
+                state, zipc = tail
+                return group1, group2, state, zipc
+        search = c2 + 1
+    return None
+
+
+def _split_address_py(
+    val: str | None,
+) -> tuple[str | None, str | None, str | None, str | None]:
+    if val is None:
+        return None, None, None, None
+    parsed = _try_parse_address(val.strip())
+    if parsed is not None:
+        return parsed
+    return val, None, None, None  # street = ORIGINAL (unstripped), rest None
+
+
+@register_transform(
+    name="split_address", input_types=["address"], auto_apply=False, priority=45, mode="dataframe"
+)
+def split_address(df: pl.DataFrame, column: str) -> pl.DataFrame:
+    """Parse 'street, city, state zip' into separate columns.
+
+    Native-first (goldenflow-core's ``address::split_address`` kernel, returning
+    four Arrow arrays); the pure-Python fallback is the byte-exact reference.
+    """
+    native = split_address_native()
+    if native is not None:
+        street, city, state, zip_col = native(df[column])
+        return df.with_columns(
+            street.rename("street"),
+            city.rename("city"),
+            state.rename("state"),
+            zip_col.rename("zip"),
+        )
+    streets: list[str | None] = []
+    cities: list[str | None] = []
+    states: list[str | None] = []
+    zips: list[str | None] = []
+    for val in df[column].to_list():
+        s, c, st, z = _split_address_py(val)
+        streets.append(s)
+        cities.append(c)
+        states.append(st)
+        zips.append(z)
+    return df.with_columns(
+        pl.Series("street", streets),
+        pl.Series("city", cities),
+        pl.Series("state", states),
+        pl.Series("zip", zips),
+    )

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.9.0"
+version = "1.10.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -72,6 +72,15 @@ from goldenflow.transforms.numeric import (  # noqa: E402
     _scientific_to_decimal_py,
     _to_integer_py,
 )
+from goldenflow.transforms.address import (  # noqa: E402
+    _address_expand_py,
+    _address_standardize_py,
+    _country_standardize_py,
+    _state_abbreviate_py,
+    _state_expand_py,
+    _unit_normalize_py,
+    _zip_normalize_py,
+)
 from goldenflow.transforms.url import (  # noqa: E402
     _url_extract_domain_py,
     _url_normalize_py,
@@ -394,6 +403,74 @@ _CASES: list[tuple[str, str | None]] = [
     ("url_extract_domain", ""),  # empty -> None
     ("url_extract_domain", "   "),  # whitespace-only -> None
     ("url_extract_domain", None),  # null
+    # --- address_standardize (full street suffix -> abbreviation) ---
+    ("address_standardize", "123 Main Street"),  # Street -> St
+    ("address_standardize", "1 Park Avenue"),  # Avenue -> Ave
+    ("address_standardize", "5 Sunset Boulevard"),  # Boulevard -> Blvd
+    ("address_standardize", "10 elm STREET"),  # case-insensitive, canonical repl
+    ("address_standardize", "Streetsboro Road"),  # word-boundary: Streets NOT abbrev'd
+    ("address_standardize", "42 Nowhere"),  # no suffix -> unchanged
+    ("address_standardize", ""),  # empty
+    ("address_standardize", None),  # null
+    # --- address_expand (abbreviation -> full street suffix) ---
+    ("address_expand", "123 Main St"),  # St -> Street
+    ("address_expand", "1 Park Ave"),  # Ave -> Avenue
+    ("address_expand", "1 Park Ste"),  # St inside Ste is not a word-bound match
+    ("address_expand", "5 sunset blvd"),  # case-insensitive
+    ("address_expand", ""),  # empty
+    ("address_expand", None),  # null
+    # --- state_abbreviate (full name / valid abbr / else original) ---
+    ("state_abbreviate", "California"),  # full -> CA
+    ("state_abbreviate", "new york"),  # case-insensitive full -> NY
+    ("state_abbreviate", "North Carolina"),  # multi-word full -> NC
+    ("state_abbreviate", "ca"),  # valid 2-letter -> uppercased
+    ("state_abbreviate", "Ny"),  # valid 2-letter mixed -> NY
+    ("state_abbreviate", "DC"),  # DC is included
+    ("state_abbreviate", "  Freedonia  "),  # unmatched -> ORIGINAL (unstripped)
+    ("state_abbreviate", "XZ"),  # 2-char non-abbr -> original
+    ("state_abbreviate", ""),  # empty -> original ("")
+    ("state_abbreviate", None),  # null
+    # --- state_expand (abbr -> full name / else original) ---
+    ("state_expand", "CA"),  # -> California
+    ("state_expand", "ny"),  # case-insensitive -> New York
+    ("state_expand", "  il  "),  # stripped lookup -> Illinois
+    ("state_expand", "DC"),  # -> District Of Columbia
+    ("state_expand", "  ZZ  "),  # unmatched -> ORIGINAL (unstripped)
+    ("state_expand", ""),  # empty -> original ("")
+    ("state_expand", None),  # null
+    # --- zip_normalize (auto_apply=True; strip +4, zero-pad, preserve invalid) ---
+    ("zip_normalize", "12345"),  # already 5
+    ("zip_normalize", "12345-6789"),  # strip +4
+    ("zip_normalize", "  90210  "),  # trimmed
+    ("zip_normalize", "210"),  # zero-pad short all-digit
+    ("zip_normalize", "123456"),  # >5 all-digit -> as-is
+    ("zip_normalize", "SW1A"),  # non-numeric passthrough
+    ("zip_normalize", "SW1A-1AA"),  # base segment before '-'
+    ("zip_normalize", ""),  # empty -> unchanged
+    ("zip_normalize", None),  # null
+    # --- country_standardize (name/alias -> ISO alpha-2; else original) ---
+    ("country_standardize", "United States"),  # -> US
+    ("country_standardize", "usa"),  # alias -> US
+    ("country_standardize", "  England  "),  # trimmed alias -> GB
+    ("country_standardize", "Deutschland"),  # -> DE
+    ("country_standardize", "CA"),  # 2-letter alias -> CA
+    ("country_standardize", "  Atlantis  "),  # unknown -> ORIGINAL (unstripped)
+    ("country_standardize", ""),  # empty -> original ("")
+    ("country_standardize", None),  # null
+    # --- unit_normalize (anchored prefix subs, in order) ---
+    ("unit_normalize", "Apt 4"),  # Apt -> Unit
+    ("unit_normalize", "Apt. 4"),  # optional dot
+    ("unit_normalize", "Apartment 12B"),  # Apartment -> Unit
+    ("unit_normalize", "Suite 200"),  # Suite -> Ste
+    ("unit_normalize", "Ste. 200"),  # Ste + dot -> Ste
+    ("unit_normalize", "#5"),  # # -> Unit (no space)
+    ("unit_normalize", "# 5"),  # # + space -> Unit
+    ("unit_normalize", "APT 9"),  # case-insensitive
+    ("unit_normalize", "Apt.5"),  # no whitespace after -> no match
+    ("unit_normalize", "Aptos"),  # Apt prefix but no boundary -> unchanged
+    ("unit_normalize", "  Building C  "),  # no designator -> trimmed
+    ("unit_normalize", ""),  # empty
+    ("unit_normalize", None),  # null
     # --- currency_strip (string->float; VALUE parity, not repr) ---
     ("currency_strip", "$1,234.56"),  # strip $ and comma
     ("currency_strip", "-$42.00"),  # negative, dollar sign
@@ -514,6 +591,13 @@ _PY_FN = {
     "email_validate": _email_validate_py,
     "url_normalize": _url_normalize_py,
     "url_extract_domain": _url_extract_domain_py,
+    "address_standardize": _address_standardize_py,
+    "address_expand": _address_expand_py,
+    "state_abbreviate": _state_abbreviate_py,
+    "state_expand": _state_expand_py,
+    "zip_normalize": _zip_normalize_py,
+    "country_standardize": _country_standardize_py,
+    "unit_normalize": _unit_normalize_py,
     "currency_strip": _currency_strip_py,
     "percentage_normalize": _percentage_normalize_py,
     "to_integer": _to_integer_py,
@@ -553,6 +637,13 @@ _NATIVE_ARROW_FN = {
     "email_validate": "email_validate_arrow",
     "url_normalize": "url_normalize_arrow",
     "url_extract_domain": "url_extract_domain_arrow",
+    "address_standardize": "address_standardize_arrow",
+    "address_expand": "address_expand_arrow",
+    "state_abbreviate": "state_abbreviate_arrow",
+    "state_expand": "state_expand_arrow",
+    "zip_normalize": "zip_normalize_arrow",
+    "country_standardize": "country_standardize_arrow",
+    "unit_normalize": "unit_normalize_arrow",
     "currency_strip": "currency_strip_arrow",
     "percentage_normalize": "percentage_normalize_arrow",
     "to_integer": "to_integer_arrow",

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -28,6 +28,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from goldenflow.core._native_loader import native_available, native_module  # noqa: E402
+from goldenflow.transforms.address import (  # noqa: E402
+    _address_expand_py,
+    _address_standardize_py,
+    _country_standardize_py,
+    _state_abbreviate_py,
+    _state_expand_py,
+    _unit_normalize_py,
+    _zip_normalize_py,
+)
 from goldenflow.transforms.categorical import (  # noqa: E402
     _boolean_normalize_py,
     _category_normalize_key_py,
@@ -71,15 +80,6 @@ from goldenflow.transforms.numeric import (  # noqa: E402
     _percentage_normalize_py,
     _scientific_to_decimal_py,
     _to_integer_py,
-)
-from goldenflow.transforms.address import (  # noqa: E402
-    _address_expand_py,
-    _address_standardize_py,
-    _country_standardize_py,
-    _state_abbreviate_py,
-    _state_expand_py,
-    _unit_normalize_py,
-    _zip_normalize_py,
 )
 from goldenflow.transforms.url import (  # noqa: E402
     _url_extract_domain_py,

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -263,6 +263,67 @@
 {"transform": "url_extract_domain", "input": "", "expected": null}
 {"transform": "url_extract_domain", "input": "   ", "expected": null}
 {"transform": "url_extract_domain", "input": null, "expected": null}
+{"transform": "address_standardize", "input": "123 Main Street", "expected": "123 Main St"}
+{"transform": "address_standardize", "input": "1 Park Avenue", "expected": "1 Park Ave"}
+{"transform": "address_standardize", "input": "5 Sunset Boulevard", "expected": "5 Sunset Blvd"}
+{"transform": "address_standardize", "input": "10 elm STREET", "expected": "10 elm St"}
+{"transform": "address_standardize", "input": "Streetsboro Road", "expected": "Streetsboro Rd"}
+{"transform": "address_standardize", "input": "42 Nowhere", "expected": "42 Nowhere"}
+{"transform": "address_standardize", "input": "", "expected": ""}
+{"transform": "address_standardize", "input": null, "expected": null}
+{"transform": "address_expand", "input": "123 Main St", "expected": "123 Main Street"}
+{"transform": "address_expand", "input": "1 Park Ave", "expected": "1 Park Avenue"}
+{"transform": "address_expand", "input": "1 Park Ste", "expected": "1 Park Ste"}
+{"transform": "address_expand", "input": "5 sunset blvd", "expected": "5 sunset Boulevard"}
+{"transform": "address_expand", "input": "", "expected": ""}
+{"transform": "address_expand", "input": null, "expected": null}
+{"transform": "state_abbreviate", "input": "California", "expected": "CA"}
+{"transform": "state_abbreviate", "input": "new york", "expected": "NY"}
+{"transform": "state_abbreviate", "input": "North Carolina", "expected": "NC"}
+{"transform": "state_abbreviate", "input": "ca", "expected": "CA"}
+{"transform": "state_abbreviate", "input": "Ny", "expected": "NY"}
+{"transform": "state_abbreviate", "input": "DC", "expected": "DC"}
+{"transform": "state_abbreviate", "input": "  Freedonia  ", "expected": "  Freedonia  "}
+{"transform": "state_abbreviate", "input": "XZ", "expected": "XZ"}
+{"transform": "state_abbreviate", "input": "", "expected": ""}
+{"transform": "state_abbreviate", "input": null, "expected": null}
+{"transform": "state_expand", "input": "CA", "expected": "California"}
+{"transform": "state_expand", "input": "ny", "expected": "New York"}
+{"transform": "state_expand", "input": "  il  ", "expected": "Illinois"}
+{"transform": "state_expand", "input": "DC", "expected": "District Of Columbia"}
+{"transform": "state_expand", "input": "  ZZ  ", "expected": "  ZZ  "}
+{"transform": "state_expand", "input": "", "expected": ""}
+{"transform": "state_expand", "input": null, "expected": null}
+{"transform": "zip_normalize", "input": "12345", "expected": "12345"}
+{"transform": "zip_normalize", "input": "12345-6789", "expected": "12345"}
+{"transform": "zip_normalize", "input": "  90210  ", "expected": "90210"}
+{"transform": "zip_normalize", "input": "210", "expected": "00210"}
+{"transform": "zip_normalize", "input": "123456", "expected": "123456"}
+{"transform": "zip_normalize", "input": "SW1A", "expected": "SW1A"}
+{"transform": "zip_normalize", "input": "SW1A-1AA", "expected": "SW1A"}
+{"transform": "zip_normalize", "input": "", "expected": ""}
+{"transform": "zip_normalize", "input": null, "expected": null}
+{"transform": "country_standardize", "input": "United States", "expected": "US"}
+{"transform": "country_standardize", "input": "usa", "expected": "US"}
+{"transform": "country_standardize", "input": "  England  ", "expected": "GB"}
+{"transform": "country_standardize", "input": "Deutschland", "expected": "DE"}
+{"transform": "country_standardize", "input": "CA", "expected": "CA"}
+{"transform": "country_standardize", "input": "  Atlantis  ", "expected": "  Atlantis  "}
+{"transform": "country_standardize", "input": "", "expected": ""}
+{"transform": "country_standardize", "input": null, "expected": null}
+{"transform": "unit_normalize", "input": "Apt 4", "expected": "Unit 4"}
+{"transform": "unit_normalize", "input": "Apt. 4", "expected": "Unit 4"}
+{"transform": "unit_normalize", "input": "Apartment 12B", "expected": "Unit 12B"}
+{"transform": "unit_normalize", "input": "Suite 200", "expected": "Ste 200"}
+{"transform": "unit_normalize", "input": "Ste. 200", "expected": "Ste 200"}
+{"transform": "unit_normalize", "input": "#5", "expected": "Unit 5"}
+{"transform": "unit_normalize", "input": "# 5", "expected": "Unit 5"}
+{"transform": "unit_normalize", "input": "APT 9", "expected": "Unit 9"}
+{"transform": "unit_normalize", "input": "Apt.5", "expected": "Apt.5"}
+{"transform": "unit_normalize", "input": "Aptos", "expected": "Aptos"}
+{"transform": "unit_normalize", "input": "  Building C  ", "expected": "Building C"}
+{"transform": "unit_normalize", "input": "", "expected": ""}
+{"transform": "unit_normalize", "input": null, "expected": null}
 {"transform": "currency_strip", "input": "$1,234.56", "expected": 1234.56}
 {"transform": "currency_strip", "input": "-$42.00", "expected": -42.0}
 {"transform": "currency_strip", "input": "USD 100", "expected": 100.0}

--- a/packages/python/goldenflow/tests/transforms/test_address_kernels.py
+++ b/packages/python/goldenflow/tests/transforms/test_address_kernels.py
@@ -1,0 +1,72 @@
+"""Direct pinned-vector parity for the multi-output ``split_address`` kernel
+(Wave D address-simple): 1 column -> street/city/state/zip.
+
+``split_address`` is ``mode="dataframe"`` (one input column -> four output
+columns), so it doesn't fit the shared string->scalar corpus in
+``test_identifiers_parity.py`` (which feeds every row through a length-1 Arrow
+*string* array and compares a scalar). Instead this file asserts both the
+pure-Python fallback (``GOLDENFLOW_NATIVE=0``) and the native path (when
+built/importable) against the goldenflow-core Rust kernel's values -- the same
+pinned-vector pattern as ``test_name_kernels.py`` / ``test_numeric_kernels.py``.
+
+The 7 scalar address transforms (address_standardize/address_expand/
+state_abbreviate/state_expand/zip_normalize/country_standardize/unit_normalize)
+DO fit the shared corpus and are covered in ``test_identifiers_parity.py``.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenflow.core._native_loader import native_available, native_module
+from goldenflow.transforms.address import split_address
+
+# (input column, expected street, city, state, zip)
+_SPLIT_ADDRESS = (
+    [
+        "123 Main St, Springfield, IL 62704",  # basic match
+        "1 Park Ave, New York, NY 10001-2345",  # +4 ZIP
+        "  9 Elm Rd, Denver, CO 80014  ",  # trimmed before parse
+        "123 Main St, Apt 4, Springfield, IL 62704",  # city backtracks past a comma
+        "  just a street  ",  # no match -> street = ORIGINAL (unstripped)
+        "123 Main St, Springfield, ILL 62704",  # 3-letter state -> no match
+        None,  # null -> all null
+    ],
+    [
+        "123 Main St",
+        "1 Park Ave",
+        "9 Elm Rd",
+        "123 Main St",
+        "  just a street  ",
+        "123 Main St, Springfield, ILL 62704",
+        None,
+    ],
+    ["Springfield", "New York", "Denver", "Apt 4, Springfield", None, None, None],
+    ["IL", "NY", "CO", "IL", None, None, None],
+    ["62704", "10001-2345", "80014", "62704", None, None, None],
+)
+
+
+def _check_split_address() -> None:
+    inp, exp_street, exp_city, exp_state, exp_zip = _SPLIT_ADDRESS
+    out = split_address(pl.DataFrame({"addr": inp}), "addr")
+    assert out["street"].to_list() == exp_street
+    assert out["city"].to_list() == exp_city
+    assert out["state"].to_list() == exp_state
+    assert out["zip"].to_list() == exp_zip
+
+
+def test_fallback_matches_expected(monkeypatch):
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
+    _check_split_address()
+
+
+def test_native_matches_expected(monkeypatch):
+    if not native_available():
+        import pytest
+
+        pytest.skip("goldenflow-native not built/importable")
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
+    if not hasattr(native_module(), "split_address_arrow"):
+        import pytest
+
+        pytest.skip("installed goldenflow-native predates the address kernels")
+    _check_split_address()

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -13,6 +13,25 @@ from pathlib import Path
 import polars as pl
 import pytest
 from goldenflow.core._native_loader import native_available
+from goldenflow.transforms.address import (
+    _address_expand_series as address_expand,
+)
+from goldenflow.transforms.address import (
+    _address_standardize_series as address_standardize,
+)
+from goldenflow.transforms.address import (
+    _state_abbreviate_series as state_abbreviate,
+)
+from goldenflow.transforms.address import (
+    _state_expand_series as state_expand,
+)
+from goldenflow.transforms.address import (
+    _zip_normalize_series as zip_normalize,
+)
+from goldenflow.transforms.address import (
+    country_standardize,
+    unit_normalize,
+)
 from goldenflow.transforms.categorical import (
     _category_normalize_key_series,
     boolean_normalize,
@@ -131,6 +150,13 @@ _TRANSFORMS = {
     "email_validate": email_validate,
     "url_normalize": url_normalize,
     "url_extract_domain": url_extract_domain,
+    "address_standardize": address_standardize,
+    "address_expand": address_expand,
+    "state_abbreviate": state_abbreviate,
+    "state_expand": state_expand,
+    "zip_normalize": zip_normalize,
+    "country_standardize": country_standardize,
+    "unit_normalize": unit_normalize,
     "currency_strip": currency_strip,
     "percentage_normalize": percentage_normalize,
     "to_integer": to_integer,
@@ -179,6 +205,15 @@ _NATIVE_FLOOR_SYMBOL = {
     # symbol url_normalize_arrow), region-free/locale-free.
     "url_normalize": "url_normalize_arrow",
     "url_extract_domain": "url_normalize_arrow",
+    # address: all 7 scalar transforms wired via the single "address" component
+    # (floor symbol address_standardize_arrow), US-scoped/locale-free.
+    "address_standardize": "address_standardize_arrow",
+    "address_expand": "address_standardize_arrow",
+    "state_abbreviate": "address_standardize_arrow",
+    "state_expand": "address_standardize_arrow",
+    "zip_normalize": "address_standardize_arrow",
+    "country_standardize": "address_standardize_arrow",
+    "unit_normalize": "address_standardize_arrow",
     # numeric: all 5 string-parser transforms are wired via the single
     # "numeric" component (floor symbol currency_strip_arrow), region-free/
     # locale-free.

--- a/packages/rust/extensions/goldenflow-core/src/address.rs
+++ b/packages/rust/extensions/goldenflow-core/src/address.rs
@@ -1,0 +1,593 @@
+//! Owned US-address kernels (pyo3-free). These are the reference
+//! implementations; the Python (`goldenflow/transforms/address.py`) and TS
+//! (`transforms/address.ts`) fallbacks must reproduce their bytes exactly
+//! (byte-parity harness). Ported one-for-one from the existing pure-Polars /
+//! per-row-Python transforms (kernel = spec under reference-mode).
+//!
+//! Deliberately NO regex dependency: the `\b`-word-boundary replaces, the
+//! anchored unit-prefix substitutions, and the `split_address` grammar are all
+//! hand-rolled so the byte output is identical across Rust/Python/JS (whose
+//! regex engines differ on `\b`, greedy/non-greedy, and `replace_all`
+//! semantics -- the same reason `email.rs` hand-rolls its validator). The
+//! street/state/country tables are in-crate DATA replicated char-for-char to
+//! the other surfaces.
+
+/// `\w` in the Python regexes = `[A-Za-z0-9_]` (ASCII).
+fn is_word_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+// ---------------------------------------------------------------------------
+// Street-suffix standardize / expand
+// ---------------------------------------------------------------------------
+
+/// Full street suffix -> abbreviation, in the Python `_STREET_ABBREV` insertion
+/// order (replicated exactly -- the replaces are applied sequentially, so order
+/// is observable). `"Way" -> "Way"` is an intentional identity entry.
+const STREET_ABBREV: [(&str, &str); 15] = [
+    ("Street", "St"),
+    ("Avenue", "Ave"),
+    ("Boulevard", "Blvd"),
+    ("Drive", "Dr"),
+    ("Lane", "Ln"),
+    ("Road", "Rd"),
+    ("Court", "Ct"),
+    ("Place", "Pl"),
+    ("Circle", "Cir"),
+    ("Trail", "Trl"),
+    ("Way", "Way"),
+    ("Parkway", "Pkwy"),
+    ("Highway", "Hwy"),
+    ("Terrace", "Ter"),
+    ("Square", "Sq"),
+];
+
+/// Replace every word-boundary-delimited, case-insensitive occurrence of
+/// `needle` in `s` with `rep`. Mirrors polars `str.replace_all(r"(?i)\b{needle}\b",
+/// rep)`: a match must be bounded by a non-word char (or string edge) on both
+/// sides, so `"Streets"` is NOT matched by `"Street"`. Single left-to-right,
+/// non-overlapping pass; the replacement text is not re-scanned within this call
+/// (matching `replace_all`). `needle` is a non-empty ASCII word.
+fn replace_word_bounded(s: &str, needle: &str, rep: &str) -> String {
+    let hay: Vec<char> = s.chars().collect();
+    let ndl: Vec<char> = needle.chars().collect();
+    let nlen = ndl.len();
+    let hlen = hay.len();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < hlen {
+        let mut replaced = false;
+        if i + nlen <= hlen {
+            let matches = (0..nlen).all(|k| hay[i + k].eq_ignore_ascii_case(&ndl[k]));
+            if matches {
+                let left_ok = i == 0 || !is_word_char(hay[i - 1]);
+                let right_idx = i + nlen;
+                let right_ok = right_idx >= hlen || !is_word_char(hay[right_idx]);
+                if left_ok && right_ok {
+                    out.push_str(rep);
+                    i += nlen;
+                    replaced = true;
+                }
+            }
+        }
+        if !replaced {
+            out.push(hay[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Replace full street suffixes with abbreviations (Street->St, ...).
+/// Byte-identical to `address.py::address_standardize`.
+pub fn address_standardize(s: &str) -> String {
+    let mut out = s.to_string();
+    for (full, abbr) in STREET_ABBREV {
+        out = replace_word_bounded(&out, full, abbr);
+    }
+    out
+}
+
+/// Replace street abbreviations with full forms (St->Street, ...). Iterates the
+/// REVERSED `_STREET_ABBREV` in the same insertion order (Python
+/// `{v: k for k, v in _STREET_ABBREV.items()}`). Byte-identical to
+/// `address.py::address_expand`.
+pub fn address_expand(s: &str) -> String {
+    let mut out = s.to_string();
+    for (full, abbr) in STREET_ABBREV {
+        // reverse direction: abbr -> full, preserving the original insertion order.
+        out = replace_word_bounded(&out, abbr, full);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// US states
+// ---------------------------------------------------------------------------
+
+/// `(full name, 2-letter abbreviation)` in the Python `_STATES` insertion order.
+const STATES: [(&str, &str); 51] = [
+    ("Alabama", "AL"),
+    ("Alaska", "AK"),
+    ("Arizona", "AZ"),
+    ("Arkansas", "AR"),
+    ("California", "CA"),
+    ("Colorado", "CO"),
+    ("Connecticut", "CT"),
+    ("Delaware", "DE"),
+    ("Florida", "FL"),
+    ("Georgia", "GA"),
+    ("Hawaii", "HI"),
+    ("Idaho", "ID"),
+    ("Illinois", "IL"),
+    ("Indiana", "IN"),
+    ("Iowa", "IA"),
+    ("Kansas", "KS"),
+    ("Kentucky", "KY"),
+    ("Louisiana", "LA"),
+    ("Maine", "ME"),
+    ("Maryland", "MD"),
+    ("Massachusetts", "MA"),
+    ("Michigan", "MI"),
+    ("Minnesota", "MN"),
+    ("Mississippi", "MS"),
+    ("Missouri", "MO"),
+    ("Montana", "MT"),
+    ("Nebraska", "NE"),
+    ("Nevada", "NV"),
+    ("New Hampshire", "NH"),
+    ("New Jersey", "NJ"),
+    ("New Mexico", "NM"),
+    ("New York", "NY"),
+    ("North Carolina", "NC"),
+    ("North Dakota", "ND"),
+    ("Ohio", "OH"),
+    ("Oklahoma", "OK"),
+    ("Oregon", "OR"),
+    ("Pennsylvania", "PA"),
+    ("Rhode Island", "RI"),
+    ("South Carolina", "SC"),
+    ("South Dakota", "SD"),
+    ("Tennessee", "TN"),
+    ("Texas", "TX"),
+    ("Utah", "UT"),
+    ("Vermont", "VT"),
+    ("Virginia", "VA"),
+    ("Washington", "WA"),
+    ("West Virginia", "WV"),
+    ("Wisconsin", "WI"),
+    ("Wyoming", "WY"),
+    ("District Of Columbia", "DC"),
+];
+
+/// True if `up` (already uppercased) is one of the 51 valid state abbreviations.
+fn is_valid_abbr(up: &str) -> bool {
+    STATES.iter().any(|&(_, abbr)| abbr == up)
+}
+
+/// `_STATES_LOWER` lookup: full-name (lowercased) -> abbreviation.
+fn state_from_full_lower(key: &str) -> Option<&'static str> {
+    STATES
+        .iter()
+        .find(|&&(full, _)| full.eq_ignore_ascii_case(key))
+        .map(|&(_, abbr)| abbr)
+}
+
+/// `_STATES_REVERSE` lookup: abbreviation -> full name.
+fn state_from_abbr(up: &str) -> Option<&'static str> {
+    STATES
+        .iter()
+        .find(|&&(_, abbr)| abbr == up)
+        .map(|&(full, _)| full)
+}
+
+/// Normalize a state to its 2-letter abbreviation. Three-way fallback,
+/// byte-identical to `address.py::state_abbreviate`:
+///   1. a 2-char input whose uppercase is a valid abbreviation -> that uppercase,
+///   2. a full name (case-insensitive) -> its abbreviation,
+///   3. neither -> the ORIGINAL (unstripped) input value, unchanged.
+pub fn state_abbreviate(s: &str) -> String {
+    let cleaned = s.trim();
+    let upper = cleaned.to_uppercase();
+    if cleaned.chars().count() == 2 && is_valid_abbr(&upper) {
+        return upper;
+    }
+    if let Some(abbr) = state_from_full_lower(&cleaned.to_lowercase()) {
+        return abbr.to_string();
+    }
+    s.to_string()
+}
+
+/// Expand a 2-letter state abbreviation to its full name; unmatched inputs
+/// return the ORIGINAL (unstripped) value. Byte-identical to
+/// `address.py::state_expand`.
+pub fn state_expand(s: &str) -> String {
+    let key = s.trim().to_uppercase();
+    match state_from_abbr(&key) {
+        Some(full) => full.to_string(),
+        None => s.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ZIP
+// ---------------------------------------------------------------------------
+
+/// Left-pad `s` with `'0'` to width `width` (like `str.zfill` on an all-digit
+/// string -- no sign handling needed since the caller guarantees digits only).
+fn zfill(s: &str, width: usize) -> String {
+    let len = s.chars().count();
+    if len >= width {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(width);
+    for _ in 0..(width - len) {
+        out.push('0');
+    }
+    out.push_str(s);
+    out
+}
+
+/// Normalize a US ZIP to 5-digit form: strip, take the segment before the first
+/// `-`, and if it is all digits zero-pad to width 5; otherwise return that
+/// segment unchanged. Byte-identical to `address.py::zip_normalize`. (An empty
+/// base fails the all-digit `^\d+$` test -- the `+` requires >=1 digit -- and
+/// passes through unchanged.)
+pub fn zip_normalize(s: &str) -> String {
+    let stripped = s.trim();
+    let base = stripped.split('-').next().unwrap_or("");
+    if !base.is_empty() && base.chars().all(|c| c.is_ascii_digit()) {
+        zfill(base, 5)
+    } else {
+        base.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Country
+// ---------------------------------------------------------------------------
+
+/// `_COUNTRIES` lookup: name/alias (trimmed-lowercased) -> ISO 3166-1 alpha-2.
+fn country_lookup(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "united states" | "united states of america" | "usa" | "us" | "u.s.a." | "u.s."
+        | "america" => "US",
+        "united kingdom" | "uk" | "great britain" | "england" | "scotland" | "wales"
+        | "northern ireland" => "GB",
+        "canada" | "ca" => "CA",
+        "australia" | "au" => "AU",
+        "germany" | "deutschland" | "de" => "DE",
+        "france" | "fr" => "FR",
+        "italy" | "italia" | "it" => "IT",
+        "spain" | "espana" | "es" => "ES",
+        "mexico" | "mx" => "MX",
+        "brazil" | "brasil" | "br" => "BR",
+        "japan" | "jp" => "JP",
+        "china" | "cn" => "CN",
+        "india" | "in" => "IN",
+        "south korea" | "korea" | "kr" => "KR",
+        "netherlands" | "holland" | "nl" => "NL",
+        "sweden" | "se" => "SE",
+        "norway" | "no" => "NO",
+        "denmark" | "dk" => "DK",
+        "switzerland" | "ch" => "CH",
+        "ireland" | "ie" => "IE",
+        "new zealand" | "nz" => "NZ",
+        "singapore" | "sg" => "SG",
+        "portugal" | "pt" => "PT",
+        "argentina" | "ar" => "AR",
+        "colombia" | "co" => "CO",
+        "philippines" | "ph" => "PH",
+        "poland" | "pl" => "PL",
+        "belgium" | "be" => "BE",
+        "austria" | "at" => "AT",
+        _ => return None,
+    })
+}
+
+/// Normalize a country name to its ISO 3166-1 alpha-2 code; unknown values pass
+/// through UNCHANGED (the original, not the trimmed lookup key). Byte-identical
+/// to `address.py::country_standardize` (`_COUNTRIES.get(val.strip().lower(), val)`).
+pub fn country_standardize(s: &str) -> String {
+    match country_lookup(&s.trim().to_lowercase()) {
+        Some(code) => code.to_string(),
+        None => s.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit / apartment
+// ---------------------------------------------------------------------------
+
+/// Apply a leading `^(?:<tok>)\.?\s+` substitution (case-insensitive): if `s`
+/// starts with one of `tokens` optionally followed by `.` then one-or-more
+/// whitespace, replace that whole prefix with `rep`; else return `s`. `tokens`
+/// are tried in order (mirrors the regex alternation).
+fn sub_leading_token(s: &str, tokens: &[&str], rep: &str) -> String {
+    let lower = s.to_ascii_lowercase(); // ASCII-only fold preserves byte offsets
+    for tok in tokens {
+        let tl = tok.to_ascii_lowercase();
+        if lower.starts_with(&tl) {
+            let rest = &s[tok.len()..];
+            let after_dot = rest.strip_prefix('.').unwrap_or(rest);
+            let after_ws = after_dot.trim_start();
+            if after_ws.len() < after_dot.len() {
+                // at least one whitespace consumed -> the `\s+` matched.
+                return format!("{rep}{after_ws}");
+            }
+        }
+    }
+    s.to_string()
+}
+
+/// Apply the leading `^#\s*` -> `"Unit "` substitution (`\s*` = zero-or-more).
+fn sub_leading_hash(s: &str) -> String {
+    match s.strip_prefix('#') {
+        Some(rest) => format!("Unit {}", rest.trim_start()),
+        None => s.to_string(),
+    }
+}
+
+/// Normalize unit / apartment / suite designations. Strips, then applies the
+/// three anchored prefix substitutions IN ORDER (Apt/Apartment -> "Unit ",
+/// Ste/Suite -> "Ste ", # -> "Unit "). Byte-identical to
+/// `address.py::unit_normalize`.
+pub fn unit_normalize(s: &str) -> String {
+    let mut result = s.trim().to_string();
+    result = sub_leading_token(&result, &["Apt", "Apartment"], "Unit ");
+    result = sub_leading_token(&result, &["Ste", "Suite"], "Ste ");
+    result = sub_leading_hash(&result);
+    result
+}
+
+// ---------------------------------------------------------------------------
+// split_address
+// ---------------------------------------------------------------------------
+
+/// Match a `^\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)$` tail: after optional
+/// leading whitespace, exactly 2 ASCII letters (the state), one-or-more
+/// whitespace, then a 5- or 5+4-digit ZIP consuming the rest. Returns
+/// `(state, zip)` or `None`.
+fn parse_state_zip_tail(rem: &str) -> Option<(String, String)> {
+    let after_ws: Vec<char> = rem.trim_start().chars().collect();
+    if after_ws.len() < 2 || !(after_ws[0].is_ascii_alphabetic() && after_ws[1].is_ascii_alphabetic())
+    {
+        return None;
+    }
+    let state: String = after_ws[0..2].iter().collect();
+    let rest: String = after_ws[2..].iter().collect();
+    let zip = rest.trim_start();
+    if zip.len() == rest.len() {
+        return None; // no whitespace between state and ZIP -> `\s+` failed
+    }
+    if is_zip(zip) {
+        Some((state, zip.to_string()))
+    } else {
+        None
+    }
+}
+
+/// Full-match `^\d{5}(-\d{4})?$`.
+fn is_zip(s: &str) -> bool {
+    let c: Vec<char> = s.chars().collect();
+    match c.len() {
+        5 => c.iter().all(|ch| ch.is_ascii_digit()),
+        10 => {
+            c[0..5].iter().all(|ch| ch.is_ascii_digit())
+                && c[5] == '-'
+                && c[6..10].iter().all(|ch| ch.is_ascii_digit())
+        }
+        _ => false,
+    }
+}
+
+/// Parse a stripped `"street, city, ST zip"` string. `street` = up to the first
+/// comma; `city` = the shortest run up to a later comma whose remainder is a
+/// valid `\s*ST\s+zip$` tail (non-greedy + backtracking, mirroring the Python
+/// regex). Returns `(street, city, state, zip)` or `None`.
+fn try_parse_address(t: &str) -> Option<(String, String, String, String)> {
+    let c1 = t.find(',')?;
+    let group1 = &t[..c1];
+    if group1.is_empty() {
+        return None; // `(.+?)` requires >=1 char before the first comma
+    }
+    let after1_ws = t[c1 + 1..].trim_start(); // `\s*` before the city group
+    let mut search = 0;
+    while let Some(rel) = after1_ws[search..].find(',') {
+        let c2 = search + rel;
+        let group2 = &after1_ws[..c2];
+        if !group2.is_empty() {
+            if let Some((state, zip)) = parse_state_zip_tail(&after1_ws[c2 + 1..]) {
+                return Some((
+                    group1.to_string(),
+                    group2.to_string(),
+                    state,
+                    zip,
+                ));
+            }
+        }
+        search = c2 + 1;
+    }
+    None
+}
+
+/// Parse `"street, city, state zip"` into its four parts. On a match, all four
+/// are `Some`. On no match, `street` is the ORIGINAL (unstripped) input and the
+/// other three are `None`. Byte-identical to `address.py::split_address` (the
+/// `None`-input row -> all-`None` is handled by the marshaling layer, not here).
+pub fn split_address(s: &str) -> (String, Option<String>, Option<String>, Option<String>) {
+    match try_parse_address(s.trim()) {
+        Some((street, city, state, zip)) => (street, Some(city), Some(state), Some(zip)),
+        None => (s.to_string(), None, None, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn address_standardize_cases() {
+        assert_eq!(address_standardize("123 Main Street"), "123 Main St");
+        assert_eq!(address_standardize("1 Park Avenue"), "1 Park Ave");
+        assert_eq!(address_standardize("5 Sunset Boulevard"), "5 Sunset Blvd");
+        // case-insensitive match, canonical-cased replacement
+        assert_eq!(address_standardize("10 elm STREET"), "10 elm St");
+        // word-boundary: "Streets" must NOT be abbreviated
+        assert_eq!(address_standardize("Streetsboro Road"), "Streetsboro Rd");
+        // no suffix -> unchanged
+        assert_eq!(address_standardize("42 Nowhere"), "42 Nowhere");
+    }
+
+    #[test]
+    fn address_expand_cases() {
+        assert_eq!(address_expand("123 Main St"), "123 Main Street");
+        assert_eq!(address_expand("1 Park Ave"), "1 Park Avenue");
+        // "St" inside "Ste" is not a word-boundary match
+        assert_eq!(address_expand("1 Park Ste"), "1 Park Ste");
+        // case-insensitive
+        assert_eq!(address_expand("5 sunset blvd"), "5 sunset Boulevard");
+    }
+
+    #[test]
+    fn state_abbreviate_cases() {
+        assert_eq!(state_abbreviate("California"), "CA");
+        assert_eq!(state_abbreviate("new york"), "NY");
+        assert_eq!(state_abbreviate("North Carolina"), "NC");
+        // already a valid 2-letter -> uppercased
+        assert_eq!(state_abbreviate("ca"), "CA");
+        assert_eq!(state_abbreviate("Ny"), "NY");
+        assert_eq!(state_abbreviate("DC"), "DC");
+        // unmatched -> ORIGINAL (unstripped) value
+        assert_eq!(state_abbreviate("  Freedonia  "), "  Freedonia  ");
+        // a 2-char non-abbreviation is not valid -> falls through to original
+        assert_eq!(state_abbreviate("XZ"), "XZ");
+    }
+
+    #[test]
+    fn state_expand_cases() {
+        assert_eq!(state_expand("CA"), "California");
+        assert_eq!(state_expand("ny"), "New York");
+        assert_eq!(state_expand("  il  "), "Illinois");
+        assert_eq!(state_expand("DC"), "District Of Columbia");
+        // unmatched -> ORIGINAL (unstripped)
+        assert_eq!(state_expand("  ZZ  "), "  ZZ  ");
+    }
+
+    #[test]
+    fn zip_normalize_cases() {
+        assert_eq!(zip_normalize("12345"), "12345");
+        assert_eq!(zip_normalize("12345-6789"), "12345");
+        assert_eq!(zip_normalize("  90210  "), "90210");
+        // zero-pad short all-digit
+        assert_eq!(zip_normalize("210"), "00210");
+        // >5 all-digit returned as-is (zfill only left-pads)
+        assert_eq!(zip_normalize("123456"), "123456");
+        // non-numeric passthrough (the base segment before '-')
+        assert_eq!(zip_normalize("SW1A"), "SW1A");
+        assert_eq!(zip_normalize("SW1A-1AA"), "SW1A");
+        // empty -> unchanged
+        assert_eq!(zip_normalize(""), "");
+    }
+
+    #[test]
+    fn country_standardize_cases() {
+        assert_eq!(country_standardize("United States"), "US");
+        assert_eq!(country_standardize("usa"), "US");
+        assert_eq!(country_standardize("  England  "), "GB");
+        assert_eq!(country_standardize("Deutschland"), "DE");
+        assert_eq!(country_standardize("CA"), "CA");
+        // unknown -> original, unchanged (NOT the trimmed key)
+        assert_eq!(country_standardize("  Atlantis  "), "  Atlantis  ");
+    }
+
+    #[test]
+    fn unit_normalize_cases() {
+        assert_eq!(unit_normalize("Apt 4"), "Unit 4");
+        assert_eq!(unit_normalize("Apt. 4"), "Unit 4");
+        assert_eq!(unit_normalize("Apartment 12B"), "Unit 12B");
+        assert_eq!(unit_normalize("Suite 200"), "Ste 200");
+        assert_eq!(unit_normalize("Ste. 200"), "Ste 200");
+        assert_eq!(unit_normalize("#5"), "Unit 5");
+        assert_eq!(unit_normalize("# 5"), "Unit 5");
+        // case-insensitive
+        assert_eq!(unit_normalize("APT 9"), "Unit 9");
+        // no leading whitespace after the token -> no match (the `\s+`)
+        assert_eq!(unit_normalize("Apt.5"), "Apt.5");
+        // "Aptos" starts with "Apt" but no dot/ws boundary -> unchanged
+        assert_eq!(unit_normalize("Aptos"), "Aptos");
+        // no designator -> just trimmed
+        assert_eq!(unit_normalize("  Building C  "), "Building C");
+    }
+
+    #[test]
+    fn split_address_match() {
+        assert_eq!(
+            split_address("123 Main St, Springfield, IL 62704"),
+            (
+                "123 Main St".to_string(),
+                Some("Springfield".to_string()),
+                Some("IL".to_string()),
+                Some("62704".to_string()),
+            )
+        );
+        // +4 ZIP
+        assert_eq!(
+            split_address("1 Park Ave, New York, NY 10001-2345"),
+            (
+                "1 Park Ave".to_string(),
+                Some("New York".to_string()),
+                Some("NY".to_string()),
+                Some("10001-2345".to_string()),
+            )
+        );
+        // leading/trailing whitespace stripped before parsing
+        assert_eq!(
+            split_address("  9 Elm Rd, Denver, CO 80014  "),
+            (
+                "9 Elm Rd".to_string(),
+                Some("Denver".to_string()),
+                Some("CO".to_string()),
+                Some("80014".to_string()),
+            )
+        );
+    }
+
+    #[test]
+    fn split_address_multi_comma_backtracks() {
+        // city group backtracks past an interior comma to reach a valid tail
+        assert_eq!(
+            split_address("123 Main St, Apt 4, Springfield, IL 62704"),
+            (
+                "123 Main St".to_string(),
+                Some("Apt 4, Springfield".to_string()),
+                Some("IL".to_string()),
+                Some("62704".to_string()),
+            )
+        );
+    }
+
+    #[test]
+    fn split_address_no_match() {
+        // no match -> street = ORIGINAL (unstripped), rest None
+        assert_eq!(
+            split_address("  just a street  "),
+            ("  just a street  ".to_string(), None, None, None)
+        );
+        // one comma only (regex needs two) -> no match
+        assert_eq!(
+            split_address("123 Main St, IL 62704"),
+            ("123 Main St, IL 62704".to_string(), None, None, None)
+        );
+        // 3-letter "state" -> tail fails
+        assert_eq!(
+            split_address("123 Main St, Springfield, ILL 62704"),
+            (
+                "123 Main St, Springfield, ILL 62704".to_string(),
+                None,
+                None,
+                None
+            )
+        );
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/address.rs
+++ b/packages/rust/extensions/goldenflow-core/src/address.rs
@@ -250,7 +250,12 @@ pub fn zip_normalize(s: &str) -> String {
 /// `_COUNTRIES` lookup: name/alias (trimmed-lowercased) -> ISO 3166-1 alpha-2.
 fn country_lookup(key: &str) -> Option<&'static str> {
     Some(match key {
-        "united states" | "united states of america" | "usa" | "us" | "u.s.a." | "u.s."
+        "united states"
+        | "united states of america"
+        | "usa"
+        | "us"
+        | "u.s.a."
+        | "u.s."
         | "america" => "US",
         "united kingdom" | "uk" | "great britain" | "england" | "scotland" | "wales"
         | "northern ireland" => "GB",
@@ -350,7 +355,8 @@ pub fn unit_normalize(s: &str) -> String {
 /// `(state, zip)` or `None`.
 fn parse_state_zip_tail(rem: &str) -> Option<(String, String)> {
     let after_ws: Vec<char> = rem.trim_start().chars().collect();
-    if after_ws.len() < 2 || !(after_ws[0].is_ascii_alphabetic() && after_ws[1].is_ascii_alphabetic())
+    if after_ws.len() < 2
+        || !(after_ws[0].is_ascii_alphabetic() && after_ws[1].is_ascii_alphabetic())
     {
         return None;
     }
@@ -398,12 +404,7 @@ fn try_parse_address(t: &str) -> Option<(String, String, String, String)> {
         let group2 = &after1_ws[..c2];
         if !group2.is_empty() {
             if let Some((state, zip)) = parse_state_zip_tail(&after1_ws[c2 + 1..]) {
-                return Some((
-                    group1.to_string(),
-                    group2.to_string(),
-                    state,
-                    zip,
-                ));
+                return Some((group1.to_string(), group2.to_string(), state, zip));
             }
         }
         search = c2 + 1;

--- a/packages/rust/extensions/goldenflow-core/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! surface (`goldenflow-wasm`) are thin marshaling shims over these functions.
 //! The pure-Python / pure-TS transform paths are non-authoritative fallbacks
 //! that must reproduce these bytes (asserted by the byte-parity harness).
+pub mod address;
 pub mod categorical;
 pub mod email;
 pub mod identifiers;

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -12,6 +12,7 @@
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
+    use goldenflow_core::address;
     use goldenflow_core::categorical;
     use goldenflow_core::email;
     use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
@@ -163,6 +164,56 @@ mod wasm {
     #[wasm_bindgen]
     pub fn merge_name(first: Option<String>, last: Option<String>) -> Option<String> {
         names::merge_name(first.as_deref(), last.as_deref())
+    }
+
+    #[wasm_bindgen]
+    pub fn address_standardize(s: &str) -> String {
+        address::address_standardize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn address_expand(s: &str) -> String {
+        address::address_expand(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn state_abbreviate(s: &str) -> String {
+        address::state_abbreviate(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn state_expand(s: &str) -> String {
+        address::state_expand(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn zip_normalize(s: &str) -> String {
+        address::zip_normalize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn country_standardize(s: &str) -> String {
+        address::country_standardize(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn unit_normalize(s: &str) -> String {
+        address::unit_normalize(s)
+    }
+
+    /// `"street, city, ST zip"` -> a 4-element JS array `[street, city, state,
+    /// zip]`. `street` is always a string; `city`/`state`/`zip` are `null` on a
+    /// no-match row (only the street parsed).
+    #[wasm_bindgen]
+    pub fn split_address(s: &str) -> Vec<JsValue> {
+        let (street, city, state, zip) = address::split_address(s);
+        let opt = |v: Option<String>| v.map_or(JsValue::NULL, |x| JsValue::from_str(&x));
+        vec![
+            JsValue::from_str(&street),
+            opt(city),
+            opt(state),
+            opt(zip),
+        ]
     }
 
     #[wasm_bindgen]

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -208,12 +208,7 @@ mod wasm {
     pub fn split_address(s: &str) -> Vec<JsValue> {
         let (street, city, state, zip) = address::split_address(s);
         let opt = |v: Option<String>| v.map_or(JsValue::NULL, |x| JsValue::from_str(&x));
-        vec![
-            JsValue::from_str(&street),
-            opt(city),
-            opt(state),
-            opt(zip),
-        ]
+        vec![JsValue::from_str(&street), opt(city), opt(state), opt(zip)]
     }
 
     #[wasm_bindgen]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.7.0"
+version = "0.8.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.7.0"
+    __version__ = "0.8.0"

--- a/packages/rust/extensions/native-flow/src/address.rs
+++ b/packages/rust/extensions/native-flow/src/address.rs
@@ -1,0 +1,100 @@
+//! Arrow shims over goldenflow_core::address. Bytes in, kernel per element,
+//! bytes out; GIL released. All logic lives in the core.
+use crate::util::{map_str_to_str, map_str_to_str_quad};
+use arrow::array::ArrayData;
+use arrow::pyarrow::PyArrowType;
+use goldenflow_core::address;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn address_standardize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(address::address_standardize(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn address_expand_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(address::address_expand(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn state_abbreviate_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(address::state_abbreviate(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn state_expand_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(address::state_expand(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn zip_normalize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(address::zip_normalize(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn country_standardize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(address::country_standardize(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn unit_normalize_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(address::unit_normalize(s))
+    })?))
+}
+
+/// Parse `"street, city, state zip"` -> `(street, city, state, zip)` as four
+/// Arrow arrays. `street` is always present on a non-null row; `city`/`state`/
+/// `zip` are null on a no-match row (only the street parsed).
+#[pyfunction]
+#[allow(clippy::type_complexity)]
+pub fn split_address_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<(
+    PyArrowType<ArrayData>,
+    PyArrowType<ArrayData>,
+    PyArrowType<ArrayData>,
+    PyArrowType<ArrayData>,
+)> {
+    let (street, city, state, zip) = map_str_to_str_quad(py, array.0, address::split_address)?;
+    Ok((
+        PyArrowType(street),
+        PyArrowType(city),
+        PyArrowType(state),
+        PyArrowType(zip),
+    ))
+}

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -11,6 +11,7 @@
 
 use pyo3::prelude::*;
 
+mod address;
 mod categorical;
 mod email;
 mod identifiers;
@@ -55,6 +56,14 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(names::split_name_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(names::split_name_reverse_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(names::merge_name_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(address::address_standardize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(address::address_expand_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(address::state_abbreviate_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(address::state_expand_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(address::zip_normalize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(address::country_standardize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(address::unit_normalize_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(address::split_address_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(url::url_normalize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(url::url_extract_domain_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(numeric::currency_strip_arrow, m)?)?;

--- a/packages/rust/extensions/native-flow/src/util.rs
+++ b/packages/rust/extensions/native-flow/src/util.rs
@@ -78,6 +78,51 @@ where
     Ok((a.finish().into_data(), b.finish().into_data()))
 }
 
+/// Apply `f` over each non-null string element, producing a QUAD of outputs
+/// (e.g. `split_address` -> street + city + state + zip). A null input emits a
+/// null in ALL FOUR output arrays. On a present row `f` returns
+/// `(String, Option, Option, Option)`: the first output is always a value; the
+/// other three may each be null even on a present row (the split may match only
+/// the street) -- matching `address.py::split_address`.
+#[allow(clippy::type_complexity)]
+pub fn map_str_to_str_quad<F>(
+    py: Python,
+    data: ArrayData,
+    f: F,
+) -> PyResult<(ArrayData, ArrayData, ArrayData, ArrayData)>
+where
+    F: Fn(&str) -> (String, Option<String>, Option<String>, Option<String>) + Sync,
+{
+    let len = make_array(data.clone()).len();
+    let mut a = StringBuilder::with_capacity(len, len * 8);
+    let mut b = StringBuilder::with_capacity(len, len * 8);
+    let mut c = StringBuilder::with_capacity(len, len * 4);
+    let mut d = StringBuilder::with_capacity(len, len * 6);
+    py.detach(|| -> PyResult<()> {
+        for_each_str(&data, |_, v| match v {
+            Some(s) => {
+                let (w, x, y, z) = f(s);
+                a.append_value(w);
+                b.append_option(x);
+                c.append_option(y);
+                d.append_option(z);
+            }
+            None => {
+                a.append_null();
+                b.append_null();
+                c.append_null();
+                d.append_null();
+            }
+        })
+    })?;
+    Ok((
+        a.finish().into_data(),
+        b.finish().into_data(),
+        c.finish().into_data(),
+        d.finish().into_data(),
+    ))
+}
+
 /// Apply `f` over two string arrays element-wise, producing one output (e.g.
 /// `merge_name(first, last) -> full`). `f` sees each side's null-ness (it may
 /// combine one present + one null side), and returns `None` to emit a null.

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/core/transforms/address.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/address.ts
@@ -1,10 +1,29 @@
 /**
  * Address transforms — ported from goldenflow/transforms/address.py
  * Side-effect module: registers 8 address transforms on import.
+ *
+ * Owned-kernel family (Wave D address-simple): the 7 scalar transforms
+ * (address_standardize/address_expand/state_abbreviate/state_expand/
+ * zip_normalize/country_standardize/unit_normalize) and the multi-output
+ * split_address are byte-for-byte ports of the Python pure-TS reference
+ * (`_*_py` in `goldenflow/transforms/address.py`), which is itself proven
+ * byte-identical to the Rust `goldenflow-core::address` kernels. The 7 scalars
+ * are asserted over the shared oracle corpus
+ * (`tests/parity/identifiers_corpus.jsonl`); split_address (which doesn't fit
+ * a string->scalar row) is asserted with pinned vectors in
+ * `tests/unit/address-kernels.test.ts`. Each registered transform dispatches
+ * to the opt-in WASM backend (`FlowWasmBackend`) when `enableWasm()` has
+ * succeeded; otherwise it runs the pure-TS implementation below. Pure-TS is
+ * the default.
+ *
+ * The word-boundary / anchored-prefix / address-parse logic is hand-rolled
+ * with ASCII semantics (NOT JS regex `\b`/`\w`, which are Unicode-aware and
+ * would diverge from the Rust ASCII kernel).
  */
 
 import type { ColumnValue, Row } from "../types.js";
 import { registerTransform } from "./registry.js";
+import { getFlowWasmBackend, type FlowWasmBackend } from "../wasm/backend.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,6 +39,39 @@ function mapStrings(
   });
 }
 
+/** ASCII-only lowercase (Rust `eq_ignore_ascii_case` semantics): fold `A-Z`
+ * only, leave everything else (incl. non-ASCII) untouched. Mirrors
+ * `_ascii_lower` in address.py. */
+function asciiLower(c: string): string {
+  return c >= "A" && c <= "Z" ? String.fromCharCode(c.charCodeAt(0) + 32) : c;
+}
+
+/** `\w` = ASCII `[A-Za-z0-9_]` (matches the Rust kernel, NOT JS's
+ * Unicode-aware `\w`). Mirrors `_is_word_char`. */
+function isWordChar(c: string): boolean {
+  return (
+    (c >= "a" && c <= "z") ||
+    (c >= "A" && c <= "Z") ||
+    (c >= "0" && c <= "9") ||
+    c === "_"
+  );
+}
+
+function isAsciiAlpha(c: string): boolean {
+  return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z");
+}
+
+function isAsciiDigit(c: string): boolean {
+  return c >= "0" && c <= "9";
+}
+
+function isAllAsciiDigits(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (!isAsciiDigit(s[i]!)) return false;
+  }
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Street abbreviation maps
 // ---------------------------------------------------------------------------
@@ -30,11 +82,6 @@ const _STREET_ABBREV: Record<string, string> = {
   Circle: "Cir", Trail: "Trl", Way: "Way", Parkway: "Pkwy",
   Highway: "Hwy", Terrace: "Ter", Square: "Sq",
 };
-
-const _STREET_EXPAND: Record<string, string> = {};
-for (const [full, abbr] of Object.entries(_STREET_ABBREV)) {
-  _STREET_EXPAND[abbr] = full;
-}
 
 // ---------------------------------------------------------------------------
 // US states
@@ -105,35 +152,65 @@ const _COUNTRIES: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// Unit normalization patterns
+// address_standardize / address_expand (series, address, 50)
+//
+// Case-insensitive, ASCII-word-boundary replace-all, one per `_STREET_ABBREV`
+// entry, applied sequentially over the running string. Hand-rolled (no regex)
+// so `\b` semantics match the Rust kernel exactly.
 // ---------------------------------------------------------------------------
 
-const _UNIT_PATTERNS: [RegExp, string][] = [
-  [/^(?:Apt|Apartment)\.?\s+/i, "Unit "],
-  [/^(?:Ste|Suite)\.?\s+/i, "Ste "],
-  [/^#\s*/i, "Unit "],
-];
+/** Case-insensitive, word-boundary-delimited replace-all — byte-identical to
+ * `_replace_word_bounded` / `address.rs::replace_word_bounded`. `needle` is a
+ * non-empty ASCII word; the surrounding text is preserved and the replacement
+ * is not re-scanned. */
+function replaceWordBounded(s: string, needle: string, rep: string): string {
+  const nlen = needle.length;
+  const hlen = s.length;
+  let out = "";
+  let i = 0;
+  while (i < hlen) {
+    let replaced = false;
+    if (i + nlen <= hlen) {
+      let allMatch = true;
+      for (let k = 0; k < nlen; k++) {
+        if (asciiLower(s[i + k]!) !== asciiLower(needle[k]!)) {
+          allMatch = false;
+          break;
+        }
+      }
+      if (allMatch) {
+        const leftOk = i === 0 || !isWordChar(s[i - 1]!);
+        const rightIdx = i + nlen;
+        const rightOk = rightIdx >= hlen || !isWordChar(s[rightIdx]!);
+        if (leftOk && rightOk) {
+          out += rep;
+          i += nlen;
+          replaced = true;
+        }
+      }
+    }
+    if (!replaced) {
+      out += s[i]!;
+      i += 1;
+    }
+  }
+  return out;
+}
 
-// ---------------------------------------------------------------------------
-// address_standardize (series, address, 50)
-// ---------------------------------------------------------------------------
-
-// Pre-compiled regex for address standardize/expand (avoids re-creating per value)
-const _ABBREV_PATTERNS = Object.entries(_STREET_ABBREV).map(
-  ([full, abbr]) => [new RegExp(`\\b${full}\\b`, "gi"), abbr] as const,
-);
-const _EXPAND_PATTERNS = Object.entries(_STREET_EXPAND).map(
-  ([abbr, full]) => [new RegExp(`\\b${abbr}\\b`, "gi"), full] as const,
-);
+/** Replace full street suffixes with abbreviations (`Street`->`St` ...), in
+ * `_STREET_ABBREV` insertion order. Byte-identical to
+ * `_address_standardize_py`. */
+export function addressStandardizeTs(s: string): string {
+  let out = s;
+  for (const [full, abbr] of Object.entries(_STREET_ABBREV)) {
+    out = replaceWordBounded(out, full, abbr);
+  }
+  return out;
+}
 
 function addressStandardize(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    let result = s;
-    for (const [pattern, abbr] of _ABBREV_PATTERNS) {
-      result = result.replace(pattern, abbr);
-    }
-    return result;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.addressStandardize(s) : addressStandardizeTs);
 }
 
 registerTransform(
@@ -141,18 +218,20 @@ registerTransform(
   addressStandardize,
 );
 
-// ---------------------------------------------------------------------------
-// address_expand (series, address, 50)
-// ---------------------------------------------------------------------------
+/** Replace street abbreviations with full forms (`St`->`Street` ...), in
+ * `_STREET_ABBREV` insertion order (abbr->full). Byte-identical to
+ * `_address_expand_py`. */
+export function addressExpandTs(s: string): string {
+  let out = s;
+  for (const [full, abbr] of Object.entries(_STREET_ABBREV)) {
+    out = replaceWordBounded(out, abbr, full);
+  }
+  return out;
+}
 
 function addressExpand(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    let result = s;
-    for (const [pattern, full] of _EXPAND_PATTERNS) {
-      result = result.replace(pattern, full);
-    }
-    return result;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.addressExpand(s) : addressExpandTs);
 }
 
 registerTransform(
@@ -164,16 +243,24 @@ registerTransform(
 // state_abbreviate (series, state|string, 50)
 // ---------------------------------------------------------------------------
 
+/** Normalize a state name to a 2-letter abbreviation. Three-way fallback:
+ * (1) a 2-char input that upper-cases to a valid abbreviation -> uppercase;
+ * (2) full name (case-insensitive) -> `_STATES_LOWER`; (3) neither ->
+ * the ORIGINAL (un-stripped) value. Byte-identical to `_state_abbreviate_py`. */
+export function stateAbbreviateTs(s: string): string {
+  const cleaned = s.trim();
+  const upper = cleaned.toUpperCase();
+  if (cleaned.length === 2 && _STATES_REVERSE[upper] !== undefined) {
+    return upper;
+  }
+  const abbr = _STATES_LOWER[cleaned.toLowerCase()];
+  if (abbr !== undefined) return abbr;
+  return s;
+}
+
 function stateAbbreviate(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    const trimmed = s.trim();
-    // Already a 2-letter abbreviation?
-    if (trimmed.length === 2 && _STATES_REVERSE[trimmed.toUpperCase()]) {
-      return trimmed.toUpperCase();
-    }
-    const matched = _STATES_LOWER[trimmed.toLowerCase()];
-    return matched ?? s;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.stateAbbreviate(s) : stateAbbreviateTs);
 }
 
 registerTransform(
@@ -185,10 +272,17 @@ registerTransform(
 // state_expand (series, state|string, 50)
 // ---------------------------------------------------------------------------
 
+/** Expand a 2-letter state abbreviation to its full name; unmatched inputs
+ * pass through as the ORIGINAL (un-stripped) value. Byte-identical to
+ * `_state_expand_py`. */
+export function stateExpandTs(s: string): string {
+  const full = _STATES_REVERSE[s.trim().toUpperCase()];
+  return full !== undefined ? full : s;
+}
+
 function stateExpand(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    return _STATES_REVERSE[s.trim().toUpperCase()] ?? s;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.stateExpand(s) : stateExpandTs);
 }
 
 registerTransform(
@@ -200,16 +294,20 @@ registerTransform(
 // zip_normalize (series, zip, 55, auto_apply)
 // ---------------------------------------------------------------------------
 
+/** Normalize a US ZIP to 5-digit form: strip +4, zero-pad an all-digit base to
+ * width 5 (a >5-digit base is returned as-is; a non-digit base passes through
+ * unchanged). Byte-identical to `_zip_normalize_py`. */
+export function zipNormalizeTs(s: string): string {
+  const base = s.trim().split("-")[0]!;
+  if (base.length > 0 && isAllAsciiDigits(base)) {
+    return base.padStart(5, "0");
+  }
+  return base;
+}
+
 function zipNormalize(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    let val = s.trim();
-    // Strip +4 extension
-    val = val.split("-")[0]!;
-    if (/^\d+$/.test(val)) {
-      return val.padStart(5, "0");
-    }
-    return val; // preserve invalid
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.zipNormalize(s) : zipNormalizeTs);
 }
 
 registerTransform(
@@ -218,39 +316,19 @@ registerTransform(
 );
 
 // ---------------------------------------------------------------------------
-// split_address (dataframe, address, 45)
-// ---------------------------------------------------------------------------
-
-const _ADDRESS_PATTERN = /^(.+?),\s*(.+?),\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)$/;
-
-function splitAddress(rows: readonly Row[], column: string): Row[] {
-  return rows.map((row) => {
-    const val = row[column];
-    if (val === null || val === undefined || typeof val !== "string") {
-      return { ...row, street: null, city: null, state: null, zip: null };
-    }
-    const m = val.trim().match(_ADDRESS_PATTERN);
-    if (m) {
-      return { ...row, street: m[1], city: m[2], state: m[3], zip: m[4] };
-    }
-    return { ...row, street: val, city: null, state: null, zip: null };
-  });
-}
-
-registerTransform(
-  { name: "split_address", inputTypes: ["address"], priority: 45, mode: "dataframe" },
-  splitAddress,
-);
-
-// ---------------------------------------------------------------------------
 // country_standardize (series, country|string, 50)
 // ---------------------------------------------------------------------------
 
+/** Normalize a country name to its ISO 3166-1 alpha-2 code (trim+lowercase
+ * key); unrecognized values pass through as the ORIGINAL (un-stripped) value.
+ * Byte-identical to `_country_standardize_py`. */
+export function countryStandardizeTs(s: string): string {
+  return _COUNTRIES[s.trim().toLowerCase()] ?? s;
+}
+
 function countryStandardize(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    const lookup = s.trim().toLowerCase();
-    return _COUNTRIES[lookup] ?? s;
-  });
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.countryStandardize(s) : countryStandardizeTs);
 }
 
 registerTransform(
@@ -260,19 +338,155 @@ registerTransform(
 
 // ---------------------------------------------------------------------------
 // unit_normalize (series, address|string, 45)
+//
+// trim, then three anchored prefix substitutions applied sequentially:
+//   (Apt|Apartment)`.?`\s+ -> "Unit ", (Ste|Suite)`.?`\s+ -> "Ste ",
+//   #\s* -> "Unit ". Hand-rolled (no regex).
 // ---------------------------------------------------------------------------
 
-function unitNormalize(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    let result = s.trim();
-    for (const [pattern, replacement] of _UNIT_PATTERNS) {
-      result = result.replace(pattern, replacement);
+/** Case-insensitive ASCII prefix test — mirrors `_ci_startswith`. */
+function ciStartsWith(s: string, prefix: string): boolean {
+  if (s.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (asciiLower(s[i]!) !== asciiLower(prefix[i]!)) return false;
+  }
+  return true;
+}
+
+/** If `s` starts (case-insensitive) with one of `tokens`, then an optional `.`
+ * then one-or-more whitespace, replace that whole prefix with `rep`. Byte-
+ * identical to `_sub_leading_token` (the `\s+` requires >=1 stripped char). */
+function subLeadingToken(s: string, tokens: readonly string[], rep: string): string {
+  for (const tok of tokens) {
+    if (ciStartsWith(s, tok)) {
+      const rest = s.slice(tok.length);
+      const afterDot = rest.startsWith(".") ? rest.slice(1) : rest;
+      const afterWs = afterDot.trimStart();
+      if (afterWs.length < afterDot.length) {
+        return rep + afterWs;
+      }
     }
-    return result;
-  });
+  }
+  return s;
+}
+
+/** If `s` starts with `#`, replace `#` + zero-or-more whitespace with
+ * "Unit ". Byte-identical to `_sub_leading_hash`. */
+function subLeadingHash(s: string): string {
+  if (s.startsWith("#")) {
+    return "Unit " + s.slice(1).trimStart();
+  }
+  return s;
+}
+
+/** Normalize a unit/apartment/suite designation. Byte-identical to
+ * `_unit_normalize_py`. */
+export function unitNormalizeTs(s: string): string {
+  let result = s.trim();
+  result = subLeadingToken(result, ["Apt", "Apartment"], "Unit ");
+  result = subLeadingToken(result, ["Ste", "Suite"], "Ste ");
+  result = subLeadingHash(result);
+  return result;
+}
+
+function unitNormalize(values: readonly ColumnValue[]): ColumnValue[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return mapStrings(values, backend ? (s) => backend.unitNormalize(s) : unitNormalizeTs);
 }
 
 registerTransform(
   { name: "unit_normalize", inputTypes: ["address", "string"], priority: 45, mode: "series" },
   unitNormalize,
+);
+
+// ---------------------------------------------------------------------------
+// split_address (dataframe, address, 45)
+//
+// Parse "street, city, ST zip" -> [street, city, state, zip]. Hand-rolled
+// (no regex) port of `_split_address_py` / `_try_parse_address` /
+// `_parse_state_zip_tail` / `_is_zip`. On no-match: [origVal, null, null, null]
+// (street = the ORIGINAL, un-stripped input); null input -> all null (caller).
+// ---------------------------------------------------------------------------
+
+/** True if `s` is a 5-digit ZIP or a 5+4 dash ZIP. Mirrors `_is_zip`. */
+function isZip(s: string): boolean {
+  if (s.length === 5) return isAllAsciiDigits(s);
+  if (s.length === 10) {
+    return isAllAsciiDigits(s.slice(0, 5)) && s[5] === "-" && isAllAsciiDigits(s.slice(6, 10));
+  }
+  return false;
+}
+
+/** Parse the `\s*[A-Za-z]{2}\s+<zip>$` tail into [state, zip] or null. Mirrors
+ * `_parse_state_zip_tail`. */
+function parseStateZipTail(rem: string): [string, string] | null {
+  const afterWs = rem.trimStart();
+  if (afterWs.length < 2 || !(isAsciiAlpha(afterWs[0]!) && isAsciiAlpha(afterWs[1]!))) {
+    return null;
+  }
+  const state = afterWs.slice(0, 2);
+  const rest = afterWs.slice(2);
+  const zipc = rest.trimStart();
+  if (zipc.length === rest.length) return null; // no whitespace between state and ZIP
+  if (isZip(zipc)) return [state, zipc];
+  return null;
+}
+
+/** Parse a trimmed "street, city, ST zip" string. Mirrors `_try_parse_address`:
+ * street = up to the first comma; city = the shortest run to a later comma
+ * whose remainder is a valid `<state> <zip>` tail. */
+function tryParseAddress(t: string): [string, string, string, string] | null {
+  const c1 = t.indexOf(",");
+  if (c1 === -1) return null;
+  const group1 = t.slice(0, c1);
+  if (group1 === "") return null;
+  const after1Ws = t.slice(c1 + 1).trimStart();
+  let search = 0;
+  for (;;) {
+    const c2 = after1Ws.indexOf(",", search);
+    if (c2 === -1) break;
+    const group2 = after1Ws.slice(0, c2);
+    if (group2 !== "") {
+      const tail = parseStateZipTail(after1Ws.slice(c2 + 1));
+      if (tail !== null) {
+        return [group1, group2, tail[0], tail[1]];
+      }
+    }
+    search = c2 + 1;
+  }
+  return null;
+}
+
+/** Parse "street, city, ST zip" -> [street, city, state, zip]. On no-match
+ * returns [origVal, null, null, null] (street = the ORIGINAL, un-stripped
+ * input). Byte-identical to `_split_address_py`. */
+export function splitAddressTs(s: string): [string, string | null, string | null, string | null] {
+  const parsed = tryParseAddress(s.trim());
+  if (parsed !== null) return parsed;
+  return [s, null, null, null];
+}
+
+function splitAddress(rows: readonly Row[], column: string): Row[] {
+  const backend: FlowWasmBackend | null = getFlowWasmBackend();
+  return rows.map((row) => {
+    const val = row[column];
+    if (val === null || val === undefined || typeof val !== "string") {
+      return { ...row, street: null, city: null, state: null, zip: null };
+    }
+    const [street, city, state, zip] = backend
+      ? backend.splitAddress(val)
+      : splitAddressTs(val);
+    return {
+      ...row,
+      street: street ?? null,
+      city: city ?? null,
+      state: state ?? null,
+      zip: zip ?? null,
+    };
+  });
+}
+
+registerTransform(
+  { name: "split_address", inputTypes: ["address"], priority: 45, mode: "dataframe" },
+  splitAddress,
 );

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -6,11 +6,13 @@
  * (cc/iban/isbn/ean/vat/swift/aba/imei) for the 14 covered functions, the
  * i18n-name transforms (name_transliterate/name_script), the email
  * transforms (email_lowercase/normalize/extract_domain/validate), the URL
- * transforms (url_normalize/extract_domain), and the categorical transforms
+ * transforms (url_normalize/extract_domain), the categorical transforms
  * (boolean_normalize/gender_standardize/null_standardize/
- * category_normalize_key); everything else stays pure-TS. Mirrors
- * goldenmatch's `setScorerBackend(null)` module-singleton pattern for test
- * isolation.
+ * category_normalize_key), and the address transforms (address_standardize/
+ * address_expand/state_abbreviate/state_expand/zip_normalize/
+ * country_standardize/unit_normalize/split_address); everything else stays
+ * pure-TS. Mirrors goldenmatch's `setScorerBackend(null)` module-singleton
+ * pattern for test isolation.
  */
 
 /**
@@ -67,6 +69,16 @@ export interface FlowWasmBackend {
   genderStandardize(s: string): string;
   nullStandardize(s: string): string | undefined;
   categoryNormalizeKey(s: string): string;
+  addressStandardize(s: string): string;
+  addressExpand(s: string): string;
+  stateAbbreviate(s: string): string;
+  stateExpand(s: string): string;
+  zipNormalize(s: string): string;
+  countryStandardize(s: string): string;
+  unitNormalize(s: string): string;
+  /** `split_address` -> 4-element `[street, city, state, zip]`; `street` is
+   * always a string, the other three are `string | null` (Rust `Option`). */
+  splitAddress(s: string): (string | null)[];
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -84,6 +84,14 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     gender_standardize: (s: string) => string;
     null_standardize: (s: string) => string | undefined;
     category_normalize_key: (s: string) => string;
+    address_standardize: (s: string) => string;
+    address_expand: (s: string) => string;
+    state_abbreviate: (s: string) => string;
+    state_expand: (s: string) => string;
+    zip_normalize: (s: string) => string;
+    country_standardize: (s: string) => string;
+    unit_normalize: (s: string) => string;
+    split_address: (s: string) => (string | null)[];
   };
   await glue.default({ module_or_path: bytes });
 
@@ -131,5 +139,13 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     genderStandardize: (s) => glue.gender_standardize(s),
     nullStandardize: (s) => glue.null_standardize(s),
     categoryNormalizeKey: (s) => glue.category_normalize_key(s),
+    addressStandardize: (s) => glue.address_standardize(s),
+    addressExpand: (s) => glue.address_expand(s),
+    stateAbbreviate: (s) => glue.state_abbreviate(s),
+    stateExpand: (s) => glue.state_expand(s),
+    zipNormalize: (s) => glue.zip_normalize(s),
+    countryStandardize: (s) => glue.country_standardize(s),
+    unitNormalize: (s) => glue.unit_normalize(s),
+    splitAddress: (s) => glue.split_address(s),
   };
 }

--- a/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
@@ -65,6 +65,15 @@ import {
   genderStandardizeTs,
   nullStandardizeTs,
 } from "../../src/core/transforms/categorical.js";
+import {
+  addressStandardizeTs,
+  addressExpandTs,
+  stateAbbreviateTs,
+  stateExpandTs,
+  zipNormalizeTs,
+  countryStandardizeTs,
+  unitNormalizeTs,
+} from "../../src/core/transforms/address.js";
 import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
 import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
 
@@ -121,6 +130,13 @@ const PURE_TS_FN: Record<string, (s: string) => boolean | string | number | unde
   to_integer: toIntegerTs,
   comma_decimal: commaDecimalTs,
   scientific_to_decimal: scientificToDecimalTs,
+  address_standardize: addressStandardizeTs,
+  address_expand: addressExpandTs,
+  state_abbreviate: stateAbbreviateTs,
+  state_expand: stateExpandTs,
+  zip_normalize: zipNormalizeTs,
+  country_standardize: countryStandardizeTs,
+  unit_normalize: unitNormalizeTs,
 };
 
 /** Same transform set, dispatched through the wasm backend's method of the
@@ -164,6 +180,13 @@ function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boo
     to_integer: (s) => backend.toInteger(s),
     comma_decimal: (s) => backend.commaDecimal(s),
     scientific_to_decimal: (s) => backend.scientificToDecimal(s),
+    address_standardize: (s) => backend.addressStandardize(s),
+    address_expand: (s) => backend.addressExpand(s),
+    state_abbreviate: (s) => backend.stateAbbreviate(s),
+    state_expand: (s) => backend.stateExpand(s),
+    zip_normalize: (s) => backend.zipNormalize(s),
+    country_standardize: (s) => backend.countryStandardize(s),
+    unit_normalize: (s) => backend.unitNormalize(s),
   };
   const fn = map[transform];
   if (!fn) throw new Error(`no wasm dispatch for transform ${transform}`);

--- a/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -263,6 +263,67 @@
 {"transform": "url_extract_domain", "input": "", "expected": null}
 {"transform": "url_extract_domain", "input": "   ", "expected": null}
 {"transform": "url_extract_domain", "input": null, "expected": null}
+{"transform": "address_standardize", "input": "123 Main Street", "expected": "123 Main St"}
+{"transform": "address_standardize", "input": "1 Park Avenue", "expected": "1 Park Ave"}
+{"transform": "address_standardize", "input": "5 Sunset Boulevard", "expected": "5 Sunset Blvd"}
+{"transform": "address_standardize", "input": "10 elm STREET", "expected": "10 elm St"}
+{"transform": "address_standardize", "input": "Streetsboro Road", "expected": "Streetsboro Rd"}
+{"transform": "address_standardize", "input": "42 Nowhere", "expected": "42 Nowhere"}
+{"transform": "address_standardize", "input": "", "expected": ""}
+{"transform": "address_standardize", "input": null, "expected": null}
+{"transform": "address_expand", "input": "123 Main St", "expected": "123 Main Street"}
+{"transform": "address_expand", "input": "1 Park Ave", "expected": "1 Park Avenue"}
+{"transform": "address_expand", "input": "1 Park Ste", "expected": "1 Park Ste"}
+{"transform": "address_expand", "input": "5 sunset blvd", "expected": "5 sunset Boulevard"}
+{"transform": "address_expand", "input": "", "expected": ""}
+{"transform": "address_expand", "input": null, "expected": null}
+{"transform": "state_abbreviate", "input": "California", "expected": "CA"}
+{"transform": "state_abbreviate", "input": "new york", "expected": "NY"}
+{"transform": "state_abbreviate", "input": "North Carolina", "expected": "NC"}
+{"transform": "state_abbreviate", "input": "ca", "expected": "CA"}
+{"transform": "state_abbreviate", "input": "Ny", "expected": "NY"}
+{"transform": "state_abbreviate", "input": "DC", "expected": "DC"}
+{"transform": "state_abbreviate", "input": "  Freedonia  ", "expected": "  Freedonia  "}
+{"transform": "state_abbreviate", "input": "XZ", "expected": "XZ"}
+{"transform": "state_abbreviate", "input": "", "expected": ""}
+{"transform": "state_abbreviate", "input": null, "expected": null}
+{"transform": "state_expand", "input": "CA", "expected": "California"}
+{"transform": "state_expand", "input": "ny", "expected": "New York"}
+{"transform": "state_expand", "input": "  il  ", "expected": "Illinois"}
+{"transform": "state_expand", "input": "DC", "expected": "District Of Columbia"}
+{"transform": "state_expand", "input": "  ZZ  ", "expected": "  ZZ  "}
+{"transform": "state_expand", "input": "", "expected": ""}
+{"transform": "state_expand", "input": null, "expected": null}
+{"transform": "zip_normalize", "input": "12345", "expected": "12345"}
+{"transform": "zip_normalize", "input": "12345-6789", "expected": "12345"}
+{"transform": "zip_normalize", "input": "  90210  ", "expected": "90210"}
+{"transform": "zip_normalize", "input": "210", "expected": "00210"}
+{"transform": "zip_normalize", "input": "123456", "expected": "123456"}
+{"transform": "zip_normalize", "input": "SW1A", "expected": "SW1A"}
+{"transform": "zip_normalize", "input": "SW1A-1AA", "expected": "SW1A"}
+{"transform": "zip_normalize", "input": "", "expected": ""}
+{"transform": "zip_normalize", "input": null, "expected": null}
+{"transform": "country_standardize", "input": "United States", "expected": "US"}
+{"transform": "country_standardize", "input": "usa", "expected": "US"}
+{"transform": "country_standardize", "input": "  England  ", "expected": "GB"}
+{"transform": "country_standardize", "input": "Deutschland", "expected": "DE"}
+{"transform": "country_standardize", "input": "CA", "expected": "CA"}
+{"transform": "country_standardize", "input": "  Atlantis  ", "expected": "  Atlantis  "}
+{"transform": "country_standardize", "input": "", "expected": ""}
+{"transform": "country_standardize", "input": null, "expected": null}
+{"transform": "unit_normalize", "input": "Apt 4", "expected": "Unit 4"}
+{"transform": "unit_normalize", "input": "Apt. 4", "expected": "Unit 4"}
+{"transform": "unit_normalize", "input": "Apartment 12B", "expected": "Unit 12B"}
+{"transform": "unit_normalize", "input": "Suite 200", "expected": "Ste 200"}
+{"transform": "unit_normalize", "input": "Ste. 200", "expected": "Ste 200"}
+{"transform": "unit_normalize", "input": "#5", "expected": "Unit 5"}
+{"transform": "unit_normalize", "input": "# 5", "expected": "Unit 5"}
+{"transform": "unit_normalize", "input": "APT 9", "expected": "Unit 9"}
+{"transform": "unit_normalize", "input": "Apt.5", "expected": "Apt.5"}
+{"transform": "unit_normalize", "input": "Aptos", "expected": "Aptos"}
+{"transform": "unit_normalize", "input": "  Building C  ", "expected": "Building C"}
+{"transform": "unit_normalize", "input": "", "expected": ""}
+{"transform": "unit_normalize", "input": null, "expected": null}
 {"transform": "currency_strip", "input": "$1,234.56", "expected": 1234.56}
 {"transform": "currency_strip", "input": "-$42.00", "expected": -42.0}
 {"transform": "currency_strip", "input": "USD 100", "expected": 100.0}

--- a/packages/typescript/goldenflow/tests/unit/address-kernels.test.ts
+++ b/packages/typescript/goldenflow/tests/unit/address-kernels.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Pinned-vector parity for the multi-output `split_address` kernel (Wave D
+ * address-simple): one input column -> [street, city, state, zip]. It's a
+ * dataframe-mode transform whose scalar core (`splitAddressTs`) doesn't fit the
+ * shared string->scalar corpus in `tests/parity/identifiers.parity.test.ts`, so
+ * it's asserted here with the SAME pinned vectors as the Python
+ * `tests/transforms/test_address_kernels.py`.
+ *
+ * The 7 scalar address transforms (address_standardize/address_expand/
+ * state_abbreviate/state_expand/zip_normalize/country_standardize/
+ * unit_normalize) DO fit the shared corpus and are covered there.
+ *
+ * The pure-TS leg always runs; the WASM leg runs only when the `.wasm` artifact
+ * has been built (a CI-only build product, never committed) -- exactly the
+ * skip-guarded pattern from the identifier / name-kernel parity harnesses.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { splitAddressTs } from "../../src/core/transforms/address.js";
+import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
+import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
+
+// (input, expected street, city, state, zip) -- mirrors _SPLIT_ADDRESS in
+// test_address_kernels.py. `null` mirrors Python `None` (the null row).
+const SPLIT_ADDRESS: Array<
+  [string | null, string | null, string | null, string | null, string | null]
+> = [
+  ["123 Main St, Springfield, IL 62704", "123 Main St", "Springfield", "IL", "62704"],
+  ["1 Park Ave, New York, NY 10001-2345", "1 Park Ave", "New York", "NY", "10001-2345"],
+  ["  9 Elm Rd, Denver, CO 80014  ", "9 Elm Rd", "Denver", "CO", "80014"],
+  [
+    "123 Main St, Apt 4, Springfield, IL 62704",
+    "123 Main St",
+    "Apt 4, Springfield",
+    "IL",
+    "62704",
+  ],
+  ["  just a street  ", "  just a street  ", null, null, null],
+  [
+    "123 Main St, Springfield, ILL 62704",
+    "123 Main St, Springfield, ILL 62704",
+    null,
+    null,
+    null,
+  ],
+  [null, null, null, null, null],
+];
+
+/** Run the scalar split fn, short-circuiting the null row to all-null the way
+ * the dataframe transform does (the scalar fn doesn't accept null). */
+function runSplit(
+  fn: (s: string) => [string, string | null, string | null, string | null],
+  input: string | null,
+): [string | null, string | null, string | null, string | null] {
+  return input === null ? [null, null, null, null] : fn(input);
+}
+
+/** Same via a wasm backend method returning a 4-element (string | null)[]. */
+function runSplitWasm(
+  fn: (s: string) => (string | null)[],
+  input: string | null,
+): [string | null, string | null, string | null, string | null] {
+  if (input === null) return [null, null, null, null];
+  const [street, city, state, zip] = fn(input);
+  return [street ?? null, city ?? null, state ?? null, zip ?? null];
+}
+
+describe("goldenflow address kernels: pure-TS matches pinned vectors", () => {
+  it("split_address", () => {
+    for (const [input, street, city, state, zip] of SPLIT_ADDRESS) {
+      expect(runSplit(splitAddressTs, input)).toEqual([street, city, state, zip]);
+    }
+  });
+});
+
+describe("goldenflow address kernels: wasm matches pinned vectors", () => {
+  let wasmAvailable = false;
+
+  beforeAll(async () => {
+    // Resolves false (no throw) when the `.wasm` artifact isn't built -- the
+    // true default/local state (CI-only build product; never committed).
+    wasmAvailable = await enableWasm();
+  });
+
+  afterAll(() => {
+    disableWasm();
+  });
+
+  it("reports wasm availability", () => {
+    if (!wasmAvailable) {
+      console.warn(
+        "goldenflow wasm artifact not built (src/core/wasm/artifacts/*.wasm absent) " +
+          "-- skipping the wasm address-kernel leg. Expected outside the wasm_flow CI lane.",
+      );
+    }
+    expect(true).toBe(true);
+  });
+
+  it.skipIf(!wasmAvailable)("split_address", () => {
+    const backend = getFlowWasmBackend() as FlowWasmBackend;
+    if (!backend) throw new Error("wasmAvailable=true but getFlowWasmBackend() returned null");
+
+    for (const [input, street, city, state, zip] of SPLIT_ADDRESS) {
+      expect(runSplitWasm((s) => backend.splitAddress(s), input)).toEqual([
+        street,
+        city,
+        state,
+        zip,
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
## Wave D — address-simple (owned kernels, cross-surface)

Migrates the 8 US-address `address` transforms to owned pyo3-free Rust kernels in `goldenflow-core` (the reference), with Python/TS surfaces conforming byte-for-byte. Migration, not addition — transform count stays 92; minor version bumps only. i18n addresses stay Wave C (deferred).

**Kernels moved to `goldenflow-core::address`:** `address_standardize`, `address_expand`, `state_abbreviate`, `state_expand`, `zip_normalize`, `country_standardize`, `unit_normalize` (scalar) + `split_address`.

**Novel shape — 1→4 multi-output:** `split_address` (one column → street/city/state/zip). New `map_str_to_str_quad` marshaling (1 array → 4, the last three nullable on a present row); the wasm export returns a 4-element `[street, city, state, zip]` JS array. Covered by a pinned-vector test (doesn't fit the string→scalar corpus).

**No regex dep (the parity guarantee):** the word-boundary street-suffix replace, the anchored unit-prefix subs, and the `split_address` grammar (non-greedy + backtracking city group, porting `^(.+?),\s*(.+?),\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)$`) are all hand-rolled with ASCII word-char semantics in Rust **and** the Python/TS fallbacks — JS/Py/Rust regex `\b`/greedy/`replace_all` differ, so hand-rolling is what keeps the bytes identical (same reason `email.rs` hand-rolls).

### Fan-out
- **Rust core** (`address.rs`): 8 kernels + 10 unit tests. Reference impl.
- **native shim**: 8 `*_arrow` + `map_str_to_str_quad` + `split_address_arrow` (4-tuple).
- **Python** (`address.py`): native-first dispatch with byte-matched `_*_py` fallbacks; `address` loader component (floor `address_standardize_arrow`); the 5 expr-mode transforms keep `func(column)→Expr` via `map_batches`.
- **wasm** (`goldenflow-wasm`): 8 exports. **TS** (`address.ts` + `backend.ts`/`loader.ts`): 8 fns, native-first routing.
- **Parity**: 61 new scalar rows in the identifier corpus (405 total), byte-synced to the TS copy; pinned-vector `test_address_kernels.py` + `address-kernels.test.ts` for `split_address`.

### Versions
`goldenflow` 1.10.0 · `native-flow` 0.8.0 · TS `goldenflow` 0.10.0.

### Verification
- Rust: 10 address tests + clippy clean; `cargo fmt --check` clean on native-flow (the CI-enforced crate).
- Python: 8-transform `GOLDENFLOW_NATIVE=0` fallback sweep + 406-row corpus fallback parity + `test_address_kernels` + existing `test_address.py` all green (native skipped — stale local wheel).
- TS: CI-only (box OOMs on vitest/tsc); statically cross-checked corpus == PURE_TS_FN == wasm map keys (7 scalar), 8 unique exports, wasm↔loader 8-for-8, split vectors match the Python pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
