### PR TITLE
docs: unified API surface page + mintlify staleness sweep

### DIFF
--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Architecture"
-description: "How the five Golden Suite tools compose into one pipeline across Python, TypeScript, Rust, dbt, and GitHub Actions."
+description: "How the six Golden Suite tools compose into one pipeline across Python, TypeScript, Rust, dbt, and GitHub Actions."
 keywords: ["architecture", "pipeline", "composition", "polyglot"]
 ---
 
@@ -25,13 +25,16 @@ flowchart LR
     Discovers quality rules from the data itself: encoding, format, nullability, anomalies.
   </Step>
   <Step title="GoldenFlow standardizes">
-    Normalizes phone numbers, dates, addresses, and categorical spelling with 76 built-in transforms.
+    Normalizes phone numbers, dates, addresses, and categorical spelling with 86 built-in transforms.
   </Step>
   <Step title="GoldenMatch deduplicates">
     Blocks, scores, clusters, and synthesizes golden records using fuzzy, exact, probabilistic, and LLM scoring.
   </Step>
   <Step title="GoldenPipe orchestrates">
-    Runs the whole chain with adaptive logic. It skips transformation if no issues are found and explains every decision.
+    Runs the whole chain with adaptive logic on a dependency-DAG planner. It skips transformation if no issues are found and explains every decision.
+  </Step>
+  <Step title="GoldenAnalysis reports">
+    Runs read-only analyzers over any stage's outputs — match rates, cluster distribution, quality rollups — with cross-run trend and regression detection.
   </Step>
 </Steps>
 
@@ -51,7 +54,7 @@ Every surface is exercised in CI: the Python test matrix (3.11 to 3.13), the Typ
 
 ## AI-native surface
 
-Every package ships an MCP server, a REST API, and an agent surface. Across the suite there are 35+ MCP tools. The `AutoConfigController` is visible from every interface: the web `ControllerPanel`, the TUI (`Ctrl+A`), the CLI, REST endpoints, Postgres functions, DuckDB UDFs, and MCP/agent tools.
+Every package ships an MCP server; the service-shaped packages also ship a REST API and an agent surface. Across the suite there are ~110 MCP tools (GoldenMatch alone has 69). The `AutoConfigController` is visible from every interface: the web `ControllerPanel`, the TUI (`Ctrl+A`), the CLI, REST endpoints, Postgres functions, DuckDB UDFs, and MCP/agent tools.
 
 Add the remote MCP server to Claude Desktop or Claude Code:
 

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -141,6 +141,7 @@
           {
             "group": "Reference",
             "pages": [
+              "reference/api-surface",
               "reference/vendor-comparison"
             ]
           },

--- a/docs-site/goldenflow/overview.mdx
+++ b/docs-site/goldenflow/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "GoldenFlow overview"
-description: "Standardize, reshape, and normalize messy data with 92 built-in transforms across 11 categories."
+description: "Standardize, reshape, and normalize messy data with 86 built-in transforms across 11 categories."
 keywords: ["goldenflow", "transforms", "standardization", "normalization", "data cleaning"]
 ---
 
-GoldenFlow standardizes, reshapes, and normalizes messy data before it enters a pipeline. In zero-config mode it auto-detects quality issues and applies safe transforms. It ships 92 built-in transforms across 11 categories (text, phone, name, address, date, categorical, numeric, email, identifiers, and URLs), plus domain packs for healthcare, finance, ecommerce, people/HR, and real estate. The identifiers group includes checksummed/structural validators/formatters for payment cards (Luhn), IBAN (mod-97), ISBN, EAN/UPC, EU VAT, SWIFT/BIC, US ABA routing numbers, and IMEI, running on owned Rust kernels. The name group includes two owned i18n kernels: `name_transliterate` (deterministic Unicode-to-ASCII fold via a curated map) and `name_script` (dominant-script detection). It scores 100/100 on the DQBench transform benchmarks.
+GoldenFlow standardizes, reshapes, and normalizes messy data before it enters a pipeline. In zero-config mode it auto-detects quality issues and applies safe transforms. It ships 86 built-in transforms across 11 categories (text, phone, name, address, date, categorical, numeric, email, identifiers, and URLs), plus domain packs for healthcare, finance, ecommerce, people/HR, and real estate. The identifiers group includes checksummed/structural validators/formatters for payment cards (Luhn), IBAN (mod-97), ISBN, EAN/UPC, EU VAT, SWIFT/BIC, US ABA routing numbers, and IMEI, running on owned Rust kernels. The name group includes two owned i18n kernels: `name_transliterate` (deterministic Unicode-to-ASCII fold via a curated map) and `name_script` (dominant-script detection). It scores 100/100 on the DQBench transform benchmarks.
 
 <CardGroup cols={2}>
   <Card title="CLI reference" icon="terminal" href="/goldenflow/cli">
