### PR TITLE
fix(native): guard 5 beyond-floor native calls against wheel/symbol skew

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -237,13 +237,24 @@ def native_available() -> bool:
     return _native is not None
 
 
-def native_enabled(component: str) -> bool:
+def native_enabled(component: str, symbol: str | None = None) -> bool:
     """Whether to use the native kernel for ``component`` on this call.
 
     Records the decision (see :func:`native_dispatch_report`) and, the first
     time it runs under ``auto`` with the kernel importable, logs a one-line hint
     that the gated-only allowlist is in effect (set ``GOLDENMATCH_NATIVE=1`` for
     full native acceleration on large / benchmark runs).
+
+    When ``symbol`` is given, the component is treated as native ONLY if that
+    specific kernel symbol is actually present on the loaded wheel. Use this at a
+    call site that depends on a symbol NEWER than the component's floor
+    (:data:`_COMPONENT_SYMBOLS`): on a published wheel that carries the floor
+    symbol but predates ``symbol``, this returns ``False`` so the caller falls
+    back to pure Python instead of ``AttributeError``-crashing — the wheel/caller
+    symbol-skew class the #688 post-mortem documents. (Even under
+    ``GOLDENMATCH_NATIVE=1`` a missing beyond-floor symbol falls back rather than
+    crashing; the ``=1`` contract is about the module being importable, not about
+    every optional sub-kernel being present.)
     """
     global _AUTO_HINT_LOGGED
     mode = os.environ.get("GOLDENMATCH_NATIVE", "auto").lower()
@@ -255,8 +266,9 @@ def native_enabled(component: str) -> bool:
             raise RuntimeError(
                 "GOLDENMATCH_NATIVE=1 but goldenmatch._native is not built/importable"
             )
-        _record_dispatch(component, True)
-        return True
+        result = symbol is None or hasattr(_native, symbol)
+        _record_dispatch(component, result)
+        return result
     # auto / unset: Rust is the reference -- run native wherever the component's
     # kernel symbol exists on this wheel; pure-Python is the lossy fallback. The
     # only auto exceptions are _FALLBACK_ONLY (known-divergent kernels).
@@ -271,6 +283,7 @@ def native_enabled(component: str) -> bool:
         _native is not None
         and component not in _FALLBACK_ONLY
         and _has_symbol(component)
+        and (symbol is None or hasattr(_native, symbol))
     )
     _record_dispatch(component, result)
     return result

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -325,7 +325,7 @@ def _severe_bridge_count(members: list[int], pair_scores: dict) -> int:
     """Count edges whose removal splits this cluster into two components each
     with >= 2 nodes -- the 'merged by one weak link' pathology. A bridge between
     a node and a singleton tail is not severe (one side < 2)."""
-    if native_enabled("clustering"):
+    if native_enabled("clustering", "severe_bridge_count"):
         edges = [(k[0], k[1], v) for k, v in pair_scores.items()
                  if isinstance(k, tuple) and len(k) == 2]
         return native_module().severe_bridge_count(members, edges)
