### PR TITLE
feat(datafusion): goldenmatch_record_fingerprint FFI UDF (DataFusion coverage parity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,10 @@ jobs:
               # crate. A score-core-only change must re-trigger this lane so the
               # FFI scorer-parity test (vs native) re-runs.
               - 'packages/rust/extensions/score-core/**'
+              # The FFI record-fingerprint UDF delegates to fingerprint-core; a
+              # fingerprint-core-only change must re-trigger this lane so the
+              # cross-surface fingerprint-golden parity test re-runs.
+              - 'packages/rust/extensions/fingerprint-core/**'
             python_goldenmatch_postgres:
               - 'packages/python/goldenmatch/tests/test_db.py'
               - 'packages/python/goldenmatch/tests/test_reconcile.py'
@@ -859,7 +863,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: dist-dfudf
-          key: dfudf-wheel-${{ runner.os }}-${{ hashFiles('packages/rust/extensions/datafusion-udf/**', 'packages/rust/extensions/score-core/**', 'packages/rust/extensions/graph-core/**', 'packages/rust/extensions/goldenembed/**') }}
+          key: dfudf-wheel-${{ runner.os }}-${{ hashFiles('packages/rust/extensions/datafusion-udf/**', 'packages/rust/extensions/score-core/**', 'packages/rust/extensions/graph-core/**', 'packages/rust/extensions/goldenembed/**', 'packages/rust/extensions/fingerprint-core/**') }}
       # DataFusion FFI ScalarUDF gate (Stage B): the FFI string scorers
       # (jaro_winkler / token_sort / levenshtein) are diffed against the native
       # per-pair scorers by tests/test_datafusion_ffi_udf.py, which HARD-imports

--- a/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
@@ -144,3 +144,53 @@ def test_ffi_pair_dedup():
     rows = out[0].column(0).to_pylist()[0]  # list of {a,b,s} structs for row 0
     got = sorted((r["a"], r["b"], r["s"]) for r in rows)
     assert got == [(1, 2, 0.9), (3, 3, 0.1)], got
+
+
+def _fingerprint_golden():
+    """The shared cross-surface record-fingerprint oracle: the same
+    `fingerprint-core/golden/fingerprint_golden.json` the Rust
+    `fingerprint-core/tests/golden.rs`, the edge-TS parity test, and the Python
+    surface all check. Anchored to the repo root from this file's location."""
+    import json
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[4]  # tests -> goldenmatch -> python -> packages -> root
+    golden = root / "packages/rust/extensions/fingerprint-core/golden/fingerprint_golden.json"
+    return json.loads(golden.read_text())
+
+
+def test_ffi_record_fingerprint_matches_golden():
+    """`goldenmatch_record_fingerprint(json)`, exposed as an FFI ScalarUDF over
+    Utf8 -> Utf8, reproduces the shared cross-surface fingerprint golden exactly
+    — so the SQL DataFusion surface emits the SAME 64-hex record id as Postgres /
+    DuckDB / edge-TS / Python. NULL propagates to NULL."""
+    from datafusion import SessionContext, udf
+    from goldenmatch_datafusion_udf import FingerprintUDF
+
+    cases = _fingerprint_golden()
+    assert len(cases) >= 13
+
+    ctx = SessionContext()
+    ctx.register_udf(udf(FingerprintUDF()))
+    # Carry name + expected through so row order across collect() doesn't matter,
+    # plus one explicit NULL row to pin the NULL-propagation convention.
+    names = [c["name"] for c in cases] + ["__null__"]
+    jsons = [c["json"] for c in cases] + [None]
+    expected = {c["name"]: c["hash"] for c in cases}
+    expected["__null__"] = None
+
+    t = pa.table(
+        {"name": pa.array(names, pa.string()), "j": pa.array(jsons, pa.string())}
+    )
+    ctx.from_arrow(t, name="recs")
+    out = ctx.sql(
+        "SELECT name, goldenmatch_record_fingerprint(j) AS fp FROM recs"
+    ).collect()
+
+    got = {}
+    for batch in out:
+        cols = {n: batch.column(i).to_pylist() for i, n in enumerate(batch.schema.names)}
+        for i in range(batch.num_rows):
+            got[cols["name"][i]] = cols["fp"][i]
+
+    assert got == expected

--- a/packages/rust/extensions/datafusion-udf/Cargo.toml
+++ b/packages/rust/extensions/datafusion-udf/Cargo.toml
@@ -41,6 +41,10 @@ goldenmatch-score-core = { path = "../score-core" }
 # pin never meets this crate's arrow-58 stack. See graph_udf.rs ARROW-VERSION
 # NOTE.
 goldenmatch-graph-core = { path = "../graph-core" }
+# Pyo3-free canonical record-fingerprint kernel (SHA-256 over canonicalized JSON),
+# shared with the Postgres / DuckDB / edge-TS / Python surfaces. Pure sha2 +
+# serde_json — no arrow — so it adds no version constraint to the arrow-58 stack.
+goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
 # Standalone local embedding runtime (featurize + ONNX). Lets goldenmatch_embed
 # run the in-house embed path with zero CPython inside the SQL engine. Pulls
 # `ort` (onnxruntime) into this cdylib — heavier build; validated in CI.

--- a/packages/rust/extensions/datafusion-udf/src/fingerprint_udf.rs
+++ b/packages/rust/extensions/datafusion-udf/src/fingerprint_udf.rs
@@ -1,0 +1,98 @@
+// Canonical record fingerprint exposed as a datafusion-ffi ScalarUDF over
+// Utf8 -> Utf8, delegating to the pyo3-free `goldenmatch-fingerprint-core` crate
+// — the SAME source of truth the Postgres `goldenmatch_record_fingerprint`, the
+// DuckDB UDF, the edge-TS wasm, and the Python native path use. So the 64-hex
+// SHA-256 record id is byte-identical across every surface by construction
+// (parity asserted in tests/test_datafusion_ffi_udf.py against the shared
+// `fingerprint-core/golden/fingerprint_golden.json` oracle).
+//
+// fingerprint-core is a pure hashing crate (sha2 + serde_json, no arrow), so —
+// unlike graph-core/goldenembed — it introduces no arrow-version constraint on
+// this crate's arrow-58 stack.
+//
+// NULL / error convention: a NULL input yields NULL (propagated); an input that
+// is not a fingerprintable JSON object (invalid JSON, a non-object, a nested
+// array/object value, or a non-finite float) also yields NULL — the graceful
+// SQL choice (Postgres `error!`s; this surface, like DuckDB's fail-soft, returns
+// NULL). Valid records hash identically on every surface.
+//
+// The FFI boilerplate (trait-method signatures, the cr"datafusion_scalar_udf"
+// capsule name, the FFI_ScalarUDF::from(Arc::new(ScalarUDF::from(self.clone())))
+// chain) mirrors `scalar_udf.rs` / the canonical datafusion-ffi-example verbatim.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow_array::cast::AsArray;
+use arrow_array::StringArray;
+use arrow_schema::DataType;
+use datafusion_common::error::Result as DataFusionResult;
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_ffi::udf::FFI_ScalarUDF;
+use pyo3::types::PyCapsule;
+use pyo3::{Bound, PyResult, Python, pyclass, pymethods};
+
+#[pyclass(
+    from_py_object,
+    name = "FingerprintUDF",
+    module = "goldenmatch_datafusion_udf",
+    subclass
+)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct FingerprintUDF {
+    signature: Signature,
+}
+
+#[pymethods]
+impl FingerprintUDF {
+    #[new]
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::Utf8], Volatility::Immutable),
+        }
+    }
+
+    fn __datafusion_scalar_udf__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let name = cr"datafusion_scalar_udf".into();
+        let func = Arc::new(ScalarUDF::from(self.clone()));
+        let provider = FFI_ScalarUDF::from(func);
+        PyCapsule::new(py, provider, Some(name))
+    }
+}
+
+impl ScalarUDFImpl for FingerprintUDF {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "goldenmatch_record_fingerprint"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> DataFusionResult<ColumnarValue> {
+        let arrs = ColumnarValue::values_to_arrays(&args.args)?;
+        let a = arrs[0].as_string::<i32>();
+        // NULL in -> NULL; un-fingerprintable input (Err) -> NULL; else the hex.
+        let out: StringArray = a
+            .iter()
+            .map(|oa| oa.and_then(|s| goldenmatch_fingerprint_core::fingerprint_json(s).ok()))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(out)))
+    }
+}

