### PR TITLE
feat(goldenflow): Wave D — text part 1 (mechanical owned kernels, cross-surface)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-goldenflow-wave-d-text-plan.md
+++ b/docs/superpowers/plans/2026-07-04-goldenflow-wave-d-text-plan.md
@@ -1,0 +1,120 @@
+# Wave D text — owned goldenflow-core kernels (cross-surface)
+
+**Program:** GoldenFlow owned-kernel + cross-surface (Rust-is-the-reference).
+**Predecessors:** Wave 0/A/B, D1 email, D2 url, sweep (url/numeric/categorical),
+names-remainder (#1431), address-simple (#1432 — this branch stacks on it).
+**Thesis (Ben, locked):** commit fully — ALL transforms become owned Rust
+kernels; language surfaces fall out of Rust; kernel = spec under reference-mode.
+No "keep it Python" escape hatches. Migration (not addition): count stays 92,
+minor version bumps.
+
+## Scope: the 18 `text` transforms — split into TWO stacked PRs by parity risk
+
+`goldenflow-core::text` ALREADY has `strip` + `collapse_whitespace` kernels
+(P9 #1423, wired for the SQL de-bridge only — NOT yet the native wheel / wasm /
+Python-native dispatch). This wave surfaces those two AND migrates the other 16.
+
+### PR text-1 — mechanical / ASCII-bound (12 transforms + surface the 2 existing)
+All hand-rolled, NO regex dep (JS/Py/Rust regex diverge on `\s`/`\d`/greedy —
+the address/email precedent), ASCII-bounded where a Unicode char-class would
+otherwise leak runtime differences (documented boundary, reference-mode).
+
+| transform | mode | auto | shape / kernel |
+|---|---|---|---|
+| `strip` | expr | **True** | EXISTS `text::strip` — wire surfaces |
+| `collapse_whitespace` | expr | **True** | EXISTS `text::collapse_whitespace` — wire surfaces |
+| `normalize_quotes` | expr | **True** | 6 explicit smart-quote→ASCII replaces |
+| `normalize_line_endings` | expr | False | `\r\n`→`\n` then `\r`→`\n` (literal, order matters) |
+| `truncate(n=255)` | expr | False | char slice `[0,n)` (param) |
+| `pad_left(width=10,char="0")` | expr | False | left-pad to width (param) |
+| `pad_right(width=10,char=" ")` | expr | False | right-pad to width (param) |
+| `remove_html_tags` | expr | False | strip `<...>` spans (hand-rolled scan) |
+| `remove_urls` | expr | False | strip `https?://` + non-whitespace run |
+| `remove_digits` | expr | False | remove ASCII digits (bound; document) |
+| `remove_punctuation` | expr | False | keep ASCII-alnum + whitespace, drop rest |
+| `extract_numbers` | expr | False | extract `\d+\.?\d*` runs, join " " |
+
+- **Parameterized transforms** (`truncate`/`pad_left`/`pad_right`): the kernel is
+  a plain fn `(s, n[, char]) -> String`; the arrow shim/native runner take the
+  params. These are per-column-constant params (like numeric `round(n)`/
+  `clamp(min,max)`), so the runner is `fn(**params) -> Callable[[Series],Series]`
+  — mirror `round_native`/`clamp_native`.
+- **`remove_digits`/`remove_punctuation`/`extract_numbers` char-class boundary:**
+  the old Polars used Rust-regex `\d`/`\s` (Unicode-aware). Owned kernels use
+  ASCII digit (`0-9`) and ASCII-or-Unicode whitespace via `char::is_whitespace`
+  (matches across surfaces for the ASCII whitespace that appears in real data);
+  document that exotic Unicode digits/whitespace are out of the bounded set.
+  Corpus pins realistic ASCII + a couple non-ASCII rows to lock the boundary.
+- All 12 are scalar `string→string` → fit the shared corpus. `truncate`/`pad_*`
+  are parameterized: corpus rows use the DEFAULT params (the harness feeds
+  length-1 arrays through the default-param path); dedicated pinned-vector tests
+  cover non-default params (numeric `round`/`clamp` precedent).
+
+### PR text-2 — Unicode-heavy (6 transforms; explicit-map / bounded)
+The load-bearing parity risk. Casing + NFKD normalization diverge across
+Rust std / Python `str` / JS by Unicode-DB version. Strategy per the
+`name_transliterate` precedent: **explicit curated maps in the crate, replicated
+char-for-char to Py/TS, corpus pinned to UCD-STABLE inputs** (common Latin
+diacritics/ligatures whose casing + NFKD have been fixed for decades). Kernel =
+spec; the rare exotic input is the documented reference-mode boundary.
+
+| transform | mode | auto | strategy |
+|---|---|---|---|
+| `lowercase` | expr | False | Rust `to_lowercase` = spec; corpus = agreeing inputs; document |
+| `uppercase` | expr | False | Rust `to_uppercase` = spec; ß→SS etc. verified equal on Py/JS |
+| `title_case` | expr | False | ASCII-title (reuse `name_proper`'s `ascii_title`) + document boundary |
+| `normalize_unicode` | series | **True** | EXPLICIT NFKD-decompose map (extend the transliterate approach) + strip combining; NO `unicode-normalization` crate dep (its UCD wouldn't match Py/JS runtime) |
+| `fix_mojibake` | series | False | latin-1 encode → utf-8 decode round-trip (deterministic byte op; portable) |
+
+- **`normalize_unicode` is `auto_apply=True`** — highest-risk. Keep the existing
+  ASCII-fast-path (pure-ASCII column → no-op) so zero-config runs on ASCII data
+  are byte-identical AND fast. The owned kernel decomposes via an explicit
+  precomposed→base+combining map (curated superset of the transliterate map,
+  covering the Latin-1 + Latin-Extended-A precomposed range) then drops the
+  combining marks. Bounded + documented; corpus pins the common diacritics.
+- **`lowercase`/`uppercase`:** measure first — Rust `char::to_lowercase`/
+  `to_uppercase` vs Python `str.lower`/`upper` vs JS agree on the FULL BMP for
+  the vast majority; the corpus generator asserts native==python per row, so any
+  divergence surfaces as a corpus-build failure to investigate, not silent drift.
+- **`fix_mojibake`:** port `val.encode("latin-1").decode("utf-8")` exactly —
+  Rust: map each char (must be ≤ U+00FF) to a byte, then `str::from_utf8`; on any
+  failure (char >255, or invalid utf-8) return the original. Deterministic; no
+  Unicode-DB dependency. Verify byte-identical to the Python round-trip.
+
+## Cross-surface fan-out (established recipe, per PR)
+For each kernel: **goldenflow-core::text** (pure Rust + `#[cfg(test)]` tests) →
+**native-flow** `*_arrow` shim → **`_native.py`** `*_native()` runner →
+**Python transform** native-first + byte-matched `_*_py` fallback →
+**goldenflow-wasm** export → **TS** pure-fallback + wasm dispatch →
+**`_native_loader`** `_COMPONENT_SYMBOLS["text"]` (floor symbol `strip_arrow`) →
+**corpus/parity**. All `mode="expr"` transforms keep `func(column)->Expr` via
+`map_batches`.
+
+## Tasks (per PR: TDD, sequential — shared text.rs/text.py/lib.rs/loader/corpus)
+1. goldenflow-core `text.rs` kernels + unit tests (locally testable).
+2. native-flow `text.rs` shim (+ any param-passing arrow fns).
+3. `_native.py` runners + Python migration + `text` loader component.
+4. goldenflow-wasm exports + TS `text.ts` + backend/loader.
+5. Corpus + parity (scalar rows; pinned-vector tests for parameterized/Unicode).
+6. Versions + docs (text-1 → 1.11.0/0.11.0/0.9.0; text-2 → 1.12.0/0.12.0/0.10.0).
+
+## Landmines
+- **Three auto_apply transforms** (`strip`, `collapse_whitespace`,
+  `normalize_quotes` in text-1; `normalize_unicode` in text-2) — a zero-config
+  regression is user-visible. Kernels MUST reproduce the existing output
+  byte-for-byte on realistic inputs; corpus pins them.
+- **`strip`/`collapse_whitespace` already exist** — do NOT re-add the kernels;
+  add the arrow shim + native runner + wasm export + Python native dispatch + TS.
+  Confirm the existing kernel signatures (`strip(&str)->&str`,
+  `collapse_whitespace(&str)->String`) match what the shim needs.
+- **NO regex dep** — hand-roll html-tag/url/number scans + char-class filters.
+- **CI fmt/tsc are the ONLY signal for native-flow fmt + TS** (box OOMs): run
+  `cargo fmt --check` on native-flow AND grep TS for `[A-Za-z0-9]\*/` before push
+  (the names #1431 lesson). Statically cross-check corpus==PURE_TS_FN==wasm keys.
+- **P-series overlap (#1423):** shares `goldenflow-core::text`. Expect lib.rs
+  module-list already has `text`; APPEND kernels, keep both P-series + our fns.
+
+## Base / merge
+text-1 stacks on `feat/goldenflow-wave-d-address` (#1432). text-2 stacks on
+text-1. After each base merges, `git rebase --onto origin/main <base-tip>` then
+open the PR + arm auto-merge (squash).

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.11.0 (2026-07-04)
+
+Wave D (text, part 1): the 13 mechanical/ASCII-bound text transforms are now backed by owned Rust kernels in `goldenflow-core::text` (native + WASM/TS + pure-Python fallback), Rust is the reference implementation. This wave migrated existing transforms to the owned-kernel pattern; it did not add new transforms (count unchanged).
+
+- Migrated: `strip`, `collapse_whitespace`, `normalize_quotes`, `normalize_line_endings`, `remove_html_tags`, `remove_urls`, `remove_digits`, `remove_punctuation`, `remove_emojis`, `extract_numbers` (scalar), plus the parameterized `truncate`, `pad_left`, `pad_right`. (`strip`/`collapse_whitespace` reuse the kernels added in the SQL de-bridge; the rest are new owned kernels.)
+- **Behavior change (reference-mode, resolved in Rust's favor):** the HTML-tag / URL / number-extraction scans and char-class filters are hand-rolled with no regex engine for byte-identical output across Rust/Python/JS. `remove_digits`/`extract_numbers` are bounded to ASCII digits (`0-9`, not the old Unicode-aware `\d`); `remove_emojis` uses the explicit emoji codepoint ranges. `char::is_whitespace` is byte-equal to the old polars `\s`, so `strip`/`collapse_whitespace`/`remove_urls`/`remove_punctuation` whitespace handling is exact. The 10 non-parameterized transforms moved from vectorized Polars to native-first dispatch (the pure-Python fallback runs per-row when the native wheel is absent). Outputs are unchanged for well-formed inputs.
+- The 5 Unicode-heavy text transforms (`lowercase`, `uppercase`, `title_case`, `normalize_unicode`, `fix_mojibake`) are intentionally deferred to a follow-up (text part 2) where the cross-runtime Unicode-casing/normalization parity is handled explicitly.
+
 ## 1.10.0 (2026-07-04)
 
 Wave D (address-simple): the eight US-address transforms are now backed by owned Rust kernels in `goldenflow-core` (native + WASM/TS + pure-Python fallback), Rust is the reference implementation. This wave migrated existing transforms to the owned-kernel pattern; it did not add new transforms (count unchanged).

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -287,6 +287,26 @@ package. Loader discover order in `goldenflow/core/_native_loader.py`:
   hand-rolling is the parity guarantee (email.rs precedent). US-scoped; i18n
   addresses stay Wave C (deferred). The 7 scalar transforms live in the shared
   corpus; `split_address` gets pinned-vector `test_address_kernels.py`.
+- **Text family, part 1 migrated to owned kernels (Wave D text-1).** 13
+  mechanical/ASCII-bound text transforms now dispatch native-first through
+  goldenflow-core (`strip`/`collapse_whitespace` reuse the SQL de-bridge
+  kernels; `normalize_quotes`/`normalize_line_endings`/`remove_html_tags`/
+  `remove_urls`/`remove_digits`/`remove_punctuation`/`remove_emojis`/
+  `extract_numbers` new; `truncate`/`pad_left`/`pad_right` parameterized), all
+  wired via the single `"text"` `_native_loader` component (floor symbol
+  `strip_arrow`). `strip`/`collapse_whitespace` stay `auto_apply=True` (plus
+  `normalize_quotes`); the rest `auto_apply=False`. All `mode="expr"` via
+  `map_batches`. **NO regex dep** in the kernels (html-tag/url/number scans +
+  char-class filters hand-rolled). `char::is_whitespace` == polars `\s` (proven
+  in `text_golden.rs`), so the whitespace kernels are EXACT; `\d` is bounded to
+  ASCII `[0-9]` and `remove_emojis` uses explicit codepoint ranges (documented
+  boundaries). The parameterized `truncate`/`pad_left`/`pad_right` take
+  per-column-constant params through the arrow shim (`#[pyo3(signature)]`
+  defaults, mirroring `round`/`clamp`); their non-default-param behavior lives
+  in pinned-vector `test_text_kernels.py`, the 10 scalar transforms in the
+  shared corpus. **text-2 (deferred):** `lowercase`/`uppercase`/`title_case`/
+  `normalize_unicode`/`fix_mojibake` (Unicode-casing/NFKD parity, explicit-map
+  bounded like `name_transliterate`).
 - **Byte-parity harness (cross-surface oracle = goldenflow-core).**
   `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` (mirrored
   byte-identical into `packages/typescript/goldenflow/tests/parity/`) is the

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -121,6 +121,12 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # unit_normalize (scalar) + split_address (1->4 quad) -- floor symbol only
     # (address_standardize_arrow), US-scoped/locale-free.
     "address": ("address_standardize_arrow",),
+    # text: the mechanical text family (strip/collapse_whitespace/
+    # normalize_quotes/normalize_line_endings/truncate/pad_left/pad_right/
+    # remove_html_tags/remove_urls/remove_digits/remove_punctuation/
+    # remove_emojis/extract_numbers) -- floor symbol only (strip_arrow),
+    # locale-free (ASCII-bounded char classes; explicit emoji ranges).
+    "text": ("strip_arrow",),
 }
 
 # Components whose only native path is intentionally non-authoritative (the

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -558,6 +558,110 @@ def split_address_native() -> (
     return run
 
 
+def _text_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for a scalar text kernel function ``attr``
+    (strip/collapse_whitespace/normalize_quotes/normalize_line_endings/
+    remove_html_tags/remove_urls/remove_digits/remove_punctuation/
+    remove_emojis/extract_numbers) if native ``text`` is enabled and
+    importable; else ``None``. Single string array in, one out."""
+    if not native_enabled("text"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow()))
+
+    return run
+
+
+def strip_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("strip_arrow")
+
+
+def collapse_whitespace_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("collapse_whitespace_arrow")
+
+
+def normalize_quotes_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("normalize_quotes_arrow")
+
+
+def normalize_line_endings_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("normalize_line_endings_arrow")
+
+
+def remove_html_tags_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("remove_html_tags_arrow")
+
+
+def remove_urls_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("remove_urls_arrow")
+
+
+def remove_digits_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("remove_digits_arrow")
+
+
+def remove_punctuation_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("remove_punctuation_arrow")
+
+
+def remove_emojis_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("remove_emojis_arrow")
+
+
+def extract_numbers_native() -> Callable[[pl.Series], pl.Series] | None:
+    return _text_kernel_runner("extract_numbers_arrow")
+
+
+def _text_param_kernel_runner(
+    attr: str, **kwargs: int | str
+) -> Callable[[pl.Series], pl.Series] | None:
+    """Build a whole-series runner for a PARAMETERIZED text kernel function
+    ``attr`` (truncate/pad_left/pad_right) if native ``text`` is enabled and
+    importable; else ``None``. The per-column-constant params (``n`` for
+    truncate, ``width``/``pad`` for the pads) are forwarded as kwargs to the
+    kernel call, mirroring the numeric ``round``/``clamp`` runners."""
+    if not native_enabled("text"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(s: pl.Series) -> pl.Series:
+        return pl.from_arrow(func(_as_str_series(s).to_arrow(), **kwargs))
+
+    return run
+
+
+def truncate_native(n: int = 255) -> Callable[[pl.Series], pl.Series] | None:
+    return _text_param_kernel_runner("truncate_arrow", n=n)
+
+
+def pad_left_native(
+    width: int = 10, pad: str = "0"
+) -> Callable[[pl.Series], pl.Series] | None:
+    return _text_param_kernel_runner("pad_left_arrow", width=width, pad=pad)
+
+
+def pad_right_native(
+    width: int = 10, pad: str = " "
+) -> Callable[[pl.Series], pl.Series] | None:
+    return _text_param_kernel_runner("pad_right_arrow", width=width, pad=pad)
+
+
 def _email_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
     """Build a whole-series runner for email kernel function ``attr`` if
     native ``email`` is enabled and the dependencies are importable; else

--- a/packages/python/goldenflow/goldenflow/transforms/text.py
+++ b/packages/python/goldenflow/goldenflow/transforms/text.py
@@ -6,11 +6,350 @@ import unicodedata
 import polars as pl
 
 from goldenflow.transforms import register_transform
+from goldenflow.transforms._native import (
+    collapse_whitespace_native,
+    extract_numbers_native,
+    normalize_line_endings_native,
+    normalize_quotes_native,
+    pad_left_native,
+    pad_right_native,
+    remove_digits_native,
+    remove_emojis_native,
+    remove_html_tags_native,
+    remove_punctuation_native,
+    remove_urls_native,
+    strip_native,
+    truncate_native,
+)
+
+# --- Wave D text-1: mechanical / ASCII-bound transforms migrated to owned
+# goldenflow-core::text kernels (native-first + byte-matched pure-Python
+# fallback = the reference under reference-mode). All are mode="expr",
+# dispatched via map_batches so the func(column)->Expr signature is unchanged.
+# The pure-Python fallbacks reproduce the Rust kernel bytes; where a kernel is
+# ASCII-bounded (remove_digits/extract_numbers), the fallback uses an explicit
+# ASCII char class ([0-9]) NOT `\d`, to match the kernel not the old polars.
+
+
+def _strip_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return val.strip()
+
+
+def _strip_series(series: pl.Series) -> pl.Series:
+    native = strip_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_strip_py, return_dtype=pl.Utf8)
 
 
 @register_transform(name="strip", input_types=["string"], auto_apply=True, priority=90, mode="expr")
 def strip(column: str) -> pl.Expr:
-    return pl.col(column).str.strip_chars()
+    return pl.col(column).map_batches(_strip_series, return_dtype=pl.Utf8)
+
+
+def _collapse_whitespace_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return re.sub(r"\s{2,}", " ", val)
+
+
+def _collapse_whitespace_series(series: pl.Series) -> pl.Series:
+    native = collapse_whitespace_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_collapse_whitespace_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="collapse_whitespace", input_types=["string"], auto_apply=True, priority=80, mode="expr"
+)
+def collapse_whitespace(column: str) -> pl.Expr:
+    return pl.col(column).map_batches(_collapse_whitespace_series, return_dtype=pl.Utf8)
+
+
+def _normalize_quotes_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return (
+        val.replace("“", '"')
+        .replace("”", '"')
+        .replace("‘", "'")
+        .replace("’", "'")
+        .replace("″", '"')
+        .replace("′", "'")
+    )
+
+
+def _normalize_quotes_series(series: pl.Series) -> pl.Series:
+    native = normalize_quotes_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_normalize_quotes_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="normalize_quotes", input_types=["string"], auto_apply=True, priority=84, mode="expr"
+)
+def normalize_quotes(column: str) -> pl.Expr:
+    """Replace smart/curly quotes with straight quotes."""
+    return pl.col(column).map_batches(_normalize_quotes_series, return_dtype=pl.Utf8)
+
+
+def _normalize_line_endings_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return val.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _normalize_line_endings_series(series: pl.Series) -> pl.Series:
+    native = normalize_line_endings_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_normalize_line_endings_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="normalize_line_endings", input_types=["string"], auto_apply=False, priority=82,
+    mode="expr",
+)
+def normalize_line_endings(column: str) -> pl.Expr:
+    r"""Normalize \r\n and \r to \n."""
+    return pl.col(column).map_batches(_normalize_line_endings_series, return_dtype=pl.Utf8)
+
+
+def _remove_html_tags_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return re.sub(r"<[^>]+>", "", val)
+
+
+def _remove_html_tags_series(series: pl.Series) -> pl.Series:
+    native = remove_html_tags_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_remove_html_tags_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="remove_html_tags", input_types=["string"], auto_apply=False, priority=45, mode="expr"
+)
+def remove_html_tags(column: str) -> pl.Expr:
+    """Strip HTML tags from text."""
+    return pl.col(column).map_batches(_remove_html_tags_series, return_dtype=pl.Utf8)
+
+
+def _remove_urls_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return re.sub(r"https?://\S+", "", val)
+
+
+def _remove_urls_series(series: pl.Series) -> pl.Series:
+    native = remove_urls_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_remove_urls_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="remove_urls", input_types=["string"], auto_apply=False, priority=40, mode="expr"
+)
+def remove_urls(column: str) -> pl.Expr:
+    """Strip URLs (http/https) from text."""
+    return pl.col(column).map_batches(_remove_urls_series, return_dtype=pl.Utf8)
+
+
+def _remove_digits_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    # ASCII-bounded to match the Rust kernel (NOT `\d`, which is Unicode-aware).
+    return re.sub(r"[0-9]", "", val)
+
+
+def _remove_digits_series(series: pl.Series) -> pl.Series:
+    native = remove_digits_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_remove_digits_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="remove_digits", input_types=["string"], auto_apply=False, priority=35, mode="expr"
+)
+def remove_digits(column: str) -> pl.Expr:
+    """Remove all digit characters from text."""
+    return pl.col(column).map_batches(_remove_digits_series, return_dtype=pl.Utf8)
+
+
+def _remove_punctuation_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return re.sub(r"[^a-zA-Z0-9\s]", "", val)
+
+
+def _remove_punctuation_series(series: pl.Series) -> pl.Series:
+    native = remove_punctuation_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_remove_punctuation_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="remove_punctuation", input_types=["string"], auto_apply=False, priority=40, mode="expr"
+)
+def remove_punctuation(column: str) -> pl.Expr:
+    return pl.col(column).map_batches(_remove_punctuation_series, return_dtype=pl.Utf8)
+
+
+_EMOJI_RE = re.compile(
+    "["
+    "\U0001f600-\U0001f64f"  # emoticons
+    "\U0001f300-\U0001f5ff"  # symbols & pictographs
+    "\U0001f680-\U0001f6ff"  # transport & map
+    "\U0001f1e0-\U0001f1ff"  # flags
+    "\U00002702-\U000027b0"  # dingbats
+    "\U000024c2-\U0001f251"  # enclosed characters
+    "\U0001f900-\U0001f9ff"  # supplemental symbols
+    "\U0001fa00-\U0001fa6f"  # chess symbols
+    "\U0001fa70-\U0001faff"  # symbols extended-A
+    "\U00002600-\U000026ff"  # misc symbols
+    "\U0000200d"             # zero-width joiner
+    "\U0000fe0f"             # variation selector
+    "]+",
+    flags=re.UNICODE,
+)
+
+
+def _remove_emojis_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    return _EMOJI_RE.sub("", val)
+
+
+def _remove_emojis_series(series: pl.Series) -> pl.Series:
+    native = remove_emojis_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_remove_emojis_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="remove_emojis", input_types=["string"], auto_apply=False, priority=38, mode="expr"
+)
+def remove_emojis(column: str) -> pl.Expr:
+    """Remove emoji characters from text."""
+    return pl.col(column).map_batches(_remove_emojis_series, return_dtype=pl.Utf8)
+
+
+def _extract_numbers_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    # ASCII-bounded to match the Rust kernel (NOT `\d`).
+    return " ".join(re.findall(r"[0-9]+\.?[0-9]*", val))
+
+
+def _extract_numbers_series(series: pl.Series) -> pl.Series:
+    native = extract_numbers_native()
+    if native is not None:
+        return native(series)
+    return series.map_elements(_extract_numbers_py, return_dtype=pl.Utf8)
+
+
+@register_transform(
+    name="extract_numbers", input_types=["string"], auto_apply=False, priority=30, mode="expr"
+)
+def extract_numbers(column: str) -> pl.Expr:
+    """Extract all numbers from text, joined by spaces."""
+    return pl.col(column).map_batches(_extract_numbers_series, return_dtype=pl.Utf8)
+
+
+# --- parameterized text transforms (truncate / pad_left / pad_right). The
+# per-column-constant params are captured into the map_batches closure; the
+# non-default-param behavior is pinned in tests/transforms/test_text_kernels.py
+# (the numeric round/clamp precedent), so these don't sit in the shared corpus.
+
+
+def _truncate_py(val: str | None, n: int) -> str | None:
+    if val is None:
+        return None
+    return val[:n]
+
+
+@register_transform(name="truncate", input_types=["string"], auto_apply=False, priority=30,
+                    mode="expr")
+def truncate(column: str, n: int | str = 255) -> pl.Expr:
+    """Truncate string to the first n characters.
+
+    Native-first (goldenflow-core's ``text::truncate`` kernel); the pure-Python
+    fallback is the byte-exact reference. Accepts str or int for ``n`` (the
+    engine passes config params as strings).
+    """
+    nn = int(n)
+
+    def _series(series: pl.Series) -> pl.Series:
+        native = truncate_native(nn)
+        if native is not None:
+            return native(series)
+        return series.map_elements(lambda v: _truncate_py(v, nn), return_dtype=pl.Utf8)
+
+    return pl.col(column).map_batches(_series, return_dtype=pl.Utf8)
+
+
+def _pad_left_py(val: str | None, width: int, pad: str) -> str | None:
+    if val is None:
+        return None
+    return val.rjust(width, pad)
+
+
+@register_transform(name="pad_left", input_types=["string"], auto_apply=False, priority=30,
+                    mode="expr")
+def pad_left(column: str, width: int | str = 10, char: str = "0") -> pl.Expr:
+    """Left-pad strings to a fixed width.
+
+    Native-first (goldenflow-core's ``text::pad_left`` kernel); the pure-Python
+    fallback is the byte-exact reference.
+    """
+    w = int(width)
+
+    def _series(series: pl.Series) -> pl.Series:
+        native = pad_left_native(w, char)
+        if native is not None:
+            return native(series)
+        return series.map_elements(lambda v: _pad_left_py(v, w, char), return_dtype=pl.Utf8)
+
+    return pl.col(column).map_batches(_series, return_dtype=pl.Utf8)
+
+
+def _pad_right_py(val: str | None, width: int, pad: str) -> str | None:
+    if val is None:
+        return None
+    return val.ljust(width, pad)
+
+
+@register_transform(name="pad_right", input_types=["string"], auto_apply=False, priority=30,
+                    mode="expr")
+def pad_right(column: str, width: int | str = 10, char: str = " ") -> pl.Expr:
+    """Right-pad strings to a fixed width.
+
+    Native-first (goldenflow-core's ``text::pad_right`` kernel); the pure-Python
+    fallback is the byte-exact reference.
+    """
+    w = int(width)
+
+    def _series(series: pl.Series) -> pl.Series:
+        native = pad_right_native(w, char)
+        if native is not None:
+            return native(series)
+        return series.map_elements(lambda v: _pad_right_py(v, w, char), return_dtype=pl.Utf8)
+
+    return pl.col(column).map_batches(_series, return_dtype=pl.Utf8)
+
+
+# --- text-2 (Unicode-heavy) transforms: NOT yet migrated to owned kernels.
+# lowercase / uppercase / title_case / normalize_unicode / fix_mojibake stay
+# pure-Polars/Python until Wave D text-2 (explicit-map/bounded Unicode work).
 
 
 @register_transform(
@@ -68,183 +407,6 @@ def normalize_unicode(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="remove_punctuation", input_types=["string"], auto_apply=False, priority=40, mode="expr"
-)
-def remove_punctuation(column: str) -> pl.Expr:
-    return pl.col(column).str.replace_all(r"[^a-zA-Z0-9\s]", "")
-
-
-@register_transform(
-    name="collapse_whitespace", input_types=["string"], auto_apply=True, priority=80, mode="expr"
-)
-def collapse_whitespace(column: str) -> pl.Expr:
-    return pl.col(column).str.replace_all(r"\s{2,}", " ")
-
-
-@register_transform(
-    name="truncate", input_types=["string"], auto_apply=False, priority=30, mode="expr"
-)
-def truncate(column: str, n: int | str = 255) -> pl.Expr:
-    """Truncate string to first n characters.
-
-    Native Polars: str.slice. Accepts str or int for `n` because the engine
-    passes config params as strings; tests + code passing kwargs use int.
-    Spec docs/superpowers/specs/2026-05-15-map-elements-attack-design.md
-    Tier 1 (parameterized).
-    """
-    return pl.col(column).str.slice(0, int(n))
-
-
-@register_transform(
-    name="normalize_quotes",
-    input_types=["string"],
-    auto_apply=True,
-    priority=84,
-    mode="expr",
-)
-def normalize_quotes(column: str) -> pl.Expr:
-    """Replace smart/curly quotes with straight quotes."""
-    return (
-        pl.col(column)
-        .str.replace_all("\u201c", '"')   # left double
-        .str.replace_all("\u201d", '"')   # right double
-        .str.replace_all("\u2018", "'")   # left single
-        .str.replace_all("\u2019", "'")   # right single
-        .str.replace_all("\u2033", '"')   # double prime
-        .str.replace_all("\u2032", "'")   # prime
-    )
-
-
-@register_transform(
-    name="remove_html_tags",
-    input_types=["string"],
-    auto_apply=False,
-    priority=45,
-    mode="expr",
-)
-def remove_html_tags(column: str) -> pl.Expr:
-    """Strip HTML tags from text.
-
-    Native Polars regex replace_all. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    return pl.col(column).str.replace_all(r"<[^>]+>", "")
-
-
-@register_transform(
-    name="remove_urls",
-    input_types=["string"],
-    auto_apply=False,
-    priority=40,
-    mode="expr",
-)
-def remove_urls(column: str) -> pl.Expr:
-    """Strip URLs (http/https) from text.
-
-    Native Polars regex replace_all. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    return pl.col(column).str.replace_all(r"https?://\S+", "")
-
-
-@register_transform(
-    name="remove_digits",
-    input_types=["string"],
-    auto_apply=False,
-    priority=35,
-    mode="expr",
-)
-def remove_digits(column: str) -> pl.Expr:
-    """Remove all digit characters from text."""
-    return pl.col(column).str.replace_all(r"\d", "")
-
-
-@register_transform(
-    name="pad_left",
-    input_types=["string"],
-    auto_apply=False,
-    priority=30,
-    mode="expr",
-)
-def pad_left(column: str, width: int | str = 10, char: str = "0") -> pl.Expr:
-    """Left-pad strings to a fixed width.
-
-    Native Polars: str.pad_start. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    return pl.col(column).str.pad_start(int(width), char)
-
-
-@register_transform(
-    name="pad_right",
-    input_types=["string"],
-    auto_apply=False,
-    priority=30,
-    mode="expr",
-)
-def pad_right(column: str, width: int | str = 10, char: str = " ") -> pl.Expr:
-    """Right-pad strings to a fixed width.
-
-    Native Polars: str.pad_end. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    return pl.col(column).str.pad_end(int(width), char)
-
-
-_EMOJI_RE = re.compile(
-    "["
-    "\U0001f600-\U0001f64f"  # emoticons
-    "\U0001f300-\U0001f5ff"  # symbols & pictographs
-    "\U0001f680-\U0001f6ff"  # transport & map
-    "\U0001f1e0-\U0001f1ff"  # flags
-    "\U00002702-\U000027b0"  # dingbats
-    "\U000024c2-\U0001f251"  # enclosed characters
-    "\U0001f900-\U0001f9ff"  # supplemental symbols
-    "\U0001fa00-\U0001fa6f"  # chess symbols
-    "\U0001fa70-\U0001faff"  # symbols extended-A
-    "\U00002600-\U000026ff"  # misc symbols
-    "\U0000200d"             # zero-width joiner
-    "\U0000fe0f"             # variation selector
-    "]+",
-    flags=re.UNICODE,
-)
-
-
-_EMOJI_PATTERN = (
-    "["
-    "\U0001f600-\U0001f64f"
-    "\U0001f300-\U0001f5ff"
-    "\U0001f680-\U0001f6ff"
-    "\U0001f1e0-\U0001f1ff"
-    "\U00002702-\U000027b0"
-    "\U000024c2-\U0001f251"
-    "\U0001f900-\U0001f9ff"
-    "\U0001fa00-\U0001fa6f"
-    "\U0001fa70-\U0001faff"
-    "\U00002600-\U000026ff"
-    "\U0000200d"
-    "\U0000fe0f"
-    "]+"
-)
-
-
-@register_transform(
-    name="remove_emojis",
-    input_types=["string"],
-    auto_apply=False,
-    priority=38,
-    mode="expr",
-)
-def remove_emojis(column: str) -> pl.Expr:
-    """Remove emoji characters from text.
-
-    Native Polars regex replace_all. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    return pl.col(column).str.replace_all(_EMOJI_PATTERN, "")
-
-
-@register_transform(
     name="fix_mojibake",
     input_types=["string"],
     auto_apply=False,
@@ -263,43 +425,3 @@ def fix_mojibake(series: pl.Series) -> pl.Series:
             return val
 
     return series.map_elements(_fix, return_dtype=pl.Utf8)
-
-
-@register_transform(
-    name="normalize_line_endings",
-    input_types=["string"],
-    auto_apply=False,
-    priority=82,
-    mode="expr",
-)
-def normalize_line_endings(column: str) -> pl.Expr:
-    """Normalize \\r\\n and \\r to \\n.
-
-    Native Polars: chained literal replace_all. Order matters — replace
-    \\r\\n first (longer match wins), then any remaining \\r. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    return (
-        pl.col(column)
-        .str.replace_all("\r\n", "\n", literal=True)
-        .str.replace_all("\r", "\n", literal=True)
-    )
-
-
-_NUMBER_RE = re.compile(r"\d+\.?\d*")
-
-
-@register_transform(
-    name="extract_numbers",
-    input_types=["string"],
-    auto_apply=False,
-    priority=30,
-    mode="expr",
-)
-def extract_numbers(column: str) -> pl.Expr:
-    """Extract all numbers from text, joined by spaces.
-
-    Native Polars: extract_all → list.join. Spec
-    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
-    """
-    return pl.col(column).str.extract_all(r"\d+\.?\d*").list.join(" ")

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.10.0"
+version = "1.11.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
+++ b/packages/python/goldenflow/scripts/gen_identifiers_corpus.py
@@ -81,6 +81,18 @@ from goldenflow.transforms.numeric import (  # noqa: E402
     _scientific_to_decimal_py,
     _to_integer_py,
 )
+from goldenflow.transforms.text import (  # noqa: E402
+    _collapse_whitespace_py,
+    _extract_numbers_py,
+    _normalize_line_endings_py,
+    _normalize_quotes_py,
+    _remove_digits_py,
+    _remove_emojis_py,
+    _remove_html_tags_py,
+    _remove_punctuation_py,
+    _remove_urls_py,
+    _strip_py,
+)
 from goldenflow.transforms.url import (  # noqa: E402
     _url_extract_domain_py,
     _url_normalize_py,
@@ -471,6 +483,71 @@ _CASES: list[tuple[str, str | None]] = [
     ("unit_normalize", "  Building C  "),  # no designator -> trimmed
     ("unit_normalize", ""),  # empty
     ("unit_normalize", None),  # null
+    # --- strip (auto_apply; leading/trailing whitespace) ---
+    ("strip", "  hello  "),
+    ("strip", "a    b   c"),  # internal untouched
+    ("strip", " nbsp "),  # NBSP is whitespace
+    ("strip", "nochange"),
+    ("strip", ""),
+    ("strip", None),
+    # --- collapse_whitespace (auto_apply; runs of 2+ -> single space) ---
+    ("collapse_whitespace", "a    b   c"),
+    ("collapse_whitespace", "a\tb"),  # lone ws unchanged
+    ("collapse_whitespace", "a\t\tb"),  # 2-run -> space
+    ("collapse_whitespace", "  lead"),  # leading run
+    ("collapse_whitespace", ""),
+    ("collapse_whitespace", None),
+    # --- normalize_quotes (auto_apply; smart quotes -> ASCII) ---
+    ("normalize_quotes", "“hi”"),
+    ("normalize_quotes", "it’s"),
+    ("normalize_quotes", "‘a’"),
+    ("normalize_quotes", "5″ x 3′"),
+    ("normalize_quotes", "plain"),
+    ("normalize_quotes", None),
+    # --- normalize_line_endings ---
+    ("normalize_line_endings", "a\r\nb"),
+    ("normalize_line_endings", "a\rb"),
+    ("normalize_line_endings", "a\nb"),
+    ("normalize_line_endings", "a\r\r b"),
+    ("normalize_line_endings", "a\r\n\rb"),
+    ("normalize_line_endings", None),
+    # --- remove_html_tags ---
+    ("remove_html_tags", "<b>hi</b>"),
+    ("remove_html_tags", 'a <a href="x">link</a> b'),
+    ("remove_html_tags", "<>"),  # empty tag not matched
+    ("remove_html_tags", "2 < 3"),  # no closing '>'
+    ("remove_html_tags", "<unclosed"),
+    ("remove_html_tags", None),
+    # --- remove_urls ---
+    ("remove_urls", "see http://x.com/y now"),
+    ("remove_urls", "https://a.com?q=1 end"),
+    ("remove_urls", "no url here"),
+    ("remove_urls", "http:// x"),  # bare scheme, no non-ws -> no match
+    ("remove_urls", None),
+    # --- remove_digits (ASCII-bounded) ---
+    ("remove_digits", "abc123def"),
+    ("remove_digits", "no digits"),
+    ("remove_digits", "42"),
+    ("remove_digits", None),
+    # --- remove_punctuation (keep ASCII-alnum + whitespace) ---
+    ("remove_punctuation", "hello, world!"),
+    ("remove_punctuation", "a-b_c.d"),
+    ("remove_punctuation", "keep 123 ok"),
+    ("remove_punctuation", "café"),  # non-ASCII letter dropped
+    ("remove_punctuation", None),
+    # --- remove_emojis (explicit codepoint ranges) ---
+    ("remove_emojis", "hi \U0001f600 there"),
+    ("remove_emojis", "\U0001f680\U0001f600rocket"),
+    ("remove_emojis", "no emoji"),
+    ("remove_emojis", "café"),  # accented letter kept
+    ("remove_emojis", None),
+    # --- extract_numbers (ASCII-bounded) ---
+    ("extract_numbers", "abc12.5def7"),
+    ("extract_numbers", "price $9.99 x2"),
+    ("extract_numbers", "no numbers"),
+    ("extract_numbers", "12."),  # greedy dot, empty trailing
+    ("extract_numbers", "3.14.159"),
+    ("extract_numbers", None),
     # --- currency_strip (string->float; VALUE parity, not repr) ---
     ("currency_strip", "$1,234.56"),  # strip $ and comma
     ("currency_strip", "-$42.00"),  # negative, dollar sign
@@ -598,6 +675,16 @@ _PY_FN = {
     "zip_normalize": _zip_normalize_py,
     "country_standardize": _country_standardize_py,
     "unit_normalize": _unit_normalize_py,
+    "strip": _strip_py,
+    "collapse_whitespace": _collapse_whitespace_py,
+    "normalize_quotes": _normalize_quotes_py,
+    "normalize_line_endings": _normalize_line_endings_py,
+    "remove_html_tags": _remove_html_tags_py,
+    "remove_urls": _remove_urls_py,
+    "remove_digits": _remove_digits_py,
+    "remove_punctuation": _remove_punctuation_py,
+    "remove_emojis": _remove_emojis_py,
+    "extract_numbers": _extract_numbers_py,
     "currency_strip": _currency_strip_py,
     "percentage_normalize": _percentage_normalize_py,
     "to_integer": _to_integer_py,
@@ -644,6 +731,16 @@ _NATIVE_ARROW_FN = {
     "zip_normalize": "zip_normalize_arrow",
     "country_standardize": "country_standardize_arrow",
     "unit_normalize": "unit_normalize_arrow",
+    "strip": "strip_arrow",
+    "collapse_whitespace": "collapse_whitespace_arrow",
+    "normalize_quotes": "normalize_quotes_arrow",
+    "normalize_line_endings": "normalize_line_endings_arrow",
+    "remove_html_tags": "remove_html_tags_arrow",
+    "remove_urls": "remove_urls_arrow",
+    "remove_digits": "remove_digits_arrow",
+    "remove_punctuation": "remove_punctuation_arrow",
+    "remove_emojis": "remove_emojis_arrow",
+    "extract_numbers": "extract_numbers_arrow",
     "currency_strip": "currency_strip_arrow",
     "percentage_normalize": "percentage_normalize_arrow",
     "to_integer": "to_integer_arrow",

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -324,6 +324,61 @@
 {"transform": "unit_normalize", "input": "  Building C  ", "expected": "Building C"}
 {"transform": "unit_normalize", "input": "", "expected": ""}
 {"transform": "unit_normalize", "input": null, "expected": null}
+{"transform": "strip", "input": "  hello  ", "expected": "hello"}
+{"transform": "strip", "input": "a    b   c", "expected": "a    b   c"}
+{"transform": "strip", "input": " nbsp ", "expected": "nbsp"}
+{"transform": "strip", "input": "nochange", "expected": "nochange"}
+{"transform": "strip", "input": "", "expected": ""}
+{"transform": "strip", "input": null, "expected": null}
+{"transform": "collapse_whitespace", "input": "a    b   c", "expected": "a b c"}
+{"transform": "collapse_whitespace", "input": "a\tb", "expected": "a\tb"}
+{"transform": "collapse_whitespace", "input": "a\t\tb", "expected": "a b"}
+{"transform": "collapse_whitespace", "input": "  lead", "expected": " lead"}
+{"transform": "collapse_whitespace", "input": "", "expected": ""}
+{"transform": "collapse_whitespace", "input": null, "expected": null}
+{"transform": "normalize_quotes", "input": "“hi”", "expected": "\"hi\""}
+{"transform": "normalize_quotes", "input": "it’s", "expected": "it's"}
+{"transform": "normalize_quotes", "input": "‘a’", "expected": "'a'"}
+{"transform": "normalize_quotes", "input": "5″ x 3′", "expected": "5\" x 3'"}
+{"transform": "normalize_quotes", "input": "plain", "expected": "plain"}
+{"transform": "normalize_quotes", "input": null, "expected": null}
+{"transform": "normalize_line_endings", "input": "a\r\nb", "expected": "a\nb"}
+{"transform": "normalize_line_endings", "input": "a\rb", "expected": "a\nb"}
+{"transform": "normalize_line_endings", "input": "a\nb", "expected": "a\nb"}
+{"transform": "normalize_line_endings", "input": "a\r\r b", "expected": "a\n\n b"}
+{"transform": "normalize_line_endings", "input": "a\r\n\rb", "expected": "a\n\nb"}
+{"transform": "normalize_line_endings", "input": null, "expected": null}
+{"transform": "remove_html_tags", "input": "<b>hi</b>", "expected": "hi"}
+{"transform": "remove_html_tags", "input": "a <a href=\"x\">link</a> b", "expected": "a link b"}
+{"transform": "remove_html_tags", "input": "<>", "expected": "<>"}
+{"transform": "remove_html_tags", "input": "2 < 3", "expected": "2 < 3"}
+{"transform": "remove_html_tags", "input": "<unclosed", "expected": "<unclosed"}
+{"transform": "remove_html_tags", "input": null, "expected": null}
+{"transform": "remove_urls", "input": "see http://x.com/y now", "expected": "see  now"}
+{"transform": "remove_urls", "input": "https://a.com?q=1 end", "expected": " end"}
+{"transform": "remove_urls", "input": "no url here", "expected": "no url here"}
+{"transform": "remove_urls", "input": "http:// x", "expected": "http:// x"}
+{"transform": "remove_urls", "input": null, "expected": null}
+{"transform": "remove_digits", "input": "abc123def", "expected": "abcdef"}
+{"transform": "remove_digits", "input": "no digits", "expected": "no digits"}
+{"transform": "remove_digits", "input": "42", "expected": ""}
+{"transform": "remove_digits", "input": null, "expected": null}
+{"transform": "remove_punctuation", "input": "hello, world!", "expected": "hello world"}
+{"transform": "remove_punctuation", "input": "a-b_c.d", "expected": "abcd"}
+{"transform": "remove_punctuation", "input": "keep 123 ok", "expected": "keep 123 ok"}
+{"transform": "remove_punctuation", "input": "café", "expected": "caf"}
+{"transform": "remove_punctuation", "input": null, "expected": null}
+{"transform": "remove_emojis", "input": "hi 😀 there", "expected": "hi  there"}
+{"transform": "remove_emojis", "input": "🚀😀rocket", "expected": "rocket"}
+{"transform": "remove_emojis", "input": "no emoji", "expected": "no emoji"}
+{"transform": "remove_emojis", "input": "café", "expected": "café"}
+{"transform": "remove_emojis", "input": null, "expected": null}
+{"transform": "extract_numbers", "input": "abc12.5def7", "expected": "12.5 7"}
+{"transform": "extract_numbers", "input": "price $9.99 x2", "expected": "9.99 2"}
+{"transform": "extract_numbers", "input": "no numbers", "expected": ""}
+{"transform": "extract_numbers", "input": "12.", "expected": "12."}
+{"transform": "extract_numbers", "input": "3.14.159", "expected": "3.14 159"}
+{"transform": "extract_numbers", "input": null, "expected": null}
 {"transform": "currency_strip", "input": "$1,234.56", "expected": 1234.56}
 {"transform": "currency_strip", "input": "-$42.00", "expected": -42.0}
 {"transform": "currency_strip", "input": "USD 100", "expected": 100.0}

--- a/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_identifiers_parity.py
@@ -82,6 +82,36 @@ from goldenflow.transforms.numeric import (
     comma_decimal,
     scientific_to_decimal,
 )
+from goldenflow.transforms.text import (
+    _collapse_whitespace_series as collapse_whitespace,
+)
+from goldenflow.transforms.text import (
+    _extract_numbers_series as extract_numbers,
+)
+from goldenflow.transforms.text import (
+    _normalize_line_endings_series as normalize_line_endings,
+)
+from goldenflow.transforms.text import (
+    _normalize_quotes_series as normalize_quotes,
+)
+from goldenflow.transforms.text import (
+    _remove_digits_series as remove_digits,
+)
+from goldenflow.transforms.text import (
+    _remove_emojis_series as remove_emojis,
+)
+from goldenflow.transforms.text import (
+    _remove_html_tags_series as remove_html_tags,
+)
+from goldenflow.transforms.text import (
+    _remove_punctuation_series as remove_punctuation,
+)
+from goldenflow.transforms.text import (
+    _remove_urls_series as remove_urls,
+)
+from goldenflow.transforms.text import (
+    _strip_series as strip,
+)
 from goldenflow.transforms.url import url_extract_domain, url_normalize
 
 _CORPUS_PATH = Path(__file__).parent.parent / "parity" / "identifiers_corpus.jsonl"
@@ -157,6 +187,16 @@ _TRANSFORMS = {
     "zip_normalize": zip_normalize,
     "country_standardize": country_standardize,
     "unit_normalize": unit_normalize,
+    "strip": strip,
+    "collapse_whitespace": collapse_whitespace,
+    "normalize_quotes": normalize_quotes,
+    "normalize_line_endings": normalize_line_endings,
+    "remove_html_tags": remove_html_tags,
+    "remove_urls": remove_urls,
+    "remove_digits": remove_digits,
+    "remove_punctuation": remove_punctuation,
+    "remove_emojis": remove_emojis,
+    "extract_numbers": extract_numbers,
     "currency_strip": currency_strip,
     "percentage_normalize": percentage_normalize,
     "to_integer": to_integer,
@@ -214,6 +254,18 @@ _NATIVE_FLOOR_SYMBOL = {
     "zip_normalize": "address_standardize_arrow",
     "country_standardize": "address_standardize_arrow",
     "unit_normalize": "address_standardize_arrow",
+    # text: the mechanical text family wired via the single "text" component
+    # (floor symbol strip_arrow), locale-free (ASCII-bounded / explicit ranges).
+    "strip": "strip_arrow",
+    "collapse_whitespace": "strip_arrow",
+    "normalize_quotes": "strip_arrow",
+    "normalize_line_endings": "strip_arrow",
+    "remove_html_tags": "strip_arrow",
+    "remove_urls": "strip_arrow",
+    "remove_digits": "strip_arrow",
+    "remove_punctuation": "strip_arrow",
+    "remove_emojis": "strip_arrow",
+    "extract_numbers": "strip_arrow",
     # numeric: all 5 string-parser transforms are wired via the single
     # "numeric" component (floor symbol currency_strip_arrow), region-free/
     # locale-free.

--- a/packages/python/goldenflow/tests/transforms/test_text_kernels.py
+++ b/packages/python/goldenflow/tests/transforms/test_text_kernels.py
@@ -1,0 +1,61 @@
+"""Direct pinned-vector parity for the PARAMETERIZED text kernels (Wave D
+text-1): ``truncate(n)`` / ``pad_left(width, char)`` / ``pad_right(width,
+char)``.
+
+These carry per-column-constant params (like numeric ``round(n)`` /
+``clamp(min,max)``), so a single ``(transform, input) -> expected`` corpus row
+can't express the non-default-param cases. This file asserts both the
+pure-Python fallback (``GOLDENFLOW_NATIVE=0``) and the native path (when
+built/importable) against the goldenflow-core Rust kernel's values -- the same
+pinned-vector pattern as ``test_numeric_kernels.py`` / ``test_name_kernels.py``.
+
+The 10 non-parameterized text transforms (strip/collapse_whitespace/... /
+extract_numbers) fit the shared corpus and are covered in
+``test_identifiers_parity.py``.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenflow.core._native_loader import native_available, native_module
+from goldenflow.transforms.text import pad_left, pad_right, truncate
+
+
+def _apply(expr_fn, col_values: list[str | None], *args) -> list[str | None]:
+    df = pl.DataFrame({"x": col_values})
+    return df.select(expr_fn("x", *args)).to_series().to_list()
+
+
+# (transform-fn, args, input column, expected output)
+_CASES = [
+    (truncate, (5,), ["hello world", "hi", "", None], ["hello", "hi", "", None]),
+    (truncate, (0,), ["abc", None], ["", None]),
+    # char-based, not byte (accented char counts as 1)
+    (truncate, (4,), ["cafés", None], ["café", None]),
+    (pad_left, (5, "0"), ["42", "already?", None], ["00042", "already?", None]),
+    (pad_left, (3, "0"), ["already", None], ["already", None]),  # len >= width
+    (pad_right, (5, " "), ["42", None], ["42   ", None]),
+    (pad_right, (4, "."), ["ab", None], ["ab..", None]),
+]
+
+
+def _check_all() -> None:
+    for fn, args, inp, expected in _CASES:
+        assert _apply(fn, inp, *args) == expected
+
+
+def test_fallback_matches_expected(monkeypatch):
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
+    _check_all()
+
+
+def test_native_matches_expected(monkeypatch):
+    if not native_available():
+        import pytest
+
+        pytest.skip("goldenflow-native not built/importable")
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
+    if not hasattr(native_module(), "truncate_arrow"):
+        import pytest
+
+        pytest.skip("installed goldenflow-native predates the text kernels")
+    _check_all()

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenflow-core/src/text.rs
+++ b/packages/rust/extensions/goldenflow-core/src/text.rs
@@ -230,6 +230,33 @@ pub fn extract_numbers(s: &str) -> String {
     nums.join(" ")
 }
 
+/// True if `c` is in the emoji codepoint set (the exact ranges of the Python
+/// `_EMOJI_PATTERN`). Explicit ranges -> portable across surfaces, NO
+/// Unicode-DB dependency (mirrors the `name_script` range approach).
+fn is_emoji(c: char) -> bool {
+    matches!(c as u32,
+        0x1F600..=0x1F64F   // emoticons
+        | 0x1F300..=0x1F5FF // symbols & pictographs
+        | 0x1F680..=0x1F6FF // transport & map
+        | 0x1F1E0..=0x1F1FF // flags
+        | 0x2702..=0x27B0   // dingbats
+        | 0x24C2..=0x1F251  // enclosed characters (wide range, per the source)
+        | 0x1F900..=0x1F9FF // supplemental symbols
+        | 0x1FA00..=0x1FA6F // chess symbols
+        | 0x1FA70..=0x1FAFF // symbols extended-A
+        | 0x2600..=0x26FF   // misc symbols
+        | 0x200D            // zero-width joiner
+        | 0xFE0F            // variation selector
+    )
+}
+
+/// Remove emoji characters (regex `[<emoji ranges>]+` -> ""). Removing each
+/// matching char is equivalent to removing maximal runs. Byte-identical to
+/// `text.py::remove_emojis`.
+pub fn remove_emojis(s: &str) -> String {
+    s.chars().filter(|c| !is_emoji(*c)).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -332,5 +359,13 @@ mod tests {
         assert_eq!(extract_numbers("no numbers"), "");
         assert_eq!(extract_numbers("12."), "12."); // greedy dot, empty \d*
         assert_eq!(extract_numbers("3.14.159"), "3.14 159");
+    }
+
+    #[test]
+    fn remove_emojis_cases() {
+        assert_eq!(remove_emojis("hi \u{1f600} there"), "hi  there");
+        assert_eq!(remove_emojis("\u{1f680}\u{1f600}rocket"), "rocket");
+        assert_eq!(remove_emojis("no emoji"), "no emoji");
+        assert_eq!(remove_emojis("caf\u{e9}"), "caf\u{e9}"); // accented letter kept
     }
 }

--- a/packages/rust/extensions/goldenflow-core/src/text.rs
+++ b/packages/rust/extensions/goldenflow-core/src/text.rs
@@ -233,6 +233,14 @@ pub fn extract_numbers(s: &str) -> String {
 /// True if `c` is in the emoji codepoint set (the exact ranges of the Python
 /// `_EMOJI_PATTERN`). Explicit ranges -> portable across surfaces, NO
 /// Unicode-DB dependency (mirrors the `name_script` range approach).
+///
+/// The source pattern's ranges OVERLAP (the wide `0x24C2..=0x1F251` "enclosed
+/// characters" range subsumes the later dingbats / misc-symbols / flags /
+/// variation-selector arms), so several arms are `unreachable` -- harmless
+/// since the union is identical, but a hard error under `-D warnings`. We keep
+/// the arms 1:1 with the Python `_EMOJI_PATTERN` (readable, auditable against
+/// the source) and allow the lint rather than silently pruning them.
+#[allow(unreachable_patterns)]
 fn is_emoji(c: char) -> bool {
     matches!(c as u32,
         0x1F600..=0x1F64F   // emoticons

--- a/packages/rust/extensions/goldenflow-core/src/text.rs
+++ b/packages/rust/extensions/goldenflow-core/src/text.rs
@@ -40,6 +40,196 @@ pub fn collapse_whitespace(s: &str) -> String {
     out
 }
 
+// ---------------------------------------------------------------------------
+// Wave D text-1: mechanical / ASCII-bound kernels. Each is the reference
+// implementation; the Python (`goldenflow/transforms/text.py`) and TS
+// (`transforms/text.ts`) fallbacks reproduce these bytes exactly. Ported
+// one-for-one from the polars transforms; NO regex dep (JS/Py/Rust regex
+// engines differ on `\s`/`\d`/greedy). `char::is_whitespace` == polars `\s`
+// (proven in tests/text_golden.rs), so the whitespace-based kernels are exact;
+// `\d` is bounded to ASCII digits (documented boundary, reference-mode).
+// ---------------------------------------------------------------------------
+
+/// Replace smart/curly quotes with straight ASCII quotes. Byte-identical to the
+/// chained `str.replace_all` in `text.py::normalize_quotes` (left/right double
+/// + double-prime -> `"`; left/right single + prime -> `'`).
+pub fn normalize_quotes(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\u{201c}' | '\u{201d}' | '\u{2033}' => out.push('"'),
+            '\u{2018}' | '\u{2019}' | '\u{2032}' => out.push('\''),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Normalize `\r\n` and lone `\r` to `\n`. Byte-identical to
+/// `text.py::normalize_line_endings` (replace `\r\n` first, then any `\r`).
+pub fn normalize_line_endings(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\r' {
+            if chars.peek() == Some(&'\n') {
+                chars.next();
+            }
+            out.push('\n');
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Truncate to the first `n` characters (polars `str.slice(0, n)` is
+/// character-based). Byte-identical to `text.py::truncate`.
+pub fn truncate(s: &str, n: usize) -> String {
+    s.chars().take(n).collect()
+}
+
+/// Left-pad to `width` characters with `pad` (polars `str.pad_start`); a string
+/// already at/over `width` is unchanged. Byte-identical to `text.py::pad_left`.
+pub fn pad_left(s: &str, width: usize, pad: char) -> String {
+    let len = s.chars().count();
+    if len >= width {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(width);
+    for _ in 0..(width - len) {
+        out.push(pad);
+    }
+    out.push_str(s);
+    out
+}
+
+/// Right-pad to `width` characters with `pad` (polars `str.pad_end`); a string
+/// already at/over `width` is unchanged. Byte-identical to `text.py::pad_right`.
+pub fn pad_right(s: &str, width: usize, pad: char) -> String {
+    let len = s.chars().count();
+    if len >= width {
+        return s.to_string();
+    }
+    let mut out = String::from(s);
+    for _ in 0..(width - len) {
+        out.push(pad);
+    }
+    out
+}
+
+/// Strip HTML tags: remove each `<...>` span with at least one char between the
+/// angle brackets (regex `<[^>]+>`, minimal to the first `>`). `<>` and an
+/// unclosed `<` are left intact. Byte-identical to `text.py::remove_html_tags`.
+pub fn remove_html_tags(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < n {
+        if chars[i] == '<' {
+            let mut j = i + 1;
+            while j < n && chars[j] != '>' {
+                j += 1;
+            }
+            // matched `<[^>]+>`: at least one non-`>` char (j > i+1) then a `>`.
+            if j < n && j > i + 1 {
+                i = j + 1;
+                continue;
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+/// `"http://"` (7 chars) or `"https://"` (8 chars) at `chars[i..]`; returns the
+/// index just past the `://`. `https` is tried first (regex `s?` is greedy).
+fn match_url_scheme(chars: &[char], i: usize) -> Option<usize> {
+    const HTTP: [char; 7] = ['h', 't', 't', 'p', ':', '/', '/'];
+    const HTTPS: [char; 8] = ['h', 't', 't', 'p', 's', ':', '/', '/'];
+    if chars[i..].starts_with(&HTTPS) {
+        Some(i + HTTPS.len())
+    } else if chars[i..].starts_with(&HTTP) {
+        Some(i + HTTP.len())
+    } else {
+        None
+    }
+}
+
+/// Strip URLs: remove each `https?://` followed by one-or-more non-whitespace
+/// chars (regex `https?://\S+`). `\S` = non-`is_whitespace` (== polars `\s`
+/// complement). Byte-identical to `text.py::remove_urls`.
+pub fn remove_urls(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < n {
+        if let Some(after) = match_url_scheme(&chars, i) {
+            let mut j = after;
+            while j < n && !chars[j].is_whitespace() {
+                j += 1;
+            }
+            if j > after {
+                // scheme + `\S+` (>=1 non-ws char) -> drop the whole URL.
+                i = j;
+                continue;
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+/// Remove ASCII digit characters. The old polars `\d` was Unicode-aware; this
+/// kernel is bounded to ASCII `0-9` (documented reference-mode boundary --
+/// exotic Unicode digits are out of the bounded set). Byte-identical to
+/// `text.py::remove_digits`.
+pub fn remove_digits(s: &str) -> String {
+    s.chars().filter(|c| !c.is_ascii_digit()).collect()
+}
+
+/// Remove punctuation: keep ASCII alphanumerics and whitespace, drop everything
+/// else (regex `[^a-zA-Z0-9\s]` -> ""). `\s` == `is_whitespace`; non-ASCII
+/// letters are dropped (as in the old polars behavior). Byte-identical to
+/// `text.py::remove_punctuation`.
+pub fn remove_punctuation(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric() || c.is_whitespace())
+        .collect()
+}
+
+/// Extract all number runs (regex `\d+\.?\d*`: one-or-more digits, an optional
+/// dot, zero-or-more digits) joined by single spaces. ASCII digits only
+/// (documented boundary). Byte-identical to `text.py::extract_numbers`.
+pub fn extract_numbers(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    let mut nums: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < n {
+        if chars[i].is_ascii_digit() {
+            let start = i;
+            while i < n && chars[i].is_ascii_digit() {
+                i += 1; // \d+
+            }
+            if i < n && chars[i] == '.' {
+                i += 1; // greedy \.?
+                while i < n && chars[i].is_ascii_digit() {
+                    i += 1; // \d*
+                }
+            }
+            nums.push(chars[start..i].iter().collect());
+        } else {
+            i += 1;
+        }
+    }
+    nums.join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -65,5 +255,82 @@ mod tests {
             collapse_whitespace("\u{200b}\u{200b}zwrun"),
             "\u{200b}\u{200b}zwrun"
         );
+    }
+
+    #[test]
+    fn normalize_quotes_cases() {
+        assert_eq!(normalize_quotes("\u{201c}hi\u{201d}"), "\"hi\"");
+        assert_eq!(normalize_quotes("it\u{2019}s"), "it's");
+        assert_eq!(normalize_quotes("\u{2018}a\u{2019}"), "'a'");
+        assert_eq!(normalize_quotes("5\u{2033} x 3\u{2032}"), "5\" x 3'");
+        assert_eq!(normalize_quotes("plain"), "plain");
+    }
+
+    #[test]
+    fn normalize_line_endings_cases() {
+        assert_eq!(normalize_line_endings("a\r\nb"), "a\nb");
+        assert_eq!(normalize_line_endings("a\rb"), "a\nb");
+        assert_eq!(normalize_line_endings("a\nb"), "a\nb");
+        assert_eq!(normalize_line_endings("a\r\r b"), "a\n\n b");
+        assert_eq!(normalize_line_endings("a\r\n\rb"), "a\n\nb");
+    }
+
+    #[test]
+    fn truncate_cases() {
+        assert_eq!(truncate("hello world", 5), "hello");
+        assert_eq!(truncate("hi", 5), "hi");
+        assert_eq!(truncate("", 3), "");
+        assert_eq!(truncate("caf\u{e9}s", 4), "caf\u{e9}"); // char-based, not byte
+    }
+
+    #[test]
+    fn pad_cases() {
+        assert_eq!(pad_left("42", 5, '0'), "00042");
+        assert_eq!(pad_left("already", 3, '0'), "already");
+        assert_eq!(pad_right("42", 5, ' '), "42   ");
+        assert_eq!(pad_right("already", 3, ' '), "already");
+    }
+
+    #[test]
+    fn remove_html_tags_cases() {
+        assert_eq!(remove_html_tags("<b>hi</b>"), "hi");
+        assert_eq!(remove_html_tags("a <a href=\"x\">link</a> b"), "a link b");
+        assert_eq!(remove_html_tags("<>"), "<>"); // empty tag not matched
+        assert_eq!(remove_html_tags("2 < 3"), "2 < 3"); // no closing '>'
+        assert_eq!(remove_html_tags("<unclosed"), "<unclosed");
+    }
+
+    #[test]
+    fn remove_urls_cases() {
+        assert_eq!(remove_urls("see http://x.com/y now"), "see  now");
+        assert_eq!(remove_urls("https://a.com?q=1 end"), " end");
+        assert_eq!(remove_urls("no url here"), "no url here");
+        // bare scheme with no following non-ws char is not a match
+        assert_eq!(remove_urls("http:// x"), "http:// x");
+    }
+
+    #[test]
+    fn remove_digits_cases() {
+        assert_eq!(remove_digits("abc123def"), "abcdef");
+        assert_eq!(remove_digits("no digits"), "no digits");
+        assert_eq!(remove_digits("42"), "");
+    }
+
+    #[test]
+    fn remove_punctuation_cases() {
+        assert_eq!(remove_punctuation("hello, world!"), "hello world");
+        assert_eq!(remove_punctuation("a-b_c.d"), "abcd");
+        assert_eq!(remove_punctuation("keep 123 ok"), "keep 123 ok");
+        // non-ASCII letters are dropped (matches the old [^a-zA-Z0-9\s])
+        assert_eq!(remove_punctuation("caf\u{e9}"), "caf");
+    }
+
+    #[test]
+    fn extract_numbers_cases() {
+        assert_eq!(extract_numbers("abc12.5def7"), "12.5 7");
+        assert_eq!(extract_numbers("price $9.99 x2"), "9.99 2");
+        assert_eq!(extract_numbers("no numbers"), "");
+        assert_eq!(extract_numbers("12."), "12."); // greedy dot, empty \d*
+        assert_eq!(extract_numbers("3.14.159"), "3.14 159");
     }
 }

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.lock
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "goldenflow-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "phonenumber",
 ]

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -18,6 +18,7 @@ mod wasm {
     use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
     use goldenflow_core::names;
     use goldenflow_core::numeric;
+    use goldenflow_core::text;
     use goldenflow_core::url;
     use wasm_bindgen::prelude::*;
 
@@ -209,6 +210,71 @@ mod wasm {
         let (street, city, state, zip) = address::split_address(s);
         let opt = |v: Option<String>| v.map_or(JsValue::NULL, |x| JsValue::from_str(&x));
         vec![JsValue::from_str(&street), opt(city), opt(state), opt(zip)]
+    }
+
+    #[wasm_bindgen]
+    pub fn strip(s: &str) -> String {
+        text::strip(s).to_string()
+    }
+
+    #[wasm_bindgen]
+    pub fn collapse_whitespace(s: &str) -> String {
+        text::collapse_whitespace(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn normalize_quotes(s: &str) -> String {
+        text::normalize_quotes(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn normalize_line_endings(s: &str) -> String {
+        text::normalize_line_endings(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn remove_html_tags(s: &str) -> String {
+        text::remove_html_tags(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn remove_urls(s: &str) -> String {
+        text::remove_urls(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn remove_digits(s: &str) -> String {
+        text::remove_digits(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn remove_punctuation(s: &str) -> String {
+        text::remove_punctuation(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn remove_emojis(s: &str) -> String {
+        text::remove_emojis(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn extract_numbers(s: &str) -> String {
+        text::extract_numbers(s)
+    }
+
+    #[wasm_bindgen]
+    pub fn truncate(s: &str, n: u32) -> String {
+        text::truncate(s, n as usize)
+    }
+
+    #[wasm_bindgen]
+    pub fn pad_left(s: &str, width: u32, pad: char) -> String {
+        text::pad_left(s, width as usize, pad)
+    }
+
+    #[wasm_bindgen]
+    pub fn pad_right(s: &str, width: u32, pad: char) -> String {
+        text::pad_right(s, width as usize, pad)
     }
 
     #[wasm_bindgen]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "phonenumber",
 ]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.8.0"
+version = "0.9.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.8.0"
+    __version__ = "0.9.0"

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -73,6 +73,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(text::remove_urls_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(text::remove_digits_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(text::remove_punctuation_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::remove_emojis_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(text::extract_numbers_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(text::truncate_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(text::pad_left_arrow, m)?)?;

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -18,6 +18,7 @@ mod identifiers;
 mod names;
 mod numeric;
 mod phone;
+mod text;
 mod url;
 mod util;
 
@@ -64,6 +65,18 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(address::country_standardize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(address::unit_normalize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(address::split_address_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::strip_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::collapse_whitespace_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::normalize_quotes_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::normalize_line_endings_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::remove_html_tags_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::remove_urls_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::remove_digits_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::remove_punctuation_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::extract_numbers_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::truncate_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::pad_left_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(text::pad_right_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(url::url_normalize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(url::url_extract_domain_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(numeric::currency_strip_arrow, m)?)?;

--- a/packages/rust/extensions/native-flow/src/text.rs
+++ b/packages/rust/extensions/native-flow/src/text.rs
@@ -84,6 +84,16 @@ pub fn remove_punctuation_arrow(
 }
 
 #[pyfunction]
+pub fn remove_emojis_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::remove_emojis(s))
+    })?))
+}
+
+#[pyfunction]
 pub fn extract_numbers_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,

--- a/packages/rust/extensions/native-flow/src/text.rs
+++ b/packages/rust/extensions/native-flow/src/text.rs
@@ -1,0 +1,139 @@
+//! Arrow shims over goldenflow_core::text. Bytes in, kernel per element, bytes
+//! out; GIL released. All logic lives in the core.
+use crate::util::map_str_to_str;
+use arrow::array::ArrayData;
+use arrow::pyarrow::PyArrowType;
+use goldenflow_core::text;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn strip_arrow(py: Python, array: PyArrowType<ArrayData>) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::strip(s).to_string())
+    })?))
+}
+
+#[pyfunction]
+pub fn collapse_whitespace_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::collapse_whitespace(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn normalize_quotes_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::normalize_quotes(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn normalize_line_endings_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::normalize_line_endings(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn remove_html_tags_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::remove_html_tags(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn remove_urls_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::remove_urls(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn remove_digits_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::remove_digits(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn remove_punctuation_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::remove_punctuation(s))
+    })?))
+}
+
+#[pyfunction]
+pub fn extract_numbers_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
+        Some(text::extract_numbers(s))
+    })?))
+}
+
+/// Truncate to the first `n` characters. `n` defaults to 255; a negative `n`
+/// clamps to 0.
+#[pyfunction]
+#[pyo3(signature = (array, n=255))]
+pub fn truncate_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+    n: i64,
+) -> PyResult<PyArrowType<ArrayData>> {
+    let nn = if n < 0 { 0usize } else { n as usize };
+    Ok(PyArrowType(map_str_to_str(py, array.0, move |s| {
+        Some(text::truncate(s, nn))
+    })?))
+}
+
+/// Left-pad to `width` characters with `pad` (default width 10, pad `'0'`).
+#[pyfunction]
+#[pyo3(signature = (array, width=10, pad='0'))]
+pub fn pad_left_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+    width: i64,
+    pad: char,
+) -> PyResult<PyArrowType<ArrayData>> {
+    let w = if width < 0 { 0usize } else { width as usize };
+    Ok(PyArrowType(map_str_to_str(py, array.0, move |s| {
+        Some(text::pad_left(s, w, pad))
+    })?))
+}
+
+/// Right-pad to `width` characters with `pad` (default width 10, pad `' '`).
+#[pyfunction]
+#[pyo3(signature = (array, width=10, pad=' '))]
+pub fn pad_right_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+    width: i64,
+    pad: char,
+) -> PyResult<PyArrowType<ArrayData>> {
+    let w = if width < 0 { 0usize } else { width as usize };
+    Ok(PyArrowType(map_str_to_str(py, array.0, move |s| {
+        Some(text::pad_right(s, w, pad))
+    })?))
+}

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/core/transforms/text.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/text.ts
@@ -1,10 +1,32 @@
 /**
  * Text transforms — ported from goldenflow/transforms/text.py
  * Side-effect module: registers 18 text transforms on import.
+ *
+ * Owned-kernel family (Wave D text-1): 13 mechanical / ASCII-bound transforms
+ * (`strip`/`collapse_whitespace`/`normalize_quotes`/`normalize_line_endings`/
+ * `remove_html_tags`/`remove_urls`/`remove_digits`/`remove_punctuation`/
+ * `remove_emojis`/`extract_numbers` scalar + parameterized `truncate`/
+ * `pad_left`/`pad_right`) are byte-for-byte ports of the goldenflow-core Rust
+ * kernels (`goldenflow-core::text`), proven byte-identical to the Python
+ * reference. Each dispatches to the opt-in WASM backend (`FlowWasmBackend`)
+ * when `enableWasm()` has succeeded; otherwise it runs the pure-TS
+ * implementation below. Pure-TS is the default.
+ *
+ * NO regex is used where the JS engine would diverge from the Rust kernel: the
+ * html-tag / url / number scans and char-class filters mirror the hand-rolled
+ * Rust logic (or, for the simple literal cases, use a regex proven
+ * byte-identical over the shared corpus). `\d` is spelled `[0-9]` (ASCII
+ * bounded, matching the kernel); `remove_emojis` uses the kernel's explicit
+ * codepoint ranges; `truncate`/`pad_*` are codepoint-based (`[...s]`) to match
+ * Rust `chars()`.
+ *
+ * text-2 (deferred): lowercase / uppercase / title_case / normalize_unicode /
+ * fix_mojibake stay pure-TS (Unicode-casing / NFKD parity, a later wave).
  */
 
 import type { ColumnValue } from "../types.js";
 import { registerTransform } from "./registry.js";
+import { getFlowWasmBackend } from "../wasm/backend.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -21,11 +43,107 @@ function mapStrings(
 }
 
 // ---------------------------------------------------------------------------
+// Pure-TS kernel references (byte-identical to goldenflow-core::text). These
+// are the fallbacks + the parity-harness entry points; the transform wrappers
+// below dispatch native-first through the WASM backend when it is active.
+// ---------------------------------------------------------------------------
+
+/** `strip`: remove leading/trailing whitespace (Rust `str::trim`). */
+function stripTs(s: string): string {
+  return s.trim();
+}
+
+/** `collapse_whitespace`: replace each run of 2+ whitespace with a single
+ * space; a lone whitespace char is unchanged (Rust `\s{2,}` -> " "). */
+function collapseWhitespaceTs(s: string): string {
+  return s.replace(/\s{2,}/g, " ");
+}
+
+/** `normalize_quotes`: smart double/prime -> `"`, smart single/prime -> `'`
+ * (the exact 6 codepoints of the Rust kernel). */
+function normalizeQuotesTs(s: string): string {
+  return s
+    .replace(/[“”″]/g, '"')
+    .replace(/[‘’′]/g, "'");
+}
+
+/** `normalize_line_endings`: `\r\n` and lone `\r` -> `\n` (replace `\r\n`
+ * first, then any remaining `\r`). */
+function normalizeLineEndingsTs(s: string): string {
+  return s.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/** `remove_html_tags`: strip each `<...>` span with >=1 char between the
+ * angle brackets (Rust regex `<[^>]+>`, SINGLE pass — `<>` / unclosed `<`
+ * are left intact). */
+function removeHtmlTagsTs(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+/** `remove_urls`: drop each `https?://` followed by >=1 non-whitespace char
+ * (Rust regex `https?://\S+`). NO trailing trim — the kernel leaves
+ * surrounding whitespace intact. */
+function removeUrlsTs(s: string): string {
+  return s.replace(/https?:\/\/\S+/g, "");
+}
+
+/** `remove_digits`: remove ASCII digit characters (kernel is bounded to
+ * `[0-9]`, not Unicode `\d`). */
+function removeDigitsTs(s: string): string {
+  return s.replace(/[0-9]/g, "");
+}
+
+/** `remove_punctuation`: keep ASCII alphanumerics + whitespace, drop the rest
+ * (Rust regex `[^a-zA-Z0-9\s]` -> ""; non-ASCII letters and `_` are dropped). */
+function removePunctuationTs(s: string): string {
+  return s.replace(/[^a-zA-Z0-9\s]/g, "");
+}
+
+/** `remove_emojis`: drop chars in the kernel's explicit emoji codepoint set.
+ * `u` flag so astral ranges match per-codepoint (mirrors Rust `is_emoji`). */
+function removeEmojisTs(s: string): string {
+  return s.replace(
+    /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2702}-\u{27B0}\u{24C2}-\u{1F251}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{2600}-\u{26FF}\u{200D}\u{FE0F}]/gu,
+    "",
+  );
+}
+
+/** `extract_numbers`: all `[0-9]+\.?[0-9]*` runs joined by single spaces
+ * (ASCII digits only; no-match -> ""). */
+function extractNumbersTs(s: string): string {
+  const nums = [...s.matchAll(/[0-9]+\.?[0-9]*/g)].map((m) => m[0]);
+  return nums.join(" ");
+}
+
+/** `truncate`: first `n` characters (codepoint-based, Rust `chars().take(n)`). */
+function truncateTs(s: string, n: number): string {
+  return [...s].slice(0, n).join("");
+}
+
+/** `pad_left`: left-pad to `width` codepoints with `pad`; unchanged when the
+ * string is already at/over `width` (Rust `pad_start`). */
+function padLeftTs(s: string, width: number, pad: string): string {
+  const len = [...s].length;
+  if (len >= width) return s;
+  return pad.repeat(width - len) + s;
+}
+
+/** `pad_right`: right-pad to `width` codepoints with `pad`; unchanged when the
+ * string is already at/over `width` (Rust `pad_end`). */
+function padRightTs(s: string, width: number, pad: string): string {
+  const len = [...s].length;
+  if (len >= width) return s;
+  return s + pad.repeat(width - len);
+}
+
+// ---------------------------------------------------------------------------
 // strip (priority 90, auto_apply, string)
 // ---------------------------------------------------------------------------
 
 function strip(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => s.trim());
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.strip(s) : stripTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -34,7 +152,7 @@ registerTransform(
 );
 
 // ---------------------------------------------------------------------------
-// lowercase (50, string)
+// lowercase (50, string) -- text-2, pure-TS
 // ---------------------------------------------------------------------------
 
 function lowercase(values: readonly ColumnValue[]): ColumnValue[] {
@@ -47,7 +165,7 @@ registerTransform(
 );
 
 // ---------------------------------------------------------------------------
-// uppercase (50, string)
+// uppercase (50, string) -- text-2, pure-TS
 // ---------------------------------------------------------------------------
 
 function uppercase(values: readonly ColumnValue[]): ColumnValue[] {
@@ -60,7 +178,7 @@ registerTransform(
 );
 
 // ---------------------------------------------------------------------------
-// title_case (50, string)
+// title_case (50, string) -- text-2, pure-TS
 // ---------------------------------------------------------------------------
 
 function titleCase(values: readonly ColumnValue[]): ColumnValue[] {
@@ -75,7 +193,7 @@ registerTransform(
 );
 
 // ---------------------------------------------------------------------------
-// normalize_unicode (85, auto_apply, string)
+// normalize_unicode (85, auto_apply, string) -- text-2, pure-TS
 // ---------------------------------------------------------------------------
 
 function normalizeUnicode(values: readonly ColumnValue[]): ColumnValue[] {
@@ -94,7 +212,9 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function removePunctuation(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => s.replace(/[^\w\s]/g, ""));
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.removePunctuation(s) : removePunctuationTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -107,7 +227,9 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function collapseWhitespace(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => s.replace(/\s+/g, " ").trim());
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.collapseWhitespace(s) : collapseWhitespaceTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -121,7 +243,11 @@ registerTransform(
 
 function truncate(values: readonly ColumnValue[], n: unknown = 255): ColumnValue[] {
   const maxLen = typeof n === "number" ? n : Number(n) || 255;
-  return mapStrings(values, (s) => s.slice(0, maxLen));
+  const backend = getFlowWasmBackend();
+  const fn = backend
+    ? (s: string) => backend.truncate(s, maxLen)
+    : (s: string) => truncateTs(s, maxLen);
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -134,11 +260,9 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function normalizeQuotes(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) =>
-    s
-      .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
-      .replace(/[\u201C\u201D\u201E\u201F]/g, '"'),
-  );
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.normalizeQuotes(s) : normalizeQuotesTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -151,20 +275,9 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function removeHtmlTags(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    // Single-pass `<[^>]*>` removal lets nested-tag payloads like
-    // `<<script>script>` collapse to `<script>` after one rewrite.
-    // Loop until the output stabilises so the transform is idempotent
-    // against adversarial input. Bounded by string length -- each pass
-    // strictly shrinks the input (or matches zero, ending the loop).
-    let prev: string;
-    let out = s;
-    do {
-      prev = out;
-      out = out.replace(/<[^>]*>/g, "");
-    } while (out !== prev);
-    return out;
-  });
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.removeHtmlTags(s) : removeHtmlTagsTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -177,9 +290,9 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function removeUrls(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) =>
-    s.replace(/https?:\/\/[^\s]+/g, "").trim(),
-  );
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.removeUrls(s) : removeUrlsTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -192,7 +305,9 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function removeDigits(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => s.replace(/\d/g, ""));
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.removeDigits(s) : removeDigitsTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -211,7 +326,11 @@ function padLeft(
 ): ColumnValue[] {
   const w = typeof width === "number" ? width : Number(width) || 10;
   const c = typeof char === "string" ? char : "0";
-  return mapStrings(values, (s) => s.padStart(w, c));
+  const backend = getFlowWasmBackend();
+  const fn = backend
+    ? (s: string) => backend.padLeft(s, w, c)
+    : (s: string) => padLeftTs(s, w, c);
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -230,7 +349,11 @@ function padRight(
 ): ColumnValue[] {
   const w = typeof width === "number" ? width : Number(width) || 10;
   const c = typeof char === "string" ? char : " ";
-  return mapStrings(values, (s) => s.padEnd(w, c));
+  const backend = getFlowWasmBackend();
+  const fn = backend
+    ? (s: string) => backend.padRight(s, w, c)
+    : (s: string) => padRightTs(s, w, c);
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -243,11 +366,9 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function removeEmojis(values: readonly ColumnValue[]): ColumnValue[] {
-  // Covers common emoji Unicode ranges including emoticons, symbols, dingbats,
-  // supplemental symbols, flags, and extended pictographic.
-  const emojiPattern =
-    /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]/gu;
-  return mapStrings(values, (s) => s.replace(emojiPattern, ""));
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.removeEmojis(s) : removeEmojisTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -256,7 +377,7 @@ registerTransform(
 );
 
 // ---------------------------------------------------------------------------
-// fix_mojibake (86, string)
+// fix_mojibake (86, string) -- text-2, pure-TS
 // ---------------------------------------------------------------------------
 
 function fixMojibake(values: readonly ColumnValue[]): ColumnValue[] {
@@ -264,7 +385,6 @@ function fixMojibake(values: readonly ColumnValue[]): ColumnValue[] {
     try {
       // Attempt latin1 -> utf8 re-encoding: encode string bytes as latin1,
       // then decode as UTF-8. If the result is valid and different, use it.
-      const encoder = new TextEncoder();
       const bytes = new Uint8Array(s.length);
       for (let i = 0; i < s.length; i++) {
         const code = s.charCodeAt(i);
@@ -290,7 +410,9 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function normalizeLineEndings(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => s.replace(/\r\n/g, "\n").replace(/\r/g, "\n"));
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.normalizeLineEndings(s) : normalizeLineEndingsTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
@@ -303,13 +425,35 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function extractNumbers(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => {
-    const nums = s.match(/-?\d+(?:\.\d+)?/g);
-    return nums ? nums.join(" ") : "";
-  });
+  const backend = getFlowWasmBackend();
+  const fn = backend ? (s: string) => backend.extractNumbers(s) : extractNumbersTs;
+  return mapStrings(values, fn);
 }
 
 registerTransform(
   { name: "extract_numbers", inputTypes: ["string"], priority: 30, mode: "series" },
   extractNumbers,
 );
+
+// ---------------------------------------------------------------------------
+// Pure-TS single-value exports (cross-surface byte-parity harness)
+//
+// Bypass the wasm-dispatch wrappers above so a parity test can assert the
+// pure-TS path independently of whatever backend is currently registered.
+// ---------------------------------------------------------------------------
+
+export {
+  stripTs,
+  collapseWhitespaceTs,
+  normalizeQuotesTs,
+  normalizeLineEndingsTs,
+  removeHtmlTagsTs,
+  removeUrlsTs,
+  removeDigitsTs,
+  removePunctuationTs,
+  removeEmojisTs,
+  extractNumbersTs,
+  truncateTs,
+  padLeftTs,
+  padRightTs,
+};

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -10,9 +10,12 @@
  * (boolean_normalize/gender_standardize/null_standardize/
  * category_normalize_key), and the address transforms (address_standardize/
  * address_expand/state_abbreviate/state_expand/zip_normalize/
- * country_standardize/unit_normalize/split_address); everything else stays
- * pure-TS. Mirrors goldenmatch's `setScorerBackend(null)` module-singleton
- * pattern for test isolation.
+ * country_standardize/unit_normalize/split_address), and the text transforms
+ * (strip/collapse_whitespace/normalize_quotes/normalize_line_endings/
+ * remove_html_tags/remove_urls/remove_digits/remove_punctuation/remove_emojis/
+ * extract_numbers/truncate/pad_left/pad_right); everything else stays pure-TS.
+ * Mirrors goldenmatch's `setScorerBackend(null)` module-singleton pattern for
+ * test isolation.
  */
 
 /**
@@ -79,6 +82,19 @@ export interface FlowWasmBackend {
   /** `split_address` -> 4-element `[street, city, state, zip]`; `street` is
    * always a string, the other three are `string | null` (Rust `Option`). */
   splitAddress(s: string): (string | null)[];
+  strip(s: string): string;
+  collapseWhitespace(s: string): string;
+  normalizeQuotes(s: string): string;
+  normalizeLineEndings(s: string): string;
+  removeHtmlTags(s: string): string;
+  removeUrls(s: string): string;
+  removeDigits(s: string): string;
+  removePunctuation(s: string): string;
+  removeEmojis(s: string): string;
+  extractNumbers(s: string): string;
+  truncate(s: string, n: number): string;
+  padLeft(s: string, width: number, pad: string): string;
+  padRight(s: string, width: number, pad: string): string;
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -92,6 +92,19 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     country_standardize: (s: string) => string;
     unit_normalize: (s: string) => string;
     split_address: (s: string) => (string | null)[];
+    strip: (s: string) => string;
+    collapse_whitespace: (s: string) => string;
+    normalize_quotes: (s: string) => string;
+    normalize_line_endings: (s: string) => string;
+    remove_html_tags: (s: string) => string;
+    remove_urls: (s: string) => string;
+    remove_digits: (s: string) => string;
+    remove_punctuation: (s: string) => string;
+    remove_emojis: (s: string) => string;
+    extract_numbers: (s: string) => string;
+    truncate: (s: string, n: number) => string;
+    pad_left: (s: string, width: number, pad: string) => string;
+    pad_right: (s: string, width: number, pad: string) => string;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -147,5 +160,18 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     countryStandardize: (s) => glue.country_standardize(s),
     unitNormalize: (s) => glue.unit_normalize(s),
     splitAddress: (s) => glue.split_address(s),
+    strip: (s) => glue.strip(s),
+    collapseWhitespace: (s) => glue.collapse_whitespace(s),
+    normalizeQuotes: (s) => glue.normalize_quotes(s),
+    normalizeLineEndings: (s) => glue.normalize_line_endings(s),
+    removeHtmlTags: (s) => glue.remove_html_tags(s),
+    removeUrls: (s) => glue.remove_urls(s),
+    removeDigits: (s) => glue.remove_digits(s),
+    removePunctuation: (s) => glue.remove_punctuation(s),
+    removeEmojis: (s) => glue.remove_emojis(s),
+    extractNumbers: (s) => glue.extract_numbers(s),
+    truncate: (s, n) => glue.truncate(s, n),
+    padLeft: (s, width, pad) => glue.pad_left(s, width, pad),
+    padRight: (s, width, pad) => glue.pad_right(s, width, pad),
   };
 }

--- a/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/identifiers.parity.test.ts
@@ -74,6 +74,18 @@ import {
   countryStandardizeTs,
   unitNormalizeTs,
 } from "../../src/core/transforms/address.js";
+import {
+  stripTs,
+  collapseWhitespaceTs,
+  normalizeQuotesTs,
+  normalizeLineEndingsTs,
+  removeHtmlTagsTs,
+  removeUrlsTs,
+  removeDigitsTs,
+  removePunctuationTs,
+  removeEmojisTs,
+  extractNumbersTs,
+} from "../../src/core/transforms/text.js";
 import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
 import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
 
@@ -137,6 +149,16 @@ const PURE_TS_FN: Record<string, (s: string) => boolean | string | number | unde
   zip_normalize: zipNormalizeTs,
   country_standardize: countryStandardizeTs,
   unit_normalize: unitNormalizeTs,
+  strip: stripTs,
+  collapse_whitespace: collapseWhitespaceTs,
+  normalize_quotes: normalizeQuotesTs,
+  normalize_line_endings: normalizeLineEndingsTs,
+  remove_html_tags: removeHtmlTagsTs,
+  remove_urls: removeUrlsTs,
+  remove_digits: removeDigitsTs,
+  remove_punctuation: removePunctuationTs,
+  remove_emojis: removeEmojisTs,
+  extract_numbers: extractNumbersTs,
 };
 
 /** Same transform set, dispatched through the wasm backend's method of the
@@ -187,6 +209,16 @@ function wasmFn(backend: FlowWasmBackend, transform: string): (s: string) => boo
     zip_normalize: (s) => backend.zipNormalize(s),
     country_standardize: (s) => backend.countryStandardize(s),
     unit_normalize: (s) => backend.unitNormalize(s),
+    strip: (s) => backend.strip(s),
+    collapse_whitespace: (s) => backend.collapseWhitespace(s),
+    normalize_quotes: (s) => backend.normalizeQuotes(s),
+    normalize_line_endings: (s) => backend.normalizeLineEndings(s),
+    remove_html_tags: (s) => backend.removeHtmlTags(s),
+    remove_urls: (s) => backend.removeUrls(s),
+    remove_digits: (s) => backend.removeDigits(s),
+    remove_punctuation: (s) => backend.removePunctuation(s),
+    remove_emojis: (s) => backend.removeEmojis(s),
+    extract_numbers: (s) => backend.extractNumbers(s),
   };
   const fn = map[transform];
   if (!fn) throw new Error(`no wasm dispatch for transform ${transform}`);

--- a/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
+++ b/packages/typescript/goldenflow/tests/parity/identifiers_corpus.jsonl
@@ -324,6 +324,61 @@
 {"transform": "unit_normalize", "input": "  Building C  ", "expected": "Building C"}
 {"transform": "unit_normalize", "input": "", "expected": ""}
 {"transform": "unit_normalize", "input": null, "expected": null}
+{"transform": "strip", "input": "  hello  ", "expected": "hello"}
+{"transform": "strip", "input": "a    b   c", "expected": "a    b   c"}
+{"transform": "strip", "input": " nbsp ", "expected": "nbsp"}
+{"transform": "strip", "input": "nochange", "expected": "nochange"}
+{"transform": "strip", "input": "", "expected": ""}
+{"transform": "strip", "input": null, "expected": null}
+{"transform": "collapse_whitespace", "input": "a    b   c", "expected": "a b c"}
+{"transform": "collapse_whitespace", "input": "a\tb", "expected": "a\tb"}
+{"transform": "collapse_whitespace", "input": "a\t\tb", "expected": "a b"}
+{"transform": "collapse_whitespace", "input": "  lead", "expected": " lead"}
+{"transform": "collapse_whitespace", "input": "", "expected": ""}
+{"transform": "collapse_whitespace", "input": null, "expected": null}
+{"transform": "normalize_quotes", "input": "“hi”", "expected": "\"hi\""}
+{"transform": "normalize_quotes", "input": "it’s", "expected": "it's"}
+{"transform": "normalize_quotes", "input": "‘a’", "expected": "'a'"}
+{"transform": "normalize_quotes", "input": "5″ x 3′", "expected": "5\" x 3'"}
+{"transform": "normalize_quotes", "input": "plain", "expected": "plain"}
+{"transform": "normalize_quotes", "input": null, "expected": null}
+{"transform": "normalize_line_endings", "input": "a\r\nb", "expected": "a\nb"}
+{"transform": "normalize_line_endings", "input": "a\rb", "expected": "a\nb"}
+{"transform": "normalize_line_endings", "input": "a\nb", "expected": "a\nb"}
+{"transform": "normalize_line_endings", "input": "a\r\r b", "expected": "a\n\n b"}
+{"transform": "normalize_line_endings", "input": "a\r\n\rb", "expected": "a\n\nb"}
+{"transform": "normalize_line_endings", "input": null, "expected": null}
+{"transform": "remove_html_tags", "input": "<b>hi</b>", "expected": "hi"}
+{"transform": "remove_html_tags", "input": "a <a href=\"x\">link</a> b", "expected": "a link b"}
+{"transform": "remove_html_tags", "input": "<>", "expected": "<>"}
+{"transform": "remove_html_tags", "input": "2 < 3", "expected": "2 < 3"}
+{"transform": "remove_html_tags", "input": "<unclosed", "expected": "<unclosed"}
+{"transform": "remove_html_tags", "input": null, "expected": null}
+{"transform": "remove_urls", "input": "see http://x.com/y now", "expected": "see  now"}
+{"transform": "remove_urls", "input": "https://a.com?q=1 end", "expected": " end"}
+{"transform": "remove_urls", "input": "no url here", "expected": "no url here"}
+{"transform": "remove_urls", "input": "http:// x", "expected": "http:// x"}
+{"transform": "remove_urls", "input": null, "expected": null}
+{"transform": "remove_digits", "input": "abc123def", "expected": "abcdef"}
+{"transform": "remove_digits", "input": "no digits", "expected": "no digits"}
+{"transform": "remove_digits", "input": "42", "expected": ""}
+{"transform": "remove_digits", "input": null, "expected": null}
+{"transform": "remove_punctuation", "input": "hello, world!", "expected": "hello world"}
+{"transform": "remove_punctuation", "input": "a-b_c.d", "expected": "abcd"}
+{"transform": "remove_punctuation", "input": "keep 123 ok", "expected": "keep 123 ok"}
+{"transform": "remove_punctuation", "input": "café", "expected": "caf"}
+{"transform": "remove_punctuation", "input": null, "expected": null}
+{"transform": "remove_emojis", "input": "hi 😀 there", "expected": "hi  there"}
+{"transform": "remove_emojis", "input": "🚀😀rocket", "expected": "rocket"}
+{"transform": "remove_emojis", "input": "no emoji", "expected": "no emoji"}
+{"transform": "remove_emojis", "input": "café", "expected": "café"}
+{"transform": "remove_emojis", "input": null, "expected": null}
+{"transform": "extract_numbers", "input": "abc12.5def7", "expected": "12.5 7"}
+{"transform": "extract_numbers", "input": "price $9.99 x2", "expected": "9.99 2"}
+{"transform": "extract_numbers", "input": "no numbers", "expected": ""}
+{"transform": "extract_numbers", "input": "12.", "expected": "12."}
+{"transform": "extract_numbers", "input": "3.14.159", "expected": "3.14 159"}
+{"transform": "extract_numbers", "input": null, "expected": null}
 {"transform": "currency_strip", "input": "$1,234.56", "expected": 1234.56}
 {"transform": "currency_strip", "input": "-$42.00", "expected": -42.0}
 {"transform": "currency_strip", "input": "USD 100", "expected": 100.0}

--- a/packages/typescript/goldenflow/tests/unit/text-kernels.test.ts
+++ b/packages/typescript/goldenflow/tests/unit/text-kernels.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Pinned-vector parity for the PARAMETERIZED text kernels (Wave D text-1):
+ * `truncate(n)` / `pad_left(width, char)` / `pad_right(width, char)`. These
+ * carry per-column-constant params, so a single `(transform, input) ->
+ * expected` corpus row can't express the non-default-param cases -- they're
+ * asserted here with the SAME pinned vectors as the Python
+ * `tests/transforms/test_text_kernels.py`, against the goldenflow-core Rust
+ * kernel's values.
+ *
+ * The 10 non-parameterized text transforms (strip/collapse_whitespace/... /
+ * extract_numbers) DO fit the shared string->scalar corpus and are covered in
+ * `tests/parity/identifiers.parity.test.ts`.
+ *
+ * The pure-TS leg always runs; the WASM leg runs only when the `.wasm` artifact
+ * has been built (a CI-only build product, never committed) -- exactly the
+ * skip-guarded pattern from the identifier / name / address kernel harnesses.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { truncateTs, padLeftTs, padRightTs } from "../../src/core/transforms/text.js";
+import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
+import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
+
+// (input, expected) rows. `null` mirrors the dataframe transform short-circuit:
+// a null cell stays null (never reaches the kernel), so it's asserted outside
+// the scalar fn just like the Python column-level `None` rows.
+const TRUNCATE: Array<[number, string | null, string | null]> = [
+  [5, "hello world", "hello"],
+  [5, "hi", "hi"],
+  [0, "abc", ""],
+  [3, "", ""],
+  [4, "cafés", "café"], // char-based, not byte
+  [5, null, null],
+];
+
+const PAD_LEFT: Array<[number, string, string | null, string | null]> = [
+  [5, "0", "42", "00042"],
+  [3, "0", "already", "already"], // len >= width -> unchanged
+  [5, "0", null, null],
+];
+
+const PAD_RIGHT: Array<[number, string, string | null, string | null]> = [
+  [5, " ", "42", "42   "],
+  [4, ".", "ab", "ab.."],
+  [3, " ", "already", "already"], // len >= width -> unchanged
+  [5, " ", null, null],
+];
+
+describe("goldenflow text kernels: pure-TS matches pinned vectors", () => {
+  it("truncate", () => {
+    for (const [n, input, expected] of TRUNCATE) {
+      expect(input === null ? null : truncateTs(input, n)).toEqual(expected);
+    }
+  });
+
+  it("pad_left", () => {
+    for (const [width, char, input, expected] of PAD_LEFT) {
+      expect(input === null ? null : padLeftTs(input, width, char)).toEqual(expected);
+    }
+  });
+
+  it("pad_right", () => {
+    for (const [width, char, input, expected] of PAD_RIGHT) {
+      expect(input === null ? null : padRightTs(input, width, char)).toEqual(expected);
+    }
+  });
+});
+
+describe("goldenflow text kernels: wasm matches pinned vectors", () => {
+  let wasmAvailable = false;
+
+  beforeAll(async () => {
+    // Resolves false (no throw) when the `.wasm` artifact isn't built -- the
+    // true default/local state (CI-only build product; never committed).
+    wasmAvailable = await enableWasm();
+  });
+
+  afterAll(() => {
+    disableWasm();
+  });
+
+  it("reports wasm availability", () => {
+    if (!wasmAvailable) {
+      console.warn(
+        "goldenflow wasm artifact not built (src/core/wasm/artifacts/*.wasm absent) " +
+          "-- skipping the wasm text-kernel leg. Expected outside the wasm_flow CI lane.",
+      );
+    }
+    expect(true).toBe(true);
+  });
+
+  it.skipIf(!wasmAvailable)("truncate / pad_left / pad_right", () => {
+    const backend = getFlowWasmBackend() as FlowWasmBackend;
+    if (!backend) throw new Error("wasmAvailable=true but getFlowWasmBackend() returned null");
+
+    for (const [n, input, expected] of TRUNCATE) {
+      expect(input === null ? null : backend.truncate(input, n)).toEqual(expected);
+    }
+    for (const [width, char, input, expected] of PAD_LEFT) {
+      expect(input === null ? null : backend.padLeft(input, width, char)).toEqual(expected);
+    }
+    for (const [width, char, input, expected] of PAD_RIGHT) {
+      expect(input === null ? null : backend.padRight(input, width, char)).toEqual(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Wave D — text, part 1 (owned kernels, cross-surface)

Migrates the 13 mechanical/ASCII-bound `text` transforms to owned pyo3-free Rust kernels in `goldenflow-core::text` (the reference), with Python/TS surfaces conforming byte-for-byte. Migration, not addition — transform count stays 92; minor version bumps only.

The 5 Unicode-heavy text transforms (`lowercase`/`uppercase`/`title_case`/`normalize_unicode`/`fix_mojibake`) are intentionally deferred to **text part 2**, where the cross-runtime Unicode-casing/NFKD parity is handled explicitly (explicit-map/bounded, like `name_transliterate`).

**Migrated to `goldenflow-core::text`:** `strip`, `collapse_whitespace` (reuse the kernels added in the SQL de-bridge), `normalize_quotes`, `normalize_line_endings`, `remove_html_tags`, `remove_urls`, `remove_digits`, `remove_punctuation`, `remove_emojis`, `extract_numbers` (scalar), plus the parameterized `truncate`, `pad_left`, `pad_right`.

**No regex dep (the parity guarantee):** the HTML-tag / URL / number-extraction scans and char-class filters are hand-rolled with ASCII semantics — JS/Py/Rust regex `\d`/greedy/`replace_all` differ, so hand-rolling keeps the bytes identical. `char::is_whitespace` is proven byte-equal to polars `\s` (`text_golden.rs`), so `strip`/`collapse_whitespace`/`remove_urls`/`remove_punctuation` are exact; `\d` is bounded to ASCII `[0-9]` (not the old Unicode-aware `\d`) and `remove_emojis` uses the explicit emoji codepoint ranges (documented boundaries, reference-mode).

**Parameterized kernels:** `truncate(n)` / `pad_left(width, char)` / `pad_right(width, char)` take per-column-constant params through the arrow shim (`#[pyo3(signature)]` defaults, mirroring `round`/`clamp`); their non-default-param behavior is pinned in `test_text_kernels.py`, the 10 scalar transforms in the shared corpus.

### Fan-out
- **Rust core** (`text.rs`): 11 new kernels (+ 2 existing), 13 unit tests.
- **native shim** + **Python** (`text.py`): 13 native-first, byte-matched `_*_py` fallbacks; `text` loader component (floor `strip_arrow`); all `mode="expr"` via `map_batches`.
- **wasm** (`goldenflow-wasm`): 13 exports. **TS** (`text.ts` + backend/loader): 13 native-first; also fixed several pre-existing pure-TS divergences vs the Rust reference (single-pass tag strip, no extra URL trim, `[^a-zA-Z0-9\s]`, trailing-dot number, exact quote/emoji codepoints).
- **Parity**: 55 new corpus rows (460 total), byte-synced to TS; pinned-vector `test_text_kernels.py` / `text-kernels.test.ts` for the parameterized three.

### Versions
`goldenflow` 1.11.0 · `native-flow` 0.9.0 · TS `goldenflow` 0.11.0.

### Verification
- Rust: 13 text tests + clippy clean; `cargo fmt --check` clean on native-flow (the CI-enforced crate).
- Python: whole-package `ruff` clean; 462 corpus + kernel fallback rows pass; count stays 92.
- TS: CI-only (box OOMs); statically cross-checked corpus == PURE_TS_FN == wasm keys, no dup exports, wasm↔loader 13-for-13, vectors match the Python pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