@@ -65,7 +65,7 @@ console.log(result.rows[0]);
 ## Key features
 
 - **Zero-config mode**: auto-detects column types and applies safe transforms.
-- **92 transforms** across 11 categories, including checksummed/structural identifiers (payment card, IBAN, ISBN, EAN/UPC, EU VAT, SWIFT/BIC, ABA routing, IMEI) and owned i18n name kernels (`name_transliterate`, `name_script`).
+- **86 transforms** across 11 categories, including checksummed/structural identifiers (payment card, IBAN, ISBN, EAN/UPC, EU VAT, SWIFT/BIC, ABA routing, IMEI) and owned i18n name kernels (`name_transliterate`, `name_script`).
 - **5 domain packs**: healthcare, finance, ecommerce, people/HR, real estate.
 - **Audit trail**: a JSON manifest of every transform, which rows changed, and before/after samples.
 - **Schema mapping**: auto-map columns between systems by name similarity and data profiling.

--- a/docs-site/goldenmatch/agent.mdx
+++ b/docs-site/goldenmatch/agent.mdx
@@ -256,7 +256,7 @@ print(session.last_telemetry)                    # same shape as autoconfigure's
 | `sensitivity` | Parameter-sweep stability analysis |
 | `incremental` | Match new records against an existing base dataset |
 
-These are additive -- existing MCP tools (`suggest_config`, `list_domains`, etc.) continue to work. The full MCP surface is **54 tools** (16 agent-level + 24 data + 7 Learning Memory + 7 Identity Graph) -- see [MCP Server](/goldenmatch/mcp).
+These are additive -- existing MCP tools (`suggest_config`, `list_domains`, etc.) continue to work. The full MCP surface is **69 tools** spanning agent-level ER, data inspection, config suggestions, PPRL, Learning Memory, and Identity Graph -- see [MCP Server](/goldenmatch/mcp).
 
 ## A2A Agent Card
 

--- a/docs-site/goldenmatch/api-quick-reference.mdx
+++ b/docs-site/goldenmatch/api-quick-reference.mdx
@@ -4,7 +4,7 @@ description: "Practical examples for the most-used surface. Authoritative type s
 keywords: ["api", "reference", "dedupe", "config", "python"]
 ---
 