--- a/packages/rust/extensions/datafusion-udf/src/lib.rs
+++ b/packages/rust/extensions/datafusion-udf/src/lib.rs
@@ -9,10 +9,12 @@
 use pyo3::prelude::*;
 
 use crate::embed_udf::EmbedUDF;
+use crate::fingerprint_udf::FingerprintUDF;
 use crate::graph_udf::{ConnectedComponentsUDF, PairDedupUDF};
 use crate::scalar_udf::{JaroWinklerUDF, LevenshteinUDF, TokenSortUDF};
 
 pub(crate) mod embed_udf;
+pub(crate) mod fingerprint_udf;
 pub(crate) mod graph_udf;
 pub(crate) mod scalar_udf;
 
@@ -24,5 +26,6 @@ fn goldenmatch_datafusion_udf(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<EmbedUDF>()?;
     m.add_class::<ConnectedComponentsUDF>()?;
     m.add_class::<PairDedupUDF>()?;
+    m.add_class::<FingerprintUDF>()?;
     Ok(())
 }


### PR DESCRIPTION
## What and why

Item #4's DataFusion coverage audit found the FFI surface exposes score / graph / embed but **not fingerprint** — a real parity gap: the record-fingerprint kernel is native on **Postgres** (`goldenmatch_record_fingerprint`) *and* **DuckDB**, but absent on DataFusion. This closes it (the simplest of the four flagged gaps — a single-arg `Utf8 → Utf8` scalar).

