### PR TITLE
chore(golden-suite): bump stale goldenflow floors to latest PyPI + v0.1.2

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.1.2] - 2026-07-04
+
+### Changed
+- Bumped the two stale goldenflow-family floors to the latest PyPI releases:
+  **`goldenflow>=1.4.0`** (was `>=1.3`) and **`goldenflow-native>=0.2.0`** (was
+  `>=0.1.1`), per the lockstep policy (whenever a bundled member releases,
+  golden-suite bumps its floor and re-cuts). Floors track the latest *published*
+  member versions so `pip install golden-suite` stays satisfiable; the workspace
+  carries newer unreleased goldenflow work whose floor can be mandated once it
+  ships to PyPI.
+
 ## [0.1.1] - 2026-07-02
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.1"
+version = "0.1.2"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -39,14 +39,14 @@ dependencies = [
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch>=2.8",                 # entity resolution: dedupe, match, golden records (>=2.8 mandates the B1 silent-corruption + healer fixes)
     "goldencheck>=1.4.1",               # data validation (rules discovered from your data; >=1.4.1 = rapidfuzz cell_quality)
-    "goldenflow>=1.3",                  # transform / standardize / normalize
+    "goldenflow>=1.4.0",                # transform / standardize / normalize (>=1.4.0 = latest PyPI)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
     "goldenmatch-native>=0.1.12",       # >=0.1.12 carries perceptual + the current kernel surface
     "goldencheck-native>=0.1",
-    "goldenflow-native>=0.1.1",
+    "goldenflow-native>=0.2.0",
     "goldenanalysis-native>=0.1",
     # --- CLI (doctor / optimize) ---
     "typer>=0.12",


### PR DESCRIPTION
## What and why

The publish-skew audit (item #4, Area 3) found two golden-suite dependency floors lagging the lockstep policy: `goldenflow>=1.3` and `goldenflow-native>=0.1.1`.

**Key nuance found during the fix:** the *workspace* versions (goldenflow **1.9.0**, goldenflow-native **0.7.0**) are **not on PyPI** — PyPI max is **1.4.0 / 0.2.0**. Bumping the floor to the workspace versions would be the **unsatisfiable-floor trap** the standing rule explicitly warns against (`pip install golden-suite` would fail to resolve). So this bumps to the latest *published* versions:

- `goldenflow>=1.3` → **`>=1.4.0`**
- `goldenflow-native>=0.1.1` → **`>=0.2.0`**

This mandates a newer baseline and keeps `golden-suite` installable. The workspace's newer unreleased goldenflow work (1.5→1.9, 0.3→0.7) can have its floor mandated once those members ship to PyPI (land member on PyPI first, then bump the floor — the standing sequencing rule).

## Changes

- `pyproject.toml` — the two floor bumps + `version` 0.1.1 → **0.1.2**.
- `golden_suite/__init__.py` — `__version__` → 0.1.2 (the lockstep spot).
- `CHANGELOG.md` — new `[0.1.2]` entry.

The version bump is required: `publish-golden-suite.yml` has `skip-existing: true`, so a same-version republish silently no-ops and the corrected floors would never reach PyPI. CI resolves golden-suite floors against the **workspace** (goldenflow 1.9.0 / goldenflow-native 0.7.0), both of which satisfy the new floors.

## Testing

- `pyproject.toml` parses; the two goldenflow floors read `>=1.4.0` / `>=0.2.0`; version 0.1.2.
- Deps-only meta-package — no code, no runtime behavior change.

## Release note (for the maintainer)

This PR only prepares the bump. The actual release is a **`golden-suite-v0.1.2`** tag you cut (deps-only). Separately: goldenflow/goldenflow-native have substantial unreleased work in the workspace (1.9.0 / 0.7.0 vs PyPI 1.4.0 / 0.2.0) — releasing those, then re-bumping golden-suite's floors to match, is a follow-up you own.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (parse check; deps-only)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (CHANGELOG; the lockstep + unsatisfiable-floor rules are already in root CLAUDE.md)
- [x] Package `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_