-## `AgentSession.autoconfigure()` — run controller; return config + telemetry (v1.7-v1.12)
+## `AgentSession.autoconfigure()` — run controller; return config + telemetry
 
 ```python
 from goldenmatch import AgentSession

--- a/docs-site/goldenmatch/learning-memory.mdx
+++ b/docs-site/goldenmatch/learning-memory.mdx
@@ -186,7 +186,7 @@ print(result.memory_stats)
 
 ## MCP
 
-Six MCP tools bring Learning Memory into Claude Desktop / Code. Total tool count is now 54.
+Six MCP tools bring Learning Memory into Claude Desktop / Code. Total tool count is now 69.
 
 | Tool | Behavior |
 |---|---|

--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -1,10 +1,10 @@
 ---
 title: "MCP Server"
-description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 54 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
+description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 69 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
 keywords: ["mcp", "claude desktop", "model context protocol", "entity resolution", "learning memory"]
 ---
 
-GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 54 tools total: 16 agent-level tools for autonomous ER, 24 data tools for inspection and management, 7 Learning Memory tools (v1.6.0) for persisting steward decisions, and 7 Identity Graph tools.
+GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 69 tools total, spanning agent-level tools for autonomous ER, data tools for inspection and management, config-suggestion and PPRL tools, Learning Memory tools for persisting steward decisions, and Identity Graph tools.
 
 <Tip>
   Looking for AI-to-AI autonomy? See the [ER Agent (A2A)](/goldenmatch/agent) page for agent framework integration (LangChain, CrewAI, AutoGen).

--- a/docs-site/goldenmatch/overview.mdx
+++ b/docs-site/goldenmatch/overview.mdx
@@ -65,7 +65,7 @@ pip install goldenmatch[mcp]          # MCP server for Claude Desktop
 - **Golden records**: five merge strategies with field-level provenance and quality-weighted survivorship.
 - **PPRL**: privacy-preserving record linkage across organizations (F1 0.924 on FEBRL4).
 - **Learning Memory**: persists steward corrections, unmerges, and LLM votes across runs.
-- **Interactive TUI**, REST API, MCP server (54 tools), A2A agent (31 skills), and a localhost web workbench.
+- **Interactive TUI**, REST API, MCP server (69 tools), A2A agent, and a localhost web workbench.
 
 ## Benchmarks
 

--- a/docs-site/goldenmatch/typescript.mdx
+++ b/docs-site/goldenmatch/typescript.mdx
@@ -269,7 +269,7 @@ See [`packages/goldenmatch-js/examples/`](https://github.com/benseverndev-oss/go
 | ANN blocking | FAISS | hnswlib-node |
 | Parallel scoring | Threads + Ray | piscina worker threads |
 | Interactive UI | Textual TUI | Ink TUI |
-| MCP server | 30 tools | 19 tools |
+| MCP server | 69 tools | 34 tools |
 | REST API | Yes | Yes |
 | A2A server | Yes | Yes |
 | YAML configs | Yes | Yes (round-trippable) |

--- a/docs-site/goldenpipe/overview.mdx
+++ b/docs-site/goldenpipe/overview.mdx
@@ -4,18 +4,30 @@ description: "The orchestrator that chains data-quality checking, transformation
 keywords: ["goldenpipe", "orchestration", "pipeline", "check", "flow", "match"]
 ---
 
-GoldenPipe chains GoldenCheck, GoldenFlow, and GoldenMatch into one pipeline. It profiles your data, conditionally routes it through transformation, deduplicates it (or routes sensitive fields to privacy-preserving matching), and emits golden records. Its logic is adaptive: it skips transformation when no issues are found, and it explains the reasoning behind every decision.
+GoldenPipe chains GoldenCheck, GoldenFlow, and GoldenMatch into one pipeline. It profiles your data, conditionally routes it through transformation, deduplicates it (or routes sensitive fields to privacy-preserving matching), and emits golden records. Its logic is adaptive: a dependency-DAG planner orders the stages from their declared dependencies, it skips transformation when no issues are found, and it explains the reasoning behind every decision.
+
+It runs in Python and TypeScript, on the CLI, and behind MCP, REST, and A2A servers.
 
 ## Install
 
-```bash
+<CodeGroup>
+
+```bash pip
 pip install goldenpipe
 pip install goldenpipe[mcp]   # MCP server mode
 ```
 
+```bash npm
+npm install goldenpipe        # edge-safe; enableWasm() opts into the Rust planner
+```
+
+</CodeGroup>
+
 ## Quickstart
 
-```python
+<CodeGroup>
+
+```python Python
 import goldenpipe as gp
 
 result = gp.run("customers.csv")
@@ -27,6 +39,16 @@ print(result.match)      # deduplicated clusters
 print(result.reasoning)  # why each decision was made
 ```
 
+```ts TypeScript
+import { runDf } from "goldenpipe";
+
+const result = await runDf(rows);   // zero-config: scan -> transform -> dedupe
+console.log(result.status);         // "success"
+console.log(result.artifacts.golden);
+```
+
+</CodeGroup>
+
 On the CLI:
 
 ```bash
@@ -35,18 +57,25 @@ goldenpipe run customers.csv --verbose       # show reasoning
 goldenpipe run customers.csv --skip-flow     # check + match only
 goldenpipe run customers.csv --strategy pprl # force privacy mode
 goldenpipe run customers.csv -o golden.csv   # save golden records