## Changes

- **`src/fingerprint_udf.rs`** — `FingerprintUDF`, a `Utf8 → Utf8` datafusion-ffi ScalarUDF named **`goldenmatch_record_fingerprint`** (matching the PG + DuckDB SQL siblings for cross-surface name parity), delegating to the pyo3-free `goldenmatch-fingerprint-core::fingerprint_json` — the **same source of truth** as every other surface, so the 64-hex SHA-256 record id is byte-identical by construction. `fingerprint-core` is pure `sha2` + `serde_json` (no arrow), so it adds **no** version constraint to the crate's arrow-58 stack (unlike graph-core/goldenembed). NULL → NULL; un-fingerprintable input (`Err`) → NULL (graceful SQL fail-soft, like DuckDB; Postgres `error!`s).
- **`src/lib.rs`** — register `FingerprintUDF`. **`Cargo.toml`** — add the `fingerprint-core` path dep.
- **`tests/test_datafusion_ffi_udf.py`** — `test_ffi_record_fingerprint_matches_golden` replays the shared `fingerprint-core/golden/fingerprint_golden.json` oracle (the same file the Rust golden test + the edge-TS parity test check) through the UDF and asserts exact hashes + NULL propagation.
- **`ci.yml`** — the datafusion lane's path filter *and* wheel cache key gain `fingerprint-core/**`, so a fingerprint-core change re-triggers the lane and busts the cached wheel.

## Testing

- `cargo check` on the crate → **clean** (compiles with the new UDF).
- Formatting mirrors the committed sibling `embed_udf.rs` / `scalar_udf.rs` exactly (multi-line FFI signatures, import order) — the local stable rustfmt disagrees with CI's on the *existing* files too, so I matched the committed style rather than the local formatter.
- The parity test runs in the datafusion lane against the maturin-built wheel (hard import — a build break is a test FAILURE, not a skip).

## Remaining DataFusion gaps (follow-ups, documented in the audit)

perceptual (S–M), sketch/LSH (M), HNSW (M) — the last two have their pairing orchestration already written in `postgres/kernels.rs`, liftable into `invoke_with_args`. Not in this PR (kept to the clean single-kernel slice).

## Checklist

- [x] Tests added/updated and passing locally for the changed package (cargo check; parity test runs in CI against the wheel)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (the UDF's own header documents the cross-surface contract; extensions CLAUDE.md's SQL-surface list is a light follow-up)
- [ ] Package `CHANGELOG.md` — N/A (additive SQL surface; no goldenmatch API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA

---
_Generated by [Claude Code](https://claude.ai/code/session_019KeG7htToSUaWqmha2WaaA)_