@@ -1196,7 +1196,7 @@ def compute_cluster_confidence(
     Returns:
         Dict with: min_edge, avg_edge, connectivity, bottleneck_pair, confidence.
     """
-    if native_enabled("clustering"):
+    if native_enabled("clustering", "cluster_confidence"):
         # pair_scores keys are ALWAYS canonical (min, max) 2-tuples by
         # construction -- every writer in this module builds them that way
         # (_build_clusters_dict_path, add_to_cluster, unmerge, the split/merge

--- a/packages/python/goldenmatch/goldenmatch/core/pairs.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pairs.py
@@ -50,7 +50,7 @@ def dedup_pairs_max_score(pairs: list[Pair]) -> list[Pair]:
 
 def candidate_pair_count(block_sizes: list[int]) -> int:
     """Total candidate comparisons across blocks: ``sum(n*(n-1)//2)``."""
-    if native_enabled("pairs"):
+    if native_enabled("pairs", "candidate_pair_count"):
         return native_module().candidate_pair_count(block_sizes)
     return sum(n * (n - 1) // 2 for n in block_sizes if n >= 2)
 
@@ -62,7 +62,7 @@ def block_histogram(block_sizes: list[int]) -> dict[str, int]:
     ``p95`` / ``p99`` (the percentile definition in ``core/cluster.py``). Empty
     input yields all zeros.
     """
-    if native_enabled("pairs"):
+    if native_enabled("pairs", "block_histogram"):
         count, total, mx, p50, p95, p99 = native_module().block_histogram(block_sizes)
         return {
             "count": count,
@@ -106,7 +106,7 @@ def connected_components(
             seen.add(a)
             seen.add(b)
         all_ids = list(seen)
-    if native_enabled("pairs"):
+    if native_enabled("pairs", "connected_components"):
         return native_module().connected_components(list(pairs), all_ids)
     from goldenmatch.core.cluster import UnionFind
 

--- a/packages/python/goldenmatch/tests/test_native_symbol_skew.py
+++ b/packages/python/goldenmatch/tests/test_native_symbol_skew.py
@@ -1,0 +1,91 @@
+"""Wheel/caller symbol-skew guard (the #688 secondary-bug class).
+
+Several call sites are gated by ``native_enabled(component)`` on the component's
+FLOOR symbol (``_COMPONENT_SYMBOLS``) but then invoke a symbol NEWER than that
+floor. On a published wheel that carries the floor symbol but predates the newer
+one, the gate fired True and the call raised ``AttributeError`` — a hard crash
+instead of the intended silent-slow fallback.
+
+The fix threads the specific symbol through ``native_enabled(component, symbol)``
+so the gate is False when the exact symbol is absent, and the call site falls
+back to pure Python. These tests simulate that skew with a fake native module
+that has each component's floor symbol but NONE of the beyond-floor symbols, and
+assert every guarded call site falls back (correct result, no crash).
+"""
+import types
+
+import pytest
+
+from goldenmatch.core import _native_loader
+from goldenmatch.core import cluster as cluster_mod
+from goldenmatch.core import pairs as pairs_mod
+
+
+@pytest.fixture
+def floor_only_native(monkeypatch):
+    """Fake native module carrying only the FLOOR symbols for ``pairs`` and
+    ``clustering`` — none of the beyond-floor symbols the call sites use."""
+
+    def _boom(*_a, **_k):  # floor symbols exist for the gate but must NOT be called
+        raise AssertionError("native floor symbol unexpectedly invoked")
+
+    fake = types.SimpleNamespace(
+        dedup_pairs_max_score=_boom,  # 'pairs' floor (_COMPONENT_SYMBOLS)
+        mst_split_components=_boom,  # 'clustering' floor (NOT connected_components)
+    )
+    monkeypatch.setattr(_native_loader, "_native", fake)
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "auto")
+
+    # The component gate is ON (floor present) but each specific symbol is absent.
+    assert _native_loader.native_enabled("pairs")
+    assert not _native_loader.native_enabled("pairs", "candidate_pair_count")
+    assert not _native_loader.native_enabled("pairs", "block_histogram")
+    assert not _native_loader.native_enabled("pairs", "connected_components")
+    assert _native_loader.native_enabled("clustering")
+    assert not _native_loader.native_enabled("clustering", "severe_bridge_count")
+    assert not _native_loader.native_enabled("clustering", "cluster_confidence")
+    return fake
+
+
+def test_candidate_pair_count_falls_back(floor_only_native):
+    # 3*(3-1)//2 + 2*(2-1)//2 = 3 + 1
+    assert pairs_mod.candidate_pair_count([3, 2]) == 4
+
+
+def test_block_histogram_falls_back(floor_only_native):
+    h = pairs_mod.block_histogram([1, 2, 3])
+    assert h["count"] == 3
+    assert h["total_records"] == 6
+    assert h["max"] == 3
+
+
+def test_connected_components_falls_back(floor_only_native):
+    comps = pairs_mod.connected_components([(0, 1, 1.0), (1, 2, 1.0)], [0, 1, 2, 3])
+    assert sorted(sorted(c) for c in comps) == [[0, 1, 2], [3]]
+
+
+def test_severe_bridge_count_falls_back(floor_only_native):
+    # No crash, returns the pure-Python int (a-b-c chain: the middle edges are
+    # bridges to sides of size < 2, so the exact count is not asserted here —
+    # the point is fallback, not native-parity, which other tests cover).
+    out = cluster_mod._severe_bridge_count([0, 1, 2], {(0, 1): 0.9, (1, 2): 0.9})
+    assert isinstance(out, int)
+
+
+def test_cluster_confidence_falls_back(floor_only_native):
+    out = cluster_mod.compute_cluster_confidence({(0, 1): 0.9, (1, 2): 0.8}, 3)
+    assert "confidence" in out
+    assert out["confidence"] is not None
+    assert 0.0 <= out["confidence"] <= 1.0
+
+
+def test_native_enabled_symbol_present_still_native(monkeypatch):
+    """Sanity: when the specific symbol IS present, the gate stays native."""
+
+    def _ok(*_a, **_k):
+        return 0
+
+    fake = types.SimpleNamespace(dedup_pairs_max_score=_ok, candidate_pair_count=_ok)
+    monkeypatch.setattr(_native_loader, "_native", fake)
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "auto")
+    assert _native_loader.native_enabled("pairs", "candidate_pair_count")

--- a/packages/python/goldenmatch/tests/test_native_symbol_skew.py
+++ b/packages/python/goldenmatch/tests/test_native_symbol_skew.py
@@ -15,7 +15,6 @@ assert every guarded call site falls back (correct result, no crash).
 import types
 
 import pytest
-
 from goldenmatch.core import _native_loader
 from goldenmatch.core import cluster as cluster_mod
 from goldenmatch.core import pairs as pairs_mod


### PR DESCRIPTION
## What and why

The publish/wheel-skew audit (item #4) found the **#688 symbol-skew footgun live in 5 call sites** — and worse than the documented case: **unguarded**. Each is gated `native_enabled(component)` on the component's *floor* symbol (`_COMPONENT_SYMBOLS`), then invokes a symbol **newer than that floor**. On a published `goldenmatch[native]` wheel that carries the floor symbol but predates the newer one, the gate fires `True` and the call raises **`AttributeError` — a hard crash**, instead of the intended silent-slow fallback.

| file | component gate | symbol invoked | in floor tuple? |
|---|---|---|:--:|
| `core/pairs.py` | `pairs` | `candidate_pair_count` | no |
| `core/pairs.py` | `pairs` | `block_histogram` | no |
| `core/pairs.py` | `pairs` | `connected_components` | no (it's `clustering`'s floor) |
| `core/cluster.py` | `clustering` | `severe_bridge_count` | no |
| `core/cluster.py` | `clustering` | `cluster_confidence` | no |

Each site already has a full pure-Python fallback right below the native branch — the bug is purely that the gate didn't reflect the *specific* symbol.

## Changes

- **`_native_loader.py`** — `native_enabled(component, symbol=None)`: when `symbol` is given, the component is native **only if that exact symbol is present**, so a beyond-floor dependency falls back instead of crashing. Central, records dispatch correctly (native only when the symbol is truly present), and documented. Even under `GOLDENMATCH_NATIVE=1` a missing beyond-floor symbol falls back rather than crashing (the `=1` contract is "module importable", not "every optional sub-kernel present").
- **`pairs.py` / `cluster.py`** — the 5 sites now pass their symbol: `native_enabled("pairs", "candidate_pair_count")`, etc. One-line changes.
- **`tests/test_native_symbol_skew.py`** — simulates the skew with a fake native module carrying only the floor symbols (none of the 5 beyond-floor ones) and asserts every site falls back (correct result, no crash) + a sanity case that a present symbol stays native.

**No wheel/symbol change** (callers made defensive), so **no native version bump** needed — this is pure Python-side robustness.

## Testing

- `pytest tests/test_native_symbol_skew.py tests/test_pairs.py tests/test_cluster.py` → **45 passed**.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (N/A — behavior-preserving hardening; the footgun is already documented in root CLAUDE.md)
- [ ] Package `CHANGELOG.md` — N/A (defensive fallback fix; no public-API or output change on a wheel that has the symbols)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_