+goldenpipe stages                            # list registered stages
+goldenpipe validate -c pipeline.yml          # dry-run wiring validation
+goldenpipe serve | mcp-serve | agent-serve   # REST / MCP / A2A servers
 ```
 
 ## Key features
 
 - **Orchestrates the full pipeline** (Check → Flow → Match) in one call.
+- **Dependency-DAG planner** that activates each stage's `needs`, reorders a consumer ahead of its sole producer instead of erroring, and rejects genuinely ambiguous co-production, cycles, and unknown `needs` as typed errors (`MissingProducer`, `AmbiguousProducer`, `Cycle`, `UnknownNeed`).
 - **Adaptive logic** that skips transformation when there are no quality issues.
 - **Privacy-preserving routing** that detects sensitive fields and routes to PPRL.
 - **Reasoning transparency** that reports why each stage ran or was skipped.
 - **Column-context enrichment** that builds targeted dedupe config from GoldenCheck profiles and column-name heuristics.
-- **Remote and local MCP server** (`goldenpipe mcp-serve`).
+- **Polyglot planner, one source of truth.** The planner (stage ordering, decision routing, auto-config, `skip_if`) is a pyo3-free `goldenpipe-core` Rust kernel; Python and edge-TS compute it identically, locked byte-for-byte by a CI parity gate. TypeScript opts into the WASM kernel with `enableWasm()`; pure-TS is the default. Only the planner is in Rust — stage execution and IO stay a per-language host.
+- **Four server surfaces**: MCP (`goldenpipe mcp-serve`, 4 tools), REST (`goldenpipe serve`), and A2A (`goldenpipe agent-serve`), plus the local CLI.
 
 GoldenPipe scores 88.07 on the DQBench Pipeline category.
+
+See the [API surface](/reference/api-surface#goldenpipe) for every entry point in one place.
 
 ## Selective stages
 
@@ -85,7 +114,11 @@ result.skipped     # list[str]
   A few sharp edges from the package docs: `PipeResult` does not expose the output DataFrame directly. Use `gp.run(path)` (file-based) rather than `gp.run_df(df)`, since GoldenCheck needs a file extension. And cast mixed-type columns (for example a `birth_year` that is sometimes an int and sometimes a string) to a single type before dedup, or GoldenMatch will raise.
 </Warning>
 
-## MCP endpoints
+## Servers
 
-- Remote: `https://goldenpipe-mcp-production.up.railway.app/mcp/`
-- Local: `goldenpipe mcp-serve --transport http --port 8250`
+GoldenPipe ships three server surfaces, each exposing the same four operations —
+`list_stages`, `validate_pipeline`, `run_pipeline`, `explain_pipeline`:
+
+- **MCP** — remote `https://goldenpipe-mcp-production.up.railway.app/mcp/` or local `goldenpipe mcp-serve --transport http --port 8250` (4 tools).
+- **REST** — `goldenpipe serve` (`GET /stages`, `POST /validate`, `POST /run`).
+- **A2A** — `goldenpipe agent-serve` (agent card at `/.well-known/agent.json`, 4 skills).

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -4,7 +4,7 @@ description: "A polyglot data-quality and entity-resolution toolkit. Zero-config
 keywords: ["entity resolution", "deduplication", "data quality", "record linkage", "golden records"]
 ---
 
-The Golden Suite is a polyglot data-quality and entity-resolution toolkit. Each tool stands alone, but together they form a single pipeline: profile your data, standardize it, deduplicate it, and emit golden records. Every package ships zero-config defaults, a CLI, a Python and (mostly) a TypeScript library, and an AI-native surface (MCP server, REST API, agent skills).
+The Golden Suite is a polyglot data-quality and entity-resolution toolkit. Each tool stands alone, but together they form a single pipeline: profile your data, standardize it, deduplicate it, and emit golden records. Every package ships zero-config defaults, a CLI, a Python and a TypeScript library, and an AI-native surface (MCP server, and — for the service-shaped packages — a REST API and agent skills).
 
 ## Start where you fit
 
@@ -25,13 +25,16 @@ The Golden Suite is a polyglot data-quality and entity-resolution toolkit. Each 
     Deduplicate a CSV in 30 seconds.
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/concepts/architecture">
-    How the five tools compose into one pipeline.
+    How the six tools compose into one pipeline.
   </Card>
   <Card title="GoldenMatch" icon="object-group" href="/goldenmatch/overview">
     The headline package: zero-config entity resolution.
   </Card>
   <Card title="Scale envelope" icon="gauge-high" href="/concepts/scale-envelope">
     Pick the right backend for your row count.
+  </Card>
+  <Card title="API surface" icon="table-list" href="/reference/api-surface">
+    Every entry point in one place — Python, TypeScript, CLI, MCP, REST, and agent skills across all six packages.
   </Card>
 </CardGroup>
 
@@ -68,7 +71,7 @@ flowchart LR
     Data-quality scanning that discovers rules automatically.
   </Card>
   <Card title="GoldenFlow" icon="wand-magic-sparkles" href="/goldenflow/overview">
-    76 transforms across 11 categories for cleaning messy data.
+    86 transforms across 11 categories for cleaning messy data.
   </Card>
   <Card title="GoldenPipe" icon="diagram-project" href="/goldenpipe/overview">
     One call to chain Check, Flow, and Match.
@@ -88,7 +91,7 @@ flowchart LR
 
 - **Zero-config that beats hand-tuned.** GoldenMatch's introspective auto-config controller reaches F1 0.964 on DBLP-ACM out of the box, above the hand-tuned ceiling of 0.918.
 - **Polyglot.** Python is the headline runtime; TypeScript runs the same scorers on edge runtimes (Vercel Edge, Cloudflare Workers, Deno); Rust powers the Postgres and DuckDB extensions.
-- **AI-native.** Every package ships an MCP server (50+ tools across the suite), a REST API, and agent skills.
+- **AI-native.** Every package ships an MCP server (~110 tools across the suite), and the service-shaped packages add a REST API and agent skills.
 - **MIT-licensed.** Every package in the suite.
 
 <Note>

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -1,0 +1,282 @@
+---
+title: "API surface"
+description: "One page for the whole suite's programmatic surface — Python, TypeScript, CLI, MCP, REST, and agent skills across all six packages, with the primary entry points for each."
+keywords: ["api", "reference", "surface", "python", "typescript", "cli", "mcp", "rest", "a2a"]
+---
+
+Every Golden Suite package exposes the same operation through several surfaces: a
+Python library, a TypeScript library, a CLI, an MCP server, and — for the
+service-shaped packages — a REST API and an A2A agent server. This page is the
+single map of all of them. Pick a package, pick a surface, and follow the link to
+its deep reference.
+
+<Note>
+  Versions below are the current published releases. TypeScript packages track the
+  same API but lag the Python versions and expose a subset of the MCP tools — see
+  the [coverage notes](#coverage-notes) at the bottom.
+</Note>
+
+## Capability matrix
+
+What each package ships, at a glance. **MCP** counts are the Python server's tools
+(the TS server exposes a subset). A dash means the package does not ship that
+surface.
+
+| Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
+|---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
+| [GoldenMatch](#goldenmatch) | `2.8.0` | `1.1.0` | `goldenmatch` | 69 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenCheck](#goldencheck) | `1.4.1` | `0.4.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
+| [GoldenFlow](#goldenflow)   | `1.9.0` | `0.9.0` | `goldenflow`  | 10 | ✓ | ✓ | wheel |
+| [GoldenPipe](#goldenpipe)   | `1.3.0` | `0.2.0` | `goldenpipe`  | 4  | ✓ | ✓ | core (WASM) |
+| [GoldenAnalysis](#goldenanalysis) | `0.3.0` | `0.1.0` | `goldenanalysis` | 4 | — | — | core (WASM) |
+| [InferMap](#infermap)       | `0.5.1` | `0.5.0` | `infermap`    | 4  | — | — | — |
+
+## Install
+
+<CodeGroup>
+
+```bash pip
+pip install goldenmatch          # + [native] for the compiled kernel, [mcp] for the server
+pip install goldencheck goldenflow goldenpipe goldenanalysis infermap
+```
+
+```bash npm
+npm install goldenmatch          # edge-safe core; enableWasm() opts into the Rust kernel
+npm install goldencheck goldenflow goldenpipe goldenanalysis infermap
+```
+
+</CodeGroup>
+
+Each package's MCP server ships in the same distribution: `pip install <pkg>[mcp]`
+(Python) or the `<pkg>-mcp` npm bin.
+
+---
+
+## GoldenMatch
+
+Zero-config entity resolution: dedupe, match, cluster, survivorship, identity
+graph, privacy-preserving linkage. The flagship — the only package with a native
+wheel, SQL extensions, REST, and A2A.
+
+**Python** — `import goldenmatch`
+
+| Entry point | Does |
+|-------------|------|
+| `dedupe_df(df, ...)` / `dedupe(path)` | Deduplicate a DataFrame or file into clusters + golden records |
+| `match_df(...)` / `match(...)` | Match a target dataset against reference sources |
+| `auto_configure_df(df)` | Zero-config: infer the full `GoldenMatchConfig` from the data |
+| `AgentSession()` | Stateful, agent-facing ER session (`autoconfigure`, `deduplicate`, `review`) |
+| `run_pprl(...)` / `pprl_link(...)` | Privacy-preserving record linkage (Bloom filters, SMC) |
+| `IdentityStore` / `resolve_clusters(...)` | Durable Identity Graph — stable `entity_id`s across runs |
+| `record_fingerprint(record)` | Stable cross-surface record-id hash |
+
+**TypeScript** — `import { dedupe, match, autoConfigureRows, enableWasm } from "goldenmatch"`
+
+**CLI** — `goldenmatch <cmd>`: `autoconfig`, `dedupe`, `match`, `review`, `explain`,
+`identity`, `pprl`, `memory`, `serve`, `serve-ui`, `mcp-serve`, `agent-serve`, … (30+ commands)
+
+**Servers** — REST (`goldenmatch serve`: `/match`, `/autoconfig`, `/clusters`,
+`/reviews`, `/controller/telemetry`, …) · A2A (`goldenmatch agent-serve`) · local
+web UI (`goldenmatch serve-ui`) · **69 MCP tools**.
+
+**Native / SQL** — `goldenmatch-native` wheel, a Postgres extension (pgrx:
+`goldenmatch_dedupe`, `goldenmatch_autoconfig`, `goldenmatch_connected_components`, …),
+and a DuckDB extension.
+
+→ [Python API](/goldenmatch/python-api) · [TypeScript](/goldenmatch/typescript) ·
+[REST](/goldenmatch/rest-api) · [MCP](/goldenmatch/mcp) · [Agent](/goldenmatch/agent) ·
+[API quick reference](/goldenmatch/api-quick-reference)
+
+---
+
+## GoldenCheck
+
+Data-quality scanning: profile a dataset, discover rules automatically, emit
+findings with severities, auto-triage and fix, diff two versions.
+
+**Python** — `import goldencheck`
+
+| Entry point | Does |
+|-------------|------|
+| `scan_file(path)` / `scan_dataframe(df)` | Run a quality scan → `ScanResult` (findings, severities, profile) |
+| `scan_file_with_llm(path)` | Scan with LLM-assisted checks |
+| `validate_file(path)` | Rule-based validation |
+| `auto_triage(result)` → `TriageResult` | Rank/route findings |
+| `apply_fixes(...)` → `FixReport` | Apply suggested fixes |
+| `diff_files(a, b)` → `DiffReport` | Schema / finding / stat drift between versions |
+
+**TypeScript** — `import { scanData, createBaseline, runDriftChecks } from "goldencheck"`
+
+**CLI** — `goldencheck <cmd>`: `scan`, `validate`, `fix`, `diff`, `baseline`,
+`refs`, `scan-db`, `serve`, `mcp-serve`, `agent-serve`, …
+
+**Servers** — REST (`goldencheck serve`: `/scan`, `/checks`, `/domains`) · A2A
+(9 skills) · **19 MCP tools**.
+
+**Native** — `goldencheck-native` wheel.
+
+→ [Overview](/goldencheck/overview) · [CLI](/goldencheck/cli) ·
+[Native](/goldencheck/native) · [Integrations](/goldencheck/integrations)
+
+---
+
+## GoldenFlow
+
+Data transformation: 86 built-in transforms across 11 categories (phone, date,
+address, name, categorical, identifiers, …), a transform registry, schema mapping,
+and owned identifier kernels (card / IBAN / ISBN / EAN / VAT).
+
+**Python** — `import goldenflow`
+
+| Entry point | Does |
+|-------------|------|
+| `transform_df(df, config)` / `transform_file(path)` | Apply a transform pipeline |
+| `TransformEngine(config)` | Configurable engine → `TransformResult` |
+| `canonicalize(value, rules)` | Pure scalar canonicalizers |
+| `select_transforms(profile)` | Auto-pick transforms from a profile |
+| `register_transform(...)` / `list_transforms()` | The transform registry |
+| `SchemaMapper` / `load_domain(name)` | Schema mapping + domain packs |
+
+**TypeScript** — `import { TransformEngine, canonicalize, enableWasm } from "goldenflow"`
+
+**CLI** — `goldenflow <cmd>`: `transform`, `map`, `profile`, `learn`, `diff`,
+`stream`, `serve`, `mcp-serve`, `agent-serve`, …
+
+**Servers** — REST (`goldenflow serve`: `/transforms`, `/transform`, `/map`) · A2A
+(6 skills) · **10 MCP tools**.
+
+**Native** — `goldenflow-native` wheel; the pure canonicalizers are also compiled
+to a `goldenflow-core` Rust kernel (opt-in WASM in TS).
+
+→ [Overview](/goldenflow/overview) · [CLI](/goldenflow/cli) · [Performance](/goldenflow/performance)
+
+---
+
+## GoldenPipe
+
+Pipeline orchestration: chains Check → Flow → Match into one adaptive call, with a
+**dependency-DAG planner** that orders stages from their declared `needs` and
+`consumes`/`produces`, routes on decision gates, and explains every choice.
+
+**Python** — `import goldenpipe as gp`
+
+| Entry point | Does |
+|-------------|------|
+| `gp.run(source)` / `run_df(df)` | Execute the default or a configured pipeline |
+| `run_stages([...])` | Run an explicit list of stages |
+| `Pipeline(config)` / `PipelineConfig` / `StageSpec` | Build a custom pipeline |
+| `stage` (decorator) / `Stage` | Define a programmatic stage |
+| `severity_gate` / `pii_router` / `row_count_gate` | Built-in decision stages |
+
+The planner is a pyo3-free `goldenpipe-core` Rust kernel — the single reference
+that Python and edge-TS compute identically. It activates the `needs` field,
+reorders a consumer ahead of its sole producer instead of erroring, and rejects
+genuinely ambiguous co-production, cycles, and unknown `needs` as typed errors
+(`MissingProducer`, `AmbiguousProducer`, `Cycle`, `UnknownNeed`). Opt into the WASM
+kernel in TypeScript with `enableWasm()`.
+
+**TypeScript** — `import { runDf, Pipeline, StageRegistry, enableWasm } from "goldenpipe"`
+
+**CLI** — `goldenpipe <cmd>`: `run`, `stages`, `validate`, `init`, `serve`,
+`mcp-serve`, `agent-serve`, `interactive`.
+
+**Servers** — REST (`goldenpipe serve`: `/stages`, `/validate`, `/run`) · A2A
+(4 skills) · **4 MCP tools** (`run_pipeline`, `validate_pipeline`, `list_stages`,
+`explain_pipeline`).
+
+→ [Overview](/goldenpipe/overview)
+
+---
+
+## GoldenAnalysis
+
+Read-only cross-cutting reporting: run analyzers over any package's artifacts,
+build trends across runs, and gate regressions.
+
+**Python** — `import goldenanalysis`
+
+| Entry point | Does |
+|-------------|------|
+| `analyze(frame_or_artifacts)` → `AnalysisReport` | Run analyzers → metrics |
+| `analyze_match(...)` / `analyze_pipeline(...)` | Package-specific entry points |
+| `ReportHistory` / `RegressionPolicy` | Trend tracking + regression gating |
+
+**TypeScript** — `import { analyze, buildTrend, detectRegressions } from "goldenanalysis"`
+
+**CLI** — `goldenanalysis <cmd>`: `report`, `trend`, `regressions`, `mcp-serve`.
+
+**Servers** — **4 MCP tools** (`analyze_frame`, `detect_regressions`, `get_trend`,
+`list_analyzers`). No REST or A2A server — it is a reporting library, not a service.
+
+→ [Overview](/goldenanalysis/overview) · [Cross-run](/goldenanalysis/cross-run) ·
+[Native](/goldenanalysis/native)
+
+---
+
+## InferMap
+
+Schema / column mapping: align source columns to a target schema with Hungarian
+assignment over pluggable field scorers, plus domain detection.
+
+**Python** — `import infermap`
+
+| Entry point | Does |
+|-------------|------|
+| `map(source, target)` → `MapResult` | Map a source schema/dataset to a target |
+| `MapEngine.from_config(...)` | Configurable mapping engine |
+| `detect_domain(...)` | Infer the domain pack |
+| `extract_schema(source)` → `SchemaInfo` | Pull a schema from data |
+| `write_aliases_from_mapping(...)` | Persist a mapping as aliases |
+
+**TypeScript** — `import { map, MapEngine, detectDomain } from "infermap"`
+
+**CLI** — `infermap <cmd>`: `map`, `apply`, `inspect`, `validate`, `mcp-serve`.
+
+**Servers** — **4 MCP tools** (`map`, `apply`, `inspect`, `validate`). Pure Python +
+pure TypeScript — no native wheel, no SQL, no REST or A2A.
+
+→ [Overview](/infermap/overview)
+
+---
+
+## Same operation, every surface
+
+The suite's design goal is one computation reachable identically from anywhere.
+GoldenMatch's auto-config is the canonical example — the same config + telemetry
+comes back whether you call it from Python, the CLI, REST, MCP, an agent, or SQL:
+
+```python
+from goldenmatch import AgentSession
+result = AgentSession().autoconfigure("customers.csv")
+# result["config"]     — GoldenMatchConfig as a JSON-safe dict
+# result["telemetry"]  — stop_reason, health, decisions, column priors
+```
+
+| Surface | Call |
+|---------|------|
+| Python  | `AgentSession().autoconfigure(path)` |
+| CLI     | `goldenmatch autoconfig customers.csv` |
+| REST    | `POST /autoconfig` · `GET /controller/telemetry` |
+| MCP     | `auto_configure` tool |
+| A2A     | `autoconfig` skill |
+| SQL     | `goldenmatch_autoconfig(...)` (Postgres / DuckDB) |
+
+## Coverage notes
+
+- **TypeScript lags Python.** Every package has a TS twin, but the npm versions
+  trail the PyPI ones and the TS MCP servers expose a subset of the Python tools
+  (e.g. GoldenMatch: 34 TS tools vs 69 Python). The public function names match.
+- **REST + A2A are for the service-shaped packages only** — GoldenMatch,
+  GoldenCheck, GoldenFlow, and GoldenPipe. GoldenAnalysis and InferMap ship a CLI
+  and an MCP server but no long-running HTTP service.
+- **Native acceleration** is a compiled Rust kernel behind a pure-Python/TS
+  fallback. GoldenMatch, GoldenCheck, GoldenFlow, and GoldenAnalysis ship it;
+  GoldenPipe's `goldenpipe-core` is the planner-only reference (execution stays in
+  the host language); InferMap is pure Python/TS.
+- **SQL extensions** (Postgres + DuckDB) are GoldenMatch-only.
+
+<Note>
+  Authoritative type signatures live in each package's source (`<pkg>/__init__.py`
+  and the config schema modules). This page maps the surface; the linked deep pages
+  carry the full signatures and examples.
+</Note>

--- a/docs-site/reference/vendor-comparison.mdx
+++ b/docs-site/reference/vendor-comparison.mdx
@@ -22,7 +22,7 @@ This page summarizes the entity-resolution landscape as recorded in the reposito
 | Accuracy (NCVR) | F1 0.972 zero-config. |
 | Zero-config | Introspective auto-config controller with cross-run memory and LLM fallback. |
 | PPRL | Bloom-filter PPRL, F1 0.924 on FEBRL4. |
-| AI-native surface | 35+ MCP tools, agent skills, REST API. |
+| AI-native surface | 69 MCP tools, agent skills, REST API. |
 
 ## OSS engines
 

--- a/docs/.docs-sweep.json
+++ b/docs/.docs-sweep.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.3.0",
-  "commit": "03ce2e85",
-  "date": "2026-06-24",
+  "version": "2.8.0",
+  "commit": "d664b5e2",
+  "date": "2026-07-04",
   "note": "Set by the rollout-docs-sweep skill when a docs sweep completes for a release. The check_docs_sweep.py gate asserts version == current packages/python/goldenmatch version; bump this marker at the END of a docs sweep."
 }


### PR DESCRIPTION
The Mintlify site had **no single place to see the suite's API** — it was fragmented per-package, and only GoldenMatch had API/reference pages — and it carried stale counts and versions across a wave of merged PRs.

## New: one API surface page
`docs-site/reference/api-surface.mdx` — the single front door:
- A **capability matrix** across all 6 packages × every surface (Python / TypeScript / CLI / MCP tools / REST / A2A / native+SQL).
- Per-package primary entry points (the key functions/classes for each).
- A **"same operation, every surface"** example (auto-config from Python / CLI / REST / MCP / A2A / SQL).
- Wired into the Reference nav and surfaced from the landing page.

## Staleness sweep (verified against code)
- **GoldenFlow transform count** reconciled to **86** (pages disagreed — some said 92, others 76).
- **GoldenMatch MCP tools 54 → 69** across overview/mcp/agent/learning-memory; TS comparison 30/19 → 69/34; suite total 35+/50+ → **~110**.
- **"five tools" → six** — GoldenAnalysis added to the landing pipeline table and the architecture Steps.
- **GoldenPipe overview rewritten** to cover what shipped: the dependency-DAG planner (`needs` + typed errors), `goldenpipe-core`/WASM (`enableWasm`), the TypeScript library, and the REST/A2A/MCP servers. Dropped the stale "(mostly) a TypeScript library" — all 6 now have one.
- Bumped `docs/.docs-sweep.json` to 2.8.0.

Docs-only. `check_docs_consistency.py` passes on Linux (the local Windows run false-flags orphans due to a `\` vs `/` path artifact in the gate — verified zero real orphans with POSIX normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)